### PR TITLE
Add patch for missing template instantiation in pika 0.7.0 on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -104,6 +104,13 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     patch("transform_mpi_includes.patch", when="@0.3.0 +mpi")
     patch("mimalloc_no_version_requirement.patch", when="@:0.5 malloc=mimalloc")
 
+    # Fix missing template instantiation on macOS
+    patch(
+        "https://github.com/pika-org/pika/commit/dd1dfb85781ec2e76fa37ce7311323e69fbe42a1.patch?full_index=1",
+        sha256="2944f746f5ae4385aba11b7c4a2f991abc108b08ea3dc394bf61c20fc7a2c4f2",
+        when="@0.7.0 platform=darwin",
+    )
+
     def cmake_args(self):
         spec, args = self.spec, []
 


### PR DESCRIPTION
Backports the patch in https://github.com/pika-org/pika/pull/405 to pika 0.7.0.