### PR TITLE
libxc: remove compiler optimize level limit of O2 for GCC

### DIFF
--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -72,11 +72,6 @@ class Libxc(AutotoolsPackage, CudaPackage):
         # microarchitecture-specific optimization flags should be controlled
         # by Spack, otherwise we may end up with contradictory or invalid flags
         # see https://github.com/spack/spack/issues/17794
-        # libxc on the other hand only sets the generic -O2 when it detects GCC
-
-        optflags = "-O2"
-        env.append_flags("CFLAGS", optflags)
-        env.append_flags("FCFLAGS", optflags)
 
         if "%intel" in self.spec:
             env.append_flags("CFLAGS", "-std=c99")


### PR DESCRIPTION
gfortran can make it with O3, it might be better to remove this limitation.