### PR TITLE
Ascent package fixes

### DIFF
--- a/var/spack/repos/builtin/packages/apcomp/package.py
+++ b/var/spack/repos/builtin/packages/apcomp/package.py
@@ -156,7 +156,7 @@ class Apcomp(Package):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC":
+            if cpp_compiler == "CC" and "@3.14" in spec["cmake"]:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
             cfg.write(cmake_cache_entry("ENABLE_MPI", "ON"))

--- a/var/spack/repos/builtin/packages/ascent/ascent-configure-deps-pr962.patch
+++ b/var/spack/repos/builtin/packages/ascent/ascent-configure-deps-pr962.patch
@@ -1,0 +1,83 @@
+diff --git a/src/config/ascent_setup_deps.cmake b/src/config/ascent_setup_deps.cmake
+index 3b369717..28c60df6 100644
+--- a/src/config/ascent_setup_deps.cmake
++++ b/src/config/ascent_setup_deps.cmake
+@@ -51,7 +51,7 @@ endif()
+ 
+ if(VTKH_DIR)
+     if(NOT EXISTS ${VTKH_DIR}/lib/VTKhConfig.cmake)
+-        message(FATAL_ERROR "Could not find VTKh CMake include file (${VTKH_DIR}/lib/VTKhConfig.cmake)")
++      message(FATAL_ERROR "Could not find VTKh CMake include file (${VTKH_DIR}/lib/VTKhConfig.cmake)")
+     endif()
+ 
+     ###############################################################################
+@@ -59,7 +59,7 @@ if(VTKH_DIR)
+     ###############################################################################
+     find_dependency(VTKh REQUIRED
+                     NO_DEFAULT_PATH
+-                    PATHS ${VTKH_DIR}/lib/)
++                    PATHS ${VTKH_DIR}/lib)
+ endif()
+ 
+ ###############################################################################
+@@ -71,15 +71,16 @@ endif()
+ 
+ if(VTKM_DIR)
+     # use VTKM_DIR to setup the options that cmake's find VTKm needs
+-    file(GLOB VTKm_DIR "${VTKM_DIR}/lib/cmake/vtkm-*")
+-    if(NOT VTKm_DIR)
+-        message(FATAL_ERROR "Failed to find VTKm at VTKM_DIR=${VTKM_DIR}/lib/cmake/vtk-*")
++    if(NOT EXISTS ${VTKM_DIR})
++        message(FATAL_ERROR "Failed to find VTKm at VTKM_DIR=${VTKM_DIR}")
+     endif()
+ 
+     ###############################################################################
+     # Import CMake targets
+     ###############################################################################
+-    find_dependency(VTKm REQUIRED)
++    find_dependency(VTKm REQUIRED
++      NO_DEFAULT_PATH
++      PATHS ${VTKM_DIR})
+ endif()
+ 
+ ###############################################################################
+@@ -168,8 +169,8 @@ if(NOT ADIOS2_DIR)
+ endif()
+ 
+ if(ADIOS2_DIR)
+-    if(NOT EXISTS ${ADIOS2_DIR}/lib/cmake/adios2)
+-      message(FATAL_ERROR "Could not find ADIOS2 CMake include info (${ADIOS2_DIR}/lib/cmake/adios2)")
++    if(NOT EXISTS ${ADIOS2_DIR})
++      message(FATAL_ERROR "Could not find ADIOS2 CMake include info (${ADIOS2_DIR})")
+     endif()
+ 
+     ###############################################################################
+@@ -177,7 +178,7 @@ if(ADIOS2_DIR)
+     ###############################################################################
+     find_dependency(ADIOS2 REQUIRED
+                     NO_DEFAULT_PATH
+-                    PATHS ${ADIOS2_DIR}/lib/cmake/adios2)
++                    PATHS ${ADIOS2_DIR})
+ endif()
+ 
+ ###############################################################################
+@@ -188,8 +189,8 @@ if(NOT FIDES_DIR)
+ endif()
+ 
+ if(FIDES_DIR)
+-    if(NOT EXISTS ${FIDES_DIR}/lib/cmake/fides)
+-        message(FATAL_ERROR "Could not find FIDES CMake include info (${FIDES_DIR}/lib/cmake/fides)")
++    if(NOT EXISTS ${FIDES_DIR})
++        message(FATAL_ERROR "Could not find FIDES CMake include info (${FIDES_DIR})")
+     endif()
+ 
+     ###############################################################################
+@@ -197,7 +198,7 @@ if(FIDES_DIR)
+     ###############################################################################
+     find_dependency(Fides REQUIRED
+                     NO_DEFAULT_PATH
+-                    PATHS ${FIDES_DIR}/lib/cmake/fides)
++                    PATHS ${FIDES_DIR})
+ endif()
+ 
+ ###############################################################################

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -107,6 +107,9 @@ class Ascent(CMakePackage, CudaPackage):
     # patch for finding Conduit python more reliably
     # https://github.com/Alpine-DAV/ascent/pull/935
     patch("ascent-find-conduit-python-pr935.patch", when="@0.8.0")
+    # patch for finding dependencies in configure file
+    # https://github.com/Alpine-DAV/ascent/pull/962
+    patch("ascent-configure-deps-pr962.patch", when="@0.8.0")
 
     ##########################################################################
     # package dependencies

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -220,11 +220,15 @@ class Ascent(CMakePackage, CudaPackage):
     # Note: cmake, build, and install stages are handled by CMakePackage
     ####################################################################
 
+    @property
+    def root_cmakelists_dir(self):
+        return os.path.join(self.stage.source_path, 'src')
+
     # provide cmake args (pass host config as cmake cache file)
     def cmake_args(self):
         host_config = self._get_host_config_path(self.spec)
         options = []
-        options.extend(["-C", host_config, "../spack-src/src/"])
+        options.extend(["-C", host_config])
         return options
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -225,7 +225,7 @@ class Ascent(CMakePackage, CudaPackage):
 
     @property
     def root_cmakelists_dir(self):
-        return os.path.join(self.stage.source_path, 'src')
+        return os.path.join(self.stage.source_path, "src")
 
     # provide cmake args (pass host config as cmake cache file)
     def cmake_args(self):
@@ -456,7 +456,7 @@ class Ascent(CMakePackage, CudaPackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC" and  "@3.14" in spec["cmake"]:
+            if cpp_compiler == "CC" and "@3.14" in spec["cmake"]:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -456,7 +456,7 @@ class Ascent(CMakePackage, CudaPackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC":
+            if cpp_compiler == "CC" and  "@3.14" in spec["cmake"]:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -457,7 +457,7 @@ class Conduit(CMakePackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if spec["mpi"].mpicc == spack_cc:
+            if spec["mpi"].mpicc == spack_cc and  "@3.14" in spec["cmake"]:
                 mpicc_path = c_compiler
                 mpicxx_path = cpp_compiler
                 mpifc_path = f_compiler

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -457,7 +457,7 @@ class Conduit(CMakePackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if spec["mpi"].mpicc == spack_cc and  "@3.14" in spec["cmake"]:
+            if spec["mpi"].mpicc == spack_cc and "@3.14" in spec["cmake"]:
                 mpicc_path = c_compiler
                 mpicxx_path = cpp_compiler
                 mpifc_path = f_compiler

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -200,7 +200,7 @@ class VtkH(CMakePackage, CudaPackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC":
+            if cpp_compiler == "CC" and  "@3.14" in spec["cmake"]:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -200,7 +200,7 @@ class VtkH(CMakePackage, CudaPackage):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC" and  "@3.14" in spec["cmake"]:
+            if cpp_compiler == "CC" and "@3.14" in spec["cmake"]:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"


### PR DESCRIPTION
I have found issues with mixing `~btl_find_mpi` into builds on perlmutter. I am still needing to test this on crusher, but I found that this fix with `+blt_find_mpi` on cray systems works better when building downstream projects.