### PR TITLE
Add pic variant to bacio

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -27,3 +27,12 @@ class Bacio(CMakePackage):
         sha256="7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200",
         preferred=True,
     )
+
+    variant("pic", default=True, description="Build with position-independent-code")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")
+        ]
+
+        return args

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -31,8 +31,6 @@ class Bacio(CMakePackage):
     variant("pic", default=True, description="Build with position-independent-code")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")
-        ]
+        args = [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 
         return args


### PR DESCRIPTION
As the title says. Add `pic` variant to package `bacio`. This changes is cherry-picked from the JCSDA/NOAA-EMC spack fork (code originally contributed by @kgerheiser), with a style error fix on top of it.