### PR TITLE
Python: fix clingo bootstrapping on Apple M1/M2

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -74,8 +74,8 @@ class Clingo(CMakePackage):
         """
         python = self.spec["python"]
         return [
-            self.define("Python_EXECUTABLE", str(python.command)),
-            self.define("Python_INCLUDE_DIR", python.package.config_vars["include"]),
+            self.define("Python_EXECUTABLE", python.command),
+            self.define("Python_INCLUDE_DIR", python.headers.directories[0]),
         ]
 
     @property

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1106,8 +1106,8 @@ config.update(get_paths())
         if os.path.exists(config_h):
             headers = HeaderList(config_h)
         else:
-            # If not, one of these settings should contain the right directory
-            for var in ["INCLUDEPY", "CONFINCLUDEPY", "INCLUDEDIR", "CONFINCLUDEDIR"]:
+            # If not, one of these config vars should contain the right directory
+            for var in ["INCLUDEPY", "CONFINCLUDEPY"]:
                 headers = find_headers("pyconfig", self.config_vars[var])
                 if headers:
                     config_h = headers[0]

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -961,10 +961,8 @@ config.update(get_paths())
                 # get_config_vars
                 "BINDIR": self.prefix.bin,
                 "CC": "cc",
-                "CONFINCLUDEDIR": self.prefix.include.join("python{}").format(version),
                 "CONFINCLUDEPY": self.prefix.include.join("python{}").format(version),
                 "CXX": "c++",
-                "INCLUDEDIR": self.prefix.include.join("python{}").format(version),
                 "INCLUDEPY": self.prefix.include.join("python{}").format(version),
                 "LIBDEST": self.prefix.lib.join("python{}").format(version),
                 "LIBDIR": self.prefix.lib,

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -961,7 +961,10 @@ config.update(get_paths())
                 # get_config_vars
                 "BINDIR": self.prefix.bin,
                 "CC": "cc",
+                "CONFINCLUDEDIR": self.prefix.include.join("python{}").format(version),
+                "CONFINCLUDEPY": self.prefix.include.join("python{}").format(version),
                 "CXX": "c++",
+                "INCLUDEDIR": self.prefix.include.join("python{}").format(version),
                 "INCLUDEPY": self.prefix.include.join("python{}").format(version),
                 "LIBDEST": self.prefix.lib.join("python{}").format(version),
                 "LIBDIR": self.prefix.lib,
@@ -1098,15 +1101,17 @@ config.update(get_paths())
 
     @property
     def headers(self):
-        directory = self.config_vars["include"]
+        # Location where pyconfig.h is _supposed_ to be
         config_h = self.config_vars["config_h_filename"]
-
         if os.path.exists(config_h):
             headers = HeaderList(config_h)
         else:
-            headers = find_headers("pyconfig", directory)
-            if headers:
-                config_h = headers[0]
+            # If not, one of these settings should contain the right directory
+            for var in ["INCLUDEPY", "CONFINCLUDEPY", "INCLUDEDIR", "CONFINCLUDEDIR"]:
+                headers = find_headers("pyconfig", self.config_vars[var])
+                if headers:
+                    config_h = headers[0]
+                    break
             else:
                 msg = "Unable to locate {} headers in {}"
                 raise spack.error.NoHeadersError(msg.format(self.name, directory))


### PR DESCRIPTION
Follow-up to #30834 that solves one last issue with clingo bootstrapping when using the system Python that comes with Xcode. This is a more general solution than #31791 and should also help when using an external Python to install packages.

Fixes #31717
Fixes #31735 
Closes #31791

@sethrj 