### PR TITLE
hpctoolkit: update git url from github to gitlab

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -17,7 +17,7 @@ class Hpctoolkit(AutotoolsPackage):
     and attributes them to the full calling context in which they occur."""
 
     homepage = "http://hpctoolkit.org"
-    git = "https://github.com/HPCToolkit/hpctoolkit.git"
+    git = "https://gitlab.com/hpctoolkit/hpctoolkit.git"
     maintainers = ["mwkrentel"]
 
     tags = ["e4s"]


### PR DESCRIPTION
As of today (8/18/2022), we're moving the hpctoolkit repo from github to gitlab,
mostly for better CI support.   The github copy will remain as a read-only mirror
for some time, so old spack links won't break.