### PR TITLE
Python: add new maintainer

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -32,7 +32,7 @@ class PythonPackage(PackageBase):
     #: Package name, version, and extension on PyPI
     pypi = None  # type: Optional[str]
 
-    maintainers = ["adamjstewart"]
+    maintainers = ["adamjstewart", "pradyunsg"]
 
     # Default phases
     phases = ["install"]

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -15,7 +15,7 @@ class PyPip(Package):
     url = "https://files.pythonhosted.org/packages/py3/p/pip/pip-20.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/pip/"
 
-    maintainers = ["adamjstewart"]
+    maintainers = ["adamjstewart", "pradyunsg"]
 
     version(
         "22.1.2",

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -36,7 +36,7 @@ class Python(Package):
     list_url = "https://www.python.org/ftp/python/"
     list_depth = 1
 
-    maintainers = ["adamjstewart", "skosukhin", "scheibelp", "varioustoxins"]
+    maintainers = ["adamjstewart", "skosukhin", "scheibelp", "varioustoxins", "pradyunsg"]
 
     phases = ["configure", "build", "install"]
 


### PR DESCRIPTION
@pradyunsg I opened a PR to discuss what we talked about on Slack. If you're willing to help maintain Spack's Python packaging ecosystem, there are a few places where you can be listed as an official "maintainer":

1. In the `python` build recipe
2. In the `PythonPackage` build system
3. In specific Python libraries (pip, toml, etc.)

By adding your GitHub username to these locations, you'll be automatically pinged on any issues/PRs related to these. The difference between these is the scope of packages they cover:

1. Only the `python` package itself
2. All packages that subclass `PythonPackage` (close to 2K libraries)
3. Only the Python libraries you care about

If you only want to support 1 or 3 and avoid 2 that's completely fine. 2 keeps me pretty busy because I need to manually check to make sure that all the dependencies of a package are listed correctly. 1 is a pretty light workload, there are occasionally small changes to the Python package itself, and when I change the `PythonPackage` base class I usually ping the same people. Same for 3, most packages don't get updated too often.

"Maintainers" of packages in Spack are entirely voluntary. You'll be asked to review PRs or help with issues, but if you're busy or don't know how to solve an issue you can simply ignore it. You also don't need to be a Spack expert (we have plenty of those, we have fewer Python packaging experts).

Also, if you know anyone else who may be interested in the above, let me know and I can add them too (with their consent of course).