### PR TITLE
ASP-based solver: prevent the use of hashes that are not available

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1059,6 +1059,11 @@ no_flags(Package, FlagType)
 % you can't choose an installed hash for a dev spec
 :- hash(Package, Hash), variant_value(Package, "dev_path", _).
 
+% You can't install a hash, if it is not installed
+:- hash(Package, Hash), not installed_hash(Package, Hash).
+% This should be redundant given the constraint above
+:- hash(Package, Hash1), hash(Package, Hash2), Hash1 != Hash2.
+
 % if a hash is selected, we impose all the constraints that implies
 impose(Hash) :- hash(Package, Hash).
 


### PR DESCRIPTION
fixes #32348