### PR TITLE
Bug fix for esmf@8.3.0b09 with PIO

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -19,7 +19,7 @@ class Esmf(MakefilePackage):
     url = "https://github.com/esmf-org/esmf/archive/ESMF_8_0_1.tar.gz"
     git = "https://github.com/esmf-org/esmf.git"
 
-    maintainers = ["climbfuji"]
+    maintainers = ["climbfuji", "jedwards4b"]
 
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
@@ -65,10 +65,22 @@ class Esmf(MakefilePackage):
         when="@8.3:",
     )
     variant(
+        "parallelio",
+        default=False,
+        description="Build with external parallelio library",
+        when="@8.3.b09",
+    )
+    variant(
         "pio",
         default=True,
         description="Enable Internal ParallelIO support",
         when="@:8.2.99",
+    )
+    variant(
+        "pio",
+        default=True,
+        description="Enable Internal ParallelIO support",
+        when="@8.3.0b09",
     )
     variant("debug", default=False, description="Make a debuggable version of the library")
 


### PR DESCRIPTION
ESMF 8.3.0 beta snapshot 9 (`esmf@8.3.0b09`) uses internal Parallel IO code, similar to releases 8.2.0 and earlier. The behavior changed for more recent beta snapshots of ESMF 8.3.0 and for the official 8.3.0 release.

This PR fixes a bug in the current ESMF package so that the Parallel IO logic in `esmf@8.3.0b09` is handled like in versions 8.2.0 and earlier. It also adds @jedwards4b to the list of maintainers of the package.