### PR TITLE
clingo: fix bootstrapping on m1 (at least my configuration)

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -6,6 +6,7 @@
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
+import os
 
 class Clingo(CMakePackage):
     """Clingo: A grounder and solver for logic programs
@@ -71,10 +72,11 @@ class Clingo(CMakePackage):
         current spec is the one found by CMake find_package(Python, ...)
         """
         python = self.spec['python']
-        return [
-            self.define('Python_EXECUTABLE', str(python.command)),
-            self.define('Python_INCLUDE_DIR', python.package.config_vars['include'])
-        ]
+        include_dir = python.package.config_vars['include']
+        hints = [self.define('Python_EXECUTABLE', str(python.command))]
+        if os.path.exists(include_dir):
+            hints.append(self.define('Python_INCLUDE_DIR', include_dir))
+        return hints
 
     @property
     def cmake_py_shared(self):


### PR DESCRIPTION
This is with a very very fresh system on an M2 mac running macOS 12.5, with Xcode 13.4.1 (Build version 13F100) and MacOSX12.3.sdk. `xcode-select` points to XCode rather than CommandLine Tools. CMake 3.23.2 successfully detects the Python include dirs at
```
/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/include/python3.8
```