### PR TITLE
Parallel testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,6 +29,7 @@ max-line-length = 99
 #
 per-file-ignores =
   var/spack/repos/*/package.py:F403,F405,F821
+  *-ci-package.py:F403,F405,F821
 
 # exclude things we usually do not want linting for.
 # These still get linted when passed explicitly, as when spack flake8 passes

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -11,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: audit-${{inputs.python_version}}-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: audit-${{inputs.python_version}}-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,44 @@
+name: audit
+
+on:
+  workflow_call:
+    inputs:
+      with_coverage:
+        required: true
+        type: string
+      python_version:
+        required: true
+        type: string
+
+concurrency:
+  group: audit-${{inputs.python_version}}-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  cancel-in-progress: true
+
+jobs:
+  # Run audits on all the packages in the built-in repository
+  package-audits:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
+    - uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # @v2
+      with:
+        python-version: ${{inputs.python_version}}
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip six setuptools pytest codecov 'coverage[toml]<=6.2'
+    - name: Package audits (with coverage)
+      if: ${{ inputs.with_coverage == 'true' }}
+      run: |
+          . share/spack/setup-env.sh
+          coverage run $(which spack) audit packages
+          coverage combine
+          coverage xml
+    - name: Package audits (without coverage)
+      if: ${{ inputs.with_coverage == 'false' }}
+      run: |
+          . share/spack/setup-env.sh
+          $(which spack) audit packages
+    - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # @v2.1.0
+      if: ${{ inputs.with_coverage == 'true' }}
+      with:
+        flags: unittests,linux,audits

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -11,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: audit-${{inputs.python_version}}-${{github.ref}}-${{github.run_number}}
+  group: audit-${{inputs.python_version}}-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,7 +9,7 @@ on:
     - cron: '16 2 * * *'
 
 concurrency:
-  group: bootstrap-${{github.ref}}-${{github.run_number}}
+  group: bootstrap-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,7 +9,7 @@ on:
     - cron: '16 2 * * *'
 
 concurrency:
-  group: bootstrap-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: bootstrap-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -20,7 +20,7 @@ on:
     types: [published]
 
 concurrency:
-  group: build_containers--${{github.ref}}-${{github.run_number}}
+  group: build_containers--${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -20,7 +20,7 @@ on:
     types: [published]
 
 concurrency:
-  group: build_containers--${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
+  group: build_containers-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -20,7 +20,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: build_containers--${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
             - 'share/spack/**'
             - '.github/workflows/bootstrap.yml'
             core:
+            - '!lib/spack/docs/**'
             - './!(var/**)/**'
             packages:
             - 'var/**'
@@ -79,7 +80,7 @@ jobs:
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/bootstrap.yml
   unit-tests:
-    if: ${{ github.repository == 'spack/spack' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/unit_tests.yaml
     with:
@@ -87,7 +88,7 @@ jobs:
       packages: ${{ needs.changes.outputs.packages }}
       with_coverage: ${{ needs.changes.outputs.with_coverage }}
   windows:
-    if: ${{ github.repository == 'spack/spack' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
     needs: [ prechecks ]
     uses: ./.github/workflows/windows_python.yml
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
     needs: [ prechecks ]
     uses: ./.github/workflows/windows_python.yml
   all:
-    needs: [ windows, unit-tests, bootstrap ]
+    needs: [ windows, unit-tests, bootstrap, audit-ancient-python ]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,18 @@ jobs:
     uses: ./.github/workflows/valid-style.yml
     with:
       with_coverage: ${{ needs.changes.outputs.with_coverage }}
+  audit-ancient-python:
+    uses: ./.github/workflows/audit.yaml
+    needs: [ changes ]
+    with:
+      with_coverage: ${{ needs.changes.outputs.with_coverage }}
+      python_version: 2.7
+  all-prechecks:
+    needs: [ prechecks ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
   # Check which files have been updated by the PR
   changes:
     runs-on: ubuntu-latest
@@ -91,4 +103,10 @@ jobs:
     if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
     needs: [ prechecks ]
     uses: ./.github/workflows/windows_python.yml
+  all:
+    needs: [ windows, unit-tests, bootstrap ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
       - releases/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: ci-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
       - releases/**
 
 concurrency:
-  group: ci-${{github.ref}}-${{github.run_number}}
+  group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -15,7 +15,7 @@ on:
         type: string
 
 concurrency:
-  group: unit_tests-${{github.ref}}-${{github.run_number}}
+  group: unit_tests-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,6 +1,7 @@
 name: unit tests
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       core:
@@ -25,11 +26,26 @@ jobs:
       matrix:
         python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
         concretizer: ['clingo']
+        on_develop:
+        - ${{ github.ref == 'refs/heads/develop' }}
         include:
         - python-version: 2.7
           concretizer: original
+          on_develop: false
         - python-version: '3.10'
           concretizer: original
+          on_develop: false
+        exclude:
+        - python-version: '3.7'
+          concretizer: 'clingo'
+          on_develop: false
+        - python-version: '3.8'
+          concretizer: 'clingo'
+          on_develop: false
+        - python-version: '3.9'
+          concretizer: 'clingo'
+          on_develop: false
+
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
       with:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -15,7 +15,7 @@ on:
         type: string
 
 concurrency:
-  group: unit_tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: unit_tests-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -46,11 +46,11 @@ jobs:
               patchelf cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov "coverage[toml]<=6.2"
+          pip install --upgrade pip six setuptools pytest codecov "coverage[toml]<=6.2" pytest-xdist
           # ensure style checks are not skipped in unit tests for python >= 3.6
           # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
           if python -c 'import sys; sys.exit(not sys.version_info >= (3, 6))'; then
-              pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click==8.0.4" "black<=21.12b0" pytest-xdist
+              pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click==8.0.4" "black<=21.12b0"
           fi
     - name: Pin pathlib for Python 2.7
       if: ${{ matrix.python-version == 2.7 }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -28,7 +28,7 @@ jobs:
         include:
         - python-version: 2.7
           concretizer: original
-        - python-version: 3.9
+        - python-version: '3.10'
           concretizer: original
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
@@ -50,7 +50,7 @@ jobs:
           # ensure style checks are not skipped in unit tests for python >= 3.6
           # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
           if python -c 'import sys; sys.exit(not sys.version_info >= (3, 6))'; then
-              pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click==8.0.4" "black<=21.12b0"
+              pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click==8.0.4" "black<=21.12b0" pytest-xdist
           fi
     - name: Pin pathlib for Python 2.7
       if: ${{ matrix.python-version == 2.7 }}
@@ -108,7 +108,7 @@ jobs:
           sudo apt-get install -y coreutils kcov csh zsh tcsh fish dash bash
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2
+          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2 pytest-xdist
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -174,7 +174,7 @@ jobs:
               patchelf kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2 clingo
+          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2 clingo pytest-xdist
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -216,7 +216,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
-          pip install --upgrade pytest codecov coverage[toml]==6.2
+          pip install --upgrade pytest codecov coverage[toml]==6.2 pytest-xdist
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov
@@ -229,9 +229,10 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap untrust spack-install
         $(which spack) solve zlib
+        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
         if [ "${{ inputs.with_coverage }}" == "true" ]
         then
-          coverage run $(which spack) unit-test -x
+          coverage run $(which spack) unit-test "${common_args[@]}"
           coverage combine
           coverage xml
           # Delete the symlink going from ./lib/spack/docs/_spack_root back to
@@ -239,7 +240,7 @@ jobs:
           rm lib/spack/docs/_spack_root
         else
           echo "ONLY PACKAGE RECIPES CHANGED [skipping coverage]"
-          $(which spack) unit-test -x -m "not maybeslow" -k "test_all_virtual_packages_have_default_providers"
+          $(which spack) unit-test "${common_args[@]}" -m "not maybeslow" -k "test_all_virtual_packages_have_default_providers"
         fi
     - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # @v2.1.0
       if: ${{ inputs.with_coverage == 'true' }}

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: style-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: style-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: style-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 
@@ -53,30 +53,8 @@ jobs:
     - name: Run style tests
       run: |
           share/spack/qa/run-style-tests
-  # Run audits on all the packages in the built-in repository
-  package-audits:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
-    - uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # @v2
-      with:
-        python-version: '3.10'
-    - name: Install Python packages
-      run: |
-        pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2
-    - name: Package audits (with coverage)
-      if: ${{ inputs.with_coverage == 'true' }}
-      run: |
-          . share/spack/setup-env.sh
-          coverage run $(which spack) audit packages
-          coverage combine
-          coverage xml
-    - name: Package audits (without coverage)
-      if: ${{ inputs.with_coverage == 'false' }}
-      run: |
-          . share/spack/setup-env.sh
-          $(which spack) audit packages
-    - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # @v2.1.0
-      if: ${{ inputs.with_coverage == 'true' }}
-      with:
-        flags: unittests,linux,audits
+  audit:
+    uses: ./.github/workflows/audit.yaml
+    with:
+      with_coverage: ${{ inputs.with_coverage }}
+      python_version: '3.10'

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: style-${{github.ref}}-${{github.run_number}}
+  group: style-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: windows-${{github.ref}}-${{github.run_number}}
+  group: windows-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
+  group: windows-${{github.ref}}-${{github.run_number}}
   cancel-in-progress: true
 
 defaults:

--- a/bin/spack-tmpconfig
+++ b/bin/spack-tmpconfig
@@ -7,7 +7,6 @@ export TMPDIR="${XDG_RUNTIME_DIR}"
 export TMP_DIR="$(mktemp -d -t spack-test-XXXXX)"
 clean_up() {
     [[ -n "$TMPCONFIG_DEBUG" ]] && printf "cleaning up: $TMP_DIR\n"
-    [[ -n "$TMPCONFIG_DEBUG" ]] && tree "$TMP_DIR"
     rm -rf "$TMP_DIR"
 }
 trap clean_up EXIT

--- a/lib/spack/llnl/util/tty/pty.py
+++ b/lib/spack/llnl/util/tty/pty.py
@@ -228,8 +228,8 @@ class PseudoShell(object):
         self.minion_function = minion_function
 
         # these can be optionally set to change defaults
-        self.controller_timeout = 1
-        self.sleep_time = 0
+        self.controller_timeout = 3
+        self.sleep_time = 0.1
 
     def start(self, **kwargs):
         """Start the controller and minion processes.

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -31,6 +31,12 @@ def setup_parser(subparser):
     )
     subparser.add_argument("-c", dest="python_command", help="command to execute")
     subparser.add_argument(
+        "-u",
+        dest="unbuffered",
+        action="store_true",
+        help="for compatibility with xdist, do not use without adding -u to the interpreter",
+    )
+    subparser.add_argument(
         "-i",
         dest="python_interpreter",
         help="python interpreter",

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -18,6 +18,7 @@ import os.path
 import pstats
 import re
 import signal
+import subprocess as sp
 import sys
 import traceback
 import warnings
@@ -623,15 +624,17 @@ class SpackCommand(object):
     their output.
     """
 
-    def __init__(self, command_name):
+    def __init__(self, command_name, subprocess=False):
         """Create a new SpackCommand that invokes ``command_name`` when called.
 
         Args:
             command_name (str): name of the command to invoke
+            subprocess (bool): whether to fork a subprocess or not
         """
         self.parser = make_argument_parser()
         self.command = self.parser.add_command(command_name)
         self.command_name = command_name
+        self.subprocess = subprocess
 
     def __call__(self, *argv, **kwargs):
         """Invoke this SpackCommand.
@@ -656,25 +659,36 @@ class SpackCommand(object):
         self.error = None
 
         prepend = kwargs["global_args"] if "global_args" in kwargs else []
-
-        args, unknown = self.parser.parse_known_args(prepend + [self.command_name] + list(argv))
-
         fail_on_error = kwargs.get("fail_on_error", True)
 
-        out = StringIO()
-        try:
-            with log_output(out):
-                self.returncode = _invoke_command(self.command, self.parser, args, unknown)
+        if self.subprocess:
+            p = sp.Popen(
+                [spack.paths.spack_script, self.command_name] + prepend + list(argv),
+                stdout=sp.PIPE,
+                stderr=sp.STDOUT,
+            )
+            out, self.returncode = p.communicate()
+            out = out.decode()
+        else:
+            args, unknown = self.parser.parse_known_args(
+                prepend + [self.command_name] + list(argv)
+            )
 
-        except SystemExit as e:
-            self.returncode = e.code
+            out = StringIO()
+            try:
+                with log_output(out):
+                    self.returncode = _invoke_command(self.command, self.parser, args, unknown)
 
-        except BaseException as e:
-            tty.debug(e)
-            self.error = e
-            if fail_on_error:
-                self._log_command_output(out)
-                raise
+            except SystemExit as e:
+                self.returncode = e.code
+
+            except BaseException as e:
+                tty.debug(e)
+                self.error = e
+                if fail_on_error:
+                    self._log_command_output(out)
+                    raise
+            out = out.getvalue()
 
         if fail_on_error and self.returncode not in (None, 0):
             self._log_command_output(out)
@@ -683,7 +697,7 @@ class SpackCommand(object):
                 % (self.returncode, self.command_name, ", ".join("'%s'" % a for a in argv))
             )
 
-        return out.getvalue()
+        return out
 
     def _log_command_output(self, out):
         if tty.is_verbose():

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -634,7 +634,8 @@ class SpackCommand(object):
         self.parser = make_argument_parser()
         self.command = self.parser.add_command(command_name)
         self.command_name = command_name
-        self.subprocess = subprocess
+        # TODO: figure out how to support this on windows
+        self.subprocess = subprocess if sys.platform != "win32" else False
 
     def __call__(self, *argv, **kwargs):
         """Invoke this SpackCommand.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -629,7 +629,8 @@ class SpackCommand(object):
 
         Args:
             command_name (str): name of the command to invoke
-            subprocess (bool): whether to fork a subprocess or not
+            subprocess (bool): whether to fork a subprocess or not. Currently not supported on 
+                Windows, where it is always False.
         """
         self.parser = make_argument_parser()
         self.command = self.parser.add_command(command_name)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -629,7 +629,7 @@ class SpackCommand(object):
 
         Args:
             command_name (str): name of the command to invoke
-            subprocess (bool): whether to fork a subprocess or not. Currently not supported on 
+            subprocess (bool): whether to fork a subprocess or not. Currently not supported on
                 Windows, where it is always False.
         """
         self.parser = make_argument_parser()

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -484,6 +484,7 @@ def test_get_spec_filter_list(mutable_mock_env_path, config, mutable_mock_repo):
     assert affected_pkg_names == expected_affected_pkg_names
 
 
+@pytest.mark.maybeslow
 @pytest.mark.regression("29947")
 def test_affected_specs_on_first_concretization(mutable_mock_env_path, config):
     e = ev.create("first_concretization")

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -50,12 +50,14 @@ def test_checksum(arguments, expected, mock_packages, mock_stage):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_checksum_interactive(mock_packages, mock_fetch, mock_stage, monkeypatch):
+    # TODO: mock_fetch doesn't actually work with stage, working around with ignoring
+    # fail_on_error for now
     def _get_number(*args, **kwargs):
         return 1
 
     monkeypatch.setattr(tty, "get_number", _get_number)
 
-    output = spack_checksum("preferred-test")
+    output = spack_checksum("preferred-test", fail_on_error=False)
     assert "version of preferred-test" in output
     assert "version(" in output
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2192,10 +2192,8 @@ spack:
 )
 def test_ci_help(subcmd, capsys):
     """Make sure `spack ci` --help describes the (sub)command help."""
-    with pytest.raises(SystemExit):
-        ci_cmd(subcmd, "--help")
+    out = spack.main.SpackCommand("ci", subprocess=True)(subcmd, "--help")
 
-    out = str(capsys.readouterr())
     usage = "usage: spack ci {0}{1}[".format(subcmd, " " if subcmd else "")
     assert usage in out
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -16,7 +16,7 @@ import spack.main
 import spack.paths
 from spack.cmd.commands import _positional_to_subroutine
 
-commands = spack.main.SpackCommand("commands")
+commands = spack.main.SpackCommand("commands", subprocess=True)
 
 parser = spack.main.make_argument_parser()
 spack.main.add_all_commands(parser)
@@ -104,17 +104,18 @@ _cmd-spack-install:
 
 
 def test_rst_with_header(tmpdir):
+    local_commands = spack.main.SpackCommand("commands")
     fake_header = "this is a header!\n\n"
 
     filename = tmpdir.join("header.txt")
     with filename.open("w") as f:
         f.write(fake_header)
 
-    out = commands("--format=rst", "--header", str(filename))
+    out = local_commands("--format=rst", "--header", str(filename))
     assert out.startswith(fake_header)
 
     with pytest.raises(spack.main.SpackCommandError):
-        commands("--format=rst", "--header", "asdfjhkf")
+        local_commands("--format=rst", "--header", "asdfjhkf")
 
 
 def test_rst_update(tmpdir):
@@ -207,13 +208,14 @@ def test_update_completion_arg(tmpdir, monkeypatch):
 
     monkeypatch.setattr(spack.cmd.commands, "update_completion_args", mock_args)
 
+    local_commands = spack.main.SpackCommand("commands")
     # ensure things fail if --update-completion isn't specified alone
     with pytest.raises(spack.main.SpackCommandError):
-        commands("--update-completion", "-a")
+        local_commands("--update-completion", "-a")
 
     # ensure arg is restored
     assert "--update-completion" not in mock_bashfile.read()
-    commands("--update-completion")
+    local_commands("--update-completion")
     assert "--update-completion" in mock_bashfile.read()
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -869,7 +869,7 @@ def test_env_with_included_config_var_path(packages_file):
 
     config_real_path = substitute_path_variables(config_var_path)
     fs.mkdirp(os.path.dirname(config_real_path))
-    fs.rename(packages_file.strpath, config_real_path)
+    shutil.move(packages_file.strpath, config_real_path)
     assert os.path.exists(config_real_path)
 
     with e:

--- a/lib/spack/spack/test/cmd/help.py
+++ b/lib/spack/spack/test/cmd/help.py
@@ -11,7 +11,7 @@ from spack.main import SpackCommand
 @pytest.mark.xfail
 def test_reuse_after_help():
     """Test `spack help` can be called twice with the same SpackCommand."""
-    help_cmd = SpackCommand("help")
+    help_cmd = SpackCommand("help", subprocess=True)
     help_cmd()
 
     # This second invocation will somehow fail because the parser no
@@ -30,14 +30,14 @@ def test_reuse_after_help():
 
 def test_help():
     """Sanity check the help command to make sure it works."""
-    help_cmd = SpackCommand("help")
+    help_cmd = SpackCommand("help", subprocess=True)
     out = help_cmd()
     assert "These are common spack commands:" in out
 
 
 def test_help_all():
     """Test the spack help --all flag"""
-    help_cmd = SpackCommand("help")
+    help_cmd = SpackCommand("help", subprocess=True)
     out = help_cmd("--all")
     assert "Complete list of spack commands:" in out
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -210,7 +210,7 @@ def test_setdefault_command(mutable_database, mutable_config):
     for k in preferred, other_spec:
         assert os.path.exists(writers[k].layout.filename)
     assert os.path.exists(link_name) and os.path.islink(link_name)
-    assert os.path.realpath(link_name) == writers[other_spec].layout.filename
+    assert os.path.realpath(link_name) == os.path.realpath(writers[other_spec].layout.filename)
 
     # Reset the default to be the preferred spec
     module("lmod", "setdefault", preferred)
@@ -219,4 +219,4 @@ def test_setdefault_command(mutable_database, mutable_config):
     for k in preferred, other_spec:
         assert os.path.exists(writers[k].layout.filename)
     assert os.path.exists(link_name) and os.path.islink(link_name)
-    assert os.path.realpath(link_name) == writers[preferred].layout.filename
+    assert os.path.realpath(link_name) == os.path.realpath(writers[preferred].layout.filename)

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -139,7 +139,10 @@ def test_changed_files_all_files():
 
     # a builtin package
     zlib = spack.repo.path.get_pkg_class("zlib")
-    assert zlib.module.__file__ in files
+    zlib_file = zlib.module.__file__
+    if zlib_file.endswith("pyc"):
+        zlib_file = zlib_file[:-1]
+    assert zlib_file in files
 
     # a core spack file
     assert os.path.join(spack.paths.module_path, "spec.py") in files

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -71,20 +71,17 @@ def flake8_package_with_errors(scope="function"):
     filename = repo.filename_for_package_name("flake8")
     tmp = filename + ".tmp"
 
-    try:
-        shutil.copy(filename, tmp)
-        package = FileFilter(filename)
+    shutil.copy(filename, tmp)
+    package = FileFilter(tmp)
 
-        # this is a black error (quote style and spacing before/after operator)
-        package.filter('state = "unmodified"', "state    =    'modified'", string=True)
+    # this is a black error (quote style and spacing before/after operator)
+    package.filter('state = "unmodified"', "state    =    'modified'", string=True)
 
-        # this is an isort error (orderign) and a flake8 error (unused import)
-        package.filter(
-            "from spack.package import *", "from spack.package import *\nimport os", string=True
-        )
-        yield filename
-    finally:
-        shutil.move(tmp, filename)
+    # this is an isort error (orderign) and a flake8 error (unused import)
+    package.filter(
+        "from spack.package import *", "from spack.package import *\nimport os", string=True
+    )
+    yield tmp
 
 
 def test_changed_files_from_git_rev_base(tmpdir, capfd):

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -46,22 +46,22 @@ skip_old_python = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="function")
-def flake8_package():
+def flake8_package(tmpdir):
     """Style only checks files that have been modified. This fixture makes a small
     change to the ``flake8`` mock package, yields the filename, then undoes the
     change on cleanup.
     """
     repo = spack.repo.Repo(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("flake8")
-    tmp = filename + ".tmp"
+    rel_path = os.path.dirname(os.path.relpath(filename, spack.paths.prefix))
+    tmp = tmpdir / rel_path / "flake8-ci-package.py"
+    tmp.ensure()
+    tmp = str(tmp)
 
-    try:
-        shutil.copy(filename, tmp)
-        package = FileFilter(filename)
-        package.filter("state = 'unmodified'", "state = 'modified'", string=True)
-        yield filename
-    finally:
-        shutil.move(tmp, filename)
+    shutil.copy(filename, tmp)
+    package = FileFilter(tmp)
+    package.filter("state = 'unmodified'", "state = 'modified'", string=True)
+    yield tmp
 
 
 @pytest.fixture
@@ -125,7 +125,7 @@ def test_changed_no_base(tmpdir, capfd):
         assert "This repository does not have a 'foobar'" in err
 
 
-def test_changed_files_all_files(flake8_package):
+def test_changed_files_all_files():
     # it's hard to guarantee "all files", so do some sanity checks.
     files = set(
         [
@@ -145,7 +145,9 @@ def test_changed_files_all_files(flake8_package):
     assert os.path.join(spack.paths.module_path, "spec.py") in files
 
     # a mock package
-    assert flake8_package in files
+    repo = spack.repo.Repo(spack.paths.mock_packages_path)
+    filename = repo.filename_for_package_name("flake8")
+    assert filename in files
 
     # this test
     assert __file__ in files

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -9,6 +9,8 @@ import sys
 
 import pytest
 
+from llnl.util.filesystem import working_dir
+
 import spack.cmd
 import spack.config
 import spack.extensions
@@ -228,14 +230,17 @@ def test_missing_command():
     ],
     ids=["no_stem", "vacuous", "leading_hyphen", "basic_good", "trailing_slash", "hyphenated"],
 )
-def test_extension_naming(extension_path, expected_exception, config):
+def test_extension_naming(tmpdir, extension_path, expected_exception, config):
     """Ensure that we are correctly validating configured extension paths
     for conformity with the rules: the basename should match
     ``spack-<name>``; <name> may have embedded hyphens but not begin with one.
     """
-    with spack.config.override("config:extensions", [extension_path]):
-        with pytest.raises(expected_exception):
-            spack.cmd.get_module("no-such-command")
+    # NOTE: if the directory is a valid extension directory name the "vacuous" test will
+    # fail because it resolves to current working directory
+    with working_dir(str(tmpdir)):
+        with spack.config.override("config:extensions", [extension_path]):
+            with pytest.raises(expected_exception):
+                spack.cmd.get_module("no-such-command")
 
 
 def test_missing_command_function(extension_creator, capsys):

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -9,8 +9,6 @@ import sys
 
 import pytest
 
-from llnl.util.filesystem import working_dir
-
 import spack.cmd
 import spack.config
 import spack.extensions
@@ -237,7 +235,7 @@ def test_extension_naming(tmpdir, extension_path, expected_exception, config):
     """
     # NOTE: if the directory is a valid extension directory name the "vacuous" test will
     # fail because it resolves to current working directory
-    with working_dir(str(tmpdir)):
+    with tmpdir.as_cwd():
         with spack.config.override("config:extensions", [extension_path]):
             with pytest.raises(expected_exception):
                 spack.cmd.get_module("no-such-command")

--- a/lib/spack/spack/util/debug.py
+++ b/lib/spack/spack/util/debug.py
@@ -10,6 +10,7 @@ a stack trace and drops the user into an interpreter.
 
 """
 import code
+import io
 import os
 import pdb
 import signal
@@ -53,7 +54,10 @@ class ForkablePdb(pdb.Pdb):
     the run of Spack.install, or any where else Spack spawns a child process.
     """
 
-    _original_stdin_fd = sys.stdin.fileno()
+    try:
+        _original_stdin_fd = sys.stdin.fileno()
+    except io.UnsupportedOperation:
+        _original_stdin_fd = None
     _original_stdin = None
 
     def __init__(self, stdout_fd=None, stderr_fd=None):

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -56,7 +56,7 @@ fi
 
 # Check if xdist is available
 if python -m pytest --trace-config 2>&1 | grep xdist; then
-  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=2}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=3}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
 fi
 
 $coverage_run $(which spack) unit-test -x --verbose

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -54,6 +54,11 @@ elif [[ "$SPACK_TEST_SOLVER" == "original" ]]; then
   export PYTEST_ADDOPTS='-m "not maybeslow"'
 fi
 
+# Check if xdist is available
+if python -m pytest --trace-config 2>&1 | grep xdist; then
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=2}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
+fi
+
 $coverage_run $(which spack) unit-test -x --verbose
 
 bash "$QA_DIR/test-env-cfg.sh"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1568,7 +1568,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -V --version -c -i -m --path"
+        SPACK_COMPREPLY="-h --help -V --version -c -u -i -m --path"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
This PR leverages the tmpconfig script from #32183 and a number of fixes and test enhancements to enable parallel testing with pytest-xdist. On a 32-core zen workstation, a 16-way parallel run of the tests can finish in under four minutes, where a sequential run is more than 30 minutes.  The remaining question here is how to expose parallelism in the interface, and if we want to make xdist part of the bootstrap set or not.