### PR TITLE
ADIOS2: ZFP<1.0

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -106,7 +106,7 @@ class Adios2(CMakePackage, CudaPackage):
     depends_on("c-blosc", when="+blosc")
     depends_on("bzip2", when="+bzip2")
     depends_on("libpng@1.6:", when="+png")
-    depends_on("zfp@0.5.1:", when="+zfp")
+    depends_on("zfp@0.5.1:0.5.99", when="+zfp")
     depends_on("sz@2.0.2.0:", when="+sz")
 
     extends("python", when="+python")

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -106,7 +106,7 @@ class Adios2(CMakePackage, CudaPackage):
     depends_on("c-blosc", when="+blosc")
     depends_on("bzip2", when="+bzip2")
     depends_on("libpng@1.6:", when="+png")
-    depends_on("zfp@0.5.1:0.5.99", when="+zfp")
+    depends_on("zfp@0.5.1:0.5", when="+zfp")
     depends_on("sz@2.0.2.0:", when="+sz")
 
     extends("python", when="+python")


### PR DESCRIPTION
The tagged ADIOS2 releases in Spack (and develop) do not yet work with ZFP 1.0. Express valid dependency range before someone updates the ZFP package and triggers the incompatibility.

X-Ref.: https://github.com/ornladios/ADIOS2/issues/3303