### PR TITLE
kokkos: fix conflict for deprecated `sycl` namespace

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -54,7 +54,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+openmptarget", when="@:3.5")
 
     # https://github.com/spack/spack/issues/29052
-    conflicts("@:3.5.00 +sycl", when="%dpcpp@2022.0.0")
+    conflicts("@:3.5 +sycl", when="%dpcpp@2022:")
+    conflicts("@:3.5 +sycl", when="%oneapi@2022:")
 
     tpls_variants = {
         "hpx": [False, "Whether to enable the HPX library"],


### PR DESCRIPTION
We're seeing errors pop up with older versions of Kokkos and newer versions of `oneapi`, specifically:

    error: no member named 'ONEAPI' in namespace 'sycl'

This hapens because `sycl::ONEAPI` is `sycl::ext::oneapi` since oneapi `2022.0.0`. `kokkos@3.6:` uses the new namespace. A conflict was present for this, but it was too specific -- both to `dpcpp` and to the `2022.0.0` version.

This should fix the `oneapi` build on `develop`, or if it doesn't, the version(s) of Kokkos there will need to be updated (@eugeneswalker FYI).

- [x] Expand version ranges in `kokkos` conflict
- [x] Add conflict for `oneapi` in addition to `dpcpp`