### PR TITLE
New package: py-griffe and new build backend: py-pdm-pep517

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -50,8 +50,9 @@ important to understand.
    include `setuptools <https://setuptools.pypa.io/>`__,
    `flit <https://flit.pypa.io/>`_,
    `poetry <https://python-poetry.org/>`_,
-   `hatchling <https://hatch.pypa.io/latest/>`_, and
-   `meson <https://meson-python.readthedocs.io/>`_.
+   `hatchling <https://hatch.pypa.io/latest/>`_,
+   `meson <https://meson-python.readthedocs.io/>`_, and
+   `pdm <https://pdm.fming.dev/latest/>`_.
 
 ^^^^^^^^^^^
 Downloading
@@ -367,6 +368,16 @@ it uses the meson build system. Meson uses the default
 
 See https://meson-python.readthedocs.io/en/latest/usage/start.html
 for more information.
+
+"""
+pdm
+"""
+
+If the ``pyproject.toml`` lists ``pdm.pep517.api`` as the ``build-backend``,
+it uses the PDM build system. PDM uses the default ``pyproject.toml``
+keys to list dependencies.
+
+See https://pdm.fming.dev/latest/ for more information.
 
 """"""
 wheels
@@ -758,3 +769,4 @@ For more information on build backend tools, see:
 * poetry: https://python-poetry.org/
 * hatchling: https://hatch.pypa.io/latest/
 * meson: https://meson-python.readthedocs.io/
+* pdm: https://pdm.fming.dev/latest/

--- a/var/spack/repos/builtin/packages/py-griffe/package.py
+++ b/var/spack/repos/builtin/packages/py-griffe/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyGriffe(PythonPackage):
+    """Signatures for entire Python programs. Extract the structure, the frame,
+    the skeleton of your project, to generate API documentation or find
+    breaking changes in your API."""
+
+    homepage = "https://mkdocstrings.github.io/griffe/"
+    pypi = "griffe/griffe-0.22.0.tar.gz"
+
+    version("0.22.0", sha256="a3c25a2b7bf729ecee7cd455b4eff548f01c620b8f58a8097a800caad221f12e")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-pdm-pep517", type="build")
+    depends_on("py-cached-property", type=("build", "run"), when="^python@:3.7")

--- a/var/spack/repos/builtin/packages/py-pdm-pep517/package.py
+++ b/var/spack/repos/builtin/packages/py-pdm-pep517/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyPdmPep517(PythonPackage):
+    """A PEP 517 backend for PDM that supports PEP 621 metadata."""
+
+    homepage = "https://pdm.fming.dev/latest/"
+    pypi = "pdm-pep517/pdm-pep517-1.0.4.tar.gz"
+
+    version("1.0.4", sha256="392f8c2b47c6ec20550cb8e19e24b9dbd27373413f067b56ecd75f9767f93015")
+
+    depends_on("python@3.7:", type=("build", "run"))


### PR DESCRIPTION
griffe requires a build backend, pdm-pep517, which I have never heard of. I added both packages in this PR for more context, but I can create separate PRs if necessary. Do I need to add a few sentences to the build backend section of the PythonPackage docs?