### PR TITLE
Make parmmg dependent on mmg and metis

### DIFF
--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -3,7 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
+from spack.util.executable import which
 
 
 class Mmg(CMakePackage):
@@ -58,3 +61,11 @@ class Mmg(CMakePackage):
             args.append("-DLIBMMG_STATIC=ON")
 
         return args
+
+    # parmmg requires this for its build
+    @run_after("install")
+    def install_source(self):
+        prefix = self.spec.prefix
+        cp = which("cp")
+        cp("-r", os.path.join(self.stage.source_path, "src"), prefix)
+        cp("-r", os.path.join(self.build_directory, "src"), prefix)

--- a/var/spack/repos/builtin/packages/parmmg/package.py
+++ b/var/spack/repos/builtin/packages/parmmg/package.py
@@ -27,8 +27,13 @@ class Parmmg(CMakePackage):
     variant("pic", default=True, description="Build with position independent code")
 
     def cmake_args(self):
+        define = CMakePackage.define
         args = [
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            define("DOWNLOAD_MMG", False),
+            define("MMG_DIR", self.spec["mmg"].prefix),
+            define("DOWNLOAD_METIS", False),
+            define("METIS_DIR", self.spec["metis"].prefix),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -252,6 +252,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("parmetis~int64", when="+metis+mpi~int64")
     depends_on("valgrind", when="+valgrind")
     depends_on("mmg", when="+mmg")
+    depends_on("mmg", when="+parmmg")
     depends_on("parmmg", when="+parmmg")
     depends_on("tetgen+pic", when="+tetgen")
     # hypre+/~fortran based on wheter fortran is enabled/disabled


### PR DESCRIPTION
1. copy source of mmg to installation tree
2. add cmake args for parmmg
3. add '+mmg' when '+parmmg' for petsc