### PR TITLE
Local cache for buildcache files

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -216,6 +216,16 @@ config:
   # for updates, within a single Spack invocation. Defaults to 10 minutes.
   binary_index_ttl: 600
 
+  # Directory (or multiple directories) to cache files downloaded from buildcaches.
+  # Should be 'null' in most cases, unless you wipe your Spack install tree frequently (e.g. in CI).
+  local_binary_cache: null
+  # Examples:
+  # local_binary_cache: /path/to/cachedir
+  # local_binary_cache:
+  #   - prefixes: ['https://binaries.spack.io/']
+  #     root: /cachedir/for/public/buildcache
+  #   - root: /cachedir/for/everything/else
+
   flags:
     # Whether to keep -Werror flags active in package builds.
     keep_werror: 'none'

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -15,6 +15,7 @@ import tarfile
 import tempfile
 import time
 import traceback
+import urllib.parse
 import warnings
 from contextlib import closing
 from urllib.error import HTTPError, URLError
@@ -29,6 +30,7 @@ from llnl.util.filesystem import BaseDirectoryVisitor, mkdirp, visit_directory_t
 import spack.cmd
 import spack.config as config
 import spack.database as spack_db
+import spack.fetch_strategy
 import spack.hooks
 import spack.hooks.sbang
 import spack.mirror
@@ -550,6 +552,96 @@ def _binary_index():
 binary_index = llnl.util.lang.Singleton(_binary_index)
 
 
+class LocalBinaryCache(object):
+    """
+    The LocalBinaryCache caches files that would have been pulled from a (usually remote)
+    buildcache in a closer local directory. For cases where the Spack instance is being wiped
+    regularly (e.g. containers and/or CI) this can reduce the network I/O needed to
+    reinstall the packages.
+
+    By default this class does nothing and all requests go straight to the remote URL.
+    To change this set `config:binary_cache_root` to a value other than `null`.
+    """
+
+    def __init__(self):
+        self._file_caches = []
+        settings = config.get("config:local_binary_cache", None)
+        if settings is not None:
+            if isinstance(settings, str):
+                settings = [{"root": settings}]
+            for cache in settings:
+                prefixes = tuple(cache.get("prefixes", [""]))
+                self._file_caches.append((prefixes, file_cache.FileCache(cache["root"])))
+
+    def __bool__(self):
+        return len(self._file_caches) > 0
+
+    def destroy(self):
+        for _, c in self._file_caches:
+            c.destroy()
+
+    @staticmethod
+    def _url2key(url):
+        url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        parsed_url = urllib.parse.urlparse(url)
+        return "{0}_{1}".format(url_hash[:10], parsed_url.path.split("/")[-1])
+
+    def get(self, url, checksum, force=False):
+        """
+        Get the cached file for the given URL, fetching if needed.
+
+        Args:
+            url (str): Remote URL to fetch from.
+            checksum (str): Checksum for the target file.
+            force (bool): If True, cache even if ``url`` is a local path.
+
+        Returns tuple of:
+            cached_path (str): Path to the cached file
+            fetched (bool): ``True`` if the file had to be fetched, ``False`` otherwise
+
+            If the cache is disabled or if ``url`` is local (and ``force`` is not ``True``),
+            all fields above are None.
+        """
+        if len(self._file_caches) == 0 or (not force and url_util.local_file_path(url)):
+            return None, None
+
+        for prefixes, cache in self._file_caches:
+            if any(url[: len(prefix)] == prefix for prefix in prefixes):
+                break
+        else:
+            return None, None
+        checker = spack.util.crypto.Checker(checksum)
+        key = self.__class__._url2key(url)
+        cached_path = cache.cache_path(key)
+
+        # Check if the key is already in the cache with a valid checksum
+        if cache.init_entry(key):
+            with cache.read_transaction(key):
+                if checker.check(cached_path):
+                    tty.debug("Reusing cached result for url {0}".format(url))
+                    return cached_path, False
+
+        # Otherwise, attempt to fetch from the remote url and save to the cache
+        tty.debug("Saving url to local binary cache: {0}".format(url))
+        _, _, response = web_util.read_from_url(url)
+        with cache.write_transaction(key, binary=True) as (_, cache_f):
+            shutil.copyfileobj(response, cache_f)
+
+        # Validate the checksum. At this point failure is a hard error.
+        if not checker.check(cached_path):
+            raise NoChecksumException("File failed checksum verification.")
+
+        return cached_path, True
+
+
+def _local_binary_cache():
+    """Get the singleton local binary cache instance."""
+    return LocalBinaryCache()
+
+
+local_binary_cache = llnl.util.lang.Singleton(_local_binary_cache)
+
+
 class NoOverwriteException(spack.error.SpackError):
     """
     Raised when a file exists and must be overwritten.
@@ -845,18 +937,6 @@ def tarball_path_name(spec, ext):
     <tarball_directory_name>/<tarball_name>
     """
     return os.path.join(tarball_directory_name(spec), tarball_name(spec, ext))
-
-
-def checksum_tarball(file):
-    # calculate sha256 hash of tar file
-    block_size = 65536
-    hasher = hashlib.sha256()
-    with open(file, "rb") as tfile:
-        buf = tfile.read(block_size)
-        while len(buf) > 0:
-            hasher.update(buf)
-            buf = tfile.read(block_size)
-    return hasher.hexdigest()
 
 
 def select_signing_key(key=None):
@@ -1286,7 +1366,7 @@ def _build_tarball(
     shutil.rmtree(workdir)
 
     # get the sha256 checksum of the tarball
-    checksum = checksum_tarball(tarfile_path)
+    checksum = spack.util.crypto.checksum(hashlib.sha256, tarfile_path)
 
     # add sha256 checksum to spec.json
 
@@ -1423,21 +1503,34 @@ def try_verify(specfile_path):
     return True
 
 
-def try_fetch(url_to_fetch):
+def try_fetch(url_to_fetch, cache=True, checksum=None, **kwargs):
     """Utility function to try and fetch a file from a url, stage it
     locally, and return the path to the staged file.
 
     Args:
         url_to_fetch (str): Url pointing to remote resource to fetch
+        cache (bool): If False, don't cache via the LocalBinaryCache
+        checksum (str): Checksum for the fetched file, if available
 
     Returns:
         Path to locally staged resource or ``None`` if it could not be fetched.
     """
-    stage = Stage(url_to_fetch, keep=True)
+
+    fetcher = None
+    if cache and checksum is not None:
+        cached_path, fetched = local_binary_cache.get(url_to_fetch, checksum, **kwargs)
+        if cached_path is not None:
+            fetcher = spack.fetch_strategy.CacheURLFetchStrategy(cached_path, notify=not fetched)
+            checksum = None
+    fetcher = fetcher or spack.fetch_strategy.from_url_scheme(url_to_fetch, checksum=checksum)
+
+    stage = Stage(fetcher, keep=True)
     stage.create()
 
     try:
         stage.fetch()
+        if checksum is not None:
+            stage.check()
     except web_util.FetchError:
         stage.destroy()
         return None
@@ -1480,7 +1573,7 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
        }
     """
     if not spack.mirror.MirrorCollection():
-        tty.die("Please add a spack mirror to allow " + "download of pre-compiled packages.")
+        tty.die("Please add a spack mirror to allow download of pre-compiled packages.")
 
     tarball = tarball_path_name(spec, ".spack")
     specfile_prefix = tarball_name(spec, ".spec")
@@ -1513,14 +1606,19 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
 
     tried_to_verify_sigs = []
 
+    specfile_loaders = [
+        ("json.sig", Spec.extract_json_from_clearsig),
+        ("json", sjson.load),
+    ]
+
     # Assumes we care more about finding a spec file by preferred ext
     # than by mirrory priority.  This can be made less complicated as
     # we remove support for deprecated spec formats and buildcache layouts.
-    for ext in ["json.sig", "json"]:
+    for ext, loader in specfile_loaders:
         for mirror_to_try in mirrors_to_try:
             specfile_url = "{0}.{1}".format(mirror_to_try["specfile"], ext)
             spackfile_url = mirror_to_try["spackfile"]
-            local_specfile_stage = try_fetch(specfile_url)
+            local_specfile_stage = try_fetch(specfile_url, cache=False)
             if local_specfile_stage:
                 local_specfile_path = local_specfile_stage.save_filename
                 signature_verified = False
@@ -1533,6 +1631,18 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                     signature_verified = try_verify(local_specfile_path)
                     if not signature_verified:
                         tty.warn("Failed to verify: {0}".format(specfile_url))
+
+                # Extract the hash from the specfile to verify the spackfile
+                with open(local_specfile_path, "r") as specfile:
+                    specfile_data = loader(specfile.read())
+                if (
+                    "buildcache_layout_version" in specfile_data
+                    and int(specfile_data["buildcache_layout_version"]) >= 1
+                ):
+                    checksum = specfile_data["binary_cache_checksum"]["hash"]
+                else:
+                    # Old-form buildcache layout, don't verify
+                    checksum = None
 
                 if unsigned or signature_verified or not ext.endswith(".sig"):
                     # We will download the tarball in one of three cases:
@@ -1551,7 +1661,7 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                     #     verify signature, checksum doesn't match) we will fail at
                     #     that point instead of trying to download more tarballs from
                     #     the remaining mirrors, looking for one we can use.
-                    tarball_stage = try_fetch(spackfile_url)
+                    tarball_stage = try_fetch(spackfile_url, checksum=checksum)
                     if tarball_stage:
                         return {
                             "tarball_stage": tarball_stage,
@@ -1825,11 +1935,9 @@ def _extract_inner_tarball(spec, filename, extract_to, unsigned, remote_checksum
             raise UnsignedPackageException(
                 "To install unsigned packages, use the --no-check-signature option."
             )
-    # get the sha256 checksum of the tarball
-    local_checksum = checksum_tarball(tarfile_path)
 
     # if the checksums don't match don't install
-    if local_checksum != remote_checksum["hash"]:
+    if not spack.util.crypto.Checker(remote_checksum["hash"]).check(tarfile_path):
         raise NoChecksumException(
             "Package tarball failed checksum verification.\n" "It cannot be installed."
         )
@@ -1886,16 +1994,6 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         if not unsigned and not signature_verified:
             raise UnsignedPackageException(
                 "To install unsigned packages, use the --no-check-signature option."
-            )
-
-        # compute the sha256 checksum of the tarball
-        local_checksum = checksum_tarball(tarfile_path)
-
-        # if the checksums don't match don't install
-        if local_checksum != bchecksum["hash"]:
-            _delete_staged_downloads(download_result)
-            raise NoChecksumException(
-                "Package tarball failed checksum verification.\n" "It cannot be installed."
             )
 
     new_relative_prefix = str(os.path.relpath(spec.prefix, spack.store.layout.root))

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -29,7 +29,7 @@ class AllClean(argparse.Action):
     """Activates flags -s -d -f -m and -p simultaneously"""
 
     def __call__(self, parser, namespace, values, option_string=None):
-        parser.parse_args(["-sdfmp"], namespace=namespace)
+        parser.parse_args(["-sdfmpB"], namespace=namespace)
 
 
 def setup_parser(subparser):
@@ -58,6 +58,12 @@ def setup_parser(subparser):
         help="remove .pyc, .pyo files and __pycache__ folders",
     )
     subparser.add_argument(
+        "-B",
+        "--binary-cache",
+        action="store_true",
+        help="remove software and configuration needed to bootstrap Spack",
+    )
+    subparser.add_argument(
         "-b",
         "--bootstrap",
         action="store_true",
@@ -67,7 +73,7 @@ def setup_parser(subparser):
         "-a",
         "--all",
         action=AllClean,
-        help="equivalent to -sdfmp (does not include --bootstrap)",
+        help="equivalent to -sdfmpB (does not include --bootstrap)",
         nargs=0,
     )
     arguments.add_common_arguments(subparser, ["specs"])
@@ -98,6 +104,7 @@ def clean(parser, args):
             args.failures,
             args.misc_cache,
             args.python_cache,
+            args.binary_cache,
             args.bootstrap,
         ]
     ):
@@ -134,6 +141,11 @@ def clean(parser, args):
     if args.python_cache:
         tty.msg("Removing python cache files")
         remove_python_cache()
+
+    if args.binary_cache:
+        if spack.binary_distribution.local_binary_cache:
+            tty.msg("Removing local binary cache files")
+        spack.binary_distribution.local_binary_cache.destroy()
 
     if args.bootstrap:
         bootstrap_prefix = spack.util.path.canonicalize_path(spack.config.get("bootstrap:root"))

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -539,6 +539,10 @@ class URLFetchStrategy(FetchStrategy):
 class CacheURLFetchStrategy(URLFetchStrategy):
     """The resource associated with a cache URL may be out of date."""
 
+    def __init__(self, url=None, checksum=None, notify=False, **kwargs):
+        super(CacheURLFetchStrategy, self).__init__(url, checksum, **kwargs)
+        self.notify = bool(notify)
+
     @_needs_stage
     def fetch(self):
         path = url_util.file_url_string_to_path(self.url)
@@ -565,7 +569,8 @@ class CacheURLFetchStrategy(URLFetchStrategy):
                 raise
 
         # Notify the user how we fetched.
-        tty.msg("Using cached archive: {0}".format(path))
+        if self.notify:
+            tty.msg("Using cached archive: {0}".format(path))
 
 
 class VCSFetchStrategy(FetchStrategy):

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -85,7 +85,23 @@ properties = {
                 "anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}],
             },
             "allow_sgid": {"type": "boolean"},
-            "binary_index_root": {"type": "string"},
+            "local_binary_cache": {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["root"],
+                            "properties": {
+                                "prefixes": {"type": "array", "items": {"type": "string"}},
+                                "root": {"type": "string"},
+                            },
+                        },
+                    },
+                    {"type": "string"},
+                    {"type": "null"},
+                ]
+            },
             "url_fetch_method": {"type": "string", "enum": ["urllib", "curl"]},
             "additional_external_search_paths": {"type": "array", "items": {"type": "string"}},
             "binary_index_ttl": {"type": "integer", "minimum": 0},

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import hashlib
 import os
 import os.path
 import sys
@@ -46,3 +47,119 @@ def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmpdi
 
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
             spack.binary_distribution._build_tarball(spec, out_url, unsigned=True)
+
+
+def test_binary_cache_single(tmpdir):
+    test_file = tmpdir.join("test.txt")
+    test_url = "file://" + test_file.strpath
+    cache_dir = tmpdir.join("cache").strpath
+
+    def save(contents):
+        with test_file.open("w") as f:
+            f.write(contents)
+        return spack.util.crypto.checksum(hashlib.sha256, test_file.strpath)
+
+    with spack.config.override("config:local_binary_cache", cache_dir):
+        lbc = spack.binary_distribution.local_binary_cache
+
+        checksum = save("test data")
+
+        # Local paths should never be cached unless force is given
+        cached_path, fetched = lbc.get(test_url, "blah")
+        assert cached_path is None and fetched is None
+
+        # First call to get should cache the result, second should use the cached result
+        cached_path, fetched = lbc.get(test_url, checksum, force=True)
+        assert fetched
+        assert cached_path[: len(cache_dir) + 1] == cache_dir + "/"
+
+        cached_path2, fetched = lbc.get(test_url, checksum, force=True)
+        assert cached_path2 == cached_path
+        assert not fetched
+
+        checksum = save("other test data")
+
+        # If the URL didn't change but the hash did, we should re-fetch
+        cached_path3, fetched = lbc.get(test_url, checksum, force=True)
+        assert cached_path3 == cached_path
+        assert fetched
+
+        # If the checksum is outright wrong, we should get a NoChecksumException
+        with pytest.raises(spack.binary_distribution.NoChecksumException):
+            lbc.get(test_url, "00" * 16, force=True)
+
+        # Destruction should not error
+        lbc.destroy()
+
+
+def test_binary_cache_multiple(tmpdir):
+    data_dirs = (tmpdir.join("data0"), tmpdir.join("data1"))
+    test_files = tuple(ddir.join("test.txt") for ddir in data_dirs)
+    test_urls = tuple("file://" + fn.strpath for fn in test_files)
+    cache_dirs = (tmpdir.join("cache0").strpath, tmpdir.join("cache1").strpath)
+
+    for ddir in data_dirs:
+        ddir.mkdir()
+
+    def save(idx, contents):
+        with test_files[idx].open("w") as f:
+            f.write(contents)
+        return spack.util.crypto.checksum(hashlib.sha256, test_files[idx].strpath)
+
+    caches = [
+        {"prefixes": ["file://" + data_dirs[0].strpath], "root": cache_dirs[0]},
+        {"root": cache_dirs[1]},
+    ]
+
+    with spack.config.override("config:local_binary_cache", caches):
+        lbc = spack.binary_distribution.local_binary_cache
+
+        checksums = (save(0, "test data"), save(1, "other test data"))
+
+        # Data should land in the appropriate root based on prefix matching
+        cached_path, fetched = lbc.get(test_urls[0], checksums[0], force=True)
+        assert fetched
+        assert cached_path[: len(cache_dirs[0]) + 1] == cache_dirs[0] + "/"
+
+        cached_path, fetched = lbc.get(test_urls[1], checksums[1], force=True)
+        assert fetched
+        assert cached_path[: len(cache_dirs[1]) + 1] == cache_dirs[1] + "/"
+
+        # Destruction should not error
+        lbc.destroy()
+
+
+def test_binary_cache_fallthrough(tmpdir):
+    data_dirs = (tmpdir.join("data0"), tmpdir.join("data1"))
+    test_files = tuple(ddir.join("test.txt") for ddir in data_dirs)
+    test_urls = tuple("file://" + fn.strpath for fn in test_files)
+    cache_dirs = (tmpdir.join("cache0").strpath, tmpdir.join("cache1").strpath)
+
+    for ddir in data_dirs:
+        ddir.mkdir()
+
+    def save(idx, contents):
+        with test_files[idx].open("w") as f:
+            f.write(contents)
+        return spack.util.crypto.checksum(hashlib.sha256, test_files[idx].strpath)
+
+    caches = [
+        {"prefixes": ["file://" + data_dirs[0].strpath], "root": cache_dirs[0]},
+    ]
+
+    with spack.config.override("config:local_binary_cache", caches):
+        lbc = spack.binary_distribution.local_binary_cache
+
+        checksums = (save(0, "test data"), save(1, "other test data"))
+
+        # URLs with a matching prefix should be cached
+        cached_path, fetched = lbc.get(test_urls[0], checksums[0], force=True)
+        assert fetched
+        assert cached_path[: len(cache_dirs[0]) + 1] == cache_dirs[0] + "/"
+
+        # URLs without should not be
+        cached_path, fetched = lbc.get(test_urls[1], checksums[1], force=True)
+        assert cached_path is None and fetched is None
+
+        # Destruction should not error
+        lbc.destroy()

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -38,12 +38,15 @@ def mock_calls_for_clean(monkeypatch):
     monkeypatch.setattr(spack.caches.fetch_cache, "destroy", Counter("downloads"), raising=False)
     monkeypatch.setattr(spack.caches.misc_cache, "destroy", Counter("caches"))
     monkeypatch.setattr(spack.installer, "clear_failures", Counter("failures"))
+    monkeypatch.setattr(
+        spack.binary_distribution.local_binary_cache, "destroy", Counter("binary_cache")
+    )
     monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
 
     yield counts
 
 
-all_effects = ["stages", "downloads", "caches", "failures", "python_cache"]
+all_effects = ["stages", "downloads", "caches", "failures", "python_cache", "binary_cache"]
 
 
 @pytest.mark.usefixtures("mock_packages", "config")
@@ -56,6 +59,7 @@ all_effects = ["stages", "downloads", "caches", "failures", "python_cache"]
         ("-m", ["caches"]),
         ("-f", ["failures"]),
         ("-p", ["python_cache"]),
+        ("-B", ["binary_cache"]),
         ("-a", all_effects),
         ("", []),
     ],

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1724,6 +1724,14 @@ def brand_new_binary_cache():
     )
 
 
+@pytest.fixture(autouse=True)
+def brand_new_local_binary_cache():
+    yield
+    spack.binary_distribution.local_binary_cache = llnl.util.lang.Singleton(
+        spack.binary_distribution._local_binary_cache
+    )
+
+
 @pytest.fixture
 def directory_with_manifest(tmpdir):
     """Create a manifest file in a directory. Used by 'spack external'."""

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -96,7 +96,7 @@ class FileCache(object):
             self._get_lock(key)
         return exists
 
-    def read_transaction(self, key):
+    def read_transaction(self, key, binary=False):
         """Get a read transaction on a file cache item.
 
         Returns a ReadTransaction context manager and opens the cache file for
@@ -106,9 +106,12 @@ class FileCache(object):
                cache_file.read()
 
         """
-        return ReadTransaction(self._get_lock(key), acquire=lambda: open(self.cache_path(key)))
+        mode = "rb" if binary else "r"
+        return ReadTransaction(
+            self._get_lock(key), acquire=lambda: open(self.cache_path(key), mode)
+        )
 
-    def write_transaction(self, key):
+    def write_transaction(self, key, binary=False):
         """Get a write transaction on a file cache item.
 
         Returns a WriteTransaction context manager that opens a temporary file
@@ -122,6 +125,9 @@ class FileCache(object):
                 "Insufficient permissions to write to file cache at {0}".format(filename)
             )
 
+        r_mode = "rb" if binary else "r"
+        w_mode = "wb" if binary else "w"
+
         # TODO: this nested context manager adds a lot of complexity and
         # TODO: is pretty hard to reason about in llnl.util.lock. At some
         # TODO: point we should just replace it with functions and simplify
@@ -131,10 +137,10 @@ class FileCache(object):
                 cm.orig_filename = self.cache_path(key)
                 cm.orig_file = None
                 if os.path.exists(cm.orig_filename):
-                    cm.orig_file = open(cm.orig_filename, "r")
+                    cm.orig_file = open(cm.orig_filename, r_mode)
 
                 cm.tmp_filename = self.cache_path(key) + ".tmp"
-                cm.tmp_file = open(cm.tmp_filename, "w")
+                cm.tmp_file = open(cm.tmp_filename, w_mode)
 
                 return cm.orig_file, cm.tmp_file
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -619,7 +619,7 @@ _spack_ci_reproduce_build() {
 _spack_clean() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -s --stage -d --downloads -f --failures -m --misc-cache -p --python-cache -b --bootstrap -a --all"
+        SPACK_COMPREPLY="-h --help -s --stage -d --downloads -f --failures -m --misc-cache -p --python-cache -B --binary-cache -b --bootstrap -a --all"
     else
         _all_packages
     fi


### PR DESCRIPTION
There are cases (e.g. containers in CI) where the Spack install tree is frequently wiped. Buildcaches provide a convenient way to restore a Spack install from zero, but they require significant network I/O to redownload the buildcache files. Every. Single. Time.

While this can be reduced somewhat by caching the entire install prefix, this (a) affects concretization in non-trivial ways and (b) does not mesh well with [GitLab CI's `cache:` functionality](https://docs.gitlab.com/ee/ci/yaml/index.html#cache) (which [stores the cache as a zip file](https://docs.gitlab.com/ee/ci/caching/index.html#where-the-caches-are-stored)). Dodging these issues is possible but very awkward.

This patch adds a new local cache for some of these files (`.spack`). This cache is disabled by default but can be enabled by specifying a path in the `config:local_binary_cache` config entry (default `null`). Running `spack clean -B` (or `spack clean -a`) will wipe this cache.

**EDIT:** The `config:local_binary_cache` key can be a single directory where all cached files will be saved, or a list:
```yaml
local_binary_cache:
- prefixes: ['https://url/prefix', 's3://another/url/prefix']
  root: /path/to/cachedir
```
Any fetched binaries with the given prefix in their URL will be stored in the listed cache directory, first match wins. `prefixes` can be elided to match all URLs. This feature was added to better support mixed buildcaches, a temporary buildcache can be placed in a per-branch/PR GitLab cache (`key`) while a more permanent buildcache can use a shared GitLab cache (`key`).

**EDIT:** The key used in the cache is composed of a hash of the original URL plus the filename part of the path, e.g.:
```
cache-dir/817a9506ce_linux-almalinux8-x86_64_v3-gcc-8.5.0-pigz-2.7-dwvh5t2d3gbnjut6bkm74qzm6r6a6rg4.spack
```
The checksum from the `.json` or `.json.sig` file is used to verify the validity of the cached file and the file will be re-fetched if needed. The `.json` and `.json.sig` files are **not** cached, this was done to allow buildcaches to "refresh" their contents without requiring a manual cache refresh.

/cc @tgamblin @becker33

* * *

Performance reinstalling `llvm`, without this patch:
```console
$ time spack install --cache-only -f llvm.json
... preinstalled dependencies...
==> Installing llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd
gpg: Signature made Fri 12 Aug 2022 07:33:15 AM UTC
gpg:                using RSA key D2C7EB3F2B05FA86590D293C04001B2E3DB0C723
gpg: Good signature from "Spack Project Official Binaries <maintainers@spack.io>" [ultimate]
==> Extracting llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd from binary cache
... snip ...
real	5m43.580s
user	2m18.305s
sys	0m48.059s
```

With this patch:
```console
$ time spack install --cache-only -f llvm.json
... preinstalled dependencies...
==> Installing llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd
==> Using cached archive: /tmp/binary_cache/s3___spack-binaries_develop-nmqjxwyuhckmvx47w7b7vvujnvwvsmox/linux-ubuntu18.04-x86_64-gcc-7.5.0-llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd.spec.json.sig
gpg: Signature made Sun 14 Aug 2022 07:59:50 PM UTC
gpg:                using RSA key D2C7EB3F2B05FA86590D293C04001B2E3DB0C723
gpg: Good signature from "Spack Project Official Binaries <maintainers@spack.io>" [ultimate]
==> Using cached archive: /tmp/binary_cache/s3___spack-binaries_develop-nmqjxwyuhckmvx47w7b7vvujnvwvsmox/linux-ubuntu18.04-x86_64/gcc-7.5.0/llvm-12.0.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd.spack
==> Extracting llvm-12.0.1-odiouhgxol2wi55qkqtedbhcgqgoppwd from binary cache
... snip ...
real	4m16.808s
user	2m36.772s
sys	0m43.384s
```