### PR TITLE
libedit: Make sure libedit linkes to the correct terminfo lib from spack

### DIFF
--- a/var/spack/repos/builtin/packages/libedit/package.py
+++ b/var/spack/repos/builtin/packages/libedit/package.py
@@ -34,3 +34,13 @@ class Libedit(AutotoolsPackage):
     def url_for_version(self, version):
         url = "http://thrysoee.dk/editline/libedit-{0}-{1}.tar.gz"
         return url.format(version[-1], version.up_to(-1))
+
+    def configure_args(self):
+        args = ["ac_cv_lib_curses_tgetent=no", "ac_cv_lib_termcap_tgetent=no"]
+
+        if "+termlib" in self.spec["ncurses"]:
+            args.append("ac_cv_lib_ncurses_tgetent=no")
+        else:
+            args.append("ac_cv_lib_tinfo_tgetent=no")
+
+        return args


### PR DESCRIPTION
This makes sure that libedit links to the terminfo provided by spack and not one it finds elsewhere on the system.  Fixes the llvm build failure #31808