### PR TITLE
Check that no reserved names are overridden by package recipes

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -323,6 +323,7 @@ def _check_patch_urls(pkgs, error_cls):
 
 @package_attributes
 def _search_for_reserved_attributes_names_in_packages(pkgs, error_cls):
+    """Ensure that packages don't override reserved names"""
     RESERVED_NAMES = ("name",)
     errors = []
     for pkg_name in pkgs:

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -36,6 +36,7 @@ the decorator object, that will forward the keyword arguments passed
 as input.
 """
 import collections
+import inspect
 import itertools
 import re
 
@@ -252,6 +253,13 @@ package_directives = AuditClass(
     kwargs=("pkgs",),
 )
 
+package_attributes = AuditClass(
+    group="packages",
+    tag="PKG-ATTRIBUTES",
+    description="Sanity checks on reserved attributes of packages",
+    kwargs=("pkgs",),
+)
+
 
 #: Sanity checks on linting
 # This can take some time, so it's run separately from packages
@@ -309,6 +317,37 @@ def _check_patch_urls(pkgs, error_cls):
                             [patch.url],
                         )
                     )
+
+    return errors
+
+
+@package_attributes
+def _search_for_reserved_attributes_names_in_packages(pkgs, error_cls):
+    RESERVED_NAMES = ("name",)
+    errors = []
+    for pkg_name in pkgs:
+        name_definitions = collections.defaultdict(list)
+        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+
+        for cls_item in inspect.getmro(pkg_cls):
+            for name in RESERVED_NAMES:
+                current_value = cls_item.__dict__.get(name)
+                if current_value is None:
+                    continue
+                name_definitions[name].append((cls_item, current_value))
+
+        for name in RESERVED_NAMES:
+            if len(name_definitions[name]) == 1:
+                continue
+
+            error_msg = (
+                "Package '{}' overrides the '{}' attribute or method, "
+                "which is reserved for Spack internal use"
+            )
+            definitions = [
+                "defined in '{}'".format(x[0].__module__) for x in name_definitions[name]
+            ]
+            errors.append(error_cls(error_msg.format(pkg_name, name), definitions))
 
     return errors
 


### PR DESCRIPTION
A few attribute in packages are meant to be reserved for Spack internal use. This audit checks packages to ensure none of these attributes are overridden.

See https://github.com/spack/spack/pull/32005#discussion_r942798320 Using this diff to introduce an error in built-in:
```diff
diff --git a/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py b/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
index 75346eac70..1765318158 100644
--- a/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
@@ -16,5 +16,5 @@ class RktSchemeLib(RacketPackage):
     version("8.3", commit="a36e729680818712820ee5269f5208c3c0715a6a")  # tag='v8.3'
     depends_on("rkt-base@8.3", type=("build", "run"), when="@8.3")
 
-    racket_name = "scheme-lib"
+    name = "scheme-lib"
     pkgs = True

```
I get the following output:
![Screenshot from 2022-08-12 14-02-03](https://user-images.githubusercontent.com/4199709/184350694-4a4760cc-55aa-437a-ad24-adda9958b852.png)
