### PR TITLE
bracken: added new version and removed depreciated version

### DIFF
--- a/var/spack/repos/builtin/packages/bracken/package.py
+++ b/var/spack/repos/builtin/packages/bracken/package.py
@@ -14,41 +14,30 @@ class Bracken(Package):
     sequences from a metagenomics sample."""
 
     homepage = "https://ccb.jhu.edu/software/bracken"
-    url = "https://github.com/jenniferlu717/Bracken/archive/1.0.0.tar.gz"
+    url = "https://github.com/jenniferlu717/Bracken/archive/v2.7.tar.gz"
 
-    version("1.0.0", sha256="8ee736535ad994588339d94d0db4c0b1ba554a619f5f96332ee09f2aabdfe176")
+    version("2.7", sha256="1795ecd9f9e5582f37549795ba68854780936110a2f6f285c3e626d448cd1532")
 
-    depends_on("perl", type=("build", "link", "run"))
-    depends_on("python@2.7:", type=("build", "link", "run"))
-    depends_on("perl-exporter-tiny")
-    depends_on("perl-list-moreutils")
-    depends_on("perl-parallel-forkmanager")
+    depends_on("python", type="run")
+    depends_on("kraken2", type="run")
 
     def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install_tree("sample_data", prefix.sample_data)
-
-        filter_file(r"#!/bin/env perl", "#!/usr/bin/env perl", "count-kmer-abundances.pl")
-
-        filter_file(
-            r"#!/usr/bin/python",
-            "#!/usr/bin/env {0}".format(os.path.basename(self.spec["python"].command.path)),
-            "est_abundance.py",
-        )
-
-        filter_file(
-            r"#!/usr/bin/python",
-            "#!/usr/bin/env {0}".format(os.path.basename(self.spec["python"].command.path)),
-            "generate_kmer_distribution.py",
-        )
-
-        files = (
-            "count-kmer-abundances.pl",
-            "est_abundance.py",
-            "generate_kmer_distribution.py",
-        )
-
+        mkdirp(prefix.bin.src)
+        # installer builds kmer2read_distr in src
         chmod = which("chmod")
-        for name in files:
-            install(name, prefix.bin)
-            chmod("+x", join_path(self.prefix.bin, name))
+        chmod("+x", "./install_bracken.sh")
+        installer = Executable("./install_bracken.sh")
+        installer(self.stage.source_path)
+        # move main scripts to bin
+        install("bracken", prefix.bin)
+        install("bracken-build", prefix.bin)
+        install("./src/kmer2read_distr", prefix.bin)
+        install("./analysis_scripts/combine_bracken_outputs.py", prefix.bin)
+        chmod("+x", join_path(prefix.bin, "combine_bracken_outputs.py"))
+        # move scripts to src and create symlinks
+        files = ("est_abundance.py", "generate_kmer_distribution.py")
+        for file in files:
+            filepath = join_path("./src", file)
+            if os.path.isfile(filepath):
+                install(filepath, prefix.bin.src)
+                symlink(join_path(prefix.bin.src, file), join_path(prefix.bin, file))


### PR DESCRIPTION
@alalazo This is a resubmission of #31614. I had some conflicts which were not resolving easily when trying to rebase and it was just faster for me close that and submit a new PR

Original submission:

> the bracken package was significantly out of date (5+ years), and has changed a lot since v1.0.0. Some of the functionalities have moved to KrakenTools, and it works in a really different way now. Because of that, I removed v1.0.0 to simplify things (also no one should be using it).
> 
> I copied a lot from the Kraken2 package and Bracken bioconda recipe:
> 
> https://github.com/spack/spack/blob/18c2f1a57a69224748e091e912851317d8a00eea/var/spack/repos/builtin/packages/kraken2/package.py
> 
> https://github.com/bioconda/bioconda-recipes/blob/master/recipes/bracken/build.sh