### PR TITLE
qt: new version 5.15.5

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -31,6 +31,7 @@ class Qt(Package):
 
     phases = ["configure", "build", "install"]
 
+    version("5.15.5", sha256="5a97827bdf9fd515f43bc7651defaf64fecb7a55e051c79b8f80510d0e990f06")
     version("5.15.4", sha256="615ff68d7af8eef3167de1fd15eac1b150e1fd69d1e2f4239e54447e7797253b")
     version("5.15.3", sha256="b7412734698a87f4a0ae20751bab32b1b07fdc351476ad8e35328dbe10efdedb")
     version("5.15.2", sha256="3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240")


### PR DESCRIPTION
Bugfix release, now also available for open source, 1 year after the commercial release.

Full set of changes at https://github.com/qt/qtbase/commit/231d3670981a33ec42b91ad1cb33c1fc50551066, but here are the only ones I can see that may be relevant (we don't require specific versions for these dependencies anyway):
- libjpeg bundled version updated from 2.0.6 to 2.1.0
- pcre bundled version updated from 10.36 to 10.37
- sqlite bundled version updated from 3.35.2 to 3.35.5