### PR TITLE
document common packages.yaml not respected due to --reuse issue

### DIFF
--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -56,6 +56,7 @@ or refer to the full manual below.
    basic_usage
    Tutorial: Spack 101 <https://spack-tutorial.readthedocs.io>
    replace_conda_homebrew
+   known_issues
 
 .. toctree::
    :maxdepth: 2

--- a/lib/spack/docs/known_issues.rst
+++ b/lib/spack/docs/known_issues.rst
@@ -24,10 +24,6 @@ packages, the concretizer values reuse of installed packages higher than prefere
 set in ``packages.yaml``. Note that ``packages.yaml`` specifies only preferences, not
 hard constraints.
 
-To verify you are affected by this problem, you can use
-``spack spec --install-status <spec>``. This should indicate with a ``[+]`` that
-certain "problematic" specs were picked because they were already installed.
-
 There are multiple workarounds:
 
 1. Disable reuse during concretization: ``spack install --fresh <spec>`` when installing

--- a/lib/spack/docs/known_issues.rst
+++ b/lib/spack/docs/known_issues.rst
@@ -1,0 +1,37 @@
+.. Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+============
+Known Issues
+============
+
+This is a list of known issues in Spack. It provides ways of getting around these
+problems if you encounter them.
+
+------------------------------------------------
+Spack does not seem to respect ``packages.yaml``
+------------------------------------------------
+
+A common problem in Spack v0.18 and above is that package, compiler and target
+preferences specified in ``packages.yaml`` do not seem to be respected. Spack picks the
+"wrong" compilers and their versions, package versions and variants, and
+micro-architectures.
+
+This is however not a bug. In order to reduce the number of builds of the same
+packages, the concretizer values reuse of installed packages higher than preferences
+set in ``packages.yaml``. Note that ``packages.yaml`` specifies only preferences, not
+hard constraints.
+
+To verify you are affected by this problem, you can use
+``spack spec --install-status <spec>``, which should show at least some already
+installed packages indicated by the leading ``[+]``.
+
+There are multiple workarounds:
+
+1. Disable reuse during concretization: ``spack install --fresh <spec>`` when installing
+   and individual spec, or ``spack concretize --fresh --force`` when using environments.  
+2. Turn preferences into constrains, by moving them to the input spec. For example,
+   use ``spack spec zlib%gcc@12`` when you want to force GCC 12 even if ``zlib`` was
+   already installed with GCC 10.

--- a/lib/spack/docs/known_issues.rst
+++ b/lib/spack/docs/known_issues.rst
@@ -25,13 +25,14 @@ set in ``packages.yaml``. Note that ``packages.yaml`` specifies only preferences
 hard constraints.
 
 To verify you are affected by this problem, you can use
-``spack spec --install-status <spec>``, which should show at least some already
-installed packages indicated by the leading ``[+]``.
+``spack spec --install-status <spec>``. This should indicate with a ``[+]`` that
+certain "problematic" specs were picked because they were already installed.
 
 There are multiple workarounds:
 
 1. Disable reuse during concretization: ``spack install --fresh <spec>`` when installing
-   and individual spec, or ``spack concretize --fresh --force`` when using environments.  
+   from the command line, or ``spack concretize --fresh --force`` when using
+   environments.  
 2. Turn preferences into constrains, by moving them to the input spec. For example,
    use ``spack spec zlib%gcc@12`` when you want to force GCC 12 even if ``zlib`` was
    already installed with GCC 10.


### PR DESCRIPTION
Since this comes up twice a day... resurrect Known issues in the docs.

And also, this should probably enter the 0.18 docs, since I don't think we can backport any breaking changes w.r.t. packages.yaml behavior.

https://spack--31864.org.readthedocs.build/en/31864/known_issues.html