### PR TITLE
VisIt: Add vtkm variant.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/cmake-findvtkh-3.3.patch
+++ b/var/spack/repos/builtin/packages/visit/cmake-findvtkh-3.3.patch
@@ -1,0 +1,31 @@
+--- a/src/CMake/FindVTKh.cmake	2022-07-21 15:39:17.991222000 -0700
++++ b/src/CMake/FindVTKh.cmake	2022-07-21 15:42:12.326207000 -0700
+@@ -15,6 +15,10 @@
+ #   Kathleen Biagas, Tue Jan 21 10:46:31 PST 2020
+ #   Set VTKm_INCLUDE_DIRS.
+ #
++#   Eric Brugger, Thu 21 Jul 2022 06:39:36 PM EDT
++#   Modified the logic to handle the case where a RELWITHDEBINFO build of
++#   VTKh was created. Modified the logic not to install static libraries.
++#
+ #****************************************************************************/
+ 
+ IF (DEFINED VISIT_VTKH_DIR)
+@@ -47,13 +51,16 @@
+    # all interface link dependencies
+    function(get_lib_loc_and_install _lib)
+        get_target_property(ttype ${_lib} TYPE)
+-       if (ttype STREQUAL "INTERFACE_LIBRARY")
++       if (ttype STREQUAL "INTERFACE_LIBRARY" OR ttype STREQUAL "STATIC_LIBRARY")
+            return()
+        endif()
+        get_target_property(i_loc ${_lib} IMPORTED_LOCATION)
+        if (NOT i_loc)
+          get_target_property(i_loc ${_lib} IMPORTED_LOCATION_RELEASE)
+        endif()
++       if (NOT i_loc)
++         get_target_property(i_loc ${_lib} IMPORTED_LOCATION_RELWITHDEBINFO)
++       endif()
+        if(i_loc)
+            THIRD_PARTY_INSTALL_LIBRARY(${i_loc})
+        endif()

--- a/var/spack/repos/builtin/packages/visit/vtk-m_transport_tag_topology_field_in.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk-m_transport_tag_topology_field_in.patch
@@ -1,0 +1,12 @@
+--- a/vtkm/cont/arg/TransportTagTopologyFieldIn.h	2022-07-18 19:02:03.153633000 -0400
++++ b/vtkm/cont/arg/TransportTagTopologyFieldIn.h	2022-07-18 19:02:51.538743000 -0400
+@@ -90,7 +90,9 @@
+   {
+     if (object.GetNumberOfValues() != detail::TopologyDomainSize(inputDomain, TopologyElementTag()))
+     {
++#if 0
+       throw vtkm::cont::ErrorBadValue("Input array to worklet invocation the wrong size.");
++#endif
+     }
+ 
+     return object.PrepareForInput(Device(), token);


### PR DESCRIPTION
Added a vtkm variant to the VisIt package.

The vtkm support in VisIt is done through vtkh, so that support is also enabled in VisIt as part of the vtkm variant.

It includes a patch to VisIt to include the vtkh libraries in the install.
It includes a patch to vtkm that prevents throwing an exception with some vtkm functionality when used in VisIt.
The variant disables cuda in vtkm and vtkh since the cuda support doesn't work with VisIt with the current versions of vtkm and vtkh. It will in the next release.

I tested this on "crusher.olcf.ornl.gov", an early access system for the Frontier exascale system at Oak Ridge National Lab. I successfully displayed images in the GUI.