### PR TITLE
Move type hint to satisfy Python 3.6, 3.7 interpreters

### DIFF
--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -37,8 +37,8 @@ class WindowsOs(OperatingSystem):
             extra_args = {}
             if sys.version_info[:3] >= (3, 6, 0):
                 extra_args = {"encoding": "mbcs", "errors": "strict"}
-            paths = subprocess.check_output(
-                [  # type: ignore[call-overload] # novermin
+            paths = subprocess.check_output(  # type: ignore[call-overload] # novermin
+                [
                     os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
                     "-prerelease",
                     "-requires",


### PR DESCRIPTION
When checking style with `spack style -t mypy` under Python 3.6 or
Python 3.7, the type hint for `subprocess.check_output()` is not honored
in its current location.

This PR moves that hint so that it is honored by these interpreters
without breaking behavior for other Python versions.
