### PR TITLE
add bug fix for geant4-10.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/geant4-10.7.2_bug2444.patch
+++ b/var/spack/repos/builtin/packages/geant4/geant4-10.7.2_bug2444.patch
@@ -1,0 +1,22 @@
+diff --git a/source/persistency/ascii/src/G4tgrEvaluator.cc b/source/persistency/ascii/src/G4tgrEvaluator.cc
+index 3e0e7de7a..d702b384f 100644
+--- a/source/persistency/ascii/src/G4tgrEvaluator.cc
++++ b/source/persistency/ascii/src/G4tgrEvaluator.cc
+@@ -70,7 +70,7 @@ G4double ftanh(G4double arg) { return std::tanh(arg); }
+ // G4double fasinh( G4double arg ){  return std::asinh(arg); }
+ // G4double facosh( G4double arg ){  return std::acosh(arg); }
+ // G4double fatanh( G4double arg ){  return std::atanh(arg); }
+-G4double fsqrt(G4double arg) { return std::sqrt(arg); }
++G4double fltsqrt(G4double arg) { return std::sqrt(arg); }
+ G4double fexp(G4double arg) { return std::exp(arg); }
+ G4double flog(G4double arg) { return std::log(arg); }
+ G4double flog10(G4double arg) { return std::log10(arg); }
+@@ -92,7 +92,7 @@ void G4tgrEvaluator::AddCommonFunctions()
+   //  setFunction("asinh", (*fasinh));
+   //  setFunction("acosh", (*facosh));
+   //  setFunction("atanh", (*fatanh));
+-  setFunction("sqrt", (*fsqrt));
++  setFunction("sqrt", (*fltsqrt));
+   setFunction("exp", (*fexp));
+   setFunction("log", (*flog));
+   setFunction("log10", (*flog10));

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -124,6 +124,8 @@ class Geant4(CMakePackage):
     depends_on("motif", when="+motif")
     depends_on("qt@5: +opengl", when="+qt")
 
+    # Fixes bug 2444 on 10.7.2: https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2444
+    patch("geant4-10.7.2_bug2444.patch", when="@10.7.2")
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.
     patch("CLHEP-10.03.03.patch", level=1, when="@10.3.3")


### PR DESCRIPTION
Added a simple patch to prevent compilation error of geant4-10.7.2 associated with bug 2444 (https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2444). This was fixed by geant4 in 10.7.3 release. 