### PR TITLE
Allow default requirements in packages.yaml

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -396,10 +396,33 @@ choose between a set of options using ``any_of`` or ``one_of``:
   ``mpich`` already includes a conflict, so this is redundant but
   still demonstrates the concept).
 
+You can also set default requirements for all packages under ``all``
+like this:
+
+.. code-block:: yaml
+
+   packages:
+     all:
+       require: '%clang'
+
+which means every spec will be required to use ``clang`` as a compiler. Note that
+in this case ``all`` represents a *default set of requirements*, so with a configuration
+like this:
+
+.. code-block:: yaml
+
+   packages:
+     all:
+       require: '%clang'
+     cmake:
+       require: '%gcc'
+
+Spack requires ``cmake`` to use ``gcc`` and all other nodes (including cmake dependencies)
+to use ``clang``. More in general, if there are specific package requirements, the default
+requirements under ``all`` are disregarded.
+
 Other notes about ``requires``:
 
-* You can only specify requirements for specific packages: you cannot
-  add ``requires`` under ``all``.
 * You cannot specify requirements for virtual packages (e.g. you can
   specify requirements for ``openmpi`` but not ``mpi``).
 * For ``any_of`` and ``one_of``, the order of specs indicates a

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -405,9 +405,11 @@ like this:
      all:
        require: '%clang'
 
-which means every spec will be required to use ``clang`` as a compiler. Note that
-in this case ``all`` represents a *default set of requirements*, so with a configuration
-like this:
+which means every spec will be required to use ``clang`` as a compiler.
+
+Note that in this case ``all`` represents a *default set of requirements* -
+if there are specific package requirements, then the default requirements
+under ``all`` are disregarded. For example, with a configuration like this:
 
 .. code-block:: yaml
 
@@ -418,8 +420,7 @@ like this:
        require: '%gcc'
 
 Spack requires ``cmake`` to use ``gcc`` and all other nodes (including cmake dependencies)
-to use ``clang``. More in general, if there are specific package requirements, the default
-requirements under ``all`` are disregarded.
+to use ``clang``.
 
 Other notes about ``requires``:
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -930,7 +930,9 @@ class SpackSolverSetup(object):
     def package_requirement_rules(self, pkg):
         pkg_name = pkg.name
         config = spack.config.get("packages")
-        requirements = config.get(pkg_name, {}).get("require", [])
+        requirements = config.get(pkg_name, {}).get("require", []) or config.get("all", {}).get(
+            "require", []
+        )
         if isinstance(requirements, string_types):
             rules = [(pkg_name, "one_of", [requirements])]
         else:

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -305,8 +305,6 @@ def test_default_requirements_with_all(spec_str, requirement_str, concretize_sco
     if spack.config.get("config:concretizer") == "original":
         pytest.skip("Original concretizer does not support configuration" " requirements")
 
-    # @2.3 is a deprecated versions. Ensure that any_of picks both constraints,
-    # since they are possible
     conf_str = """\
 packages:
   all:
@@ -319,3 +317,23 @@ packages:
     spec = Spec(spec_str).concretized()
     for s in spec.traverse():
         assert s.satisfies(requirement_str)
+
+
+def test_default_and_package_specific_requirements(concretize_scope, test_repo):
+    """Test that users can override a deprecated version with a requirement."""
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration" " requirements")
+
+    conf_str = """\
+packages:
+  all:
+    require: "%gcc"
+  x:
+    require: "%clang"
+"""
+    update_packages_config(conf_str)
+
+    spec = Spec("x").concretized()
+    assert spec.satisfies("%clang")
+    for s in spec.traverse(root=False):
+        assert s.satisfies("%gcc")

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -297,3 +297,25 @@ packages:
     s1 = Spec("y").concretized()
     assert s1.satisfies("@2.3")
     assert s1.satisfies("%gcc")
+
+
+@pytest.mark.parametrize("spec_str,requirement_str", [("x", "%gcc"), ("x", "%clang")])
+def test_default_requirements_with_all(spec_str, requirement_str, concretize_scope, test_repo):
+    """Test that users can override a deprecated version with a requirement."""
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration" " requirements")
+
+    # @2.3 is a deprecated versions. Ensure that any_of picks both constraints,
+    # since they are possible
+    conf_str = """\
+packages:
+  all:
+    require: "{}"
+""".format(
+        requirement_str
+    )
+    update_packages_config(conf_str)
+
+    spec = Spec(spec_str).concretized()
+    for s in spec.traverse():
+        assert s.satisfies(requirement_str)


### PR DESCRIPTION
fixes #1371 

This PR allow users to express default requirements in packages.yaml. These requirements are overridden if more specific requirements are present for a package.

Modifications:
- [x] Account for requirements under `all` as a fallback to package specific requirements
- [x] Updated docs
- [x] Added unit tests