### PR TITLE
Increase verbosity when merging prefixes

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -769,7 +769,7 @@ class SimpleFilesystemView(FilesystemView):
         # Inform about file-file conflicts.
         if visitor.file_conflicts:
             if self.ignore_conflicts:
-                tty.debug("{0} file conflicts".format(len(visitor.file_conflicts)))
+                tty.info(MergeConflictSummary(visitor.file_conflicts))
             else:
                 raise MergeConflictSummary(visitor.file_conflicts)
 


### PR DESCRIPTION
When creating a view, Spack ignores file-file conflicts.

This PR turns the debug message into a normal message, and improves the
readability a bit.

```
$ spack -e . env view regenerate
==> Updating view at /tmp/tmp.rHMugQJiBm/.spack-env/view
==> MergeConflictSummary: 281 issues when merging prefixes:
    /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/gdbm-1.19-yfz2agazed7ohevqvnrmm7jfkmsgwjao/share/info/dir:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/readline-8.1-73t7ndb5w72hrat5hsax4caox2sgumzu/share/info/dir:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/gettext-0.21-ajblnmiotgb5ph3socepdxlpkqlywetx/share/info/dir:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/tar-1.34-55vqlcz5yvcmodufep2erajhvs7q6jst/share/info/dir:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/libffi-3.4.2-tdhityljopjgvl65oi4ejgzxs3r53gbl/share/info/dir map to share/info/dir
    /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/python-3.9.10-2j63ijzirnutznbmpkkkcegfeu247oae/lib/python3.9/site-packages/_distutils_hack/__init__.py:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/py-setuptools-59.4.0-ily72r6lb2gz4fpvees42d3fjs3dfiad/lib/python3.9/site-packages/_distutils_hack/__init__.py map to lib/python3.9/site-packages/_distutils_hack/__init__.py
    /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/python-3.9.10-2j63ijzirnutznbmpkkkcegfeu247oae/lib/python3.9/site-packages/_distutils_hack/__pycache__/__init__.cpython-39.pyc:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/py-setuptools-59.4.0-ily72r6lb2gz4fpvees42d3fjs3dfiad/lib/python3.9/site-packages/_distutils_hack/__pycache__/__init__.cpython-39.pyc map to lib/python3.9/site-packages/_distutils_hack/__pycache__/__init__.cpython-39.pyc
    /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/python-3.9.10-2j63ijzirnutznbmpkkkcegfeu247oae/lib/python3.9/site-packages/_distutils_hack/__pycache__/override.cpython-39.pyc:/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/py-setuptools-59.4.0-ily72r6lb2gz4fpvees42d3fjs3dfiad/lib/python3.9/site-packages/_distutils_hack/__pycache__/override.cpython-39.pyc map to lib/python3.9/site-packages/_distutils_hack/__pycache__/override.cpython-39.pyc
    ...
```
