### PR TITLE
gdk-pixbuf: new bugfix version 2.42.9

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -18,6 +18,7 @@ class GdkPixbuf(Package):
     list_url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/"
     list_depth = 1
 
+    version("2.42.9", sha256="28f7958e7bf29a32d4e963556d241d0a41a6786582ff6a5ad11665e0347fc962")
     version("2.42.6", sha256="c4a6b75b7ed8f58ca48da830b9fa00ed96d668d3ab4b1f723dcf902f78bde77f")
     version("2.42.2", sha256="83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15")
     # https://nvd.nist.gov/vuln/detail/CVE-2021-20240


### PR DESCRIPTION
No changes of note. Just bugfixes. Full diff at https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/compare/2.42.6...2.42.9?from_project_id=1548