### PR TITLE
New packages: roary plus 5 new perl-*

### DIFF
--- a/var/spack/repos/builtin/packages/mcl/package.py
+++ b/var/spack/repos/builtin/packages/mcl/package.py
@@ -20,3 +20,15 @@ class Mcl(AutotoolsPackage):
     def patch(self):
         filter_file("^dim", "extern dim", "src/impala/iface.h")
         filter_file("^double", "extern double", "src/impala/iface.h")
+
+    depends_on("perl", type="run")
+
+    variant("blast", default=False, description="Build bio-informatics tools.")
+
+    def configure_args(self):
+        args = []
+
+        if "+blast" in self.spec:
+            args.append("--enable-blast")
+
+        return args

--- a/var/spack/repos/builtin/packages/perl-digest-md5-file/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-md5-file/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDigestMd5File(PerlPackage):
+    """Digest::MD5::File - Perl extension for getting MD5 sums for files and urls."""
+
+    homepage = "https://metacpan.org/pod/Digest::MD5::File"
+    url = "https://cpan.metacpan.org/authors/id/D/DM/DMUEY/Digest-MD5-File-0.08.tar.gz"
+
+    version("0.08", sha256="adb43a54e32627b4f7e57c9640e6eb06d0bb79d8ea54cd0bd79ed35688fb1218")
+
+    depends_on("perl-extutils-makemaker", type="build")
+    depends_on("perl-libwww-perl", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/perl-file-find-rule/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-find-rule/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlFileFindRule(PerlPackage):
+    """File::Find::Rule is a friendlier interface to File::Find. It allows you to
+    build rules which specify the desired files and directories."""
+
+    homepage = "https://metacpan.org/pod/File::Find::Rule"
+    url = "https://cpan.metacpan.org/authors/id/R/RC/RCLAMP/File-Find-Rule-0.34.tar.gz"
+
+    version("0.34", sha256="7e6f16cc33eb1f29ff25bee51d513f4b8a84947bbfa18edb2d3cc40a2d64cafe")
+
+    depends_on("perl-extutils-makemaker", type="build")
+    depends_on("perl-number-compare", type=("build", "run"))
+    depends_on("perl-text-glob", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/perl-file-grep/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-grep/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlFileGrep(PerlPackage):
+    """File::Grep - Find matches to a pattern in a series of files and related functions"""
+
+    homepage = "https://metacpan.org/pod/File::Grep"
+    url = "https://cpan.metacpan.org/authors/id/M/MN/MNEYLON/File-Grep-0.02.tar.gz"
+
+    version("0.02", sha256="462e15274eb6278521407ea302d9eea7252cd44cab2382871f7de833d5f85632")
+
+    depends_on("perl-extutils-makemaker", type="build")

--- a/var/spack/repos/builtin/packages/perl-number-compare/package.py
+++ b/var/spack/repos/builtin/packages/perl-number-compare/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlNumberCompare(PerlPackage):
+    """Number::Compare - numeric comparisons"""
+
+    homepage = "https://metacpan.org/pod/Number::Compare"
+    url = "https://cpan.metacpan.org/authors/id/R/RC/RCLAMP/Number-Compare-0.03.tar.gz"
+
+    version("0.03", sha256="83293737e803b43112830443fb5208ec5208a2e6ea512ed54ef8e4dd2b880827")
+
+    depends_on("perl-extutils-makemaker", type="build")

--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -12,6 +12,7 @@ class PerlPerlioUtf8Strict(PerlPackage):
     homepage = "https://metacpan.org/pod/PerlIO::utf8_strict"
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.002.tar.gz"
 
+    version("0.009", sha256="ba82cf144820655d6d4836d12dde65f8895a3d905aeb4aa0b421249f43284c14")
     version("0.002", sha256="6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f")
 
     depends_on("perl-module-build", type="build")

--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -15,4 +15,4 @@ class PerlPerlioUtf8Strict(PerlPackage):
     version("0.009", sha256="ba82cf144820655d6d4836d12dde65f8895a3d905aeb4aa0b421249f43284c14")
     version("0.002", sha256="6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f")
 
-    depends_on("perl-module-build", type="build")
+    depends_on("perl-module-build", type="build", when="@:0.005")

--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -15,4 +15,4 @@ class PerlPerlioUtf8Strict(PerlPackage):
     version("0.009", sha256="ba82cf144820655d6d4836d12dde65f8895a3d905aeb4aa0b421249f43284c14")
     version("0.002", sha256="6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f")
 
-    depends_on("perl-module-build", type="build", when="@:0.005")
+    depends_on("perl-module-build", type="build")

--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -13,3 +13,5 @@ class PerlPerlioUtf8Strict(PerlPackage):
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.002.tar.gz"
 
     version("0.002", sha256="6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f")
+
+    depends_on("perl-module-build", type="build")

--- a/var/spack/repos/builtin/packages/perl-text-glob/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-glob/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTextGlob(PerlPackage):
+    """Text::Glob implements glob(3) style matching that can be used to match
+    against text rather than fetching names from a filesystem."""
+
+    homepage = "https://metacpan.org/pod/Text::Glob"
+    url = "https://cpan.metacpan.org/authors/id/R/RC/RCLAMP/Text-Glob-0.11.tar.gz"
+
+    version("0.11", sha256="069ccd49d3f0a2dedb115f4bdc9fbac07a83592840953d1fcdfc39eb9d305287")
+
+    depends_on("perl-extutils-makemaker", type="build")

--- a/var/spack/repos/builtin/packages/roary/package.py
+++ b/var/spack/repos/builtin/packages/roary/package.py
@@ -1,0 +1,71 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Roary(Package):
+    """Rapid large-scale prokaryote pan genome analysis"""
+
+    homepage = "https://github.com/sanger-pathogens/Roary"
+    url = "https://github.com/sanger-pathogens/Roary/archive/refs/tags/v3.13.0.tar.gz"
+
+    version("3.13.0", sha256="375f83c8750b0f4dea5b676471e73e94f3710bc3a327ec88b59f25eae1c3a1e8")
+
+    variant("kraken", default=False, description="Enable kraken support")
+
+    depends_on("bedtools2", type="run")
+    depends_on("blast-plus", type="run")
+    depends_on("cdhit", type="run")
+    depends_on("fasttree~openmp", type="run")
+    depends_on("kraken", type="run", when="+kraken")
+    depends_on("mafft", type="run")
+    depends_on("mcl+blast", type="run")
+    depends_on("parallel", type="run")
+    depends_on("perl@5.8:", type="run")
+    depends_on("perl-array-utils", type="run")
+    depends_on("perl-bioperl", type="run")
+    depends_on("perl-devel-overloadinfo", type="run")
+    depends_on("perl-digest-md5-file", type="run")
+    depends_on("perl-exception-class", type="run")
+    depends_on("perl-file-find-rule", type="run")
+    depends_on("perl-file-grep", type="run")
+    depends_on("perl-file-slurper", type="run")
+    depends_on("perl-file-which", type="run")
+    depends_on("perl-graph-readwrite", type="run")
+    depends_on("perl-graph", type="run")
+    depends_on("perl-log-log4perl", type="run")
+    depends_on("perl-moose", type="run")
+    depends_on("perl-perlio-utf8-strict", type="run")
+    depends_on("perl-text-csv", type="run")
+    depends_on("perl-xml-parser", type="run")
+    depends_on("perl-xml-writer", type="run")
+    depends_on("prank", type="run")
+    depends_on("r-ggplot2", type="run")
+    depends_on("r", type="run")
+    # roary2svg dependencies
+    depends_on("perl-data-dumper", type="run")
+    depends_on("perl-list-moreutils", type="run")
+    depends_on("perl-svg", type="run")
+    # roary_plots dependencies
+    depends_on("python", type="run")
+    depends_on("py-biopython", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("py-pandas", type="run")
+    depends_on("py-matplotlib", type="run")
+    depends_on("py-seaborn", type="run")
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", join_path(prefix, "contrib", "roary2svg"))
+        env.prepend_path("PATH", join_path(prefix, "contrib", "roary_plots"))
+        env.prepend_path("PERL5LIB", self.prefix.lib)
+
+    @run_after("install")
+    def modify_roary_pm(self):
+        with working_dir(join_path(prefix.lib, "Bio")):
+            filter_file("use Bio::Perl", "use BioPerl", "Roary.pm", string=True)


### PR DESCRIPTION
Included in this pull request are the new and modified package files which are required for roary to install and run.

Roary - Rapid large-scale prokaryote pan genome analysis

New:
perl-digest-md5-file
perl-file-find-rule
perl-file-grep
perl-number-compare
perl-text-glob

Modified:
fasttree - the current version of fasttree installs only the openmp-compatible version, that was left the default, but the non-openmp-compatible version was made a variant to fill a roary requirement.

mcl - the current version of mcl does not allow for the --blast variant (which builds the bioinformatics tools needed by roary) to be built  +blast /  --enable-blast was added as a variant.

perl-perlio-utf8-strict - required the perl-module-build dependency to build on a fresh Spack install.