### PR TITLE
Fix prefix in Makefile for QTLTools.

### DIFF
--- a/var/spack/repos/builtin/packages/qtltools/package.py
+++ b/var/spack/repos/builtin/packages/qtltools/package.py
@@ -28,3 +28,4 @@ class Qtltools(MakefilePackage):
         makefile.filter("RMATH_LIB=.*", "RMATH_LIB=" + self.spec["r"].prefix.rlib)
         makefile.filter("HTSLD_INC=.*", "HTSLD_INC=" + self.spec["htslib"].prefix.include)
         makefile.filter("HTSLD_LIB=.*", "HTSLD_LIB=" + self.spec["htslib"].prefix.lib)
+        makefile.filter("prefix *=.*", "prefix = " + prefix)


### PR DESCRIPTION
The default prefix for QTLTools is not correct in the generated Makefile. This PR fixes it.