### PR TITLE
Allow building with camp@0.2.3 for raja@0.14.0 and umpire@6.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -59,7 +59,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.4.0:", type="build", when="@0.13.0")
     depends_on("blt@0.3.6:", type="build", when="@:0.12.0")
 
-    depends_on("camp@0.2.2", when="@0.14.0")
+    depends_on('camp@0.2.2:0.2.3', when='@0.14.0')
     depends_on("camp@0.1.0", when="@0.10.0:0.13.0")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -59,7 +59,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.4.0:", type="build", when="@0.13.0")
     depends_on("blt@0.3.6:", type="build", when="@:0.12.0")
 
-    depends_on('camp@0.2.2:0.2.3', when='@0.14.0')
+    depends_on("camp@0.2.2:0.2.3", when='@0.14.0')
     depends_on("camp@0.1.0", when="@0.10.0:0.13.0")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -59,7 +59,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.4.0:", type="build", when="@0.13.0")
     depends_on("blt@0.3.6:", type="build", when="@:0.12.0")
 
-    depends_on("camp@0.2.2:0.2.3", when='@0.14.0')
+    depends_on("camp@0.2.2:0.2.3", when="@0.14.0")
     depends_on("camp@0.1.0", when="@0.10.0:0.13.0")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -91,7 +91,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.3.6:", type="build", when="@:4.1.2")
 
     depends_on("camp", when="@5.0.0:")
-    depends_on("camp@0.2.2:0.2.3", when='@6.0.0')
+    depends_on("camp@0.2.2:0.2.3", when="@6.0.0")
     depends_on("camp@0.1.0", when="@5.0.0:5.0.1")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -91,7 +91,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.3.6:", type="build", when="@:4.1.2")
 
     depends_on("camp", when="@5.0.0:")
-    depends_on('camp@0.2.2:0.2.3', when='@6.0.0')
+    depends_on("camp@0.2.2:0.2.3", when='@6.0.0')
     depends_on("camp@0.1.0", when="@5.0.0:5.0.1")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -91,7 +91,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.3.6:", type="build", when="@:4.1.2")
 
     depends_on("camp", when="@5.0.0:")
-    depends_on("camp@0.2.2", when="@6.0.0")
+    depends_on('camp@0.2.2:0.2.3', when='@6.0.0')
     depends_on("camp@0.1.0", when="@5.0.0:5.0.1")
     depends_on("camp@2022.03.0:", when="@2022.03.0:")
 


### PR DESCRIPTION
This is a conservative relaxation of a `depends_on` constraint in the `umpire`/`raja` packages. I have been able to build/use `raja@0.14.0` and `umpire@6.0.0` with `camp@0.2.3`.