### PR TITLE
tophat: fixing build issue with newer automake versions

### DIFF
--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -29,6 +29,10 @@ class Tophat(AutotoolsPackage):
 
     parallel = False
 
+    def patch(self):
+        # Newer versions of autoconf hate calling AM_INIT_AUTOMAKE twice
+        filter_file(r"^AM_INIT_AUTOMAKE$", "", "configure.ac")
+
     def setup_build_environment(self, env):
         env.append_flags("CFLAGS", self.compiler.cxx98_flag)
 


### PR DESCRIPTION
At some point autoreconf started complaining about multiple uses of the AM_INIT_AUTOMAKE macro.

I opened https://github.com/DaehwanKimLab/tophat/pull/63 in hopes to merge this upstream, but the project doesn't seem terribly active at the moment.