### PR TITLE
e4s oneapi: build trilinos@13.4.0 to avoid using vendored kokkos 3.4.xx in trilinos@13.0.1

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -170,7 +170,7 @@ spack:
   - sz
   - tasmanian
   - tau +mpi +python %oneapi ^binutils%gcc
-  - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
+  - trilinos@13.4.0 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
    +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
    +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
    +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long


### PR DESCRIPTION
FYI @trws @tgamblin @keitat @kuberry @sethrj @wspear 