### PR TITLE
acts: add v19.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,6 +39,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("19.6.0", commit="333082914e6a51b381abc1cf52856829e3eb7890", submodules=True)
     version("19.5.0", commit="bf9f0270eadd8e78d283557b7c9070b80dece4a7", submodules=True)
     version("19.4.0", commit="498af243755219486c26d32fb125b7ebf2557166", submodules=True)
     version("19.3.0", commit="747053f60254c5ad3aa1fe7b18ae89c19029f4a6", submodules=True)
@@ -232,6 +233,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("boost @1.71: +filesystem +program_options +test", when="@0.10.4:")
     depends_on("cmake @3.14:", type="build")
     depends_on("dd4hep @1.11: +dddetectors +ddrec", when="+dd4hep")
+    depends_on("dd4hep @1.21: +dddetectors +ddrec", when="@20: +dd4hep")
     depends_on("dd4hep +ddg4", when="+dd4hep +geant4 +examples")
     depends_on("edm4hep @0.4.1:", when="+edm4hep")
     depends_on("eigen @3.3.7:", when="@15.1:")


### PR DESCRIPTION
 and update dd4hep dependency following https://github.com/acts-project/acts/pull/1257