### PR TITLE
make shared lib the default for parallelio

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/gfortran.patch
+++ b/var/spack/repos/builtin/packages/parallelio/gfortran.patch
@@ -1,0 +1,23 @@
+--- old/CMakeLists.txt
++++ new/CMakeLists.txt
+@@ -4,7 +4,7 @@
+ 
+ # Jim Edwards
+ 
+-cmake_minimum_required (VERSION 3.5.2)
++cmake_minimum_required (VERSION 3.7)
+ project (PIO C)
+ 
+ # The project version number.
+@@ -243,6 +243,11 @@ if (PIO_ENABLE_COVERAGE)
+   endif ()
+ endif ()
+ 
++# Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
++if ("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER_EQUAL 10)
++   set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
++endif()
++
+ # Include this so we can check values in netcdf_meta.h.
+ INCLUDE(CheckCSourceCompiles)
+ INCLUDE(FindNetCDF)

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -13,7 +13,8 @@ class Parallelio(CMakePackage):
 
     homepage = "https://ncar.github.io/ParallelIO/"
     url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_8.tar.gz"
-
+    git = "https://github.com/NCAR/ParallelIO.git"
+    
     maintainers = ["jedwards4b"]
 
     version("2_5_8", sha256="f2584fb4310ff7da39d51efbe3f334efd0ac53ae2995e5fc157decccc0570a89")
@@ -46,6 +47,8 @@ class Parallelio(CMakePackage):
             define("NetCDF_C_PATH", spec["netcdf-c"].prefix),
             define("USER_CMAKE_MODULE_PATH", join_path(src, "cmake")),
             define("GENF90_PATH", join_path(src, "genf90")),
+            define("BUILD_SHARED_LIBS",True),
+            define("PIO_ENABLE_EXAMPLES",False),
         ]
         if spec.satisfies("+pnetcdf"):
             args.extend(
@@ -68,3 +71,6 @@ class Parallelio(CMakePackage):
             ]
         )
         return args
+
+    def url_for_version(self, version):
+        return "https://github.com/NCAR/ParallelIO/archive/pio{0}.tar.gz".format(version.underscored)

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -33,7 +33,7 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-c +mpi", type="link")
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
-    
+
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="+fortran %gcc@10:")
 

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -34,6 +34,8 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
+    patch("gfortran.patch", when="+fortran %gcc@10:")
+
     resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -33,7 +33,8 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-c +mpi", type="link")
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
-
+    
+    # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="+fortran %gcc@10:")
 
     resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -14,7 +14,7 @@ class Parallelio(CMakePackage):
     homepage = "https://ncar.github.io/ParallelIO/"
     url = "https://github.com/NCAR/ParallelIO/archive/pio2_5_8.tar.gz"
     git = "https://github.com/NCAR/ParallelIO.git"
-    
+
     maintainers = ["jedwards4b"]
 
     version("2_5_8", sha256="f2584fb4310ff7da39d51efbe3f334efd0ac53ae2995e5fc157decccc0570a89")
@@ -47,8 +47,8 @@ class Parallelio(CMakePackage):
             define("NetCDF_C_PATH", spec["netcdf-c"].prefix),
             define("USER_CMAKE_MODULE_PATH", join_path(src, "cmake")),
             define("GENF90_PATH", join_path(src, "genf90")),
-            define("BUILD_SHARED_LIBS",True),
-            define("PIO_ENABLE_EXAMPLES",False),
+            define("BUILD_SHARED_LIBS", True),
+            define("PIO_ENABLE_EXAMPLES", False),
         ]
         if spec.satisfies("+pnetcdf"):
             args.extend(
@@ -73,4 +73,6 @@ class Parallelio(CMakePackage):
         return args
 
     def url_for_version(self, version):
-        return "https://github.com/NCAR/ParallelIO/archive/pio{0}.tar.gz".format(version.underscored)
+        return "https://github.com/NCAR/ParallelIO/archive/pio{0}.tar.gz".format(
+            version.underscored
+        )


### PR DESCRIPTION
Make shared lib build by default.   Add some git repo information.
Turn off examples build by default.