### PR TITLE
WPS: add MPI dependency

### DIFF
--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -41,6 +41,9 @@ class Wps(Package):
     depends_on("wrf")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
+    # Dependence on mpi needs to be explicit because concretizers
+    # won't do the right thing and will mix mpi stacks.
+    depends_on("mpi") 
     # build script use csh
     depends_on("tcsh", type=("build"))
 

--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -43,7 +43,7 @@ class Wps(Package):
     depends_on("netcdf-fortran")
     # Dependence on mpi needs to be explicit because concretizers
     # won't do the right thing and will mix mpi stacks.
-    depends_on("mpi") 
+    depends_on("mpi")
     # build script use csh
     depends_on("tcsh", type=("build"))
 

--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -41,8 +41,6 @@ class Wps(Package):
     depends_on("wrf")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
-    # Dependence on mpi needs to be explicit because concretizers
-    # won't do the right thing and will mix mpi stacks.
     depends_on("mpi")
     # build script use csh
     depends_on("tcsh", type=("build"))


### PR DESCRIPTION
Makes dependence on mpi explicit because without it, concretizers will mix mpi stacks. The inherited dependence through wrf, netcdf, hdf5 is not sufficient. 

@MichaelLaufer