### PR TITLE
Update PyTorch ecosystem

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -24,6 +24,7 @@ class PyTorch(PythonPackage, CudaPackage):
     import_modules = ["torch", "torch.autograd", "torch.nn", "torch.utils"]
 
     version("master", branch="master", submodules=True)
+    version("1.12.1", tag="v1.12.1", submodules=True)
     version("1.12.0", tag="v1.12.0", submodules=True)
     version("1.11.0", tag="v1.11.0", submodules=True)
     version("1.10.2", tag="v1.10.2", submodules=True)

--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -16,14 +16,16 @@ class PyTorchdata(PythonPackage):
     maintainers = ["adamjstewart"]
 
     version("main", branch="main")
+    version("0.4.1", sha256="71c0aa3aca3b04a986a2cd4cc2e0be114984ca836dc4def2c700bf1bd1ff087e")
     version("0.4.0", sha256="b4ec446a701680faa620fcb828b98ba36a63fa79da62a1e568d4a683889172da")
     version("0.3.0", sha256="ac36188bf133cf5f1041a28ccb3ee82ba52d4b5d99617be37d64d740acd6cfd4")
 
     # https://github.com/pytorch/data#version-compatibility
     depends_on("python@3.7:3.10", type=("build", "run"))
     depends_on("py-torch@master", when="@main", type=("build", "run"))
-    depends_on("py-torch@1.12", when="@0.4", type=("build", "run"))
-    depends_on("py-torch@1.11", when="@0.3", type=("build", "run"))
+    depends_on("py-torch@1.12.1", when="@0.4.1", type=("build", "run"))
+    depends_on("py-torch@1.12.0", when="@0.4.0", type=("build", "run"))
+    depends_on("py-torch@1.11.0", when="@0.3.0", type=("build", "run"))
 
     # requirements.txt
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -18,6 +18,7 @@ class PyTorchvision(PythonPackage):
     maintainers = ["adamjstewart"]
 
     version("main", branch="main")
+    version("0.13.1", sha256="c32fab734e62c7744dadeb82f7510ff58cc3bca1189d17b16aa99b08afc42249")
     version("0.13.0", sha256="2fe9139150800820d02c867a0b64b7c7fbc964d48d76fae235d6ef9215eabcf4")
     version("0.12.0", sha256="99e6d3d304184895ff4f6152e2d2ec1cbec89b3e057d9c940ae0125546b04e91")
     version("0.11.3", sha256="b4c51d27589783e6e6941ecaa67b55f6f41633874ec37f80b64a0c92c3196e0c")
@@ -67,6 +68,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@1.12.1", when="@0.13.1", type=("build", "link", "run"))
     depends_on("py-torch@1.12.0", when="@0.13.0", type=("build", "link", "run"))
     depends_on("py-torch@1.11.0", when="@0.12.0", type=("build", "link", "run"))
     depends_on("py-torch@1.10.2", when="@0.11.3", type=("build", "link", "run"))


### PR DESCRIPTION
Successfully builds on macOS 12.5 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/pytorch/pytorch/releases/tag/v1.12.1
https://github.com/pytorch/vision/releases/tag/v0.13.1
https://github.com/pytorch/data/releases/tag/v0.4.1