### PR TITLE
Require recent patchelf

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -40,6 +40,7 @@ import spack.util.executable
 import spack.util.path
 import spack.util.spack_yaml
 import spack.util.url
+import spack.version
 
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
@@ -794,10 +795,26 @@ def patchelf_root_spec():
     return _root_spec("patchelf@0.13.1:0.13.99")
 
 
+def verify_patchelf(patchelf):
+    """Older patchelf versions can produce broken binaries in many, many
+    different ways, we should guard against that."""
+    out = patchelf("--version", output=str, error=os.devnull, fail_on_error=False).strip()
+    if patchelf.returncode != 0:
+        return False
+    parts = out.split(" ")
+    if len(parts) < 2:
+        return False
+    try:
+        version = spack.version.Version(parts[1])
+    except ValueError:
+        return False
+    return version >= spack.version.Version("0.13.1")
+
+
 def ensure_patchelf_in_path_or_raise():
     """Ensure patchelf is in the PATH or raise."""
     return ensure_executables_in_path_or_raise(
-        executables=["patchelf"], abstract_spec=patchelf_root_spec()
+        executables=["patchelf"], abstract_spec=patchelf_root_spec(), cmd_check=verify_patchelf
     )
 
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -81,10 +81,8 @@ def _patchelf():
     if is_macos:
         return None
 
-    patchelf = executable.which("patchelf")
-    if patchelf is None:
-        with spack.bootstrap.ensure_bootstrap_configuration():
-            patchelf = spack.bootstrap.ensure_patchelf_in_path_or_raise()
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        patchelf = spack.bootstrap.ensure_patchelf_in_path_or_raise()
 
     return patchelf.path
 


### PR DESCRIPTION
System `patchelf` is almost always full of bugs, so require a more recent version

Just leaving this here as a comment: why don't we use `spack external find` to detect system executables, install those so they're registered as external specs in the bootstrap store, and then we can simply query the bootstrap db instead of reinventing the wheel for externals.