### PR TITLE
coreutils: add the external find feature using md5sum

### DIFF
--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -44,6 +46,8 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
 
     build_directory = "spack-build"
 
+    executables = [r"^md5sum$"]
+
     def configure_args(self):
         spec = self.spec
         configure_args = []
@@ -54,3 +58,9 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
             configure_args.append("gl_cv_func_ftello_works=yes")
 
         return configure_args
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"\(GNU coreutils\)\s+([\d\.]+)", output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -20,6 +20,8 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
 
     tags = ["core-packages"]
 
+    executables = [r"^md5sum$"]
+
     version("9.1", sha256="61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423")
     version("9.0", sha256="ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce")
     version("8.32", sha256="4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa")
@@ -45,8 +47,6 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
     )
 
     build_directory = "spack-build"
-
-    executables = [r"^md5sum$"]
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Adds the external find feature that works for GNU systems.
This uses md5sum.
