### PR TITLE
calculate make_jobs in  ninja

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
-from spack.build_environment import MakeExecutable
+from spack.build_environment import MakeExecutable, determine_number_of_jobs
 from spack.package import *
 from spack.util.executable import which_string
 
@@ -74,6 +74,8 @@ class Ninja(Package):
 
     def setup_dependent_package(self, module, dspec):
         name = "ninja"
+
         module.ninja = MakeExecutable(
-            which_string(name, path=[self.spec.prefix.bin], required=True), module.make_jobs
+            which_string(name, path=[self.spec.prefix.bin], required=True),
+            determine_number_of_jobs(parallel=self.parallel),
         )


### PR DESCRIPTION
The make_jobs attribute should only be missing if the build_environment for ninja's package is not complete when it is called to set up another package, but it seems to be happening somehow.  Using this method to calculate it should be safer.

fixes #32353