### PR TITLE
e4s ci: use ecp-data-vis-sdk instead of individual root specs [don't merge yet]

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -54,25 +54,21 @@ spack:
   specs:
   # CPU
   - adios
-  - adios2
   - alquimia
   - aml
   - amrex
   - arborx
   - archer
   - argobots
-  - ascent
   - axom
   - bolt
   - bricks
   - butterflypack
   - cabana
   - chai ~benchmarks ~tests
-  - conduit
-  - darshan-runtime
-  - darshan-util
   - datatransferkit
   - dyninst
+  - ecp-data-vis-sdk +adios2 +ascent +cinema ~cuda +darshan +faodel +hdf5 +paraview +pnetcdf ~rocm ~sensei +sz +unifyfs+ veloc +visit +vtkm +zfp
   - exaworks
   - faodel
   - flecsi
@@ -84,7 +80,6 @@ spack:
   - globalarrays
   - gmp
   - gptune
-  - hdf5 +fortran +hl +shared
   - hdf5-vol-async
   - heffte +fftw
   - hpctoolkit
@@ -140,7 +135,6 @@ spack:
   - superlu-dist
   - swig
   - swig@4.0.2-fortran
-  - sz
   - tasmanian
   - tau +mpi +python
   - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack
@@ -149,15 +143,11 @@ spack:
     +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
   - turbine
   - umap
-  - umpire
   - upcxx
-  - veloc
-  - vtk-m
   - wannier90
-  - zfp
 
   # CUDA
-  - adios2 +cuda cuda_arch=80
+  - ecp-data-vis-sdk +adios2 +ascent +cinema +cuda +darshan +faodel +hdf5 ~paraview +pnetcdf ~rocm ~sensei +sz +unifyfs +veloc +visit +vtkm +zfp cuda_arch=80
   - arborx +cuda cuda_arch=80 ^kokkos@3.6.00 +wrapper
   - bricks +cuda
   - cabana +cuda ^kokkos@3.6.00 +wrapper +cuda_lambda +cuda cuda_arch=80
@@ -182,13 +172,11 @@ spack:
   - superlu-dist +cuda cuda_arch=80
   - tasmanian +cuda cuda_arch=80
   - tau +mpi +cuda
-  - umpire ~shared +cuda cuda_arch=80
-  - vtk-m +cuda cuda_arch=80
-  - zfp +cuda cuda_arch=80
 
   # ROCm
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
+  - ecp-data-vis-sdk +vtkm +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a


### PR DESCRIPTION
Use `ecp-data-vis-sdk` instead of enumerating the component packages individually.