### PR TITLE
CI: reduce the amount of tests run in the original concretizer

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -106,8 +106,6 @@ jobs:
         include:
         - python-version: 2.7
           concretizer: original
-        - python-version: 3.6
-          concretizer: original
         - python-version: 3.9
           concretizer: original
     steps:

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -47,8 +47,11 @@ $coverage_run $(which spack) python -c "import spack.pkg.builtin.mpileaks; repr(
 # Run unit tests with code coverage
 #-----------------------------------------------------------
 if [[ "$ONLY_PACKAGES" == "true" ]]; then
-  echo "ONLY PACKAGE RECIPES CHANGED [skipping slow unit tests]"
+  echo "ONLY PACKAGE RECIPES CHANGED [running only package sanity]"
   export PYTEST_ADDOPTS='-k "package_sanity" -m "not maybeslow"'
+elif [[ "$SPACK_TEST_SOLVER" == "original" ]]; then
+  echo "ORIGINAL CONCRETIZER [skipping slow unit tests]"
+  export PYTEST_ADDOPTS='-m "not maybeslow"'
 fi
 
 $coverage_run $(which spack) unit-test -x --verbose


### PR DESCRIPTION
Modifications:
- [x] Skip all the tests marked as `maybeslow` when testing the original concretizer
- [x] Don't test Python 3.6 on the original concretizer