### PR TITLE
minc-toolkit: add MINC_TOOLKIT environment variable at runtime

### DIFF
--- a/var/spack/repos/builtin/packages/minc-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/minc-toolkit/package.py
@@ -43,3 +43,6 @@ class MincToolkit(CMakePackage):
             # should be packaged separately with newer ITK
             "-DMT_BUILD_ELASTIX=OFF",
         ]
+
+    def setup_run_environment(self, env):
+        env.set("MINC_TOOLKIT", self.prefix)


### PR DESCRIPTION
This variable is used by some programs both internal and external to the
toolkit itself to discover shared objects, data, etc.