### PR TITLE
teckit:  Fixes missing xmlparse.h issue.

### DIFF
--- a/var/spack/repos/builtin/packages/teckit/package.py
+++ b/var/spack/repos/builtin/packages/teckit/package.py
@@ -16,14 +16,28 @@ class Teckit(AutotoolsPackage):
     TECkit compiler creates these tables from plain-text, human-readable
     descriptions."""
 
+    maintainers = ["rountree"]
     homepage = "https://scripts.sil.org/cms/scripts/page.php?cat_id=TECkit"
-    url = "https://github.com/silnrsi/teckit/releases/download/v2.5.9/teckit-2.5.9.tar.gz"
+    git = "https://github.com/silnrsi/teckit.git"
 
-    version("2.5.9", sha256="6823fb3142efa34e5d74de35d37cdf4724efbf577f5ff15a8e2b364e6ef47d3d")
+    version("2.5.11", commit="fea17dbf17266387c96f74fd9c0ce44d065f0f50")
+    version("2.5.10", commit="1c510d4de7ff844207b1273e856fd27a15b3486d")
+    version("2.5.9", commit="e2434cef98d59487514450304513efb42c376365")
+    version("2.5.8", commit="f7838e4e61329ae8e1a788a3d35f7865c68c4da5")
+    version("2.5.7", commit="50c7346dc3c887b16b26c3ff269fd4cfc9f8a892")
+    version("2.5.6", commit="41c20be2793e1afcbb8de6339af89d1eeab84fe8")
+    version("2.5.5", commit="2733fd9895819e3697257550cc39b8e419c1ee7e")
 
-    depends_on("expat")
     depends_on("zlib")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
 
     def configure_args(self):
         args = ["--with-system-zlib"]
         return args
+
+    def autoreconf(self, spec, prefix):
+        sh = which("sh")
+        sh("./autogen.sh")


### PR DESCRIPTION
The "release" tarball provided by github lacks several files in
the SFconv/expat/xmlparse directory, including xmlparse.  Using
tarballs based off of version tags solves the problem.

o Changes version() to use commits associated with version tags.
o Adds several additional versions.
o Adds myself as maintainer.
o Adds hook to execute autogen.sh.
o Adds autotools &ct dependences.
o Removes expat dependence.

Fixes #32294 