### PR TITLE
OpenMC: add v0.13.1

### DIFF
--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -20,6 +20,7 @@ class Openmc(CMakePackage):
     homepage = "https://docs.openmc.org/"
     url = "https://github.com/openmc-dev/openmc/tarball/v0.13.1"
     git = "https://github.com/openmc-dev/openmc.git"
+    maintainers = ["paulromano"]
 
     version("develop", branch="develop", submodules=True)
     version("master", branch="master", submodules=True)

--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -32,10 +32,7 @@ class Openmc(CMakePackage):
     version("0.11.0", sha256="19a9d8e9c3b581e9060fbd96d30f1098312d217cb5c925eb6372a5786d9175af")
     version("0.10.0", sha256="47650cb45e2c326ae439208d6f137d75ad3e5c657055912d989592c6e216178f")
 
-    variant("mpi", default=False, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
-    variant("optimize", default=False, description="Enable optimization flags")
-    variant("debug", default=False, description="Enable debug flags")
 
     depends_on("git", type="build")
     depends_on("hdf5+hl~mpi", when="~mpi")
@@ -45,26 +42,18 @@ class Openmc(CMakePackage):
     def cmake_args(self):
         options = ["-DCMAKE_INSTALL_LIBDIR=lib"]  # forcing bc sometimes goes to lib64
 
-        use_newer_options = self.spec.satisfies('@0.13.1:')
+        use_newer_options = self.spec.satisfies("@0.13.1:")
         if "+mpi" in self.spec:
             options += [
                 "-DCMAKE_C_COMPILER=%s" % self.spec["mpi"].mpicc,
                 "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
             ]
             if use_newer_options:
-                options += ["-DOPENMC_USE_MPI:BOOL=ON"]
+                options += [self.define("OPENMC_USE_MPI", True)]
 
         if use_newer_options:
             options += [self.define_from_variant("OPENMC_USE_OPENMP", "openmp")]
         else:
             options += [self.define_from_variant("openmp")]
-            options += [self.define_from_variant("optimize")]
-            options += [self.define_from_variant("debug")]
-
-        if "+optimize" in self.spec:
-            self.spec.variants["build_type"].value = "Release"
-
-        if "+debug" in self.spec:
-            self.spec.variants["build_type"].value = "Debug"
 
         return options

--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -32,6 +32,7 @@ class Openmc(CMakePackage):
     version("0.11.0", sha256="19a9d8e9c3b581e9060fbd96d30f1098312d217cb5c925eb6372a5786d9175af")
     version("0.10.0", sha256="47650cb45e2c326ae439208d6f137d75ad3e5c657055912d989592c6e216178f")
 
+    variant("mpi", default=False, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
 
     depends_on("git", type="build")

--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -18,11 +18,12 @@ class Openmc(CMakePackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.0"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.1"
     git = "https://github.com/openmc-dev/openmc.git"
 
     version("develop", branch="develop", submodules=True)
     version("master", branch="master", submodules=True)
+    version("0.13.1", commit="33bc948f4b855c037975f16d16091fe4ecd12de3", submodules=True)
     version("0.13.0", commit="cff247e35785e7236d67ccf64a3401f0fc50a469", submodules=True)
     version("0.12.2", commit="cbfcf908f8abdc1ef6603f67872dcf64c5c657b1", submodules=True)
     version("0.12.1", commit="36913589c4f43b7f843332181645241f0f10ae9e", submodules=True)
@@ -43,15 +44,21 @@ class Openmc(CMakePackage):
     def cmake_args(self):
         options = ["-DCMAKE_INSTALL_LIBDIR=lib"]  # forcing bc sometimes goes to lib64
 
+        use_newer_options = self.spec.satisfies('@0.13.1:')
         if "+mpi" in self.spec:
             options += [
                 "-DCMAKE_C_COMPILER=%s" % self.spec["mpi"].mpicc,
                 "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
             ]
+            if use_newer_options:
+                options += ["-DOPENMC_USE_MPI:BOOL=ON"]
 
-        options += [self.define_from_variant("openmp")]
-        options += [self.define_from_variant("optimize")]
-        options += [self.define_from_variant("debug")]
+        if use_newer_options:
+            options += [self.define_from_variant("OPENMC_USE_OPENMP", "openmp")]
+        else:
+            options += [self.define_from_variant("openmp")]
+            options += [self.define_from_variant("optimize")]
+            options += [self.define_from_variant("debug")]
 
         if "+optimize" in self.spec:
             self.spec.variants["build_type"].value = "Release"

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -19,6 +19,7 @@ class PyOpenmc(PythonPackage):
     homepage = "https://docs.openmc.org/"
     url = "https://github.com/openmc-dev/openmc/tarball/v0.13.1"
     git = "https://github.com/openmc-dev/openmc.git"
+    maintainers = ["paulromano"]
 
     version("develop", branch="develop")
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -17,11 +17,12 @@ class PyOpenmc(PythonPackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.0"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.1"
     git = "https://github.com/openmc-dev/openmc.git"
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("0.13.1", commit="33bc948f4b855c037975f16d16091fe4ecd12de3", submodules=True)
     version("0.13.0", commit="cff247e35785e7236d67ccf64a3401f0fc50a469", submodules=True)
     version("0.12.2", commit="cbfcf908f8abdc1ef6603f67872dcf64c5c657b1", submodules=True)
     version("0.12.1", commit="36913589c4f43b7f843332181645241f0f10ae9e", submodules=True)
@@ -31,7 +32,7 @@ class PyOpenmc(PythonPackage):
     variant("mpi", default=False, description="Enable MPI support")
 
     # keep py-openmc and openmc at the same version
-    for ver in ["develop", "master", "0.13.0", "0.12.2", "0.12.1", "0.12.0", "0.11.0"]:
+    for ver in ["develop", "master", "0.13.1", "0.13.0", "0.12.2", "0.12.1", "0.12.0", "0.11.0"]:
         depends_on(
             "openmc+mpi@{0}".format(ver), when="@{0}+mpi".format(ver), type=("build", "run")
         )


### PR DESCRIPTION
This PR adds version 0.13.1 for packages openmc and py-openmc.