### PR TITLE
openblas@0.3.20 %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -177,6 +177,14 @@ class Openblas(MakefilePackage):
 
     depends_on("perl", type="build")
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        iflags = []
+        if name == "cflags":
+            if spec.satisfies("@0.3.20 %oneapi"):
+                iflags.append("-Wno-error=implicit-function-declaration")
+        return (iflags, None, None)
+
     @classmethod
     def determine_version(cls, lib):
         ver = None


### PR DESCRIPTION
Use `flag_handler` to add `-Wno-error=implicit-function-declaration` to builds of `openblas@0.3.20 %oneapi`. This will preserve the warning but prevent the error.

FYI @martin-frbg @rscohn2 @wspear

This gets us past builds that fail due to strict ISO C99 standards:
```
...
  >> 14318    linktest.c:18:1: error: call to undeclared function 'sger_'; ISO 
              C99 and later do not support implicit function declarations [-Wim
              plicit-function-declaration]
     14319    sger_();
     14320    ^
  >> 14321    linktest.c:19:1: error: call to undeclared function 'smax_'; ISO 
              C99 and later do not support implicit function declarations [-Wim
              plicit-function-declaration]
     14322    smax_();
     14323    ^
  >> 14324    linktest.c:20:1: error: call to undeclared function 'smin_'; ISO 
              C99 and later do not support implicit function declarations [-Wim
              plicit-function-declaration]
     14325    smin_();
...
```
