### PR TITLE
py-pygments: add v2.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -12,6 +12,7 @@ class PyPygments(PythonPackage):
     homepage = "https://pygments.org/"
     pypi = "Pygments/Pygments-2.4.2.tar.gz"
 
+    version("2.13.0", sha256="56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1")
     version("2.10.0", sha256="f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6")
     version("2.6.1", sha256="647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44")
     version("2.4.2", sha256="881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297")
@@ -21,6 +22,7 @@ class PyPygments(PythonPackage):
     version("2.0.1", sha256="5e039e1d40d232981ed58914b6d1ac2e453a7e83ddea22ef9f3eeadd01de45cb")
     version("2.0.2", sha256="7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51")
 
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@:2.5")
+    depends_on("python@3.6:", type=("build", "run"), when="@2.12:")
     depends_on("python@3.5:", type=("build", "run"), when="@2.6:")
+    depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@:2.5")
     depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
Successfully builds on macOS 12.5 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.

@scheibelp should help debug #32163