### PR TITLE
`spack ci rebuild`: Don't install in a login shell

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -521,10 +521,9 @@ def ci_rebuild(args):
     install_copy_path = os.path.join(repro_dir, "install.sh")
     shutil.copyfile("install.sh", install_copy_path)
 
-    # Run the generated install.sh shell script as if it were being run in
-    # a login shell.
+    # Run the generated install.sh shell script
     try:
-        install_process = subprocess.Popen(["bash", "-l", "./install.sh"])
+        install_process = subprocess.Popen(["bash", "./install.sh"])
         install_process.wait()
         install_exit_code = install_process.returncode
     except (ValueError, subprocess.CalledProcessError, OSError) as inst:


### PR DESCRIPTION
On some systems (e.g. OpenSUSE Leap 15) running the shell in login mode wipes important parts of the environment, such as `PATH`. Currently `spack ci rebuild` runs it's generated `install.sh` script in a login shell, which causes all the build-jobs to fail with [a mysterious `spack: command not found` error](https://gitlab.spack.io/spack/spack/-/jobs/2841392#L93).

This hotpatch changes to run the `install.sh` script in a normal shell without any extra modifications.