### PR TITLE
snphylo: update to new version

### DIFF
--- a/var/spack/repos/builtin/packages/snphylo/package.py
+++ b/var/spack/repos/builtin/packages/snphylo/package.py
@@ -10,10 +10,13 @@ class Snphylo(Package):
     """A pipeline to generate a phylogenetic tree from huge SNP data"""
 
     homepage = "http://chibba.pgml.uga.edu/snphylo/"
-    url = "http://chibba.pgml.uga.edu/snphylo/snphylo.tar.gz"
+    url = "https://github.com/thlee/SNPhylo/archive/refs/tags/20180901.tar.gz"
 
+    version("20180901", sha256="46273bcafc8f6cc2465fc524926af7dd122bcc7b7ce1b7c3f5c278111c3a9ddd")
     version(
-        "2016-02-04", sha256="d9e144021c83dbef97bebf743b92109ad0afcfe70f37c244059b43f11b8a50da"
+        "2016-02-04",
+        sha256="d9e144021c83dbef97bebf743b92109ad0afcfe70f37c244059b43f11b8a50da",
+        deprecated=True,
     )
 
     depends_on("python", type=("build", "run"))


### PR DESCRIPTION
The old distribution point fell off the internet. New url appears to be the original author's github. 