### PR TITLE
VisIt: Add patch to include jpeg library in install.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/cmake-findjpeg-3.3.patch
+++ b/var/spack/repos/builtin/packages/visit/cmake-findjpeg-3.3.patch
@@ -1,0 +1,40 @@
+--- a/src/CMake/FindJPEG.cmake	2022-07-22 15:00:18.831409000 -0700
++++ b/src/CMake/FindJPEG.cmake	2022-07-22 15:01:07.682528000 -0700
+@@ -25,5 +25,9 @@
+   else() 
+       SET_UP_THIRD_PARTY(JPEG LIBS jpeg)
+   endif()
++ELSE()
++  if (VISIT_JPEG_DIR)
++      SET_UP_THIRD_PARTY(JPEG LIBS jpeg)
++  endif()
+ ENDIF (WIN32)
+ 
+--- a/src/CMakeLists.txt	2022-08-09 12:01:55.564360000 -0700
++++ b/src/CMakeLists.txt	2022-08-09 12:02:46.100508000 -0700
+@@ -895,10 +895,8 @@
+ VISIT_3RDPARTY_VAR(ICET_DIR   "Path containing the Ice-T library's include and lib")
+ 
+ # Libraries some third-parties are dependent upon
+-IF(WIN32)
+-  VISIT_3RDPARTY_VAR(JPEG_DIR   "Path containing the jpeg library's include and lib")
+-  VISIT_3RDPARTY_VAR(SZIP_DIR   "Path containing the szip library's include and lib")
+-ENDIF(WIN32)
++VISIT_3RDPARTY_VAR(JPEG_DIR   "Path containing the jpeg library's include and lib")
++VISIT_3RDPARTY_VAR(SZIP_DIR   "Path containing the szip library's include and lib")
+ 
+ # Define the options that let us pick I/O library installation locations. When
+ # the library option is defined then we also define the variable name passed as
+@@ -1351,10 +1349,8 @@
+ INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindZlib.cmake)
+ 
+ # szip and jpeg
+-IF(WIN32)
+-    INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindJPEG.cmake)
+-    INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindSzip.cmake)
+-ENDIF(WIN32)
++INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindJPEG.cmake)
++INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindSzip.cmake)
+ 
+ # dl and large file support.
+ IF(CMAKE_HOST_UNIX)

--- a/var/spack/repos/builtin/packages/visit/cmake-findjpeg.patch
+++ b/var/spack/repos/builtin/packages/visit/cmake-findjpeg.patch
@@ -1,0 +1,44 @@
+--- a/src/CMake/FindJPEG.cmake	2022-07-22 15:00:18.831409000 -0700
++++ b/src/CMake/FindJPEG.cmake	2022-07-22 15:01:07.682528000 -0700
+@@ -25,5 +25,13 @@
+   else() 
+       SET_UP_THIRD_PARTY(JPEG lib include jpeg)
+   endif()
++ELSE()
++  if (VISIT_JPEG_DIR)
++      if(EXISTS ${JPEG_DIR}/lib)
++          SET_UP_THIRD_PARTY(JPEG lib include jpeg)
++      elseif(EXISTS ${JPEG_DIR}/lib64)
++          SET_UP_THIRD_PARTY(JPEG lib64 include jpeg)
++      endif()
++  endif()
+ ENDIF (WIN32)
+ 
+--- a/src/CMakeLists.txt	2022-08-09 12:01:55.564360000 -0700
++++ b/src/CMakeLists.txt	2022-08-09 12:02:46.100508000 -0700
+@@ -895,10 +895,8 @@
+ VISIT_3RDPARTY_VAR(ICET_DIR   "Path containing the Ice-T library's include and lib")
+ 
+ # Libraries some third-parties are dependent upon
+-IF(WIN32)
+-  VISIT_3RDPARTY_VAR(JPEG_DIR   "Path containing the jpeg library's include and lib")
+-  VISIT_3RDPARTY_VAR(SZIP_DIR   "Path containing the szip library's include and lib")
+-ENDIF(WIN32)
++VISIT_3RDPARTY_VAR(JPEG_DIR   "Path containing the jpeg library's include and lib")
++VISIT_3RDPARTY_VAR(SZIP_DIR   "Path containing the szip library's include and lib")
+ 
+ # Define the options that let us pick I/O library installation locations. When
+ # the library option is defined then we also define the variable name passed as
+@@ -1351,10 +1349,8 @@
+ INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindZlib.cmake)
+ 
+ # szip and jpeg
+-IF(WIN32)
+-    INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindJPEG.cmake)
+-    INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindSzip.cmake)
+-ENDIF(WIN32)
++INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindJPEG.cmake)
++INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindSzip.cmake)
+ 
+ # dl and large file support.
+ IF(CMAKE_HOST_UNIX)

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -86,6 +86,8 @@ class Visit(CMakePackage):
     patch("parallel-hdf5.patch", when="@3.0.1:3.2.2+hdf5+mpi")
     patch("parallel-hdf5-3.3.patch", when="@3.3.0:+hdf5+mpi")
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:+vtkm")
+    patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
+    patch("cmake-findjpeg-3.3.patch", when="@3.3.0:")
 
     # Fix pthread and librt link errors
     patch("visit32-missing-link-libs.patch", when="@3.2")
@@ -193,6 +195,7 @@ class Visit(CMakePackage):
             self.define("VTK_MINOR_VERSION", spec["vtk"].version[1]),
             self.define("VISIT_VTK_DIR", spec["vtk"].prefix),
             self.define("VISIT_ZLIB_DIR", spec["zlib"].prefix),
+            self.define("VISIT_JPEG_DIR", spec["jpeg"].prefix),
             self.define("VISIT_USE_GLEW", False),
             self.define("VISIT_CONFIG_SITE", "NONE"),
             self.define("VISIT_INSTALL_THIRD_PARTY", False),


### PR DESCRIPTION
When VisIt is run in parallel it needs the jpeg library to be installed in it's `lib` directory. This patch modifies the CMake related files to accomplish this.

I tested this building VisIt 3.2.2 and 3.3.0 on crusher.olcf.ornl.gov.