### PR TITLE
concretizer:unify:true as a default

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -33,4 +33,4 @@ concretizer:
   # environments can always be activated. When "false" perform concretization separately
   # on each root spec, allowing different versions and variants of the same package in
   # an environment.
-  unify: false
+  unify: true

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1322,24 +1322,6 @@ class Environment(object):
         if user_specs_did_not_change:
             return []
 
-        # Check that user specs don't have duplicate packages
-        counter = collections.defaultdict(int)
-        for user_spec in self.user_specs:
-            counter[user_spec.name] += 1
-
-        duplicates = []
-        for name, count in counter.items():
-            if count > 1:
-                duplicates.append(name)
-
-        if duplicates:
-            msg = (
-                "environment that are configured to concretize specs"
-                " together cannot contain more than one spec for each"
-                " package [{0}]".format(", ".join(duplicates))
-            )
-            raise SpackEnvironmentError(msg)
-
         # Proceed with concretization
         self.concretized_user_specs = []
         self.concretized_order = []

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1327,7 +1327,17 @@ class Environment(object):
         self.concretized_order = []
         self.specs_by_hash = {}
 
-        concrete_specs = spack.concretize.concretize_specs_together(*self.user_specs, tests=tests)
+        try:
+            concrete_specs = spack.concretize.concretize_specs_together(
+                *self.user_specs, tests=tests
+            )
+        except spack.error.UnsatisfiableSpecError as e:
+            # "Enhance" the error message for multiple root specs, suggest a less strict
+            # form of concretization.
+            if len(self.user_specs) > 1:
+                e.message += ". It may help to reduce the strictness of the concretizer by setting `concretizer:unify` to `when_possible` or `false`."
+            raise
+
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]
         for abstract, concrete in concretized_specs:
             self._add_concrete_spec(abstract, concrete)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1335,7 +1335,10 @@ class Environment(object):
             # "Enhance" the error message for multiple root specs, suggest a less strict
             # form of concretization.
             if len(self.user_specs) > 1:
-                e.message += ". It may help to reduce the strictness of the concretizer by setting `concretizer:unify` to `when_possible` or `false`."
+                e.message += (
+                    ". Consider setting `concretizer:unify` to `when_possible` "
+                    "or `false` to relax the concretizer strictness."
+                )
             raise
 
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -18,6 +18,7 @@ import llnl.util.link_tree
 import spack.cmd.env
 import spack.environment as ev
 import spack.environment.shell
+import spack.error
 import spack.modules
 import spack.paths
 import spack.repo
@@ -2403,7 +2404,9 @@ def test_duplicate_packages_raise_when_concretizing_together():
     e.add("mpileaks~opt")
     e.add("mpich")
 
-    with pytest.raises(ev.SpackEnvironmentError, match=r"cannot contain more"):
+    with pytest.raises(
+        spack.error.UnsatisfiableSpecError, match=r"relax the concretizer strictness"
+    ):
         e.concretize()
 
 


### PR DESCRIPTION
`spack env create` enables a view by default (in a weird hidden
directory, but well...). This is asking for trouble with the other
default of `concretizer:unify:false`, since having different flavors of
the same spec in an environment, leads to collision errors when
generating the view.

A change of defaults would improve user experience:

Either views should be disabled by default, or we should set
`concretizer:unify:true`.

I guess not everybody creating an environment really uses views,
especially when they're in this hidden `.spack-env/view` folder, so in
that sense disabling views could make sense.

However, `unify:true` makes even more sense, since any time the issue is
brought up in Slack, the user changes the concretization config, since
it wasn't the intention to have different flavors of the same spec, and
as a bonus it reduces install times.

`unify: when_possible` is another possible default, but I think it's better
to hit a concretization error than it is to hit an obscure view collision
error *after* waiting an hour for the environment to build. (to be fair,
we could do a better job warning the user after concretization that
the view contains the same package twice)

---

Note, this is a follow-up to #30038, which made this change of defaults less breaking going from 0.18 -> 0.19:

> Store the default value `spack:concretizer:unify` in new `spack.yaml` files to make it easier for us to change the default of unify: false to unify: true in 0.19.
