### PR TITLE
Add support for macOS Ventura

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -122,6 +122,7 @@ class MacOs(OperatingSystem):
         will use a generic "macos" version string until Spack is updated.
         """
         mac_releases = {
+<<<<<<< HEAD
             "10.0": "cheetah",
             "10.1": "puma",
             "10.2": "jaguar",
@@ -141,6 +142,7 @@ class MacOs(OperatingSystem):
             "10.16": "bigsur",
             "11": "bigsur",
             "12": "monterey",
+            "13": "ventura",
         }
 
         version = macos_version()

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -122,7 +122,6 @@ class MacOs(OperatingSystem):
         will use a generic "macos" version string until Spack is updated.
         """
         mac_releases = {
-<<<<<<< HEAD
             "10.0": "cheetah",
             "10.1": "puma",
             "10.2": "jaguar",


### PR DESCRIPTION
Hasn't been released yet, but we know the official name now, so it's probably best to get this in sooner rather than later.

@alalazo do we need to update archspec too?