### PR TITLE
bump patchelf on amazon linux

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -241,6 +241,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-aarch64.tar.gz; echo "03f8ad07dbd8fbdb5f47a9c168684be9d10b900a73b2df3f408fb0228e05fe6a  patchelf-0.15.0-aarch64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-aarch64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -242,6 +242,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-x86_64.tar.gz; echo "0b9b93da52f51b3262f783596421a0d1376893d5f865d93f1493da293bd1d4b5  patchelf-0.15.0-x86_64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-x86_64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -159,6 +159,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-aarch64.tar.gz; echo "03f8ad07dbd8fbdb5f47a9c168684be9d10b900a73b2df3f408fb0228e05fe6a  patchelf-0.15.0-aarch64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-aarch64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -160,6 +160,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-x86_64.tar.gz; echo "0b9b93da52f51b3262f783596421a0d1376893d5f865d93f1493da293bd1d4b5  patchelf-0.15.0-x86_64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-x86_64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -62,6 +62,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-aarch64.tar.gz; echo "03f8ad07dbd8fbdb5f47a9c168684be9d10b900a73b2df3f408fb0228e05fe6a  patchelf-0.15.0-aarch64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-aarch64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -61,6 +61,7 @@ spack:
   gitlab-ci:
 
     script:
+      - (cd "$(mktemp -d)" || exit 1; curl -LfsO https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-x86_64.tar.gz; echo "0b9b93da52f51b3262f783596421a0d1376893d5f865d93f1493da293bd1d4b5  patchelf-0.15.0-x86_64.tar.gz" | sha256sum --check --quiet || exit 1; tar -xf patchelf-0.15.0-x86_64.tar.gz -C /usr; patchelf --version)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}


### PR DESCRIPTION
@bollig can you make this persistent in the image, amazon linux ships patchelf
0.9 which produces broken binaries more often than not, it's a bit of a miracle
it works so far.

FWIW, bugs are surfacing in #32086, libcublas.so breaks after patchelf, likely
due to one of the many bugs related to large filesize, or any other bug that was
fixed in the past 6 years after the 0.9 release...