### PR TITLE
sundials@6.1.0:6.2.0 +rocm: patch nvector to use pic

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -199,6 +199,7 @@ spack:
   - slate +rocm amdgpu_target=gfx90a
   - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a
   - strumpack ~slate +rocm amdgpu_target=gfx90a
+  - sundials +rocm amdgpu_target=gfx90a
   - superlu-dist +rocm amdgpu_target=gfx90a
   - tasmanian ~openmp +rocm amdgpu_target=gfx90a
   - tau +mpi +rocm

--- a/var/spack/repos/builtin/packages/sundials/nvector-pic.patch
+++ b/var/spack/repos/builtin/packages/sundials/nvector-pic.patch
@@ -1,0 +1,24 @@
+diff -ruN spack-src/examples/nvector/CMakeLists.txt spack-src-patched/examples/nvector/CMakeLists.txt
+--- spack-src/examples/nvector/CMakeLists.txt	2022-04-22 16:55:14.000000000 +0000
++++ spack-src-patched/examples/nvector/CMakeLists.txt	2022-08-03 16:34:47.789320825 +0000
+@@ -25,6 +25,10 @@
+ 
+ # Build the nvector test utilities
+ add_library(test_nvector_obj OBJECT test_nvector.c)
++if(BUILD_SHARED_LIBS)
++  # need PIC when shared libs are used since the example executables will link to the shared lib
++  set_property(TARGET test_nvector_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
++endif()
+ target_link_libraries(test_nvector_obj PRIVATE sundials_nvecserial)
+ 
+ if(ENABLE_MPI AND MPI_C_FOUND)
+@@ -33,6 +37,9 @@
+   add_subdirectory(mpiplusx)
+   # Build the mpi nvector test utilities
+   add_library(test_nvectormpi_obj OBJECT test_mpinvector.c)
++  if(BUILD_SHARED_LIBS)
++    set_property(TARGET test_nvectormpi_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
++  endif()
+   target_link_libraries(test_nvectormpi_obj PRIVATE MPI::MPI_C sundials_nvecparallel)
+ endif()
+ add_subdirectory(manyvector)

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -237,6 +237,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # ==========================================================================
     # Patches
     # ==========================================================================
+    # https://github.com/spack/spack/issues/29526
+    patch("nvector-pic.patch", when="@6.1.0:6.2.0 +rocm")
 
     # remove OpenMP header file and function from hypre vector test code
     patch("test_nvector_parhyp.patch", when="@2.7.0:3.0.0")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/29526 via https://github.com/LLNL/sundials/commit/c147095f728870dd9a73df8660d5650491db9243

@balos1 @cswoodward @gardner48