### PR TITLE
mbedtls, xz: add missing install_name fixes for darwin

### DIFF
--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -137,3 +137,8 @@ class Mbedtls(MakefilePackage):
 
     def install(self, spec, prefix):
         make("install", "DESTDIR={0}".format(prefix))
+
+    @run_after("install")
+    def darwin_fix(self):
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -53,3 +53,8 @@ class Xz(AutotoolsPackage, SourceforgePackage):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"xz \(XZ Utils\) (\S+)", output)
         return match.group(1) if match else None
+
+    @run_after("install")
+    def darwin_fix(self):
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
the mbedtls fix should be enough to close #31793 