### PR TITLE
Update the binary index before attempting direct fetches

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -201,3 +201,7 @@ config:
   # building and installing packages. This gives information about Spack's
   # current progress as well as the current and total number of packages.
   terminal_title: false
+
+  # Number of seconds a buildcache's index.json is cached locally before probing
+  # for updates, within a single Spack invocation. Defaults to 10 minutes.
+  binary_index_ttl: 600

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -259,7 +259,7 @@ class BinaryCacheIndex(object):
         """
         if find_hash not in self._mirrors_for_spec:
             # Not found in the cached index, pull the latest from the server.
-            self.update()
+            self.update(with_cooldown=True)
         if find_hash not in self._mirrors_for_spec:
             return None
         results = self._mirrors_for_spec[find_hash]
@@ -290,7 +290,7 @@ class BinaryCacheIndex(object):
                         "spec": new_entry["spec"],
                     }
 
-    def update(self):
+    def update(self, with_cooldown=False):
         """Make sure local cache of buildcache index files is up to date.
         If the same mirrors are configured as the last time this was called
         and none of the remote buildcache indices have changed, calling this
@@ -342,7 +342,8 @@ class BinaryCacheIndex(object):
             if cached_mirror_url in configured_mirror_urls:
                 # Only do a fetch if the last fetch was longer than TTL ago
                 if (
-                    ttl > 0
+                    with_cooldown
+                    and ttl > 0
                     and cached_mirror_url in self._last_fetch_times
                     and now - self._last_fetch_times[cached_mirror_url] < ttl
                 ):

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -73,6 +73,7 @@ properties = {
             "binary_index_root": {"type": "string"},
             "url_fetch_method": {"type": "string", "enum": ["urllib", "curl"]},
             "additional_external_search_paths": {"type": "array", "items": {"type": "string"}},
+            "binary_index_ttl": {"type": "integer", "minimum": 0},
         },
         "deprecatedProperties": {
             "properties": ["module_roots"],

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -453,10 +453,11 @@ def test_generate_index_missing(monkeypatch, tmpdir, mutable_config):
     # Update index
     buildcache_cmd("update-index", "-d", mirror_dir.strpath)
 
-    # Check dependency not in buildcache
-    cache_list = buildcache_cmd("list", "--allarch")
-    assert "libdwarf" in cache_list
-    assert "libelf" not in cache_list
+    with spack.config.override("config:binary_index_ttl", 0):
+        # Check dependency not in buildcache
+        cache_list = buildcache_cmd("list", "--allarch")
+        assert "libdwarf" in cache_list
+        assert "libelf" not in cache_list
 
 
 def test_generate_indices_key_error(monkeypatch, capfd):


### PR DESCRIPTION
`spack install` will not update the binary index if given a concrete spec, which causes it to fall back to direct fetches when a simple index update would have helped. For S3 buckets in particular, this significantly and needlessly slows down the install process.

This commit alters the logic so that the binary index is updated whenever a by-hash lookup fails. The lookup is attempted again with the updated index before falling back to direct fetches.

* * *

With 3 nonexistent mirrors + the Spack public binary cache, before the commit:
```console
$ spack mirror list
spack-public    https://mirror.spack.io
public          s3://spack-binaries/develop
dud1            s3://spack-binaries/nonexistent1
dud2            s3://spack-binaries/nonexistent2
dud3            s3://spack-binaries/nonexistent3
$ \time spack install -f zlib.json
==> Installing zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd
gpg: Signature made Sun 14 Aug 2022 12:32:43 PM UTC
gpg:                using RSA key D2C7EB3F2B05FA86590D293C04001B2E3DB0C723
gpg: Good signature from "Spack Project Official Binaries <maintainers@spack.io>" [ultimate]
==> Extracting zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd from binary cache
[+] /tmp/spackinstall/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd
1.55user 0.18system 0:50.60elapsed 3%CPU (0avgtext+0avgdata 108108maxresident)k
0inputs+3328outputs (0major+70477minor)pagefaults 0swaps
```

After this commit:
```console
$ \time spack install -f zlib.json
==> Installing zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd
gpg: Signature made Sun 14 Aug 2022 12:32:43 PM UTC
gpg:                using RSA key D2C7EB3F2B05FA86590D293C04001B2E3DB0C723
gpg: Good signature from "Spack Project Official Binaries <maintainers@spack.io>" [ultimate]
==> Extracting zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd from binary cache
[+] /tmp/spackinstall/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12-m4fqokrwbprfci4rptvgevnklpdo3dhd
12.92user 0.74system 0:38.37elapsed 35%CPU (0avgtext+0avgdata 611908maxresident)k
0inputs+176624outputs (0major+329861minor)pagefaults 0swaps
```