### PR TITLE
PythonPackage: add --config-settings support

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -214,7 +214,7 @@ Note that ``py-wheel`` is already listed as a build dependency in the
 need to specify a specific version requirement or change the
 dependency type.
 
-See `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ and
+See `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`__ and
 `PEP 518 <https://www.python.org/dev/peps/pep-0518/>`_ for more
 information on the design of ``pyproject.toml``.
 
@@ -403,7 +403,7 @@ Config settings
 """""""""""""""
 
 These settings are passed to
-`PEP 517 <https://peps.python.org/pep-0517/>`_ build backends.
+`PEP 517 <https://peps.python.org/pep-0517/>`__ build backends.
 For example, ``py-scipy`` package allows you to specify the name of
 the BLAS/LAPACK library you want pkg-config to search for:
 

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -398,6 +398,34 @@ packages. However, the installation instructions for a package may
 suggest passing certain flags to the ``setup.py`` call. The
 ``PythonPackage`` class has two techniques for doing this.
 
+"""""""""""""""
+Config settings
+"""""""""""""""
+
+These settings are passed to
+`PEP 517 <https://peps.python.org/pep-0517/>`_ build backends.
+For example, ``py-scipy`` package allows you to specify the name of
+the BLAS/LAPACK library you want pkg-config to search for:
+
+.. code-block:: python
+
+   depends_on('py-pip@22.1:', type='build')
+
+   def config_settings(self, spec, prefix):
+       return {
+           'blas': spec['blas'].libs.names[0],
+           'lapack': spec['lapack'].libs.names[0],
+       }
+
+
+.. note::
+
+   This flag only works for packages that define a ``build-backend``
+   in ``pyproject.toml``. Also, it is only supported by pip 22.1+,
+   which requires Python 3.7+. For packages that still support Python
+   3.6 and older, ``install_options`` should be used instead.
+
+
 """"""""""""""
 Global options
 """"""""""""""
@@ -415,6 +443,16 @@ has an optional dependency on ``libyaml`` that can be enabled like so:
        else:
            options.append('--without-libyaml')
        return options
+
+
+.. note::
+
+   Direct invocation of ``setup.py`` is
+   `deprecated <https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html>`_.
+   This flag forces pip to use a deprecated installation procedure.
+   It should only be used in packages that don't define a
+   ``build-backend`` in ``pyproject.toml`` or packages that still
+   support Python 3.6 and older.
 
 
 """""""""""""""
@@ -435,6 +473,16 @@ allows you to specify the directories to search for ``libyaml``:
                spec['libyaml'].headers.include_flags,
            ])
        return options
+
+
+.. note::
+
+   Direct invocation of ``setup.py`` is
+   `deprecated <https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html>`_.
+   This flag forces pip to use a deprecated installation procedure.
+   It should only be used in packages that don't define a
+   ``build-backend`` in ``pyproject.toml`` or packages that still
+   support Python 3.6 and older.
 
 
 ^^^^^^^

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -201,13 +201,13 @@ class PythonPackage(PackageBase):
         args = PythonPackage._std_args(self) + ["--prefix=" + prefix]
 
         for key, value in self.config_settings(spec, prefix).items():
-            if spec['py-pip'].version < Version('22.1'):
+            if spec["py-pip"].version < Version("22.1"):
                 raise SpecError(
                     "'{}' package uses 'config_settings' which is only supported by "
                     "pip 22.1+. Add the following line to the package to fix this:\n\n"
                     '    depends_on("py-pip@22.1:", type="build")'.format(spec.name)
                 )
-            args.append('--config-settings={}={}'.format(key, value))
+            args.append("--config-settings={}={}".format(key, value))
         for option in self.install_options(spec, prefix):
             args.append("--install-option=" + option)
         for option in self.global_options(spec, prefix):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -22,8 +22,9 @@ from llnl.util.filesystem import (
 from llnl.util.lang import classproperty, match_predicate
 
 from spack.directives import depends_on, extends
-from spack.error import NoHeadersError, NoLibrariesError
+from spack.error import NoHeadersError, NoLibrariesError, SpecError
 from spack.package_base import PackageBase, run_after
+from spack.version import Version
 
 
 class PythonPackage(PackageBase):
@@ -155,13 +156,43 @@ class PythonPackage(PackageBase):
         """
         return self.stage.source_path
 
+    def config_settings(self, spec, prefix):
+        """Configuration settings to be passed to the PEP 517 build backend.
+
+        Requires pip 22.1+, which requires Python 3.7+.
+
+        Args:
+            spec (spack.spec.Spec): build spec
+            prefix (spack.util.prefix.Prefix): installation prefix
+
+        Returns:
+            dict: dictionary of KEY, VALUE settings
+        """
+        return {}
+
     def install_options(self, spec, prefix):
-        """Extra arguments to be supplied to the setup.py install command."""
+        """Extra arguments to be supplied to the setup.py install command.
+
+        Args:
+            spec (spack.spec.Spec): build spec
+            prefix (spack.util.prefix.Prefix): installation prefix
+
+        Returns:
+            list: list of options
+        """
         return []
 
     def global_options(self, spec, prefix):
         """Extra global options to be supplied to the setup.py call before the install
-        or bdist_wheel command."""
+        or bdist_wheel command.
+
+        Args:
+            spec (spack.spec.Spec): build spec
+            prefix (spack.util.prefix.Prefix): installation prefix
+
+        Returns:
+            list: list of options
+        """
         return []
 
     def install(self, spec, prefix):
@@ -169,6 +200,14 @@ class PythonPackage(PackageBase):
 
         args = PythonPackage._std_args(self) + ["--prefix=" + prefix]
 
+        for key, value in self.config_settings(spec, prefix).items():
+            if spec['py-pip'].version < Version('22.1'):
+                raise SpecError(
+                    "'{}' package uses 'config_settings' which is only supported by "
+                    "pip 22.1+. Add the following line to the package to fix this:\n\n"
+                    '    depends_on("py-pip@22.1:", type="build")'.format(spec.name)
+                )
+            args.append('--config-settings={}={}'.format(key, value))
         for option in self.install_options(spec, prefix):
             args.append("--install-option=" + option)
         for option in self.global_options(spec, prefix):


### PR DESCRIPTION
@rgommers taught me about a new `pip install` flag we'll want to use with `py-scipy`. Here is my understanding of the history of this flag (@pradyunsg please correct me if I'm wrong, I'm probably oversimplifying things):

1. Once upon a time, `pip install` was simply a wrapper around `python setup.py install`. If you wanted to pass extra options to the build, you could use `pip install --global-option=<global> --install-option=<install>`, which would in turn run `python setup.py <global> install <install>`.
2. [PEP 517](https://peps.python.org/pep-0517/) added a way to specify a "build backend". Instead of running `python setup.py install`, if a `build-backend` is specified in `pyproject.toml`, it is invoked directly. However, there was no way to pass options to a build backend.
3. https://github.com/pypa/pip/pull/11059 added a `--config-settings` flag to pip (first available in 22.1 release) which allows you to pass extra options to the build backend.

There is one important thing to note about this flag. It was first added in pip 22.1, which only supports Python 3.7+. This means that any package we add `config_settings` to will only support Python 3.7+. For `py-scipy`, we will only add this flag to scipy 1.9+, which already only supports Python 3.7+, so there's no issue there. But for other packages which specify a `build-backend` in `pyproject.toml`, this raises the question of which Python versions we are willing to support. Opened #31824 to discuss this without getting side-tracked with this PR.