### PR TITLE
e4s: add hypre +rocm

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -210,6 +210,7 @@ spack:
   - heffte +rocm amdgpu_target=gfx90a
   - hpctoolkit +rocm
   - hpx +rocm amdgpu_target=gfx90a
+  - hypre +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
   - magma ~cuda +rocm amdgpu_target=gfx90a
   - papi +rocm amdgpu_target=gfx90a


### PR DESCRIPTION
add `hypre +rocm` to E4S stack

FYI @wspear @balay @osborn9 @ulrikeyang 