### PR TITLE
VTK-h: Patch VTK-h to build +shared+cuda

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -98,6 +98,8 @@ class VtkH(CMakePackage, CudaPackage):
 
     depends_on("vtk-m~shared", when="~shared")
 
+    patch("vtk-h-shared-cuda.patch", when="@0.8")
+
     # provide cmake args (pass host config as cmake cache file)
     def cmake_args(self):
         host_config = self._get_host_config_path(self.spec)


### PR DESCRIPTION
@cyrush I thought I had made this PR ages ago, but here is the back port patch to let VTK-h build +shared+cuda

@eugeneswalker @wspear FYI