### PR TITLE
Refactor `cmd/install.py` for better readability

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -332,30 +332,39 @@ def install_specs(cli_args, kwargs, specs):
         raise
 
 
-def install(parser, args, **kwargs):
-    # TODO: unify args.verbose?
-    tty.set_verbose(args.verbose or args.install_verbose)
-
-    if args.help_cdash:
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            epilog=textwrap.dedent(
-                """\
+def _print_cdash_help():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
 environment variables:
-  SPACK_CDASH_AUTH_TOKEN
-                        authentication token to present to CDash
-                        """
-            ),
-        )
-        arguments.add_cdash_args(parser, True)
-        parser.print_help()
-        return
+SPACK_CDASH_AUTH_TOKEN
+                    authentication token to present to CDash
+                    """
+        ),
+    )
+    arguments.add_cdash_args(parser, True)
+    parser.print_help()
 
+
+def _create_log_reporter(args):
     reporter = spack.report.collect_info(
         spack.package_base.PackageInstaller, "_install_task", args.log_format, args
     )
     if args.log_file:
         reporter.filename = args.log_file
+    return reporter
+
+
+def install(parser, args, **kwargs):
+    # TODO: unify args.verbose?
+    tty.set_verbose(args.verbose or args.install_verbose)
+
+    if args.help_cdash:
+        _print_cdash_help()
+        return
+
+    reporter = _create_log_reporter(args)
 
     def get_tests(specs):
         if args.test == "all":

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -261,20 +261,16 @@ def install_specs_inside_environment(specs, install_kwargs, cli_args):
         # the matches.  Getting to this point means there were either
         # no matches or exactly one match.
 
-        if not m_spec:
-            tty.debug("{0} matched nothing in the env".format(abstract.name))
-            # no matches in the env
-            if cli_args.no_add:
-                msg = (
-                    "You asked to install {0} without adding it "
-                    + "(--no-add), but no such spec exists in "
-                    + "environment"
-                ).format(abstract.name)
-                tty.die(msg)
-            else:
-                tty.debug("adding {0} as a root".format(abstract.name))
-                specs_to_add.append((abstract, concrete))
+        if not m_spec and cli_args.no_add:
+            msg = (
+                "You asked to install {0} without adding it (--no-add), but no such spec "
+                "exists in environment"
+            ).format(abstract.name)
+            tty.die(msg)
 
+        if not m_spec:
+            tty.debug("adding {0} as a root".format(abstract.name))
+            specs_to_add.append((abstract, concrete))
             continue
 
         tty.debug("exactly one match for {0} in env -> {1}".format(m_spec.name, m_spec.dag_hash()))

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -28,7 +28,9 @@ level = "short"
 
 
 def install_kwargs_from_args(args):
-    """Translate command line arguments into a dictionary that will be passed to the package installer."""
+    """Translate command line arguments into a dictionary that will be passed
+    to the package installer.
+    """
     result = {
         "fail_fast": args.fail_fast,
         "keep_prefix": args.keep_prefix,
@@ -352,7 +354,15 @@ def _create_log_reporter(args):
 
 
 def install_from_active_environment(install_kwargs, only_concrete, cli_test_arg, reporter):
-    """Install specs from the active environment"""
+    """Install specs from the active environment
+
+    Args:
+        install_kwargs (dict): dictionary of options to be passed to the installer
+        only_concrete (bool): if true don't concretize the environment, but install
+            only the specs that are already concrete
+        cli_test_arg (bool or str): command line argument to select which test to run
+        reporter: reporter object for the installations
+    """
     env = ev.active_environment()
     if not env:
         msg = "install requires a package argument or active environment"
@@ -379,18 +389,18 @@ def install_from_active_environment(install_kwargs, only_concrete, cli_test_arg,
             env.write(regenerate=False)
 
     specs = env.all_specs()
-    if specs:
-        if not reporter.filename:
-            reporter.filename = default_log_file(specs[0])
-        reporter.specs = specs
-
-        tty.msg("Installing environment {0}".format(env.name))
-        with reporter("build"):
-            env.install_all(**install_kwargs)
-
-    else:
+    if not specs:
         msg = "{0} environment has no specs to install".format(env.name)
         tty.msg(msg)
+        return
+
+    if not reporter.filename:
+        reporter.filename = default_log_file(specs[0])
+    reporter.specs = specs
+
+    tty.msg("Installing environment {0}".format(env.name))
+    with reporter("build"):
+        env.install_all(**install_kwargs)
 
     tty.debug("Regenerating environment views for {0}".format(env.name))
     with env.write_transaction():

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -15,10 +15,14 @@ import llnl.util.tty as tty
 import spack.build_environment
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.config
 import spack.environment as ev
 import spack.fetch_strategy
+import spack.package_base
 import spack.paths
 import spack.report
+import spack.spec
+import spack.store
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 
@@ -209,8 +213,7 @@ packages. If neither are chosen, don't run tests for any packages.""",
     )
     arguments.add_cdash_args(subparser, False)
     arguments.add_common_arguments(subparser, ["yes_to_all", "spec"])
-
-    spack.cmd.common.arguments.add_concretizer_args(subparser)
+    arguments.add_concretizer_args(subparser)
 
 
 def default_log_file(spec):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -43,7 +43,7 @@ def install_kwargs_from_args(args):
         "use_cache": args.use_cache,
         "cache_only": args.cache_only,
         "include_build_deps": args.include_build_deps,
-        "explicit": True,  # Always true for install command
+        "explicit": True,  # Use true as a default for install command
         "stop_at": args.until,
         "unsigned": args.unsigned,
         "install_deps": ("dependencies" in args.things_to_install),


### PR DESCRIPTION
Modifications:
- [x] Split long functions into multiple logical units
- [x] Renamed a few variables to better convey their properties (e.g. `specs` -> `concrete_specs`)
- [x] Removed dead code 