### PR TITLE
mpich: fix hwloc config option for version >= 4.0

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -280,7 +280,7 @@ with '-Wl,-commons,use_dylibs' and without
         for exe in exes:
             variants = []
             output = Executable(exe)(output=str, error=str)
-            if re.search(r"--with-hwloc[-prefix]*=embedded", output):
+            if re.search(r"--with-hwloc(-prefix)*=embedded", output):
                 variants.append("~hwloc")
 
             if re.search(r"--with-pm=hydra", output):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -457,15 +457,24 @@ with '-Wl,-commons,use_dylibs' and without
         config_args = [
             "--disable-silent-rules",
             "--enable-shared",
-            "--with-hwloc-prefix={0}".format(
-                spec["hwloc"].prefix if "^hwloc" in spec else "embedded"
-            ),
             "--with-pm={0}".format("hydra" if "+hydra" in spec else "no"),
             "--{0}-romio".format("enable" if "+romio" in spec else "disable"),
             "--{0}-ibverbs".format("with" if "+verbs" in spec else "without"),
             "--enable-wrapper-rpath={0}".format("no" if "~wrapperrpath" in spec else "yes"),
             "--with-yaksa={0}".format(spec["yaksa"].prefix if "^yaksa" in spec else "embedded"),
         ]
+
+        # hwloc configure option changed in 4.0
+        if spec.satisfies("@4.0:"):
+            config_args.append(
+                "--with-hwloc={0}".format(spec["hwloc"].prefix if "^hwloc" in spec else "embedded")
+            )
+        else:
+            config_args.append(
+                "--with-hwloc-prefix={0}".format(
+                    spec["hwloc"].prefix if "^hwloc" in spec else "embedded"
+                )
+            )
 
         if "~fortran" in spec:
             config_args.append("--disable-fortran")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -280,7 +280,7 @@ with '-Wl,-commons,use_dylibs' and without
         for exe in exes:
             variants = []
             output = Executable(exe)(output=str, error=str)
-            if re.search(r"--with-hwloc-prefix=embedded", output):
+            if re.search(r"--with-hwloc[-prefix]*=embedded", output):
                 variants.append("~hwloc")
 
             if re.search(r"--with-pm=hydra", output):


### PR DESCRIPTION
In MPICH 4.0, the config option for external hwloc changed from
--with-hwloc-prefix to --with-hwloc. Fixes #31797