### PR TITLE
Deprecate visit 3.3.0 because it is broken

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -69,7 +69,7 @@ class Visit(CMakePackage):
     executables = ['^visit$']
 
     version('develop', branch='develop')
-    version('3.3.0', sha256='1a7485146133ac5f1e330d9029697750046ef8d9e9de23a6c2a3685c1c5f4aac')
+    version('3.3.0', sha256='1a7485146133ac5f1e330d9029697750046ef8d9e9de23a6c2a3685c1c5f4aac', deprecated=True)
     version('3.2.2', sha256='d19ac24c622a3bc0a71bc9cd6e5c9860e43f39e3279672129278b6ebce8d0ead')
     version('3.2.1', sha256='779d59564c63f31fcbfeff24b14ddd6ac941b3bb7d671d31765a770d193f02e8')
     version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')


### PR DESCRIPTION
Based on this [comment](https://github.com/spack/spack/pull/31790), it seems like deprecating version `3.3.0` is the best way to fix the currently broken pipelines by making spack prefer the previous (working) version.  When the new version `3.3.1` is added, that should become the preferred version.