### PR TITLE
Match documentation of spack create with actual generated file.

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -126,7 +126,7 @@ generates a boilerplate template for your package, and opens up the new
    # If you submit this package back to Spack as a pull request,
    # please first remove this boilerplate and all FIXME comments.
    #
-   from spack import *
+   from spack.package import *
 
 
    class Gmp(AutotoolsPackage):


### PR DESCRIPTION
`spack create` has been update to change the default import. It has been changed from `from spack import *` to `from spack.package import *`.

This modification has not been changed in the example code provided in the documentation of the command. This PR aims at fixing that.