### PR TITLE
Remove macOS 10.15 from bootstrap tests

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -184,7 +184,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
-        macos-version: ['macos-10.15', 'macos-11', 'macos-12']
+        macos-version: ['macos-11', 'macos-12']
     if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies


### PR DESCRIPTION
That version of the runners have been deprecated, see [The GitHub blog](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/)