### PR TITLE
copy view does not work because tries to copy directories

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -68,7 +68,7 @@ def view_copy(src, dst, view, spec=None):
     Use spec and view to generate relocations
     """
     if os.path.isdir(src):
-        shutil.copytree(src, dst)
+        shutil.copytree(src, dst, symlink=True)
     else:
         shutil.copy2(src, dst)
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -67,7 +67,11 @@ def view_copy(src, dst, view, spec=None):
 
     Use spec and view to generate relocations
     """
-    shutil.copy2(src, dst)
+    if os.path.isdir(src):
+        shutil.copytree(src, dst)
+    else:
+        shutil.copy2(src, dst)
+
     if spec and not spec.external:
         # Not metadata, we have to relocate it
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -775,6 +775,9 @@ def relocate_text(files, prefixes, concurrency=32):
 
     args = []
     for filename in files:
+        # Passing a directory to _replace_prefix_text will still throw error
+        if os.path.isdir(filename):
+            continue
         args.append((filename, compiled_prefixes))
 
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -776,7 +776,7 @@ def relocate_text(files, prefixes, concurrency=32):
     args = []
     for filename in files:
         # Passing a directory to _replace_prefix_text will still throw error
-        if os.path.isdir(filename):
+        if os.path.isdir(filename) and os.path.islink(filename):
             continue
         args.append((filename, compiled_prefixes))
 


### PR DESCRIPTION
This fix ensures that we do a check to not read a directory as a binary file, and use shutil.copytree to copy a directory in full. The flux install to a view was broken (working on locally) and these two fixes resolved it (at least to finish the install / create the view).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>