### PR TITLE
Constrain `__skip_rocmclang` workaround in pika package

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -122,7 +122,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
         # HIP support requires compiling with hipcc
         if "+rocm" in self.spec:
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
-            if self.spec.satisfies("^cmake@3.21:"):
+            if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]
 
         return args


### PR DESCRIPTION
Constraining it to a maximum CMake version as has been done in most other packages.