### PR TITLE
gitlab ci: Fix broken SPACK_CHECKOUT_VERSION

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1327,7 +1327,10 @@ def generate_gitlab_ci_yaml(
         if v_match:
             version_to_clone = "v{0}".format(v_match.group(0))
         else:
-            v_match = re.match(r"^[^-]+-[^-]+-([a-f\d]+)$", spack_version)
+            # spack_version returns something like:
+            #     0.18.1.dev0 (<git-commit-sha>)
+            # So capture anything within the parens at the end of the line
+            v_match = re.search(r"\(([^\)]+)\)$", spack_version)
             if v_match:
                 version_to_clone = v_match.group(1)
             else:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1292,7 +1292,7 @@ spack:
         outputfile = str(tmpdir.join(".gitlab-ci.yml"))
 
         with ev.read("test"):
-            monkeypatch.setattr(spack.main, "get_version", lambda: "0.15.3-416-12ad69eb1")
+            monkeypatch.setattr(spack.main, "get_version", lambda: "0.19.0.dev0 (blah)")
             ci_cmd("generate", "--output-file", outputfile)
 
         with open(outputfile) as f:
@@ -1302,9 +1302,9 @@ spack:
             assert "variables" in yaml_contents
             global_vars = yaml_contents["variables"]
             assert "SPACK_VERSION" in global_vars
-            assert global_vars["SPACK_VERSION"] == "0.15.3-416-12ad69eb1"
+            assert global_vars["SPACK_VERSION"] == "0.19.0.dev0 (blah)"
             assert "SPACK_CHECKOUT_VERSION" in global_vars
-            assert global_vars["SPACK_CHECKOUT_VERSION"] == "12ad69eb1"
+            assert global_vars["SPACK_CHECKOUT_VERSION"] == "blah"
 
             for ci_key in yaml_contents.keys():
                 if "(specs) b" in ci_key:


### PR DESCRIPTION
fixes #31952

The generated `.gitlab-ci.yml` contains a variable `SPACK_CHECKOUT_VERSION` that generated child jobs should be able to use  to checkout the version of spack that generated the pipeline.  Since the value returned by `spack.main.get_version()` looks like `0.18.1.dev0 (<git-commit-sha>)` these days, this PR updates the way the commit sha is extracted accordingly.