### PR TITLE
Enforcing ncurses with 'ABI=5' as dependency for ARM HPC Compiler 22.0.1 on Rocky Linux 8.6

### DIFF
--- a/var/spack/repos/builtin/packages/arm/package.py
+++ b/var/spack/repos/builtin/packages/arm/package.py
@@ -78,7 +78,7 @@ class Arm(Package):
     conflicts("target=x86_64:", msg="Only available on Aarch64")
     conflicts("target=ppc64:", msg="Only available on Aarch64")
     conflicts("target=ppc64le:", msg="Only available on Aarch64")
-    depends_on('ncurses abi=5')
+    depends_on("ncurses abi=5")
     executables = [r"armclang", r"armclang\+\+", r"armflang"]
 
     # Licensing - Not required from 22.0.1 on.

--- a/var/spack/repos/builtin/packages/arm/package.py
+++ b/var/spack/repos/builtin/packages/arm/package.py
@@ -78,7 +78,9 @@ class Arm(Package):
     conflicts("target=x86_64:", msg="Only available on Aarch64")
     conflicts("target=ppc64:", msg="Only available on Aarch64")
     conflicts("target=ppc64le:", msg="Only available on Aarch64")
-
+    
+    depends_on('ncurses abi=5')
+    
     executables = [r"armclang", r"armclang\+\+", r"armflang"]
 
     # Licensing - Not required from 22.0.1 on.
@@ -149,3 +151,5 @@ class Arm(Package):
         env.prepend_path("CPATH", join_path(arm_dir, "include"))
         env.prepend_path("MANPATH", join_path(arm_dir, "share", "man"))
         env.prepend_path("ARM_LICENSE_DIR", join_path(self.prefix, "licences"))
+        if "ncurses" in self.dependencies:
+            env.prepend_path("LD_LIBRARY_PATH", join_path(self.spec["ncurses"].prefix, "lib"))

--- a/var/spack/repos/builtin/packages/arm/package.py
+++ b/var/spack/repos/builtin/packages/arm/package.py
@@ -78,9 +78,7 @@ class Arm(Package):
     conflicts("target=x86_64:", msg="Only available on Aarch64")
     conflicts("target=ppc64:", msg="Only available on Aarch64")
     conflicts("target=ppc64le:", msg="Only available on Aarch64")
-
     depends_on('ncurses abi=5')
- 
     executables = [r"armclang", r"armclang\+\+", r"armflang"]
 
     # Licensing - Not required from 22.0.1 on.

--- a/var/spack/repos/builtin/packages/arm/package.py
+++ b/var/spack/repos/builtin/packages/arm/package.py
@@ -151,5 +151,5 @@ class Arm(Package):
         env.prepend_path("CPATH", join_path(arm_dir, "include"))
         env.prepend_path("MANPATH", join_path(arm_dir, "share", "man"))
         env.prepend_path("ARM_LICENSE_DIR", join_path(self.prefix, "licences"))
-        if "ncurses" in self.dependencies:
+        if "ncurses" in self.spec:
             env.prepend_path("LD_LIBRARY_PATH", join_path(self.spec["ncurses"].prefix, "lib"))

--- a/var/spack/repos/builtin/packages/arm/package.py
+++ b/var/spack/repos/builtin/packages/arm/package.py
@@ -78,9 +78,9 @@ class Arm(Package):
     conflicts("target=x86_64:", msg="Only available on Aarch64")
     conflicts("target=ppc64:", msg="Only available on Aarch64")
     conflicts("target=ppc64le:", msg="Only available on Aarch64")
-    
+
     depends_on('ncurses abi=5')
-    
+ 
     executables = [r"armclang", r"armclang\+\+", r"armflang"]
 
     # Licensing - Not required from 22.0.1 on.


### PR DESCRIPTION
Deploying ARM HPC Compiler 22.0.1 on Rocky Linux release 8.6 was successful but unable to use the compiler due to a missing library `libtinfo.so.5`. 

Solved by enforcing new ncurses with `abi=5` variant. It may be redundant for other OSes.

Suggestions how to improve this are welcome.