### PR TITLE
quantum-espresso: adding some missing build deps

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -208,6 +208,8 @@ class QuantumEspresso(CMakePackage):
     depends_on("blas")
     depends_on("lapack")
     depends_on("fftw-api@3")
+    depends_on("git@2.13:", type="build")
+    depends_on("m4", type="build")
 
     # CONFLICTS SECTION
     # Omitted for now due to concretizer bug


### PR DESCRIPTION
the build requires git 2.13 or newer, and my paired down rhel7 env doesn't have that so it would be good to have that explicit. It also requires m4 or the checkouts fail.