### PR TITLE
autotools: add activation value "non_system_prefix"

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -17,6 +17,7 @@ from spack.build_environment import InstallError
 from spack.directives import conflicts, depends_on
 from spack.operating_systems.mac_os import macos_version
 from spack.package_base import PackageBase, run_after, run_before
+from spack.util.environment import is_system_path
 from spack.util.executable import Executable
 from spack.version import Version
 
@@ -533,6 +534,8 @@ To resolve this problem, please try the following:
 
         if activation_value == "prefix":
             activation_value = lambda x: spec[x].prefix
+        elif activation_value == "non_system_prefix":
+            activation_value = lambda x: None if is_system_path(spec[x].prefix) else spec[x].prefix
 
         variant = variant or name
 


### PR DESCRIPTION
Most of the Autotools packages trust the users and blindly take whatever paths they provide as arguments for the `--with-some-package` configure options. The configure scripts normally use the path to extend `LDFLAGS` with `-L` flags and even `-Wl,-rpath,` flags. The problem is that we don't want those flags for the system directories. Some time ago, I have implemented a custom [`activation_value`](https://github.com/spack/spack/blob/b8b1a85e4dd0435129db81e54b49ff020f8c5d46/var/spack/repos/builtin/packages/cdo/package.py#L182-L184) that filters the system paths out. I think that other packages can benefit from that too. We already have the activation value `prefix` and this PR introduces an additional one, `non_system_prefix` (note that `--with-some-package` is the same as `--with-some-package=yes`, therefore we can make it `yes_or_prefix` instead).

The problem with the suggested change is that the maintainers of Spack packages (myself included) often forget to cover the case when a dependency is an external from a system prefix and will keep using `prefix`. Therefore, I think that we should not really introduce `non_system_prefix` but make `prefix` do what `non_system_prefix` does.

I would also change
https://github.com/spack/spack/blob/b8b1a85e4dd0435129db81e54b49ff020f8c5d46/lib/spack/spack/build_systems/autotools.py#L585
to
```python
if activation_value is not None and activation_value(option_value) is not None:
```
because `--with-some-package` and `--with-some-package=` are different things and an empty string returned by a user-provided `activation_value` might be intended.