### PR TITLE
eospac: support intel-classic@2021

### DIFF
--- a/var/spack/repos/builtin/packages/eospac/640-ic2021.patch
+++ b/var/spack/repos/builtin/packages/eospac/640-ic2021.patch
@@ -1,0 +1,17 @@
+--- a/Source/config/Makefile.-linux-gnu.hashes	2019-02-25 13:02:10.000000000 -0700
++++ b/Source/config/Makefile.-linux-gnu.hashes	2022-08-22 16:42:16.389092431 -0600
+@@ -214,6 +214,14 @@
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-19-haswell,       -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-19-knl,           -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
+ 
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx,         -qopenmp-simd -fp-speculation=safe -xAVX -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx2,        -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512,      -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512f,     -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512pf,    -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-haswell,     -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-knl,         -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++
+ ###  GNU Fortran:
+ GNU_DIAG_OPTIONS = -fopt-info-vec
+ $(call set,_F90-CPUINFO_COMP_FLAGS,gfortran-4-avx,         -ftree-vectorize -mavx -mno-fma -DDISABLE_OMP_SIMD_PRAGMA)

--- a/var/spack/repos/builtin/packages/eospac/641-ic2021.patch
+++ b/var/spack/repos/builtin/packages/eospac/641-ic2021.patch
@@ -1,0 +1,17 @@
+--- a/Source/config/Makefile.-linux-gnu.hashes	2020-09-01 19:26:51.000000000 -0600
++++ b/Source/config/Makefile.-linux-gnu.hashes	2022-08-22 16:45:19.266087035 -0600
+@@ -233,6 +233,14 @@
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-haswell,       -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-knl,           -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
+ 
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx,         -qopenmp-simd -fp-speculation=safe -xAVX -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx2,        -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512,      -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512f,     -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512pf,    -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-haswell,     -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-knl,         -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++
+ ###  GNU Fortran:
+ GNU_DIAG_OPTIONS = -fopt-info-vec
+ $(call set,_F90-CPUINFO_COMP_FLAGS,gfortran-4-avx,         -ftree-vectorize -mavx -mno-fma -DDISABLE_OMP_SIMD_PRAGMA)

--- a/var/spack/repos/builtin/packages/eospac/642-ic2021.patch
+++ b/var/spack/repos/builtin/packages/eospac/642-ic2021.patch
@@ -1,0 +1,17 @@
+--- a/Source/config/Makefile.-linux-gnu.hashes	2021-02-03 11:42:33.000000000 -0700
++++ b/Source/config/Makefile.-linux-gnu.hashes	2022-08-22 16:46:48.249084410 -0600
+@@ -242,6 +242,14 @@
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-haswell,       -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-knl,           -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
+ 
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx,         -qopenmp-simd -fp-speculation=safe -xAVX -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx2,        -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512,      -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512f,     -qopenmp-simd -fp-speculation=safe -xCOMMON-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512pf,    -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-haswell,     -qopenmp-simd -fp-speculation=safe -xCORE-AVX2 -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-knl,         -qopenmp-simd -fp-speculation=safe -xMIC-AVX512 -no-fma $(INTEL_DIAG_OPTIONS))
++
+ ###  GNU Fortran:
+ GNU_DIAG_OPTIONS = -fopt-info-vec
+ $(call set,_F90-CPUINFO_COMP_FLAGS,gfortran-4-avx,         -ftree-vectorize -mavx -mno-fma -DDISABLE_OMP_SIMD_PRAGMA)

--- a/var/spack/repos/builtin/packages/eospac/650-ic2021.patch
+++ b/var/spack/repos/builtin/packages/eospac/650-ic2021.patch
@@ -1,0 +1,17 @@
+--- a/Source/config/Makefile.-linux-gnu.hashes	2021-09-20 07:27:28.000000000 -0600
++++ b/Source/config/Makefile.-linux-gnu.hashes	2022-08-22 16:48:14.802081857 -0600
+@@ -336,6 +336,14 @@
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-haswell,       -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifort-20-knl,           -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
+ 
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx,         -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx2,        -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512,      -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512f,     -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-avx512pf,    -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-haswell,     -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++$(call set,_F90-CPUINFO_COMP_FLAGS,ifort-2021-knl,         -qopenmp-simd -fp-speculation=safe $(AVX_FLAGS) -no-fma $(INTEL_DIAG_OPTIONS))
++
+ ###  Intel OneAPI Fortran:
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifx-2021-avx,           -qopenmp-simd -fp-speculation=safe -xAVX           -no-fma $(INTEL_DIAG_OPTIONS))
+ $(call set,_F90-CPUINFO_COMP_FLAGS,ifx-2021-avx2,          -qopenmp-simd -fp-speculation=safe -xCORE-AVX2     -no-fma $(INTEL_DIAG_OPTIONS))

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -136,10 +136,7 @@ class Eospac(Package):
             if "%gcc@10:" in spec:
                 compilerArgs.append("CFLAGS=-fcommon")
             if self.run_tests:
-                make(
-                    "check",
-                    *compilerArgs
-                )
+                make("check", *compilerArgs)
             make(
                 "install",
                 "prefix={0}".format(prefix),

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -108,6 +108,12 @@ class Eospac(Package):
     # This patch corrects EOSPAC's selection of compiler flags when
     # compilers are specified using absolute pathnames.
     patch("cpuinfo_comp_flags_key.patch", when="@:6.4.1,6.4.2beta")
+    # This patchset corrects EOSPAC's selection of compiler flags when
+    # intel-classic@2021 is used.
+    patch("650-ic2021.patch", when="@6.5.0%intel")
+    patch("642-ic2021.patch", when="@6.4.2%intel")
+    patch("641-ic2021.patch", when="@6.4.1%intel")
+    patch("640-ic2021.patch", when="@6.4.0%intel")
 
     # GPU offload is only available for version 6.5+
     variant("offload", default=False, description="Build GPU offload library instead of standard")

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -135,6 +135,11 @@ class Eospac(Package):
             #   but gcc@10 flipped to default fno-common
             if "%gcc@10:" in spec:
                 compilerArgs.append("CFLAGS=-fcommon")
+            if self.run_tests:
+                make(
+                    "check",
+                    *compilerArgs
+                )
             make(
                 "install",
                 "prefix={0}".format(prefix),


### PR DESCRIPTION
This MR adds support for `intel-classic@2021` in the relevant GA releases.