### PR TITLE
e4s oneapi ci: try builds that were previously failing due to binutils failure

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -99,6 +99,7 @@ spack:
   - aml
   - amrex
   - arborx
+  - archer
   - argobots
   - axom
   - bolt
@@ -122,6 +123,7 @@ spack:
   - gotcha
   - hdf5 +fortran +hl +shared
   - heffte +fftw
+  - hpctoolkit
   - hypre
   - kokkos-kernels +openmp
   - kokkos +openmp
@@ -144,6 +146,7 @@ spack:
   - papi
   - papyrus
   - parallel-netcdf
+  - paraview +qt
   - parsec ~cuda
   - pdt
   - petsc
@@ -168,6 +171,7 @@ spack:
   - swig@4.0.2-fortran
   - sz
   - tasmanian
+  - tau +mpi +python
   - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
    +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
    +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
@@ -184,12 +188,11 @@ spack:
   # GPU
   - arborx +sycl ^kokkos +sycl +openmp std=17 +tests +examples
   - cabana +sycl ^kokkos+sycl +openmp std=17 +tests +examples
-  - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp std=17 +tests +examples %oneapi
+  - kokkos-kernels build_type=Release ^kokkos +sycl +openmp std=17 +tests +examples
   - kokkos +sycl +openmp std=17 +tests +examples %oneapi
 
   # CPU BUILD FAILURES
   #- adios2@2.8.0                                     # adios2
-  #- archer@2.0.0                                     # binutils
   #- ascent ^vtk-m ~openmp                            # ascent
   #- charliecloud@0.26                                # charliecloud
   #- dyninst@12.1.0                                   # intel-tbb
@@ -197,11 +200,9 @@ spack:
   #- geopm@1.1.0                                      # ruby
   #- gptune@3.0.0                                     # intel-tbb
   #- h5bench@1.2                                      # h5bench
-  #- hpctoolkit@2022.04.15                            # binutils
   #- hpx@1.7.1 networking=mpi                         # boost@1.79.0
   #- nrm@0.1.0                                        # py-numpy@1.23.1
   #- openpmd-api@0.14.4                               # adios2
-  #- paraview@5.10.1 +qt                              # binutils
   #- phist@1.9.5                                      # phist
   #- pruners-ninja@1.0.1                              # pruners-ninja
   #- py-libensemble@0.9.1                             # py-numpy@1.23.1
@@ -209,14 +210,12 @@ spack:
   #- py-warpx@22.05 ^warpx dims=2                     # adios2
   #- py-warpx@22.05 ^warpx dims=3                     # adios2
   #- py-warpx@22.05 ^warpx dims=rz                    # adios2
-  #- tau@2.31 +mpi +python                            # binutils
   #- unifyfs@0.9.2                                    # unifyfs
   #- variorum@0.4.1                                   # variorum
 
   # CPU BUILD FAILURES - NOTES
   # adios2: /usr/bin/ld: ../../lib/libadios2_fortran.so.2.8.2: version node not found for symbol adios2_adios_init_mod@adios2_adios_init_serial_smod._; /usr/bin/ld: failed to set dynamic section sizes: bad value
   # ascent: examples/proxies/cloverleaf3d-ref/clover_main.cpp:24: multiple definition of `main'; /opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin/for_main.o:for_main.c:(.text+0x0): first defined here
-  # binutils: gold/powerpc.cc:3590: undefined reference to `gold::Sized_symbol<64>::Value_type gold::Symbol_table::compute_final_value<64>(gold::Sized_symbol<64> const*, gold::Symbol_table::Compute_final_value_status*) const'
   # boost@1.79.0 cxxstd=17: clang++: error: unsupported argument 'h-create' to option '-pc'; clang++: error: no such file or directory: 'bin.v2/libs/math/build/intel-linux-2022.1.0/release/cxxstd-17-iso/threading-multi/visibility-hidden/pch.pchi'
   # charliecloud: autoreconf phase: RuntimeError: configure script not found in ...
   # flux-sched: include/yaml-cpp/emitter.h:164:9: error: comparison with NaN always evaluates to false in fast floating point modes [-Werror,-Wtautological-constant-compare]
@@ -236,7 +235,7 @@ spack:
   #- ginkgo@1.4.0 +oneapi %dpcpp ^cmake%oneapi                                              # ginkgo
   #- hpctoolkit@2022.04.15 +level_zero                                                      # dyninst
   #- sundials@6.2.0 +sycl cxxstd=17                                                         # sundials
-  #- tau@2.31.1 +mpi +opencl +level_zero ~pdt %oneapi ^binutils%gcc@9.4.0 ^papi%gcc@9.4.0   # tau
+  #- tau +mpi +opencl +level_zero ~pdt %oneapi ^papi%gcc                                    # tau
 
   # GPU BUILD FAILURES - NOTES
   # berkeley-db %dpcpp: dpcpp: dpcpperror: : no such file or directory: '/tmp/conftest-9d8d34.o'


### PR DESCRIPTION
Try building packages that had previously failed due to https://github.com/spack/spack/issues/29382 which may now be resolved.