### PR TITLE
vdt: add missing python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -24,7 +24,7 @@ class Vdt(CMakePackage):
     variant('preload', default=False,
             description='Create in the library the symbols to preload the library')
 
-    depends_on('python', when='build')
+    depends_on('python', type='build')
 
     @property
     def build_directory(self):
@@ -42,12 +42,14 @@ class Vdt(CMakePackage):
         elif spec.satisfies('target=ppc64le:'):
             disable_features.add('fma')
 
-        options = []
+        args = [
+            self.define_from_variant('PRELOAD'),
+            self.define('PYTHON_EXECUTABLE', spec['python'].command),
+        ]
         for f in ['sse', 'avx', 'avx2', 'fma', 'neon']:
-            options.append(self.define(
+            args.append(self.define(
                 f.upper(),
                 f not in disable_features and f in self.spec.target
             ))
 
-        options.append(self.define_from_variant('PRELOAD'))
-        return options
+        return args

--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -24,6 +24,8 @@ class Vdt(CMakePackage):
     variant('preload', default=False,
             description='Create in the library the symbols to preload the library')
 
+    depends_on('python', when='build')
+
     @property
     def build_directory(self):
         d = join_path(self.stage.path, 'spack-build')


### PR DESCRIPTION
There's a build-time use of the `PythonInterp` CMake package in vdt: I assume it's been using the system python on everyone's computers, but since I have macOS (which only has the `python3` command, not `python`) the older CMake find script fails.
```
CMake Error at /opt/spack/opt/spack/monterey/cmake/3.23.2/jjddmrr7avba6v6ircadgmx7ziinfyd5/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE)
Call Stack (most recent call first):
  /opt/spack/opt/spack/monterey/cmake/3.23.2/jjddmrr7avba6v6ircadgmx7ziinfyd5/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /opt/spack/opt/spack/monterey/cmake/3.23.2/jjddmrr7avba6v6ircadgmx7ziinfyd5/share/cmake-3.23/Modules/FindPythonInterp.cmake:169 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  src/CMakeLists.txt:4 (find_package)
```