### PR TITLE
libfabric: Match main version.

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -109,7 +109,7 @@ class Libfabric(AutotoolsPackage):
         if self.run_tests:
             env.prepend_path("PATH", self.prefix.bin)
 
-    @when("@develop")
+    @when("@main")
     def autoreconf(self, spec, prefix):
         bash = which("bash")
         bash("./autogen.sh")

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -97,10 +97,10 @@ class Libfabric(AutotoolsPackage):
     depends_on("psm", when="fabrics=psm")
     depends_on("ucx", when="fabrics=mlx")
 
-    depends_on("m4", when="@develop", type="build")
-    depends_on("autoconf", when="@develop", type="build")
-    depends_on("automake", when="@develop", type="build")
-    depends_on("libtool", when="@develop", type="build")
+    depends_on("m4", when="@main", type="build")
+    depends_on("autoconf", when="@main", type="build")
+    depends_on("automake", when="@main", type="build")
+    depends_on("libtool", when="@main", type="build")
 
     conflicts("@1.9.0", when="platform=darwin", msg="This distribution is missing critical files")
     conflicts("fabrics=opx", when="@:1.14.99")


### PR DESCRIPTION
`develop` no loger exists.