### PR TITLE
ruby-asciidoctor: adding version 2.0.17

### DIFF
--- a/var/spack/repos/builtin/packages/ruby-asciidoctor/package.py
+++ b/var/spack/repos/builtin/packages/ruby-asciidoctor/package.py
@@ -14,6 +14,7 @@ class RubyAsciidoctor(RubyPackage):
     homepage = "https://asciidoctor.org/"
     url = "https://github.com/asciidoctor/asciidoctor/archive/v2.0.10.tar.gz"
 
+    version("2.0.17", sha256="ca939b978d5d3bfe0cfcf1bcf5513f199aa77813e4a19f568dc6b6f17b892728")
     version("2.0.10", sha256="afca74837e6d4b339535e8ba0b79f2ad00bd1eef78bf391cc36995ca2e31630a")
 
     depends_on("ruby@2.3.0:", type=("build", "run"))


### PR DESCRIPTION
From https://github.com/asciidoctor/asciidoctor/releases much work done from 2.0.10 from may 2019 up to 2.0.17 in january 2022.