### PR TITLE
acts: new versions 19.7.0, 20.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,6 +39,8 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("20.0.0", commit="3740e6cdbfb1f75d8e481686acdfa5b16d3c41a3", submodules=True)
+    version("19.7.0", commit="03cf7a3ae74b632b3f89416dc27cc993c9ae4628", submodules=True)
     version("19.6.0", commit="333082914e6a51b381abc1cf52856829e3eb7890", submodules=True)
     version("19.5.0", commit="bf9f0270eadd8e78d283557b7c9070b80dece4a7", submodules=True)
     version("19.4.0", commit="498af243755219486c26d32fb125b7ebf2557166", submodules=True)
@@ -226,7 +228,7 @@ class Acts(CMakePackage, CudaPackage):
     # Build dependencies
     # FIXME: Use spack's vecmem package once there is one
     # (https://github.com/acts-project/acts/pull/998)
-    depends_on("acts-dd4hep", when="@19.1: +dd4hep")
+    depends_on("acts-dd4hep", when="@19 +dd4hep")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")
     depends_on("boost @1.62:1.69 +program_options +test", when="@:0.10.3")
@@ -331,7 +333,7 @@ class Acts(CMakePackage, CudaPackage):
             if cuda_arch != "none":
                 args.append("-DCUDA_FLAGS=-arch=sm_{0}".format(cuda_arch[0]))
 
-        if spec.satisfies("@19.1: +dd4hep"):
+        if spec.satisfies("@19 +dd4hep"):
             args.append("-DACTS_USE_SYSTEM_ACTSDD4HEP=ON")
 
         if spec.satisfies("@:16"):


### PR DESCRIPTION
No major changes from [19.6.0 to 19.7.0](https://github.com/acts-project/acts/compare/v19.6.0...v19.7.0).

More major changes from [19.7.0 to 20.0.0](https://github.com/acts-project/acts/compare/v19.7.0...v20.0.0):
- requires `dd4hep@1.21:` (already implemented)
- `ACTS_USE_SYSTEM_ACTSDD4HEP` removed again