### PR TITLE
VisIt: Fix missing link libs patch for parallel.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/visit32-missing-link-libs.patch
+++ b/var/spack/repos/builtin/packages/visit/visit32-missing-link-libs.patch
@@ -17,7 +17,7 @@ index 162ed1c439..7ddd0a7144 100644
      ADD_PARALLEL_LIBRARY(avtquery_par ${AVTQUERY_SOURCES})
      TARGET_LINK_LIBRARIES(avtquery_par visitcommon avtmath avtshapelets avtexpressions_par avtfilters_par visit_vtk)
 +    IF(CMAKE_SYSTEM_NAME MATCHES Linux)
-+        TARGET_LINK_LIBRARIES(avtquery_ser rt)
++        TARGET_LINK_LIBRARIES(avtquery_par rt)
 +    ENDIF(CMAKE_SYSTEM_NAME MATCHES Linux)
      IF(VISIT_PYTHON_FILTERS)
          TARGET_LINK_LIBRARIES(avtquery_par avtpythonfilters_par)


### PR DESCRIPTION
The missing link patch adds the `rt` library to `avtquery_ser` for both the serial and parallel versions of the library. The second fix should be to `avtquery_par`, which is the parallel version of the library. This was most likely from doing a cut and paste and not changing the pasted version appropriately.