### PR TITLE
solver setup: extract virtual dependencies from reusable specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1463,6 +1463,9 @@ class SpackSolverSetup(object):
                         if concrete_build_deps or dtype != "build":
                             clauses.append(fn.depends_on(spec.name, dep.name, dtype))
 
+                            for virtual in dep.package.virtuals_provided:
+                                clauses.append(fn.depends_on(spec.name, virtual.name, dtype))
+
                     # imposing hash constraints for all but pure build deps of
                     # already-installed concrete specs.
                     if concrete_build_deps or dspec.deptypes != ("build",):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1463,8 +1463,11 @@ class SpackSolverSetup(object):
                         if concrete_build_deps or dtype != "build":
                             clauses.append(fn.depends_on(spec.name, dep.name, dtype))
 
+                            # Ensure Spack will not coconcretize this with another provider
+                            # for the same virtual
                             for virtual in dep.package.virtuals_provided:
-                                clauses.append(fn.depends_on(spec.name, virtual.name, dtype))
+                                clauses.append(fn.virtual_node(virtual.name))
+                                clauses.append(fn.provider(dep.name, virtual.name))
 
                     # imposing hash constraints for all but pure build deps of
                     # already-installed concrete specs.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1715,7 +1715,7 @@ class TestConcretize(object):
             result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
 
         for spec in result.specs:
-            assert 'zmpi' in spec
+            assert "zmpi" in spec
 
     @pytest.mark.regression("30864")
     def test_misleading_error_message_on_version(self, mutable_database):


### PR DESCRIPTION
Fixes #32430 

Previously, we did not extract dependency information from specs as part of their imposed constraints for reuse. This meant that a concrete specs could be co-concretized with conflicting virtuals. Extracting that information and imposing dependencies on virtual packages fixes the bug.

Includes unit test.