### PR TITLE
flex %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -58,6 +58,14 @@ class Flex(AutotoolsPackage):
         when="@2.6.4",
     )
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        iflags = []
+        if name == "cflags":
+            if spec.satisfies("%oneapi"):
+                iflags.append("-Wno-error=implicit-function-declaration")
+        return (iflags, None, None)
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)


### PR DESCRIPTION
Add `-Wno-error=implicit-function-declaration` to `flex %oneapi` via `flag_handler`

Silences errors such as:
```
  >> 330    scan.l:1036:16: error: call to undeclared function 'xstrdup'; ISO C
            99 and later do not support implicit function declarations [-Wimpli
            cit-function-declaration]
     331                    infilename = xstrdup(file);
     332                                 ^
     333    scan.l:1036:16: note: did you mean 'strdup'?
     334    /usr/include/string.h:167:14: note: 'strdup' declared here
     335    extern char *strdup (const char *__s)
     336                 ^
  >> 337    scan.l:1037:17: error: use of undeclared identifier 'infilename'
     338                    yyin = fopen( infilename, "r" );
     339                                  ^
  >> 340    scan.l:1040:4: error: call to undeclared function 'lerr'; ISO C99 a
            nd later do not support implicit function declarations [-Wimplicit-
            function-declaration]
     341                            lerr( _( "can't open %s" ), file );
```

FYI @wspear 