### PR TITLE
e4s mac ci: use lambda, the new M1 mac studio runner

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -200,7 +200,7 @@ e4s-mac-pr-generate:
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags:
-  - omicron
+  - lambda
   interruptible: true
   retry:
     max: 2

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -15,7 +15,7 @@ spack:
 
   packages:
     all:
-      compiler: [apple-clang@13.0.0]
+      compiler: [apple-clang@13.1.6]
       target: [m1]
 
   definitions:
@@ -24,7 +24,7 @@ spack:
     - ncurses
 
   - arch:
-    - '%apple-clang@13.0.0 target=m1'
+    - '%apple-clang@13.1.6 target=m1'
 
   specs:
 
@@ -50,16 +50,18 @@ spack:
       - match: ['os=monterey']
         runner-attributes:
           tags:
-          - omicron
+          - lambda
 
     broken-specs-url: "s3://spack-binaries/broken-specs"
 
     service-job-attributes:
       before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
+      - export SPACK_USER_CACHE_PATH=$(pwd)/.spack-user-cache
+      - export SPACK_USER_CONFIG_PATH=$(pwd)/.spack-user-config
+      - . "./share/spack/setup-env.sh"
+      - spack --version
       tags:
-      - omicron
+      - lambda
 
   cdash:
     build-group: E4S Mac


### PR DESCRIPTION
Use `lambda`, the new mac studio runner running macOS monterey with apple-clang@13.1.6

Second attempt at https://github.com/spack/spack/pull/32004 , to try and get around pipelines issues.

