### PR TITLE
update esmf package for cce (cray) compiler

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/cce.patch
+++ b/var/spack/repos/builtin/packages/esmf/cce.patch
@@ -1,0 +1,22 @@
+--- old/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
++++ new/src/Infrastructure/Mesh/src/Legacy/ESMCI_MeshPNC.C
+@@ -122,7 +122,7 @@ void LoadNCDualMeshPar(Mesh &mesh, const std::string fname) {
+       local_grid_start = my_start*grid_dims[0];
+     }
+     
+-    int local_grid_dims[2] = {grid_dims[0], my_num > 0 ? my_num+1 : 0};
++    int local_grid_dims[2] = {grid_dims[0], (int) my_num > 0 ? (int) my_num+1 : 0};
+ 
+     Par::Out() << "min_row=" << min_row << ", max_row=" << max_row << std::endl;
+     Par::Out() << "local_grid_start=" << local_grid_start << ", local_grid_size:" << local_grid_size << std::endl;
+--- old/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
++++ new/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
+@@ -229,7 +229,7 @@ static void get_nc_grid_file1(nc_grid_file1 &ncf, const std::string &ncfile, boo
+   ncf.local_grid_size = local_grid_size;
+   ncf.local_grid_start = local_grid_start;
+   
+-  int local_grid_dims[2] = {grid_dims[0], my_num > 0 ? my_num+1 : 0};
++  int local_grid_dims[2] = {grid_dims[0], (int) my_num > 0 ? (int) my_num+1 : 0};
+ 
+   Par::Out() << "min_row=" << min_row << ", max_row=" << max_row << std::endl;
+   Par::Out() << "local_grid_start=" << local_grid_start << ", local_grid_size:" << local_grid_size << std::endl;

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -98,6 +98,9 @@ class Esmf(MakefilePackage):
     # https://sourceforge.net/p/esmf/esmf/ci/34de0ccf556ba75d35c9687dae5d9f666a1b2a18/
     patch("mvapich2.patch", when="@:7.0")
 
+    # explicit type cast of variables from long to int
+    patch("cce.patch", when="@:8.4.0 %cce@14.0.0")
+
     # Allow different directories for creation and
     # installation of dynamic libraries on OSX:
     patch("darwin_dylib_install_name.patch", when="platform=darwin @:7.0")
@@ -192,6 +195,8 @@ class Esmf(MakefilePackage):
             os.environ["ESMF_COMPILER"] = "nag"
         elif self.compiler.name == "pgi":
             os.environ["ESMF_COMPILER"] = "pgi"
+        elif self.compiler.name == "cce":
+            os.environ["ESMF_COMPILER"] = "cce"
         else:
             msg = "The compiler you are building with, "
             msg += '"{0}", is not supported by ESMF.'
@@ -297,10 +302,6 @@ class Esmf(MakefilePackage):
             # When defined, enables the use of Parallel-NetCDF.
             # ESMF_PNETCDF_LIBS will be set to "-lpnetcdf".
             os.environ["ESMF_PNETCDF"] = "pnetcdf-config"
-
-            # FIXME: determine whether or not we need to set these.
-            # ESMF_PNETCDF_INCLUDE
-            # ESMF_PNETCDF_LIBPATH
 
         ##############
         # ParallelIO #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -99,7 +99,7 @@ class Esmf(MakefilePackage):
     patch("mvapich2.patch", when="@:7.0")
 
     # explicit type cast of variables from long to int
-    patch("cce.patch", when="@:8.4.0 %cce@14.0.0")
+    patch("cce.patch", when="@:8.4.0 %cce@13.99:")
 
     # Allow different directories for creation and
     # installation of dynamic libraries on OSX:


### PR DESCRIPTION
Update esmf package to build with cce compiler and add a patch for esmf < 8.4.0 and
cce > 13