### PR TITLE
root: setup_dependent_build_environment (regression)

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -611,7 +611,7 @@ class Root(CMakePackage):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib.root)
-        if "platform=darwin" in spec:
+        if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 


### PR DESCRIPTION
`setup_dependent_build_environment(self, env, dependent_spec)` does not have a variable `spec`.

This causes several issues right now for `root` dependents, e.g.
```console
==> Installing gaudi-36.6-cjjrpjwpcqrtojyrdqml3jpzkbn55hpb
==> No binary for gaudi-36.6-cjjrpjwpcqrtojyrdqml3jpzkbn55hpb found: installing from source
==> Error: NameError: name 'spec' is not defined

/home/wdconinc/git/spack/var/spack/repos/builtin/packages/root/package.py:614, in setup_dependent_build_environment:
        611        env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
        612        if "+rpath" not in self.spec:
        613            env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib.root)
  >>    614        if "platform=darwin" in spec:
        615            # Newer deployment targets cause fatal errors in rootcling
        616            env.unset("MACOSX_DEPLOYMENT_TARGET")
```

@sethrj 