### PR TITLE
crunch: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/crunch/package.py
+++ b/var/spack/repos/builtin/packages/crunch/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Crunch(CMakePackage):
+    """Advanced DXTc texture compression and transcoding library."""
+
+    homepage = "https://github.com/BinomialLLC/crunch"
+    # Fork with CMake build system
+    git = "https://github.com/rouault/crunch.git"
+
+    # No stable releases since 2012
+    version("master", branch="build_fixes")
+
+    depends_on("cmake@3.5:", type="build")
+
+    conflicts("platform=darwin")

--- a/var/spack/repos/builtin/packages/crunch/package.py
+++ b/var/spack/repos/builtin/packages/crunch/package.py
@@ -10,7 +10,10 @@ class Crunch(CMakePackage):
     """Advanced DXTc texture compression and transcoding library."""
 
     homepage = "https://github.com/BinomialLLC/crunch"
-    # Fork with CMake build system
+    # The original repo does not have any build system or installation instructions. This package
+    # was added primarily as a possible dependency of GDAL. The following fork was created by the
+    # maintainer of GDAL and includes several additional commits to add a CMake build system and
+    # fix compilation bugs. If these commits are ever merged into upstream, we can switch to that.
     git = "https://github.com/rouault/crunch.git"
 
     # No stable releases since 2012

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -222,9 +222,9 @@ class Gdal(CMakePackage):
     depends_on("arrow", when="+arrow")
     depends_on("c-blosc", when="+blosc")
     depends_on("brunsli", when="+brunsli")
-    # depends_on('bsb', when='+bdb')
+    # depends_on('bsb', when='+bsb')
     depends_on("cfitsio", when="+cfitsio")
-    # depends_on('crunch', when='+crnlib')
+    depends_on("crunch", when="+crnlib")
     depends_on("curl", when="+curl")
     depends_on("cryptopp", when="+cryptopp")
     depends_on("libdeflate", when="+deflate")
@@ -355,7 +355,6 @@ class Gdal(CMakePackage):
 
     # TODO: add packages for the following dependencies
     conflicts("+bsb")
-    conflicts("+crnlib")
     conflicts("+dods")
     conflicts("+ecw")
     conflicts("+epsilon")


### PR DESCRIPTION
Successfully builds on Ubuntu 18.04 with GCC 7.5.0. DDS shows up in the list of supported drivers in `gdalinfo --formats`.