### PR TITLE
Make prefix_inspections start with `./`

### DIFF
--- a/etc/spack/defaults/darwin/modules.yaml
+++ b/etc/spack/defaults/darwin/modules.yaml
@@ -15,7 +15,7 @@
 # -------------------------------------------------------------------------
 modules:
   prefix_inspections:
-    lib:
+    ./lib:
       - DYLD_FALLBACK_LIBRARY_PATH
-    lib64:
+    ./lib64:
       - DYLD_FALLBACK_LIBRARY_PATH

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -14,23 +14,24 @@
 #   ~/.spack/modules.yaml
 # -------------------------------------------------------------------------
 modules:
-  # Paths to check when creating modules for all module sets
+  # This maps paths in the package install prefix to environment variables
+  # they should be added to. For example, <prefix>/bin should be in PATH.
   prefix_inspections:
-    bin:
+    ./bin:
       - PATH
-    man:
+    ./man:
       - MANPATH
-    share/man:
+    ./share/man:
       - MANPATH
-    share/aclocal:
+    ./share/aclocal:
       - ACLOCAL_PATH
-    lib/pkgconfig:
+    ./lib/pkgconfig:
       - PKG_CONFIG_PATH
-    lib64/pkgconfig:
+    ./lib64/pkgconfig:
       - PKG_CONFIG_PATH
-    share/pkgconfig:
+    ./share/pkgconfig:
       - PKG_CONFIG_PATH
-    '':
+    ./:
       - CMAKE_PREFIX_PATH
 
   # These are configurations for the module set named "default"


### PR DESCRIPTION
Not a proper fix to #22866, but at least an improvement...

1. This is a way to get rid of the weird `spack config blame modules` output involving a question mark (due to empty string as a key, which imho is a bit questionable anyways ~so in that sense a question mark _does_ make sense~):
   ```yaml
   $ spack config get modules
   # before
   modules:
     prefix_inspections:
       share/pkgconfig:
       - PKG_CONFIG_PATH
       ? ''
       : - CMAKE_PREFIX_PATH
   
   # after
   modules:
     prefix_inspections:
       /share/pkgconfig:
       - PKG_CONFIG_PATH
       /:
       - CMAKE_PREFIX_PATH
   ```
3. Might actually me more clear to users that this is a mapping from path -> environment variables, especially `/` vs `''`.