### PR TITLE
ncurses 6.3 restrict patch

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -50,7 +50,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     patch("patch_gcc_5.txt", when="@6.0%gcc@5.0:")
     patch("sed_pgi.patch", when="@:6.0")
-    patch("nvhpc_fix_preprocessor_flag.patch", when="@6.0:%nvhpc")
+    patch("nvhpc_fix_preprocessor_flag.patch", when="@6.0:6.2%nvhpc")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
doesn't apply and seems no longer required
