### PR TITLE
bugfix: silence `clingo` warning about `requirement_policy/3`

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -542,6 +542,7 @@ error(2, "Cannot satisfy requirement group for package '{0}'", Package) :-
 #defined requirement_group/2.
 #defined requirement_group_member/3.
 #defined requirement_has_weight/2.
+#defined requirement_policy/3.
 
 %-----------------------------------------------------------------------------
 % Variant semantics


### PR DESCRIPTION
`requirement_policy/3` is generated and may not be in Spack's inputs to Clingo.
Currently this is causing warnings like:

```
$ spack spec zlib
/global/u2/t/tgamblin/src/spack/lib/spack/spack/solver/concretize.lp:510:3-43: info: atom does not occur in any rule head:
  requirement_policy(Package,X,"one_of")

/global/u2/t/tgamblin/src/spack/lib/spack/spack/solver/concretize.lp:517:3-43: info: atom does not occur in any rule head:
  requirement_policy(Package,X,"one_of")

/global/u2/t/tgamblin/src/spack/lib/spack/spack/solver/concretize.lp:523:3-43: info: atom does not occur in any rule head:
  requirement_policy(Package,X,"any_of")

/global/u2/t/tgamblin/src/spack/lib/spack/spack/solver/concretize.lp:534:3-43: info: atom does not occur in any rule head:
  requirement_policy(Package,X,"any_of")

Input spec
--------------------------------
zlib

Concretized
--------------------------------
zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=cray-sles15-haswell
```

- [x] Silence warning with `#defined requirement_policy/3`