### PR TITLE
Add netcdf-c 4.9.0 and netcdf-fortran 4.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -20,6 +20,7 @@ class NetcdfC(AutotoolsPackage):
     maintainers = ["skosukhin", "WardF"]
 
     version("main", branch="main")
+    version("4.9.0", sha256="9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6")
     version("4.8.1", sha256="bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0")
     version("4.8.0", sha256="aff58f02b1c3e91dc68f989746f652fe51ff39e6270764e484920cb8db5ad092")
     version("4.7.4", sha256="99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b")
@@ -65,7 +66,7 @@ class NetcdfC(AutotoolsPackage):
     patch("4.7.3-spectrum-mpi-pnetcdf-detect.patch", when="@4.7.3:4.7.4 +parallel-netcdf")
 
     # See https://github.com/Unidata/netcdf-c/pull/2293
-    patch("4.8.1-no-strict-aliasing-config.patch", when="@4.8.1:")
+    patch("4.8.1-no-strict-aliasing-config.patch", when="@4.8.1")
 
     variant("mpi", default=True, description="Enable parallel I/O for netcdf-4")
     variant("parallel-netcdf", default=False, description="Enable parallel I/O for classic files")
@@ -75,6 +76,7 @@ class NetcdfC(AutotoolsPackage):
     variant("dap", default=False, description="Enable DAP support")
     variant("jna", default=False, description="Enable JNA support")
     variant("fsync", default=False, description="Enable fsync support")
+    variant("zstd", default=False, description="Enable ZStandard compression", when="@4.9.0:")
 
     # It's unclear if cdmremote can be enabled if '--enable-netcdf-4' is passed
     # to the configure script. Since netcdf-4 support is mandatory we comment
@@ -122,6 +124,8 @@ class NetcdfC(AutotoolsPackage):
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250
     depends_on("hdf5@:1.8", when="@:4.4.0")
+
+    depends_on("zstd", when="@4.9.0:")
 
     # The feature was introduced in version 4.1.2
     # and was removed in version 4.4.0
@@ -234,6 +238,16 @@ class NetcdfC(AutotoolsPackage):
             if "+external-xdr" in hdf4 and hdf4["rpc"].name != "libc":
                 libs.append(hdf4["rpc"].libs.link_flags)
 
+        if "+zstd" in self.spec:
+            zstd = self.spec["zstd"]
+            cppflags.append(zstd.headers.cpp_flags)
+            ldflags.append(zstd.libs.search_flags)
+            config_args.append("--with-plugin-dir={}".format(self.prefix.plugins))
+        elif "~zstd" in self.spec:
+            # Prevent linking to system zstd.
+            # There is no explicit option to disable zstd.
+            config_args.append("ac_cv_lib_zstd_ZSTD_compress=no")
+
         # Fortran support
         # In version 4.2+, NetCDF-C and NetCDF-Fortran have split.
         # Use the netcdf-fortran package to install Fortran support.
@@ -244,6 +258,13 @@ class NetcdfC(AutotoolsPackage):
         config_args.append("LIBS=" + " ".join(libs))
 
         return config_args
+
+    def setup_run_environment(self, env):
+        if "+zstd" in self.spec:
+            env.append_path("HDF5_PLUGIN_PATH", self.prefix.plugins)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
 
     def check(self):
         # h5_test fails when run in parallel

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -125,7 +125,7 @@ class NetcdfC(AutotoolsPackage):
     # https://github.com/Unidata/netcdf-c/issues/250
     depends_on("hdf5@:1.8", when="@:4.4.0")
 
-    depends_on("zstd", when="@4.9.0:")
+    depends_on("zstd", when="+zstd")
 
     # The feature was introduced in version 4.1.2
     # and was removed in version 4.4.0

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -21,6 +21,7 @@ class NetcdfFortran(AutotoolsPackage):
 
     maintainers = ["skosukhin", "WardF"]
 
+    version("4.6.0", sha256="198bff6534cc85a121adc9e12f1c4bc53406c403bda331775a1291509e7b2f23")
     version("4.5.4", sha256="0a19b26a2b6e29fab5d29d7d7e08c24e87712d09a5cafeea90e16e0a2ab86b81")
     version("4.5.3", sha256="123a5c6184336891e62cf2936b9f2d1c54e8dee299cfd9d2c1a1eb05dd668a74")
     version("4.5.2", sha256="b959937d7d9045184e9d2040a915d94a7f4d0185f4a9dceb8f08c94b0c3304aa")


### PR DESCRIPTION
With v4.9.0 netcdf-c introduces zstandard compression option which is added as a variant.

@edwardhartnett @climbfuji FYI