### PR TITLE
e4s ci: packages: prefer openssl certs=system due to binary relocation issue #31401

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -80,6 +80,8 @@ spack:
       variants: +termlib
     openblas:
       variants: threads=openmp
+    openssl:
+      variants: certs=system # https://github.com/spack/spack/issues/31401
     python:
       version: [3.8.13]
     trilinos:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -39,6 +39,8 @@ spack:
       variants: +termlib
     openblas:
       variants: threads=openmp
+    openssl:
+      variants: certs=system # https://github.com/spack/spack/issues/31401
     python:
       version: [3.8.13]
     trilinos:


### PR DESCRIPTION
Prefer `openssl certs=system` since `openssl certs=mozilla` cannot be properly relocated due to https://github.com/spack/spack/issues/31401

FYI @wspear @scottwittenburg 