### PR TITLE
libzmq: add patch for gcc-12; conflict for older gcc-11 versions

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -64,13 +64,20 @@ class Libzmq(AutotoolsPackage):
     depends_on("libunwind", when="+libunwind")
 
     conflicts("%gcc@8:", when="@:4.2.2")
-    conflicts("%gcc@12:", when="@4.3.2:4.3.4")
+    conflicts("%gcc@11:", when="@:4.3.2")
 
     # Fix aggressive compiler warning false positive
     patch(
         "https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch?full_index=1",
         sha256="310b8aa57a8ea77b7ac74debb3bf928cbafdef5e7ca35beaac5d9c61c7edd239",
-        when="@4.2.3:4.3.4 %gcc@11:",
+        when="@4.3.3:4.3.4 %gcc@11:",
+    )
+
+    # Fix build issues with gcc-12
+    patch(
+        "https://github.com/zeromq/libzmq/pull/4334.patch?full_index=1",
+        sha256="edca864cba914481a5c97d2e975ba64ca1d2fbfc0044e9a78c48f1f7b2bedb6f",
+        when="@4.3.4 %gcc@12:",
     )
 
     def url_for_version(self, version):


### PR DESCRIPTION
Per #32214, the existing patch `92b2c...` for `gcc@11:` only applies cleanly for `libzmq@4.3.3:4.3.4`. This PR adds a conflict for earlier versions, as they cannot be patched due to different context.

For `gcc@11`, this leaves the most recent two versions available (a satisfactory compromise).

For `gcc@12`, however, there is another existing conflict that makes these most recent two versions unavailable. This PR adds an upstream patch for the single most recent version that allows compilation with `gcc@12` for that most recent version.

Starting point:
- `gcc@11` concretizes on all versions, attempts to apply patch on `@4.2.3:4.3.4`, and only succeeds to apply patch on `@4.3.3:4.3.4`,
- `gcc@12` concretizes on `@:4.3.1` (and `@master`), attempts to apply patch on `@4.2.3:4.3.1`, fails to apply patch on all.

Ending point:
- `gcc@11` concretizes on `@4.3.3:4.3.4` (and `@master`), attempts and succeeds to apply patch on `@4.3.3:4.3.4`,
- `gcc@12` concretizes on `@4.3.4` (and `@master`), attempts and succeeds to apply patch on `@4.3.4`.

Verified with environment build:
```yaml
spack:
  specs:
  - libzmq@4.3.4%gcc@12.1.0
  - libzmq@4.3.4%gcc@11.3.0
  - libzmq@4.3.3%gcc@11.3.0
  view: false
```
which returns the following:
```console
16:14:47 wdconinc@menelaos ~/git/spack (libzmq-patch-gcc12 *+$%=) $ spack install --fresh
==> Installing environment libzmq
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-12.1.0/libmd-1.0.4-egpgd6eoaqtsl5fja2iwsl6gyc4o32p5
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-12.1.0/libsodium-1.0.18-af3rsfnvck6anxf7eeog3f2bph44tjia
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-12.1.0/pkgconf-1.8.0-z5of2hj2c6ygd3kxr4cwv7u7t42sxair
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/libmd-1.0.4-tec234gco2sd7n52dkwbrad43sdhaw4o
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/libsodium-1.0.18-uljf675u3yrn5c7fdjdpa5c7qnnkynke
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/pkgconf-1.8.0-l4hzc2g4pnn7dwyttphmxivt3xghvpoq
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-12.1.0/libbsd-0.11.5-fi3ri64moy45ksr4sf5pcwd6k23dsa4o
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/libbsd-0.11.5-2matmm7im7oygrr77k7wznttv4rbupfz
==> Installing libzmq-4.3.4-t7ad54q3atrnte4rzq7g7cfjcw5227pr
==> No binary for libzmq-4.3.4-t7ad54q3atrnte4rzq7g7cfjcw5227pr found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/c5/c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5.tar.gz
==> Fetching https://mirror.spack.io/_source-cache/archive/31/310b8aa57a8ea77b7ac74debb3bf928cbafdef5e7ca35beaac5d9c61c7edd239
==> Fetching https://github.com/zeromq/libzmq/pull/4334.patch?full_index=1
==> Applied patch https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch?full_index=1
==> Applied patch https://github.com/zeromq/libzmq/pull/4334.patch?full_index=1
==> libzmq: Executing phase: 'autoreconf'
==> libzmq: Executing phase: 'configure'
==> libzmq: Executing phase: 'build'
==> libzmq: Executing phase: 'install'
==> libzmq: Successfully installed libzmq-4.3.4-t7ad54q3atrnte4rzq7g7cfjcw5227pr
  Fetch: 0.61s.  Build: 1m 31.57s.  Total: 1m 32.18s.
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-12.1.0/libzmq-4.3.4-t7ad54q3atrnte4rzq7g7cfjcw5227pr
==> Installing libzmq-4.3.3-pxrd6piprucu65bkro2ixms6d3x2eudz
==> No binary for libzmq-4.3.3-pxrd6piprucu65bkro2ixms6d3x2eudz found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/9d/9d9285db37ae942ed0780c016da87060497877af45094ff9e1a1ca736e3875a2.tar.gz
==> Using cached archive: /home/wdconinc/.spack/cache/_source-cache/archive/31/310b8aa57a8ea77b7ac74debb3bf928cbafdef5e7ca35beaac5d9c61c7edd239
==> Applied patch https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch?full_index=1
==> libzmq: Executing phase: 'autoreconf'
==> libzmq: Executing phase: 'configure'
==> libzmq: Executing phase: 'build'
==> libzmq: Executing phase: 'install'
==> libzmq: Successfully installed libzmq-4.3.3-pxrd6piprucu65bkro2ixms6d3x2eudz
  Fetch: 0.93s.  Build: 11.55s.  Total: 12.48s.
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/libzmq-4.3.3-pxrd6piprucu65bkro2ixms6d3x2eudz
==> Installing libzmq-4.3.4-hiil6dzy2reb4nk555zztwh44rpbyv4h
==> No binary for libzmq-4.3.4-hiil6dzy2reb4nk555zztwh44rpbyv4h found: installing from source
==> Using cached archive: /home/wdconinc/.spack/cache/_source-cache/archive/c5/c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5.tar.gz
==> Using cached archive: /home/wdconinc/.spack/cache/_source-cache/archive/31/310b8aa57a8ea77b7ac74debb3bf928cbafdef5e7ca35beaac5d9c61c7edd239
==> Applied patch https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch?full_index=1
==> libzmq: Executing phase: 'autoreconf'
==> libzmq: Executing phase: 'configure'
==> libzmq: Executing phase: 'build'
==> libzmq: Executing phase: 'install'
==> libzmq: Successfully installed libzmq-4.3.4-hiil6dzy2reb4nk555zztwh44rpbyv4h
  Fetch: 0.01s.  Build: 10.77s.  Total: 10.78s.
[+] /opt/software/linux-ubuntu22.04-skylake/gcc-11.3.0/libzmq-4.3.4-hiil6dzy2reb4nk555zztwh44rpbyv4h
```