### PR TITLE
package_base: remove rpath_args and "deprecate" rpath properties

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2751,13 +2751,6 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
         return rpaths
 
-    @property
-    def rpath_args(self):
-        """
-        Get the rpath args as a string, with -Wl,-rpath, for each element
-        """
-        return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
-
     def _run_test_callbacks(self, method_names, callback_type="install"):
         """Tries to call all of the listed methods, returning immediately
         if the list is None."""

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -33,7 +33,7 @@ import six
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
-from llnl.util.lang import classproperty, match_predicate, memoized, nullcontext
+from llnl.util.lang import classproperty, dedupe, match_predicate, memoized, nullcontext
 from llnl.util.link_tree import LinkTree
 
 import spack.compilers
@@ -2763,10 +2763,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
         rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
 
-        from llnl.util.lang import dedupe
-        from spack.util.environment import filter_system_paths
-
-        rpaths = list(dedupe(filter_system_paths(rpaths)))
+        rpaths = list(dedupe(spack.util.environment.filter_system_paths(rpaths)))
         return rpaths
 
     def _run_test_callbacks(self, method_names, callback_type="install"):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2749,6 +2749,11 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         deps = self.spec.dependencies(deptype="link")
         rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
         rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
+
+        from llnl.util.lang import dedupe
+        from spack.util.environment import filter_system_paths
+
+        rpaths = list(dedupe(filter_system_paths(rpaths)))
         return rpaths
 
     def _run_test_callbacks(self, method_names, callback_type="install"):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2745,6 +2745,19 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     @property
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
+        # TODO: this method is deprecated and will be removed in the future versions of Spack:
+        #  1. The method duplicates the logic of build_environment.set_wrapper_variables(), which
+        #     sets the actual rpath flags to be used when building the package. Therefore, the
+        #     output of this method is prone to not delivering what it promises. For example, the
+        #     current implementation does not return the contents of SPACK_COMPILER_IMPLICIT_RPATHS
+        #     and SPACK_COMPILER_EXTRA_RPATHS, which would be fair to assume that it does.
+        #  2. Most of the packages should not need this method: the compiler wrappers are supposed
+        #     to do the injection of the rpaths automatically, and if they do not, it is a bug in
+        #     the core functionality of Spack, which should be fixed.
+        #  3. A few packages that can make reasonable use of this method (e.g. gcc, which needs
+        #     the rpath flags at the bootstrapping stage) should take over the responsibility and
+        #     implement their own versions of the method that deliver what they actually need (e.g.
+        #     gcc does not need its installation prefix on the list).
         rpaths = [self.prefix.lib, self.prefix.lib64]
         deps = self.spec.dependencies(deptype="link")
         rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -262,16 +262,6 @@ def test_git_url_top_level_conflicts(version_str):
         spack.fetch_strategy.for_package_version(s.package, version_str)
 
 
-def test_rpath_args(mutable_database):
-    """Test a package's rpath_args property."""
-
-    rec = mutable_database.get_record("mpich")
-
-    rpath_args = rec.spec.package.rpath_args
-    assert "-rpath" in rpath_args
-    assert "mpich" in rpath_args
-
-
 def test_bundle_version_checksum(mock_directive_bundle, clear_directive_functions):
     """Test raising exception on a version checksum with a bundle package."""
     with pytest.raises(VersionChecksumError, match="Checksums not allowed"):

--- a/var/spack/repos/builtin/packages/bamtools/package.py
+++ b/var/spack/repos/builtin/packages/bamtools/package.py
@@ -27,6 +27,8 @@ class Bamtools(CMakePackage):
 
     def cmake_args(self):
         args = []
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         rpath = self.rpath
         rpath.append(os.path.join(self.prefix.lib, "bamtools"))
         args.append("-DCMAKE_INSTALL_RPATH=%s" % ":".join(rpath))

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -719,6 +719,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             str(self.spec.target.family),
             [None] * 2,
         )
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         stage1_ldflags = " ".join("{0}{1}".format(compiler.cc_rpath_arg, d) for d in self.rpath)
         boot_ldflags = stage1_ldflags + " -static-libstdc++ -static-libgcc"
         options.append("--with-stage1-ldflags=" + stage1_ldflags)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -713,7 +713,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             )
 
         # enable appropriate bootstrapping flags
-        stage1_ldflags = str(self.rpath_args)
+        compiler = spack.compilers.gcc.Gcc(
+            "gcc@{0}".format(self.spec.version),
+            self.spec.os,
+            str(self.spec.target.family),
+            [None] * 2,
+        )
+        stage1_ldflags = " ".join("{0}{1}".format(compiler.cc_rpath_arg, d) for d in self.rpath)
         boot_ldflags = stage1_ldflags + " -static-libstdc++ -static-libgcc"
         options.append("--with-stage1-ldflags=" + stage1_ldflags)
         options.append("--with-boot-ldflags=" + boot_ldflags)

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -566,6 +566,8 @@ class Paraview(CMakePackage, CudaPackage):
         # Encourage Paraview to use the correct Python libs
         if spec.satisfies("+python") or spec.satisfies("+python3"):
             pylibdirs = spec["python"].libs.directories
+            # TODO: the usage of self.rpath is deprecated.
+            #  See comments in the implementation of the property for more details.
             cmake_args.append("-DCMAKE_INSTALL_RPATH={0}".format(":".join(self.rpath + pylibdirs)))
 
         if "+advanced_debug" in spec:

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -88,6 +88,8 @@ class PyGpaw(PythonPackage):
 
         lib_dirs = list(libs.directories)
         libs = list(libs.names)
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         rpath_str = ":".join(self.rpath)
 
         if spec.satisfies("@:19.8.1"):

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -78,6 +78,8 @@ class PyPillowBase(PythonPackage):
             for variant in variants:
                 setup.write(variant_to_cfg(variant))
 
+            # TODO: the usage of self.rpath is deprecated.
+            #  See comments in the implementation of the property for more details.
             setup.write("rpath={0}\n".format(":".join(self.rpath)))
             setup.write("[install]\n")
 

--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -45,6 +45,8 @@ class PyPyside(PythonPackage):
     def patch(self):
         """Undo PySide RPATH handling and add Spack RPATH."""
         # Figure out the special RPATH
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         rpath = self.rpath
         rpath.append(os.path.join(python_platlib, "PySide"))
 

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -30,6 +30,8 @@ class PyShiboken(PythonPackage):
         """Undo Shiboken RPATH handling and add Spack RPATH."""
         # Add Spack's standard CMake args to the sub-builds.
         # They're called BY setup.py so we have to patch it.
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         rpath = self.rpath
         rpath.append(os.path.join(python_platlib, "Shiboken"))
 

--- a/var/spack/repos/builtin/packages/rdc/package.py
+++ b/var/spack/repos/builtin/packages/rdc/package.py
@@ -128,6 +128,8 @@ class Rdc(CMakePackage):
         return ver
 
     def cmake_args(self):
+        # TODO: the usage of self.rpath is deprecated.
+        #  See comments in the implementation of the property for more details.
         rpath = self.rpath
         rpath.append(self.prefix.opt.rocm.rdc.lib)
         rpath = ";".join(rpath)

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -140,7 +140,10 @@ class Tau(Package):
 
     def set_compiler_options(self, spec):
 
-        useropt = ["-O2 -g", self.rpath_args]
+        useropt = [
+            "-O2 -g",
+            " ".join("{0}{1}".format(self.compiler.cc_rpath_arg, d) for d in self.rpath),
+        ]
 
         ##########
         # Selecting a compiler with TAU configure is quite tricky:

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -142,6 +142,8 @@ class Tau(Package):
 
         useropt = [
             "-O2 -g",
+            # TODO: the usage of self.rpath is deprecated.
+            #  See comments in the implementation of the property for more details.
             " ".join("{0}{1}".format(self.compiler.cc_rpath_arg, d) for d in self.rpath),
         ]
 


### PR DESCRIPTION
I dared to remove and "deprecate" two properties of the `PackageBase` class:
1. Property `rpath_args` currently returns flags with hardcoded flag prefixes `-Wl,-rpath,`. Instead, it should be the compiler-specific properties `cc_rpath_arg`, `cxx_rpath_arg`, etc. We could try to extend the interface instead of removing it but that does not make much sense if I manage to convince you all that the property `rpath`, which is used in `rpath_args`, should be removed as well.
2. There are several problems with the `rpath` property, which I tried to describe in the comments:
    ```python
    # TODO: this method is deprecated and will be removed in the future versions of Spack:
    #  1. The method duplicates the logic of build_environment.set_wrapper_variables(), which
    #     sets the actual rpath flags to be used when building the package. Therefore, the
    #     output of this method is prone to not delivering what it promises. For example, the
    #     current implementation does not return the contents of SPACK_COMPILER_IMPLICIT_RPATHS
    #     and SPACK_COMPILER_EXTRA_RPATHS, which would be fair to assume that it does.
    #  2. Most of the packages should not need this method: the compiler wrappers are supposed
    #     to do the injection of the rpaths automatically, and if they do not, it is a bug in
    #     the core functionality of Spack, which should be fixed.
    #  3. A few packages that can make reasonable use of this method (e.g. gcc, which needs
    #     the rpath flags at the bootstrapping stage) should take over the responsibility and
    #     implement their own versions of the method that deliver what they actually need (e.g.
    #     gcc does not need its installation prefix on the list).
    ```
    So, I think that `rpath` should be removed too. I have added `TODO` comments to the packages that use the method to notify their maintainers about this change. I would like to ask the maintainers to check whether they actually need the method. It might be the case that the issues they tried to workaround with it have already been resolved and the respective code that uses `self.rpath` can be simply removed.
3. Regardless of whether `rpath` stays, it should filter the system paths out (relevant for external packages installed to, for example, `/usr`).

I also have two questions about `build_environment.set_wrapper_variables()`. Maybe somebody can answer them:
1. Should we really prefer `prefix.lib` over `prefix.lib64` [here](https://github.com/spack/spack/blob/8d8aa5c6cf294e65d96edc8ee276cc0a315a4693/lib/spack/spack/build_environment.py#L446) and [here](https://github.com/spack/spack/blob/8d8aa5c6cf294e65d96edc8ee276cc0a315a4693/lib/spack/spack/build_environment.py#L474), and not the other way around?
2. Given that we skip the system prefixes when iterating over the link dependencies
    https://github.com/spack/spack/blob/8d8aa5c6cf294e65d96edc8ee276cc0a315a4693/lib/spack/spack/build_environment.py#L438
    does `filter_system_paths` actually do anything?
    https://github.com/spack/spack/blob/8d8aa5c6cf294e65d96edc8ee276cc0a315a4693/lib/spack/spack/build_environment.py#L480