### PR TITLE
spack checksum: black compliance

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -959,7 +959,7 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
 
     # Generate the version directives to put in a package.py
     version_lines = "\n".join(
-        ["    version('{0}', sha256='{1}'{2})".format(v, h, expand_arg) for v, h in version_hashes]
+        ['    version("{0}", sha256="{1}"{2})'.format(v, h, expand_arg) for v, h in version_hashes]
     )
 
     num_hash = len(version_hashes)


### PR DESCRIPTION
@tgamblin 

### Before

```console
$ spack checksum py-flake8
...
    version('5.0.2', sha256='9cc32bc0c5d16eacc014c7ec6f0e9565fd81df66c2092c3c9df06e3c1ac95e5d')
    version('5.0.1', sha256='9c51d3d1426379fd444d3b79eabbeb887849368bd053039066439523d8486961')
    version('5.0.0', sha256='503b06b6795189e55298a70b695b1eb4f6b8d479fae81352fc97c72ca242509e')
```

### After

```console
$ spack checksum py-flake8
...
    version("5.0.2", sha256="9cc32bc0c5d16eacc014c7ec6f0e9565fd81df66c2092c3c9df06e3c1ac95e5d")
    version("5.0.1", sha256="9c51d3d1426379fd444d3b79eabbeb887849368bd053039066439523d8486961")
    version("5.0.0", sha256="503b06b6795189e55298a70b695b1eb4f6b8d479fae81352fc97c72ca242509e")
```