### PR TITLE
llvm: fix 15.0.0rc builds on MacOS with command-line-tools

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -680,11 +680,9 @@ class Llvm(CMakePackage, CudaPackage):
                 projects.append("compiler-rt")
         if "+libcxx" in spec:
             if self.spec.satisfies("@15.0.0:"):
-                runtimes.append("libcxx")
-                runtimes.append("libcxxabi")
+                runtimes.extend(["libcxx", "libcxxabi"])
             else:
-                projects.append("libcxx")
-                projects.append("libcxxabi")
+                projects.extend(["libcxx", "libcxxabi"])
         if "+mlir" in spec:
             projects.append("mlir")
         if "+internal_unwind" in spec:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -36,7 +36,7 @@ class Llvm(CMakePackage, CudaPackage):
 
     # fmt: off
     version('main', branch='main')
-    version('15.0.0-rc1', sha256='b026a1b32ba0dc5612da36f14977c7e9fb910d545251a26dcfefca85d94139e4')
+    version('15.0.0-rc3', sha256='e096e5a8728e3bda68f92332bc057f4f26bc6b063c8c87b283ffbbb87736b753')
     version('14.0.6', sha256='98f15f842700bdb7220a166c8d2739a03a72e775b67031205078f39dd756a055', preferred=True)
     version('14.0.5', sha256='a4a57f029cb81f04618e05853f05fc2d21b64353c760977d8e7799bf7218a23a')
     version('14.0.4', sha256='1333236f9bee38658762076be4236cb5ebf15ae9b7f2bfce6946b96ae962dc73')
@@ -674,14 +674,24 @@ class Llvm(CMakePackage, CudaPackage):
         if "+lld" in spec:
             projects.append("lld")
         if "+compiler-rt" in spec:
-            projects.append("compiler-rt")
+            if self.spec.satisfies("@15.0.0:"):
+                runtimes.append("compiler-rt")
+            else:
+                projects.append("compiler-rt")
         if "+libcxx" in spec:
-            projects.append("libcxx")
-            projects.append("libcxxabi")
+            if self.spec.satisfies("@15.0.0:"):
+                runtimes.append("libcxx")
+                runtimes.append("libcxxabi")
+            else:
+                projects.append("libcxx")
+                projects.append("libcxxabi")
         if "+mlir" in spec:
             projects.append("mlir")
         if "+internal_unwind" in spec:
-            projects.append("libunwind")
+            if self.spec.satisfies("@15.0.0:"):
+                runtimes.append("libunwind")
+            else:
+                projects.append("libunwind")
         if "+polly" in spec:
             projects.append("polly")
             cmake_args.append(define("LINK_POLLY_INTO_TOOLS", True))
@@ -718,6 +728,11 @@ class Llvm(CMakePackage, CudaPackage):
 
         if self.spec.satisfies("~code_signing platform=darwin"):
             cmake_args.append(define("LLDB_USE_SYSTEM_DEBUGSERVER", True))
+
+        # Enable building with CLT [and not require full Xcode]
+        # https://github.com/llvm/llvm-project/issues/57037
+        if self.spec.satisfies("@15.0.0: platform=darwin"):
+            cmake_args.append(define("BUILTINS_CMAKE_ARGS", "-DCOMPILER_RT_ENABLE_IOS=OFF"))
 
         # Semicolon seperated list of projects to enable
         cmake_args.append(define("LLVM_ENABLE_PROJECTS", projects))


### PR DESCRIPTION
Ref: https://github.com/llvm/llvm-project/issues/57037

i.e use -DBUILTINS_CMAKE_ARGS=-DCOMPILER_RT_ENABLE_IOS=OFF. But this needs switching "compiler-rt" from "projects" to "runtimes".

Also fixing the warnings below fixes compile errors

CMake Warning at CMakeLists.txt:101 (message):
  Using LLVM_ENABLE_PROJECTS=libcxx is deprecated now, please use
  -DLLVM_ENABLE_RUNTIMES=libcxx or see the instructions at
  https://libcxx.llvm.org/BuildingLibcxx.html for building the runtimes.


CMake Warning at CMakeLists.txt:101 (message):
  Using LLVM_ENABLE_PROJECTS=libcxxabi is deprecated now, please use
  -DLLVM_ENABLE_RUNTIMES=libcxxabi or see the instructions at
  https://libcxx.llvm.org/BuildingLibcxx.html for building the runtimes.


CMake Warning at CMakeLists.txt:101 (message):
  Using LLVM_ENABLE_PROJECTS=libunwind is deprecated now, please use
  -DLLVM_ENABLE_RUNTIMES=libunwind or see the instructions at
  https://libcxx.llvm.org/BuildingLibcxx.html for building the runtimes.


/private/var/folders/nt/_m1t_x7j76q6sl3xt91tqgs00000gn/T/balay/spack-stage/spack-stage-llvm-15.0.0-rc2-h2t5bohzyy7exz2ub3m42pfycjcmbndk/spack-build-h2t5boh/include/c++/v1/cstdlib:135:9: error: no member named 'at_quick_exit' in the global namespace
using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
      ~~^

Also ref: https://github.com/spack/spack/pull/31945
cc: @William-Mou