### PR TITLE
Improve error message for yaml config file

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1020,9 +1020,13 @@ def read_config_file(filename, schema=None):
         raise ConfigFileError("Config file is empty or is not a valid YAML dict: %s" % filename)
 
     except MarkedYAMLError as e:
-        msg = "Error parsing yaml: %s" % (filename)
-        if e.context_mark:
-            msg += ": %s" % str(e.context_mark)
+        msg = "Error parsing yaml"
+        mark = e.context_mark if e.context_mark else e.problem_mark
+        if mark:
+            line, column = mark.line, mark.column
+            msg += ": near %s, %s, %s" % (mark.name, str(line), str(column))
+        else:
+            msg += ": %s" % (filename)
         msg += ": %s" % (e.problem)
         raise ConfigFileError(msg)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1020,7 +1020,11 @@ def read_config_file(filename, schema=None):
         raise ConfigFileError("Config file is empty or is not a valid YAML dict: %s" % filename)
 
     except MarkedYAMLError as e:
-        raise ConfigFileError("Error parsing yaml%s: %s" % (str(e.context_mark), e.problem))
+        msg = "Error parsing yaml: %s" % (filename)
+        if e.context_mark:
+            msg += ": %s" % str(e.context_mark)
+        msg += ": %s" % (e.problem)
+        raise ConfigFileError(msg)
 
     except IOError as e:
         raise ConfigFileError("Error reading configuration file %s: %s" % (filename, str(e)))


### PR DESCRIPTION
I had an ill-formed configuration file.  The error message was originally this:

```
==> Error: Error parsing yamlNone: mapping values are not allowed here
```

This changes it to tell you what file is wrong:

```
==> Error: Error parsing yaml: near /spack/etc/spack/defaults/packages.yaml, 39, 13: mapping values are not allowed here
```