### PR TITLE
flux packages used in a spack view will already be unshallow

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -131,6 +131,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("jansson@2.10:", when="@0.21.0:")
     depends_on("pkgconfig")
     depends_on("lz4")
+    depends_on("sqlite")
 
     depends_on("asciidoc", type="build", when="+docs")
     depends_on("py-docutils", type="build", when="@0.32.0:")
@@ -177,10 +178,10 @@ class FluxCore(AutotoolsPackage):
             # When using spack develop, this will already be unshallow
             try:
                 git("fetch", "--unshallow")
+                git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                git("fetch", "origin")
             except spack.util.executable.ProcessError:
                 git("fetch")
-            git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
-            git("fetch", "origin")
 
     def autoreconf(self, spec, prefix):
         self.setup()

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.util.executable
 from spack.package import *
 
 
@@ -173,7 +174,11 @@ class FluxCore(AutotoolsPackage):
         with working_dir(self.stage.source_path):
             # Allow git-describe to get last tag so flux-version works:
             git = which("git")
-            git("fetch", "--unshallow")
+            # When using spack develop, this will already be unshallow
+            try:
+                git("fetch", "--unshallow")
+            except spack.util.executable.ProcessError:
+                git("fetch")
             git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
             git("fetch", "origin")
 

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -111,10 +111,10 @@ class FluxSched(AutotoolsPackage):
             # When using spack develop, this will already be unshallow
             try:
                 git("fetch", "--unshallow")
+                git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                git("fetch", "origin")
             except spack.util.executable.ProcessError:
                 git("fetch")
-            git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
-            git("fetch", "origin")
 
     def autoreconf(self, spec, prefix):
         self.setup()

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.util.executable
 from spack.package import *
 
 
@@ -107,7 +108,11 @@ class FluxSched(AutotoolsPackage):
         with working_dir(self.stage.source_path):
             # Allow git-describe to get last tag so flux-version works:
             git = which("git")
-            git("fetch", "--unshallow")
+            # When using spack develop, this will already be unshallow
+            try:
+                git("fetch", "--unshallow")
+            except spack.util.executable.ProcessError:
+                git("fetch")
             git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
             git("fetch", "origin")
 


### PR DESCRIPTION
And this particular command will error and break the entire build. Instead we want to catch the ProcessError and allow for a regular fetch.

cc @trws 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>