### PR TITLE
Fix performance regression with `spack mirror create --all`

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -13,7 +13,7 @@ import re
 import sys
 import traceback
 from datetime import datetime, timedelta
-from typing import List, Tuple
+from typing import Any, Callable, Iterable, List, Tuple
 
 import six
 from six import string_types
@@ -977,7 +977,11 @@ def enum(**kwargs):
     return type("Enum", (object,), kwargs)
 
 
-def stable_partition(input_iterable, predicate_fn):
+def stable_partition(
+    input_iterable,  # type: Iterable
+    predicate_fn,  # type: Callable[[Any], bool]
+):
+    # type: (...) -> Tuple[List[Any], List[Any]]
     """Partition the input iterable according to a custom predicate.
 
     Args:

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -981,8 +981,8 @@ def stable_partition(input_iterable, predicate_fn):
     """Partition the input iterable according to a custom predicate.
 
     Args:
-        input_iterable (list of Spec): input iterable to be partitioned.
-        predicate_fn (callable): predicate function accepting an iterable item
+        input_iterable: input iterable to be partitioned.
+        predicate_fn: predicate function accepting an iterable item
             as argument.
 
     Return:

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -977,6 +977,27 @@ def enum(**kwargs):
     return type("Enum", (object,), kwargs)
 
 
+def stable_partition(input_iterable, predicate_fn):
+    """Partition the input iterable according to a custom predicate.
+
+    Args:
+        input_iterable (list of Spec): input iterable to be partitioned.
+        predicate_fn (callable): predicate function accepting an iterable item
+            as argument.
+
+    Return:
+        Tuple of the list of elements evaluating to True, and
+        list of elements evaluating to False.
+    """
+    true_items, false_items = [], []
+    for item in input_iterable:
+        if predicate_fn(item):
+            true_items.append(item)
+            continue
+        false_items.append(item)
+    return true_items, false_items
+
+
 class TypedMutableSequence(MutableSequence):
     """Base class that behaves like a list, just with a different type.
 

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -40,13 +40,13 @@ class RacketPackage(PackageBase):
 
     pkgs = False
     subdirectory = None  # type: Optional[str]
-    name = None  # type: Optional[str]
+    racket_name = None  # type: Optional[str]
     parallel = True
 
     @lang.classproperty
     def homepage(cls):
         if cls.pkgs:
-            return "https://pkgs.racket-lang.org/package/{0}".format(cls.name)
+            return "https://pkgs.racket-lang.org/package/{0}".format(cls.racket_name)
 
     @property
     def build_directory(self):
@@ -66,7 +66,7 @@ class RacketPackage(PackageBase):
                 "-t",
                 "dir",
                 "-n",
-                self.name,
+                self.racket_name,
                 "--deps",
                 "fail",
                 "--ignore-implies",
@@ -86,5 +86,5 @@ class RacketPackage(PackageBase):
                     (
                         "Racket package {0} was already installed, uninstalling via "
                         "Spack may make someone unhappy!"
-                    ).format(self.name)
+                    ).format(self.racket_name)
                 )

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -265,8 +265,6 @@ def _determine_specs_to_mirror(args):
 
         # If there is a file, parse each line as a spec and add it to the list.
         if args.file:
-            if specs:
-                tty.die("Cannot pass specs on the command line with --file.")
             specs = _read_specs_from_file(args.file)
 
         env_specs = None
@@ -338,6 +336,9 @@ def mirror_create(args):
         raise SpackError(
             "Cannot specify specs with a file if you chose to mirror all specs with '--all'"
         )
+
+    if args.file and args.specs:
+        raise SpackError("Cannot specify specs with a file AND on command line")
 
     mirror_specs = _determine_specs_to_mirror(args)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -268,6 +268,7 @@ def concrete_specs_from_user(args):
     mirror_specs, _ = spack.spec.partition_spec_list(
         mirror_specs, predicate_fn=not_excluded_fn(args)
     )
+    mirror_specs = [x.concretized() for x in mirror_specs]
     return mirror_specs
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -325,7 +325,7 @@ def all_specs_with_all_versions(args):
     mirror_specs = spack.mirror.get_all_versions(specs)
     mirror_specs.sort(key=lambda s: (s.name, s.version))
     mirror_specs = filter_mirror_specs(args, mirror_specs)
-    return mirror_specs[:10]
+    return mirror_specs
 
 
 def versions_per_spec(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -356,7 +356,7 @@ def versions_per_spec(args):
     return num_versions
 
 
-def create_mirror_from_concrete_specs(mirror_specs, directory_hint, skip_unstable_versions):
+def create_mirror_for_individual_specs(mirror_specs, directory_hint, skip_unstable_versions):
     local_push_url = local_mirror_url_from_user(directory_hint)
     present, mirrored, error = spack.mirror.create(
         local_push_url, mirror_specs, skip_unstable_versions
@@ -432,7 +432,12 @@ def mirror_create(args):
         create_mirror_for_all_specs_inside_environment(args)
         return
 
-    create_mirror_for_individual_specs(args)
+    mirror_specs = concrete_specs_from_user(args)
+    create_mirror_for_individual_specs(
+        mirror_specs,
+        directory_hint=args.directory,
+        skip_unstable_versions=args.skip_unstable_versions,
+    )
 
 
 def create_mirror_for_all_specs(args):
@@ -451,19 +456,7 @@ def create_mirror_for_all_specs(args):
 
 def create_mirror_for_all_specs_inside_environment(args):
     mirror_specs = concrete_specs_from_environment(args)
-    create_mirror_from_concrete_specs(
-        mirror_specs,
-        directory_hint=args.directory,
-        skip_unstable_versions=args.skip_unstable_versions,
-    )
-
-
-def create_mirror_for_individual_specs(args):
-    """Create a mirror from a list of individual specs, read from either the command line
-    or from a file.
-    """
-    mirror_specs = concrete_specs_from_user(args)
-    create_mirror_from_concrete_specs(
+    create_mirror_for_individual_specs(
         mirror_specs,
         directory_hint=args.directory,
         skip_unstable_versions=args.skip_unstable_versions,

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -324,25 +324,32 @@ def versions_per_spec(args):
 
 def mirror_create(args):
     """Create a directory to be used as a spack mirror, and fill it with
-    package archives."""
+    package archives.
+    """
     if args.specs and args.all:
         raise SpackError(
-            "Cannot specify specs on command line if you chose to mirror all specs with '--all'"
+            "cannot specify specs on command line if you chose to mirror all specs with '--all'"
         )
 
     if args.file and args.all:
         raise SpackError(
-            "Cannot specify specs with a file if you chose to mirror all specs with '--all'"
+            "cannot specify specs with a file if you chose to mirror all specs with '--all'"
         )
 
     if args.file and args.specs:
-        raise SpackError("Cannot specify specs with a file AND on command line")
+        raise SpackError("cannot specify specs with a file AND on command line")
 
     if not args.specs and not args.file and not args.all:
         raise SpackError(
-            "No packages were specified.",
+            "no packages were specified.",
             "To mirror all packages, use the '--all' option "
             "(this will require significant time and space).",
+        )
+
+    if args.versions_per_spec and args.all:
+        raise SpackError(
+            "cannot specify '--versions_per-spec' and '--all' together",
+            "The option '--all' already implies mirroring all versions for each package.",
         )
 
     mirror_specs = _determine_specs_to_mirror(args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -286,7 +286,7 @@ def _determine_specs_to_mirror(args):
                 tty.warn("Ignoring '--versions-per-spec' for mirroring specs" " in environment.")
             mirror_specs = env_specs
         else:
-            if num_versions == "all":
+            if num_versions == "all" or args.all:
                 mirror_specs = spack.mirror.get_all_versions(specs)
             else:
                 mirror_specs = spack.mirror.get_matching_versions(specs, num_versions=num_versions)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -257,14 +257,7 @@ def _determine_specs_to_mirror(args):
 
         env_specs = None
         if not specs:
-            # If nothing is passed, use environment or all if no active env
-            if not args.all:
-                tty.die(
-                    "No packages were specified.",
-                    "To mirror all packages, use the '--all' option"
-                    " (this will require significant time and space).",
-                )
-
+            assert args.all, "args.all is required if no specs are computed"
             env = ev.active_environment()
             if env:
                 env_specs = env.all_specs()
@@ -344,6 +337,13 @@ def mirror_create(args):
 
     if args.file and args.specs:
         raise SpackError("Cannot specify specs with a file AND on command line")
+
+    if not args.specs and not args.file and not args.all:
+        raise SpackError(
+            "No packages were specified.",
+            "To mirror all packages, use the '--all' option "
+            "(this will require significant time and space).",
+        )
 
     mirror_specs = _determine_specs_to_mirror(args)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -246,16 +246,6 @@ def _read_specs_from_file(filename):
 
 
 def _determine_specs_to_mirror(args):
-    if args.specs and args.all:
-        raise SpackError(
-            "Cannot specify specs on command line if you" " chose to mirror all specs with '--all'"
-        )
-    elif args.file and args.all:
-        raise SpackError(
-            "Cannot specify specs with a file ('-f') if you"
-            " chose to mirror all specs with '--all'"
-        )
-
     if not args.versions_per_spec:
         num_versions = 1
     elif args.versions_per_spec == "all":
@@ -339,6 +329,16 @@ def _determine_specs_to_mirror(args):
 def mirror_create(args):
     """Create a directory to be used as a spack mirror, and fill it with
     package archives."""
+    if args.specs and args.all:
+        raise SpackError(
+            "Cannot specify specs on command line if you chose to mirror all specs with '--all'"
+        )
+
+    if args.file and args.all:
+        raise SpackError(
+            "Cannot specify specs with a file if you chose to mirror all specs with '--all'"
+        )
+
     mirror_specs = _determine_specs_to_mirror(args)
 
     mirror = spack.mirror.Mirror(args.directory or spack.config.get("config:source_cache"))

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -246,19 +246,7 @@ def _read_specs_from_file(filename):
 
 
 def _determine_specs_to_mirror(args):
-    if not args.versions_per_spec:
-        num_versions = 1
-    elif args.versions_per_spec == "all":
-        num_versions = "all"
-    else:
-        try:
-            num_versions = int(args.versions_per_spec)
-        except ValueError:
-            raise SpackError(
-                "'--versions-per-spec' must be a number or 'all',"
-                " got '{0}'".format(args.versions_per_spec)
-            )
-
+    num_versions = versions_per_spec(args)
     # try to parse specs from the command line first.
     with spack.concretize.disable_compiler_existence_check():
         specs = spack.cmd.parse_specs(args.specs, concretize=True)
@@ -322,6 +310,23 @@ def _determine_specs_to_mirror(args):
         )
 
     return mirror_specs
+
+
+def versions_per_spec(args):
+    """Return how many versions should be mirrored per spec."""
+    if not args.versions_per_spec:
+        num_versions = 1
+    elif args.versions_per_spec == "all":
+        num_versions = "all"
+    else:
+        try:
+            num_versions = int(args.versions_per_spec)
+        except ValueError:
+            raise SpackError(
+                "'--versions-per-spec' must be a number or 'all',"
+                " got '{0}'".format(args.versions_per_spec)
+            )
+    return num_versions
 
 
 def mirror_create(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -377,8 +377,8 @@ def process_mirror_stats(present, mirrored, error):
 
 
 def mirror_directory_from_cli(args):
-    mirror_path = args.directory or spack.util.path.canonicalize_path(
-        spack.config.get("config:source_cache")
+    mirror_path = spack.util.path.canonicalize_path(
+        args.directory or spack.config.get("config:source_cache")
     )
     mirror = spack.mirror.Mirror(mirror_path)
     directory = url_util.format(mirror.push_url)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -322,12 +322,12 @@ def not_excluded_fn(args):
     return not_excluded
 
 
-def concrete_specs_from_environment(args):
+def concrete_specs_from_environment(selection_fn):
     env = ev.active_environment()
     assert env, "an active environment is required"
     mirror_specs = env.all_specs()
     mirror_specs = filter_externals(mirror_specs)
-    mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=not_excluded_fn(args))
+    mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=selection_fn)
     return mirror_specs
 
 
@@ -433,7 +433,11 @@ def mirror_create(args):
         return
 
     if args.all and ev.active_environment():
-        create_mirror_for_all_specs_inside_environment(args)
+        create_mirror_for_all_specs_inside_environment(
+            directory_hint=args.directory,
+            skip_unstable_versions=args.skip_unstable_versions,
+            selection_fn=not_excluded_fn(args),
+        )
         return
 
     mirror_specs = concrete_specs_from_user(args)
@@ -458,12 +462,14 @@ def create_mirror_for_all_specs(directory_hint, skip_unstable_versions, selectio
     process_mirror_stats(*mirror_stats.stats())
 
 
-def create_mirror_for_all_specs_inside_environment(args):
-    mirror_specs = concrete_specs_from_environment(args)
+def create_mirror_for_all_specs_inside_environment(
+    directory_hint, skip_unstable_versions, selection_fn
+):
+    mirror_specs = concrete_specs_from_environment(selection_fn=selection_fn)
     create_mirror_for_individual_specs(
         mirror_specs,
-        directory_hint=args.directory,
-        skip_unstable_versions=args.skip_unstable_versions,
+        directory_hint=directory_hint,
+        skip_unstable_versions=skip_unstable_versions,
     )
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -5,6 +5,7 @@
 
 import sys
 
+import llnl.util.lang as lang
 import llnl.util.tty as tty
 import llnl.util.tty.colify as colify
 
@@ -265,17 +266,13 @@ def concrete_specs_from_user(args):
             specs, num_versions=versions_per_spec(args)
         )
     mirror_specs.sort(key=lambda s: (s.name, s.version))
-    mirror_specs, _ = spack.spec.partition_spec_list(
-        mirror_specs, predicate_fn=not_excluded_fn(args)
-    )
+    mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=not_excluded_fn(args))
     mirror_specs = [x.concretized() for x in mirror_specs]
     return mirror_specs
 
 
 def filter_externals(specs):
-    specs, external_specs = spack.spec.partition_spec_list(
-        specs, predicate_fn=lambda x: not x.external
-    )
+    specs, external_specs = lang.stable_partition(specs, predicate_fn=lambda x: not x.external)
     for spec in external_specs:
         msg = "Skipping {0} as it is an external spec."
         tty.msg(msg.format(spec.cshort_spec))
@@ -327,9 +324,7 @@ def concrete_specs_from_environment(args):
     assert env, "an active environment is required"
     mirror_specs = env.all_specs()
     mirror_specs = filter_externals(mirror_specs)
-    mirror_specs, _ = spack.spec.partition_spec_list(
-        mirror_specs, predicate_fn=not_excluded_fn(args)
-    )
+    mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=not_excluded_fn(args))
     return mirror_specs
 
 
@@ -337,9 +332,7 @@ def all_specs_with_all_versions(args):
     specs = [spack.spec.Spec(n) for n in spack.repo.all_package_names()]
     mirror_specs = spack.mirror.get_all_versions(specs)
     mirror_specs.sort(key=lambda s: (s.name, s.version))
-    mirror_specs, _ = spack.spec.partition_spec_list(
-        mirror_specs, predicate_fn=not_excluded_fn(args)
-    )
+    mirror_specs, _ = lang.stable_partition(mirror_specs, predicate_fn=not_excluded_fn(args))
     return mirror_specs
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -353,10 +353,10 @@ def versions_per_spec(args):
     return num_versions
 
 
-def create_mirror_from_concrete_specs(mirror_specs, args):
-    local_push_url = local_mirror_url_from_user(args.directory)
+def create_mirror_from_concrete_specs(mirror_specs, directory_hint, skip_unstable_versions):
+    local_push_url = local_mirror_url_from_user(directory_hint)
     present, mirrored, error = spack.mirror.create(
-        local_push_url, mirror_specs, args.skip_unstable_versions
+        local_push_url, mirror_specs, skip_unstable_versions
     )
     tty.msg("Summary for mirror in {}".format(local_push_url))
     process_mirror_stats(present, mirrored, error)
@@ -448,7 +448,11 @@ def create_mirror_for_all_specs(args):
 
 def create_mirror_for_all_specs_inside_environment(args):
     mirror_specs = concrete_specs_from_environment(args)
-    create_mirror_from_concrete_specs(mirror_specs, args)
+    create_mirror_from_concrete_specs(
+        mirror_specs,
+        directory_hint=args.directory,
+        skip_unstable_versions=args.skip_unstable_versions,
+    )
 
 
 def create_mirror_for_individual_specs(args):
@@ -456,7 +460,11 @@ def create_mirror_for_individual_specs(args):
     or from a file.
     """
     mirror_specs = concrete_specs_from_user(args)
-    create_mirror_from_concrete_specs(mirror_specs, args)
+    create_mirror_from_concrete_specs(
+        mirror_specs,
+        directory_hint=args.directory,
+        skip_unstable_versions=args.skip_unstable_versions,
+    )
 
 
 def mirror_destroy(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -15,6 +15,7 @@ import spack.config
 import spack.environment as ev
 import spack.mirror
 import spack.repo
+import spack.util.path
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.error import SpackError
@@ -369,7 +370,10 @@ def process_mirror_stats(present, mirrored, error):
 
 
 def mirror_directory_from_cli(args):
-    mirror = spack.mirror.Mirror(args.directory or spack.config.get("config:source_cache"))
+    mirror_path = args.directory or spack.util.path.canonicalize_path(
+        spack.config.get("config:source_cache")
+    )
+    mirror = spack.mirror.Mirror(mirror_path)
     directory = url_util.format(mirror.push_url)
     return directory
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -503,32 +503,42 @@ def create(path, specs, skip_unstable_versions=False):
     it creates specs for those versions.  If the version satisfies any spec
     in the specs list, it is downloaded and added to the mirror.
     """
+    # automatically spec-ify anything in the specs array.
+    specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
+
+    mirror_cache, mirror_stats = mirror_cache_and_stats(path, skip_unstable_versions)
+    for spec in specs:
+        mirror_stats.next_spec(spec)
+        create_mirror_from_package_object(spec.package, mirror_cache, mirror_stats)
+
+    return mirror_stats.stats()
+
+
+def mirror_cache_and_stats(path, skip_unstable_versions=False):
+    """Return both a mirror cache and a mirror stats, starting from the path
+    where a mirror ought to be created.
+
+    Args:
+        path (str): path to create a mirror directory hierarchy in.
+        skip_unstable_versions: if true, this skips adding resources when
+            they do not have a stable archive checksum (as determined by
+            ``fetch_strategy.stable_target``)
+    """
     parsed = url_util.parse(path)
     mirror_root = url_util.local_file_path(parsed)
     if not mirror_root:
         raise spack.error.SpackError("MirrorCaches only work with file:// URLs")
-
-    # automatically spec-ify anything in the specs array.
-    specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]
-
     # Get the absolute path of the root before we start jumping around.
     if not os.path.isdir(mirror_root):
         try:
             mkdirp(mirror_root)
         except OSError as e:
             raise MirrorError("Cannot create directory '%s':" % mirror_root, str(e))
-
     mirror_cache = spack.caches.MirrorCache(
         mirror_root, skip_unstable_versions=skip_unstable_versions
     )
     mirror_stats = MirrorStats()
-
-    # Iterate through packages and download all safe tarballs for each
-    for spec in specs:
-        mirror_stats.next_spec(spec)
-        _add_single_spec(spec, mirror_cache, mirror_stats)
-
-    return mirror_stats.stats()
+    return mirror_cache, mirror_stats
 
 
 def add(name, url, scope, args={}):
@@ -630,35 +640,27 @@ class MirrorStats(object):
         self.errors.add(self.current_spec)
 
 
-def _add_single_spec(spec, mirror_cache, mirror_stats):
-    """Add a single spec to a mirror.
+def create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats):
+    """Add a single package object to a mirror.
+
+    The package object is only required to have an associated spec
+    with a concrete version.
 
     Args:
-        spec (spack.spec.Spec): spec to be added. If not concrete it will
-            be concretized.
+        pkg_obj (spack.spec.PackageBase): package object with to be added.
         mirror_cache (spack.caches.MirrorCache): mirror where to add the spec.
         mirror_stats (spack.mirror.MirrorStats): statistics on the current mirror
 
     Return:
         True if the spec was added successfully, False otherwise
     """
-    # Ensure that the spec is concrete, since we'll stage it later
-    try:
-        if not spec.concrete:
-            spec = spec.concretized()
-    except Exception as e:
-        msg = "Skipping '{0}', as it fails to concretize [{1}]".format(spec, str(e))
-        tty.debug(msg)
-        mirror_stats.error()
-        return False
-
-    tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("{name}{@version}")))
+    tty.msg("Adding package {} to mirror".format(pkg_obj.spec.format("{name}{@version}")))
     num_retries = 3
     while num_retries > 0:
         try:
-            with spec.package.stage as pkg_stage:
+            with pkg_obj.stage as pkg_stage:
                 pkg_stage.cache_mirror(mirror_cache, mirror_stats)
-                for patch in spec.package.all_patches():
+                for patch in pkg_obj.all_patches():
                     if patch.stage:
                         patch.stage.cache_mirror(mirror_cache, mirror_stats)
                     patch.clean()
@@ -668,18 +670,16 @@ def _add_single_spec(spec, mirror_cache, mirror_stats):
             exc_tuple = sys.exc_info()
             exception = e
         num_retries -= 1
-
     if exception:
         if spack.config.get("config:debug"):
             traceback.print_exception(file=sys.stderr, *exc_tuple)
         else:
             tty.warn(
-                "Error while fetching %s" % spec.cformat("{name}{@version}"),
+                "Error while fetching %s" % pkg_obj.spec.cformat("{name}{@version}"),
                 getattr(exception, "message", exception),
             )
         mirror_stats.error()
         return False
-
     return True
 
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -498,10 +498,6 @@ def create(path, specs, skip_unstable_versions=False):
         * present:  Package specs that were already present.
         * mirrored: Package specs that were successfully mirrored.
         * error:    Package specs that failed to mirror due to some error.
-
-    This routine iterates through all known package versions, and
-    it creates specs for those versions.  If the version satisfies any spec
-    in the specs list, it is downloaded and added to the mirror.
     """
     # automatically spec-ify anything in the specs array.
     specs = [s if isinstance(s, spack.spec.Spec) else spack.spec.Spec(s) for s in specs]

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -643,7 +643,7 @@ def create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats):
     with a concrete version.
 
     Args:
-        pkg_obj (spack.spec.PackageBase): package object with to be added.
+        pkg_obj (spack.package_base.PackageBase): package object with to be added.
         mirror_cache (spack.caches.MirrorCache): mirror where to add the spec.
         mirror_stats (spack.mirror.MirrorStats): statistics on the current mirror
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 """
 This file contains code for creating spack mirror directories.  A
 mirror is an organized hierarchy containing specially named archive
@@ -56,7 +55,7 @@ class Mirror(object):
 
     Mirrors have a fetch_url that indicate where and how artifacts are fetched
     from them, and a push_url that indicate where and how artifacts are pushed
-    to them.  These two URLs are usually the same.
+    to them. These two URLs are usually the same.
     """
 
     def __init__(self, fetch_url, push_url=None, name=None):
@@ -631,13 +630,13 @@ class MirrorStats(object):
         self.errors.add(self.current_spec)
 
 
-def _add_single_spec(spec, mirror, mirror_stats):
+def _add_single_spec(spec, mirror_cache, mirror_stats):
     """Add a single spec to a mirror.
 
     Args:
         spec (spack.spec.Spec): spec to be added. If not concrete it will
             be concretized.
-        mirror (spack.mirror.Mirror): mirror where to add the spec.
+        mirror_cache (spack.caches.MirrorCache): mirror where to add the spec.
         mirror_stats (spack.mirror.MirrorStats): statistics on the current mirror
 
     Return:
@@ -658,10 +657,10 @@ def _add_single_spec(spec, mirror, mirror_stats):
     while num_retries > 0:
         try:
             with spec.package.stage as pkg_stage:
-                pkg_stage.cache_mirror(mirror, mirror_stats)
+                pkg_stage.cache_mirror(mirror_cache, mirror_stats)
                 for patch in spec.package.all_patches():
                     if patch.stage:
-                        patch.stage.cache_mirror(mirror, mirror_stats)
+                        patch.stage.cache_mirror(mirror_cache, mirror_stats)
                     patch.clean()
             exception = None
             break

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5364,26 +5364,6 @@ def save_dependency_specfiles(
             fd.write(dep_spec.to_json(hash=ht.dag_hash))
 
 
-def partition_spec_list(input_specs, predicate_fn):
-    """Partition a list of specs according to a custom predicate.
-
-    Args:
-        input_specs (list of Spec): input specs to be partitioned.
-        predicate_fn (callable): predicate function accepting a spec as argument.
-
-    Return:
-        Tuple of the list of elements evaluating to True, and
-        list of elements evaluating to False.
-    """
-    true_items, false_items = [], []
-    for item in input_specs:
-        if predicate_fn(item):
-            true_items.append(item)
-            continue
-        false_items.append(item)
-    return true_items, false_items
-
-
 class SpecParseError(spack.error.SpecError):
     """Wrapper for ParseError for when we're parsing specs."""
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5364,6 +5364,26 @@ def save_dependency_specfiles(
             fd.write(dep_spec.to_json(hash=ht.dag_hash))
 
 
+def partition_spec_list(input_specs, predicate_fn):
+    """Partition a list of specs according to a custom predicate.
+
+    Args:
+        input_specs (list of Spec): input specs to be partitioned.
+        predicate_fn (callable): predicate function accepting a spec as argument.
+
+    Return:
+        Tuple of the list of elements evaluating to True, and
+        list of elements evaluating to False.
+    """
+    true_items, false_items = [], []
+    for item in input_specs:
+        if predicate_fn(item):
+            true_items.append(item)
+            continue
+        false_items.append(item)
+    return true_items, false_items
+
+
 class SpecParseError(spack.error.SpecError):
     """Wrapper for ParseError for when we're parsing specs."""
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -340,10 +340,10 @@ class TestMirrorCreate(object):
     )
     def test_mirror_path_is_valid(self, cli_args, expected_end, config):
         args = MockMirrorArgs(**cli_args)
-        directory = spack.cmd.mirror.mirror_directory_from_cli(args)
-        assert directory.startswith("file:")
-        assert os.path.isabs(directory.replace("file://", ""))
-        assert directory.endswith(expected_end)
+        local_push_url = spack.cmd.mirror.local_mirror_url_from_user(args.directory)
+        assert local_push_url.startswith("file:")
+        assert os.path.isabs(local_push_url.replace("file://", ""))
+        assert local_push_url.endswith(expected_end)
 
     @pytest.mark.parametrize(
         "cli_args,not_expected",

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -8,9 +8,11 @@ import sys
 
 import pytest
 
+import spack.cmd.mirror
 import spack.config
 import spack.environment as ev
 from spack.main import SpackCommand, SpackCommandError
+from spack.util.pattern import Bunch
 
 mirror = SpackCommand("mirror")
 env = SpackCommand("env")
@@ -288,3 +290,12 @@ def test_mirror_destroy(
 
     uninstall("-y", spec_name)
     mirror("remove", "atest")
+
+
+class TestMirrorCreate(object):
+    @pytest.mark.regression("31736")
+    @pytest.mark.maybeslow
+    def test_all_specs_with_all_versions_dont_concretize(self):
+        args = Bunch(exclude_file=None, exclude_specs=None)
+        specs = spack.cmd.mirror.all_specs_with_all_versions(args)
+        assert all(not s.concrete for s in specs)

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -128,7 +128,7 @@ def test_exclude_specs(mock_packages, config):
         specs=["mpich"], versions_per_spec="all", exclude_specs="mpich@3.0.1:3.0.2 mpich@1.0"
     )
 
-    mirror_specs = spack.cmd.mirror._determine_specs_to_mirror(args)
+    mirror_specs = spack.cmd.mirror.concrete_specs_from_user(args)
     expected_include = set(spack.spec.Spec(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"])
     expected_exclude = set(spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"])
     assert expected_include <= set(mirror_specs)
@@ -147,7 +147,7 @@ mpich@1.0
 
     args = MockMirrorArgs(specs=["mpich"], versions_per_spec="all", exclude_file=exclude_path)
 
-    mirror_specs = spack.cmd.mirror._determine_specs_to_mirror(args)
+    mirror_specs = spack.cmd.mirror.concrete_specs_from_user(args)
     expected_include = set(spack.spec.Spec(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"])
     expected_exclude = set(spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"])
     assert expected_include <= set(mirror_specs)

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -334,14 +334,15 @@ class TestMirrorCreate(object):
     @pytest.mark.parametrize(
         "cli_args,expected_end",
         [
-            ({"directory": None}, os.path.join("var", "spack", "cache")),
+            ({"directory": None}, os.path.join("source")),
             ({"directory": os.path.join("foo", "bar")}, os.path.join("foo", "bar")),
         ],
     )
-    def test_mirror_path_is_valid(self, cli_args, expected_end):
+    def test_mirror_path_is_valid(self, cli_args, expected_end, config):
         args = MockMirrorArgs(**cli_args)
         directory = spack.cmd.mirror.mirror_directory_from_cli(args)
         assert directory.startswith("file:")
+        assert os.path.isabs(directory.replace("file://", ""))
         assert directory.endswith(expected_end)
 
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -399,8 +399,8 @@ class TestMirrorCreate(object):
         [
             ("callpath", 1),
             ("mpich", 4),
-            ("callpath bowtie", 3),
-            ("callpath bowtie", "all"),
+            ("callpath mpich", 3),
+            ("callpath mpich", "all"),
         ],
     )
     def test_versions_per_spec_produces_concrete_specs(self, input_specs, nversions, config):

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -302,7 +302,9 @@ class TestMirrorCreate(object):
     @pytest.mark.regression("31736", "31985")
     def test_all_specs_with_all_versions_dont_concretize(self):
         args = MockMirrorArgs(exclude_file=None, exclude_specs=None)
-        specs = spack.cmd.mirror.all_specs_with_all_versions(args)
+        specs = spack.cmd.mirror.all_specs_with_all_versions(
+            selection_fn=spack.cmd.mirror.not_excluded_fn(args)
+        )
         assert all(not s.concrete for s in specs)
 
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -325,3 +325,16 @@ class TestMirrorCreate(object):
         args = Bunch(**cli_args)
         with pytest.raises(spack.error.SpackError, match=error_str):
             spack.cmd.mirror.mirror_create(args)
+
+    @pytest.mark.parametrize(
+        "cli_args,expected_end",
+        [
+            ({"directory": None}, os.path.join("var", "spack", "cache")),
+            ({"directory": os.path.join("foo", "bar")}, os.path.join("foo", "bar")),
+        ],
+    )
+    def test_mirror_path_is_valid(self, cli_args, expected_end):
+        args = Bunch(**cli_args)
+        directory = spack.cmd.mirror.mirror_directory_from_cli(args)
+        assert directory.startswith("file:")
+        assert directory.endswith(expected_end)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -324,6 +324,6 @@ def test_non_concretizable_spec_does_not_raise():
             self.called = True
 
     mirror_stats = Stats()
-    result = spack.mirror._add_single_spec(s, mirror=None, mirror_stats=mirror_stats)
+    result = spack.mirror._add_single_spec(s, mirror_cache=None, mirror_stats=mirror_stats)
     assert result is False
     assert mirror_stats.called is True

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -311,19 +311,3 @@ def test_get_all_versions(specs, expected_specs):
     output_list = [str(x) for x in output_list]
     # Compare sets since order is not important
     assert set(output_list) == set(expected_specs)
-
-
-@pytest.mark.regression("31736")
-def test_non_concretizable_spec_does_not_raise():
-    s = Spec("doesnotexist")
-
-    class Stats(object):
-        called = False
-
-        def error(self):
-            self.called = True
-
-    mirror_stats = Stats()
-    result = spack.mirror._add_single_spec(s, mirror_cache=None, mirror_stats=mirror_stats)
-    assert result is False
-    assert mirror_stats.called is True

--- a/var/spack/repos/builtin/packages/rkt-base/package.py
+++ b/var/spack/repos/builtin/packages/rkt-base/package.py
@@ -17,6 +17,6 @@ class RktBase(RacketPackage):
     version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f")  # tag='v8.3'
     depends_on("racket@8.3", type=("build", "run"), when="@8.3")
 
-    name = "base"
+    racket_name = "base"
     pkgs = True
-    subdirectory = "pkgs/{0}".format(name)
+    subdirectory = "pkgs/{0}".format(racket_name)

--- a/var/spack/repos/builtin/packages/rkt-cext-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-cext-lib/package.py
@@ -20,6 +20,6 @@ class RktCextLib(RacketPackage):
     depends_on("rkt-dynext-lib@8.3", type=("build", "run"), when="@8.3")
     depends_on("rkt-scheme-lib@8.3", type=("build", "run"), when="@8.3")
 
-    name = "cext-lib"
+    racket_name = "cext-lib"
     pkgs = True
-    subdirectory = name
+    subdirectory = racket_name

--- a/var/spack/repos/builtin/packages/rkt-compiler-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-compiler-lib/package.py
@@ -20,6 +20,6 @@ class RktCompilerLib(RacketPackage):
     depends_on("rkt-rackunit-lib@8.3", type=("build", "run"), when="@8.3")
     depends_on("rkt-zo-lib@1.3", type=("build", "run"), when="@8.3")
 
-    name = "compiler-lib"
+    racket_name = "compiler-lib"
     pkgs = True
-    subdirectory = "pkgs/{0}".format(name)
+    subdirectory = "pkgs/{0}".format(racket_name)

--- a/var/spack/repos/builtin/packages/rkt-dynext-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-dynext-lib/package.py
@@ -16,6 +16,6 @@ class RktDynextLib(RacketPackage):
     version("8.3", commit="cc22e2456df881a9008240d70dd9012ef37395f5")  # tag = 'v8.3'
     depends_on("rkt-base@8.3", type=("build", "run"), when="@8.3")
 
-    name = "dynext-lib"
+    racket_name = "dynext-lib"
     pkgs = True
-    subdirectory = name
+    subdirectory = racket_name

--- a/var/spack/repos/builtin/packages/rkt-rackunit-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-rackunit-lib/package.py
@@ -17,6 +17,6 @@ class RktRackunitLib(RacketPackage):
     depends_on("rkt-base@8.3:", type=("build", "run"), when="@8.3")
     depends_on("rkt-testing-util-lib@8.3", type=("build", "run"), when="@8.3")
 
-    name = "rackunit-lib"
+    racket_name = "rackunit-lib"
     pkgs = True
-    subdirectory = name
+    subdirectory = racket_name

--- a/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
@@ -16,5 +16,5 @@ class RktSchemeLib(RacketPackage):
     version("8.3", commit="a36e729680818712820ee5269f5208c3c0715a6a")  # tag='v8.3'
     depends_on("rkt-base@8.3", type=("build", "run"), when="@8.3")
 
-    name = "scheme-lib"
+    racket_name = "scheme-lib"
     pkgs = True

--- a/var/spack/repos/builtin/packages/rkt-testing-util-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-testing-util-lib/package.py
@@ -16,6 +16,6 @@ class RktTestingUtilLib(RacketPackage):
     version("8.3", commit="683237bee2a979c7b1541092922fb51a75ea8ca9")  # tag='v8.3'
     depends_on("rkt-base@8.3:", type=("build", "run"), when="@8.3")
 
-    name = "testing-util-lib"
+    racket_name = "testing-util-lib"
     pkgs = True
-    subdirectory = name
+    subdirectory = racket_name

--- a/var/spack/repos/builtin/packages/rkt-zo-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-zo-lib/package.py
@@ -16,6 +16,6 @@ class RktZoLib(RacketPackage):
     version("1.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f")  # tag='v1.3'
     depends_on("rkt-base@8.3:", type=("build", "run"), when="@1.3")
 
-    name = "zo-lib"
+    racket_name = "zo-lib"
     pkgs = True
-    subdirectory = "pkgs/{0}".format(name)
+    subdirectory = "pkgs/{0}".format(racket_name)


### PR DESCRIPTION
fixes #31985 

This PR fixes the performance regression reported in #31985 and a few other issues found while refactoring the `spack mirror create` command (e.g. default directory not canonicalized, specs read from text file treated differently than specs from command line, allowing `-n` together with `--all`, etc.).

Modifications:
- [x] Do not require concretization for `spack mirror create --all`
- [x] Forbid using `--versions-per-spec` together with `--all`
- [x] Fixed a few issues when reading specs from input file (specs were not concretized, command would fail when trying to mirror dependencies)
- [x] Fix issue with default directory for `spack mirror create` not being canonicalized
- [x] Changed slightly the wording for reporting (it was mentioning "Successfully  created" even in presence of errors)
- [x] Fix issue with `colify` (was not called properly during error reporting)
- [x] Add more unit tests to poke `spack mirror create` 
- [x] Skip externals also when mirroring environments 