### PR TITLE
gaudi: disentangle variant 'optional'

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -109,7 +109,7 @@ class Gaudi(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("BUILD_TESTING", self.run_tests or ),
+            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies('+examples')),
             self.define_from_variant("GAUDI_USE_AIDA",       "aida"),
             self.define_from_variant("GAUDI_USE_CPPUNIT",    "cppunit"),
             self.define_from_variant("GAUDI_USE_GPERFTOOLS", "gperftools"),

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -107,10 +107,13 @@ class Gaudi(CMakePackage):
     depends_on("doxygen +graphviz", when="+docs")
     depends_on("gperftools", when="+gperftools")
     depends_on("gdb")
+    depends_on("gsl", when="@:31 +examples")
+    depends_on("heppdt", when="@:34 +examples")
     depends_on("heppdt", when="+heppdt")
     depends_on("jemalloc", when="+jemalloc")
+    depends_on("libng", when="@:34 +examples")
     depends_on("libunwind", when="+unwind")
-    # depends_on("relax", when="@:33 +optional")
+    depends_on("relax", when="@:34 +examples")
     depends_on("xerces-c", when="+xercesc")
     # NOTE: pocl cannot be added as a minimal OpenCL implementation because
     #       ROOT does not like being exposed to LLVM symbols.

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -35,26 +35,16 @@ class Gaudi(CMakePackage):
 
     maintainers = ["drbenmorgan", "vvolkl"]
 
-    variant("aida", default=False,
-            description="Build AIDA interfaces support")
-    variant("cppunit", default=False,
-            description="Build with CppUnit unit testing")
-    variant("docs", default=False,
-            description="Build documentation with Doxygen")
-    variant("examples", default=False,
-            description="Build examples")
-    variant("gperftools", default=False,
-            description="Build with Google PerfTools support")
-    variant("heppdt", default=False,
-            description="Build with HEP Particle Data Table support")
-    variant("jemalloc", default=False,
-            description="Build with jemalloc allocator support")
-    variant("unwind", default=False,
-            description="Build with unwind call-chains")
-    variant("vtune", default=False,
-            description="Build with Intel VTune profiler support")
-    variant("xercesc", default=False,
-            description="Build with Xerces-C XML support")
+    variant("aida", default=False, description="Build AIDA interfaces support")
+    variant("cppunit", default=False, description="Build with CppUnit unit testing")
+    variant("docs", default=False, description="Build documentation with Doxygen")
+    variant("examples", default=False, description="Build examples")
+    variant("gperftools", default=False, description="Build with Google PerfTools support")
+    variant("heppdt", default=False, description="Build with HEP Particle Data Table support")
+    variant("jemalloc", default=False, description="Build with jemalloc allocator support")
+    variant("unwind", default=False, description="Build with unwind call-chains")
+    variant("vtune", default=False, description="Build with Intel VTune profiler support")
+    variant("xercesc", default=False, description="Build with Xerces-C XML support")
 
     # only build subdirectory GaudiExamples when +examples
     patch("build_testing.patch", when="@:34")
@@ -99,7 +89,7 @@ class Gaudi(CMakePackage):
     depends_on("heppdt", when="+heppdt")
     depends_on("jemalloc", when="+jemalloc")
     depends_on("libunwind", when="+unwind")
-    #depends_on("relax", when="@:33 +optional")
+    # depends_on("relax", when="@:33 +optional")
     depends_on("xerces-c", when="+xercesc")
     # NOTE: pocl cannot be added as a minimal OpenCL implementation because
     #       ROOT does not like being exposed to LLVM symbols.
@@ -109,15 +99,15 @@ class Gaudi(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies('+examples')),
-            self.define_from_variant("GAUDI_USE_AIDA",       "aida"),
-            self.define_from_variant("GAUDI_USE_CPPUNIT",    "cppunit"),
+            self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies("+examples")),
+            self.define_from_variant("GAUDI_USE_AIDA", "aida"),
+            self.define_from_variant("GAUDI_USE_CPPUNIT", "cppunit"),
             self.define_from_variant("GAUDI_USE_GPERFTOOLS", "gperftools"),
-            self.define_from_variant("GAUDI_USE_HEPPDT",     "heppdt"),
-            self.define_from_variant("GAUDI_USE_JEMALLOC",   "jemalloc"),
-            self.define_from_variant("GAUDI_USE_UNWIND",     "unwind"),
-            self.define_from_variant("GAUDI_USE_XERCESC",    "xercesc"),
-            self.define_from_variant("GAUDI_USE_DOXYGEN",    "docs"),
+            self.define_from_variant("GAUDI_USE_HEPPDT", "heppdt"),
+            self.define_from_variant("GAUDI_USE_JEMALLOC", "jemalloc"),
+            self.define_from_variant("GAUDI_USE_UNWIND", "unwind"),
+            self.define_from_variant("GAUDI_USE_XERCESC", "xercesc"),
+            self.define_from_variant("GAUDI_USE_DOXYGEN", "docs"),
             # needed to build core services like rndmsvc
             self.define("GAUDI_USE_CLHEP", True),
             self.define("GAUDI_USE_PYTHON_MAJOR", str(self.spec["python"].version.up_to(1))),

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -85,7 +85,7 @@ class Gaudi(CMakePackage):
     depends_on("cmake", type="build")
     depends_on("cppgsl")
     depends_on("fmt", when="@33.2:")
-    depends_on("tbb")
+    depends_on("intel-tbb")
     depends_on("uuid")
     depends_on("nlohmann-json", when="@35.0:")
     depends_on("python", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -46,6 +46,27 @@ class Gaudi(CMakePackage):
     variant("vtune", default=False, description="Build with Intel VTune profiler support")
     variant("xercesc", default=False, description="Build with Xerces-C XML support")
 
+    # meta-variants
+    optional_variants = [
+        "aida",
+        "cppunit",
+        "examples",
+        "gperftools",
+        "heppdt",
+        "jemalloc",
+        "unwind",
+        "xercesc",
+    ]
+    variant(
+        "optional",
+        default=False,
+        description="Build optional components; equivalent to{}".format(
+            " +".join([""] + optional_variants)
+        ),
+    )
+    for v in optional_variants:
+        conflicts("-" + v, when="+optional")
+
     # only build subdirectory GaudiExamples when +examples
     patch("build_testing.patch", when="@:34")
     # fixes for the cmake config which could not find newer boost versions

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -35,11 +35,28 @@ class Gaudi(CMakePackage):
 
     maintainers = ["drbenmorgan", "vvolkl"]
 
-    variant("optional", default=False, description="Build most optional components and tests")
-    variant("docs", default=False, description="Build documentation with Doxygen")
-    variant("vtune", default=False, description="Build with Intel VTune profiler support")
+    variant("aida", default=False,
+            description="Build AIDA interfaces support")
+    variant("cppunit", default=False,
+            description="Build with CppUnit unit testing")
+    variant("docs", default=False,
+            description="Build documentation with Doxygen")
+    variant("examples", default=False,
+            description="Build examples")
+    variant("gperftools", default=False,
+            description="Build with Google PerfTools support")
+    variant("heppdt", default=False,
+            description="Build with HEP Particle Data Table support")
+    variant("jemalloc", default=False,
+            description="Build with jemalloc allocator support")
+    variant("unwind", default=False,
+            description="Build with unwind call-chains")
+    variant("vtune", default=False,
+            description="Build with Intel VTune profiler support")
+    variant("xercesc", default=False,
+            description="Build with Xerces-C XML support")
 
-    # only build subdirectory GaudiExamples when +optional
+    # only build subdirectory GaudiExamples when +examples
     patch("build_testing.patch", when="@:34")
     # fixes for the cmake config which could not find newer boost versions
     patch("link_target_fixes.patch", when="@33.0:34")
@@ -57,12 +74,15 @@ class Gaudi(CMakePackage):
     depends_on("cmake", type="build")
     depends_on("cppgsl")
     depends_on("fmt", when="@33.2:")
-    depends_on("intel-tbb")
+    depends_on("tbb")
     depends_on("uuid")
     depends_on("nlohmann-json", when="@35.0:")
     depends_on("python", type=("build", "run"))
     depends_on("python@:3.7", when="@32.2:34", type=("build", "run"))
     depends_on("python@:2", when="@:32.1", type=("build", "run"))
+    depends_on("py-networkx@:2.2", when="^python@:2.7")
+    depends_on("py-networkx", when="^python@3.0.0:")
+    depends_on("py-nose", type="test")
     depends_on("py-setuptools@:45", when="^python@:2.7", type="build")
     depends_on("py-six", type=("build", "run"))
     depends_on("py-xenv@1:", when="@:34.9", type=("build", "run"))
@@ -70,27 +90,17 @@ class Gaudi(CMakePackage):
     depends_on("root +python +root7 +ssl +tbb +threads")
     depends_on("zlib")
 
-    # todo: this should be a test dependency only,
-    depends_on("py-nose", when="@35.0:36.1", type=("build", "run"))
-    depends_on("py-pytest", when="@36.2:", type=("build", "run"))
-
     # Adding these dependencies triggers the build of most optional components
-    depends_on("cppgsl", when="+optional")
-    depends_on("cppunit", when="+optional")
+    depends_on("cppgsl", when="+cppunit")
+    depends_on("cppunit", when="+cppunit")
     depends_on("doxygen +graphviz", when="+docs")
-    depends_on("gperftools", when="+optional")
-    depends_on("gdb", when="+optional")
-    depends_on("gsl", when="+optional")
-    depends_on("heppdt@:2", when="+optional")
-    depends_on("jemalloc", when="+optional")
-    depends_on("libpng", when="+optional")
-    depends_on("libunwind", when="+optional")
-    depends_on("py-networkx@:2.2", when="+optional ^python@:2.7")
-    depends_on("py-networkx", when="+optional ^python@3.0.0:")
-    depends_on("py-setuptools", when="+optional")
-    depends_on("py-nose", when="+optional")
-    depends_on("relax", when="@:33 +optional")
-    depends_on("xerces-c", when="+optional")
+    depends_on("gperftools", when="+gperftools")
+    depends_on("gdb")
+    depends_on("heppdt", when="+heppdt")
+    depends_on("jemalloc", when="+jemalloc")
+    depends_on("libunwind", when="+unwind")
+    #depends_on("relax", when="@:33 +optional")
+    depends_on("xerces-c", when="+xercesc")
     # NOTE: pocl cannot be added as a minimal OpenCL implementation because
     #       ROOT does not like being exposed to LLVM symbols.
 
@@ -99,20 +109,20 @@ class Gaudi(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("BUILD_TESTING", "optional"),
-            self.define_from_variant("GAUDI_USE_AIDA", "optional"),
-            self.define_from_variant("GAUDI_USE_CPPUNIT", "optional"),
-            self.define_from_variant("GAUDI_USE_HEPPDT", "optional"),
-            self.define_from_variant("GAUDI_USE_JEMALLOC", "optional"),
-            self.define_from_variant("GAUDI_USE_UNWIND", "optional"),
-            self.define_from_variant("GAUDI_USE_XERCESC", "optional"),
-            self.define_from_variant("GAUDI_USE_DOXYGEN", "docs"),
+            self.define("BUILD_TESTING", self.run_tests or ),
+            self.define_from_variant("GAUDI_USE_AIDA",       "aida"),
+            self.define_from_variant("GAUDI_USE_CPPUNIT",    "cppunit"),
+            self.define_from_variant("GAUDI_USE_GPERFTOOLS", "gperftools"),
+            self.define_from_variant("GAUDI_USE_HEPPDT",     "heppdt"),
+            self.define_from_variant("GAUDI_USE_JEMALLOC",   "jemalloc"),
+            self.define_from_variant("GAUDI_USE_UNWIND",     "unwind"),
+            self.define_from_variant("GAUDI_USE_XERCESC",    "xercesc"),
+            self.define_from_variant("GAUDI_USE_DOXYGEN",    "docs"),
             # needed to build core services like rndmsvc
             self.define("GAUDI_USE_CLHEP", True),
             self.define("GAUDI_USE_PYTHON_MAJOR", str(self.spec["python"].version.up_to(1))),
             # todo:
             self.define("GAUDI_USE_INTELAMPLIFIER", False),
-            self.define("GAUDI_USE_GPERFTOOLS", False),
         ]
         # this is not really used in spack builds, but needs to be set
         if self.spec.version < Version("34"):

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -46,7 +46,6 @@ class Gaudi(CMakePackage):
     variant("vtune", default=False, description="Build with Intel VTune profiler support")
     variant("xercesc", default=False, description="Build with Xerces-C XML support")
 
-
     # only build subdirectory GaudiExamples when +examples
     patch("build_testing.patch", when="@:34")
     # fixes for the cmake config which could not find newer boost versions

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -46,26 +46,6 @@ class Gaudi(CMakePackage):
     variant("vtune", default=False, description="Build with Intel VTune profiler support")
     variant("xercesc", default=False, description="Build with Xerces-C XML support")
 
-    # meta-variants
-    optional_variants = [
-        "aida",
-        "cppunit",
-        "examples",
-        "gperftools",
-        "heppdt",
-        "jemalloc",
-        "unwind",
-        "xercesc",
-    ]
-    variant(
-        "optional",
-        default=False,
-        description="Build optional components; equivalent to{}".format(
-            " +".join([""] + optional_variants)
-        ),
-    )
-    for v in optional_variants:
-        conflicts("-" + v, when="+optional")
 
     # only build subdirectory GaudiExamples when +examples
     patch("build_testing.patch", when="@:34")

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -111,7 +111,7 @@ class Gaudi(CMakePackage):
     depends_on("heppdt", when="@:34 +examples")
     depends_on("heppdt", when="+heppdt")
     depends_on("jemalloc", when="+jemalloc")
-    depends_on("libng", when="@:34 +examples")
+    depends_on("libpng", when="@:34 +examples")
     depends_on("libunwind", when="+unwind")
     depends_on("relax", when="@:34 +examples")
     depends_on("xerces-c", when="+xercesc")


### PR DESCRIPTION
The catch-all `optional` variant included a few not-quite-so-optional components. This attempts to split the `optional` variant into a number of more fine-grained variants.

TODO:
- [x] maintain backwards-compatibility by defining `optional` as equivalent to the corresponding set of new variants.

Maintainers: @vvolkl @drbenmorgan 