### PR TITLE
Use property instead of methods in PythonPackage

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -156,7 +156,6 @@ class PythonPackage(PackageBase):
         """
         return self.stage.source_path
 
-    @property
     def config_settings(self):
         """Configuration settings to be passed to the PEP 517 build backend.
 
@@ -171,7 +170,6 @@ class PythonPackage(PackageBase):
         """
         return {}
 
-    @property
     def install_options(self):
         """Extra arguments to be supplied to the setup.py install command.
 
@@ -184,7 +182,6 @@ class PythonPackage(PackageBase):
         """
         return []
 
-    @property
     def global_options(self):
         """Extra global options to be supplied to the setup.py call before the install
         or bdist_wheel command.
@@ -203,7 +200,7 @@ class PythonPackage(PackageBase):
 
         args = PythonPackage._std_args(self) + ["--prefix=" + prefix]
 
-        for key, value in self.config_settings.items():
+        for key, value in self.config_settings().items():
             if spec["py-pip"].version < Version("22.1"):
                 raise SpecError(
                     "'{}' package uses 'config_settings' which is only supported by "
@@ -211,9 +208,9 @@ class PythonPackage(PackageBase):
                     '    depends_on("py-pip@22.1:", type="build")'.format(spec.name)
                 )
             args.append("--config-settings={}={}".format(key, value))
-        for option in self.install_options:
+        for option in self.install_options():
             args.append("--install-option=" + option)
-        for option in self.global_options:
+        for option in self.global_options():
             args.append("--global-option=" + option)
 
         if self.stage.archive_file and self.stage.archive_file.endswith(".whl"):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -156,7 +156,8 @@ class PythonPackage(PackageBase):
         """
         return self.stage.source_path
 
-    def config_settings(self, spec, prefix):
+    @property
+    def config_settings(self):
         """Configuration settings to be passed to the PEP 517 build backend.
 
         Requires pip 22.1+, which requires Python 3.7+.
@@ -170,7 +171,8 @@ class PythonPackage(PackageBase):
         """
         return {}
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         """Extra arguments to be supplied to the setup.py install command.
 
         Args:
@@ -182,7 +184,8 @@ class PythonPackage(PackageBase):
         """
         return []
 
-    def global_options(self, spec, prefix):
+    @property
+    def global_options(self):
         """Extra global options to be supplied to the setup.py call before the install
         or bdist_wheel command.
 
@@ -200,7 +203,7 @@ class PythonPackage(PackageBase):
 
         args = PythonPackage._std_args(self) + ["--prefix=" + prefix]
 
-        for key, value in self.config_settings(spec, prefix).items():
+        for key, value in self.config_settings.items():
             if spec["py-pip"].version < Version("22.1"):
                 raise SpecError(
                     "'{}' package uses 'config_settings' which is only supported by "
@@ -208,9 +211,9 @@ class PythonPackage(PackageBase):
                     '    depends_on("py-pip@22.1:", type="build")'.format(spec.name)
                 )
             args.append("--config-settings={}={}".format(key, value))
-        for option in self.install_options(spec, prefix):
+        for option in self.install_options:
             args.append("--install-option=" + option)
-        for option in self.global_options(spec, prefix):
+        for option in self.global_options:
             args.append("--global-option=" + option)
 
         if self.stage.archive_file and self.stage.archive_file.endswith(".whl"):

--- a/var/spack/repos/builtin/packages/py-abipy/package.py
+++ b/var/spack/repos/builtin/packages/py-abipy/package.py
@@ -57,10 +57,8 @@ class PyAbipy(PythonPackage):
     depends_on("py-jupyter", type=("build", "run"), when="+ipython")
     depends_on("py-nbformat", type=("build", "run"), when="+ipython")
 
-    def install_options(self, spec, prefix):
-        args = []
-
-        if "+ipython" in spec:
-            args.append("--with-ipython")
-
-        return args
+    @property
+    def install_options(self):
+        if "+ipython" in self.spec:
+            return ["--with-ipython"]
+        return []

--- a/var/spack/repos/builtin/packages/py-abipy/package.py
+++ b/var/spack/repos/builtin/packages/py-abipy/package.py
@@ -57,7 +57,6 @@ class PyAbipy(PythonPackage):
     depends_on("py-jupyter", type=("build", "run"), when="+ipython")
     depends_on("py-nbformat", type=("build", "run"), when="+ipython")
 
-    @property
     def install_options(self):
         if "+ipython" in self.spec:
             return ["--with-ipython"]

--- a/var/spack/repos/builtin/packages/py-arcgis/package.py
+++ b/var/spack/repos/builtin/packages/py-arcgis/package.py
@@ -32,5 +32,4 @@ class PyArcgis(PythonPackage):
     depends_on("py-requests-toolbelt", type=("build", "run"))
     depends_on("py-requests-ntlm", type=("build", "run"))
 
-    def global_options(self, spec, prefix):
-        return ["--conda-install-mode"]
+    global_options = ["--conda-install-mode"]

--- a/var/spack/repos/builtin/packages/py-arcgis/package.py
+++ b/var/spack/repos/builtin/packages/py-arcgis/package.py
@@ -32,4 +32,5 @@ class PyArcgis(PythonPackage):
     depends_on("py-requests-toolbelt", type=("build", "run"))
     depends_on("py-requests-ntlm", type=("build", "run"))
 
-    global_options = ["--conda-install-mode"]
+    def global_options(self):
+        return ["--conda-install-mode"]

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -74,16 +74,13 @@ class PyAstropy(PythonPackage):
         # cython-ized files
         os.remove("astropy/cython_version.py")
 
-    def install_options(self, spec, prefix):
-        args = [
-            "--use-system-libraries",
-            "--use-system-erfa",
-            "--use-system-wcslib",
-            "--use-system-cfitsio",
-            "--use-system-expat",
-        ]
-
-        return args
+    install_options = [
+        "--use-system-libraries",
+        "--use-system-erfa",
+        "--use-system-wcslib",
+        "--use-system-cfitsio",
+        "--use-system-expat",
+    ]
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -74,13 +74,14 @@ class PyAstropy(PythonPackage):
         # cython-ized files
         os.remove("astropy/cython_version.py")
 
-    install_options = [
-        "--use-system-libraries",
-        "--use-system-erfa",
-        "--use-system-wcslib",
-        "--use-system-cfitsio",
-        "--use-system-expat",
-    ]
+    def install_options(self):
+        return [
+            "--use-system-libraries",
+            "--use-system-erfa",
+            "--use-system-wcslib",
+            "--use-system-cfitsio",
+            "--use-system-expat",
+        ]
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-brian2/package.py
+++ b/var/spack/repos/builtin/packages/py-brian2/package.py
@@ -33,5 +33,4 @@ class PyBrian2(PythonPackage):
     depends_on("py-setuptools@21:", type=("build", "run"))
     depends_on("py-setuptools@24.2:", type=("build", "run"), when="@2.4:")
 
-    def install_options(self, spec, prefix):
-        return ["--with-cython"]
+    install_options = ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-brian2/package.py
+++ b/var/spack/repos/builtin/packages/py-brian2/package.py
@@ -33,4 +33,5 @@ class PyBrian2(PythonPackage):
     depends_on("py-setuptools@21:", type=("build", "run"))
     depends_on("py-setuptools@24.2:", type=("build", "run"), when="@2.4:")
 
-    install_options = ["--with-cython"]
+    def install_options(self):
+        return ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -62,7 +62,6 @@ class PyCharm4py(PythonPackage):
     def setup_build_environment(self, env):
         env.set("SPACK_CHARM4PY_EXTRALIBS", self.spec["cuda"].libs.ld_flags)
 
-    @property
     def install_options(self):
         if "+mpi" in self.spec:
             return ["--mpi"]

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -62,8 +62,8 @@ class PyCharm4py(PythonPackage):
     def setup_build_environment(self, env):
         env.set("SPACK_CHARM4PY_EXTRALIBS", self.spec["cuda"].libs.ld_flags)
 
-    def install_options(self, spec, prefix):
-        args = []
-        if "+mpi" in spec:
-            args.append("--mpi")
-        return args
+    @property
+    def install_options(self):
+        if "+mpi" in self.spec:
+            return ["--mpi"]
+        return []

--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -40,4 +40,5 @@ class PyCmake(PythonPackage):
             placement="cmake-src",
         )
 
-    install_options = ["-DBUILD_CMAKE_FROM_SOURCE=ON", "-DCMakeProject_SOURCE_DIR=cmake-src"]
+    def install_options(self):
+        return ["-DBUILD_CMAKE_FROM_SOURCE=ON", "-DCMakeProject_SOURCE_DIR=cmake-src"]

--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -40,5 +40,4 @@ class PyCmake(PythonPackage):
             placement="cmake-src",
         )
 
-    def install_options(self, spec, prefix):
-        return ["-DBUILD_CMAKE_FROM_SOURCE=ON", "-DCMakeProject_SOURCE_DIR=cmake-src"]
+    install_options = ["-DBUILD_CMAKE_FROM_SOURCE=ON", "-DCMakeProject_SOURCE_DIR=cmake-src"]

--- a/var/spack/repos/builtin/packages/py-fastrlock/package.py
+++ b/var/spack/repos/builtin/packages/py-fastrlock/package.py
@@ -18,4 +18,5 @@ class PyFastrlock(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")
 
-    install_options = ["--with-cython"]
+    def install_options(self):
+        return ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-fastrlock/package.py
+++ b/var/spack/repos/builtin/packages/py-fastrlock/package.py
@@ -18,5 +18,4 @@ class PyFastrlock(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")
 
-    def install_options(self, spec, prefix):
-        return ["--with-cython"]
+    install_options = ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-gluoncv/package.py
+++ b/var/spack/repos/builtin/packages/py-gluoncv/package.py
@@ -30,4 +30,5 @@ class PyGluoncv(PythonPackage):
 
     patch("no-unicode-readme.patch")
 
-    install_options = ["--with-cython"]
+    def install_options(self):
+        return ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-gluoncv/package.py
+++ b/var/spack/repos/builtin/packages/py-gluoncv/package.py
@@ -30,5 +30,4 @@ class PyGluoncv(PythonPackage):
 
     patch("no-unicode-readme.patch")
 
-    def install_options(self, spec, prefix):
-        return ["--with-cython"]
+    install_options = ["--with-cython"]

--- a/var/spack/repos/builtin/packages/py-lightgbm/package.py
+++ b/var/spack/repos/builtin/packages/py-lightgbm/package.py
@@ -27,10 +27,8 @@ class PyLightgbm(PythonPackage):
 
     depends_on("mpi", when="+mpi")
 
-    def install_options(self, spec, prefix):
-        args = []
-
-        if spec.satisfies("+mpi"):
-            args.append("--mpi")
-
-        return args
+    @property
+    def install_options(self):
+        if self.spec.satisfies("+mpi"):
+            return ["--mpi"]
+        return []

--- a/var/spack/repos/builtin/packages/py-lightgbm/package.py
+++ b/var/spack/repos/builtin/packages/py-lightgbm/package.py
@@ -27,7 +27,6 @@ class PyLightgbm(PythonPackage):
 
     depends_on("mpi", when="+mpi")
 
-    @property
     def install_options(self):
         if self.spec.satisfies("+mpi"):
             return ["--mpi"]

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -33,6 +33,7 @@ class PyMpi4py(PythonPackage):
     depends_on("py-cython@0.27.0:", when="@master", type="build")
     depends_on("py-3to2", when="@3.1: ^python@:2", type="build")
 
-    @when("@3.1:")
-    def install_options(self, spec, prefix):
-        return ["--mpicc=%s -shared" % spec["mpi"].mpicc]
+    def install_options(self):
+        if self.spec.satisfies("@3.1:"):
+            return ["--mpicc={} -shared".format(self.spec["mpi"].mpicc)]
+        return []

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -45,6 +45,7 @@ class PyNetworkit(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("python@3:", type=("build", "run"))
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         # Enable ext. core-library + parallel build
         return ["-j{0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -45,7 +45,6 @@ class PyNetworkit(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("python@3:", type=("build", "run"))
 
-    @property
     def install_options(self):
         # Enable ext. core-library + parallel build
         return ["-j{0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -85,9 +85,11 @@ class PyProtobuf(PythonPackage):
         protobuf_dir = self.spec["protobuf"].libs.directories[0]
         env.prepend_path("LIBRARY_PATH", protobuf_dir)
 
-    @when("+cpp")
-    def install_options(self, spec, prefix):
-        return ["--cpp_implementation"]
+    @property
+    def install_options(self):
+        if self.spec.satisfies("+cpp"):
+            return ["--cpp_implementation"]
+        return []
 
     @run_after("install")
     def fix_import_error(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -85,7 +85,6 @@ class PyProtobuf(PythonPackage):
         protobuf_dir = self.spec["protobuf"].libs.directories[0]
         env.prepend_path("LIBRARY_PATH", protobuf_dir)
 
-    @property
     def install_options(self):
         if self.spec.satisfies("+cpp"):
             return ["--cpp_implementation"]

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -64,7 +64,6 @@ class PyPyarrow(PythonPackage, CudaPackage):
 
     patch("for_aarch64.patch", when="@0 target=aarch64:")
 
-    @property
     def install_options(self):
         args, spec = [], self.spec
         if spec.satisfies("+parquet"):

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -64,8 +64,9 @@ class PyPyarrow(PythonPackage, CudaPackage):
 
     patch("for_aarch64.patch", when="@0 target=aarch64:")
 
-    def install_options(self, spec, prefix):
-        args = []
+    @property
+    def install_options(self):
+        args, spec = [], self.spec
         if spec.satisfies("+parquet"):
             args.append("--with-parquet")
         if spec.satisfies("+cuda"):

--- a/var/spack/repos/builtin/packages/py-pymol/package.py
+++ b/var/spack/repos/builtin/packages/py-pymol/package.py
@@ -39,14 +39,13 @@ class PyPymol(PythonPackage):
     depends_on("py-numpy", type=("build", "link", "run"))
     depends_on("py-msgpack", type=("build", "run"))
 
-    def install_options(self, spec, prefix):
-        return ["--no-launcher"]
+    install_options = ["--no-launcher"]
 
     def install(self, spec, prefix):
         # Note: pymol monkeypatches distutils which breaks pip install, use deprecated
         # `python setup.py install` and distutils instead of `pip install` and
         # setuptools. See: https://github.com/schrodinger/pymol-open-source/issues/217
-        python("setup.py", "install", "--prefix=" + prefix, *self.install_options(spec, prefix))
+        python("setup.py", "install", "--prefix=" + prefix, *self.install_options)
 
     @run_after("install")
     def install_launcher(self):

--- a/var/spack/repos/builtin/packages/py-pymol/package.py
+++ b/var/spack/repos/builtin/packages/py-pymol/package.py
@@ -39,13 +39,14 @@ class PyPymol(PythonPackage):
     depends_on("py-numpy", type=("build", "link", "run"))
     depends_on("py-msgpack", type=("build", "run"))
 
-    install_options = ["--no-launcher"]
+    def install_options(self):
+        return ["--no-launcher"]
 
     def install(self, spec, prefix):
         # Note: pymol monkeypatches distutils which breaks pip install, use deprecated
         # `python setup.py install` and distutils instead of `pip install` and
         # setuptools. See: https://github.com/schrodinger/pymol-open-source/issues/217
-        python("setup.py", "install", "--prefix=" + prefix, *self.install_options)
+        python("setup.py", "install", "--prefix=" + prefix, *self.install_options())
 
     @run_after("install")
     def install_launcher(self):

--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -91,6 +91,5 @@ class PyPyside(PythonPackage):
             "setup.py",
         )
 
-    @property
     def install_options(self):
         return ["--jobs={0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -91,5 +91,6 @@ class PyPyside(PythonPackage):
             "setup.py",
         )
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         return ["--jobs={0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -47,18 +47,19 @@ class PyPyside2(PythonPackage):
     depends_on("libxslt@1.1.19:", when="+doc", type="build")
     depends_on("py-sphinx", when="+doc", type="build")
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         args = [
             "--parallel={0}".format(make_jobs),
             "--ignore-git",
-            "--qmake={0}".format(spec["qt"].prefix.bin.qmake),
+            "--qmake={0}".format(self.spec["qt"].prefix.bin.qmake),
         ]
         if self.run_tests:
             args.append("--build-tests")
         return args
 
     def install(self, spec, prefix):
-        python("setup.py", "install", "--prefix=" + prefix, *self.install_options(spec, prefix))
+        python("setup.py", "install", "--prefix=" + prefix, *self.install_options)
 
     @run_after("install")
     def install_docs(self):

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -47,7 +47,6 @@ class PyPyside2(PythonPackage):
     depends_on("libxslt@1.1.19:", when="+doc", type="build")
     depends_on("py-sphinx", when="+doc", type="build")
 
-    @property
     def install_options(self):
         args = [
             "--parallel={0}".format(make_jobs),
@@ -59,7 +58,7 @@ class PyPyside2(PythonPackage):
         return args
 
     def install(self, spec, prefix):
-        python("setup.py", "install", "--prefix=" + prefix, *self.install_options)
+        python("setup.py", "install", "--prefix=" + prefix, *self.install_options())
 
     @run_after("install")
     def install_docs(self):

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -39,7 +39,6 @@ class PyPyyaml(PythonPackage):
 
         return modules
 
-    @property
     def global_options(self):
         if "+libyaml" in self.spec:
             return ["--with-libyaml"]

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -39,12 +39,8 @@ class PyPyyaml(PythonPackage):
 
         return modules
 
-    def global_options(self, spec, prefix):
-        args = []
-
+    @property
+    def global_options(self):
         if "+libyaml" in self.spec:
-            args.append("--with-libyaml")
-        else:
-            args.append("--without-libyaml")
-
-        return args
+            return ["--with-libyaml"]
+        return ["--without-libyaml"]

--- a/var/spack/repos/builtin/packages/py-qiskit-aer/package.py
+++ b/var/spack/repos/builtin/packages/py-qiskit-aer/package.py
@@ -39,9 +39,9 @@ class PyQiskitAer(PythonPackage, CudaPackage):
         env.set("DISABLE_DEPENDENCY_INSTALL", "1")
         env.set("CUDAHOSTCXX", spack_cxx)
 
-    def install_options(self, spec, prefix):
-        args = []
-        args.append("-DDISABLE_CONAN=ON")
+    @property
+    def install_options(self):
+        args = ["-DDISABLE_CONAN=ON"]
         if "~gdr" in self.spec:
             args.append("-DAER_DISABLE_GDR=True")
         else:
@@ -52,7 +52,7 @@ class PyQiskitAer(PythonPackage, CudaPackage):
             args.append("-DAER_MPI=False")
         if "+cuda" in self.spec:
             args.append("-DAER_THRUST_BACKEND=CUDA")
-            cuda_archs = spec.variants["cuda_arch"].value
+            cuda_archs = self.spec.variants["cuda_arch"].value
             if "none" not in cuda_archs:
                 args.append("-DCUDA_NVCC_FLAGS={0}".format(" ".join(self.cuda_flags(cuda_archs))))
         return args

--- a/var/spack/repos/builtin/packages/py-qiskit-aer/package.py
+++ b/var/spack/repos/builtin/packages/py-qiskit-aer/package.py
@@ -39,7 +39,6 @@ class PyQiskitAer(PythonPackage, CudaPackage):
         env.set("DISABLE_DEPENDENCY_INSTALL", "1")
         env.set("CUDAHOSTCXX", spack_cxx)
 
-    @property
     def install_options(self):
         args = ["-DDISABLE_CONAN=ON"]
         if "~gdr" in self.spec:

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -125,11 +125,11 @@ class PyScipy(PythonPackage):
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
 
-    def install_options(self, spec, prefix):
-        args = []
-        if spec.satisfies("%fj"):
-            args.extend(["config_fc", "--fcompiler=fujitsu"])
-        return args
+    @property
+    def install_options(self):
+        if self.spec.satisfies("%fj"):
+            return ["config_fc", "--fcompiler=fujitsu"]
+        return []
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -125,7 +125,6 @@ class PyScipy(PythonPackage):
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
 
-    @property
     def install_options(self):
         if self.spec.satisfies("%fj"):
             return ["config_fc", "--fcompiler=fujitsu"]

--- a/var/spack/repos/builtin/packages/py-scs/package.py
+++ b/var/spack/repos/builtin/packages/py-scs/package.py
@@ -28,7 +28,6 @@ class PyScs(PythonPackage, CudaPackage):
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.13.2:", type=("build", "run"))
 
-    @property
     def install_options(self):
         args, spec = [], self.spec
         if (

--- a/var/spack/repos/builtin/packages/py-scs/package.py
+++ b/var/spack/repos/builtin/packages/py-scs/package.py
@@ -28,8 +28,9 @@ class PyScs(PythonPackage, CudaPackage):
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.13.2:", type=("build", "run"))
 
-    def install_options(self, spec, prefix):
-        args = []
+    @property
+    def install_options(self):
+        args, spec = [], self.spec
         if (
             "+cuda" in spec
             or "+float32" in spec

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -51,5 +51,6 @@ class PyShiboken(PythonPackage):
             "shiboken_postinstall.py",
         )
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         return ["--jobs={0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -51,6 +51,5 @@ class PyShiboken(PythonPackage):
             "shiboken_postinstall.py",
         )
 
-    @property
     def install_options(self):
         return ["--jobs={0}".format(make_jobs)]

--- a/var/spack/repos/builtin/packages/py-symengine/package.py
+++ b/var/spack/repos/builtin/packages/py-symengine/package.py
@@ -32,5 +32,6 @@ class PySymengine(PythonPackage):
     depends_on("symengine@0.2.0", when="@0.2.0")
     depends_on("symengine@0.8.1", when="@0.8.1")
 
-    def install_options(self, spec, prefix):
-        return ["--symengine-dir={0}".format(spec["symengine"].prefix)]
+    @property
+    def install_options(self):
+        return ["--symengine-dir={0}".format(self.spec["symengine"].prefix)]

--- a/var/spack/repos/builtin/packages/py-symengine/package.py
+++ b/var/spack/repos/builtin/packages/py-symengine/package.py
@@ -32,6 +32,5 @@ class PySymengine(PythonPackage):
     depends_on("symengine@0.2.0", when="@0.2.0")
     depends_on("symengine@0.8.1", when="@0.8.1")
 
-    @property
     def install_options(self):
         return ["--symengine-dir={0}".format(self.spec["symengine"].prefix)]

--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -48,7 +48,6 @@ class PyTomopy(PythonPackage):
     depends_on("py-dxchange", type=("build", "run"))
     depends_on("py-numexpr", when="@1.11:", type=("build", "run"))
 
-    @property
     def install_options(self):
         if not self.spec.satisfies("@1.10:"):
             return []

--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -48,8 +48,11 @@ class PyTomopy(PythonPackage):
     depends_on("py-dxchange", type=("build", "run"))
     depends_on("py-numexpr", when="@1.11:", type=("build", "run"))
 
-    @when("@1.10:")
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
+        if not self.spec.satisfies("@1.10:"):
+            return []
+
         args = ["--enable-arch"]
         if "avx512" in self.spec.target:
             args.append("--enable-avx512")

--- a/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
@@ -35,10 +35,11 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
                 )
                 env.set("TORCH_CUDA_ARCH_LIST", torch_cuda_arch)
 
-    def install_options(self, spec, prefix):
+    @property
+    def install_options(self):
         args = []
-        if spec.satisfies("^py-torch@1.0:"):
+        if self.spec.satisfies("^py-torch@1.0:"):
             args.append("--cpp_ext")
-            if "+cuda" in spec:
+            if "+cuda" in self.spec:
                 args.append("--cuda_ext")
         return args

--- a/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
@@ -35,7 +35,6 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
                 )
                 env.set("TORCH_CUDA_ARCH_LIST", torch_cuda_arch)
 
-    @property
     def install_options(self):
         args = []
         if self.spec.satisfies("^py-torch@1.0:"):

--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -67,4 +67,5 @@ class PyXgboost(PythonPackage):
             string=True,
         )
 
-    install_options = ["--use-system-libxgboost"]
+    def install_options(self):
+        return ["--use-system-libxgboost"]

--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -67,5 +67,4 @@ class PyXgboost(PythonPackage):
             string=True,
         )
 
-    def install_options(self, spec, prefix):
-        return ["--use-system-libxgboost"]
+    install_options = ["--use-system-libxgboost"]


### PR DESCRIPTION
This change helps maintaining the consistency in the signature of methods that are used during build. Currently we have:
1. `phases` which accept `(self, spec, prefix)` mainly because of historical reasons
2. Other methods which accept only `(self)`, like e.g. `cmake_args`
3. Properties

Keeping consistency helps in #30738 because we forward functions for packages coded with the current style.

Modifications:
- [x] Change `config_settings`, `install_options` and `global_options` to be property
- [x] Modify all the Python packages in the built-in repository

 