### PR TITLE
filesystem: in recursive mtime, check only files that exist

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1296,6 +1296,7 @@ def last_modification_time_recursive(path):
         os.stat(os.path.join(root, name)).st_mtime
         for root, dirs, files in os.walk(path)
         for name in dirs + files
+        if os.path.exists(os.path.join(root, name))
     )
     return max(times)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1293,10 +1293,9 @@ def last_modification_time_recursive(path):
     path = os.path.abspath(path)
     times = [os.stat(path).st_mtime]
     times.extend(
-        os.stat(os.path.join(root, name)).st_mtime
+        os.lstat(os.path.join(root, name)).st_mtime
         for root, dirs, files in os.walk(path)
         for name in dirs + files
-        if os.path.exists(os.path.join(root, name))
     )
     return max(times)
 


### PR DESCRIPTION
When a `develop` path contains a dead symlink, the `os.stat` in the recursive `mtime` determination trips up over it. This ensures that the recursive `mtime` only `stat`s existing files.

Closes #32165.