### PR TITLE
minc-toolkit: add runtime flex dependency

### DIFF
--- a/var/spack/repos/builtin/packages/minc-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/minc-toolkit/package.py
@@ -27,7 +27,7 @@ class MincToolkit(CMakePackage):
     depends_on("perl-text-format", type=("build", "run"))
     depends_on("perl-getopt-tabular", type=("build", "run"))
     depends_on("perl-mni-perllib", type=("build", "run"))
-    depends_on("flex", type="build")
+    depends_on("flex", type=("build", "run"))  # e.g minccalc depends on libfl.so
     depends_on("bison", type="build")
     depends_on("zlib", type="link")
     depends_on("freeglut", when="+visualisation")


### PR DESCRIPTION
Some programs such as `minccalc` depend on libfl.so at runtime.