### PR TITLE
openmpi: allow for ^ucx~thread_multiple

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -536,7 +536,6 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     with when("fabrics=ucx"):
         depends_on("ucx")
         depends_on("ucx +thread_multiple", when="+thread_multiple")
-        depends_on("ucx +thread_multiple", when="@3.0.0:")
         depends_on("ucx@1.9.0:", when="@4.0.6:4.0")
         depends_on("ucx@1.9.0:", when="@4.1.1:4.1")
         depends_on("ucx@1.9.0:", when="@5.0.0:")


### PR DESCRIPTION
I currently cannot build `openmpi@3: fabrics=ucx ^ucx~thread_multiple`:

```console
$ spack spec openmpi@3: fabrics=ucx ^ucx~thread_multiple
==> Error: 'ucx' required multiple values for single-valued variant 'thread_multiple'
    Requested '~thread_multiple' and '+thread_multiple'
```

due to the openmpi recipe requiring `ucx +thread_multiple`:

```python
depends_on("ucx +thread_multiple", when="@3.0.0:")
```

Unfortunately this PR will change the current behavior of the openmpi recipe as `ucx` defaults to `~thread_multiple` and I could not figure out an easy way to maintain the existing behavior while allowing for `^ucx~thread_multiple`.

I would have thought an easy solution would be to propagate `openmpi+/~thread_multiple` to `ucx`, but `thread_multiple` is only applicable to `openmpi@1.5.4:2` and I am not familar enough with openmpi to understand why.

Alternative solutions would be appreciated.