### PR TITLE
openssl: copy mozilla certs to work around symlink relocation issue

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shutil
 
 import llnl.util.tty as tty
 
@@ -318,7 +319,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
     depends_on("zlib")
     depends_on("perl@5.14.0:", type=("build", "test"))
-    depends_on("ca-certificates-mozilla", type=("build", "run"), when="certs=mozilla")
+    depends_on("ca-certificates-mozilla", type="build", when="certs=mozilla")
     depends_on("nasm", when="platform=windows")
 
     patch(
@@ -473,7 +474,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
                 os.symlink(sys_certs, pkg_certs)
 
     @run_after("install")
-    def link_mozilla_certs(self):
+    def copy_mozilla_certs(self):
         if self.spec.variants["certs"].value != "mozilla":
             return
 
@@ -482,9 +483,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
         mozilla_pem = self.spec["ca-certificates-mozilla"].pem_path
         pkg_cert = join_path(pkg_dir, "cert.pem")
-
-        if not os.path.exists(pkg_cert):
-            os.symlink(mozilla_pem, pkg_cert)
+        install(mozilla_pem, pkg_cert)
 
     def patch(self):
         if self.spec.satisfies("%nvhpc"):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-import shutil
 
 import llnl.util.tty as tty
 


### PR DESCRIPTION
closes #31843

Alternative to #31843, make spack copy the cacerts.pem file from ca-certificates-mozilla instead of symlinking it.

This is necessary because relocation logic does not handle symlinks across spack packages.