### PR TITLE
kokkos: set CMAKE_CXX_STANDARD instead of Kokkos_CXX_STANDARD

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -265,13 +265,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
         options = [
             from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            from_variant("CMAKE_CXX_STANDARD", "std"),
             from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
-
-        if spec.satisfies("@develop"):
-            options.append(from_variant("CMAKE_CXX_STANDARD", "std"))
-        else:
-            options.append(from_variant("Kokkos_CXX_STANDARD", "std"))
 
         spack_microarches = []
         if "+cuda" in spec:

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -265,9 +265,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
         options = [
             from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            from_variant("Kokkos_CXX_STANDARD", "std"),
             from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
+
+        if spec.satisfies("@develop"):
+            options.append(from_variant("CMAKE_CXX_STANDARD", "std"))
+        else:
+            options.append(from_variant("Kokkos_CXX_STANDARD", "std"))
 
         spack_microarches = []
         if "+cuda" in spec:


### PR DESCRIPTION
It looks like CXX standard needs to be set differently for `kokkos@develop`.

Without this PR, you get this error when trying to build `kokkos@develop`:
```
  >> 5    CMake Error at cmake/kokkos_pick_cxx_std.cmake:12 (MESSAGE):
     6      Setting the variable Kokkos_CXX_STANDARD in configuration is deprec
          ated -
     7      set CMAKE_CXX_STANDARD directly instead
     8    Call Stack (most recent call first):
     9      CMakeLists.txt:43 (INCLUDE)
```

@crtrott @janciesko @wspear 