### PR TITLE
black: fix bootstrap for Python 3.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-platformdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-platformdirs/package.py
@@ -23,12 +23,9 @@ class PyPlatformdirs(PythonPackage):
     depends_on("py-setuptools-scm@5:+toml", type="build")
 
     @when("^python@:3.6")
-    @run_before("install")
-    def handle_utf8_setup_cfg(self):
-        """Sanitize setup.cfg to resolve issues with Python 3.6 and UTF-8"""
-        with open("setup.cfg", mode="r", encoding="utf-8") as input_file:
-            cfg = input_file.readlines()
-        with open(
-            "setup.cfg", mode="w", encoding="ascii", errors="backslashreplace"
-        ) as output_file:
-            output_file.writelines(cfg)
+    def setup_build_environment(self, env):
+        """Python 3.6 needs a little help with setup.cfg re:
+
+        https://github.com/platformdirs/platformdirs/issues/50
+        """
+        env.set("LC_ALL", "en_US.UTF-8")

--- a/var/spack/repos/builtin/packages/py-platformdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-platformdirs/package.py
@@ -13,15 +13,14 @@ class PyPlatformdirs(PythonPackage):
     homepage = "https://github.com/platformdirs/platformdirs"
     pypi = "platformdirs/platformdirs-2.4.0.tar.gz"
 
-    version('2.4.1', sha256='440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda')
+    version("2.4.1", sha256="440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda")
     version("2.4.0", sha256="367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2")
-    version('2.3.0', sha256='15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f')
+    version("2.3.0", sha256="15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f")
 
     depends_on("python@3.7:", when="@2.4.1:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@44:", type="build")
     depends_on("py-setuptools-scm@5:+toml", type="build")
-
 
     @when("^python@:3.6")
     @run_before("install")
@@ -29,5 +28,7 @@ class PyPlatformdirs(PythonPackage):
         """Sanitize setup.cfg to resolve issues with Python 3.6 and UTF-8"""
         with open("setup.cfg", mode="r", encoding="utf-8") as input_file:
             cfg = input_file.readlines()
-        with open("setup.cfg", mode="w", encoding="ascii", errors="backslashreplace") as output_file:
+        with open(
+            "setup.cfg", mode="w", encoding="ascii", errors="backslashreplace"
+        ) as output_file:
             output_file.writelines(cfg)

--- a/var/spack/repos/builtin/packages/py-platformdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-platformdirs/package.py
@@ -13,8 +13,21 @@ class PyPlatformdirs(PythonPackage):
     homepage = "https://github.com/platformdirs/platformdirs"
     pypi = "platformdirs/platformdirs-2.4.0.tar.gz"
 
+    version('2.4.1', sha256='440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda')
     version("2.4.0", sha256="367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2")
+    version('2.3.0', sha256='15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f')
 
+    depends_on("python@3.7:", when="@2.4.1:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@44:", type="build")
     depends_on("py-setuptools-scm@5:+toml", type="build")
+
+
+    @when("^python@:3.6")
+    @run_before("install")
+    def handle_utf8_setup_cfg(self):
+        """Sanitize setup.cfg to resolve issues with Python 3.6 and UTF-8"""
+        with open("setup.cfg", mode="r", encoding="utf-8") as input_file:
+            cfg = input_file.readlines()
+        with open("setup.cfg", mode="w", encoding="ascii", errors="backslashreplace") as output_file:
+            output_file.writelines(cfg)


### PR DESCRIPTION
- py-platformdirs: sanitize UTF-8 setup.cfg on Python 3.6
- py-platformdirs: black compliance

When Spack is using Python 3.6 (_e.g._ on RHEL7-based platforms such as
scientific7), the package `py-platformdirs` as required by black causes
the bootstrapping process to fail when the command:

```console
spack style -t black
```

is executed for the first time.

The `setup.cfg` configuration file for `py-platformdirs` contains the
line:

```
maintainer = Bernát Gábor, Julian Berman, Ofek Lev, Ronny Pfannschmidt
```

which is not handled correctly by Python 3.6. This PR replaces the
non-ASCII characters with Python escape sequences via the
`errors="backslashreplace"` feature of Python's builtin
`open()` function.
