### PR TITLE
Help with finding hdf5/blt; set host compiler properly for +mpi+cuda

### DIFF
--- a/var/spack/repos/builtin/packages/dray/package.py
+++ b/var/spack/repos/builtin/packages/dray/package.py
@@ -107,8 +107,8 @@ class Dray(Package, CudaPackage):
         env.set("CTEST_OUTPUT_ON_FAILURE", "1")
 
         spec = self.spec
-        if '+cuda' in spec and '+mpi' in spec:
-            env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)
+        if "+cuda" in spec and "+mpi" in spec:
+            env.set("CUDAHOSTCXX", spec["mpi"].mpicxx)
 
     def install(self, spec, prefix):
         """
@@ -117,8 +117,8 @@ class Dray(Package, CudaPackage):
         with working_dir("spack-build", create=True):
             host_cfg_fname = self.create_host_config(spec, prefix)
             cmake_args = [
-                '-DHDF5_DIR={0}'.format(spec['hdf5'].prefix),
-                '-DHDF5_INCLUDE_DIRS={0}'.format(';'.join(spec['hdf5'].headers.directories)),
+                "-DHDF5_DIR={0}".format(spec["hdf5"].prefix),
+                "-DHDF5_INCLUDE_DIRS={0}".format(";".join(spec["hdf5"].headers.directories)),
             ]
             # if we have a static build, we need to avoid any of
             # spack's default cmake settings related to rpaths

--- a/var/spack/repos/builtin/packages/dray/package.py
+++ b/var/spack/repos/builtin/packages/dray/package.py
@@ -210,7 +210,7 @@ class Dray(Package, CudaPackage):
         cfg.write("# cpp compiler used by spack\n")
         cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
 
-        cfg.write(cmake_cache_entry("BLT_SOURCE_DIR", spec['blt'].prefix))
+        cfg.write(cmake_cache_entry("BLT_SOURCE_DIR", spec["blt"].prefix))
         cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14"))
 
         if "+mpi" in spec:


### PR DESCRIPTION
* My build wanted to set the C++ standard. This PR sets `c++14` universally, but should that be conditioned to only apply for a specific version range?
* When building `dray+cuda+mpi` I had to set CUDAHOSTCXX: I was not able to set this using familiar CMake variables like `CUDA_HOST_COMPILER`
* `dray` was locating the wrong `blt`, so I pointed it explicitly to the Spack-built one
* `dray` was having trouble locating `hdf5` for my build, so I explicitly pointed it at the Spack-built one