### PR TITLE
perl-cgi: adding version 4.54

### DIFF
--- a/var/spack/repos/builtin/packages/perl-cgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi/package.py
@@ -15,6 +15,8 @@ class PerlCgi(PerlPackage):
     homepage = "https://metacpan.org/pod/CGI"
     url = "https://cpan.metacpan.org/authors/id/L/LE/LEEJO/CGI-4.40.tar.gz"
 
+    maintainers = ['cessenat']
+
     version("4.54", sha256="9608a044ae2e87cefae8e69b113e3828552ddaba0d596a02f9954c6ac17fa294")
     version("4.53", sha256="c67e732f3c96bcb505405fd944f131fe5c57b46e5d02885c00714c452bf14e60")
     version("4.40", sha256="10efff3061b3c31a33b3cc59f955aef9c88d57d12dbac46389758cef92f24f56")

--- a/var/spack/repos/builtin/packages/perl-cgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi/package.py
@@ -15,7 +15,7 @@ class PerlCgi(PerlPackage):
     homepage = "https://metacpan.org/pod/CGI"
     url = "https://cpan.metacpan.org/authors/id/L/LE/LEEJO/CGI-4.40.tar.gz"
 
-    maintainers = ['cessenat']
+    maintainers = ["cessenat"]
 
     version("4.54", sha256="9608a044ae2e87cefae8e69b113e3828552ddaba0d596a02f9954c6ac17fa294")
     version("4.53", sha256="c67e732f3c96bcb505405fd944f131fe5c57b46e5d02885c00714c452bf14e60")

--- a/var/spack/repos/builtin/packages/perl-cgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi/package.py
@@ -15,6 +15,7 @@ class PerlCgi(PerlPackage):
     homepage = "https://metacpan.org/pod/CGI"
     url = "https://cpan.metacpan.org/authors/id/L/LE/LEEJO/CGI-4.40.tar.gz"
 
+    version("4.54", sha256="9608a044ae2e87cefae8e69b113e3828552ddaba0d596a02f9954c6ac17fa294")
     version("4.53", sha256="c67e732f3c96bcb505405fd944f131fe5c57b46e5d02885c00714c452bf14e60")
     version("4.40", sha256="10efff3061b3c31a33b3cc59f955aef9c88d57d12dbac46389758cef92f24f56")
     version("4.39", sha256="7e73417072445f24e03d63802ed3a9e368c9b103ddc96e2a9bcb6a251215fb76")


### PR DESCRIPTION
From 
https://metacpan.org/dist/CGI/changes
    - fix use of cache when calling ->cookie (GH #252)
    - thanks to Sergey Panteleev for the PR