### PR TITLE
making qtconsole optional

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter/package.py
@@ -14,11 +14,13 @@ class PyJupyter(PythonPackage):
 
     version('1.0.0', sha256='d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f')
 
+    variant('qtconsole', default=False, description='Enable Qt console')
+
     # pip silently replaces distutils with setuptools
     depends_on('py-setuptools', type='build')
     depends_on('py-notebook', type=('build', 'run'))
-    depends_on('py-qtconsole', type=('build', 'run'))
-    depends_on('py-jupyter-console', type=('build', 'run'))
+    depends_on('py-qtconsole', type=('build', 'run'), when='+qtconsole')
+    depends_on('py-jupyter-console', type=('build', 'run'), when='+qtconsole')
     depends_on('py-nbconvert', type=('build', 'run'))
     depends_on('py-ipykernel', type=('build', 'run'))
     depends_on('py-ipywidgets', type=('build', 'run'))


### PR DESCRIPTION
The console install, with its huge Qt and related dependencies, should be optional and off by default since most people would want to use the web, rather than Qt interface