### PR TITLE
Checksum: Warn if version is deprecated

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -206,6 +206,8 @@ nitpick_ignore = [
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),
+    # Spack classes that intersphinx is unable to resolve
+    ("py:class", "spack.version.VersionBase"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -15,7 +15,7 @@ import spack.repo
 import spack.spec
 import spack.stage
 import spack.util.crypto
-from spack.package_base import preferred_version
+from spack.package_base import deprecated_version, preferred_version
 from spack.util.naming import valid_fully_qualified_module_name
 from spack.version import VersionBase, ver
 
@@ -81,6 +81,9 @@ def checksum(parser, args):
     if versions:
         remote_versions = None
         for version in versions:
+            if deprecated_version(pkg, version):
+                tty.warn("Version {0} is deprecated".format(version))
+
             version = ver(version)
             if not isinstance(version, VersionBase):
                 tty.die(
@@ -101,7 +104,7 @@ def checksum(parser, args):
         url_dict = pkg.fetch_remote_versions()
 
     if not url_dict:
-        tty.die("Could not find any versions for {0}".format(pkg.name))
+        tty.die("Could not find any remote versions for {0}".format(pkg.name))
 
     version_lines = spack.stage.get_checksums_for_versions(
         url_dict,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -100,6 +100,26 @@ _spack_configure_argsfile = "spack-configure-args.txt"
 is_windows = sys.platform == "win32"
 
 
+def deprecated_version(pkg, version):
+    """
+    Returns a list of the deprecated versions of the package.
+
+    Arguments:
+        pkg (Package): The package whose version is to be checked.
+        version (str or spack.version.VersionBase): The version being checked
+
+    Returns: (bool) True if version is deprecated, False otherwise
+    """
+    if not isinstance(version, VersionBase):
+        version = Version(version)
+
+    for k, v in pkg.versions.items():
+        if version == k and v.get("deprecated", False):
+            return True
+
+    return False
+
+
 def preferred_version(pkg):
     """
     Returns a sorted list of the preferred versions of the package.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -101,14 +101,11 @@ is_windows = sys.platform == "win32"
 
 
 def deprecated_version(pkg, version):
-    """
-    Returns a list of the deprecated versions of the package.
+    """Return True if the version is deprecated, False otherwise.
 
     Arguments:
         pkg (Package): The package whose version is to be checked.
         version (str or spack.version.VersionBase): The version being checked
-
-    Returns: (bool) True if version is deprecated, False otherwise
     """
     if not isinstance(version, VersionBase):
         version = Version(version)

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -68,3 +68,13 @@ def test_checksum_versions(mock_packages, mock_fetch, mock_stage):
     output = spack_checksum("preferred-test", versions[0])
     assert "Found 1 version" in output
     assert "version(" in output
+
+
+def test_checksum_missing_version(mock_packages, mock_fetch, mock_stage):
+    output = spack_checksum("preferred-test", "99.99.99", fail_on_error=False)
+    assert "Could not find any remote versions" in output
+
+
+def test_checksum_deprecated_version(mock_packages, mock_fetch, mock_stage):
+    output = spack_checksum("deprecated-versions", "1.1.0", fail_on_error=False)
+    assert "Version 1.1.0 is deprecated" in output

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -321,3 +321,11 @@ def test_has_test_method_fails(capsys):
 
     captured = capsys.readouterr()[1]
     assert "is not a class" in captured
+
+
+def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
+    spec = Spec("deprecated-versions")
+    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+
+    assert spack.package_base.deprecated_version(pkg_cls, "1.1.0")
+    assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")


### PR DESCRIPTION
This PR adds a method to check if a version is deprecated *and* will print a warning if that is the case for `spack checksum`.

The current output for a deprecated version can be confusing/misleading, especially when a deprecated package's URL is no longer valid or available.  For example:

```
$ spack info --no-dependencies --no-variants snphylo
Package:   snphylo

Description:
    A pipeline to generate a phylogenetic tree from huge SNP data

Homepage: http://chibba.pgml.uga.edu/snphylo/

Preferred version:  
    20180901      https://github.com/thlee/SNPhylo/archive/refs/tags/20180901.tar.gz

Safe versions:  
    20180901      https://github.com/thlee/SNPhylo/archive/refs/tags/20180901.tar.gz

Deprecated versions:  
    2016-02-04    https://github.com/thlee/SNPhylo/archive/refs/tags/2016-02-04.tar.gz

$ spack checksum snphylo 2016-02-04
==> Error: Could not find any versions for snphylo
```

So this PR adds a warning and elaborates a *little* on the issue.

```
spack checksum snphylo 2016-02-04
==> Warning: Version 2016-02-04 is deprecated
==> Error: Could not find any remote versions for snphylo
```

TODO
- [x] Add unit test(s) I(F this has a chance to be merged)