### PR TITLE
MFEM: Add an exceptions variant.

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -180,6 +180,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     )
     variant("examples", default=False, description="Build and install examples")
     variant("miniapps", default=False, description="Build and install miniapps")
+    variant("exceptions", default=False, description="Enable the use of exceptions")
 
     conflicts("+shared", when="@:3.3.2")
     conflicts("~static~shared")
@@ -531,6 +532,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             "MFEM_USE_FMS=%s" % yes_no("+fms"),
             "MFEM_MPIEXEC=%s" % mfem_mpiexec,
             "MFEM_MPIEXEC_NP=%s" % mfem_mpiexec_np,
+            "MFEM_USE_EXCEPTIONS=%s" % yes_no("+exceptions"),
         ]
 
         cxxflags = spec.compiler_flags["cxxflags"]


### PR DESCRIPTION
Added an "exceptions" variant to the MFEM package. It turns on exceptions error handling.

I tested this building it on crusher.olcf.ornl.gov and used it as part of a VisIt spack build with mfem enabled (coming in a future PR).