### PR TITLE
update config for parallelio

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -12,51 +12,52 @@ class Parallelio(CMakePackage):
     large numbers of processors on a HPC system."""
 
     homepage = "https://ncar.github.io/ParallelIO/"
-    url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_4.tar.gz"
+    url      = "https://github.com/NCAR/ParallelIO/archive/pio2_5_7.tar.gz"
 
-    maintainers = ["tkameyama"]
+    maintainers = ['jedwards4b']
 
-    version("2_5_4", sha256="e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65")
-    version("2_5_2", sha256="935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c")
+    version('2_5_7', sha256='af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd')
+    version('2_5_4', sha256='e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65')
+    version('2_5_2', sha256='935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c')
 
-    variant("pnetcdf", default=False, description="enable pnetcdf")
-    variant("timing", default=False, description="enable GPTL timing")
+    variant('pnetcdf', default=False, description='enable pnetcdf')
+    variant('timing', default=False, description='enable GPTL timing')
+    variant('logging', default=False, description='enable verbose logging')
+    variant('fortran', default=True, description='enable fortran interface (requires netcdf fortran)')
 
-    depends_on("mpi")
-    depends_on("netcdf-c +mpi", type="link")
-    depends_on("netcdf-fortran", type="link")
-    depends_on("parallel-netcdf", type="link", when="+pnetcdf")
+    depends_on('mpi')
+    depends_on('netcdf-c +mpi', type='link')
+    depends_on('netcdf-fortran', type='link', when='+fortran')
+    depends_on('parallel-netcdf', type='link', when='+pnetcdf')
 
-    resource(
-        name="CMake_Fortran_utils",
-        git="https://github.com/CESM-Development/CMake_Fortran_utils.git",
-        tag="master",
-    )
-    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
+    resource(name='genf90',
+             git='https://github.com/PARALLELIO/genf90.git',
+             tag='genf90_200608')
 
     def cmake_args(self):
         define = self.define
         define_from_variant = self.define_from_variant
         spec = self.spec
-        env["CC"] = spec["mpi"].mpicc
-        env["FC"] = spec["mpi"].mpifc
+        env['CC'] = spec['mpi'].mpicc
+        env['FC'] = spec['mpi'].mpifc
         src = self.stage.source_path
         args = [
-            define("NetCDF_C_PATH", spec["netcdf-c"].prefix),
-            define("NetCDF_Fortran_PATH", spec["netcdf-fortran"].prefix),
-            define("USER_CMAKE_MODULE_PATH", join_path(src, "CMake_Fortran_utils")),
-            define("GENF90_PATH", join_path(src, "genf90")),
+            define('NetCDF_C_PATH', spec['netcdf-c'].prefix),
+            define('USER_CMAKE_MODULE_PATH', join_path(src, 'cmake')),
+            define('GENF90_PATH', join_path(src, 'genf90')),
         ]
-        if spec.satisfies("+pnetcdf"):
-            args.extend(
-                [
-                    define("PnetCDF_C_PATH", spec["parallel-netcdf"].prefix),
-                    define("PnetCDF_Fortran_PATH", spec["parallel-netcdf"].prefix),
-                ]
-            )
-        args.extend(
-            [
-                define_from_variant("PIO_ENABLE_TIMING", "timing"),
-            ]
-        )
+        if spec.satisfies('+pnetcdf'):
+            args.extend([
+                define('PnetCDF_C_PATH', spec['parallel-netcdf'].prefix),
+            ])
+        if spec.satisfies('+fortran'):
+            args.extend([
+                define('NetCDF_Fortran_PATH', spec['netcdf-fortran'].prefix),
+                ])
+
+        args.extend([
+            define_from_variant('PIO_ENABLE_TIMING', 'timing'),
+            define_from_variant('PIO_ENABLE_LOGGING', 'logging'),
+            define_from_variant('PIO_ENABLE_FORTRAN', 'fortran'),
+        ])
         return args

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -14,50 +14,54 @@ class Parallelio(CMakePackage):
     homepage = "https://ncar.github.io/ParallelIO/"
     url      = "https://github.com/NCAR/ParallelIO/archive/pio2_5_7.tar.gz"
 
-    maintainers = ['jedwards4b']
+    maintainers = ["jedwards4b"]
 
-    version('2_5_7', sha256='af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd')
-    version('2_5_4', sha256='e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65')
-    version('2_5_2', sha256='935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c')
+    version("2_5_7", sha256="af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd")
+    version("2_5_4", sha256="e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65")
+    version("2_5_2", sha256="935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c")
 
-    variant('pnetcdf', default=False, description='enable pnetcdf')
-    variant('timing', default=False, description='enable GPTL timing')
-    variant('logging', default=False, description='enable verbose logging')
-    variant('fortran', default=True, description='enable fortran interface (requires netcdf fortran)')
+    variant("pnetcdf", default=False, description="enable pnetcdf")
+    variant("timing", default=False, description="enable GPTL timing")
+    variant("logging", default=False, description="enable verbose logging")
+    variant("fortran", default=True, description="enable fortran interface (requires netcdf fortran)")
 
-    depends_on('mpi')
-    depends_on('netcdf-c +mpi', type='link')
-    depends_on('netcdf-fortran', type='link', when='+fortran')
-    depends_on('parallel-netcdf', type='link', when='+pnetcdf')
+    depends_on("mpi")
+    depends_on("netcdf-c +mpi", type="link")
+    depends_on("netcdf-fortran", type="link", when="+fortran")
+    depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
-    resource(name='genf90',
-             git='https://github.com/PARALLELIO/genf90.git',
-             tag='genf90_200608')
+    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git",tag="genf90_200608")
 
     def cmake_args(self):
         define = self.define
         define_from_variant = self.define_from_variant
         spec = self.spec
-        env['CC'] = spec['mpi'].mpicc
-        env['FC'] = spec['mpi'].mpifc
+        env["CC"] = spec["mpi"].mpicc
+        env["FC"] = spec["mpi"].mpifc
         src = self.stage.source_path
         args = [
-            define('NetCDF_C_PATH', spec['netcdf-c'].prefix),
-            define('USER_CMAKE_MODULE_PATH', join_path(src, 'cmake')),
-            define('GENF90_PATH', join_path(src, 'genf90')),
+            define("NetCDF_C_PATH", spec["netcdf-c"].prefix),
+            define("USER_CMAKE_MODULE_PATH", join_path(src, "cmake")),
+            define("GENF90_PATH", join_path(src, "genf90")),
         ]
-        if spec.satisfies('+pnetcdf'):
-            args.extend([
-                define('PnetCDF_C_PATH', spec['parallel-netcdf'].prefix),
-            ])
-        if spec.satisfies('+fortran'):
-            args.extend([
-                define('NetCDF_Fortran_PATH', spec['netcdf-fortran'].prefix),
-                ])
+        if spec.satisfies("+pnetcdf"):
+            args.extend(
+                [
+                    define("PnetCDF_C_PATH", spec["parallel-netcdf"].prefix),
+                ]
+            )
+        if spec.satisfies("+fortran"):
+            args.extend(
+                [
+                    define("NetCDF_Fortran_PATH", spec["netcdf-fortran"].prefix),
+                ]
+            )
 
-        args.extend([
-            define_from_variant('PIO_ENABLE_TIMING', 'timing'),
-            define_from_variant('PIO_ENABLE_LOGGING', 'logging'),
-            define_from_variant('PIO_ENABLE_FORTRAN', 'fortran'),
-        ])
+        args.extend(
+            [
+                define_from_variant("PIO_ENABLE_TIMING", "timing"),
+                define_from_variant("PIO_ENABLE_LOGGING", "logging"),
+                define_from_variant("PIO_ENABLE_FORTRAN", "fortran"),
+            ]
+        )
         return args

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -16,7 +16,7 @@ class Parallelio(CMakePackage):
 
     maintainers = ["jedwards4b"]
 
-    version('2_5_8', sha256='f2584fb4310ff7da39d51efbe3f334efd0ac53ae2995e5fc157decccc0570a89')
+    version("2_5_8", sha256="f2584fb4310ff7da39d51efbe3f334efd0ac53ae2995e5fc157decccc0570a89")
     version("2_5_7", sha256="af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd")
     version("2_5_4", sha256="e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65")
     version("2_5_2", sha256="935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -12,7 +12,7 @@ class Parallelio(CMakePackage):
     large numbers of processors on a HPC system."""
 
     homepage = "https://ncar.github.io/ParallelIO/"
-    url      = "https://github.com/NCAR/ParallelIO/archive/pio2_5_7.tar.gz"
+    url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_7.tar.gz"
 
     maintainers = ["jedwards4b"]
 
@@ -23,14 +23,16 @@ class Parallelio(CMakePackage):
     variant("pnetcdf", default=False, description="enable pnetcdf")
     variant("timing", default=False, description="enable GPTL timing")
     variant("logging", default=False, description="enable verbose logging")
-    variant("fortran", default=True, description="enable fortran interface (requires netcdf fortran)")
+    variant(
+        "fortran", default=True, description="enable fortran interface (requires netcdf fortran)"
+    )
 
     depends_on("mpi")
     depends_on("netcdf-c +mpi", type="link")
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
-    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git",tag="genf90_200608")
+    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
 
     def cmake_args(self):
         define = self.define

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -12,10 +12,11 @@ class Parallelio(CMakePackage):
     large numbers of processors on a HPC system."""
 
     homepage = "https://ncar.github.io/ParallelIO/"
-    url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_7.tar.gz"
+    url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_8.tar.gz"
 
     maintainers = ["jedwards4b"]
 
+    version('2_5_8', sha256='f2584fb4310ff7da39d51efbe3f334efd0ac53ae2995e5fc157decccc0570a89')
     version("2_5_7", sha256="af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd")
     version("2_5_4", sha256="e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65")
     version("2_5_2", sha256="935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c")


### PR DESCRIPTION
Update the parallelio config to use the latest parallelio version.   Also added features to optionally exclude fortran
in the build or include logging.   Changes maintainer to jedwards4b who is the administrator of the parallelio repository.