### PR TITLE
e4s: add omega-h +cuda

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -176,6 +176,7 @@ spack:
   - kokkos-kernels +cuda cuda_arch=80 ^kokkos +wrapper +cuda cuda_arch=80
   - magma +cuda cuda_arch=80
   - mfem +cuda cuda_arch=80
+  - omega-h +cuda cuda_arch=80
   - papi +cuda
   - petsc +cuda cuda_arch=80
   - py-torch +cuda cuda_arch=80


### PR DESCRIPTION
Add `omega-h +cuda` to E4S stack

@wspear @cwsmith 