### PR TITLE
openmpi: handle externals from system directories

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -12,6 +12,7 @@ import sys
 import llnl.util.tty as tty
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Openmpi(AutotoolsPackage, CudaPackage):
@@ -859,7 +860,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     def with_or_without_psm2(self, activated):
         if not activated:
             return "--without-psm2"
-        return "--with-psm2={0}".format(self.spec["opa-psm2"].prefix)
+        return "--with-psm2={0}".format(self.yes_or_prefix("opa-psm2"))
 
     def with_or_without_verbs(self, activated):
         # Up through version 1.6, this option was named --with-openib.
@@ -867,17 +868,17 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         opt = "verbs" if self.spec.satisfies("@1.7:") else "openib"
         if not activated:
             return "--without-{0}".format(opt)
-        return "--with-{0}={1}".format(opt, self.spec["rdma-core"].prefix)
+        return "--with-{0}={1}".format(opt, self.yes_or_prefix("rdma-core"))
 
     def with_or_without_mxm(self, activated):
         if not activated:
             return "--without-mxm"
-        return "--with-mxm={0}".format(self.spec["mxm"].prefix)
+        return "--with-mxm={0}".format(self.yes_or_prefix("mxm"))
 
     def with_or_without_ucx(self, activated):
         if not activated:
             return "--without-ucx"
-        return "--with-ucx={0}".format(self.spec["ucx"].prefix)
+        return "--with-ucx={0}".format(self.yes_or_prefix("ucx"))
 
     def with_or_without_ofi(self, activated):
         # Up through version 3.0.3 this option was name --with-libfabric.
@@ -885,37 +886,37 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         opt = "ofi" if self.spec.satisfies("@3.0.4:") else "libfabric"
         if not activated:
             return "--without-{0}".format(opt)
-        return "--with-{0}={1}".format(opt, self.spec["libfabric"].prefix)
+        return "--with-{0}={1}".format(opt, self.yes_or_prefix("libfabric"))
 
     def with_or_without_fca(self, activated):
         if not activated:
             return "--without-fca"
-        return "--with-fca={0}".format(self.spec["fca"].prefix)
+        return "--with-fca={0}".format(self.yes_or_prefix("fca"))
 
     def with_or_without_hcoll(self, activated):
         if not activated:
             return "--without-hcoll"
-        return "--with-hcoll={0}".format(self.spec["hcoll"].prefix)
+        return "--with-hcoll={0}".format(self.yes_or_prefix("hcoll"))
 
     def with_or_without_xpmem(self, activated):
         if not activated:
             return "--without-xpmem"
-        return "--with-xpmem={0}".format(self.spec["xpmem"].prefix)
+        return "--with-xpmem={0}".format(self.yes_or_prefix("xpmem"))
 
     def with_or_without_knem(self, activated):
         if not activated:
             return "--without-knem"
-        return "--with-knem={0}".format(self.spec["knem"].prefix)
+        return "--with-knem={0}".format(self.yes_or_prefix("knem"))
 
     def with_or_without_lsf(self, activated):
         if not activated:
             return "--without-lsf"
-        return "--with-lsf={0}".format(self.spec["lsf"].prefix)
+        return "--with-lsf={0}".format(self.yes_or_prefix("lsf"))
 
     def with_or_without_tm(self, activated):
         if not activated:
             return "--without-tm"
-        return "--with-tm={0}".format(self.spec["pbs"].prefix)
+        return "--with-tm={0}".format(self.yes_or_prefix("pbs"))
 
     @run_before("autoreconf")
     def die_without_fortran(self):
@@ -946,10 +947,9 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
         config_args.extend(self.enable_or_disable("builtin-atomics", variant="atomics"))
 
-        if spec.satisfies("+pmi"):
-            config_args.append("--with-pmi={0}".format(spec["slurm"].prefix))
-        else:
-            config_args.extend(self.with_or_without("pmi"))
+        config_args.extend(
+            self.with_or_without("pmi", activation_value=lambda x: self.yes_or_prefix("slurm"))
+        )
 
         config_args.extend(self.enable_or_disable("static"))
 
@@ -993,22 +993,22 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         # Package dependencies
         for dep in ["libevent", "lustre", "singularity", "valgrind"]:
             if "^" + dep in spec:
-                config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
+                config_args.append("--with-{0}={1}".format(dep, self.yes_or_prefix(dep)))
 
         # PMIx support
         if spec.satisfies("+internal-pmix"):
             config_args.append("--with-pmix=internal")
         elif "^pmix" in spec:
-            config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+            config_args.append("--with-pmix={0}".format(self.yes_or_prefix("pmix")))
 
         if "^zlib-api" in spec:
-            config_args.append("--with-zlib={0}".format(spec["zlib-api"].prefix))
+            config_args.append("--with-zlib={0}".format(self.yes_or_prefix("zlib-api")))
 
         # Hwloc support
         if spec.satisfies("+internal-hwloc"):
             config_args.append("--with-hwloc=internal")
         elif "^hwloc" in spec:
-            config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
+            config_args.append("--with-hwloc={0}".format(self.yes_or_prefix("hwloc")))
 
         # Java support
         if "+java" in spec:
@@ -1045,17 +1045,13 @@ class Openmpi(AutotoolsPackage, CudaPackage):
             # OpenMPI dynamically loads libcuda.so, requires dlopen
             config_args.append("--enable-dlopen")
             # Searches for header files in DIR/include
-            config_args.append("--with-cuda={0}".format(spec["cuda"].prefix))
-            if spec.satisfies("@1.7:1.7.2"):
-                # This option was removed from later versions
-                config_args.append(
-                    "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0])
-                )
-            if spec.satisfies("@5.0:"):
-                # And then it returned
-                config_args.append(
-                    "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0] + "/stubs")
-                )
+            config_args.append("--with-cuda={0}".format(self.yes_or_prefix("cuda")))
+            if spec.satisfies("@1.7:1.7.2,5.0:"):
+                cuda_lib_dir = spec["cuda"].libs.directories[0]
+                if spec.satisfies("@5.0:"):
+                    cuda_lib_dir = join_path(cuda_lib_dir, "stubs")
+                if not is_system_path(cuda_lib_dir):
+                    config_args.append("--with-cuda-libdir={0}".format(cuda_lib_dir))
             if spec.satisfies("@1.7.2"):
                 # There was a bug in 1.7.2 when --enable-static is used
                 config_args.append("--enable-mca-no-build=pml-bfo")
@@ -1203,6 +1199,10 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         install test subdirectory for use during `spack test run`.
         """
         self.cache_extra_test_sources(self.extra_install_tests)
+
+    def yes_or_prefix(self, spec_name):
+        prefix = self.spec[spec_name].prefix
+        return "yes" if is_system_path(prefix) else prefix
 
     def run_installed_binary(self, bin, options, expected):
         """run and check outputs for the installed binary"""


### PR DESCRIPTION
If `slurm` is an external with the prefix `/usr`, the compiler wrappers of the library append `-L/usr/lib[64] -Wl,-rpath -Wl,/usr/lib[64]`. This happens because the configure script is called with `--with-pmi=/usr`. I cannot come up with a good example of how this can break things, it's just my experience (I admit that I might have to change my mind on this, see below) shows that having linker flags for the system prefixes is generally a bad idea. Especially when we are not using Spack compiler wrapper, which de-prioritises linker flags for the system directories. It looks like the developers of the library, at least partially, share this point of view (see https://github.com/open-mpi/ompi/commit/b86e0f04bfca1d6c14177e00544f5e0a500ee02c).

This PR makes sure that prefixes to the system directories are not passed to the configure script. In particular, it is called with `--with-pmi=yes` (which is equal to just `--with-pmi`) instead of `--with-package=/usr`.

Also, @haampie had a short exchange on whether the system directories should be put to `RPATH`s, which you can find in #32212. My opinion is that, as long as Spack [assumes](https://github.com/spack/spack/blob/8d8aa5c6cf294e65d96edc8ee276cc0a315a4693/lib/spack/spack/build_environment.py#L438) that the linker and the dynamic linker find and use the correct libraries when they are installed to the system directories without any additional flags, we should try to be consistent and have these changes in.