### PR TITLE
e4s oneapi ci: unify when possible

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: false
+    unify: when_possible
 
   config:
     concretizer: clingo


### PR DESCRIPTION
Unify the E4S OneAPI stack when possible. 

FYI @wspear