### PR TITLE
Change python hash to fix broken build in pipeline.

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -336,18 +336,18 @@ class Python(Package):
 
         # Some variants enable multiple modules
         try:
-            python("-c", "import ssl", error=os.devnull)
-            python("-c", "import hashlib", error=os.devnull)
-            variants += "+ssl"
-        except ProcessError:
-            variants += "~ssl"
-
-        try:
             python("-c", "import xml.parsers.expat", error=os.devnull)
             python("-c", "import xml.etree.ElementTree", error=os.devnull)
             variants += "+pyexpat"
         except ProcessError:
             variants += "~pyexpat"
+
+        try:
+            python("-c", "import ssl", error=os.devnull)
+            python("-c", "import hashlib", error=os.devnull)
+            variants += "+ssl"
+        except ProcessError:
+            variants += "~ssl"
 
         # Some modules are version-dependent
         if Version(version_str) >= Version("3.3"):


### PR DESCRIPTION
Credit to @trws for getting the diagnosis on what was happening with the broken mesa build on `develop`
![Screenshot from 2022-08-10 10-33-37](https://user-images.githubusercontent.com/4199709/183854878-f69bda3d-ef90-487f-8d46-06562f1e565d.png)

This is meant as a workaround, not a fix. Changing the hash of Python gives us a fair chance not to incur in a build broken in the same way. 