### PR TITLE
e4s oneapi stack: build vtk-m ~openmp due to issue #31830

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -174,6 +174,7 @@ spack:
   - umpire
   - upcxx
   - veloc
+  - vtk-m ~openmp # can't build +openmp w/ %oneapi: https://github.com/spack/spack/issues/31830
   - wannier90
   - zfp
 
@@ -186,7 +187,7 @@ spack:
   # CPU BUILD FAILURES
   #- adios2@2.8.0                                     # adios2
   #- archer@2.0.0                                     # binutils
-  #- ascent@0.8.0                                     # vtk-m
+  #- ascent ^vtk-m ~openmp                            # ascent
   #- axom@0.6.1                                       # axom
   #- butterflypack@2.1.1                              # butterflypack
   #- charliecloud@0.26                                # charliecloud
@@ -211,10 +212,10 @@ spack:
   #- tau@2.31 +mpi +python                            # binutils
   #- unifyfs@0.9.2                                    # unifyfs
   #- variorum@0.4.1                                   # variorum
-  #- vtk-m@1.7.1                                      # vtk-m
 
   # CPU BUILD FAILURES - NOTES
   # adios2: /usr/bin/ld: ../../lib/libadios2_fortran.so.2.8.2: version node not found for symbol adios2_adios_init_mod@adios2_adios_init_serial_smod._; /usr/bin/ld: failed to set dynamic section sizes: bad value
+  # ascent: examples/proxies/cloverleaf3d-ref/clover_main.cpp:24: multiple definition of `main'; /opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin/for_main.o:for_main.c:(.text+0x0): first defined here
   # axom: /usr/bin/ld: /lib/x86_64-linux-gnu/crt1.o: in function `_start': (.text+0x24): undefined reference to `main'
   # binutils: gold/powerpc.cc:3590: undefined reference to `gold::Sized_symbol<64>::Value_type gold::Symbol_table::compute_final_value<64>(gold::Sized_symbol<64> const*, gold::Symbol_table::Compute_final_value_status*) const'
   # boost@1.79.0 cxxstd=17: clang++: error: unsupported argument 'h-create' to option '-pc'; clang++: error: no such file or directory: 'bin.v2/libs/math/build/intel-linux-2022.1.0/release/cxxstd-17-iso/threading-multi/visibility-hidden/pch.pchi'


### PR DESCRIPTION
Build `vtk-m ~openmp` due to ICE detailed here: https://github.com/spack/spack/issues/31830

FYI @wspear @rscohn2 @kmorel @vicentebolea 