### PR TITLE
gxsview: gcc11 compilation rule for std::numeric_limits

### DIFF
--- a/var/spack/repos/builtin/packages/gxsview/gcc11.patch
+++ b/var/spack/repos/builtin/packages/gxsview/gcc11.patch
@@ -1,0 +1,9 @@
+--- a/core/fielddata/fieldcolordata.hpp
++++ b/core/fielddata/fieldcolordata.hpp
+@@ -16,6 +16,7 @@
+ #include <string>
+ #include <utility>
+ #include <numeric>
++#include <limits>
+
+ namespace fd{

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -29,7 +29,7 @@ class Gxsview(QMakePackage):
 
     patch("vtk9.patch", when="^vtk@9:")
     # gcc11 compilation rule for std::numeric_limits,
-    # avoid ‘numeric_limits’ is not a member of ‘std’
+    # avoid "numeric_limits" is not a member of "std"
     patch("gcc11.patch", when="@2021.07.01 %gcc@11:")
 
     build_directory = "gui"

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -26,9 +26,10 @@ class Gxsview(QMakePackage):
     depends_on("qt@5.14.0:+opengl+gui")
     depends_on("vtk@8.0:+qt+opengl2")  # +mpi+python are optional
     conflicts("%gcc@:7.2.0", msg="Requires C++17 compiler support")  # need C++17 standard
-    patch("gcc11.patch", when="@2021.07.01 %gcc@11:")
 
     patch("vtk9.patch", when="^vtk@9:")
+    # gcc11 compilation rule for std::numeric_limits, avoid ‘numeric_limits’ is not a member of ‘std’
+    patch("gcc11.patch", when="@2021.07.01 %gcc@11:")
 
     build_directory = "gui"
 

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -26,6 +26,7 @@ class Gxsview(QMakePackage):
     depends_on("qt@5.14.0:+opengl+gui")
     depends_on("vtk@8.0:+qt+opengl2")  # +mpi+python are optional
     conflicts("%gcc@:7.2.0", msg="Requires C++17 compiler support")  # need C++17 standard
+    patch("gcc11.patch", when="@2021.07.01 %gcc@11:")
 
     patch("vtk9.patch", when="^vtk@9:")
 

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -28,7 +28,8 @@ class Gxsview(QMakePackage):
     conflicts("%gcc@:7.2.0", msg="Requires C++17 compiler support")  # need C++17 standard
 
     patch("vtk9.patch", when="^vtk@9:")
-    # gcc11 compilation rule for std::numeric_limits, avoid ‘numeric_limits’ is not a member of ‘std’
+    # gcc11 compilation rule for std::numeric_limits,
+    # avoid ‘numeric_limits’ is not a member of ‘std’
     patch("gcc11.patch", when="@2021.07.01 %gcc@11:")
 
     build_directory = "gui"


### PR DESCRIPTION
When compiling with GNU gcc 11, typically with spack:

$ spack install gxsview %gcc@11.2.0 ^vtk@9.0.3


I get the following error
```
     183    In file included from ../core/fielddata/fieldcolordata.cpp:12:
  >> 184    ../core/fielddata/fieldcolordata.hpp:35:53: error: 'numeric_limits' is not a member of 'std'
     185       35 |     static constexpr double SMALL_FIELD_DATA = std::numeric_limits<double>::min()*10;
     186 | ^~~~~~~~~~~~~~

```

From what I read in
https://stackoverflow.com/questions/71296302/numeric-limits-is-not-a-member-of-std
it seems that putting
`#include <limits>`
in file `core/fielddata/fieldcolordata.cpp` corrects the issue.

This is the aim of the provided patch.