### PR TITLE
core: add a helpful long message for UnknownPackageError

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1478,6 +1478,8 @@ class UnknownPackageError(UnknownEntityError):
             if name.endswith(".yaml"):
                 long_msg = "Did you mean to specify a filename with './{0}'?"
                 long_msg = long_msg.format(name)
+            else:
+                long_msg = "You may need to run 'spack clean -m'."
         else:
             msg = "Attempting to retrieve anonymous package."
 


### PR DESCRIPTION
```
Error: Package 'armpl' not found.
```
is pretty useless after an upgrade unless you're a spack pro. I've recently hit this on multiple machines. See
https://github.com/spack/spack/issues/31453 ,
https://github.com/spack/spack/issues/31489  .