### PR TITLE
Update busco to 5.4.3

### DIFF
--- a/var/spack/repos/builtin/packages/busco/package.py
+++ b/var/spack/repos/builtin/packages/busco/package.py
@@ -14,6 +14,7 @@ class Busco(PythonPackage):
     url = "https://gitlab.com/api/v4/projects/ezlab%2Fbusco/repository/archive.tar.gz?sha=2.0.1"
     git = "https://gitlab.com/ezlab/busco.git"
 
+    version("5.4.3", sha256="8b92dcc32691f7c1629aaaa7bd54f96073273ba7de5a3a8586fe552c51a9d36a")
     version("4.1.3", sha256="08ded26aeb4f6aef791cd88524c3c00792a054c7672ea05219f468d495e7b072")
 
     # TODO: check the installation procedure for version 3.0.2
@@ -31,20 +32,25 @@ class Busco(PythonPackage):
     depends_on("blast-plus")
     depends_on("hmmer")
     depends_on("augustus")
-    depends_on("py-biopython", when="@4.1.3", type=("build", "run"))
+    depends_on("py-biopython", when="@4.1.3:", type=("build", "run"))
+    depends_on("py-pandas", when="@5:", type="run")
+    depends_on("bbmap", when="@5:", type="run")
+    depends_on("prodigal", when="@5:", type="run")
+    depends_on("metaeuk", when="@5:", type="run")
+    depends_on("sepp", when="@5:", type="run")
 
     def install(self, spec, prefix):
-        if self.spec.satisfies("@4.1.3"):
+        if self.spec.satisfies("@4.1.3:"):
             install_tree("bin", prefix.bin)
             install_tree("config", prefix.config)
-            super(self, PythonPackage).install(spec, prefix)
+            super(Busco, self).install(spec, prefix)
         if self.spec.satisfies("@3.0.1"):
             with working_dir("scripts"):
                 mkdirp(prefix.bin)
                 install("generate_plot.py", prefix.bin)
                 install("run_BUSCO.py", prefix.bin)
             install_tree("config", prefix.config)
-            super(self, PythonPackage).install(spec, prefix)
+            super(Busco, self).install(spec, prefix)
         if self.spec.satisfies("@2.0.1"):
             mkdirp(prefix.bin)
             install("BUSCO.py", prefix.bin)

--- a/var/spack/repos/builtin/packages/busco/package.py
+++ b/var/spack/repos/builtin/packages/busco/package.py
@@ -13,6 +13,7 @@ class Busco(PythonPackage):
     homepage = "https://busco.ezlab.org/"
     url = "https://gitlab.com/api/v4/projects/ezlab%2Fbusco/repository/archive.tar.gz?sha=2.0.1"
     git = "https://gitlab.com/ezlab/busco.git"
+    maintainers = ["snehring"]
 
     version("5.4.3", sha256="8b92dcc32691f7c1629aaaa7bd54f96073273ba7de5a3a8586fe552c51a9d36a")
     version("4.1.3", sha256="08ded26aeb4f6aef791cd88524c3c00792a054c7672ea05219f468d495e7b072")

--- a/var/spack/repos/builtin/packages/metaeuk/package.py
+++ b/var/spack/repos/builtin/packages/metaeuk/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Metaeuk(CMakePackage):
+    """MetaEuk is a modular toolkit designed for large-scale gene discovery
+    and annotation in eukaryotic metagenomic contigs.
+    """
+
+    homepage = "https://metaeuk.soedinglab.org/"
+    url = "https://github.com/soedinglab/metaeuk/archive/refs/tags/6-a5d39d9.tar.gz"
+    maintainers = ["snehring"]
+
+    version("6-a5d39d9", sha256="be19c26f5bdb7dcdd7bc48172105afecf19e5a2e5555edb3ba0c4aa0e4aac126")
+
+    depends_on("cmake@3:", type="build")

--- a/var/spack/repos/builtin/packages/metaeuk/package.py
+++ b/var/spack/repos/builtin/packages/metaeuk/package.py
@@ -17,4 +17,4 @@ class Metaeuk(CMakePackage):
 
     version("6-a5d39d9", sha256="be19c26f5bdb7dcdd7bc48172105afecf19e5a2e5555edb3ba0c4aa0e4aac126")
 
-    depends_on("cmake@3:", type="build")
+    depends_on("cmake@2.8.12:", type="build")

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -16,17 +16,18 @@ class Sepp(Package):
 
     version("4.5.1", sha256="51e052569ae89f586a1a94c804f09fe1b7910a3ffff7664e2005f18c7d3f717b")
 
-    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-dendropy@4:", type=("build", "run"))
 
     depends_on("java@1.8:", type="run")
     depends_on("pasta@1:", type="run")
     depends_on("blast-plus@2.10.1:", type="run")
 
     def install(self, spec, prefix):
-        python = which("python")
         install_tree(".", prefix)
         with working_dir(prefix):
+            prefix_string = "--prefix=" + prefix
             python("setup.py", "config", "-c")
-            python("setup.py", "install")
+            python("setup.py", "install", prefix_string)
             python("setup.py", "upp", "-c")

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Sepp(Package):
+    """SEPP stands for SATe-enabled phylogenetic placement"""
+
+    homepage = "https://github.com/smirarab/sepp"
+
+    url = "https://github.com/smirarab/sepp/archive/refs/tags/4.5.1.tar.gz"
+    maintainers = ["snehring"]
+
+    version("4.5.1", sha256="51e052569ae89f586a1a94c804f09fe1b7910a3ffff7664e2005f18c7d3f717b")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("java@1.8:", type="run")
+    depends_on("pasta@1:", type="run")
+    depends_on("blast-plus@2.10.1:", type="run")
+
+    def install(self, spec, prefix):
+        python = which("python")
+        install_tree(".", prefix)
+        with working_dir(prefix):
+            python("setup.py", "config", "-c")
+            python("setup.py", "install")
+            python("setup.py", "upp", "-c")

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -24,6 +24,8 @@ class Sepp(Package):
     depends_on("pasta@1:", type="run")
     depends_on("blast-plus@2.10.1:", type="run")
 
+    extends("python")
+
     def install(self, spec, prefix):
         dirs = ["sepp", "tools"]
         for d in dirs:
@@ -55,7 +57,3 @@ class Sepp(Package):
             dirs = ["sepp", "tools", "build", "dist", "__pycache__", "sepp.egg-info"]
             for d in dirs:
                 remove_linked_tree(d)
-
-    def setup_run_environment(self, env):
-        python_lib_path = self.spec["python"].package.platlib
-        env.set("PYTHONPATH", join_path(self.prefix, python_lib_path))

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -25,9 +25,37 @@ class Sepp(Package):
     depends_on("blast-plus@2.10.1:", type="run")
 
     def install(self, spec, prefix):
-        install_tree(".", prefix)
+        dirs = ["sepp", "tools"]
+        for d in dirs:
+            install_tree(d, join_path(prefix, d))
+        files = ["default.main.config", "*.py"]
+        for f in files:
+            install(f, prefix)
         with working_dir(prefix):
             prefix_string = "--prefix=" + prefix
             python("setup.py", "config", "-c")
             python("setup.py", "install", prefix_string)
             python("setup.py", "upp", "-c")
+            for f in ["merge_script.py", "run_ensemble.py"]:
+                install(f, prefix.bin)
+                set_executable(join_path(prefix.bin, f))
+            remove_files = [
+                "merge_script.py",
+                "run_ensemble.py",
+                "run_sepp.py",
+                "run_upp.py",
+                "setup.py",
+                "split_sequences.py",
+                "distribute_setup.py",
+                "home.path",
+                "default.main.config",
+            ]
+            for f in remove_files:
+                force_remove(f)
+            dirs = ["sepp", "tools", "build", "dist", "__pycache__", "sepp.egg-info"]
+            for d in dirs:
+                remove_linked_tree(d)
+
+    def setup_run_environment(self, env):
+        python_lib_path = self.spec["python"].package.platlib
+        env.set("PYTHONPATH", join_path(self.prefix, python_lib_path))


### PR DESCRIPTION
Updates to the most recent busco release. Also adds in some deps that were necessary to run through the test datasets provided by the project. As part of that a few new packages are added.

I think the super calls that I changed in the busco package.py were typos introduced by #27798, they were causing errors.