### PR TITLE
visit: actually set the dev env for plugins again

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -81,6 +81,7 @@ class Visit(CMakePackage):
     variant("vtkm", default=False, description="Enable VTK-m support")
     variant("conduit", default=True, description="Enable Conduit support")
     variant("mfem", default=True, description="Enable MFEM support")
+    variant("plugins", default=True, description="Enable plugin development (xml2cmake)")
 
     patch("spack-changes-3.1.patch", when="@3.1.0:3.2.2")
     patch("spack-changes-3.0.1.patch", when="@3.0.1")
@@ -211,8 +212,10 @@ class Visit(CMakePackage):
             self.define("VISIT_JPEG_DIR", spec["jpeg"].prefix),
             self.define("VISIT_USE_GLEW", False),
             self.define("VISIT_CONFIG_SITE", "NONE"),
-            self.define("VISIT_INSTALL_THIRD_PARTY", False),
         ]
+
+        # Provide the plugin compilation environment so as to extend VisIt
+        args.append(self.define_from_variant("VISIT_INSTALL_THIRD_PARTY", "plugins"))
 
         if "@3.1: platform=darwin" in spec:
             args.append(self.define("FIXUP_OSX", False))


### PR DESCRIPTION
VisIt extendable feature is based on plugin development ; plugin dev is possible when cmake is run with
VISIT_INSTALL_THIRD_PARTY=ON
From https://www.visitusers.org/index.php?title=VisIt_CMake_Build_System:
 VISIT_INSTALL_THIRD_PARTY : Install VisIt's 3rd party I/O libs and includes to permit plugin development
There are further explanations here https://www.visitusers.org/index.php?title=Installing_using_CMake
This PR in a way reverses PR https://github.com/spack/spack/pull/30594 that removed the comment,
and also PR https://github.com/spack/spack/pull/31748 where VISIT_INSTALL_THIRD_PARTY was set to False.
Probably @chuckatkins will comment as author of these PRs.
My PR adds the 'plugins' variant that as a default is set to True ; do you agree this way @chuckatkins ?