### PR TITLE
Bugfix: Compiler bootstrapping for compilers that are independently present in env

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -808,7 +808,7 @@ class PackageInstaller(object):
                 self._add_init_task(comp_pkg, request, is_compiler, all_deps)
             elif is_compiler:
                 # ensure it's queued as a compiler
-                self._modify_existing_task(pkgid, 'compiler', True)
+                self._modify_existing_task(pkgid, "compiler", True)
 
     def _modify_existing_task(self, pkgid, attr, value):
         """

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -803,13 +803,15 @@ class PackageInstaller(object):
         """
         packages = _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs)
         for (comp_pkg, is_compiler) in packages:
-            if package_id(comp_pkg) not in self.build_tasks:
+            pkgid = package_id(comp_pkg)
+            if pkgid not in self.build_tasks:
                 self._add_init_task(comp_pkg, request, is_compiler, all_deps)
             elif is_compiler:
-                # Requeue ensuring we treat it as a compiler
+                # Modify task ensuring we treat it as a compiler
                 for i, tup in enumerate(self.build_pq):
                     key, task = tup
-                    if task.pkg_id == package_id(comp_pkg):
+                    if task.pkg_id == pkgid:
+                        tty.debug("Modifying task for {0} to treat it as a compiler".format(pkgid), level=2)
                         task.compiler = True
                         self.build_pq[i] = (key, task)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -805,6 +805,13 @@ class PackageInstaller(object):
         for (comp_pkg, is_compiler) in packages:
             if package_id(comp_pkg) not in self.build_tasks:
                 self._add_init_task(comp_pkg, request, is_compiler, all_deps)
+            elif is_compiler:
+                # Requeue ensuring we treat it as a compiler
+                for i, tup in enumerate(self.build_pq):
+                    key, task = tup
+                    if task.pkg_id == package_id(comp_pkg):
+                        task.compiler = True
+                        self.build_pq[i] = (key, task)
 
     def _add_init_task(self, pkg, request, is_compiler, all_deps):
         """

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -811,7 +811,10 @@ class PackageInstaller(object):
                 for i, tup in enumerate(self.build_pq):
                     key, task = tup
                     if task.pkg_id == pkgid:
-                        tty.debug("Modifying task for {0} to treat it as a compiler".format(pkgid), level=2)
+                        tty.debug(
+                            "Modifying task for {0} to treat it as a compiler".format(pkgid),
+                            level=2,
+                        )
                         task.compiler = True
                         self.build_pq[i] = (key, task)
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -477,6 +477,7 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
     # monkeypatch to make the list of compilers be what we test
     def fake_package_list(compiler, architecture, pkgs):
         return [(spec.package, True)]
+
     monkeypatch.setattr(inst, "_packages_needed_to_bootstrap_compiler", fake_package_list)
 
     installer._add_bootstrap_compilers("fake", "fake", "fake", None, {})
@@ -484,6 +485,7 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
     # Check that the only task is now a compiler task
     assert len(installer.build_pq) == 1
     assert installer.build_pq[0][1].compiler
+
 
 def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
     """Test happy path for dump_packages with dependencies."""

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -467,6 +467,24 @@ def test_packages_needed_to_bootstrap_compiler_packages(install_mockery, monkeyp
     assert packages
 
 
+def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, monkeypatch):
+    spec = spack.spec.Spec("trivial-install-test-package").concretized()
+    installer = inst.PackageInstaller([(spec.package, {})])
+
+    # Add a task to the queue
+    installer._add_init_task(spec.package, installer.build_requests[0], False, {})
+
+    # monkeypatch to make the list of compilers be what we test
+    def fake_package_list(compiler, architecture, pkgs):
+        return [(spec.package, True)]
+    monkeypatch.setattr(inst, "_packages_needed_to_bootstrap_compiler", fake_package_list)
+
+    installer._add_bootstrap_compilers("fake", "fake", "fake", None, {})
+
+    # Check that the only task is now a compiler task
+    assert len(installer.build_pq) == 1
+    assert installer.build_pq[0][1].compiler
+
 def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
     """Test happy path for dump_packages with dependencies."""
 


### PR DESCRIPTION
The compiler bootstrapping logic currently does not add a task when the compiler package is already in the install task queue. This causes failures when the compiler package is added without the additional metadata telling the task to update the compilers list.

Solution: requeue compilers for bootstrapping when needed, to update `task.compiler` metadata.

@tgamblin @tldahlgren this is the PR we've discussed earlier today in various channels.