### PR TITLE
Update LLVM post-install steps.

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -779,7 +779,7 @@ class Llvm(CMakePackage, CudaPackage):
         if "+python" in spec and "+clang" in spec:
                 install_tree(
                     "clang/bindings/python/clang",
-                    join_path(site_packages_dir, "clang")
+                    join_path(site_packages_dir, "clang"))
 
         with working_dir(self.build_directory):
             if not os.path.exists(join_path(self.prefix, "libexec", "llvm")):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -776,14 +776,14 @@ class Llvm(CMakePackage, CudaPackage):
                 cmake(*cmake_args)
                 ninja()
                 ninja("install")
-        if "+python" in self.spec:
-            install_tree("llvm/bindings/python", python_platlib)
-
-            if "+clang" in self.spec:
-                install_tree("clang/bindings/python", python_platlib)
+        if "+python" in spec and "+clang" in spec:
+                install_tree(
+                    "clang/bindings/python/clang",
+                    join_path(site_packages_dir, "clang")
 
         with working_dir(self.build_directory):
-            install_tree("bin", join_path(self.prefix, "libexec", "llvm"))
+            if not os.path.exists(join_path(self.prefix, "libexec", "llvm")):
+                install_tree("bin", join_path(self.prefix, "libexec", "llvm"))
 
     def llvm_config(self, *args, **kwargs):
         lc = Executable(self.prefix.bin.join("llvm-config"))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -777,9 +777,9 @@ class Llvm(CMakePackage, CudaPackage):
                 ninja()
                 ninja("install")
         if "+python" in spec and "+clang" in spec:
-                install_tree(
-                    "clang/bindings/python/clang",
-                    join_path(site_packages_dir, "clang"))
+            install_tree(
+                "clang/bindings/python/clang",
+                join_path(site_packages_dir, "clang"))
 
         with working_dir(self.build_directory):
             if not os.path.exists(join_path(self.prefix, "libexec", "llvm")):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -777,9 +777,7 @@ class Llvm(CMakePackage, CudaPackage):
                 ninja()
                 ninja("install")
         if "+python" in spec and "+clang" in spec:
-            install_tree(
-                "clang/bindings/python/clang",
-                join_path(site_packages_dir, "clang"))
+            install_tree("clang/bindings/python/clang", join_path(site_packages_dir, "clang"))
 
         with working_dir(self.build_directory):
             if not os.path.exists(join_path(self.prefix, "libexec", "llvm")):


### PR DESCRIPTION
I have run into issues with the LLVM installation with Spack.  

One involves the attempt to install files from the bin directory of the build stage to the prefix/libexec/llvm directory of the installation when those files already exist.  A check was added to skip this error-causing code if it isn't necessary.

Another involves issues with the python and clang bindings section.  My builds have not needed the python binding installation and needed the clang bindings in a slightly different place.  I have been building with these changes in a separate package repo, but this led to its own issues where the `python_platlib` variable pulled from the python `setup_dependent_build` function wasn't available if the LLVM package existed in the separate package repo (noted in issue #32336 ).

@becker33 