### PR TITLE
py-scipy: Fortran compiler specify code is change to setup.cfg for Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -150,14 +150,6 @@ class PyNumpy(PythonPackage):
         when="@1.22.0:1.22.3",
     )
 
-    # Change compiler search order for Fujitsu compiler
-    def patch(self):
-        f = join_path("numpy", "distutils", "fcompiler", "__init__.py")
-        if self.spec.satisfies("%fj"):
-            r = FileFilter(f)
-            r.filter(r", 'fujitsu'", "")
-            r.filter(r"'linux\.\*', \('", "'linux.*', ('fujitsu', '")
-
     # version 1.21.0 runs into an infinit loop during printing
     # (e.g. print(numpy.ones(1000)) when compiled with gcc 11
     conflicts("%gcc@11:", when="@1.21.0")

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -150,6 +150,14 @@ class PyNumpy(PythonPackage):
         when="@1.22.0:1.22.3",
     )
 
+    # Change compiler search order for Fujitsu compiler
+    def patch(self):
+        f = join_path("numpy", "distutils", "fcompiler", "__init__.py")
+        if self.spec.satisfies("%fj"):
+            r = FileFilter(f)
+            r.filter(r", 'fujitsu'", "")
+            r.filter(r"'linux\.\*', \('", "'linux.*', ('fujitsu', '")
+
     # version 1.21.0 runs into an infinit loop during printing
     # (e.g. print(numpy.ones(1000)) when compiled with gcc 11
     conflicts("%gcc@11:", when="@1.21.0")

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -77,6 +77,7 @@ class PyScipy(PythonPackage):
         "py-numpy@1.16.5:1.22+blas+lapack", when="@1.6.2:1.7", type=("build", "link", "run")
     )
     depends_on("py-numpy@1.17.3:1.24+blas+lapack", when="@1.8:", type=("build", "link", "run"))
+    depends_on("py-numpy %fj", when="%fj", type=("build", "link", "run"))
     depends_on("python@2.6:2.8,3.2:", when="@:0.17", type=("build", "link", "run"))
     depends_on("python@2.7:2.8,3.4:", when="@0.18:1.2", type=("build", "link", "run"))
     depends_on("python@3.5:", when="@1.3:1.4", type=("build", "link", "run"))
@@ -124,12 +125,6 @@ class PyScipy(PythonPackage):
 
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
-
-    def install_options(self, spec, prefix):
-        args = []
-        if spec.satisfies("%fj"):
-            args.extend(["config_fc", "--fcompiler=fujitsu"])
-        return args
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -77,7 +77,6 @@ class PyScipy(PythonPackage):
         "py-numpy@1.16.5:1.22+blas+lapack", when="@1.6.2:1.7", type=("build", "link", "run")
     )
     depends_on("py-numpy@1.17.3:1.24+blas+lapack", when="@1.8:", type=("build", "link", "run"))
-    depends_on("py-numpy %fj", when="%fj", type=("build", "link", "run"))
     depends_on("python@2.6:2.8,3.2:", when="@:0.17", type=("build", "link", "run"))
     depends_on("python@2.7:2.8,3.4:", when="@0.18:1.2", type=("build", "link", "run"))
     depends_on("python@3.5:", when="@1.3:1.4", type=("build", "link", "run"))
@@ -112,6 +111,13 @@ class PyScipy(PythonPackage):
     def set_blas_lapack(self):
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.set_blas_lapack()
+
+    @run_before("install")
+    def set_fortran_compiler(self):
+        if self.spec.satisfies("%fj"):
+            with open("setup.cfg", "w") as f:
+                f.write("[config_fc]\n")
+                f.write("fcompiler = fujitsu\n")
 
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080


### PR DESCRIPTION
python package is build with pip In #27798.
And py-scipy%fj is used --install-option flag.
But new pip is ignored --install-option with message:

> Disabling all use of wheels due to the use of --build-option / --global-option / --install-option.

This pull request change to py-numpy's Fortran compiler detection order when fujitsu compiler, and successfull to build py-scipy%fj.