### PR TITLE
nlohmann-json: add v3.11.2 and make 'multiple_headers' the default

### DIFF
--- a/var/spack/repos/builtin/packages/nlohmann-json/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json/package.py
@@ -33,7 +33,9 @@ class NlohmannJson(CMakePackage):
     version("3.1.2", sha256="e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54")
     version("3.1.1", sha256="9f3549824af3ca7e9707a2503959886362801fb4926b869789d6929098a79e47")
 
-    variant("multiple_headers", default=False, description="Use amalgamated single-header")
+    variant(
+        "multiple_headers", default=True, description="Use non-amalgamated version of the library"
+    )
 
     depends_on("cmake@3.8:", type="build")
     depends_on("cmake@3.13:", type="test")

--- a/var/spack/repos/builtin/packages/nlohmann-json/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json/package.py
@@ -13,6 +13,8 @@ class NlohmannJson(CMakePackage):
     url = "https://github.com/nlohmann/json/archive/v3.1.2.tar.gz"
     maintainers = ["ax3l"]
 
+    version("3.11.2", sha256="d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273")
+    # v3.11.0 & v3.11.1 omitted; released with significant regressions
     version("3.10.5", sha256="5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4")
     version("3.10.4", sha256="1155fd1a83049767360e9a120c43c578145db3204d2b309eba49fbbedd0f4ed3")
     version("3.10.3", sha256="e0d7c1b120cac47fa7f14a41d10a5d390f67d423d8e97b9d6834887285d6873c")
@@ -34,6 +36,7 @@ class NlohmannJson(CMakePackage):
     variant("multiple_headers", default=False, description="Use amalgamated single-header")
 
     depends_on("cmake@3.8:", type="build")
+    depends_on("cmake@3.13:", type="test")
 
     # requires mature C++11 implementations
     conflicts("%gcc@:4.7")


### PR DESCRIPTION
Add new version of nlohmann-json: https://github.com/nlohmann/json/releases/tag/v3.11.2

Using the multiple-header variant is recommended because it produces more useful error messages (i.e., which subsystem fails to compile). Upstream made that the default in v3.11.0.