### PR TITLE
specs: include source provenance in `spec.json` and package hash

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -74,6 +74,6 @@ class MirrorCache:
 
 
 #: Spack's local cache for downloaded source archives
-FETCH_CACHE: Union[spack.fetch_strategy.FsCache, llnl.util.lang.Singleton] = (
+FETCH_CACHE: Union["spack.fetch_strategy.FsCache", llnl.util.lang.Singleton] = (
     llnl.util.lang.Singleton(_fetch_cache)
 )

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -49,6 +49,7 @@ import spack.oci.opener
 import spack.util.archive
 import spack.util.crypto as crypto
 import spack.util.git
+import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
@@ -109,6 +110,20 @@ class FetchStrategy:
         self.cache_enabled = not kwargs.pop("no_cache", False)
 
         self.package = None
+
+    def spec_attrs(self):
+        """Create a dictionary of attributes that describe this fetch strategy for a Spec.
+
+        This is included in the serialized Spec format to store provenance (like hashes).
+        """
+        attrs = syaml.syaml_dict()
+        if self.url_attr:
+            attrs["type"] = "archive" if self.url_attr == "url" else self.url_attr
+        for attr in self.optional_attrs:
+            value = getattr(self, attr, None)
+            if value:
+                attrs[attr] = value
+        return attrs
 
     def set_package(self, package):
         self.package = package
@@ -253,6 +268,16 @@ class URLFetchStrategy(FetchStrategy):
         self._curl: Optional[Executable] = None
         self.extension: Optional[str] = kwargs.get("extension", None)
         self._effective_url: Optional[str] = None
+
+    def spec_attrs(self):
+        attrs = super(URLFetchStrategy, self).spec_attrs()
+        if self.digest:
+            try:
+                hash_type = spack.util.crypto.hash_algo_for_digest(self.digest)
+            except ValueError:
+                hash_type = "digest"
+            attrs[hash_type] = self.digest
+        return attrs
 
     @property
     def curl(self) -> Executable:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -33,7 +33,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import PurePath
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import llnl.url
 import llnl.util
@@ -111,10 +111,18 @@ class FetchStrategy:
 
         self.package = None
 
-    def spec_attrs(self):
-        """Create a dictionary of attributes that describe this fetch strategy for a Spec.
+    def source_provenance(self) -> Dict:
+        """Create a metadata dictionary that describes the artifacts fetched by this FetchStrategy.
 
-        This is included in the serialized Spec format to store provenance (like hashes).
+        The returned dictionary is added to the content used to determine the full hash
+        for a package. It should be serializable as JSON.
+
+        It should include data like sha256 hashes for archives, commits for source
+        repositories, and any information needed to describe exactly what artifacts went
+        into a build.
+
+        If a package has no soruce artifacts, it should return an empty dictionary.
+
         """
         attrs = syaml.syaml_dict()
         if self.url_attr:
@@ -167,17 +175,6 @@ class FetchStrategy:
             bool: True if can cache, False otherwise.
         """
 
-    def source_id(self):
-        """A unique ID for the source.
-
-        It is intended that a human could easily generate this themselves using
-        the information available to them in the Spack package.
-
-        The returned value is added to the content which determines the full
-        hash for a package using `str()`.
-        """
-        raise NotImplementedError
-
     def mirror_id(self):
         """This is a unique ID for a source that is intended to help identify
         reuse of resources across packages.
@@ -228,9 +225,9 @@ class BundleFetchStrategy(FetchStrategy):
         """Report False as there is no code to cache."""
         return False
 
-    def source_id(self):
-        """BundlePackages don't have a source id."""
-        return ""
+    def source_provenance(self) -> Dict:
+        """BundlePackages don't have a source of their own."""
+        return {}
 
     def mirror_id(self):
         """BundlePackages don't have a mirror id."""
@@ -269,8 +266,14 @@ class URLFetchStrategy(FetchStrategy):
         self.extension: Optional[str] = kwargs.get("extension", None)
         self._effective_url: Optional[str] = None
 
-    def spec_attrs(self):
-        attrs = super().spec_attrs()
+    @property
+    def curl(self) -> Executable:
+        if not self._curl:
+            self._curl = web_util.require_curl()
+        return self._curl
+
+    def source_provenance(self) -> Dict:
+        attrs = super().source_provenance()
         if self.digest:
             try:
                 hash_type = spack.util.crypto.hash_algo_for_digest(self.digest)
@@ -278,15 +281,6 @@ class URLFetchStrategy(FetchStrategy):
                 hash_type = "digest"
             attrs[hash_type] = self.digest
         return attrs
-
-    @property
-    def curl(self) -> Executable:
-        if not self._curl:
-            self._curl = web_util.require_curl()
-        return self._curl
-
-    def source_id(self):
-        return self.digest
 
     def mirror_id(self):
         if not self.digest:
@@ -759,16 +753,6 @@ class GitFetchStrategy(VCSFetchStrategy):
         self.get_full_repo = kwargs.get("get_full_repo", False)
         self.git_sparse_paths = kwargs.get("git_sparse_paths", None)
 
-    def spec_attrs(self):
-        attrs = super().spec_attrs()
-
-        # need to fully resolve submodule callbacks for node dicts
-        submodules = attrs.get("submodules", None)
-        if submodules and callable(submodules):
-            attrs["submodules"] = submodules(self.package)
-
-        return attrs
-
     @property
     def git_version(self):
         return GitFetchStrategy.version_from_git(self.git)
@@ -807,9 +791,15 @@ class GitFetchStrategy(VCSFetchStrategy):
     def cachable(self):
         return self.cache_enabled and bool(self.commit)
 
-    def source_id(self):
-        # TODO: tree-hash would secure download cache and mirrors, commit only secures checkouts.
-        return self.commit
+    def source_provenance(self) -> Dict:
+        attrs = super().source_provenance()
+
+        # need to fully resolve submodule callbacks for node dicts
+        submodules = attrs.get("submodules", None)
+        if submodules and callable(submodules):
+            attrs["submodules"] = submodules(self.package)
+
+        return attrs
 
     def mirror_id(self):
         if self.commit:
@@ -1119,17 +1109,6 @@ class CvsFetchStrategy(VCSFetchStrategy):
     def cachable(self):
         return self.cache_enabled and (bool(self.branch) or bool(self.date))
 
-    def source_id(self):
-        if not (self.branch or self.date):
-            # We need a branch or a date to make a checkout reproducible
-            return None
-        id = "id"
-        if self.branch:
-            id += "-branch=" + self.branch
-        if self.date:
-            id += "-date=" + self.date
-        return id
-
     def mirror_id(self):
         if not (self.branch or self.date):
             # We need a branch or a date to make a checkout reproducible
@@ -1231,9 +1210,6 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @property
     def cachable(self):
         return self.cache_enabled and bool(self.revision)
-
-    def source_id(self):
-        return self.revision
 
     def mirror_id(self):
         if self.revision:
@@ -1341,9 +1317,6 @@ class HgFetchStrategy(VCSFetchStrategy):
     @property
     def cachable(self):
         return self.cache_enabled and bool(self.revision)
-
-    def source_id(self):
-        return self.revision
 
     def mirror_id(self):
         if self.revision:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -270,7 +270,7 @@ class URLFetchStrategy(FetchStrategy):
         self._effective_url: Optional[str] = None
 
     def spec_attrs(self):
-        attrs = super(URLFetchStrategy, self).spec_attrs()
+        attrs = super().spec_attrs()
         if self.digest:
             try:
                 hash_type = spack.util.crypto.hash_algo_for_digest(self.digest)
@@ -758,6 +758,16 @@ class GitFetchStrategy(VCSFetchStrategy):
         self.submodules_delete = kwargs.get("submodules_delete", False)
         self.get_full_repo = kwargs.get("get_full_repo", False)
         self.git_sparse_paths = kwargs.get("git_sparse_paths", None)
+
+    def spec_attrs(self):
+        attrs = super().spec_attrs()
+
+        # need to fully resolve submodule callbacks for node dicts
+        submodules = attrs.get("submodules", None)
+        if submodules and callable(submodules):
+            attrs["submodules"] = submodules(self.package)
+
+        return attrs
 
     @property
     def git_version(self):

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -5,7 +5,6 @@
 """Definitions that control how Spack creates Spec hashes."""
 
 import spack.deptypes as dt
-import spack.repo
 
 hashes = []
 
@@ -13,20 +12,17 @@ hashes = []
 class SpecHashDescriptor:
     """This class defines how hashes are generated on Spec objects.
 
-    Spec hashes in Spack are generated from a serialized (e.g., with
-    YAML) representation of the Spec graph.  The representation may only
-    include certain dependency types, and it may optionally include a
-    canonicalized hash of the package.py for each node in the graph.
+    Spec hashes in Spack are generated from a serialized JSON representation of the DAG.
+    The representation may only include certain dependency types, and it may optionally
+    include a canonicalized hash of the ``package.py`` for each node in the graph.
 
-    We currently use different hashes for different use cases."""
+    """
 
-    def __init__(self, depflag: dt.DepFlag, package_hash, name, override=None):
+    def __init__(self, depflag: dt.DepFlag, package_hash, name):
         self.depflag = depflag
         self.package_hash = package_hash
         self.name = name
         hashes.append(self)
-        # Allow spec hashes to have an alternate computation method
-        self.override = override
 
     @property
     def attr(self):
@@ -51,18 +47,6 @@ dag_hash = SpecHashDescriptor(depflag=dt.BUILD | dt.LINK | dt.RUN, package_hash=
 #: Hash descriptor used only to transfer a DAG, as is, across processes
 process_hash = SpecHashDescriptor(
     depflag=dt.BUILD | dt.LINK | dt.RUN | dt.TEST, package_hash=True, name="process_hash"
-)
-
-
-def _content_hash_override(spec):
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
-    pkg = pkg_cls(spec)
-    return pkg.content_hash()
-
-
-#: Package hash used as part of dag hash
-package_hash = SpecHashDescriptor(
-    depflag=0, package_hash=True, name="package_hash", override=_content_hash_override
 )
 
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -36,6 +36,7 @@ import os
 import shutil
 import sys
 import time
+import traceback
 from collections import defaultdict
 from gzip import GzipFile
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
@@ -2214,7 +2215,7 @@ class PackageInstaller:
                 if task.is_build_request:
                     if single_requested_spec:
                         raise
-                    failed_build_requests.append((pkg, pkg_id, str(exc)))
+                    failed_build_requests.append((pkg, pkg_id, exc))
 
             finally:
                 # Remove the install prefix if anything went wrong during
@@ -2241,6 +2242,9 @@ class PackageInstaller:
         if failed_build_requests or missing:
             for _, pkg_id, err in failed_build_requests:
                 tty.error(f"{pkg_id}: {err}")
+                if spack.error.debug:
+                    # note: in python 3.10+ this can just be print_exception(err)
+                    traceback.print_exception(type(err), err, err.__traceback__)
 
             for _, pkg_id in missing:
                 tty.error(f"{pkg_id}: Package was not installed")

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1807,7 +1807,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
                     tty.debug(message.format(s=self))
 
             for resource in self._get_needed_resources():
-                sources.append(resource.fetcher.spec_attrs())
+                sources.append(resource.fetcher.source_provenance())
 
             if sources:
                 hashes["sources"] = sources
@@ -1817,7 +1817,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         # We check spec._patches_assigned instead of spec.concrete because
         # we have to call package_hash *before* marking specs concrete
         if self.spec._patches_assigned():
-            hashes["patches"] = [p.sha256 for p in self.spec.patches]
+            hashes["patches"] = [
+                {"sha256": patch.sha256, "level": patch.level} for patch in self.spec.patches
+            ]
 
         # package.py contents
         hashes["package_hash"] = ph.package_hash(self.spec, source=content)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -47,6 +47,7 @@ import spack.spec
 import spack.store
 import spack.url
 import spack.util.environment
+import spack.util.package_hash as ph
 import spack.util.path
 import spack.util.spack_yaml as syaml
 import spack.util.web
@@ -55,7 +56,6 @@ from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import PackageTest, TestSuite
 from spack.solver.version_order import concretization_version_order
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
-from spack.util.package_hash import package_hash
 from spack.version import GitVersion, StandardVersion
 
 FLAG_HANDLER_RETURN_TYPE = Tuple[
@@ -1818,7 +1818,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
             hashes["patches"] = [p.sha256 for p in self.spec.patches]
 
         # package.py contents
-        hashes["package_hash"] = package_hash(self.spec, source=content)
+        hashes["package_hash"] = ph.package_hash(self.spec, source=content)
 
         return hashes
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1798,10 +1798,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
                 # if this is a develop spec, say so
                 from_local_sources = "dev_path" in self.spec.variants
 
-                # don't bother setting a source id if none is available, but warn if
+                # don't bother setting a hash if none is available, but warn if
                 # it seems like there should be one.
                 if self.has_code and not self.spec.external and not from_local_sources:
-                    message = "Missing a source id for {s.name}@{s.version}"
+                    message = "Missing a hash for {s.name}@{s.version}"
                     tty.debug(message.format(s=self))
 
             for resource in self._get_needed_resources():

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1769,7 +1769,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         hashes = syaml.syaml_dict()
 
         # source artifacts/repositories
-        # TODO: resources
         if self.spec.versions.concrete:
             sources = []
             try:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1754,16 +1754,31 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         return patches
 
     def artifact_hashes(self, content=None):
-        """Create a hash based on the artifacts and patches used to build this package.
+        """Create a dictionary of hashes of artifacts used in the build of this package.
 
         This includes:
             * source artifacts (tarballs, repositories) used to build;
             * content hashes (``sha256``'s) of all patches applied by Spack; and
             * canonicalized contents the ``package.py`` recipe used to build.
 
-        This hash is only included in Spack's DAG hash for concrete specs, but if it
-        happens to be called on a package with an abstract spec, only applicable (i.e.,
-        determinable) portions of the hash will be included.
+        Example::
+
+            {
+              "package_hash": "qovi2hm2n2qsatng2r4n55yzjlhnwflx",
+              "sources": [
+                {
+                  "sha256": "fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60",
+                  "type": "archive"
+                },
+                {
+                  "sha256": "56ab9b90f5acbc42eb7a94cf482e6c058a63e8a1effdf572b8b2a6323a06d923",
+                  "type": "archive"
+                }
+             }
+
+        All hashes are added to concrete specs at the end of concretization. If this
+        method is called on an abstract spec, only hashes that can be known from the
+        abstract spec will be included.
 
         """
         hashes = syaml.syaml_dict()

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1788,7 +1788,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
             sources = []
             try:
                 fetcher = fs.for_package_version(self)
-                sources.append(fetcher.spec_attrs())
+                provenance_dict = fetcher.source_provenance()
+                if provenance_dict:
+                    sources.append(provenance_dict)
 
             except (fs.ExtrapolationError, fs.InvalidArgsError):
                 # ExtrapolationError happens if the package has no fetchers defined.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -9,12 +9,10 @@ The spack package class structure is based strongly on Homebrew
 packages.
 """
 
-import base64
 import collections
 import copy
 import functools
 import glob
-import hashlib
 import importlib
 import io
 import os
@@ -50,6 +48,7 @@ import spack.store
 import spack.url
 import spack.util.environment
 import spack.util.path
+import spack.util.spack_yaml as syaml
 import spack.util.web
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
@@ -1754,7 +1753,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
 
         return patches
 
-    def content_hash(self, content=None):
+    def artifact_hashes(self, content=None):
         """Create a hash based on the artifacts and patches used to build this package.
 
         This includes:
@@ -1767,52 +1766,47 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         determinable) portions of the hash will be included.
 
         """
-        # list of components to make up the hash
-        hash_content = []
+        hashes = syaml.syaml_dict()
 
         # source artifacts/repositories
         # TODO: resources
         if self.spec.versions.concrete:
+            sources = []
             try:
-                source_id = fs.for_package_version(self).source_id()
+                fetcher = fs.for_package_version(self)
+                sources.append(fetcher.spec_attrs())
+
             except (fs.ExtrapolationError, fs.InvalidArgsError):
                 # ExtrapolationError happens if the package has no fetchers defined.
                 # InvalidArgsError happens when there are version directives with args,
                 #     but none of them identifies an actual fetcher.
-                source_id = None
 
-            if not source_id:
-                # TODO? in cases where a digest or source_id isn't available,
-                # should this attempt to download the source and set one? This
-                # probably only happens for source repositories which are
-                # referenced by branch name rather than tag or commit ID.
+                # if this is a develop spec, say so
                 from_local_sources = "dev_path" in self.spec.variants
+
+                # don't bother setting a source id if none is available, but warn if
+                # it seems like there should be one.
                 if self.has_code and not self.spec.external and not from_local_sources:
                     message = "Missing a source id for {s.name}@{s.version}"
                     tty.debug(message.format(s=self))
-                hash_content.append("".encode("utf-8"))
-            else:
-                hash_content.append(source_id.encode("utf-8"))
+
+            for resource in self._get_needed_resources():
+                sources.append(resource.fetcher.spec_attrs())
+
+            if sources:
+                hashes["sources"] = sources
 
         # patch sha256's
         # Only include these if they've been assigned by the concretizer.
         # We check spec._patches_assigned instead of spec.concrete because
         # we have to call package_hash *before* marking specs concrete
         if self.spec._patches_assigned():
-            hash_content.extend(
-                ":".join((p.sha256, str(p.level))).encode("utf-8") for p in self.spec.patches
-            )
+            hashes["patches"] = [p.sha256 for p in self.spec.patches]
 
         # package.py contents
-        hash_content.append(package_hash(self.spec, source=content).encode("utf-8"))
+        hashes["package_hash"] = package_hash(self.spec, source=content)
 
-        # put it all together and encode as base32
-        b32_hash = base64.b32encode(
-            hashlib.sha256(bytes().join(sorted(hash_content))).digest()
-        ).lower()
-        b32_hash = b32_hash.decode("utf-8")
-
-        return b32_hash
+        return hashes
 
     @property
     def cmake_prefix_paths(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -805,7 +805,7 @@ class RepoPath:
         return self._tag_index
 
     @property
-    def patch_index(self) -> spack.patch.PatchCache:
+    def patch_index(self) -> "spack.patch.PatchCache":
         """Merged PatchIndex from all Repos in the RepoPath."""
         if self._patch_index is None:
             self._patch_index = spack.patch.PatchCache(repository=self)
@@ -1158,7 +1158,7 @@ class Repo:
         return self.index["tags"]
 
     @property
-    def patch_index(self) -> spack.patch.PatchCache:
+    def patch_index(self) -> "spack.patch.PatchCache":
         """Index of patches and packages they're defined on."""
         return self.index["patches"]
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2202,10 +2202,12 @@ class Spec:
             d["concrete"] = False
 
         if self._concrete and hash.package_hash:
-            # We use the attribute here instead of `self.package_hash()` because this should
-            # *always* be assigned at concretization time. We don't want to try to compute a
-            # package hash for concrete spec where a) the package might not exist, or b) the
-            # `dag_hash` didn't include the package hash when the spec was concretized.
+            # We use the `_package_hash` attribute here instead of `self.package_hash()`
+            # because `_package_hash` is *always* assigned at concretization time. If
+            # the attribute is present, we should include it. If it isn't, we avoid
+            # computing it because a) the package may no longer exist, or b) this is an
+            # older spec and the `dag_hash` didn't include the package hash when the
+            # spec was concretized.
             if hasattr(self, "_package_hash") and self._package_hash:
                 d["package_hash"] = self._package_hash
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2173,10 +2173,7 @@ class Spec:
         if self.namespace:
             d["namespace"] = self.namespace
 
-        # Get all variants *except* for patches.  Patches are included in "artifacts" below.
-        params = syaml.syaml_dict(
-            sorted(v.yaml_entry() for _, v in self.variants.items() if v.name != "patches")
-        )
+        params = syaml.syaml_dict(sorted(v.yaml_entry() for _, v in self.variants.items()))
 
         # Only need the string compiler flag for yaml file
         params.update(
@@ -2200,6 +2197,11 @@ class Spec:
 
         if not self._concrete:
             d["concrete"] = False
+
+        if "patches" in self.variants:
+            variant = self.variants["patches"]
+            if hasattr(variant, "_patches_in_order_of_appearance"):
+                d["patches"] = variant._patches_in_order_of_appearance
 
         if self._concrete and hash.package_hash:
             # We use the `_package_hash` attribute here instead of `self.package_hash()`

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2923,9 +2923,8 @@ class Spec:
                 # can't use self.package here b/c not concrete yet
                 pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
                 pkg = pkg_cls(spec)
-
-                # TODO: make artifact hashes a static method
                 artifact_hashes = pkg.artifact_hashes()
+
                 spec._package_hash = artifact_hashes.pop("package_hash")
                 spec._artifact_hashes = artifact_hashes
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -765,12 +765,6 @@ def test_install_only_dependencies_of_all_in_env(
                 assert os.path.exists(dep.prefix)
 
 
-def hline(label):
-    width = 100 - len(label) - 1
-    print()
-    print(f"{label} {'=' * width}")
-
-
 def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock_env_path):
     # To test behavior of --add option, we create the following environment:
     #
@@ -785,8 +779,6 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
     #         ^pkg-b
     #     pkg-a
     #         ^pkg-b
-
-    hline("START TEST")
 
     e = ev.create("test", with_view=False)
     e.add("mpileaks")
@@ -822,38 +814,19 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
 
     # Activate the environment
     with e:
-        hline("INITIAL CONCRETE SPECS")
-        find_output = find("-lc", output=str)
-        print()
-        initial_spec_tuples = [str((s.dag_hash(7), s.name, id(s))) for s in initial_concrete_specs]
-        print("\n".join(initial_spec_tuples))
-
-        initial_libelf = next(s for s in initial_concrete_specs if s.satisfies("libelf@0.8.10"))
-
         # Assert using --no-add with a spec not in the env fails
-        hline("INSTALLING WITHOUT ADD")
         inst_out = install("--no-add", "boost", fail_on_error=False, output=str)
-
         assert "You can add specs to the environment with 'spack add boost'" in inst_out
 
         # Without --add, ensure that two packages "a" get installed
-        hline("INSTALLING WITH ADD")
         inst_out = install("pkg-a", output=str)
-
-        # 2 pkg-a's are installed
         assert len([x for x in e.all_specs() if x.installed and x.name == "pkg-a"]) == 2
-
-        hline("AFTER FIRST INSTALL")
-        # debug print output
-        find_output = find("-l", output=str)
 
         # Install an unambiguous dependency spec (that already exists as a dep
         # in the environment) and make sure it gets installed (w/ deps),
         # but is not added to the environment.
-        hline("INSTALLING DYNINST")
         install("dyninst")
 
-        hline("AFTER DYNINST INSTALL")
         find_output = find("-l", output=str)
 
         assert "dyninst" in find_output
@@ -861,48 +834,7 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
         assert "libelf" in find_output
         assert "callpath" not in find_output
 
-        hline("ARE ALL post_install_concrete_specs IN initial_concrete_specs?")
         post_install_concrete_specs = e.all_specs()
-
-        post_specs_in_initial_specs = [
-            str((s.dag_hash(7), s.name, id(s), s in initial_concrete_specs))
-            for s in post_install_concrete_specs
-        ]
-        print("\n".join(post_specs_in_initial_specs))
-
-        hline("WEIRD SPECS")
-        final_libelf = next(s for s in post_install_concrete_specs if s.satisfies("libelf@0.8.10"))
-        print(initial_libelf.to_json())
-        print(final_libelf.to_json())
-        print(initial_libelf.to_json() == final_libelf.to_json())
-        print(initial_libelf._package_hash, final_libelf._package_hash)
-        print()
-        print(initial_libelf._artifact_hashes)
-        print(final_libelf._artifact_hashes)
-        print(initial_libelf._artifact_hashes == final_libelf._artifact_hashes)
-        print()
-        print(hash(initial_libelf))
-        print(hash(final_libelf))
-        print()
-        print(tuple(initial_libelf._cmp_iter()))
-        print(tuple(final_libelf._cmp_iter()))
-        print(
-            "\n".join(
-                [
-                    str((x == y, x, y))
-                    for x, y in zip(initial_libelf._cmp_iter(), final_libelf._cmp_iter())
-                ]
-            )
-        )
-        print()
-        print(initial_libelf.variants == final_libelf.variants)
-        print(initial_libelf.variants)
-        print(final_libelf.variants)
-        print()
-        print(initial_libelf == final_libelf)
-        print(id(initial_libelf), id(final_libelf))
-        print(initial_libelf in initial_concrete_specs)
-        print(initial_libelf in post_install_concrete_specs)
 
         for s in post_install_concrete_specs:
             assert (

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -765,6 +765,12 @@ def test_install_only_dependencies_of_all_in_env(
                 assert os.path.exists(dep.prefix)
 
 
+def hline(label):
+    width = 100 - len(label) - 1
+    print()
+    print(f"{label} {'=' * width}")
+
+
 def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock_env_path):
     # To test behavior of --add option, we create the following environment:
     #
@@ -779,6 +785,9 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
     #         ^pkg-b
     #     pkg-a
     #         ^pkg-b
+
+    hline("START TEST")
+
     e = ev.create("test", with_view=False)
     e.add("mpileaks")
     e.add("libelf@0.8.10")  # so env has both root and dep libelf specs
@@ -786,14 +795,14 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
     e.add("pkg-a ~bvv")
     e.concretize()
     e.write()
-    env_specs = e.all_specs()
+    initial_concrete_specs = e.all_specs()
 
     a_spec = None
     b_spec = None
     mpi_spec = None
 
     # First find and remember some target concrete specs in the environment
-    for e_spec in env_specs:
+    for e_spec in initial_concrete_specs:
         if e_spec.satisfies(Spec("pkg-a ~bvv")):
             a_spec = e_spec
         elif e_spec.name == "pkg-b":
@@ -813,28 +822,92 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
 
     # Activate the environment
     with e:
+        hline("INITIAL CONCRETE SPECS")
+        find_output = find("-lc", output=str)
+        print()
+        initial_spec_tuples = [str((s.dag_hash(7), s.name, id(s))) for s in initial_concrete_specs]
+        print("\n".join(initial_spec_tuples))
+
+        initial_libelf = next(s for s in initial_concrete_specs if s.satisfies("libelf@0.8.10"))
+
         # Assert using --no-add with a spec not in the env fails
+        hline("INSTALLING WITHOUT ADD")
         inst_out = install("--no-add", "boost", fail_on_error=False, output=str)
 
-        assert "You can add specs to the environment with 'spack add " in inst_out
+        assert "You can add specs to the environment with 'spack add boost'" in inst_out
 
         # Without --add, ensure that two packages "a" get installed
+        hline("INSTALLING WITH ADD")
         inst_out = install("pkg-a", output=str)
+
+        # 2 pkg-a's are installed
         assert len([x for x in e.all_specs() if x.installed and x.name == "pkg-a"]) == 2
+
+        hline("AFTER FIRST INSTALL")
+        # debug print output
+        find_output = find("-l", output=str)
 
         # Install an unambiguous dependency spec (that already exists as a dep
         # in the environment) and make sure it gets installed (w/ deps),
         # but is not added to the environment.
+        hline("INSTALLING DYNINST")
         install("dyninst")
 
+        hline("AFTER DYNINST INSTALL")
         find_output = find("-l", output=str)
+
         assert "dyninst" in find_output
         assert "libdwarf" in find_output
         assert "libelf" in find_output
         assert "callpath" not in find_output
 
-        post_install_specs = e.all_specs()
-        assert all([s in env_specs for s in post_install_specs])
+        hline("ARE ALL post_install_concrete_specs IN initial_concrete_specs?")
+        post_install_concrete_specs = e.all_specs()
+
+        post_specs_in_initial_specs = [
+            str((s.dag_hash(7), s.name, id(s), s in initial_concrete_specs))
+            for s in post_install_concrete_specs
+        ]
+        print("\n".join(post_specs_in_initial_specs))
+
+        hline("WEIRD SPECS")
+        final_libelf = next(s for s in post_install_concrete_specs if s.satisfies("libelf@0.8.10"))
+        print(initial_libelf.to_json())
+        print(final_libelf.to_json())
+        print(initial_libelf.to_json() == final_libelf.to_json())
+        print(initial_libelf._package_hash, final_libelf._package_hash)
+        print()
+        print(initial_libelf._artifact_hashes)
+        print(final_libelf._artifact_hashes)
+        print(initial_libelf._artifact_hashes == final_libelf._artifact_hashes)
+        print()
+        print(hash(initial_libelf))
+        print(hash(final_libelf))
+        print()
+        print(tuple(initial_libelf._cmp_iter()))
+        print(tuple(final_libelf._cmp_iter()))
+        print(
+            "\n".join(
+                [
+                    str((x == y, x, y))
+                    for x, y in zip(initial_libelf._cmp_iter(), final_libelf._cmp_iter())
+                ]
+            )
+        )
+        print()
+        print(initial_libelf.variants == final_libelf.variants)
+        print(initial_libelf.variants)
+        print(final_libelf.variants)
+        print()
+        print(initial_libelf == final_libelf)
+        print(id(initial_libelf), id(final_libelf))
+        print(initial_libelf in initial_concrete_specs)
+        print(initial_libelf in post_install_concrete_specs)
+
+        for s in post_install_concrete_specs:
+            assert (
+                s in initial_concrete_specs
+            ), f"installed spec {s.format('{name}{@version}{/hash:7}')} not in original env"
 
         # Make sure we can install a concrete dependency spec from a spec.json
         # file on disk, and the spec is installed but not added as a root

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -410,7 +410,7 @@ def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd,
     assert "Installing dependency-install" in out[0]
 
     # Make sure a warning for missing code is issued
-    assert "Missing a source id for nosource" in out[1]
+    assert "Missing a hash for nosource" in out[1]
 
 
 @pytest.mark.disable_clean_stage_check
@@ -427,7 +427,7 @@ def test_nosource_bundle_pkg_install(
     assert "Installing dependency-install" in out[0]
 
     # Make sure a warning for missing code is *not* issued
-    assert "Missing a source id for nosource" not in out[1]
+    assert "Missing a hash for nosource" not in out[1]
 
 
 def test_nosource_pkg_install_post_install(install_mockery, mock_fetch, mock_packages):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -96,6 +96,22 @@ def test_invalid_json_spec(invalid_json, error_message):
         # Virtuals on edges
         "callpath",
         "mpileaks",
+        # all types of git versions
+        # ensure that we try to serialize all the things that might be in the node dict,
+        # e.g., submodule callbacks can fail serialization if they're not fully resolved.
+        "git-url-top-level@develop",
+        "git-url-top-level@submodules",
+        "git-url-top-level@submodules_callback",
+        "git-url-top-level@3.4",
+        "git-url-top-level@3.3",
+        "git-url-top-level@3.2",
+        "git-url-top-level@3.1",
+        "git-url-top-level@3.0",
+        "git-url-top-level@2.3",
+        "git-url-top-level@2.2",
+        "git-url-top-level@2.1",
+        "git-url-top-level@2.0",
+        "git-url-top-level@2.3",
     ],
 )
 def test_roundtrip_concrete_specs(abstract_spec, default_mock_concretization):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -111,7 +111,6 @@ def test_invalid_json_spec(invalid_json, error_message):
         "git-url-top-level@2.2",
         "git-url-top-level@2.1",
         "git-url-top-level@2.0",
-        "git-url-top-level@2.3",
     ],
 )
 def test_roundtrip_concrete_specs(abstract_spec, default_mock_concretization):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -96,8 +96,8 @@ def test_invalid_json_spec(invalid_json, error_message):
         # Virtuals on edges
         "callpath",
         "mpileaks",
-        # all types of git versions
-        # ensure that we try to serialize all the things that might be in the node dict,
+        # Vvarious types of git versions
+        # Ensure that we try to serialize all the things that might be in the node dict,
         # e.g., submodule callbacks can fail serialization if they're not fully resolved.
         "git-url-top-level@develop",
         "git-url-top-level@submodules",
@@ -107,10 +107,9 @@ def test_invalid_json_spec(invalid_json, error_message):
         "git-url-top-level@3.2",
         "git-url-top-level@3.1",
         "git-url-top-level@3.0",
+        # URL versions with checksums
         "git-url-top-level@2.3",
-        "git-url-top-level@2.2",
         "git-url-top-level@2.1",
-        "git-url-top-level@2.0",
     ],
 )
 def test_roundtrip_concrete_specs(abstract_spec, default_mock_concretization):

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -148,8 +148,6 @@ def test_package_hash_all_same_but_archive_hash(mock_packages, config):
     # the sources for these two packages will not be the same b/c their archive hashes differ
     assert spec1.to_node_dict()["sources"] != spec2.to_node_dict()["sources"]
 
-    assert spec1.dag_hash() != spec2.dag_hash()
-
 
 def test_package_hash_all_same_but_resources(mock_packages, config):
     spec1 = Spec("hash-test1@1.7").concretized()

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -19,29 +19,27 @@ from spack.util.unparse import unparse
 datadir = os.path.join(spack.paths.test_path, "data", "unparse")
 
 
-def compare_sans_name(eq, spec1, spec2):
+def canonical_source_equal_sans_name(spec1, spec2):
     content1 = ph.canonical_source(spec1)
     content1 = content1.replace(spack.repo.PATH.get_pkg_class(spec1.name).__name__, "TestPackage")
     content2 = ph.canonical_source(spec2)
     content2 = content2.replace(spack.repo.PATH.get_pkg_class(spec2.name).__name__, "TestPackage")
-    if eq:
-        assert content1 == content2
-    else:
-        assert content1 != content2
+
+    return content1 == content2
 
 
-def compare_hash_sans_name(eq, spec1, spec2):
+def package_hash_equal_sans_name(spec1, spec2):
     content1 = ph.canonical_source(spec1)
     pkg_cls1 = spack.repo.PATH.get_pkg_class(spec1.name)
     content1 = content1.replace(pkg_cls1.__name__, "TestPackage")
-    hash1 = pkg_cls1(spec1).content_hash(content=content1)
+    hash1 = ph.package_hash(spec1, source=content1)
 
     content2 = ph.canonical_source(spec2)
     pkg_cls2 = spack.repo.PATH.get_pkg_class(spec2.name)
     content2 = content2.replace(pkg_cls2.__name__, "TestPackage")
-    hash2 = pkg_cls2(spec2).content_hash(content=content2)
+    hash2 = ph.package_hash(spec2, source=content2)
 
-    assert (hash1 == hash2) == eq
+    return hash1 == hash2
 
 
 def test_hash(mock_packages, config):
@@ -57,11 +55,11 @@ def test_different_variants(mock_packages, config):
 def test_all_same_but_name(mock_packages, config):
     spec1 = Spec("hash-test1@=1.2")
     spec2 = Spec("hash-test2@=1.2")
-    compare_sans_name(True, spec1, spec2)
+    assert canonical_source_equal_sans_name(spec1, spec2)
 
     spec1 = Spec("hash-test1@=1.2 +varianty")
     spec2 = Spec("hash-test2@=1.2 +varianty")
-    compare_sans_name(True, spec1, spec2)
+    assert canonical_source_equal_sans_name(spec1, spec2)
 
 
 def test_all_same_but_archive_hash(mock_packages, config):
@@ -70,60 +68,63 @@ def test_all_same_but_archive_hash(mock_packages, config):
     """
     spec1 = Spec("hash-test1@=1.3")
     spec2 = Spec("hash-test2@=1.3")
-    compare_sans_name(True, spec1, spec2)
+    assert canonical_source_equal_sans_name(spec1, spec2)
 
 
 def test_all_same_but_patch_contents(mock_packages, config):
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.1")
-    compare_sans_name(True, spec1, spec2)
+    assert canonical_source_equal_sans_name(spec1, spec2)
 
 
 def test_all_same_but_patches_to_apply(mock_packages, config):
     spec1 = Spec("hash-test1@=1.4")
     spec2 = Spec("hash-test2@=1.4")
-    compare_sans_name(True, spec1, spec2)
+    assert canonical_source_equal_sans_name(spec1, spec2)
 
 
 def test_all_same_but_install(mock_packages, config):
     spec1 = Spec("hash-test1@=1.5")
     spec2 = Spec("hash-test2@=1.5")
-    compare_sans_name(False, spec1, spec2)
+    assert not canonical_source_equal_sans_name(spec1, spec2)
 
 
-def test_content_hash_all_same_but_patch_contents(mock_packages, config):
+def test_package_hash_all_same_but_patch_contents_different(mock_packages, config):
     spec1 = Spec("hash-test1@1.1").concretized()
     spec2 = Spec("hash-test2@1.1").concretized()
-    compare_hash_sans_name(False, spec1, spec2)
+
+    assert package_hash_equal_sans_name(spec1, spec2)
+    assert spec1.dag_hash() != spec2.dag_hash()
+    assert spec1.to_node_dict()["patches"] != spec2.to_node_dict()["patches"]
 
 
-def test_content_hash_not_concretized(mock_packages, config):
-    """Check that Package.content_hash() works on abstract specs."""
-    # these are different due to the package hash
+def test_package_hash_not_concretized(mock_packages, config):
+    """Check that ``package_hash()`` works on abstract specs."""
+    # these are different due to patches but not package hash
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.3")
-    compare_hash_sans_name(False, spec1, spec2)
+    assert package_hash_equal_sans_name(spec1, spec2)
 
     # at v1.1 these are actually the same package when @when's are removed
     # and the name isn't considered
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.1")
-    compare_hash_sans_name(True, spec1, spec2)
+    assert package_hash_equal_sans_name(spec1, spec2)
 
-    # these end up being different b/c we can't eliminate much of the package.py
-    # without a version.
+    # these end up being different b/c without a version, we can't eliminate much of the
+    # package.py when canonicalizing source.
     spec1 = Spec("hash-test1")
     spec2 = Spec("hash-test2")
-    compare_hash_sans_name(False, spec1, spec2)
+    assert not package_hash_equal_sans_name(spec1, spec2)
 
 
-def test_content_hash_different_variants(mock_packages, config):
+def test_package_hash_different_variants(mock_packages, config):
     spec1 = Spec("hash-test1@1.2 +variantx").concretized()
     spec2 = Spec("hash-test2@1.2 ~variantx").concretized()
-    compare_hash_sans_name(True, spec1, spec2)
+    assert package_hash_equal_sans_name(spec1, spec2)
 
 
-def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
+def test_package_hash_cannot_get_details_from_ast(mock_packages, config):
     """Packages hash-test1 and hash-test3 would be considered the same
     except that hash-test3 conditionally executes a phase based on
     a "when" directive that Spack cannot evaluate by examining the
@@ -135,18 +136,38 @@ def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
     """
     spec3 = Spec("hash-test1@1.7").concretized()
     spec4 = Spec("hash-test3@1.7").concretized()
-    compare_hash_sans_name(False, spec3, spec4)
+    assert not package_hash_equal_sans_name(spec3, spec4)
 
 
-def test_content_hash_all_same_but_archive_hash(mock_packages, config):
+def test_package_hash_all_same_but_archive_hash(mock_packages, config):
     spec1 = Spec("hash-test1@1.3").concretized()
     spec2 = Spec("hash-test2@1.3").concretized()
-    compare_hash_sans_name(False, spec1, spec2)
+
+    assert package_hash_equal_sans_name(spec1, spec2)
+
+    # the sources for these two packages will not be the same b/c their archive hashes differ
+    assert spec1.to_node_dict()["sources"] != spec2.to_node_dict()["sources"]
+
+    assert spec1.dag_hash() != spec2.dag_hash()
 
 
-def test_content_hash_parse_dynamic_function_call(mock_packages, config):
+def test_package_hash_all_same_but_resources(mock_packages, config):
+    spec1 = Spec("hash-test1@1.7").concretized()
+    spec2 = Spec("hash-test1@1.8").concretized()
+
+    # these should be the same
+    assert canonical_source_equal_sans_name(spec1, spec2)
+    assert package_hash_equal_sans_name(spec1, spec2)
+
+    # but 1.7 has a resource that affects the hash
+    assert spec1.to_node_dict()["sources"] != spec2.to_node_dict()["sources"]
+
+    assert spec1.dag_hash() != spec2.dag_hash()
+
+
+def test_package_hash_parse_dynamic_function_call(mock_packages, config):
     spec = Spec("hash-test4").concretized()
-    spec.package.content_hash()
+    ph.package_hash(spec)
 
 
 many_strings = '''\

--- a/var/spack/repos/builtin.mock/packages/git-url-top-level/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-url-top-level/package.py
@@ -6,6 +6,11 @@
 from spack.package import *
 
 
+def use_submodules(pkg):
+    """test example of a submodule callback"""
+    return ["a", "b"]
+
+
 class GitUrlTopLevel(Package):
     """Mock package that top-level git and url attributes.
 
@@ -22,6 +27,7 @@ class GitUrlTopLevel(Package):
     # These resolve to git fetchers
     version("develop", branch="develop")
     version("submodules", submodules=True)
+    version("submodules_callback", submodules=use_submodules)
     version("3.4", commit="abc34")
     version("3.3", branch="releases/v3.3", commit="abc33")
     version("3.2", branch="releases/v3.2")

--- a/var/spack/repos/builtin.mock/packages/hash-test1/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test1/package.py
@@ -14,19 +14,26 @@ class HashTest1(Package):
     homepage = "http://www.hashtest1.org"
     url = "http://www.hashtest1.org/downloads/hashtest1-1.1.tar.bz2"
 
-    version("1.1", md5="a" * 32)
-    version("1.2", md5="b" * 32)
-    version("1.3", md5="c" * 32)
-    version("1.4", md5="d" * 32)
-    version("1.5", md5="d" * 32)
-    version("1.6", md5="e" * 32)
-    version("1.7", md5="f" * 32)
+    version("1.1", sha256="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+    version("1.4", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+    version("1.5", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+    version("1.6", sha256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+    version("1.7", sha256="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+    version("1.8", sha256="1111111111111111111111111111111111111111111111111111111111111111")
 
     patch("patch1.patch", when="@1.1")
     patch("patch2.patch", when="@1.4")
 
     variant("variantx", default=False, description="Test variant X")
     variant("varianty", default=False, description="Test variant Y")
+
+    resource(
+        url="http://www.example.com/example-1.0-resource.tar.gz",
+        sha256="abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+        when="@1.8",
+    )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         pass

--- a/var/spack/repos/builtin.mock/packages/hash-test1/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test1/package.py
@@ -14,14 +14,14 @@ class HashTest1(Package):
     homepage = "http://www.hashtest1.org"
     url = "http://www.hashtest1.org/downloads/hashtest1-1.1.tar.bz2"
 
-    version("1.1", sha256="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
-    version("1.4", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
-    version("1.5", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
-    version("1.6", sha256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-    version("1.7", sha256="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-    version("1.8", sha256="1111111111111111111111111111111111111111111111111111111111111111")
+    version("1.1", sha256="a" * 64)
+    version("1.2", sha256="b" * 64)
+    version("1.3", sha256="c" * 64)
+    version("1.4", sha256="d" * 64)
+    version("1.5", sha256="d" * 64)
+    version("1.6", sha256="e" * 64)
+    version("1.7", sha256="f" * 64)
+    version("1.8", sha256="1" * 64)
 
     patch("patch1.patch", when="@1.1")
     patch("patch2.patch", when="@1.4")
@@ -31,7 +31,7 @@ class HashTest1(Package):
 
     resource(
         url="http://www.example.com/example-1.0-resource.tar.gz",
-        sha256="abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+        sha256="abcd1234" * 8,
         when="@1.8",
     )
 

--- a/var/spack/repos/builtin.mock/packages/hash-test2/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test2/package.py
@@ -14,13 +14,13 @@ class HashTest2(Package):
     homepage = "http://www.hashtest2.org"
     url = "http://www.hashtest1.org/downloads/hashtest2-1.1.tar.bz2"
 
-    version("1.1", sha256="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    version("1.1", sha256="a" * 64)
+    version("1.2", sha256="b" * 64)
 
     # Source hash differs from hash-test1@1.3
-    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccf")
+    version("1.3", sha256=("c" * 63) + "f")
 
-    version("1.4", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+    version("1.4", sha256="d" * 64)
 
     patch("patch1.patch", when="@1.1")
 

--- a/var/spack/repos/builtin.mock/packages/hash-test2/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test2/package.py
@@ -14,10 +14,13 @@ class HashTest2(Package):
     homepage = "http://www.hashtest2.org"
     url = "http://www.hashtest1.org/downloads/hashtest2-1.1.tar.bz2"
 
-    version("1.1", md5="a" * 32)
-    version("1.2", md5="b" * 32)
-    version("1.3", md5="c" * 31 + "x")  # Source hash differs from hash-test1@1.3
-    version("1.4", md5="d" * 32)
+    version("1.1", sha256="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # Source hash differs from hash-test1@1.3
+    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccf")
+
+    version("1.4", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 
     patch("patch1.patch", when="@1.1")
 

--- a/var/spack/repos/builtin.mock/packages/hash-test3/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test3/package.py
@@ -14,11 +14,11 @@ class HashTest3(Package):
     homepage = "http://www.hashtest3.org"
     url = "http://www.hashtest1.org/downloads/hashtest3-1.1.tar.bz2"
 
-    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
-    version("1.5", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
-    version("1.6", sha256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
-    version("1.7", sha256="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+    version("1.2", sha256="b" * 64)
+    version("1.3", sha256="c" * 64)
+    version("1.5", sha256="d" * 64)
+    version("1.6", sha256="e" * 64)
+    version("1.7", sha256="f" * 64)
 
     variant("variantx", default=False, description="Test variant X")
     variant("varianty", default=False, description="Test variant Y")

--- a/var/spack/repos/builtin.mock/packages/hash-test3/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test3/package.py
@@ -14,11 +14,11 @@ class HashTest3(Package):
     homepage = "http://www.hashtest3.org"
     url = "http://www.hashtest1.org/downloads/hashtest3-1.1.tar.bz2"
 
-    version("1.2", md5="b" * 32)
-    version("1.3", md5="c" * 32)
-    version("1.5", md5="d" * 32)
-    version("1.6", md5="e" * 32)
-    version("1.7", md5="f" * 32)
+    version("1.2", sha256="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    version("1.3", sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+    version("1.5", sha256="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+    version("1.6", sha256="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+    version("1.7", sha256="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
     variant("variantx", default=False, description="Test variant X")
     variant("varianty", default=False, description="Test variant Y")


### PR DESCRIPTION
We've included a package hash in Spack since #7193 for CI, and we started using it on the spec in #28504. However, what goes into the package hash is opaque.

We want this information to be available *from the concrete spec* so that it can be retrieved as provenance *without* referring to a `package.py` file.  Why?

1. We want to be able to look up authoritative checksums, versions, etc. and pass them through scanners long *after* an installation takes place.
2. Right now you can look at the version on a `Spec`, then look up the checksum for a version from the `package.py`, but that's not reliable in the long term.  We may remove versions from `package.py` (in fact, we might want to as they become less relevant), and checksums for particular versions/releases may change over time.
3. Only the version is stored explicitly on the spec; that's not sufficient to know *exactly* what hashes a spec was built with.

Adding hashes explicitly gets around this and gets us closer to having all the information we need for a complete SBOM.

Here's what `spec.json` looked like before:

```json
{
  "spec": {
    "_meta": {
      "version": 3
    },
    "nodes": [
      {
        "name": "zlib",
        "version": "1.2.12",
        ...
        "patches": [
          "0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
        ],
        "package_hash": "pthf7iophdyonixxeed7gyqiksopxeklzzjbxtjrw7nzlkcqleba====",
        "hash": "ke4alug7ypoxp37jb6namwlxssmws4kp"
      }
    ]
  }
}
```

The `package_hash` there is a hash of the concatenation of:

* A canonical hash of the `package.py` recipe, as implemented in #28156;
* `sha256`'s of patches applied to the spec; and
* Archive `sha256` sums of archives or commits/revisions of repos used to build the spec.

There are some issues with this: patches are counted twice in this spec (in `patches` and in the `package_hash`), the hashes of sources used to build are conflated with the `package.py` hash, and we don't actually include resources anywhere.

With this PR, I've expanded the package hash out in the `spec.json` body. Here is the "same" spec with the new fields:

```json
{
  "spec": {
    "_meta": {
      "version": 3
    },
    "nodes": [
      {
        "name": "zlib",
        "version": "1.2.12",
        ...
        "package_hash": "6kkliqdv67ucuvfpfdwaacy5bz6s6en4",
        "sources": [
          {
            "type": "archive",
            "sha256": "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
          }
        ],
        "patches": [
          "0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
        ],
        "hash": "ts3gkpltbgzr5y6nrfy6rzwbjmkscein"
      }
    ]
  }
}
```

Now:

* Patches and archive hashes are no longer included in the `package_hash`;
* Artifacts used in the build go in `sources`, and we tell you their checksum in the `spec.json`;
* `sources` will include resources for packages that have it;
* Patches are the same as before -- but only represented once; and
* The `package_hash` is a base32-encoded `sha1`, like other hashes in Spack, and it only
  tells you that the `package.py` changed.

The behavior of the DAG hash (which includes the `package_hash`) is basically the same as before, except now resources are included, and we can see differences in archives and resources directly in the `spec.json`

Note that we do not need to bump the spec meta version on this, as past versions of Spack can still read the new specs; they just will not notice the new fields (which is fine, since we currently do not do anything with them).

Among other things, this will more easily allow us to convert Spack specs to SBOM and track relevant security information (like `sha256`'s of archives). For example, we could do continuous scanning of a Spack installation based on these hashes, and if the `sha256`'s become associated with CVE's, we'll know we're affected.  (@vsoch FYI)

- [x] Add a method, `spec_attrs()` to `FetchStrategy` that can be used to describe a fetcher for a `spec.json`.
- [x] Simplify the way package_hash() is handled in Spack. Previously, it was handled as a special-case spec hash in `hash_types.py`, but it really doesn't belong there. Now, it's handled as part of `Spec._finalize_concretization()` and `hash_types.py` is much simpler.
- [x] Change `PackageBase.content_hash()` to `PackageBase.artifact_hashes()`, and include more information about artifacts in it.
- [x] Update package hash tests and make them check for artifact and resource hashes.