### PR TITLE
oneapi e4s: use require: to force gcc compiles for some packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -60,7 +60,7 @@ spack:
 
   packages:
     adios2:
-      compiler: [gcc]
+      require: "%gcc"
     all:
       compiler: [oneapi]
       providers:
@@ -69,7 +69,7 @@ spack:
       target: [x86_64]
       variants: +mpi
     binutils:
-      compiler: [gcc]
+      require: "%gcc"
       variants: +ld +gold +headers +libiberty ~nls
     cuda:
       version: [11.4.2]
@@ -82,7 +82,7 @@ spack:
     libunwind:
       variants: +pic +xz
     llvm:
-      compiler: [gcc] # undefined reference to `_intel_fast_memset' becauase of -nodefaultlibs
+      require: "%gcc" # undefined reference to `_intel_fast_memset' becauase of -nodefaultlibs
     mpich:
       variants: ~wrapperrpath
     ncurses:
@@ -92,9 +92,9 @@ spack:
     python:
       version: [3.8.13]
     ruby:
-      compiler: [gcc] # https://github.com/spack/spack/issues/31954
+      require: "%gcc" # https://github.com/spack/spack/issues/31954
     rust:
-      compiler: [gcc] # undefined reference becauase of -nodefaultlibs
+      require: "%gcc" # undefined reference becauase of -nodefaultlibs
     trilinos:
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
@@ -138,7 +138,6 @@ spack:
   - gptune
   - hdf5 +fortran +hl +shared
   - heffte +fftw
-  - hpctoolkit
   - hpx networking=mpi
   - hypre
   - kokkos-kernels +openmp
@@ -220,10 +219,11 @@ spack:
   # CPU BUILD FAILURES
   #- adios2@2.8.0                                     # adios2
   #- charliecloud@0.26                                # charliecloud
-  #- dyninst@12.1.0                                   # intel-tbb
+  #- dyninst@12.1.0                                   # old intel-tbb
   #- exaworks@0.1.0                                   # rust, flux-sched
   #- geopm@1.1.0                                      # geopm
   #- h5bench@1.2                                      # h5bench
+  #- hpctoolkit                                       # dyninst
   #- phist@1.9.5                                      # phist
   #- pruners-ninja@1.0.1                              # pruners-ninja
   #- variorum@0.4.1                                   # variorum

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -101,7 +101,7 @@ spack:
         +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
         +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     vtk-m:
-      variants: ~openmp
+      require: "~openmp"
     xz:
       variants: +pic
     mesa:
@@ -128,6 +128,7 @@ spack:
   - darshan-runtime
   - darshan-util
   - datatransferkit
+  - exaworks
   - faodel
   - flit
   - flux-core
@@ -221,7 +222,6 @@ spack:
   #- adios2@2.8.0                                     # adios2
   #- charliecloud@0.26                                # charliecloud
   #- dyninst@12.1.0                                   # old intel-tbb
-  #- exaworks@0.1.0                                   # rust, flux-sched
   #- geopm@1.1.0                                      # geopm
   #- h5bench@1.2                                      # h5bench
   #- hpctoolkit                                       # dyninst

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -91,8 +91,6 @@ spack:
       variants: threads=openmp
     python:
       version: [3.8.13]
-    qt:
-      require: "%gcc"
     ruby:
       require: "%gcc" # https://github.com/spack/spack/issues/31954
     rust:
@@ -167,7 +165,6 @@ spack:
   - papi
   - papyrus
   - parallel-netcdf
-  - paraview +qt
   - parsec ~cuda
   - pdt
   - petsc
@@ -229,6 +226,7 @@ spack:
   #- h5bench@1.2                                      # h5bench
   #- hpctoolkit                                       # dyninst
   #- phist@1.9.5                                      # phist
+  #- paraview +qt                                     # qt
   #- pruners-ninja@1.0.1                              # pruners-ninja
   #- variorum@0.4.1                                   # variorum
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -62,7 +62,7 @@ spack:
     adios2:
       require: "%gcc"
     all:
-      compiler: [oneapi]
+      require: "%oneapi"
       providers:
         blas: [openblas]
         mpi: [mpich]
@@ -100,6 +100,8 @@ spack:
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
         +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
         +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    vtk-m:
+      variants: ~openmp
     xz:
       variants: +pic
     mesa:
@@ -114,7 +116,7 @@ spack:
   - arborx
   - archer
   - argobots
-  - ascent ^vtk-m ~openmp
+  - ascent
   - axom
   - bolt
   - bricks
@@ -193,7 +195,7 @@ spack:
   - swig@4.0.2-fortran
   - sz
   - tasmanian
-  - tau +mpi +python %oneapi ^binutils%gcc
+  - tau +mpi +python
   - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
    +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
    +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -67,6 +67,7 @@ spack:
       target: [x86_64]
       variants: +mpi
     binutils:
+      compiler: [gcc]
       variants: +ld +gold +headers +libiberty ~nls
     cuda:
       version: [11.4.2]
@@ -103,6 +104,7 @@ spack:
   - aml
   - amrex
   - arborx
+  - archer
   - argobots
   - ascent ^vtk-m ~openmp
   - axom
@@ -203,7 +205,6 @@ spack:
 
   # CPU BUILD FAILURES
   #- adios2@2.8.0                                     # adios2
-  #- archer@2.0.0                                     # binutils
   #- charliecloud@0.26                                # charliecloud
   #- dyninst@12.1.0                                   # intel-tbb
   #- exaworks@0.1.0                                   # rust, flux-sched

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -59,6 +59,8 @@ spack:
       extra_rpaths: []
 
   packages:
+    adios2:
+      compiler: [gcc]
     all:
       compiler: [oneapi]
       providers:
@@ -79,6 +81,8 @@ spack:
       variants: fabrics=sockets,tcp,udp,rxm
     libunwind:
       variants: +pic +xz
+    llvm:
+      compiler: [gcc] # undefined reference to `_intel_fast_memset' becauase of -nodefaultlibs
     mpich:
       variants: ~wrapperrpath
     ncurses:
@@ -87,6 +91,10 @@ spack:
       variants: threads=openmp
     python:
       version: [3.8.13]
+    ruby:
+      compiler: [gcc] # https://github.com/spack/spack/issues/31954
+    rust:
+      compiler: [gcc] # undefined reference becauase of -nodefaultlibs
     trilinos:
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
         +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
@@ -130,6 +138,7 @@ spack:
   - gptune
   - hdf5 +fortran +hl +shared
   - heffte +fftw
+  - hpctoolkit
   - hpx networking=mpi
   - hypre
   - kokkos-kernels +openmp
@@ -151,9 +160,11 @@ spack:
   - nrm
   - omega-h
   - openmpi
+  - openpmd-api
   - papi
   - papyrus
   - parallel-netcdf
+  - paraview +qt
   - parsec ~cuda
   - pdt
   - petsc
@@ -165,6 +176,9 @@ spack:
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
+  - py-warpx ^warpx dims=2
+  - py-warpx ^warpx dims=3
+  - py-warpx ^warpx dims=rz
   - qthreads scheduler=distrib
   - raja
   - rempi
@@ -208,21 +222,14 @@ spack:
   #- charliecloud@0.26                                # charliecloud
   #- dyninst@12.1.0                                   # intel-tbb
   #- exaworks@0.1.0                                   # rust, flux-sched
-  #- geopm@1.1.0                                      # ruby
+  #- geopm@1.1.0                                      # geopm
   #- h5bench@1.2                                      # h5bench
-  #- hpctoolkit@2022.04.15                            # binutils
-  #- openpmd-api@0.14.4                               # adios2
-  #- paraview@5.10.1 +qt                              # binutils
   #- phist@1.9.5                                      # phist
   #- pruners-ninja@1.0.1                              # pruners-ninja
-  #- py-warpx@22.05 ^warpx dims=2                     # adios2
-  #- py-warpx@22.05 ^warpx dims=3                     # adios2
-  #- py-warpx@22.05 ^warpx dims=rz                    # adios2
   #- variorum@0.4.1                                   # variorum
 
   # CPU BUILD FAILURES - NOTES
   # adios2: /usr/bin/ld: ../../lib/libadios2_fortran.so.2.8.2: version node not found for symbol adios2_adios_init_mod@adios2_adios_init_serial_smod._; /usr/bin/ld: failed to set dynamic section sizes: bad value
-  # ascent: examples/proxies/cloverleaf3d-ref/clover_main.cpp:24: multiple definition of `main'; /opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin/for_main.o:for_main.c:(.text+0x0): first defined here
   # binutils: gold/powerpc.cc:3590: undefined reference to `gold::Sized_symbol<64>::Value_type gold::Symbol_table::compute_final_value<64>(gold::Sized_symbol<64> const*, gold::Symbol_table::Compute_final_value_status*) const'
   # charliecloud: autoreconf phase: RuntimeError: configure script not found in ...
   # flux-sched: include/yaml-cpp/emitter.h:164:9: error: comparison with NaN always evaluates to false in fast floating point modes [-Werror,-Wtautological-constant-compare]
@@ -231,7 +238,6 @@ spack:
   # intel-tbb: clang++clang++clang++clang++clang++clang++clang++: : : : : : : clang++error: : unknown argument: '-flifetime-dse=1'
   # phist: fortran_bindings/test/kernels.F90(63): error #8284: If the actual argument is scalar, the dummy argument shall be scalar unless the actual argument is of type character or is an element of an array that is not assumed shape, pointer, or polymorphic.   [ARGV]
   # pruners-ninja: test/ninja_test_util.c:34: multiple definition of `a';
-  # py-numpy@1.23.1: numpy/distutils/checks/cpu_avx512_knm.c:22:9: error: implicit declaration of function '_mm512_4fmadd_ps' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
   # ruby: limits.c:415:34: error: invalid suffix 'D' on floating constant
   # rust: /usr/bin/ld: /opt/intel/oneapi/compiler/2022.1.0/linux/bin-llvm/../compiler/lib/intel64_lin/libimf.a(libm_feature_flag.o): in function `__libm_feature_flag_init': libm_feature_flag.c:(.text+0x25): undefined reference to `__intel_cpu_feature_indicator_x'
   # variorum: ld: Intel/CMakeFiles/variorum_intel.dir/msr_core.c.o:(.bss+0x0): multiple definition of `g_platform'; CMakeFiles/variorum.dir/config_architecture.c.o:(.bss+0x0): first defined here

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -91,6 +91,8 @@ spack:
       variants: threads=openmp
     python:
       version: [3.8.13]
+    qt:
+      require: "%gcc"
     ruby:
       require: "%gcc" # https://github.com/spack/spack/issues/31954
     rust:


### PR DESCRIPTION
@eugeneswalker: Can you override the compiler for a package this way?