### PR TITLE
Fix to Racket spec

### DIFF
--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-
+import sys
 
 class Racket(Package):
     """The Racket programming language."""

--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import sys
+
+from spack.package import *
+
 
 class Racket(Package):
     """The Racket programming language."""


### PR DESCRIPTION
I'm surprised this worked. My guess is that spack.package reexported sys in the past.