### PR TITLE
ci: ensure publishing to root happens serially

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -720,8 +720,6 @@ def generate_gitlab_ci_yaml(
     # Values: "spack_pull_request", "spack_protected_branch", or not set
     spack_pipeline_type = os.environ.get("SPACK_PIPELINE_TYPE", None)
 
-    spack_buildcache_copy = os.environ.get("SPACK_COPY_BUILDCACHE", None)
-
     if "mirrors" not in yaml_root or len(yaml_root["mirrors"].values()) < 1:
         tty.die("spack ci generate requires an env containing a mirror")
 
@@ -1263,32 +1261,6 @@ def generate_gitlab_ci_yaml(
             signing_job["interruptible"] = True
 
             output_object["sign-pkgs"] = signing_job
-
-        if spack_buildcache_copy:
-            # Generate a job to copy the contents from wherever the builds are getting
-            # pushed to the url specified in the "SPACK_BUILDCACHE_COPY" environment
-            # variable.
-            src_url = remote_mirror_override or remote_mirror_url
-            dest_url = spack_buildcache_copy
-
-            stage_names.append("stage-copy-buildcache")
-            copy_job = {
-                "stage": "stage-copy-buildcache",
-                "tags": ["spack", "public", "medium", "aws", "x86_64"],
-                "image": "ghcr.io/spack/python-aws-bash:0.0.1",
-                "when": "on_success",
-                "interruptible": True,
-                "retry": service_job_retries,
-                "script": [
-                    ". ./share/spack/setup-env.sh",
-                    "spack --version",
-                    "aws s3 sync --exclude *index.json* --exclude *pgp* {0} {1}".format(
-                        src_url, dest_url
-                    ),
-                ],
-            }
-
-            output_object["copy-mirror"] = copy_job
 
         if rebuild_index_enabled:
             # Add a final job to regenerate the index

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -91,12 +91,28 @@ protected-publish:
   extends: [ ".protected-refs" ]
   image: "ghcr.io/spack/python-aws-bash:0.0.1"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
+  interruptible: true
+  retry:
+    max: 2
+    when: ["runner_system_failure", "stuck_or_timeout_failure"]
   variables:
     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
   script:
     - . "./share/spack/setup-env.sh"
     - spack --version
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/e4s" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/e4s-oneapi" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/build_systems" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/radiuss" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/radiuss-aws" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/radiuss-aws-aarch64" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/data-vis-sdk" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/aws-ahug" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/aws-ahug-aarch64" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/aws-isc" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/aws-isc-aarch64" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/tutorial" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
     - spack buildcache update-index --mirror-url "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
 
 ########################################
@@ -136,6 +152,16 @@ protected-publish:
 #       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
 #         job: my-super-cool-stack-protected-generate
 #     strategy: depend
+########################################
+#
+# If the stack should be published, and most are, add a line like
+# this one to the "protected-publish" job:
+#
+#     - aws s3 sync --exclude *index.json* --exclude *pgp* "s3://spack-binaries/${CI_COMMIT_REF_NAME}/<SPACK_CI_STACK_NAME>" "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+#
+# Replace "SPACK_CI_STACK_NAME" with the name of your new stack
+#
+########################################
 
 ########################################
 #          E4S Mac Stack


### PR DESCRIPTION
Previously each pipeline copied the target buildcache to the root
as a final job in the child pipeline.  When multiple stacks contain
the same spec hashes, the associated binaries files are indistinguishable
by name, and race conditions could occur where the spec.json.sig from
one stack wins the copy race, while the .spack file from another
stack wins.  This results in binaries where the checksum stored in
the spec.json.sig does not match that of the .spack file, causing
installation failures.

Until we refactor gitlab ci to make addition of stacks easier, we
do not have a good way to generate code that should operate on all
stacks.  Until we have that, this workaround fixes the race condition
described above.