### PR TITLE
HPX: ROCm and Cuda conflict needed

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -124,6 +124,9 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("papi", when="instrumentation=papi")
     depends_on("valgrind", when="instrumentation=valgrind")
 
+    # Only ROCm or CUDA maybe be enabled at once
+    conflicts("+rocm", when="+cuda")
+
     # Restrictions for 1.8.X
     with when("@1.8:"):
         conflicts("cxxstd=14")


### PR DESCRIPTION
Discovered this missing conflict when building the e4s enviroment with unify:when_possible. #31940

FYI: @eugeneswalker @wspear 