### PR TITLE
CCache: `redis` variant & macOS disable

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
-import sys
 
 from spack.package import *
 
@@ -44,10 +43,7 @@ class Ccache(CMakePackage):
     version("3.3", sha256="b220fce435fe3d86b8b90097e986a17f6c1f971e0841283dd816adb238c5fd6a")
     version("3.2.9", sha256="1e13961b83a3d215c4013469c149414a79312a22d3c7bf9f946abac9ee33e63f")
 
-    is_darwin = sys.platform == "darwin"
-
-    # macOS ships a redis lib by default, which at runtime crashes ccache
-    variant("redis", default=not is_darwin, description="Enable Redis secondary storage")
+    variant("redis", default=True, description="Enable Redis secondary storage")
 
     depends_on("cmake@3.15:", when="@4.7:", type="build")
     depends_on("cmake@3.10:", when="@4.4:", type="build")

--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -68,9 +68,8 @@ class Ccache(CMakePackage):
             self.define("ENABLE_DOCUMENTATION", False),
             self.define_from_variant("REDIS_STORAGE_BACKEND", "redis"),
             self.define("ZSTD_FROM_INTERNET", False),
+            self.define("HIREDIS_FROM_INTERNET", False),
         ]
-        if spec.satisfies("+redis"):
-            args.append(self.define("HIREDIS_FROM_INTERNET", False))
 
         return args
 

--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -62,16 +62,13 @@ class Ccache(CMakePackage):
     conflicts("%clang@:4", when="@4.4:")
 
     def cmake_args(self):
-        spec = self.spec
-        args = [
+        return [
             self.define("ENABLE_TESTING", False),
             self.define("ENABLE_DOCUMENTATION", False),
             self.define_from_variant("REDIS_STORAGE_BACKEND", "redis"),
             self.define("ZSTD_FROM_INTERNET", False),
             self.define("HIREDIS_FROM_INTERNET", False),
         ]
-
-        return args
 
     # Before 4.0 this was an Autotools package
     @when("@:3")

--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
+import sys
 
 from spack.package import *
 
@@ -43,6 +44,11 @@ class Ccache(CMakePackage):
     version("3.3", sha256="b220fce435fe3d86b8b90097e986a17f6c1f971e0841283dd816adb238c5fd6a")
     version("3.2.9", sha256="1e13961b83a3d215c4013469c149414a79312a22d3c7bf9f946abac9ee33e63f")
 
+    is_darwin = sys.platform == "darwin"
+
+    # macOS ships a redis lib by default, which at runtime crashes ccache
+    variant("redis", default=not is_darwin, description="Enable Redis secondary storage")
+
     depends_on("cmake@3.15:", when="@4.7:", type="build")
     depends_on("cmake@3.10:", when="@4.4:", type="build")
     depends_on("cmake@3.4.3:", when="@4.0:", type="build")
@@ -53,14 +59,24 @@ class Ccache(CMakePackage):
 
     depends_on("zstd", when="@4.0:")
 
-    depends_on("hiredis@0.13.3:", when="@4.4:")
+    depends_on("hiredis@0.13.3:", when="@4.4: +redis")
     depends_on("pkgconfig", type="build", when="@4.4:")
 
     conflicts("%gcc@:5", when="@4.4:")
     conflicts("%clang@:4", when="@4.4:")
 
     def cmake_args(self):
-        return [self.define("ENABLE_TESTING", False)]
+        spec = self.spec
+        args = [
+            self.define("ENABLE_TESTING", False),
+            self.define("ENABLE_DOCUMENTATION", False),
+            self.define_from_variant("REDIS_STORAGE_BACKEND", "redis"),
+            self.define("ZSTD_FROM_INTERNET", False),
+        ]
+        if spec.satisfies("+redis"):
+            args.append(self.define("HIREDIS_FROM_INTERNET", False))
+
+        return args
 
     # Before 4.0 this was an Autotools package
     @when("@:3")

--- a/var/spack/repos/builtin/packages/hiredis/package.py
+++ b/var/spack/repos/builtin/packages/hiredis/package.py
@@ -19,3 +19,8 @@ class Hiredis(MakefilePackage):
 
     def install(self, spec, prefix):
         make("PREFIX={0}".format(prefix), "install")
+
+    @run_after("install")
+    def darwin_fix(self):
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
On macOS, `ccache` is broken for years. The reason for that is that macOS seems to ship a system REDIS library that takes precedence on the final, linked binary when executed - which leads to crashes. (Could also be brew - either way, Spack does not RPath the installed binary it seems.)

I don't know how to fix linkage loader/rpaths stuff on macOS, so I add redis now as a variant and turn it off by default on macOS.

This fix is needed by half of my colleagues doing code development.