### PR TITLE
MACOSX_DEPLOYMENT_TARGET: MAJOR.MINOR

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -150,9 +150,8 @@ class MacOs(OperatingSystem):
         # only used the minor component)
         part = 1 if version >= Version('11') else 2
 
-        mac_ver = str(version.up_to(part))
-        name = mac_releases.get(mac_ver, "macos")
-        super(MacOs, self).__init__(name, mac_ver)
+        name = mac_releases.get(str(version.up_to(part)), "macos")
+        super(MacOs, self).__init__(name, version.up_to(2))
 
     def __str__(self):
         return self.name

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -150,8 +150,9 @@ class MacOs(OperatingSystem):
         # only used the minor component)
         part = 1 if version >= Version('11') else 2
 
-        name = mac_releases.get(str(version.up_to(part)), "macos")
-        super(MacOs, self).__init__(name, version.up_to(2))
+        mac_ver = str(version.up_to(part))
+        name = mac_releases.get(mac_ver, "macos")
+        super(MacOs, self).__init__(name, mac_ver)
 
     def __str__(self):
         return self.name

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -9,6 +9,7 @@ import archspec.cpu
 
 import spack.target
 from spack.operating_systems.mac_os import MacOs
+from spack.version import Version
 
 from ._platform import Platform
 
@@ -60,7 +61,7 @@ class Darwin(Platform):
         """
 
         os = self.operating_sys[pkg.spec.os]
-        version = os.version
+        version = Version(os.version)
         if len(version) == 1:
             # Version has only one component: add a minor version to prevent
             # potential errors with `ld`,


### PR DESCRIPTION
Previously, Spack was setting `MACOSX_DEPLOYMENT_TARGET` to "11" or "12" instead of "11.6" or "12.4". Many packages like `py-scikit-build` expect this env var to have at least a major and minor version number. Without this change, `py-ninja` (which uses `py-scikit-build` to build) fails to build.

Related to:

* #28991
* #28926
* #28797
* #28090

It looks like #28926 was designed to fix this same issue but doesn't seem to be working. @sethrj thoughts on this approach and whether we should revert the hack in #28926 or fix it?