### PR TITLE
Remove unused argument in test fixture

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -85,7 +85,7 @@ def override_git_repos_cache_path(tmpdir):
 
 
 @pytest.fixture
-def mock_git_version_info(tmpdir, override_git_repos_cache_path, scope="function"):
+def mock_git_version_info(tmpdir, override_git_repos_cache_path):
     """Create a mock git repo with known structure
 
     The structure of commits in this repo is as follows::


### PR DESCRIPTION
The argument is very likely a typo, and was meant to be given to the fixture decorator. Since the value being passed is the default, let's just remove it.