### PR TITLE
Packaging: Support promoting packages to explicit

### DIFF
--- a/lib/spack/spack/build_systems/bundle.py
+++ b/lib/spack/spack/build_systems/bundle.py
@@ -6,6 +6,8 @@ import spack.builder
 import spack.directives
 import spack.package_base
 
+from typing import Tuple
+
 
 class BundlePackage(spack.package_base.PackageBase):
     """General purpose bundle, or no-code, package class."""
@@ -21,6 +23,16 @@ class BundlePackage(spack.package_base.PackageBase):
     has_code = False
 
     spack.directives.build_system("bundle")
+
+    phases: Tuple[str, ...] = ("promote")
+
+    def promote(self, spec, prefix):
+        # Update the explicit dependencies
+        for _, cond_dict in self.dependencies.items():
+            for cond, dep in cond_dict.items():
+                if dep.explicit and cond in spec:
+                    spack.store.db.update_explicit(spec[dep.spec.name], True)
+
 
 
 @spack.builder.builder("bundle")

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -94,6 +94,7 @@ class Dependency:
         pkg: "spack.package_base.PackageBase",
         spec: "spack.spec.Spec",
         type: Optional[Tuple[str, ...]] = default_deptype,
+        explicit: None,
     ):
         """Create a new Dependency.
 
@@ -106,6 +107,7 @@ class Dependency:
 
         self.pkg = pkg
         self.spec = spec.copy()
+        self.explicit = explicit
 
         # This dict maps condition specs to lists of Patch objects, just
         # as the patches dict on packages does.

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -356,7 +356,7 @@ def version(ver, checksum=None, **kwargs):
     return _execute_version
 
 
-def _depends_on(pkg, spec, when=None, type=default_deptype, patches=None):
+def _depends_on(pkg, spec, when=None, type=default_deptype, patches=None, explicit=None):
     when_spec = make_when_spec(when)
     if not when_spec:
         return
@@ -397,9 +397,11 @@ def _depends_on(pkg, spec, when=None, type=default_deptype, patches=None):
 
     # this is where we actually add the dependency to this package
     if when_spec not in conditions:
-        dependency = Dependency(pkg, dep_spec, type=type)
+        dependency = Dependency(pkg, dep_spec, type=type, explicit=explicit)
         conditions[when_spec] = dependency
     else:
+        if explicit:
+            dependency.explicit = True
         dependency = conditions[when_spec]
         dependency.spec.constrain(dep_spec, deps=False)
         dependency.type |= set(type)
@@ -444,7 +446,7 @@ def conflicts(conflict_spec, when=None, msg=None):
 
 
 @directive(("dependencies"))
-def depends_on(spec, when=None, type=default_deptype, patches=None):
+def depends_on(spec, when=None, type=default_deptype, patches=None, explicit=None):
     """Creates a dict of deps with specs defining when they apply.
 
     Args:
@@ -462,7 +464,7 @@ def depends_on(spec, when=None, type=default_deptype, patches=None):
     """
 
     def _execute_depends_on(pkg):
-        _depends_on(pkg, spec, when=when, type=type, patches=patches)
+        _depends_on(pkg, spec, when=when, type=type, patches=patches, explicit=explicit)
 
     return _execute_depends_on
 

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 # Wrapper around depends_on to propagate dependency variants
 def dav_sdk_depends_on(spec, when=None, propagate=None):
     # Do the basic depends_on
-    depends_on(spec, when=when)
+    depends_on(spec, when=when, explicit=True)
 
     # Strip spec string to just the base spec name
     # ie. A +c ~b -> A

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -150,7 +150,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     # releases 0.8 and ascent can build with conduit@0.8: and vtk-m@1.7:
     conflicts("ascent@develop", when="+ascent")
 
-    depends_on("py-cinemasci", when="+cinema")
+    dav_sdk_depends_on("py-cinemasci", when="+cinema")
 
     # ParaView needs @5.11: in order to use CUDA/ROCM, therefore it is the minimum
     # required version since GPU capability is desired for ECP


### PR DESCRIPTION
BundlePackages really just more advanced versions of yaml spec lists with `unify:True`, so they should be able to mark their dependencies as being installed explicitly since the parent package is really just a pass-through package wrapper. #31961

FYI: @eugeneswalker @wspear @tgamblin 

I made the default `None` because I didn't want to imply it with forcing packages to be demoted to implicitly, not explicitly, installed. So there is either `explicit=True` which means promote, `explicit=None` which means do nothing to the explicit nature of a package, and the `explicit=False` is currently ignored because it isn't needed but could easily be implemented.

Another possible parameter name could also be `promote` to be consistent with the phase name, then it would make sense as `True` or `False`, but I just thought of that as I was typing up this PR so it isn't in there.

The implementation was done in a phase because injecting this into the `PackageInstaller` was a nightmare and it probably won't be used outside of `BundlePackage`s. I could be convinced the other way...but I would prefer not to be :)