### PR TITLE
black: fix `.git-blame-ignore-revs` commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # .git-blame-ignore-revs
 # Formatted entire codebase with black
-0e7b83453cc0115e19c87b6150b4f91eb3d824f3
+f52f6e99dbf1131886a80112b8c79dfc414afb7c


### PR DESCRIPTION
A GitHub rebase merge seems to rewrite commits even if it would be a fast-forward, which means that the commit merged from #24718 is wrong.

- [x] update `.git-blame-ignore-revs` with real commit from `develop`