### PR TITLE
Add omnitrace version 1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/omnitrace/package.py
+++ b/var/spack/repos/builtin/packages/omnitrace/package.py
@@ -27,7 +27,7 @@ class Omnitrace(CMakePackage):
         "build_type",
         default="Release",
         description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel")
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
     )
     variant(
         "rocm",

--- a/var/spack/repos/builtin/packages/omnitrace/package.py
+++ b/var/spack/repos/builtin/packages/omnitrace/package.py
@@ -16,10 +16,19 @@ class Omnitrace(CMakePackage):
     maintainers = ["jrmadsen"]
 
     version("main", branch="main", submodules=True)
+    version("1.4.0", commit="23fb3946c7f4c0702b1b168e1d78b8b62597e3f1", submodules=True)
     version("1.3.1", commit="641225f88304909fd2ca5407aec062d0fdf0ed8b", submodules=True)
     version("1.3.0", commit="4dd144a32c8b83c44e132ef53f2b44fe4b4d5569", submodules=True)
     version("1.2.0", commit="f82845388aab108ed1d1fc404f433a0def391bb3", submodules=True)
 
+    # override build_type to default to Release because this has a significant
+    # impact on build-time and the size of the build
+    variant(
+        "build_type",
+        default="Release",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel")
+    )
     variant(
         "rocm",
         default=True,
@@ -80,11 +89,6 @@ class Omnitrace(CMakePackage):
     depends_on("tau", when="+tau")
     depends_on("caliper", when="+caliper")
     depends_on("python@3:", when="+python", type=("build", "run"))
-
-    def __init__(self, *args, **kwargs):
-        super(Omnitrace, self).__init__(*args, **kwargs)
-        # default to a release build
-        self.variants["build_type"][0].default = "Release"
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
- override build variant with explicit variant instead of `__init__` workaround 
  - fixed in #31671