### PR TITLE
superlu-dist %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -129,6 +129,8 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
             flags.append(self.compiler.cxx11_flag)
         if name == "cflags" and "%pgi" not in self.spec:
             flags.append("-std=c99")
+        if name == "cflags" and self.spec.satisfies("%oneapi"):
+            flags.append("-Wno-error=implicit-function-declaration")
         return (None, None, flags)
 
     examples_src_dir = "EXAMPLE"


### PR DESCRIPTION
Add `-Wno-error=implicit-function-declaration` to `superlu-dist %oneapi` via `flag_handler`

Silence errors such as:
```
  >> 210    <TRUNCATED>/SRC/sec_structs.c:134:20: error: call to und
            eclared function 'getline'; ISO C99 and later do not support implic
            it function declarations [-Wimplicit-function-declaration]
     211        while ((read = getline(&line, &len, fp)) != -1)
```

FYI @wspear @balay @gchavez2 @liuyangzhuan @pghysels @xiaoye