### PR TITLE
Search for externals with a timeout

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -2,14 +2,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import _thread
 import collections.abc
 import contextlib
 import fnmatch
 import functools
+import inspect
 import itertools
 import os
 import re
+import signal
 import sys
+import threading
 import traceback
 import types
 import typing
@@ -1182,3 +1186,101 @@ class PriorityOrderedMapping(Mapping[KT, VT]):
         self._priorities = [(p, k) for p, k in self._priorities if k != key]
         assert len(self._data) == len(self._priorities)
         return popped_item
+
+
+class ContextTimeout(RuntimeError):
+    """Exception raised when a "timeout" context manager times out before completing execution."""
+
+    pass
+
+
+@contextlib.contextmanager
+def timeout_with_signal(seconds, error_on_timeout=True):
+    """Context manager that sets a timeout for the block to be executed.
+
+    This implementation is based on sending signal.SIGALRM, so it's usable only on Linux and macOS.
+
+    If seconds is 0 there is no timeout.
+
+    Args:
+        seconds (int): seconds before timing out
+        error_on_timeout (bool): if True raise an exception if the block times out
+
+    Raises:
+        ContextTimeout: when error_on_timeout is True and the block times out
+    """
+
+    def _raise_timeout(signum, frame):
+        """Handler to raise a ContextTimeout if called."""
+        msg = "Timeout raised from {0}".format(frame)
+        raise ContextTimeout(msg)
+
+    signal.signal(signal.SIGALRM, _raise_timeout)
+    try:
+        signal.alarm(seconds)
+        yield
+    except ContextTimeout:
+        if error_on_timeout:
+            raise
+    finally:
+        signal.alarm(0)
+
+
+@contextlib.contextmanager
+def timeout_with_threading(seconds, error_on_timeout=True):
+    """Context manager that sets a timeout for the block to be executed.
+
+    This implementation is based on having a separate thread firing a signal.SIGINT in
+    the main thread. It is portable across platforms, but require a separate thread to
+    be spawned.
+
+    If seconds is 0 there is no timeout.
+
+    Args:
+        seconds (int): seconds before timing out
+        error_on_timeout (bool): if True raise an exception if the block times out
+
+    Raises:
+        ContextTimeout: when error_on_timeout is True and the block times out
+    """
+
+    def _raise_timeout():
+        _thread.interrupt_main()  # novermin
+
+    t = threading.Timer(seconds, _raise_timeout)
+    try:
+        if seconds != 0:
+            t.start()
+        yield
+    except KeyboardInterrupt:
+        if error_on_timeout:
+            msg = "Timeout raised from {0}".format(inspect.stack())
+            raise ContextTimeout(msg)
+    finally:
+        if seconds != 0:
+            t.cancel()
+            t.join()
+
+
+@contextlib.contextmanager
+def timeout(seconds, error_on_timeout=True):
+    """Context manager that sets a timeout for the block to be executed.
+
+    The implementation depends on the platform, being ``timeout_with_signal``
+    on linux and macOS and ``timeout_with_threading`` on Windows.
+
+    If seconds is 0 there is no timeout.
+
+    Args:
+        seconds (int): seconds before timing out
+        error_on_timeout (bool): if True raise an exception if the block times out
+
+    Raises:
+        ContextTimeout: when error_on_timeout is True and the block times out
+    """
+    if sys.platform == "win32":
+        with timeout_with_threading(seconds, error_on_timeout):
+            yield
+    else:
+        with timeout_with_signal(seconds, error_on_timeout):
+            yield

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -5,6 +5,7 @@
 import os
 import re
 import sys
+import time
 from datetime import datetime, timedelta
 
 import pytest
@@ -397,3 +398,74 @@ class TestPriorityOrderedMapping:
 
         assert list(m.values()) == [1, 2, 3]
         assert list(m.reversed_values()) == [3, 2, 1]
+
+
+@pytest.mark.parametrize(
+    "timeout_contextmanager,seconds_timeout,seconds_sleep,expected",
+    [
+        pytest.param(
+            llnl.util.lang.timeout_with_signal,
+            1,
+            3,
+            False,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="signal is not supported on Windows"
+            ),
+        ),
+        pytest.param(
+            llnl.util.lang.timeout_with_signal,
+            4,
+            1,
+            True,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="signal is not supported on Windows"
+            ),
+        ),
+        pytest.param(
+            llnl.util.lang.timeout_with_signal,
+            0,
+            1,
+            True,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="signal is not supported on Windows"
+            ),
+        ),
+        (llnl.util.lang.timeout_with_threading, 1, 3, False),
+        (llnl.util.lang.timeout_with_threading, 4, 1, True),
+        (llnl.util.lang.timeout_with_threading, 0, 1, True),
+        (llnl.util.lang.timeout, 1, 3, False),
+        (llnl.util.lang.timeout, 4, 1, True),
+        (llnl.util.lang.timeout, 0, 1, True),
+    ],
+)
+def test_timeout_block_execution(timeout_contextmanager, seconds_timeout, seconds_sleep, expected):
+    """Check that the block is executed if we sleep less than the timeout,
+    and not executed otherwise.
+    """
+    block_executed = False
+    with timeout_contextmanager(seconds=seconds_timeout, error_on_timeout=False):
+        time.sleep(seconds_sleep)
+        block_executed = True
+    assert block_executed is expected
+
+
+@pytest.mark.parametrize(
+    "timeout_contextmanager",
+    [
+        pytest.param(
+            llnl.util.lang.timeout_with_signal,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="signal is not supported on Windows"
+            ),
+        ),
+        llnl.util.lang.timeout_with_threading,
+        llnl.util.lang.timeout,
+    ],
+)
+def test_timeout_exception(timeout_contextmanager):
+    """Check that we raise a ContextTimeout exception if the context manager
+    is set to error on timeout.
+    """
+    with pytest.raises(llnl.util.lang.ContextTimeout):
+        with timeout_contextmanager(seconds=1):
+            time.sleep(3)


### PR DESCRIPTION
Work in progress to try adding context managers whose blocks need to be executed within a timeout limit. 