### PR TITLE
qscintilla: coherence with py-sip

### DIFF
--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -152,11 +152,12 @@ class Qscintilla(QMakePackage):
 
     @run_after("install")
     def extend_path_setup(self):
-        # See github issue #14121 and PR #15297
-        module = self.spec["py-sip"].variants["module"].value
-        if module != "sip":
-            module = module.split(".")[0]
-            with working_dir(python_platlib):
-                with open(os.path.join(module, "__init__.py"), "w") as f:
-                    f.write("from pkgutil import extend_path\n")
-                    f.write("__path__ = extend_path(__path__, __name__)\n")
+        if self.spec["py-sip"].satisfies("@:4"):
+            # See github issue #14121 and PR #15297
+            module = self.spec["py-sip"].variants["module"].value
+            if module != "sip":
+                module = module.split(".")[0]
+                with working_dir(python_platlib):
+                    with open(os.path.join(module, "__init__.py"), "w") as f:
+                        f.write("from pkgutil import extend_path\n")
+                        f.write("__path__ = extend_path(__path__, __name__)\n")


### PR DESCRIPTION
From PR https://github.com/spack/spack/pull/27357 by @manuelakuhn
py-sip sets the variants["module"].value only before release 4 of py-sip.
Before this PR spack complained "KeyError module" on line `module = self.spec["py-sip"].variants["module"]`.
