### PR TITLE
Add c++14 support flag for xl compiler

### DIFF
--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -78,8 +78,7 @@ class Xl(Compiler):
         # is required to distinguish whether support is available
         if self.version >= ver("16.1.1.8"):
             return "-std=c++14"
-        raise UnsupportedCompilerFlag(
-            self, "the C++14 standard", "cxx14_flag", "< 16.1.1.8")
+        raise UnsupportedCompilerFlag(self, "the C++14 standard", "cxx14_flag", "< 16.1.1.8")
 
     @property
     def cc_pic_flag(self):

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -73,6 +73,13 @@ class Xl(Compiler):
         raise UnsupportedCompilerFlag(self, "the C11 standard", "c11_flag", "< 12.1")
 
     @property
+    def cxx14_flag(self):
+        if self.version >= ver("16.1.1.8"):
+            return "-std=c++14"
+        raise UnsupportedCompilerFlag(
+            self, "the C++14 standard", "cxx14_flag", "< 16.1.1.8")
+
+    @property
     def cc_pic_flag(self):
         return "-qpic"
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -74,6 +74,8 @@ class Xl(Compiler):
 
     @property
     def cxx14_flag(self):
+        # .real_version does not have the "y.z" component of "w.x.y.z", which
+        # is required to distinguish whether support is available
         if self.version >= ver("16.1.1.8"):
             return "-std=c++14"
         raise UnsupportedCompilerFlag(


### PR DESCRIPTION
See: https://www.ibm.com/support/pages/c14-language-standard-fully-supported-xl-cc-linux-1611-fix-pack-8

Note I have to use `version` (which is what the user sets in the config) vs. `real_version` (which is based off of querying the compiler exe).

`extract_version_from_output` uses `version_regex`, which is defined per-compiler, and I could update that to allow for additional version components (I don't actually know though whether the command reports that info, and would need to take care to account for the possibility that the components after the first two might not exist).