### PR TITLE
LLVM: add @15.0.0-rc1

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -36,7 +36,8 @@ class Llvm(CMakePackage, CudaPackage):
 
     # fmt: off
     version('main', branch='main')
-    version('14.0.6', sha256='98f15f842700bdb7220a166c8d2739a03a72e775b67031205078f39dd756a055')
+    version('15.0.0-rc1', sha256='b026a1b32ba0dc5612da36f14977c7e9fb910d545251a26dcfefca85d94139e4')
+    version('14.0.6', sha256='98f15f842700bdb7220a166c8d2739a03a72e775b67031205078f39dd756a055', preferred=True)
     version('14.0.5', sha256='a4a57f029cb81f04618e05853f05fc2d21b64353c760977d8e7799bf7218a23a')
     version('14.0.4', sha256='1333236f9bee38658762076be4236cb5ebf15ae9b7f2bfce6946b96ae962dc73')
     version('14.0.3', sha256='0e1d049b050127ecf6286107e9a4400b0550f841d5d2288b9d31fd32ed0683d5')


### PR DESCRIPTION
Add llvm@15.0.0-rc1
It's an important version for the M1 mac.
Clang 15 (llvm@15.0.0) started to support `-march=native` for Apple M1.

ref: [why-does-march-native-not-work-on-apple-m1](https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1)