### PR TITLE
Add the ability to limit the number of versions checksummed.

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -647,6 +647,10 @@ def setup_parser(subparser):
     subparser.add_argument(
         "-b", "--batch", action="store_true", help="don't ask which versions to checksum"
     )
+    subparser.add_argument(
+        "--limit", action="store", type=int, default=0,
+        help="maximum number of versions to checksum (implies --batch)"
+    )
 
 
 class BuildSystemGuesser:
@@ -852,7 +856,8 @@ def get_versions(args, name):
             name,
             first_stage_function=guesser,
             keep_stage=args.keep_stage,
-            batch=(args.batch or len(url_dict) == 1),
+            batch=(args.batch or len(url_dict) == 1 or args.limit > 0),
+            limit=args.limit
         )
     else:
         versions = unhashed_versions

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -875,6 +875,7 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
         keep_stage (bool): whether to keep staging area when command completes
         batch (bool): whether to ask user how many versions to fetch (false)
             or fetch all versions (true)
+        limit (int): maximum number of versions to fetch (default 0 === all)
         latest (bool): whether to take the latest version (true) or all (false)
         fetch_options (dict): Options used for the fetcher (such as timeout
             or cookies)
@@ -888,10 +889,13 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
     first_stage_function = kwargs.get("first_stage_function", None)
     keep_stage = kwargs.get("keep_stage", False)
     latest = kwargs.get("latest", False)
+    limit = kwargs.get("limit", 0)
 
     sorted_versions = sorted(url_dict.keys(), reverse=True)
     if latest:
         sorted_versions = sorted_versions[:1]
+    elif limit:
+        sorted_versions = sorted_versions[:limit]
 
     # Find length of longest string in the list for padding
     max_len = max(len(str(v)) for v in sorted_versions)


### PR DESCRIPTION
* New command option `spack create --limit #`.

* Corresponding functionality in
  `spack.stage.get_checksums_for_versions()`.
