### PR TITLE
hermes: Upgrade version from 0.7.0-beta to 0.8.0-beta.

### DIFF
--- a/var/spack/repos/builtin/packages/hermes/package.py
+++ b/var/spack/repos/builtin/packages/hermes/package.py
@@ -18,9 +18,9 @@ class Hermes(CMakePackage):
 
     version("master", branch="master")
     version(
-        "0.7.0-beta",
+        "0.8.0-beta",
         url="https://github.com/HDFGroup/hermes/archive/v0.7.0-beta.tar.gz",
-        sha256="1046f537558e479c8a828fe8e289da410a0f82bdba199a40ea7ff0eb842d9382",
+        sha256="697c8b0ca2d94512326d1dc8d1895d3d37fbff708013d7bf578a3158b06cb158",
     )
 
     variant("vfd", default=False, description="Enable HDF5 VFD")


### PR DESCRIPTION
The version 0.8.0-beta is released.