### PR TITLE
use spack-build-HASH for meson packages in develop envs

### DIFF
--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -139,12 +139,20 @@ class MesonPackage(PackageBase):
         setattr(self, "meson_flag_args", [])
 
     @property
+    def build_dirname(self):
+        """Returns the directory name to use when building the package
+
+        :return: name of the subdirectory for building the package
+        """
+        return "spack-build-%s" % self.spec.dag_hash(7)
+
+    @property
     def build_directory(self):
         """Returns the directory to use when building the package
 
         :return: directory where to build the package
         """
-        return os.path.join(self.stage.source_path, "spack-build")
+        return os.path.join(self.stage.path, self.build_dirname)
 
     def meson_args(self):
         """Produces a list containing all the arguments that must be passed to


### PR DESCRIPTION
The build directory for a meson package under development was always called `spack-build`. This will cause conflicts when one wants to compile multiple specs of the same package.
Copy/paste method `build_dirname` from `build_systems/cmake.py` to have a unique name for the build directory.