### PR TITLE
fix oce build failure due to change of intel-tbb default version

### DIFF
--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -33,6 +33,8 @@ class Oce(Package):
 
     depends_on("cmake@2.8:", type="build")
     depends_on("tbb", when="+tbb")
+    conflicts("intel-tbb@2021.1:")
+    conflicts("intel-oneapi-tbb@2021.1:")
 
     # There is a bug in OCE which appears with Clang (version?) or GCC 6.0
     # and has to do with compiler optimization, see


### PR DESCRIPTION
```
In file included from /data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.cxx:17:
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx: In static member function 'static void OSD_Parallel::ForEach(InputIterator, InputIterator, const Functor&, Standard_Boolean)':
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx:223:18: error: 'captured_exception' in namespace 'tbb' does not name a type
  223 |     catch ( tbb::captured_exception& anException )
      |                  ^~~~~~~~~~~~~~~~~~
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx:225:38: error: 'anException' was not declared in this scope
  225 |       Standard_NotImplemented::Raise(anException.what());
      |                                      ^~~~~~~~~~~
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx: In static member function 'static void OSD_Parallel::For(Standard_Integer, Standard_Integer, const Functor&, Standard_Boolean)':
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx:272:18: error: 'captured_exception' in namespace 'tbb' does not name a type
  272 |     catch ( tbb::captured_exception& anException )
      |                  ^~~~~~~~~~~~~~~~~~
/data/xsdkci/VS1mJQ1K/0/xsdk-project/spack-xsdk/spack-stage/balay/spack-stage-oce-0.18.3-rim5zhuacb7z4plxag52fjj3gbc4znv3/spack-src/src/OSD/OSD_Parallel.hxx:274:38: error: 'anException' was not declared in this scope
  274 |       Standard_NotImplemented::Raise(anException.what());
      |                                      ^~~~~~~~~~~
```

Ref: https://github.com/spack/spack/pull/32026