### PR TITLE
openmpi: disable-per-user-config-files

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -904,7 +904,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = ["--enable-shared", "--disable-silent-rules"]
+        config_args = [
+            "--enable-shared",
+            "--disable-silent-rules",
+            "--disable-per-user-config-files",
+        ]
 
         # All rpath flags should be appended with self.compiler.cc_rpath_arg.
         # Later, we might need to update share/openmpi/mpic++-wrapper-data.txt


### PR DESCRIPTION
This feature requires `HOME` to be set, otherwise the compiler wrapper errors out.

```
$ env -i "PATH=$PATH" mpicc --version
 [nid003052:41640] Error: Unable to get the user home directory
 [nid003052:41640] Error: Unable to get the user home directory
 --------------------------------------------------------------------------
 It looks like opal_init failed for some reason;
 ```

Disabling it seems sensible.

(Could be a regression too by the way, only pops up when building `@main`).

