### PR TITLE
cp2k: libcp2k.pc check

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -761,20 +761,21 @@ class Cp2k(MakefilePackage, CudaPackage):
         In case such approach causes issues in the future, it might be necessary
         to generate and override entire libcp2k.pc.
         """
-        with open(join_path(self.prefix.lib.pkgconfig, "libcp2k.pc"), "r+") as handle:
-            content = handle.read().rstrip()
+        if self.spec.satisfies("@9.1:"):
+            with open(join_path(self.prefix.lib.pkgconfig, "libcp2k.pc"), "r+") as handle:
+                content = handle.read().rstrip()
 
-            content += " " + self.spec["blas"].libs.ld_flags
-            content += " " + self.spec["lapack"].libs.ld_flags
-            content += " " + self.spec["fftw-api"].libs.ld_flags
+                content += " " + self.spec["blas"].libs.ld_flags
+                content += " " + self.spec["lapack"].libs.ld_flags
+                content += " " + self.spec["fftw-api"].libs.ld_flags
 
-            if "^fftw+openmp" in self.spec:
-                content += " -lfftw3_omp"
+                if "^fftw+openmp" in self.spec:
+                    content += " -lfftw3_omp"
 
-            content += "\n"
+                content += "\n"
 
-            handle.seek(0)
-            handle.write(content)
+                handle.seek(0)
+                handle.write(content)
 
     def check(self):
         data_dir = join_path(self.stage.source_path, "data")


### PR DESCRIPTION
Installing `cp2k@7.1` throws the following error - 

```
==> [2022-08-22-13:30:49.281263] Error: FileNotFoundError: [Errno 2] No such file or directory: '/home/amd/JENKINS/workspace/spack_wrkspc_hpctoolchainapps/spack/opt/spack/linux-rhel8-zen3/aocc-3.2.0/cp2k-7.1-txuhfqm3tyvi6s3zdtt23e233szn22mm/lib/pkgconfig/libcp2k.pc'

/home/amd/JENKINS/workspace/spack_wrkspc_hpctoolchainapps/spack/var/spack/repos/builtin/packages/cp2k/package.py:764, in fix_package_config:
        761        In case such approach causes issues in the future, it might be necessary
        762        to generate and override entire libcp2k.pc.
        763        """
  >>    764        with open(join_path(self.prefix.lib.pkgconfig, "libcp2k.pc"), "r+") as handle:
        765            content = handle.read().rstrip()
        766
        767            content += " " + self.spec["blas"].libs.ld_flags

See build log for details:
  /home/amd/JENKINS/workspace/spack_wrkspc_hpctoolchainapps/TEMP_SPACK/spack-stage/spack-stage-cp2k-7.1-txuhfqm3tyvi6s3zdtt23e233szn22mm/spack-build-out.txt
```

Turns out `libcp2k.pc` is not generated for versions 8.1 and below. This PR fixes this issue.

Command to reproduce the error - `spack install cp2k@8.1~mpi`