### PR TITLE
Fix spack locking on some NFS systems

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -393,9 +393,8 @@ class Lock(object):
                 # Directory already exists
                 if e.errno != errno.EEXIST:
                     tty.warn(
-                        "Got OSError when trying to create directory at '{!s}' that already exists: {!r}".format(
-                            parent, e
-                        )
+                        "Got OSError when trying to create directory "
+                        "at '{!s}' that already exists: {!r}".format(parent, e)
                     )
             else:
                 raise

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -392,7 +392,11 @@ class Lock(object):
             elif os.path.isdir(parent):
                 # Directory already exists
                 if e.errno != errno.EEXIST:
-                    tty.warn("Got OSError when trying to create directory at '{!s}' that already exists: {!r}".format(parent, e))
+                    tty.warn(
+                        "Got OSError when trying to create directory at '{!s}' that already exists: {!r}".format(
+                            parent, e
+                        )
+                    )
             else:
                 raise
         return parent

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -386,8 +386,14 @@ class Lock(object):
         try:
             os.makedirs(parent)
         except OSError as e:
-            # makedirs can fail when diretory already exists.
-            if not (e.errno == errno.EEXIST and os.path.isdir(parent) or e.errno == errno.EISDIR):
+            if e.errno == errno.EISDIR:
+                # Directory already exists
+                pass
+            elif os.path.isdir(parent):
+                # Directory already exists
+                if e.errno != errno.EEXIST:
+                    tty.warn("Got OSError when trying to create directory at '{!s}' that already exists: {!r}".format(parent, e))
+            else:
                 raise
         return parent
 

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -386,17 +386,12 @@ class Lock(object):
         try:
             os.makedirs(parent)
         except OSError as e:
-            if e.errno == errno.EISDIR:
-                # Directory already exists
-                pass
-            elif os.path.isdir(parent):
-                # Directory already exists
-                if e.errno != errno.EEXIST:
-                    tty.warn(
-                        "Got OSError when trying to create directory "
-                        "at '{!s}' that already exists: {!r}".format(parent, e)
-                    )
-            else:
+            # os.makedirs can fail in a number of ways when the directory already exists.
+            # With EISDIR, we know it exists, and others like EEXIST, EACCES, and EROFS
+            # are fine if we ensure that the directory exists.
+            # Python 3 allows an exist_ok parameter and ignores any OSError as long as
+            # the directory exists.
+            if not (e.errno == errno.EISDIR or os.path.isdir(parent)):
                 raise
         return parent
 


### PR DESCRIPTION
It turns out that on some filesystem/os combinations, calling `os.makedirs` can raise `PermissionError` (`errno.EPERM`) if the directory is extant and readable, but not writable. This call happened before trying to activate environments.

Fixes #17407