### PR TITLE
podio, edm4hep: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -42,6 +42,7 @@ class Edm4hep(CMakePackage):
     depends_on("python", type="build")
 
     depends_on("root@6.08:")
+    depends_on("podio@0.15:", when="@0.6:")
     depends_on("podio@0.14.1:", when="@0.4.1:")
     depends_on("podio@0.14", when="@0.4")
     depends_on("podio@0.13.0:0.13", when="@:0.3")

--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -19,6 +19,7 @@ class Edm4hep(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("0.6", sha256="625a5a939cb8d7a0a6ab5874a3e076d7dd5338446be3921b0cbc09de4d96b315")
     version("0.5", sha256="aae4f001412d57585751d858999fe78e004755aa0303a503d503a325ef97d7e0")
     version("0.4.2", sha256="5f2ff3a14729cbd4da370c7c768c2a09eb9f68f814d61690b1cc99c4248994f4")
     version("0.4.1", sha256="122987fd5969b0f1639afa9668ac5181203746d00617ddb3bf8a2a9842758a63")

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -20,6 +20,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("0.15", sha256="6c1520877ba1bce250e35a2a56c0a3da89fae0916c5ed7d5548d658237e067d9")
     version("0.14.3", sha256="2a7a405dedc7f6980a0aad7df87b427a1f43bcf6d923a9bcce1698fd296359f7")
     version("0.14.1", sha256="361ac3f3ec6f5a4830729ab45f96c19f0f62e9415ff681f7c6cdb4ebdb796f72")
     version("0.14", sha256="47f99f1190dc71d6deb52a2b1831250515dbd5c9e0f263c3c8553ffc5b260dfb")


### PR DESCRIPTION
New versions (interrelated updates):
- podio: https://github.com/AIDASoft/podio/compare/v00-14...v00-15
- edm4hep: https://github.com/key4hep/EDM4hep/compare/v00-05...v00-06

Maintainer tags: @vvolkl @drbenmorgan 