### PR TITLE
dealii:: fixed application of stdcxx variant

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -604,7 +604,6 @@ class Dealii(CMakePackage, CudaPackage):
                     self.define("CMAKE_CXX_FLAGS_RELEASE", " ".join(cxx_flags_release)),
                 ]
             )
-        
         if len(cxx_flags) > 0:
             options.extend(
                 [

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -602,6 +602,12 @@ class Dealii(CMakePackage, CudaPackage):
             options.extend(
                 [
                     self.define("CMAKE_CXX_FLAGS_RELEASE", " ".join(cxx_flags_release)),
+                ]
+            )
+        
+        if len(cxx_flags) > 0:
+            options.extend(
+                [
                     self.define("CMAKE_CXX_FLAGS", " ".join(cxx_flags)),
                 ]
             )


### PR DESCRIPTION
If the compiler does not set the c++17 standard by default (as is the case for my clang compiler), the variant `stdcxx=17` was simply ignored, because it was only used when `+optflags` and `cxx_flags_release` were being set.

With this PR, we set `CMAKE_CXX_FLAGS`, whenever the script sets `cxx_flags`. This fixes, among others, also the `stdcxx=17` issue I was observing.