### PR TITLE
Kokkos: ROCm and CUDA are not compatible in Kokkos

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -172,6 +172,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     for dev in devices_variants:
         dflt, desc = devices_variants[dev]
         variant(dev, default=dflt, description=desc)
+    conflicts("+cuda", when="+rocm", msg="CUDA and ROCm are not compatible in Kokkos.")
 
     options_values = list(options_variants.keys())
     for opt in options_values:


### PR DESCRIPTION
This may be fixable in Kokkos, but for now it seems that there is not enough logic in the Kokkos build to support mixing HIP and CUDA devices in the same build of kokkos.

<details><summary>Error Message</summary><pre>
  >> 14    CMake Error at cmake/kokkos_test_cxx_std.cmake:132 (MESSAGE):
     15      Invalid compiler for CUDA.  The compiler must be nvcc_wrapper or Clang or
     16      use kokkos_launch_compiler, but compiler ID was HIPCC
</pre></details>

FYI: @eugeneswalker @wspear 