### PR TITLE
mpifileutils %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -68,6 +68,14 @@ class Mpifileutils(Package):
     variant("experimental", default=False, description="Install experimental tools")
     conflicts("+experimental", when="@:0.6")
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        iflags = []
+        if name == "cflags":
+            if spec.satisfies("%oneapi"):
+                iflags.append("-Wno-error=implicit-function-declaration")
+        return (iflags, None, None)
+
     def cmake_args(self):
         args = std_cmake_args
         args.append("-DCMAKE_INSTALL_PREFIX=%s" % self.spec.prefix)


### PR DESCRIPTION
Add `-Wno-error=implicit-function-declaration` to `mpifileutils %oneapi` via `flag_handler`

Silences errors like:
```
...
  >> 408     <truncated>/spack-src/src/common/mfu_io.c:1583:18: error: call to
             undeclared function 'lgetxattr'; ISO C99 and later do not support 
            implicit function declarations [-Wimplicit-function-declaration]
     409        ssize_t rc = lgetxattr(path, name, value, size);
     410                     ^
  >> 411     <truncated>/spack-src/src/common/mfu_io.c:1618:18: error: call to
             undeclared function 'getxattr'; ISO C99 and later do not support i
            mplicit function declarations [-Wimplicit-function-declaration]
     412        ssize_t rc = getxattr(path, name, value, size);
...
```

FYI @wspear @rscohn2 