### PR TITLE
CMake: Override GNU Install paths for LIBDIR

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -179,6 +179,7 @@ class CMakePackage(PackageBase):
             define("CMAKE_INSTALL_PREFIX", convert_to_posix_path(pkg.prefix)),
             define("CMAKE_BUILD_TYPE", build_type),
             define("BUILD_TESTING", pkg.run_tests),
+            define("CMAKE_INSTALL_LIBDIR", "lib"),
         ]
 
         # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9


### PR DESCRIPTION
There are a number of issues using GNU Install paths when it is lib64 inside of spack. This overrides that behavior to always point at lib.