### PR TITLE
phylip: adding workarounds for gcc10+

### DIFF
--- a/var/spack/repos/builtin/packages/phylip/package.py
+++ b/var/spack/repos/builtin/packages/phylip/package.py
@@ -12,8 +12,22 @@ class Phylip(Package):
 
     homepage = "https://evolution.genetics.washington.edu/phylip/"
     url = "https://evolution.gs.washington.edu/phylip/download/phylip-3.697.tar.gz"
+    maintainers = ["snehring"]
 
     version("3.697", sha256="9a26d8b08b8afea7f708509ef41df484003101eaf4beceb5cf7851eb940510c1")
+
+    def patch(self):
+        with working_dir("src"):
+            for f in ["Makefile.unx", "Makefile.osx"]:
+                filter_file(r"CC\s*= gcc", "", f)
+                filter_file(r"CFLAGS\s*=.*$", "", f)
+
+    def flag_handler(self, name, flags):
+        if "%gcc@10:" in self.spec or "%clang@11:" in self.spec and name.lower() == "cflags":
+            flags.append("-fcommon")
+        if "platform=darwin" in self.spec and name.lower() == "cflags":
+            flags.append("-DMACOS10")
+        return (None, flags, None)
 
     def install(self, spec, prefix):
         with working_dir("src"):

--- a/var/spack/repos/builtin/packages/phylip/package.py
+++ b/var/spack/repos/builtin/packages/phylip/package.py
@@ -23,9 +23,11 @@ class Phylip(Package):
                 filter_file(r"CFLAGS\s*=.*$", "", f)
 
     def flag_handler(self, name, flags):
-        if "%gcc@10:" in self.spec or "%clang@11:" in self.spec and name.lower() == "cflags":
+        if (
+            self.spec.satisfies("%gcc@10:") or self.spec.satisfies("%clang@11:")
+        ) and name.lower() == "cflags":
             flags.append("-fcommon")
-        if "platform=darwin" in self.spec and name.lower() == "cflags":
+        if self.spec.satisfies("platform=darwin") and name.lower() == "cflags":
             flags.append("-DMACOS10")
         return (None, flags, None)
 


### PR DESCRIPTION
Lots of externs in the wrong place and missing externs. Easier here to just do -fcommon. 

I've been testing with clang more recently and also learned that they did the same change to -fno-common with clang11.