### PR TITLE
gcc: fix unstable patch urls

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -322,8 +322,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch('glibc-2.31-libsanitizer-2.patch', when='@8.1.0:8.3.0,9.0.0:9.2.0')
     patch('glibc-2.31-libsanitizer-2-gcc-6.patch', when='@5.3.0:5.5.0,6.1.0:6.5.0')
     patch('glibc-2.31-libsanitizer-2-gcc-7.patch', when='@7.1.0:7.5.0')
-    patch('https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=2b40941d23b1570cdd90083b58fa0f66aa58c86e', sha256='b48e48736062e64a6da7cbe7e21a6c1c89422d1f49ef547c73b479a3f3f4935f', when='@6.5.0,7.4.0:7.5.0,8.2.0:9.3.0')
-    patch('https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=745dae5923aba02982563481d75a21595df22ff8', sha256='eaa00c91e08a5e767f023911a49bc1b2d1a3eea38703b745ab260f90e8da41aa', when='@10.1.0:10.3.0,11.1.0')
+    patch('patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch', when='@6.5.0,7.4.0:7.5.0,8.2.0:9.3.0')
+    patch('patch-745dae5923aba02982563481d75a21595df22ff8.patch', when='@10.1.0:10.3.0,11.1.0')
 
     # Older versions do not compile with newer versions of glibc
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81712
@@ -346,10 +346,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch('zstd.patch', when='@10')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100102
-    patch('https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=fc930b3010bd0de899a3da3209eab20664ddb703',
-          sha256='28c5ab3b564d83dd7e6e35b9c683141a4cb57ee886c5367e54a0828538b3c789', when='@10.1:10.3')
-    patch('https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=f1feb74046e0feb0596b93bbb822fae02940a90e',
-          sha256='3e5029489b79fc0d47fd6719f3d5c9d3bbc727a4a0cbff161a5517e8a3c98cb6',  when='@11.1')
+    patch('patch-fc930b3010bd0de899a3da3209eab20664ddb703.patch', when='@10.1:10.3')
+    patch('patch-f1feb74046e0feb0596b93bbb822fae02940a90e.patch', when='@11.1')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/gcc/patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch
+++ b/var/spack/repos/builtin/packages/gcc/patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch
@@ -1,0 +1,121 @@
+From 2b40941d23b1570cdd90083b58fa0f66aa58c86e Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar.christina@arm.com>
+Date: Fri, 21 May 2021 12:16:56 +0100
+Subject: [PATCH] libsanitizer: Remove cyclades from libsanitizer
+
+The Linux kernel has removed the interface to cyclades from
+the latest kernel headers[1] due to them being orphaned for the
+past 13 years.
+
+libsanitizer uses this header when compiling against glibc, but
+glibcs itself doesn't seem to have any references to cyclades.
+
+Further more it seems that the driver is broken in the kernel and
+the firmware doesn't seem to be available anymore.
+
+As such since this is breaking the build of libsanitizer (and so the
+GCC bootstrap[2]) I propose to remove this.
+
+[1] https://lkml.org/lkml/2021/3/2/153
+[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100379
+
+libsanitizer/ChangeLog:
+
+	PR sanitizer/100379
+	* sanitizer_common/sanitizer_common_interceptors_ioctl.inc: Cherry-pick
+	llvm-project revision f7c5351552387bd43f6ca3631016d7f0dfe0f135.
+	* sanitizer_common/sanitizer_platform_limits_posix.cc: Likewise.
+	* sanitizer_common/sanitizer_platform_limits_posix.h: Likewise.
+---
+ .../sanitizer_common_interceptors_ioctl.inc           |  9 ---------
+ .../sanitizer_platform_limits_posix.cc                | 11 -----------
+ .../sanitizer_platform_limits_posix.h                 | 10 ----------
+ 3 files changed, 30 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 5408ea17c59..7a9cd3f5968 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -365,15 +365,6 @@ static void ioctl_table_fill() {
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   // _(SIOCDEVPLIP, WRITE, struct_ifreq_sz); // the same as EQL_ENSLAVE
+-  _(CYGETDEFTHRESH, WRITE, sizeof(int));
+-  _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+-  _(CYGETMON, WRITE, struct_cyclades_monitor_sz);
+-  _(CYGETTHRESH, WRITE, sizeof(int));
+-  _(CYGETTIMEOUT, WRITE, sizeof(int));
+-  _(CYSETDEFTHRESH, NONE, 0);
+-  _(CYSETDEFTIMEOUT, NONE, 0);
+-  _(CYSETTHRESH, NONE, 0);
+-  _(CYSETTIMEOUT, NONE, 0);
+   _(EQL_EMANCIPATE, WRITE, struct_ifreq_sz);
+   _(EQL_ENSLAVE, WRITE, struct_ifreq_sz);
+   _(EQL_GETMASTRCFG, WRITE, struct_ifreq_sz);
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+index d823a12190c..e8fce8a0287 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -157,7 +157,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+ #include <linux/lp.h>
+@@ -466,7 +465,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
+-  unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+ #if EV_VERSION > (0x010000)
+   unsigned struct_input_keymap_entry_sz = sizeof(struct input_keymap_entry);
+ #else
+@@ -833,15 +831,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+-  unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+-  unsigned IOCTL_CYGETMON = CYGETMON;
+-  unsigned IOCTL_CYGETTHRESH = CYGETTHRESH;
+-  unsigned IOCTL_CYGETTIMEOUT = CYGETTIMEOUT;
+-  unsigned IOCTL_CYSETDEFTHRESH = CYSETDEFTHRESH;
+-  unsigned IOCTL_CYSETDEFTIMEOUT = CYSETDEFTIMEOUT;
+-  unsigned IOCTL_CYSETTHRESH = CYSETTHRESH;
+-  unsigned IOCTL_CYSETTIMEOUT = CYSETTIMEOUT;
+   unsigned IOCTL_EQL_EMANCIPATE = EQL_EMANCIPATE;
+   unsigned IOCTL_EQL_ENSLAVE = EQL_ENSLAVE;
+   unsigned IOCTL_EQL_GETMASTRCFG = EQL_GETMASTRCFG;
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index 6a673a7c995..f921bf2b5b5 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1040,7 +1040,6 @@ struct __sanitizer_cookie_io_functions_t {
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   extern unsigned struct_ax25_parms_struct_sz;
+-  extern unsigned struct_cyclades_monitor_sz;
+   extern unsigned struct_input_keymap_entry_sz;
+   extern unsigned struct_ipx_config_data_sz;
+   extern unsigned struct_kbdiacrs_sz;
+@@ -1385,15 +1384,6 @@ struct __sanitizer_cookie_io_functions_t {
+ #endif  // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  extern unsigned IOCTL_CYGETDEFTHRESH;
+-  extern unsigned IOCTL_CYGETDEFTIMEOUT;
+-  extern unsigned IOCTL_CYGETMON;
+-  extern unsigned IOCTL_CYGETTHRESH;
+-  extern unsigned IOCTL_CYGETTIMEOUT;
+-  extern unsigned IOCTL_CYSETDEFTHRESH;
+-  extern unsigned IOCTL_CYSETDEFTIMEOUT;
+-  extern unsigned IOCTL_CYSETTHRESH;
+-  extern unsigned IOCTL_CYSETTIMEOUT;
+   extern unsigned IOCTL_EQL_EMANCIPATE;
+   extern unsigned IOCTL_EQL_ENSLAVE;
+   extern unsigned IOCTL_EQL_GETMASTRCFG;
+-- 
+2.31.1
+

--- a/var/spack/repos/builtin/packages/gcc/patch-745dae5923aba02982563481d75a21595df22ff8.patch
+++ b/var/spack/repos/builtin/packages/gcc/patch-745dae5923aba02982563481d75a21595df22ff8.patch
@@ -1,0 +1,123 @@
+From 745dae5923aba02982563481d75a21595df22ff8 Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar.christina@arm.com>
+Date: Fri, 21 May 2021 10:30:59 +0100
+Subject: [PATCH] libsanitizer: Remove cyclades from libsanitizer
+
+The Linux kernel has removed the interface to cyclades from
+the latest kernel headers[1] due to them being orphaned for the
+past 13 years.
+
+libsanitizer uses this header when compiling against glibc, but
+glibcs itself doesn't seem to have any references to cyclades.
+
+Further more it seems that the driver is broken in the kernel and
+the firmware doesn't seem to be available anymore.
+
+As such since this is breaking the build of libsanitizer (and so the
+GCC bootstrap[2]) I propose to remove this.
+
+[1] https://lkml.org/lkml/2021/3/2/153
+[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100379
+
+(cherry picked from commit f7c5351552387bd43f6ca3631016d7f0dfe0f135)
+
+libsanitizer/ChangeLog:
+
+	PR sanitizer/100379
+	* sanitizer_common/sanitizer_common_interceptors_ioctl.inc: Cherry-pick
+	llvm-project revision f7c5351552387bd43f6ca3631016d7f0dfe0f135.
+	* sanitizer_common/sanitizer_platform_limits_posix.cpp: Likewise.
+	* sanitizer_common/sanitizer_platform_limits_posix.h: Likewise.
+---
+ .../sanitizer_common_interceptors_ioctl.inc           |  9 ---------
+ .../sanitizer_platform_limits_posix.cpp               | 11 -----------
+ .../sanitizer_platform_limits_posix.h                 | 10 ----------
+ 3 files changed, 30 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 7f181258eab..b7da6598755 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -370,15 +370,6 @@ static void ioctl_table_fill() {
+ 
+ #if SANITIZER_GLIBC
+   // _(SIOCDEVPLIP, WRITE, struct_ifreq_sz); // the same as EQL_ENSLAVE
+-  _(CYGETDEFTHRESH, WRITE, sizeof(int));
+-  _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+-  _(CYGETMON, WRITE, struct_cyclades_monitor_sz);
+-  _(CYGETTHRESH, WRITE, sizeof(int));
+-  _(CYGETTIMEOUT, WRITE, sizeof(int));
+-  _(CYSETDEFTHRESH, NONE, 0);
+-  _(CYSETDEFTIMEOUT, NONE, 0);
+-  _(CYSETTHRESH, NONE, 0);
+-  _(CYSETTIMEOUT, NONE, 0);
+   _(EQL_EMANCIPATE, WRITE, struct_ifreq_sz);
+   _(EQL_ENSLAVE, WRITE, struct_ifreq_sz);
+   _(EQL_GETMASTRCFG, WRITE, struct_ifreq_sz);
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 35a690cba5c..6e5c330b98e 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -143,7 +143,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+ #include <linux/lp.h>
+@@ -460,7 +459,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ 
+ #if SANITIZER_GLIBC
+   unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
+-  unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+ #if EV_VERSION > (0x010000)
+   unsigned struct_input_keymap_entry_sz = sizeof(struct input_keymap_entry);
+ #else
+@@ -824,15 +822,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ #endif // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+-  unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+-  unsigned IOCTL_CYGETMON = CYGETMON;
+-  unsigned IOCTL_CYGETTHRESH = CYGETTHRESH;
+-  unsigned IOCTL_CYGETTIMEOUT = CYGETTIMEOUT;
+-  unsigned IOCTL_CYSETDEFTHRESH = CYSETDEFTHRESH;
+-  unsigned IOCTL_CYSETDEFTIMEOUT = CYSETDEFTIMEOUT;
+-  unsigned IOCTL_CYSETTHRESH = CYSETTHRESH;
+-  unsigned IOCTL_CYSETTIMEOUT = CYSETTIMEOUT;
+   unsigned IOCTL_EQL_EMANCIPATE = EQL_EMANCIPATE;
+   unsigned IOCTL_EQL_ENSLAVE = EQL_ENSLAVE;
+   unsigned IOCTL_EQL_GETMASTRCFG = EQL_GETMASTRCFG;
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index ad358eef8b7..cba41ba5494 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -983,7 +983,6 @@ extern unsigned struct_vt_mode_sz;
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+ extern unsigned struct_ax25_parms_struct_sz;
+-extern unsigned struct_cyclades_monitor_sz;
+ extern unsigned struct_input_keymap_entry_sz;
+ extern unsigned struct_ipx_config_data_sz;
+ extern unsigned struct_kbdiacrs_sz;
+@@ -1328,15 +1327,6 @@ extern unsigned IOCTL_VT_WAITACTIVE;
+ #endif  // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-extern unsigned IOCTL_CYGETDEFTHRESH;
+-extern unsigned IOCTL_CYGETDEFTIMEOUT;
+-extern unsigned IOCTL_CYGETMON;
+-extern unsigned IOCTL_CYGETTHRESH;
+-extern unsigned IOCTL_CYGETTIMEOUT;
+-extern unsigned IOCTL_CYSETDEFTHRESH;
+-extern unsigned IOCTL_CYSETDEFTIMEOUT;
+-extern unsigned IOCTL_CYSETTHRESH;
+-extern unsigned IOCTL_CYSETTIMEOUT;
+ extern unsigned IOCTL_EQL_EMANCIPATE;
+ extern unsigned IOCTL_EQL_ENSLAVE;
+ extern unsigned IOCTL_EQL_GETMASTRCFG;
+-- 
+2.31.1
+

--- a/var/spack/repos/builtin/packages/gcc/patch-f1feb74046e0feb0596b93bbb822fae02940a90e.patch
+++ b/var/spack/repos/builtin/packages/gcc/patch-f1feb74046e0feb0596b93bbb822fae02940a90e.patch
@@ -1,0 +1,133 @@
+From f1feb74046e0feb0596b93bbb822fae02940a90e Mon Sep 17 00:00:00 2001
+From: Patrick Palka <ppalka@redhat.com>
+Date: Fri, 4 Jun 2021 13:46:53 -0400
+Subject: [PATCH] c++: tsubst_function_decl and excess arg levels [PR100102]
+
+Here, when instantiating the dependent alias template
+duration::__is_harmonic with args={{T,U},{int}}, we find ourselves
+substituting the function decl _S_gcd.  Since we have more arg levels
+than _S_gcd has parm levels, an old special case in tsubst_function_decl
+causes us to unwantedly reduce args to its innermost level, yielding
+args={int}, which leads to a nonsensical substitution into the decl
+context and eventually a crash.
+
+The comment for this special case refers to three examples for which we
+ought to see more arg levels than parm levels here, but none of the
+examples actually demonstrate this.  In the first example, when
+defining S<int>::f(U) parms_depth is 2 and args_depth is 1, and
+later when instantiating say S<int>::f<char> both depths are 2.  In the
+second example, when substituting the template friend declaration
+parms_depth is 2 and args_depth is 1, and later when instantiating f
+both depths are 1.  Finally, the third example is invalid since we can't
+specialize a member template of an unspecialized class template like
+that.
+
+Given that this reduction code seems no longer relevant for its
+documented purpose and that it causes problems as in the PR, this patch
+just removes it.  Note that as far as bootstrap/regtest is concerned,
+this code is dead; the below two tests would be the first to reach it.
+
+	PR c++/100102
+
+gcc/cp/ChangeLog:
+
+	* pt.c (tsubst_function_decl): Remove old code for reducing
+	args when it has excess levels.
+
+gcc/testsuite/ChangeLog:
+
+	* g++.dg/cpp0x/alias-decl-72.C: New test.
+	* g++.dg/cpp0x/alias-decl-72a.C: New test.
+
+(cherry picked from commit 5357ab75dedef403b0eebf9277d61d1cbeb5898f)
+---
+ gcc/cp/pt.c                                 | 39 ---------------------
+ gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C  |  9 +++++
+ gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C |  9 +++++
+ 3 files changed, 18 insertions(+), 39 deletions(-)
+ create mode 100644 gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+ create mode 100644 gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+
+diff --git a/gcc/cp/pt.c b/gcc/cp/pt.c
+index 1434beb80f4..1761a902218 100644
+--- a/gcc/cp/pt.c
++++ b/gcc/cp/pt.c
+@@ -13954,45 +13954,6 @@ tsubst_function_decl (tree t, tree args, tsubst_flags_t complain,
+ 	  if (tree spec = retrieve_specialization (gen_tmpl, argvec, hash))
+ 	    return spec;
+ 	}
+-
+-      /* We can see more levels of arguments than parameters if
+-	 there was a specialization of a member template, like
+-	 this:
+-
+-	 template <class T> struct S { template <class U> void f(); }
+-	 template <> template <class U> void S<int>::f(U);
+-
+-	 Here, we'll be substituting into the specialization,
+-	 because that's where we can find the code we actually
+-	 want to generate, but we'll have enough arguments for
+-	 the most general template.
+-
+-	 We also deal with the peculiar case:
+-
+-	 template <class T> struct S {
+-	   template <class U> friend void f();
+-	 };
+-	 template <class U> void f() {}
+-	 template S<int>;
+-	 template void f<double>();
+-
+-	 Here, the ARGS for the instantiation of will be {int,
+-	 double}.  But, we only need as many ARGS as there are
+-	 levels of template parameters in CODE_PATTERN.  We are
+-	 careful not to get fooled into reducing the ARGS in
+-	 situations like:
+-
+-	 template <class T> struct S { template <class U> void f(U); }
+-	 template <class T> template <> void S<T>::f(int) {}
+-
+-	 which we can spot because the pattern will be a
+-	 specialization in this case.  */
+-      int args_depth = TMPL_ARGS_DEPTH (args);
+-      int parms_depth =
+-	TMPL_PARMS_DEPTH (DECL_TEMPLATE_PARMS (DECL_TI_TEMPLATE (t)));
+-
+-      if (args_depth > parms_depth && !DECL_TEMPLATE_SPECIALIZATION (t))
+-	args = get_innermost_template_args (args, parms_depth);
+     }
+   else
+     {
+diff --git a/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+new file mode 100644
+index 00000000000..8009756dcba
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+@@ -0,0 +1,9 @@
++// PR c++/100102
++// { dg-do compile { target c++11 } }
++
++template<int()> struct ratio;
++template<class T, class U> struct duration {
++  static constexpr int _S_gcd();
++  template<class> using __is_harmonic = ratio<_S_gcd>;
++  using type = __is_harmonic<int>;
++};
+diff --git a/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+new file mode 100644
+index 00000000000..a4443e18f9d
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+@@ -0,0 +1,9 @@
++// PR c++/100102
++// { dg-do compile { target c++11 } }
++
++template<int> struct ratio;
++template<class T> struct duration {
++  static constexpr int _S_gcd();
++  template<class> using __is_harmonic = ratio<(duration::_S_gcd)()>;
++  using type = __is_harmonic<int>;
++};
+-- 
+2.31.1
+

--- a/var/spack/repos/builtin/packages/gcc/patch-fc930b3010bd0de899a3da3209eab20664ddb703.patch
+++ b/var/spack/repos/builtin/packages/gcc/patch-fc930b3010bd0de899a3da3209eab20664ddb703.patch
@@ -1,0 +1,133 @@
+From fc930b3010bd0de899a3da3209eab20664ddb703 Mon Sep 17 00:00:00 2001
+From: Patrick Palka <ppalka@redhat.com>
+Date: Fri, 4 Jun 2021 13:46:53 -0400
+Subject: [PATCH] c++: tsubst_function_decl and excess arg levels [PR100102]
+
+Here, when instantiating the dependent alias template
+duration::__is_harmonic with args={{T,U},{int}}, we find ourselves
+substituting the function decl _S_gcd.  Since we have more arg levels
+than _S_gcd has parm levels, an old special case in tsubst_function_decl
+causes us to unwantedly reduce args to its innermost level, yielding
+args={int}, which leads to a nonsensical substitution into the decl
+context and eventually a crash.
+
+The comment for this special case refers to three examples for which we
+ought to see more arg levels than parm levels here, but none of the
+examples actually demonstrate this.  In the first example, when
+defining S<int>::f(U) parms_depth is 2 and args_depth is 1, and
+later when instantiating say S<int>::f<char> both depths are 2.  In the
+second example, when substituting the template friend declaration
+parms_depth is 2 and args_depth is 1, and later when instantiating f
+both depths are 1.  Finally, the third example is invalid since we can't
+specialize a member template of an unspecialized class template like
+that.
+
+Given that this reduction code seems no longer relevant for its
+documented purpose and that it causes problems as in the PR, this patch
+just removes it.  Note that as far as bootstrap/regtest is concerned,
+this code is dead; the below two tests would be the first to reach it.
+
+	PR c++/100102
+
+gcc/cp/ChangeLog:
+
+	* pt.c (tsubst_function_decl): Remove old code for reducing
+	args when it has excess levels.
+
+gcc/testsuite/ChangeLog:
+
+	* g++.dg/cpp0x/alias-decl-72.C: New test.
+	* g++.dg/cpp0x/alias-decl-72a.C: New test.
+
+(cherry picked from commit 5357ab75dedef403b0eebf9277d61d1cbeb5898f)
+---
+ gcc/cp/pt.c                                 | 39 ---------------------
+ gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C  |  9 +++++
+ gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C |  9 +++++
+ 3 files changed, 18 insertions(+), 39 deletions(-)
+ create mode 100644 gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+ create mode 100644 gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+
+diff --git a/gcc/cp/pt.c b/gcc/cp/pt.c
+index 5a957141ba3..7ce9ac234f8 100644
+--- a/gcc/cp/pt.c
++++ b/gcc/cp/pt.c
+@@ -13811,45 +13811,6 @@ tsubst_function_decl (tree t, tree args, tsubst_flags_t complain,
+ 	  if (tree spec = retrieve_specialization (gen_tmpl, argvec, hash))
+ 	    return spec;
+ 	}
+-
+-      /* We can see more levels of arguments than parameters if
+-	 there was a specialization of a member template, like
+-	 this:
+-
+-	 template <class T> struct S { template <class U> void f(); }
+-	 template <> template <class U> void S<int>::f(U);
+-
+-	 Here, we'll be substituting into the specialization,
+-	 because that's where we can find the code we actually
+-	 want to generate, but we'll have enough arguments for
+-	 the most general template.
+-
+-	 We also deal with the peculiar case:
+-
+-	 template <class T> struct S {
+-	   template <class U> friend void f();
+-	 };
+-	 template <class U> void f() {}
+-	 template S<int>;
+-	 template void f<double>();
+-
+-	 Here, the ARGS for the instantiation of will be {int,
+-	 double}.  But, we only need as many ARGS as there are
+-	 levels of template parameters in CODE_PATTERN.  We are
+-	 careful not to get fooled into reducing the ARGS in
+-	 situations like:
+-
+-	 template <class T> struct S { template <class U> void f(U); }
+-	 template <class T> template <> void S<T>::f(int) {}
+-
+-	 which we can spot because the pattern will be a
+-	 specialization in this case.  */
+-      int args_depth = TMPL_ARGS_DEPTH (args);
+-      int parms_depth =
+-	TMPL_PARMS_DEPTH (DECL_TEMPLATE_PARMS (DECL_TI_TEMPLATE (t)));
+-
+-      if (args_depth > parms_depth && !DECL_TEMPLATE_SPECIALIZATION (t))
+-	args = get_innermost_template_args (args, parms_depth);
+     }
+   else
+     {
+diff --git a/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+new file mode 100644
+index 00000000000..8009756dcba
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72.C
+@@ -0,0 +1,9 @@
++// PR c++/100102
++// { dg-do compile { target c++11 } }
++
++template<int()> struct ratio;
++template<class T, class U> struct duration {
++  static constexpr int _S_gcd();
++  template<class> using __is_harmonic = ratio<_S_gcd>;
++  using type = __is_harmonic<int>;
++};
+diff --git a/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+new file mode 100644
+index 00000000000..a4443e18f9d
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/cpp0x/alias-decl-72a.C
+@@ -0,0 +1,9 @@
++// PR c++/100102
++// { dg-do compile { target c++11 } }
++
++template<int> struct ratio;
++template<class T> struct duration {
++  static constexpr int _S_gcd();
++  template<class> using __is_harmonic = ratio<(duration::_S_gcd)()>;
++  using type = __is_harmonic<int>;
++};
+-- 
+2.31.1
+


### PR DESCRIPTION
the patch urls dynamically generate a diff, which includes metadata
about the git version used, meaning the shasum will change.

instead ship the patches with spack.

Closes #31759