### PR TITLE
Geant4: update cmake defines and add support for nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -58,7 +58,7 @@ class Geant4(CMakePackage):
     variant("x11", default=False, description="Optional X11 support")
     variant("motif", default=False, description="Optional motif support")
     variant("qt", default=False, description="Enable Qt support")
-    variant("python", default=False, description="Enable Python bindings")
+    variant("python", default=False, when="@10.6.2:", description="Enable Python bindings")
     variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
     variant("vtk", default=False, description="Enable VTK support", when="@11:")
 
@@ -92,9 +92,6 @@ class Geant4(CMakePackage):
     # Python, with boost requirement dealt with in cxxstd section
     depends_on("python@3:", when="+python")
     extends("python", when="+python")
-    conflicts(
-        "+python", when="@:10.6.1", msg="Geant4 <= 10.6.1 cannot be built with Python bindings"
-    )
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -187,12 +187,12 @@ class Geant4(CMakePackage):
 
         # Core options
         options = [
-            "-DGEANT4_USE_SYSTEM_CLHEP=ON",
-            "-DGEANT4_USE_SYSTEM_EXPAT=ON",
-            "-DGEANT4_USE_SYSTEM_ZLIB=ON",
-            "-DGEANT4_USE_G3TOG4=ON",
-            "-DGEANT4_USE_GDML=ON",
-            "-DXERCESC_ROOT_DIR={0}".format(spec["xerces-c"].prefix),
+            self.define("GEANT4_USE_SYSTEM_CLHEP", True),
+            self.define("GEANT4_USE_SYSTEM_EXPAT", True),
+            self.define("GEANT4_USE_SYSTEM_ZLIB", True),
+            self.define("GEANT4_USE_G3TOG4", True),
+            self.define("GEANT4_USE_GDML", True),
+            self.define("XERCESC_ROOT_DIR", spec["xerces-c"].prefix),
         ]
 
         # Use the correct C++ standard option for the requested version
@@ -223,21 +223,21 @@ class Geant4(CMakePackage):
 
         # Vecgeom
         if "+vecgeom" in spec:
-            options.append("-DGEANT4_USE_USOLIDS=ON")
-            options.append("-DUSolids_DIR=%s" % spec["vecgeom"].prefix.lib.CMake.USolids)
+            options.append(self.define("GEANT4_USE_USOLIDS", True))
+            options.append(self.define("USolids_DIR", spec["vecgeom"].prefix.lib.CMake.USolids))
 
         # Visualization options
         if "platform=darwin" not in spec:
             if "+x11" in spec and "+opengl" in spec:
-                options.append("-DGEANT4_USE_OPENGL_X11=ON")
+                options.append(self.define("GEANT4_USE_OPENGL_X11", True))
             if "+motif" in spec and "+opengl" in spec:
-                options.append("-DGEANT4_USE_XM=ON")
+                options.append(self.define("GEANT4_USE_XM", True))
             if "+x11" in spec:
-                options.append("-DGEANT4_USE_RAYTRACER_X11=ON")
+                options.append(self.define("GEANT4_USE_RAYTRACER_X11", True))
 
         if "+qt" in spec:
-            options.append("-DGEANT4_USE_QT=ON")
-            options.append("-DQT_QMAKE_EXECUTABLE=%s" % spec["qt"].prefix.bin.qmake)
+            options.append(self.define("GEANT4_USE_QT", True))
+            options.append(self.define("QT_QMAKE_EXECUTABLE", spec["qt"].prefix.bin.qmake))
 
         options.append(self.define_from_variant("GEANT4_USE_VTK", "vtk"))
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -188,8 +188,9 @@ class Geant4(CMakePackage):
             if spec.satisfies("%nvhpc"):
                 # error: excessive recursion at instantiation of class
                 # "G4Number<191>" (G4CTCounter.hh)
-                cmake_flags.append("-Wc,--pending_instantiations=256")
-        return flags, None, None
+                flags.append("-Wc,--pending_instantiations=256")
+                return (None, flags, None)
+        return (flags, None, None)
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Geant4 fails to build using the PGI-derived NVC++ (nvhpc) toolchain without these patches. The main two sets of errors are:
```
error: excessive recursion at instantiation of class "G4Number<191>"
```
due to a suboptimal implementation of "extensible enums" which can be circumvented using a magical `-Wc,--pending_instantiations` flag, and a couple instances of:
```
error: thread-local declaration follows non-thread-local declaration
```
which can probably be cleaned up in the next geant release (so for now I'm disabling threads with nvhpc).

[spack-build-out.txt](https://github.com/spack/spack/files/9353169/spack-build-out.txt)