### PR TITLE
pumi: fix path to smoketest input data

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -134,13 +134,8 @@ class Pumi(CMakePackage):
             join_path(data_dir, "pipe.dmg"),
             join_path(data_dir, "pipe.smb"),
             join_path(self.prefix.bin, "pipe_2_.smb"),
-            "2"
+            "2",
         ]
         expected = "pipe_2_.smb written"
         description = "testing pumi mesh partitioning"
-        self.run_test(
-            mpiexec,
-            options,
-            expected,
-            purpose=description
-        )
+        self.run_test(mpiexec, options, expected, purpose=description)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -126,14 +126,21 @@ class Pumi(CMakePackage):
         self.run_test(exe, options, expected, purpose=description)
 
         mpiexec = self.spec["mpi"].prefix.bin.mpiexec
-        mpiopt = ["-n", "2"]
-        exe = ["split"]
-        options = ["../share/testdata/pipe.dmg", "../share/testdata/pipe.smb", "pipe_2_.smb", "2"]
-        expected = "mesh pipe_2_.smb written"
+        data_dir = self.prefix.share.testdata
+        options = [
+            "-n",
+            "2",
+            join_path(self.prefix.bin, "split"),
+            join_path(data_dir, "pipe.dmg"),
+            join_path(data_dir, "pipe.smb"),
+            join_path(self.prefix.bin, "pipe_2_.smb"),
+            "2"
+        ]
+        expected = "pipe_2_.smb written"
         description = "testing pumi mesh partitioning"
         self.run_test(
             mpiexec,
-            mpiopt + exe + options,
+            options,
             expected,
-            purpose=description,
+            purpose=description
         )

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -115,7 +115,7 @@ class Pumi(CMakePackage):
         if self.spec.version <= Version("2.2.6"):
             return
         exe = "uniform"
-        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_unif.smb"]
+        options = ['../share/testdata/pipe.dmg', '../share/testdata/pipe.smb', 'pipe_unif.smb']
         expected = "mesh pipe_unif.smb written"
         description = "testing pumi uniform mesh refinement"
         self.run_test(exe, options, expected, purpose=description, work_dir=self.prefix.bin)
@@ -123,7 +123,7 @@ class Pumi(CMakePackage):
         mpiexec = Executable(join_path(self.spec["mpi"].prefix.bin, "mpiexec")).command
         mpiopt = ["-n", "2"]
         exe = ["split"]
-        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_2_.smb", "2"]
+        options = ['../share/testdata/pipe.dmg', '../share/testdata/pipe.smb', 'pipe_2_.smb', '2']
         expected = "mesh pipe_2_.smb written"
         description = "testing pumi mesh partitioning"
         self.run_test(

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+import warnings
 
 
 class Pumi(CMakePackage):
@@ -125,7 +126,14 @@ class Pumi(CMakePackage):
         description = "testing pumi uniform mesh refinement"
         self.run_test(exe, options, expected, purpose=description)
 
-        mpiexec = self.spec["mpi"].prefix.bin.mpiexec
+        mpiexec = ""
+        mpiexe_list = ["mpirun", "mpiexec", "srun"]
+        for mpiexe in mpiexe_list:
+            if which(mpiexe) is not None:
+                mpiexec = Executable(mpiexe).command
+                break
+        if mpiexec == "":
+            warnings.warn("MPI exec not found")
         data_dir = self.prefix.share.testdata
         options = [
             "-n",

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import warnings
+
+from spack.package import *
 
 
 class Pumi(CMakePackage):

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -115,7 +115,7 @@ class Pumi(CMakePackage):
         if self.spec.version <= Version("2.2.6"):
             return
         exe = "uniform"
-        options = ['../share/testdata/pipe.dmg', '../share/testdata/pipe.smb', 'pipe_unif.smb']
+        options = ["../share/testdata/pipe.dmg", "../share/testdata/pipe.smb", "pipe_unif.smb"]
         expected = "mesh pipe_unif.smb written"
         description = "testing pumi uniform mesh refinement"
         self.run_test(exe, options, expected, purpose=description, work_dir=self.prefix.bin)
@@ -123,7 +123,7 @@ class Pumi(CMakePackage):
         mpiexec = Executable(join_path(self.spec["mpi"].prefix.bin, "mpiexec")).command
         mpiopt = ["-n", "2"]
         exe = ["split"]
-        options = ['../share/testdata/pipe.dmg', '../share/testdata/pipe.smb', 'pipe_2_.smb', '2']
+        options = ["../share/testdata/pipe.dmg", "../share/testdata/pipe.smb", "pipe_2_.smb", "2"]
         expected = "mesh pipe_2_.smb written"
         description = "testing pumi mesh partitioning"
         self.run_test(

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -114,13 +114,18 @@ class Pumi(CMakePackage):
     def test(self):
         if self.spec.version <= Version("2.2.6"):
             return
-        exe = "uniform"
-        options = ["../share/testdata/pipe.dmg", "../share/testdata/pipe.smb", "pipe_unif.smb"]
-        expected = "mesh pipe_unif.smb written"
+        data_dir = self.prefix.share.testdata
+        exe = self.prefix.bin.uniform
+        options = [
+            join_path(data_dir, "pipe.dmg"),
+            join_path(data_dir, "pipe.smb"),
+            join_path(self.prefix.bin, "pipe_unif.smb"),
+        ]
+        expected = "pipe_unif.smb written"
         description = "testing pumi uniform mesh refinement"
-        self.run_test(exe, options, expected, purpose=description, work_dir=self.prefix.bin)
+        self.run_test(exe, options, expected, purpose=description)
 
-        mpiexec = Executable(join_path(self.spec["mpi"].prefix.bin, "mpiexec")).command
+        mpiexec = self.spec["mpi"].prefix.bin.mpiexec
         mpiopt = ["-n", "2"]
         exe = ["split"]
         options = ["../share/testdata/pipe.dmg", "../share/testdata/pipe.smb", "pipe_2_.smb", "2"]
@@ -131,5 +136,4 @@ class Pumi(CMakePackage):
             mpiopt + exe + options,
             expected,
             purpose=description,
-            work_dir=self.prefix.bin,
         )


### PR DESCRIPTION
This PR fixes the path to the input data needed to successfully run `spack test run pumi`.

https://github.com/SCOREC/core/issues/370