### PR TITLE
pin tbb version for salmon & dyninst

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -67,7 +67,10 @@ class Dyninst(CMakePackage):
     # libdwarf before that.
     depends_on("libdwarf", when="@:9")
 
+    # findtbb.cmake in the dynist repo does not work with recent tbb
+    # package layout. Need to use tbb provided config instead.
     conflicts("intel-tbb@2021.1:")
+    conflicts("intel-oneapi-tbb@2021.1:")
     depends_on("tbb@2018.6.0:", when="@10.0.0:")
 
     depends_on("cmake@3.4.0:", type="build", when="@10.1.0:")

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -67,7 +67,7 @@ class Dyninst(CMakePackage):
     # libdwarf before that.
     depends_on("libdwarf", when="@:9")
 
-    depends_on("tbb@2018.6:", when="@10.0.0:")
+    depends_on("tbb@2018.6:2020.3", when="@10.0.0:")
 
     depends_on("cmake@3.4.0:", type="build", when="@10.1.0:")
     depends_on("cmake@3.0.0:", type="build", when="@10.0.0:10.0")

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -67,7 +67,8 @@ class Dyninst(CMakePackage):
     # libdwarf before that.
     depends_on("libdwarf", when="@:9")
 
-    depends_on("tbb@2018.6:2020.3", when="@10.0.0:")
+    conflicts("intel-tbb@2021.1:")
+    depends_on("tbb@2018.6.0:", when="@10.0.0:")
 
     depends_on("cmake@3.4.0:", type="build", when="@10.1.0:")
     depends_on("cmake@3.0.0:", type="build", when="@10.0.0:10.0")

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -30,19 +30,16 @@ class IntelTbb(CMakePackage):
 
     version("master", branch="master")
     version("2021.6.0-rc1", tag="v2021.6.0-rc1")
-    version("2021.5.0", sha256="e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a")
+    version(
+        "2021.5.0",
+        sha256="e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a",
+        preferred=True,
+    )
     version("2021.4.0", sha256="021796c7845e155e616f5ecda16daa606ebb4c6f90b996e5c08aebab7a8d3de3")
     version("2021.3.0", sha256="8f616561603695bbb83871875d2c6051ea28f8187dbe59299961369904d1d49e")
     version("2021.2.0", sha256="cee20b0a71d977416f3e3b4ec643ee4f38cedeb2a9ff015303431dd9d8d79854")
     version("2021.1.1", sha256="b182c73caaaabc44ddc5ad13113aca7e453af73c1690e4061f71dfe4935d74e8")
-    version(
-        "2020.3",
-        sha256="ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3",
-        # TBB moved the contents of its version.h file, and many projects will break
-        # https://github.com/dyninst/dyninst/pull/1292/files
-        # Pin tbb to a version that works
-        preferred=True,
-    )
+    version("2020.3", sha256="ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3")
     version("2020.2", sha256="4804320e1e6cbe3a5421997b52199e3c1a3829b2ecb6489641da4b8e32faf500")
     version("2020.1", sha256="7c96a150ed22bc3c6628bc3fef9ed475c00887b26d37bca61518d76a56510971")
     version("2020.0", sha256="57714f2d2cf33935db33cee93af57eb3ecd5a7bef40c1fb7ca4a41d79684b118")

--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -25,7 +25,10 @@ class Salmon(CMakePackage):
         values=("DEBUG", "RELEASE"),
     )
 
-    depends_on("tbb")
+    # 1.8.0 relies on tbb provided config, earlier versions make
+    # assumptions about the layout of tbb files.
+    depends_on("tbb@:2020.3", when="@:1.7.0")
+    depends_on("tbb", when="@1.8.0:")
     depends_on(
         "boost@1.66.0:"
         "+program_options+exception+filesystem+system+chrono+serialization"

--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -26,9 +26,11 @@ class Salmon(CMakePackage):
     )
 
     # 1.8.0 relies on tbb provided config, earlier versions make
-    # assumptions about the layout of tbb files.
-    depends_on("tbb@:2020.3", when="@:1.7.0")
-    depends_on("tbb", when="@1.8.0:")
+    # assumptions about the layout of tbb files that are not true in
+    # 2021.1 and later
+    conflicts("intel-tbb@2021.1:", when="@:1.7.0")
+    conflicts("intel-oneapi-tbb@2021.1:", when="@:1.7.0")
+    depends_on("tbb")
     depends_on(
         "boost@1.66.0:"
         "+program_options+exception+filesystem+system+chrono+serialization"


### PR DESCRIPTION
This PR advances the preferred intel-tbb version to the latest release and pins salmon and dyninst at an old tbb.

salmon and dyninst are not compatible with tbb after 2020.3. They are part of spack ci, which blocks me from making the latest tbb release the default. Pin the version for those packages.

I submitted a PR upstream to dyninst: https://github.com/dyninst/dyninst/pull/1292

salmon has already been fixed upstream, but there is no spack release. Simply adding the new version to the salmon spack package does not work because the build procedure for salmon has changed. There is no maintainer for salmon, so hoping @akthoma (original contributor) can do the work or find someone to do it.