### PR TITLE
Vis: macOS `llvm-openmp`

### DIFF
--- a/var/spack/repos/builtin/packages/apcomp/package.py
+++ b/var/spack/repos/builtin/packages/apcomp/package.py
@@ -50,6 +50,7 @@ class Apcomp(Package):
 
     depends_on("cmake@3.9:", type="build")
     depends_on("mpi", when="+mpi")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     root_cmakelists_dir = "src"
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -66,6 +66,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@:3.20", when="+rocm", type="build")
     depends_on("cmake@3.14:", when="@2022.03.0:")
 
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
+
     with when("+rocm @0.12.0:"):
         depends_on("camp+rocm")
         for arch in ROCmPackage.amdgpu_targets:

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -90,6 +90,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda@10.1.0:", when="+cuda_native")
     depends_on("tbb", when="+tbb")
     depends_on("mpi", when="+mpi")
+    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     # VTK-m uses the default Kokkos backend
     depends_on("kokkos", when="+kokkos")


### PR DESCRIPTION
Add the usual OpenMP lib provider for Apple-Clang to the vis packages. CMake picks this one up in `find_package(OpenMP)`.