### PR TITLE
keepassxc: as an option do not build documentation

### DIFF
--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -65,11 +65,8 @@ class Keepassxc(CMakePackage):
             "-DKEEPASSXC_BUILD_TYPE=Release",
             "-DCMAKE_INSTALL_DATADIR=%s" % join_path(spec.prefix, "share"),
         ]
-        if "+autotype" in spec:
-            args.append("-DWITH_XC_ALL=ON")
-        else:
-            args.append("-DWITH_XC_ALL=OFF")
-        args.append(self.define_from_variant("WITH_XC_DOCS", "doc"))
+        args.append(self.define_from_variant("WITH_XC_ALL", "autotype"))
+        args.append(self.define_from_variant("WITH_XC_DOCS", "docs"))
 
         if spec.satisfies("platform=darwin"):
             args.append("-DCMAKE_OSX_ARCHITECTURES=x86_64")

--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -69,10 +69,7 @@ class Keepassxc(CMakePackage):
             args.append("-DWITH_XC_ALL=ON")
         else:
             args.append("-DWITH_XC_ALL=OFF")
-        if "+docs" in spec:
-            args.append("-DWITH_XC_DOCS=ON")
-        else:
-            args.append("-DWITH_XC_DOCS=OFF")
+        args.append(self.define_from_variant("WITH_XC_DOCS", "doc"))
 
         if spec.satisfies("platform=darwin"):
             args.append("-DCMAKE_OSX_ARCHITECTURES=x86_64")

--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -29,6 +29,7 @@ class Keepassxc(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
     )
     variant("autotype", default=False, description="enable auto-type")
+    variant("docs", default=True, description="Build documentation")
 
     # https://github.com/keepassxreboot/keepassxc/wiki/Building-KeePassXC
     # https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-Linux
@@ -50,7 +51,7 @@ class Keepassxc(CMakePackage):
     # Had to add libqrencode
     depends_on("libqrencode", type=("link", "build"))
     # Has anyone done gem i bundler and gem i asciidoctor ? https://asciidoctor.org/
-    depends_on("ruby-asciidoctor@2.0:", type=("build"))
+    depends_on("ruby-asciidoctor@2.0:", type=("build"), when="+docs")
     # sudo apt install libxi-dev libxtst-dev libqt5x11extras5-dev libyubikey-dev \
     # libykpers-1-dev libquazip5-dev libreadline-dev
     # These are required to build Auto-Type, Yubikey and browser integration support.
@@ -68,6 +69,10 @@ class Keepassxc(CMakePackage):
             args.append("-DWITH_XC_ALL=ON")
         else:
             args.append("-DWITH_XC_ALL=OFF")
+        if "+docs" in spec:
+            args.append("-DWITH_XC_DOCS=ON")
+        else:
+            args.append("-DWITH_XC_DOCS=OFF")
 
         if spec.satisfies("platform=darwin"):
             args.append("-DCMAKE_OSX_ARCHITECTURES=x86_64")


### PR DESCRIPTION
This avoids the dependency to asciidoctor and thus to ruby.
