### PR TITLE
Enable Tensorflow for ROCm. Add ROCm dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -35,8 +35,11 @@ class PyTensorflow(Package, CudaPackage):
     version("2.8.2", sha256="b3f860c02c22a30e9787e2548ca252ab289a76b7778af6e9fa763d4aafd904c7")
     version("2.8.1", sha256="4b487a63d6f0c1ca46a2ac37ba4687eabdc3a260c222616fa414f6df73228cec")
     version("2.8.0", sha256="66b953ae7fba61fd78969a2e24e350b26ec116cf2e6a7eb93d02c63939c6f9f7")
-    version("2.7.4-rocm-enhanced", sha256="45b79c125edfdc008274f1b150d8b5a53b3ff4713fd1ad1ff4738f515aad8191",
-            url = "https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/archive/refs/tags/v2.7.0.tar.gz")
+    version(
+        "2.7.4-rocm-enhanced",
+        sha256="45b79c125edfdc008274f1b150d8b5a53b3ff4713fd1ad1ff4738f515aad8191",
+        url="https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/archive/refs/tags/v2.7.4-rocm-enhanced.tar.gz",
+    )
     version("2.7.3", sha256="b576c2e124cd6d4d04cbfe985430a0d955614e882172b2258217f0ec9b61f39b")
     version("2.7.2", sha256="b3c8577f3b7cc82368ff7f9315821d506abd2f716ea6692977d255b7d8bc54c0")
     version("2.7.1", sha256="abebe2cf5ca379e18071693ca5f45b88ade941b16258a21cc1f12d77d5387a21")
@@ -282,20 +285,20 @@ class PyTensorflow(Package, CudaPackage):
     # depends_on('py-tensorflow-io-gcs-filesystem@0.21:',
     #            type=('build', 'run'), when='@2.7')
     with when("+rocm"):
-        depends_on('hip')
-        depends_on('rocrand')
-        depends_on('rocblas')
-        depends_on('rocfft')
-        depends_on('hipfft')
-        depends_on('rccl')
-        depends_on('hipsparse')
-        depends_on('hipcub')
-        depends_on('rocsolver')
-        depends_on('rocprim')
-        depends_on('miopen-hip')
-        depends_on('llvm-amdgpu')
-        depends_on('hsa-rocr-dev')
-        depends_on('rocminfo')
+        depends_on("hip")
+        depends_on("rocrand")
+        depends_on("rocblas")
+        depends_on("rocfft")
+        depends_on("hipfft")
+        depends_on("rccl")
+        depends_on("hipsparse")
+        depends_on("hipcub")
+        depends_on("rocsolver")
+        depends_on("rocprim")
+        depends_on("miopen-hip")
+        depends_on("llvm-amdgpu")
+        depends_on("hsa-rocr-dev")
+        depends_on("rocminfo")
 
     if sys.byteorder == "little":
         # Only builds correctly on little-endian machines
@@ -740,7 +743,8 @@ class PyTensorflow(Package, CudaPackage):
         filter_file(
             '"-U_FORTIFY_SOURCE",',
             '"-U_FORTIFY_SOURCE", "-I%s",' % self.spec["protobuf"].prefix.include,
-            "third_party/gpus/crosstool/BUILD.rocm.tpl")
+            "third_party/gpus/crosstool/BUILD.rocm.tpl",
+        )
         if self.spec.satisfies("@2.3.0:"):
             filter_file(
                 "deps = protodeps + well_known_proto_libs(),",
@@ -997,8 +1001,8 @@ def protobuf_deps():
             if "+cuda" in spec:
                 args.append("--config=cuda")
 
-            if '+rocm' in spec:
-                args.append('--config=rocm')
+            if "+rocm" in spec:
+                args.append("--config=rocm")
 
             if "~aws" in spec:
                 args.append("--config=noaws")

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -436,6 +436,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     conflicts("platform=darwin target=aarch64:", when="@:2.4")
     # https://github.com/tensorflow/tensorflow/pull/39225
     conflicts("target=aarch64:", when="@:2.2")
+    conflicts("~rocm", when="@2.7.4-rocm-enhanced")
+    conflicts("+rocm", when="@:2.7.4-a,2.7.4.0:")
 
     # TODO: why is this needed?
     patch("url-zlib.patch", when="@0.10.0")

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -30,13 +30,13 @@ class PyTensorflow(Package, CudaPackage):
     maintainers = ["adamjstewart", "aweits"]
     import_modules = ["tensorflow"]
 
-    version("2.7.4-rocm-enhanced", sha256="45b79c125edfdc008274f1b150d8b5a53b3ff4713fd1ad1ff4738f515aad8191",
-            url = "https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/archive/refs/tags/v2.7.0.tar.gz")
     version("2.9.1", sha256="6eaf86ead73e23988fe192da1db68f4d3828bcdd0f3a9dc195935e339c95dbdc")
     version("2.9.0", sha256="8087cb0c529f04a4bfe480e49925cd64a904ad16d8ec66b98e2aacdfd53c80ff")
     version("2.8.2", sha256="b3f860c02c22a30e9787e2548ca252ab289a76b7778af6e9fa763d4aafd904c7")
     version("2.8.1", sha256="4b487a63d6f0c1ca46a2ac37ba4687eabdc3a260c222616fa414f6df73228cec")
     version("2.8.0", sha256="66b953ae7fba61fd78969a2e24e350b26ec116cf2e6a7eb93d02c63939c6f9f7")
+    version("2.7.4-rocm-enhanced", sha256="45b79c125edfdc008274f1b150d8b5a53b3ff4713fd1ad1ff4738f515aad8191",
+            url = "https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/archive/refs/tags/v2.7.0.tar.gz")
     version("2.7.3", sha256="b576c2e124cd6d4d04cbfe985430a0d955614e882172b2258217f0ec9b61f39b")
     version("2.7.2", sha256="b3c8577f3b7cc82368ff7f9315821d506abd2f716ea6692977d255b7d8bc54c0")
     version("2.7.1", sha256="abebe2cf5ca379e18071693ca5f45b88ade941b16258a21cc1f12d77d5387a21")

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -133,7 +133,6 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     variant("ngraph", default=False, description="Build with Intel nGraph support")
     variant("opencl", default=False, description="Build with OpenCL SYCL support")
     variant("computecpp", default=False, description="Build with ComputeCPP support")
-    variant("rocm", default=False, description="Build with ROCm support")
     variant("tensorrt", default=False, description="Build with TensorRT support")
     variant("cuda", default=sys.platform != "darwin", description="Build with CUDA support")
     variant(

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -377,7 +377,6 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     conflicts("+opencl", when="@:0.11")
     conflicts("+computecpp", when="@:0.11")
     conflicts("+computecpp", when="~opencl")
-    conflicts("+rocm", when="@:1.11")
     conflicts("+cuda", when="platform=darwin", msg="There is no GPU support for macOS")
     conflicts(
         "cuda_arch=none",

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -10,7 +10,7 @@ from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 
 
-class PyTensorflow(Package, CudaPackage):
+class PyTensorflow(Package, CudaPackage, ROCmPackage):
     """An Open Source Machine Learning Framework for Everyone.
 
     TensorFlow is an end-to-end open source platform for machine learning. It has a


### PR DESCRIPTION
This PR has the changes to build Tensorflow for ROCm.  This uses spack's externals support for ROCm releases.  I have used ROCm-5.2.0 release for the testing.

To build tensorflow i used spack install  -v -j56 py-tensorflow@2.7.4+rocm 
For testing the tensorflow build, i did spack load py-tensorflow@2.7.4-rocm-enhanced
python3 -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())" => showed the gpu's on my local machine.
Also, i built the py-tensorflow-estimator using 
spack install -v py-tensorflow-estimator ^py-tensorflow@2.7.4-rocm-enhanced+rocm

Once this is built , i downloaded the benchmarks from https://github.com/tensorflow/benchmarks and ran restnet-50 model on my local machine that has 8 gfx906 gpu's. further evaluation of these changes on the gfx908 and gfx90a are in progress. 

The PR is intended to get the initial feedback on the approach etc.

 spack load py-tensorflow-estimator@2.7.0
cd ../  => to benchmarks directory 
MODEL=resnet50_v1.5
BATCH_SIZE=64
NUM_BATCHES=50
export AMD_DIRECT_DISPATCH=0
common_options="--model=$MODEL --batch_size=$BATCH_SIZE --num_batches=$NUM_BATCHES"
python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py $common_options --num_gpus=8

[TF-TestcaseLog.txt](https://github.com/spack/spack/files/9378220/TF-TestcaseLog.txt)

