### PR TITLE
fasta-36.3.8h_2020-05-04

### DIFF
--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -20,8 +20,11 @@ class Fasta(MakefilePackage):
     url = "https://github.com/wrpearson/fasta36/archive/fasta-v36.3.8g.tar.gz"
 
     version("36.3.8g", sha256="fa5318b6f8d6a3cfdef0d29de530eb005bfd3ca05835faa6ad63663f8dce7b2e")
-    version("36.3.8h_2020-05-04", sha256="d13ec06a040e4d77bf6913af44b705d3ecc921131da018e71d24daf47d3664d3",
-            url="https://github.com/wrpearson/fasta36/archive/refs/tags/v36.3.8h_04-May-2020.tar.gz")
+    version(
+        "36.3.8h_2020-05-04",
+        sha256="d13ec06a040e4d77bf6913af44b705d3ecc921131da018e71d24daf47d3664d3",
+        url="https://github.com/wrpearson/fasta36/archive/refs/tags/v36.3.8h_04-May-2020.tar.gz",
+    )
 
     depends_on("zlib")
 

--- a/var/spack/repos/builtin/packages/fasta/package.py
+++ b/var/spack/repos/builtin/packages/fasta/package.py
@@ -20,6 +20,8 @@ class Fasta(MakefilePackage):
     url = "https://github.com/wrpearson/fasta36/archive/fasta-v36.3.8g.tar.gz"
 
     version("36.3.8g", sha256="fa5318b6f8d6a3cfdef0d29de530eb005bfd3ca05835faa6ad63663f8dce7b2e")
+    version("36.3.8h_2020-05-04", sha256="d13ec06a040e4d77bf6913af44b705d3ecc921131da018e71d24daf47d3664d3",
+            url="https://github.com/wrpearson/fasta36/archive/refs/tags/v36.3.8h_04-May-2020.tar.gz")
 
     depends_on("zlib")
 


### PR DESCRIPTION
fasta 36.3.8g doesn't build out of the box on Rocky with gcc 8.5.0, due at a minimum to the error reported at https://lists.virginia.edu/sympa/arc/fasta_list/2018-06/msg00000.html for gcc 7.3.0 in June 2018.

As a result, updating to use 36.3.8h from 2020-05-04.