### PR TITLE
ascent: fix oneapi build

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -100,6 +100,7 @@ spack:
   - amrex
   - arborx
   - argobots
+  - ascent ^vtk-m ~openmp
   - axom
   - bolt
   - bricks
@@ -193,7 +194,6 @@ spack:
   # CPU BUILD FAILURES
   #- adios2@2.8.0                                     # adios2
   #- archer@2.0.0                                     # binutils
-  #- ascent ^vtk-m ~openmp                            # ascent
   #- charliecloud@0.26                                # charliecloud
   #- dyninst@12.1.0                                   # intel-tbb
   #- exaworks@0.1.0                                   # rust, flux-sched

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -225,6 +225,8 @@ class Ascent(CMakePackage, CudaPackage):
         host_config = self._get_host_config_path(self.spec)
         options = []
         options.extend(["-C", host_config, "../spack-src/src/"])
+        if self.spec.satisfies("%oneapi"):
+            options.extend(["-D", "CMAKE_Fortran_FLAGS=-nofor-main"])
         return options
 
     @run_after("install")


### PR DESCRIPTION
oneapi build is broken for 0.8.0. It is fixed in develop: https://github.com/Alpine-DAV/ascent/pull/981
The fix in develop depends on other commits so using a temporary workaround until it is released.
