### PR TITLE
hypre: Homepage changed

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -14,7 +14,9 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     features parallel multigrid methods for both structured and
     unstructured grid problems."""
 
-    homepage = "https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods"
+    homepage = (
+        "https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods"
+    )
     url = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git = "https://github.com/hypre-space/hypre.git"
     tags = ["e4s", "radiuss"]

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -14,7 +14,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     features parallel multigrid methods for both structured and
     unstructured grid problems."""
 
-    homepage = "https://computing.llnl.gov/project/linear_solvers/software.php"
+    homepage = "https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods"
     url = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git = "https://github.com/hypre-space/hypre.git"
     tags = ["e4s", "radiuss"]


### PR DESCRIPTION
It appears https://computing.llnl.gov/project/linear_solvers/software.php is not accessible while
https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods
is fine.
