### PR TITLE
e4s: add papi +rocm

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -197,6 +197,7 @@ spack:
   - hpx +rocm amdgpu_target=gfx90a
   - kokkos +rocm amdgpu_target=gfx90a
   - magma ~cuda +rocm amdgpu_target=gfx90a
+  - papi +rocm amdgpu_target=gfx90a
   - petsc +rocm amdgpu_target=gfx90a
   - slate +rocm amdgpu_target=gfx90a
   - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a


### PR DESCRIPTION
Add `papi +rocm` to E4S stack

FYI @wspear @G-Ragghianti 