### PR TITLE
lammps: added build dependency to py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -294,6 +294,7 @@ class Lammps(CMakePackage, CudaPackage):
     depends_on("py-cython", when="+ml-iap+python")
     depends_on("py-numpy", when="+mliap+python")
     depends_on("py-numpy", when="+ml-iap+python")
+    depends_on("py-setuptools", when="@20220217:+python", type="build")
 
     conflicts("+cuda", when="+opencl")
     conflicts("+body", when="+poems@:20180628")


### PR DESCRIPTION
LAMMPS' setup.py uses setuptools as of lammps/lammps@2ed8e5cf022. For some reason, installing `lammps+python` did not report a failed build if setuptools was missing, causing an incomplete install.

Question: when built with python bindings, LAMMPS does not `extends("python")`, should it?