### PR TITLE
py-setuptools: add v64 and v65

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -103,8 +103,7 @@ class PyNumpy(PythonPackage):
     depends_on("python@3.6:3.10", type=("build", "link", "run"), when="@1.19")
     depends_on("python@3.7:3.10", type=("build", "link", "run"), when="@1.20:1.21")
     depends_on("python@3.8:", type=("build", "link", "run"), when="@1.22:")
-    depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-setuptools@:59", when="@:1.22.1", type=("build", "run"))
+    depends_on("py-setuptools@:59", type=("build", "run"))
     # Check pyproject.toml for updates to the required cython version
     depends_on("py-cython@0.29.13:2", when="@1.18.0:", type="build")
     depends_on("py-cython@0.29.14:2", when="@1.18.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -19,7 +19,7 @@ class PySetuptools(Package):
     version(
         "65.0.0",
         sha256="fe9a97f68b064a6ddd4bacfb0b4b93a4c65a556d97ce906255540439d0c35cef",
-        expand=False
+        expand=False,
     )
     version(
         "64.0.0",

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -17,6 +17,11 @@ class PySetuptools(Package):
     maintainers = ["adamjstewart"]
 
     version(
+        "65.0.0",
+        sha256="fe9a97f68b064a6ddd4bacfb0b4b93a4c65a556d97ce906255540439d0c35cef",
+        expand=False
+    )
+    version(
         "64.0.0",
         sha256="63f463b90ff5e0a1422010100268fd688e15c44ae0798659013c8412963e15e4",
         expand=False,

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -17,6 +17,11 @@ class PySetuptools(Package):
     maintainers = ["adamjstewart"]
 
     version(
+        "64.0.0",
+        sha256="63f463b90ff5e0a1422010100268fd688e15c44ae0798659013c8412963e15e4",
+        expand=False,
+    )
+    version(
         "63.0.0",
         sha256="045aec56a3eee5c82373a70e02db8b6da9a10f7faf61ff89a14ab66c738ed370",
         expand=False,


### PR DESCRIPTION
Successfully installs on macOS 12.5 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.