### PR TITLE
CI/documentation: constrain pygments to avoid latest version (2.13.0)

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -8,4 +8,4 @@ python-levenshtein
 # Restrict to docutils <0.17 to workaround a list rendering issue in sphinx.
 # https://stackoverflow.com/questions/67542699
 docutils <0.17
-pygments <=2.12.0
+pygments <2.13

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -8,3 +8,4 @@ python-levenshtein
 # Restrict to docutils <0.17 to workaround a list rendering issue in sphinx.
 # https://stackoverflow.com/questions/67542699
 docutils <0.17
+pygments <=2.12.0


### PR DESCRIPTION
All PRs are failing the docs build on account of an error with `pygments`:

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/spack/envs/31995/lib/python3.7/site-packages/pygments/styles/__init__.py", line 82, in get_style_by_name
    mod = __import__('pygments.styles.' + mod, None, None, [cls])
ModuleNotFoundError: No module named 'pygments.styles.spack'
```

these errors coincide with a new release of `pygments` (2.13.0) so it is suspected that using the older `pygments` version will fix these issues temporarily.

See: https://pypi.org/project/Pygments/#history