### PR TITLE
llvm: fix ncurses/terminfo builds

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -636,7 +636,7 @@ class Llvm(CMakePackage, CudaPackage):
             projects.append("lldb")
             cmake_args.append(define("LLDB_ENABLE_LIBEDIT", True))
             cmake_args.append(define("LLDB_ENABLE_CURSES", True))
-            if spec['ncurses'].satisfies('+termlib'):
+            if spec["ncurses"].satisfies("+termlib"):
                 cmake_args.append(define("LLVM_ENABLE_TERMINFO", True))
             else:
                 cmake_args.append(define("LLVM_ENABLE_TERMINFO", False))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -636,7 +636,7 @@ class Llvm(CMakePackage, CudaPackage):
             projects.append("lldb")
             cmake_args.append(define("LLDB_ENABLE_LIBEDIT", True))
             cmake_args.append(define("LLDB_ENABLE_CURSES", True))
-            if "^ncurses+termlib" in spec:
+            if spec['ncurses'].satisfies('+termlib'):
                 cmake_args.append(define("LLVM_ENABLE_TERMINFO", True))
             else:
                 cmake_args.append(define("LLVM_ENABLE_TERMINFO", False))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -572,7 +572,6 @@ class Llvm(CMakePackage, CudaPackage):
             define("LLVM_REQUIRES_RTTI", True),
             define("LLVM_ENABLE_RTTI", True),
             define("LLVM_ENABLE_EH", True),
-            define("LLVM_ENABLE_TERMINFO", False),
             define("LLVM_ENABLE_LIBXML2", False),
             define("CLANG_DEFAULT_OPENMP_RUNTIME", "libomp"),
             define("PYTHON_EXECUTABLE", python.command.path),
@@ -637,6 +636,10 @@ class Llvm(CMakePackage, CudaPackage):
             projects.append("lldb")
             cmake_args.append(define("LLDB_ENABLE_LIBEDIT", True))
             cmake_args.append(define("LLDB_ENABLE_CURSES", True))
+            if "^ncurses+termlib" in spec:
+                cmake_args.append(define("LLVM_ENABLE_TERMINFO", True))
+            else:
+                cmake_args.append(define("LLVM_ENABLE_TERMINFO", False))
             cmake_args.append(define("LLDB_ENABLE_LIBXML2", False))
             if spec.version >= Version("10"):
                 cmake_args.append(from_variant("LLDB_ENABLE_PYTHON", "python"))
@@ -644,6 +647,8 @@ class Llvm(CMakePackage, CudaPackage):
                 cmake_args.append(define("LLDB_DISABLE_PYTHON", "~python" in spec))
             if spec.satisfies("@5.0.0: +python"):
                 cmake_args.append(define("LLDB_USE_SYSTEM_SIX", True))
+        else:
+            cmake_args.append(define("LLVM_ENABLE_TERMINFO", False))
 
         if "+gold" in spec:
             cmake_args.append(define("LLVM_BINUTILS_INCDIR", spec["binutils"].prefix.include))


### PR DESCRIPTION
Set LLVM_ENABLE_TERMINFO with ncurses+terminfo as a function of the lldb variant

@chuckatkins @trws @haampie 

The changes in #31331 left me with llvm build errors like this:
```
/dev/shm/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-9.3.0/binutils-2.38-ecdeglohh4j32jksrdoxqrczpw3tlmi5/bin/ld: lib/liblldbCo
re.a(IOHandlerCursesGUI.cpp.o): undefined reference to symbol 'acs_map@@NCURSES6_TINFO_5.0.19991023'
/dev/shm/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-9.3.0/binutils-2.38-ecdeglohh4j32jksrdoxqrczpw3tlmi5/bin/ld: /dev/shm/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-9.3.0/ncurses-6.2-aifdeiwtq4t2wesmu4ily65svcrezwr2/lib/libtinfo.so.6: error adding symbols: DSO missing from command line
```
