### PR TITLE
crmc: Add necessary boost variants and allow argument mismatch for all compilers

### DIFF
--- a/var/spack/repos/builtin/packages/crmc/package.py
+++ b/var/spack/repos/builtin/packages/crmc/package.py
@@ -23,7 +23,7 @@ class Crmc(CMakePackage):
     version("1.5.6", sha256="a546a9352dcbdb8a1df3d63530eacf16f8b64a190e224b72afd434f78388a8a0")
 
     depends_on("hepmc")
-    depends_on("boost")
+    depends_on("boost+filesystem+iostreams+system+program_options")
     depends_on("root")
 
     patch(
@@ -50,6 +50,5 @@ class Crmc(CMakePackage):
         ]
         if self.spec.satisfies("@1.6.0:"):
             args.append("-D__HIJING__=ON")
-        if self.spec.satisfies("%gcc@9:"):
-            args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch")
+        args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch")
         return args

--- a/var/spack/repos/builtin/packages/crmc/package.py
+++ b/var/spack/repos/builtin/packages/crmc/package.py
@@ -50,6 +50,6 @@ class Crmc(CMakePackage):
         ]
         if self.spec.satisfies("@1.6.0:"):
             args.append("-D__HIJING__=ON")
-        if self.spec.satisfies("%gcc@9:") and self.spec.satisfies("%clang@13:"):
+        if self.spec.satisfies("%gcc@9:") or self.spec.satisfies("%clang@13:"):
             args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch")
         return args

--- a/var/spack/repos/builtin/packages/crmc/package.py
+++ b/var/spack/repos/builtin/packages/crmc/package.py
@@ -50,5 +50,6 @@ class Crmc(CMakePackage):
         ]
         if self.spec.satisfies("@1.6.0:"):
             args.append("-D__HIJING__=ON")
-        args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch")
+        if self.spec.satisfies("%gcc@9:") and self.spec.satisfies("%clang@13:"):
+            args.append("-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch")
         return args


### PR DESCRIPTION
Without boost libs:
```
The following Boost libraries could not be found:

          boost_filesystem
          boost_iostreams
          boost_system
          boost_program_options
```
Without allow argument mismatch flag for clang14, e.g.:
```
     6964    
     6965      315 |               if(drangen(dummy).lt.0.45d0) then
     6966          |                         2
     6967    ......
     6968      549 |       S_RNDM= drangen(dble(idum))
     6969          |                      1
  >> 6970    Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/REAL(4)).
  >> 6971    make[2]: *** [src/sibyll/CMakeFiles/Sibyll.dir/sibyll_epos.f.o] Error 1
```