### PR TITLE
Construct flake8 excludes for all packages in defined repos

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -14,6 +14,8 @@ import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 
+import spack.bootstrap
+import spack.config
 import spack.paths
 import spack.repo
 import spack.util.git
@@ -218,6 +220,10 @@ def cwd_relative(path, root, initial_working_dir):
     return os.path.relpath(os.path.join(root, path), initial_working_dir)
 
 
+def prefix_relative(path, args):
+    return os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root)
+
+
 def rewrite_and_print_output(
     output, args, re_obj=re.compile(r"^(.+):([0-9]+):"), replacement=r"{0}:{1}:"
 ):
@@ -270,12 +276,14 @@ def print_tool_result(tool, returncode):
 def run_flake8(flake8_cmd, file_list, args):
     returncode = 0
     output = ""
+
     # run in chunks of 100 at a time to avoid line length limit
     # filename parameter in config *does not work* for this reliably
     for chunk in grouper(file_list, 100):
         output = flake8_cmd(
             # always run with config from running spack prefix
             "--config=%s" % os.path.join(spack.paths.prefix, ".flake8"),
+            *excludes_for_repos(args),
             *chunk,
             fail_on_error=False,
             output=str,
@@ -722,13 +730,7 @@ def style(parser, args):
     if not os.path.exists(spack_script):
         tty.die("This does not look like a valid spack root.", "No such file: '%s'" % spack_script)
 
-    file_list = args.files
-    if file_list:
-
-        def prefix_relative(path):
-            return os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root)
-
-        file_list = [prefix_relative(p) for p in file_list]
+    file_list = [prefix_relative(p, args) for p in args.files]
 
     # process --tool and --skip arguments
     selected = set(tool_names)
@@ -762,3 +764,37 @@ def style(parser, args):
         tty.error(color.colorize("@*{spack style found errors}"))
 
     return return_code
+
+
+def repos():
+    roots = spack.config.get("repos")
+    repos = []
+    for r in roots:
+        try:
+            repos.append(spack.repo.Repo(r))
+        except spack.repo.RepoError:
+            continue
+
+    return repos
+
+
+_repos = repos()
+
+_excludes = ["F403", "F405", "F821"]
+
+
+def excludes_for_repos(args):
+    """Construct a flake8 command-line argument with more lenient rule
+    exclusions for all packages in known repos."""
+
+    excludes_string = ",".join(_excludes)
+    ignore_args = []
+    per_file_ignores = [
+        "{path}:{excludes}".format(path=path, excludes=excludes_string)
+        for path in [
+            "%s/packages/*/package.py" % prefix_relative(repo.root, args) for repo in _repos
+        ]
+    ]
+    if len(per_file_ignores):
+        ignore_args.append("--per-file-ignores=%s" % " ".join(per_file_ignores))
+    return ignore_args


### PR DESCRIPTION
Construct a --per-file-ignores command line option for flake8 with more
lenient exclusions for packages in each defined repo.

This PR does not cause flake8 (or any other style tool) actually to
check repos not in the prefix tree, but it will apply the usual lenient
exclusions if any packages are checked as a result of non-option
arguments on the `spack style` command line.

This can be added to this PR if desired.

Notes:

1. The command line option overrides any `per-file-ignores` entry in the
   `spack/.flake8` configuration file.
1. We currently use a hardwired list of exclusions in `style.py`. This
   can be stored in a separate file, or pulled from the main
   `per-file-ignores` entry in `spack/.flake8` if preferred.
