### PR TITLE
Fix cause of checksum failures in public binary mirror

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -647,11 +647,9 @@ def generate_gitlab_ci_yaml(
 
     spack_buildcache_copy = os.environ.get("SPACK_COPY_BUILDCACHE", None)
     if spack_buildcache_copy:
-        buildcache_copies = {
-            "destination_url_prefix": spack_buildcache_copy,
-            "hashes": {},
-        }
+        buildcache_copies = {}
         buildcache_copy_src_prefix = remote_mirror_override or remote_mirror_url
+        buildcache_copy_dest_prefix = spack_buildcache_copy
 
     if "mirrors" not in yaml_root or len(yaml_root["mirrors"].values()) < 1:
         tty.die("spack ci generate requires an env containing a mirror")
@@ -1030,13 +1028,22 @@ def generate_gitlab_ci_yaml(
                 # Only keep track of these if we are doing the copy thing
                 if spack_buildcache_copy:
                     # TODO: This assumes signed version of the spec
-                    buildcache_copies["hashes"][release_spec_dag_hash] = [
-                        url_util.join(buildcache_copy_src_prefix,
-                                      bindist.build_cache_relative_path(),
-                                      bindist.tarball_name(release_spec, ".spec.json.sig")),
-                        url_util.join(buildcache_copy_src_prefix,
-                                      bindist.build_cache_relative_path(),
-                                      bindist.tarball_path_name(release_spec, ".spack"))
+                    buildcache_copies[release_spec_dag_hash] = [
+                        {
+                            "src": url_util.join(buildcache_copy_src_prefix,
+                                                 bindist.build_cache_relative_path(),
+                                                 bindist.tarball_name(release_spec, ".spec.json.sig")),
+                            "dest": url_util.join(buildcache_copy_dest_prefix,
+                                                  bindist.build_cache_relative_path(),
+                                                  bindist.tarball_name(release_spec, ".spec.json.sig")),
+                        },{
+                            "src": url_util.join(buildcache_copy_src_prefix,
+                                                 bindist.build_cache_relative_path(),
+                                                 bindist.tarball_path_name(release_spec, ".spack")),
+                            "dest": url_util.join(buildcache_copy_src_prefix,
+                                                  bindist.build_cache_relative_path(),
+                                                  bindist.tarball_path_name(release_spec, ".spack")),
+                        }
                     ]
 
                 if artifacts_root:

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -36,6 +36,7 @@ import spack.repo
 import spack.util.executable as exe
 import spack.util.gpg as gpg_util
 import spack.util.spack_yaml as syaml
+import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.error import SpackError
 from spack.reporters.cdash import CDash
@@ -645,6 +646,12 @@ def generate_gitlab_ci_yaml(
     spack_pipeline_type = os.environ.get("SPACK_PIPELINE_TYPE", None)
 
     spack_buildcache_copy = os.environ.get("SPACK_COPY_BUILDCACHE", None)
+    if spack_buildcache_copy:
+        buildcache_copies = {
+            "destination_url_prefix": spack_buildcache_copy,
+            "hashes": {},
+        }
+        buildcache_copy_src_prefix = remote_mirror_override or remote_mirror_url
 
     if "mirrors" not in yaml_root or len(yaml_root["mirrors"].values()) < 1:
         tty.die("spack ci generate requires an env containing a mirror")
@@ -1020,6 +1027,18 @@ def generate_gitlab_ci_yaml(
                         "{0} ({1})".format(release_spec, release_spec_dag_hash)
                     )
 
+                # Only keep track of these if we are doing the copy thing
+                if spack_buildcache_copy:
+                    # TODO: This assumes signed version of the spec
+                    buildcache_copies["hashes"][release_spec_dag_hash] = [
+                        url_util.join(buildcache_copy_src_prefix,
+                                      bindist.build_cache_relative_path(),
+                                      bindist.tarball_name(release_spec, ".spec.json.sig")),
+                        url_util.join(buildcache_copy_src_prefix,
+                                      bindist.build_cache_relative_path(),
+                                      bindist.tarball_path_name(release_spec, ".spack"))
+                    ]
+
                 if artifacts_root:
                     job_dependencies.append(
                         {"job": generate_job_name, "pipeline": "{0}".format(parent_pipeline_id)}
@@ -1285,6 +1304,19 @@ def generate_gitlab_ci_yaml(
         spack_stack_name = os.environ.get("SPACK_CI_STACK_NAME", None)
         if spack_stack_name:
             output_object["variables"]["SPACK_CI_STACK_NAME"] = spack_stack_name
+
+        if spack_buildcache_copy:
+            # Write out the file describing specs that should be copied
+            copy_specs_dir = os.path.join(pipeline_artifacts_dir, "specs_to_copy")
+
+            if not os.path.exists(copy_specs_dir):
+                os.makedirs(copy_specs_dir)
+
+            copy_specs_file = os.path.join(copy_specs_dir, "copy_{}_specs.json".format(
+                spack_stack_name if spack_stack_name else "rebuilt"))
+
+            with open(copy_specs_file, 'w') as fd:
+                fd.write(json.dumps(buildcache_copies))
 
         sorted_output = {}
         for output_key, output_value in sorted(output_object.items()):

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1048,7 +1048,7 @@ def generate_gitlab_ci_yaml(
                                 bindist.tarball_path_name(release_spec, ".spack"),
                             ),
                             "dest": url_util.join(
-                                buildcache_copy_src_prefix,
+                                buildcache_copy_dest_prefix,
                                 bindist.build_cache_relative_path(),
                                 bindist.tarball_path_name(release_spec, ".spack"),
                             ),

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1216,32 +1216,6 @@ def generate_gitlab_ci_yaml(
 
             output_object["sign-pkgs"] = signing_job
 
-        if spack_buildcache_copy:
-            # Generate a job to copy the contents from wherever the builds are getting
-            # pushed to the url specified in the "SPACK_BUILDCACHE_COPY" environment
-            # variable.
-            src_url = remote_mirror_override or remote_mirror_url
-            dest_url = spack_buildcache_copy
-
-            stage_names.append("stage-copy-buildcache")
-            copy_job = {
-                "stage": "stage-copy-buildcache",
-                "tags": ["spack", "public", "medium", "aws", "x86_64"],
-                "image": "ghcr.io/spack/python-aws-bash:0.0.1",
-                "when": "on_success",
-                "interruptible": True,
-                "retry": service_job_retries,
-                "script": [
-                    ". ./share/spack/setup-env.sh",
-                    "spack --version",
-                    "aws s3 sync --exclude *index.json* --exclude *pgp* {0} {1}".format(
-                        src_url, dest_url
-                    ),
-                ],
-            }
-
-            output_object["copy-mirror"] = copy_job
-
         if rebuild_index_enabled:
             # Add a final job to regenerate the index
             stage_names.append("stage-rebuild-index")

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -17,6 +17,7 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
+import spack.fetch_strategy as fs
 import spack.hash_types as ht
 import spack.mirror
 import spack.relocate
@@ -635,10 +636,14 @@ def copy_buildcache_file(src_url, dest_url, local_path=None):
             temp_stage.create()
             temp_stage.fetch()
             web_util.push_to_url(local_path, dest_url, keep_original=True)
+        except fs.FetchError as e:
+            # Expected, since we have to try all the possible extensions
+            tty.debug("no such file: {0}".format(src_url))
+            tty.debug(e)
         finally:
             temp_stage.destroy()
     finally:
-        if tmpdir:
+        if tmpdir and os.path.exists(tmpdir):
             shutil.rmtree(tmpdir)
 
 
@@ -719,8 +724,9 @@ def sync_fn(args):
         buildcache_rel_paths.extend(
             [
                 os.path.join(build_cache_dir, bindist.tarball_path_name(s, ".spack")),
-                os.path.join(build_cache_dir, bindist.tarball_name(s, ".spec.yaml")),
+                os.path.join(build_cache_dir, bindist.tarball_name(s, ".spec.json.sig")),
                 os.path.join(build_cache_dir, bindist.tarball_name(s, ".spec.json")),
+                os.path.join(build_cache_dir, bindist.tarball_name(s, ".spec.yaml")),
             ]
         )
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import glob
+import json
 import os
 import shutil
 import sys
@@ -271,7 +273,12 @@ def setup_parser(subparser):
 
     # Sync buildcache entries from one mirror to another
     sync = subparsers.add_parser("sync", help=sync_fn.__doc__)
-    source = sync.add_mutually_exclusive_group(required=True)
+    sync.add_argument(
+        "--manifest-glob",
+        default=None,
+        help="A quoted glob pattern identifying copy manifest files",
+    )
+    source = sync.add_mutually_exclusive_group(required=False)
     source.add_argument(
         "--src-directory", metavar="DIRECTORY", type=str, help="Source mirror as a local file path"
     )
@@ -281,7 +288,7 @@ def setup_parser(subparser):
     source.add_argument(
         "--src-mirror-url", metavar="MIRROR_URL", type=str, help="URL of the source mirror"
     )
-    dest = sync.add_mutually_exclusive_group(required=True)
+    dest = sync.add_mutually_exclusive_group(required=False)
     dest.add_argument(
         "--dest-directory",
         metavar="DIRECTORY",
@@ -614,6 +621,27 @@ def copy_fn(args):
     shutil.copyfile(specfile_src_path_yaml, specfile_dest_path_yaml)
 
 
+def copy_buildcache_file(src_url, dest_url, local_path=None):
+    """Copy from source url to destination url"""
+    tmpdir = None
+
+    if not local_path:
+        tmpdir = tempfile.mkdtemp()
+        local_path = os.path.join(tmpdir, os.path.basename(src_url))
+
+    try:
+        temp_stage = Stage(src_url, path=os.path.dirname(local_path))
+        try:
+            temp_stage.create()
+            temp_stage.fetch()
+            web_util.push_to_url(local_path, dest_url, keep_original=True)
+        finally:
+            temp_stage.destroy()
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir)
+
+
 def sync_fn(args):
     """Syncs binaries (and associated metadata) from one mirror to another.
     Requires an active environment in order to know which specs to sync.
@@ -622,6 +650,10 @@ def sync_fn(args):
         src (str): Source mirror URL
         dest (str): Destination mirror URL
     """
+    if args.manifest_glob:
+        manifest_copy(glob.glob(args.manifest_glob))
+        return 0
+
     # Figure out the source mirror
     source_location = None
     if args.src_directory:
@@ -701,22 +733,29 @@ def sync_fn(args):
             dest_url = url_util.join(dest_mirror_url, rel_path)
 
             tty.debug("Copying {0} to {1} via {2}".format(src_url, dest_url, local_path))
-
-            stage = Stage(
-                src_url, name="temporary_file", path=os.path.dirname(local_path), keep=True
-            )
-
-            try:
-                stage.create()
-                stage.fetch()
-                web_util.push_to_url(local_path, dest_url, keep_original=True)
-            except web_util.FetchError as e:
-                tty.debug("spack buildcache unable to sync {0}".format(rel_path))
-                tty.debug(e)
-            finally:
-                stage.destroy()
+            copy_buildcache_file(src_url, dest_url, local_path=local_path)
     finally:
         shutil.rmtree(tmpdir)
+
+
+def manifest_copy(manifest_file_list):
+    """Read manifest files containing information about specific specs to copy
+    from source to destination, remove duplicates since any binary packge for
+    a given hash should be the same as any other, and copy all files specified
+    in the manifest files."""
+    deduped_manifest = {}
+
+    for manifest_path in manifest_file_list:
+        with open(manifest_path) as fd:
+            manifest = json.loads(fd.read())
+            for spec_hash, copy_list in manifest.items():
+                # Last duplicate hash wins
+                deduped_manifest[spec_hash] = copy_list
+
+    for spec_hash, copy_list in deduped_manifest.items():
+        for copy_file in copy_list:
+            tty.debug("copying {0} to {1}".format(copy_file["src"], copy_file["dest"]))
+            copy_buildcache_file(copy_file["src"], copy_file["dest"])
 
 
 def update_index(mirror_url, update_keys=False):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -17,7 +17,6 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
-import spack.fetch_strategy as fs
 import spack.hash_types as ht
 import spack.mirror
 import spack.relocate
@@ -636,7 +635,7 @@ def copy_buildcache_file(src_url, dest_url, local_path=None):
             temp_stage.create()
             temp_stage.fetch()
             web_util.push_to_url(local_path, dest_url, keep_original=True)
-        except fs.FetchError as e:
+        except web_util.FetchError as e:
             # Expected, since we have to try all the possible extensions
             tty.debug("no such file: {0}".format(src_url))
             tty.debug(e)

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -12,7 +12,7 @@ default:
   - /^pr[\d]+_.*$/
   - /^github\/pr[\d]+_.*$/
   variables:
-    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}"
+    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
     SPACK_PIPELINE_TYPE: "spack_pull_request"
     SPACK_PRUNE_UNTOUCHED: "True"
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -88,7 +88,7 @@ default:
 
 protected-publish:
   stage: publish
-  extends: [ ".protected-refs" ]
+  extends: [ ".protected" ]
   image: "ghcr.io/spack/python-aws-bash:0.0.1"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   variables:
@@ -97,7 +97,9 @@ protected-publish:
   script:
     - . "./share/spack/setup-env.sh"
     - spack --version
-    - spack buildcache update-index --mirror-url "s3://spack-binaries/${CI_COMMIT_REF_NAME}"
+    - export COPY_SPECS_DIR=${CI_PROJECT_DIR}/jobs_scratch_dir/specs_to_copy
+    - jq -s '. | map(.hashes) | add | map(values)[][]' ${COPY_SPECS_DIR}/*.json | xargs -I% aws s3 cp % ${SPACK_COPY_BUILDCACHE}
+    - spack buildcache update-index --mirror-url ${SPACK_COPY_BUILDCACHE}
 
 ########################################
 # TEMPLATE FOR ADDING ANOTHER PIPELINE

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -89,7 +89,7 @@ default:
 protected-publish:
   stage: publish
   extends: [ ".protected" ]
-  image: "ghcr.io/scottwittenburg/python-aws-bash:0.0.3"
+  image: "ghcr.io/spack/python-aws-bash:0.0.1"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   variables:
     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -88,7 +88,7 @@ default:
 
 protected-publish:
   stage: publish
-  extends: [ ".protected" ]
+  extends: [ ".protected-refs" ]
   image: "ghcr.io/scottwittenburg/python-aws-bash:0.0.3"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   variables:
@@ -98,7 +98,7 @@ protected-publish:
     - . "./share/spack/setup-env.sh"
     - spack --version
     - export COPY_SPECS_DIR=${CI_PROJECT_DIR}/jobs_scratch_dir/specs_to_copy
-    - jq -s '. | map(.hashes) | add | map(values)[][]' ${COPY_SPECS_DIR}/*.json | xargs -I% aws s3 cp % "${SPACK_COPY_BUILDCACHE}/"
+    - spack buildcache sync --manifest-glob "${COPY_SPECS_DIR}/*.json"
     - spack buildcache update-index --mirror-url ${SPACK_COPY_BUILDCACHE}
 
 ########################################

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -88,7 +88,7 @@ default:
 
 protected-publish:
   stage: publish
-  extends: [ ".protected-refs" ]
+  extends: [ ".protected" ]
   image: "ghcr.io/scottwittenburg/python-aws-bash:0.0.3"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   variables:

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -98,7 +98,7 @@ protected-publish:
     - . "./share/spack/setup-env.sh"
     - spack --version
     - export COPY_SPECS_DIR=${CI_PROJECT_DIR}/jobs_scratch_dir/specs_to_copy
-    - jq -s '. | map(.hashes) | add | map(values)[][]' ${COPY_SPECS_DIR}/*.json | xargs -I% aws s3 cp % ${SPACK_COPY_BUILDCACHE}
+    - jq -s '. | map(.hashes) | add | map(values)[][]' ${COPY_SPECS_DIR}/*.json | xargs -I% aws s3 cp % "${SPACK_COPY_BUILDCACHE}/"
     - spack buildcache update-index --mirror-url ${SPACK_COPY_BUILDCACHE}
 
 ########################################

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -89,7 +89,7 @@ default:
 protected-publish:
   stage: publish
   extends: [ ".protected" ]
-  image: "ghcr.io/spack/python-aws-bash:0.0.1"
+  image: "ghcr.io/scottwittenburg/python-aws-bash:0.0.3"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   variables:
     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -569,7 +569,7 @@ _spack_buildcache_copy() {
 }
 
 _spack_buildcache_sync() {
-    SPACK_COMPREPLY="-h --help --src-directory --src-mirror-name --src-mirror-url --dest-directory --dest-mirror-name --dest-mirror-url"
+    SPACK_COMPREPLY="-h --help --manifest-glob --src-directory --src-mirror-name --src-mirror-url --dest-directory --dest-mirror-name --dest-mirror-url"
 }
 
 _spack_buildcache_update_index() {


### PR DESCRIPTION
Protected pipeilnes are configured to sync all specs from stack-specific mirrors into a single root mirror for more convenient public use.  Until now, this was managed by a final job generated into each stack-specific child pipeline.  If multiple child pipelines built the same hash, this could result in the root mirror sometimes containing `spec.json.sig` and `.spack` files corresponding to the same hash, but coming from different child pipeline mirrors.  While two binary packages with the same hash are otherwise equivalent (and relocatable), the install path is reflected in the package and causes the two packages to have different checksums.

This change moves the copying of the buildcache to a root job that runs after all the child pipelines have finished, so that the operation can be coordinated across all child pipelines.  This lets us ensure the `.spec.json.sig` and `.spack` files for any spec in the root mirror always come from the same child pipeline mirror, and also it allows us to avoid copying of duplicates.

Also with this change, only the *new* binary packages (built in the current pipeline) are copied to the mirror.  To support this, `spack ci generate` writes out a json file containing the urls of buildcache files to be copied, and `spack buildcache sync` can now  consume json files from all child pipelines at once to determine the subset of specs to sync to a mirror.  This is enabled by providing the option `--manifest-glob` and a quoted file pattern to select the json files to read.  

<details>
<summary>JSON format</summary>

```json
{
    "cn7znah2eetd7ueztmxzf76plh6tftws": [
        {
            "src": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.8-cn7znah2eetd7ueztmxzf76plh6tftws.spec.json.sig",
            "dest": "s3://spack-binaries/testing/develop/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.8-cn7znah2eetd7ueztmxzf76plh6tftws.spec.json.sig"
        }, 
        {
            "src": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.8-cn7znah2eetd7ueztmxzf76plh6tftws.spack",
            "dest": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.8-cn7znah2eetd7ueztmxzf76plh6tftws.spack"
        }
    ],
    "6wpnwvhne2xnlsvsegcw2ap34ziapzqa": [
        {
            "src": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-6wpnwvhne2xnlsvsegcw2ap34ziapzqa.spec.json.sig",
            "dest": "s3://spack-binaries/testing/develop/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-6wpnwvhne2xnlsvsegcw2ap34ziapzqa.spec.json.sig"
        }, 
        {
            "src": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-6wpnwvhne2xnlsvsegcw2ap34ziapzqa.spack",
            "dest": "s3://spack-binaries/testing/develop/tutorial/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-6wpnwvhne2xnlsvsegcw2ap34ziapzqa.spack"
        }
    ],
    ...
}
```

</details>

The copying of buildcache files addressed here remains off by default, and enabled using the `SPACK_COPY_BUILDCACHE` environment variable set to the copy target url.

Though all the changes above only affected protected pipelines, this includes one small fix for PR pipelines as well.  Now PR binaries are created into stack-specific mirrors (the same as is already done for protected pipelines).  This avoids jobs in PR pipelines that rebuild many (or sometimes all) specs overwriting each others binaries when there are hash conflicts.

Also note that although this should prevent the creation of future mismatched binaries (fixes the cause of the problem), it doesn't address mismatched `.spec` and `.spack` files already present in the public binary mirror.  We will clean out and repopulate that mirror [manually](https://github.com/spack/spack-infrastructure/pull/310) once this PR is merged and after the termination of any remaining `develop` pipeline that might create more mismatches.
 