### PR TITLE
py-gpytorch: add v1.9.0; add new py-linear-operator

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-gpytorch/package.py
@@ -17,6 +17,7 @@ class PyGpytorch(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("1.9.0", sha256="a0608184c18a1f518d6a102473427abf00f5351421e12a934530953f6887b34b")
     version("1.8.1", sha256="fe8e412a73a2b07027e30c65c61323de15ebcef439f5bd21200cf26551fd0e30")
     version("1.8.0", sha256="d6c0c77d9a61f47feac2d19456816ccea1ed48c32c72d7ea33aa13b259e2a455")
     version("1.7.0", sha256="e91cb8a1883d54f8f57cebbc0c61c227b3cd72528d8e90e770f971fc4e408538")
@@ -25,15 +26,19 @@ class PyGpytorch(PythonPackage):
     version("1.2.0", sha256="fcb216e0c1f128a41c91065766508e91e487d6ffadf212a51677d8014aefca84")
     version("1.1.1", sha256="76bd455db2f17af5425f73acfaa6d61b8adb1f07ad4881c0fa22673f84fb571a")
 
+    depends_on("python@3.8:", when="@1.9:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.7:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", when="@1.9:", type="build")
+    depends_on("py-torch@1.11:", when="@1.9:", type=("build", "run"))
     depends_on("py-torch@1.10:", when="@1.7:", type=("build", "run"))
     depends_on("py-torch@1.9:", when="@1.6:", type=("build", "run"))
     depends_on("py-torch@1.8.1:", when="@1.5:", type=("build", "run"))
     depends_on("py-torch@1.7:", when="@1.3:", type=("build", "run"))
     depends_on("py-torch@1.6:", when="@1.2:", type=("build", "run"))
     depends_on("py-torch@1.5:", type=("build", "run"))
-    depends_on("py-numpy", when="@1.7:", type=("build", "run"))
     depends_on("py-scikit-learn", when="@1.2:", type=("build", "run"))
-    depends_on("py-scipy", when="@1.2:", type=("build", "run"))
+    depends_on("py-linear-operator@0.1.1:", when="@1.9:", type=("build", "run"))
+    depends_on("py-numpy", when="@1.7:1.8", type=("build", "run"))
+    depends_on("py-scipy", when="@1.2:1.8", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-linear-operator/package.py
+++ b/var/spack/repos/builtin/packages/py-linear-operator/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLinearOperator(PythonPackage):
+    """A linear operator implementation, primarily designed for finite-dimensional
+    positive definite operators (i.e. kernel matrices)."""
+
+    homepage = "https://github.com/cornellius-gp/linear_operator/"
+    pypi = "linear_operator/linear_operator-0.1.1.tar.gz"
+
+    version("0.1.1", sha256="81adc1aea9e98f3c4f07f5608eb77b689bc61793e9beebfea82155e9237bf1be")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")
+    depends_on("py-torch@1.11:", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))


### PR DESCRIPTION
Successfully builds on macOS 12.5 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/cornellius-gp/gpytorch/releases/tag/v1.9.0