### PR TITLE
Meaningful diagnostics on unimplemented phase

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -376,11 +376,13 @@ class PackageMeta(
                         else:
                             tty.die(
                                 """\
-bad directive @{directive}() for functions {funcs} in package {pkg}:""".format(
-                                    directive=check_name, funcs=funcs, pkg=name
+bad callback decorator @{decorator}() for functions {funcs} in package {pkg}:""".format(
+                                    decorator=check_name,
+                                    funcs=[f.__name__ for f in funcs],
+                                    pkg=name,
                                 ),
-                                'no phase "{phase}" in any base {bases}'.format(
-                                    phase=phase_name, bases=bases
+                                'no phase "{phase}" in {pkg} or any base class thereof'.format(
+                                    phase=phase_name, pkg=name
                                 ),
                             )
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -373,6 +373,14 @@ class PackageMeta(
                             phase = getattr(base, phase_attr, None)
                             if phase is not None:
                                 break
+                        else:
+                            tty.die(
+                                """\
+                            bad directive @{0}() for functions {funcs} in package {1}:
+                            no phase "{2}" in any base {3}""".format(
+                                    check_name, name, phase_name, bases, funcs=funcs
+                                )
+                            )
 
                         phase = attr_dict[phase_attr] = phase.copy()
                     getattr(phase, check_name).extend(funcs)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -376,10 +376,12 @@ class PackageMeta(
                         else:
                             tty.die(
                                 """\
-                            bad directive @{0}() for functions {funcs} in package {1}:
-                            no phase "{2}" in any base {3}""".format(
-                                    check_name, name, phase_name, bases, funcs=funcs
-                                )
+bad directive @{directive}() for functions {funcs} in package {pkg}:""".format(
+                                    directive=check_name, funcs=funcs, pkg=name
+                                ),
+                                'no phase "{phase}" in any base {bases}'.format(
+                                    phase=phase_name, bases=bases
+                                ),
                             )
 
                         phase = attr_dict[phase_attr] = phase.copy()


### PR DESCRIPTION
Produce meaningful diagnostics when a recipe invokes a `@run_before()`
or `@run_after()` directive for a phase not implemented in any package
base class, _e.g._:

```python
class PyBadPackage(PythonPackage):
    ...
    @run_before("build")
    def my_early_func(self)
        ...
```

would fail with:

```console
$ spack spec -It --reuse python@3.9.12
==> Error: bad directive @run_before() for functions [<function PyJltheme.ensure_readme_rst at 0x7fa46e16df80>] in package PyJltheme:
  no phase "build" in any base (<class 'spack.build_systems.python.PythonPackage'>,)
```
