### PR TITLE
pcsclite: new package, Middleware to access a smart card using SCard …

### DIFF
--- a/var/spack/repos/builtin/packages/pcsclite/package.py
+++ b/var/spack/repos/builtin/packages/pcsclite/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Pcsclite(AutotoolsPackage):
+    """PCSC lite project
+
+    Middleware to access a smart card using SCard API (PC/SC)."""
+
+    homepage = "https://pcsclite.apdu.fr"
+    url = "https://pcsclite.apdu.fr/files/pcsc-lite-1.9.8.tar.bz2"
+
+    maintainers = ["cessenat"]
+
+    version("1.9.8", sha256="502d80c557ecbee285eb99fe8703eeb667bcfe067577467b50efe3420d1b2289")
+
+    # no libudev/systemd package currently in spack
+    variant("libudev", default=False, description="Build with libudev")
+
+    depends_on("flex", type="build")
+    depends_on("libusb")
+
+    depends_on("autoconf", type="build")
+    depends_on("autoconf-archive", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
+
+    force_autoreconf = True
+
+    def configure_args(self):
+        args = []
+        # no libudev/systemd package currently in spack
+        args.append("--disable-libsystemd")
+        args.extend(self.enable_or_disable("libudev"))
+        return args

--- a/var/spack/repos/builtin/packages/pcsclite/package.py
+++ b/var/spack/repos/builtin/packages/pcsclite/package.py
@@ -50,4 +50,5 @@ class Pcsclite(AutotoolsPackage):
         # no libudev/systemd package currently in spack
         args.append("--disable-libsystemd")
         args.extend(self.enable_or_disable("libudev"))
+        args.append("--with-systemdsystemunitdir=no")
         return args

--- a/var/spack/repos/builtin/packages/pcsclite/package.py
+++ b/var/spack/repos/builtin/packages/pcsclite/package.py
@@ -33,17 +33,13 @@ class Pcsclite(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
 
-    phases = ["bootstrap", "configure", "build", "install"]
-    force_autoreconf = True
+    def autoreconf(self, spec, prefix):
+        pass
 
     @when("@master")
-    def bootstrap(self, spec, prefix):
+    def autoreconf(self, spec, prefix):
         bootstrap = Executable("./bootstrap")
         bootstrap()
-
-    @when("@1.9.8")
-    def bootstrap(self, spec, prefix):
-        pass
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pcsclite/package.py
+++ b/var/spack/repos/builtin/packages/pcsclite/package.py
@@ -13,9 +13,11 @@ class Pcsclite(AutotoolsPackage):
 
     homepage = "https://pcsclite.apdu.fr"
     url = "https://pcsclite.apdu.fr/files/pcsc-lite-1.9.8.tar.bz2"
-
+    git = "https://salsa.debian.org/rousseau/PCSC.git"
+    
     maintainers = ["cessenat"]
 
+    version("master", branch="master")
     version("1.9.8", sha256="502d80c557ecbee285eb99fe8703eeb667bcfe067577467b50efe3420d1b2289")
 
     # no libudev/systemd package currently in spack
@@ -31,7 +33,17 @@ class Pcsclite(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
 
+    phases = ["bootstrap", "configure", "build", "install"]
     force_autoreconf = True
+
+    @when("@master")
+    def bootstrap(self, spec, prefix):
+        bootstrap = Executable("./bootstrap")
+        bootstrap()
+
+    @when("@1.9.8")
+    def bootstrap(self, spec, prefix):
+        pass
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pcsclite/package.py
+++ b/var/spack/repos/builtin/packages/pcsclite/package.py
@@ -14,7 +14,7 @@ class Pcsclite(AutotoolsPackage):
     homepage = "https://pcsclite.apdu.fr"
     url = "https://pcsclite.apdu.fr/files/pcsc-lite-1.9.8.tar.bz2"
     git = "https://salsa.debian.org/rousseau/PCSC.git"
-    
+
     maintainers = ["cessenat"]
 
     version("master", branch="master")


### PR DESCRIPTION
…API (PC/SC)
Home page https://pcsclite.apdu.fr/
When spack install keepassxc+autotype there is a dependency to PCSC which is provided on Ubuntu by libpcsclite-dev.
For the long story, there is also a need for other packages, that, still on Ubuntu, are provided by gengetopt and libusb-1.0-0-dev
According to the author, there is no need to build pcsc-lite on Darwin