### PR TITLE
Add meson Python build backend

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -48,9 +48,10 @@ important to understand.
 **build backend**
    Libraries used to define how to build a wheel. Examples
    include `setuptools <https://setuptools.pypa.io/>`__,
-   `flit <https://flit.readthedocs.io/>`_,
-   `poetry <https://python-poetry.org/>`_, and
-   `hatchling <https://hatch.pypa.io/latest/>`_.
+   `flit <https://flit.pypa.io/>`_,
+   `poetry <https://python-poetry.org/>`_,
+   `hatchling <https://hatch.pypa.io/latest/>`_, and
+   `meson <https://meson-python.readthedocs.io/>`_.
 
 ^^^^^^^^^^^
 Downloading
@@ -174,9 +175,9 @@ package. The "Project description" tab may also contain a longer
 description of the package. Either of these can be used to populate
 the package docstring.
 
-^^^^^^^^^^^^^
-Build backend
-^^^^^^^^^^^^^
+^^^^^^^^^^^^
+Dependencies
+^^^^^^^^^^^^
 
 Once you've determined the basic metadata for a package, the next
 step is to determine the build backend. ``PythonPackage`` uses
@@ -219,7 +220,28 @@ See `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ and
 information on the design of ``pyproject.toml``.
 
 Depending on which build backend a project uses, there are various
-places that run-time dependencies can be listed.
+places that run-time dependencies can be listed. Most modern build
+backends support listing dependencies directly in ``pyproject.toml``.
+Look for dependencies under the following keys:
+
+* ``requires-python`` under ``[project]``
+
+  This specifies the version of Python that is required
+
+* ``dependencies`` under ``[project]``
+
+  These packages are required for building and installation. You can
+  add them with ``type=('build', 'run')``.
+
+* ``[project.optional-dependencies]``
+
+  This section includes keys with lists of optional dependencies
+  needed to enable those features. You should add a variant that
+  optionally adds these dependencies. This variant should be ``False``
+  by default.
+
+Some build backends may have additional locations where dependencies
+can be found.
 
 """""""""
 distutils
@@ -245,9 +267,9 @@ If the ``pyproject.toml`` lists ``setuptools.build_meta`` as a
 ``build-backend``, or if the package has a ``setup.py`` that imports
 ``setuptools``, or if the package has a ``setup.cfg`` file, then it
 uses setuptools to build. Setuptools is a replacement for the
-distutils library, and has almost the exact same API. Dependencies
-can be listed in the ``setup.py`` or ``setup.cfg`` file. Look for the
-following arguments:
+distutils library, and has almost the exact same API. In addition to
+``pyproject.toml``, dependencies can be listed in the ``setup.py`` or
+``setup.cfg`` file. Look for the following arguments:
 
 * ``python_requires``
 
@@ -292,25 +314,22 @@ listed directly in the ``pyproject.toml`` file. Older versions of
 flit used to store this info in a ``flit.ini`` file, so check for
 this too.
 
-Either of these files may contain keys like:
+In addition to the default ``pyproject.toml`` keys listed above,
+older versions of flit may use the following keys:
 
-* ``requires-python``
-
-  This specifies the version of Python that is required
-
-* ``dependencies`` or ``requires``
+* ``requires`` under ``[tool.flit.metadata]``
 
   These packages are required for building and installation. You can
   add them with ``type=('build', 'run')``.
 
-* ``project.optional-dependencies`` or ``requires-extra``
+* ``[tool.flit.metadata.requires-extra]``
 
   This section includes keys with lists of optional dependencies
   needed to enable those features. You should add a variant that
   optionally adds these dependencies. This variant should be False
   by default.
 
-See https://flit.readthedocs.io/en/latest/pyproject_toml.html for
+See https://flit.pypa.io/en/latest/pyproject_toml.html for
 more information.
 
 """"""
@@ -332,27 +351,22 @@ hatchling
 """""""""
 
 If the ``pyproject.toml`` lists ``hatchling.build`` as the
-``build-backend``, it uses the hatchling build system. Look for
-dependencies under the following keys:
-
-* ``requires-python``
-
-  This specifies the version of Python that is required
-
-* ``project.dependencies``
-
-  These packages are required for building and installation. You can
-  add them with ``type=('build', 'run')``.
-
-* ``project.optional-dependencies``
-
-  This section includes keys with lists of optional dependencies
-  needed to enable those features. You should add a variant that
-  optionally adds these dependencies. This variant should be ``False``
-  by default.
+``build-backend``, it uses the hatchling build system. Hatchling
+uses the default ``pyproject.toml`` keys to list dependencies.
 
 See https://hatch.pypa.io/latest/config/dependency/ for more
 information.
+
+"""""
+meson
+"""""
+
+If the ``pyproject.toml`` lists ``mesonpy`` as the ``build-backend``,
+it uses the meson build system. Meson uses the default
+``pyproject.toml`` keys to list dependencies.
+
+See https://meson-python.readthedocs.io/en/latest/usage/start.html
+for more information.
 
 """"""
 wheels
@@ -692,6 +706,7 @@ For more information on build and installation frontend tools, see:
 For more information on build backend tools, see:
 
 * setuptools: https://setuptools.pypa.io/
-* flit: https://flit.readthedocs.io/
+* flit: https://flit.pypa.io/
 * poetry: https://python-poetry.org/
 * hatchling: https://hatch.pypa.io/latest/
+* meson: https://meson-python.readthedocs.io/

--- a/var/spack/repos/builtin/packages/py-meson-python/package.py
+++ b/var/spack/repos/builtin/packages/py-meson-python/package.py
@@ -10,14 +10,14 @@ class PyMesonPython(PythonPackage):
     """Meson Python build backend (PEP 517)."""
 
     homepage = "https://github.com/FFY00/mesonpy"
-    pypi     = "meson_python/meson_python-0.7.0.tar.gz"
+    pypi = "meson_python/meson_python-0.7.0.tar.gz"
 
-    version('0.7.0', sha256='9fcfa350f44ca80dd4f5f9c3d251725434acf9a07d9618f382e6cc4629dcbe84')
+    version("0.7.0", sha256="9fcfa350f44ca80dd4f5f9c3d251725434acf9a07d9618f382e6cc4629dcbe84")
 
-    depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-meson@0.62:', type=('build', 'run'))
-    depends_on('py-ninja', type=('build', 'run'))
-    depends_on('py-pyproject-metadata@0.5:', type=('build', 'run'))
-    depends_on('py-tomli@1:', type=('build', 'run'))
-    depends_on('py-typing-extensions@3.7.4:', when='^python@:3.7', type=('build', 'run'))
-    depends_on('py-colorama', when='platform=windows', type=('build', 'run'))
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-meson@0.62:", type=("build", "run"))
+    depends_on("py-ninja", type=("build", "run"))
+    depends_on("py-pyproject-metadata@0.5:", type=("build", "run"))
+    depends_on("py-tomli@1:", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7.4:", when="^python@:3.7", type=("build", "run"))
+    depends_on("py-colorama", when="platform=windows", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-meson-python/package.py
+++ b/var/spack/repos/builtin/packages/py-meson-python/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMesonPython(PythonPackage):
+    """Meson Python build backend (PEP 517)."""
+
+    homepage = "https://github.com/FFY00/mesonpy"
+    pypi     = "meson_python/meson_python-0.7.0.tar.gz"
+
+    version('0.7.0', sha256='9fcfa350f44ca80dd4f5f9c3d251725434acf9a07d9618f382e6cc4629dcbe84')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-meson@0.62:', type=('build', 'run'))
+    depends_on('py-ninja', type=('build', 'run'))
+    depends_on('py-pyproject-metadata@0.5:', type=('build', 'run'))
+    depends_on('py-tomli@1:', type=('build', 'run'))
+    depends_on('py-typing-extensions@3.7.4:', when='^python@:3.7', type=('build', 'run'))
+    depends_on('py-colorama', when='platform=windows', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-meson/package.py
+++ b/var/spack/repos/builtin/packages/py-meson/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMeson(PythonPackage):
+    """A high performance build system.
+
+    Meson is a cross-platform build system designed to be both as fast and as user
+    friendly as possible. It supports many languages and compilers, including GCC,
+    Clang, PGI, Intel, and Visual Studio. Its build definitions are written in a simple
+    non-Turing complete DSL.
+    """
+
+    homepage = "https://mesonbuild.com/"
+    pypi     = "meson/meson-0.62.2.tar.gz"
+
+    version('0.62.2', sha256='a7669e4c4110b06b743d57cc5d6432591a6677ef2402139fe4f3d42ac13380b0')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools@42:', type='build')

--- a/var/spack/repos/builtin/packages/py-meson/package.py
+++ b/var/spack/repos/builtin/packages/py-meson/package.py
@@ -16,9 +16,9 @@ class PyMeson(PythonPackage):
     """
 
     homepage = "https://mesonbuild.com/"
-    pypi     = "meson/meson-0.62.2.tar.gz"
+    pypi = "meson/meson-0.62.2.tar.gz"
 
-    version('0.62.2', sha256='a7669e4c4110b06b743d57cc5d6432591a6677ef2402139fe4f3d42ac13380b0')
+    version("0.62.2", sha256="a7669e4c4110b06b743d57cc5d6432591a6677ef2402139fe4f3d42ac13380b0")
 
-    depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools@42:', type='build')
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools@42:", type="build")

--- a/var/spack/repos/builtin/packages/py-pyproject-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproject-metadata/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyprojectMetadata(PythonPackage):
+    """PEP 621 metadata parsing."""
+
+    homepage = "https://github.com/FFY00/python-pyproject-metadata"
+    pypi     = "pyproject-metadata/pyproject-metadata-0.6.1.tar.gz"
+
+    version('0.6.1', sha256='b5fb09543a64a91165dfe85796759f9e415edc296beb4db33d1ecf7866a862bd')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools@42:', type='build')
+    depends_on('py-packaging@19:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyproject-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproject-metadata/package.py
@@ -10,10 +10,10 @@ class PyPyprojectMetadata(PythonPackage):
     """PEP 621 metadata parsing."""
 
     homepage = "https://github.com/FFY00/python-pyproject-metadata"
-    pypi     = "pyproject-metadata/pyproject-metadata-0.6.1.tar.gz"
+    pypi = "pyproject-metadata/pyproject-metadata-0.6.1.tar.gz"
 
-    version('0.6.1', sha256='b5fb09543a64a91165dfe85796759f9e415edc296beb4db33d1ecf7866a862bd')
+    version("0.6.1", sha256="b5fb09543a64a91165dfe85796759f9e415edc296beb4db33d1ecf7866a862bd")
 
-    depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools@42:', type='build')
-    depends_on('py-packaging@19:', type=('build', 'run'))
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-packaging@19:", type=("build", "run"))


### PR DESCRIPTION
This PR adds Yet Another Build Backend (YABB) to the Python ecosystem. In particular, the latest version of scipy switched from setuptools to meson for its builds. I also updated the documentation to describe this new build backend. Since almost all build backends share the same format for listing dependencies, I consolidated much of this information so I only list differences between each build system.