### PR TITLE
hdf5 %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -331,10 +331,10 @@ class Hdf5(CMakePackage):
         cmake_flags = []
 
         if name == "cflags":
-            if spec.compiler.name in ["gcc", "clang", "apple-clang"]:
+            if spec.compiler.name in ["gcc", "clang", "apple-clang", "oneapi"]:
                 # Quiet warnings/errors about implicit declaration of functions
                 # in C99:
-                cmake_flags.append("-Wno-implicit-function-declaration")
+                cmake_flags.append("-Wno-error=implicit-function-declaration")
                 # Note that this flag will cause an error if building %nvhpc.
             if spec.satisfies("@:1.8.12~shared"):
                 # More recent versions set CMAKE_POSITION_INDEPENDENT_CODE to


### PR DESCRIPTION
Add `-Wno-error=implicit-function-declaration` to flags when using `%oneapi`. This will preserve the warning while preventing the error.

Resolves errors like this:
```
     835    ...src/H5Dio.c:475:5: note: did you mean 'H5T_patch_fi
            le'?
     836    ...src/H5Tprivate.h:139:15: note: 'H5T_patch_file' dec
            lared here
     837    H5_DLL herr_t H5T_patch_file(H5T_t *dt, H5F_t *f);
     838                  ^
  >> 839    ...src/H5Dio.c:698:5: error: call to undeclared functi
            on 'H5T_patch_vlen_file'; ISO C99 and later do not support implicit
             function declarations [-Wimplicit-function-declaration]
     840        H5T_patch_vlen_file(dataset->shared->type, dataset->oloc.file);
```

@rscohn2 @ChristopherHogan @brtnfld @byrnHDF@epourmal @gheber @hyoklee @lkurz @lrknox @soumagne @wspear