### PR TITLE
Fix installations with system Python on Ubuntu/Fedora

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -222,6 +222,15 @@ class PythonPackage(PackageBase):
         with working_dir(self.build_directory):
             pip(*args)
 
+        # NOTE: Debian, and some other distros, inject `local` into the path in
+        # sysconfig, newer versions of pip apply this to the prefix path as well as the
+        # system path.  This works around it in a way that will let us largely ignore
+        # it.  See: https://github.com/spack/spack/pull/31939
+        local_path = os.path.join(prefix, "local")
+        if os.path.isdir(local_path) and not os.path.isdir(os.path.join(prefix, "lib")):
+            for p in os.listdir(local_path):
+                os.symlink(os.path.join(local_path, p), os.path.join(prefix, p))
+
     @property
     def headers(self):
         """Discover header files in platlib."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -227,7 +227,7 @@ class PythonPackage(PackageBase):
         # system path.  This works around it in a way that will let us largely ignore
         # it.  See: https://github.com/spack/spack/pull/31939
         local_path = os.path.join(prefix, "local")
-        if os.path.isdir(local_path) and not os.path.isdir(os.path.join(prefix, "lib")):
+        if os.path.isdir(local_path):
             for p in os.listdir(local_path):
                 os.symlink(os.path.join(local_path, p), os.path.join(prefix, p))
 

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -39,6 +39,8 @@ class PyDocutils(PythonPackage):
     @run_after("install")
     def post_install(self):
         bin_path = self.prefix.bin
+        if not os.path.exists(bin_path):
+            return
         for file in os.listdir(bin_path):
             if file.endswith(".py"):
                 os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -39,8 +39,6 @@ class PyDocutils(PythonPackage):
     @run_after("install")
     def post_install(self):
         bin_path = self.prefix.bin
-        if not os.path.exists(bin_path):
-            return
         for file in os.listdir(bin_path):
             if file.endswith(".py"):
                 os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -93,6 +93,15 @@ class PyPip(Package):
         args = [os.path.join(whl, "pip")] + std_pip_args + ["--prefix=" + prefix, whl]
         python(*args)
 
+        # NOTE: Debian, and some other distros, inject `local` into the path in
+        # sysconfig, newer versions of pip (and pip's installer) apply this to the
+        # prefix path as well as the system path.  This works around it in a way that
+        # will let us largely ignore it.  See: https://github.com/spack/spack/pull/31939
+        local_path = os.path.join(prefix, "local")
+        if os.path.isdir(local_path) and not os.path.isdir(os.path.join(prefix, "lib")):
+            for p in os.listdir(local_path):
+                os.symlink(os.path.join(local_path, p), os.path.join(prefix, p))
+
     def setup_dependent_package(self, module, dependent_spec):
         pip = self.spec["python"].command
         pip.add_default_arg("-m")

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -98,7 +98,7 @@ class PyPip(Package):
         # prefix path as well as the system path.  This works around it in a way that
         # will let us largely ignore it.  See: https://github.com/spack/spack/pull/31939
         local_path = os.path.join(prefix, "local")
-        if os.path.isdir(local_path) and not os.path.isdir(os.path.join(prefix, "lib")):
+        if os.path.isdir(local_path):
             for p in os.listdir(local_path):
                 os.symlink(os.path.join(local_path, p), os.path.join(prefix, p))
 


### PR DESCRIPTION
If docutils doesn't have a bin, then don't try to iterate over files in it.