### PR TITLE
flux-sched: fix oneapi build

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -138,6 +138,8 @@ class FluxSched(AutotoolsPackage):
             args.append("CXXFLAGS=-Wno-uninitialized")
         if self.spec.satisfies("%clang@12:"):
             args.append("CXXFLAGS=-Wno-defaulted-function-deleted")
+        if self.spec.satisfies("%oneapi"):
+            args.append("CXXFLAGS=-Wno-tautological-constant-compare")
         # flux-sched's ax_boost is sometimes weird about non-system locations
         # explicitly setting the path guarantees success
         args.append("--with-boost={0}".format(self.spec["boost"].prefix))


### PR DESCRIPTION
Fixes oneapi build
```
  >> 427    /localdisk/work/rscohn1/projects/spack/spack/opt/spack/linux-ubuntu20.04-cascadelake/oneapi-2022.1.0/yaml-cpp-0.6.3-2dp
            ubmrs7n6zzffx5lhwgeedesy5reu4/include/yaml-cpp/emitter.h:171:24: error: comparison with infinity always evaluates to fa
            lse in fast floating point modes [-Werror,-Wtautological-constant-compare]
     428          } else if (value == -std::numeric_limits<T>::infinity()) {
     429                     ~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     430    6 errors generated.
  >> 431    make[3]: *** [Makef
```
@grondo 

@eugeneswalker: This fixes flux-sched build, but exaworks is still failing because of rust
