### PR TITLE
spec: fix typo in Spec._finalize_concretization

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2991,7 +2991,7 @@ class Spec(object):
         # Any specs that were concrete before finalization will already have a cached
         # DAG hash.
         for spec in self.traverse():
-            self._cached_hash(ht.dag_hash)
+            spec._cached_hash(ht.dag_hash)
 
     def concretized(self, tests=False):
         """This is a non-destructive version of concretize().


### PR DESCRIPTION
It seems in a loop to assign DAG hash to nodes we always call `self` instead of `spec`