### PR TITLE
bridger: adding ncurses dep

### DIFF
--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -19,6 +19,7 @@ class Bridger(MakefilePackage, SourceforgePackage):
         "2014-12-01", sha256="8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737"
     )
     depends_on("boost + exception + filesystem + system + serialization + graph")
+    depends_on("ncurses~termlib")
     depends_on("perl", type="run")
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
Not sure how I haven't hit this before.

Also actually depends on https://github.com/spack/spack/pull/32037 to build, otherwise it'll report that it can't find the curses library.