### PR TITLE
spack mirror: skip non-concretizable specs

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -650,6 +650,7 @@ def _add_single_spec(spec, mirror, mirror_stats):
     except Exception as e:
         msg = "Skipping '{0}', as it fails to concretize [{1}]".format(spec, str(e))
         tty.debug(msg)
+        mirror_stats.error()
         return False
 
     tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("{name}{@version}")))

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -632,9 +632,25 @@ class MirrorStats(object):
 
 
 def _add_single_spec(spec, mirror, mirror_stats):
+    """Add a single spec to a mirror.
+
+    Args:
+        spec (spack.spec.Spec): spec to be added. If not concrete it will
+            be concretized.
+        mirror (spack.mirror.Mirror): mirror where to add the spec.
+        mirror_stats (spack.mirror.MirrorStats): statistics on the current mirror
+
+    Return:
+        True if the spec was added successfully, False otherwise
+    """
     # Ensure that the spec is concrete, since we'll stage it later
-    if not spec.concrete:
-        spec = spec.concretized()
+    try:
+        if not spec.concrete:
+            spec = spec.concretized()
+    except Exception as e:
+        msg = "Skipping '{0}', as it fails to concretize [{1}]".format(spec, str(e))
+        tty.debug(msg)
+        return False
 
     tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("{name}{@version}")))
     num_retries = 3
@@ -662,6 +678,9 @@ def _add_single_spec(spec, mirror, mirror_stats):
                 getattr(exception, "message", exception),
             )
         mirror_stats.error()
+        return False
+
+    return True
 
 
 def push_url_from_directory(output_directory):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -311,3 +311,10 @@ def test_get_all_versions(specs, expected_specs):
     output_list = [str(x) for x in output_list]
     # Compare sets since order is not important
     assert set(output_list) == set(expected_specs)
+
+
+@pytest.mark.regression("31736")
+def test_non_concretizable_spec_does_not_raise():
+    s = Spec("doesnotexist")
+    result = spack.mirror._add_single_spec(s, mirror=None, mirror_stats=None)
+    assert result is False

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -316,5 +316,14 @@ def test_get_all_versions(specs, expected_specs):
 @pytest.mark.regression("31736")
 def test_non_concretizable_spec_does_not_raise():
     s = Spec("doesnotexist")
-    result = spack.mirror._add_single_spec(s, mirror=None, mirror_stats=None)
+
+    class Stats(object):
+        called = False
+
+        def error(self):
+            self.called = True
+
+    mirror_stats = Stats()
+    result = spack.mirror._add_single_spec(s, mirror=None, mirror_stats=mirror_stats)
     assert result is False
+    assert mirror_stats.called is True


### PR DESCRIPTION
fixes #31736

Catch errors when concretizing specs and report them as debug messages. The corresponding spec is skipped.