### PR TITLE
imagemagick: new variant ghostscript

### DIFF
--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -18,7 +18,7 @@ class Imagemagick(AutotoolsPackage):
     version("7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa")
     version("7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3")
 
-    variant("ghostscript", default=True, description="Compile with Ghostscript support")
+    variant("ghostscript", default=False, description="Compile with Ghostscript support")
 
     depends_on("jpeg")
     depends_on("pango")

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -37,8 +37,6 @@ class Imagemagick(AutotoolsPackage):
         args = []
         spec = self.spec
         if spec.satisfies("+ghostscript"):
-            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
-        if spec.satisfies("+ghostscript"):
             args.append("--with-gslib")
             gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
             args.append("--with-gs-font-dir={0}".format(gs_font_dir))

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -18,6 +18,8 @@ class Imagemagick(AutotoolsPackage):
     version("7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa")
     version("7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3")
 
+    variant("ghostscript", default=True, description="Compile with Ghostscript support")
+
     depends_on("jpeg")
     depends_on("pango")
     depends_on("libtool", type="build")
@@ -26,15 +28,20 @@ class Imagemagick(AutotoolsPackage):
     depends_on("freetype")
     depends_on("fontconfig")
     depends_on("libtiff")
-    depends_on("ghostscript")
-    depends_on("ghostscript-fonts")
+    depends_on("ghostscript", when="+ghostscript")
+    depends_on("ghostscript-fonts", when="+ghostscript")
     depends_on("libsm")
     depends_on("pkgconfig", type="build")
 
     def configure_args(self):
+        args = []
         spec = self.spec
-        gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
-        return ["--with-gs-font-dir={0}".format(gs_font_dir)]
+        if spec.satisfies("+ghostscript"):
+            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
+            args.append("--with-gs-font-dir={0}".format(gs_font_dir))
+        else:
+            args.append("--without-gslib")
+        return args
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -38,6 +38,9 @@ class Imagemagick(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies("+ghostscript"):
             gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
+        if spec.satisfies("+ghostscript"):
+            args.append("--with-gslib")
+            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
             args.append("--with-gs-font-dir={0}".format(gs_font_dir))
         else:
             args.append("--without-gslib")

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -38,7 +38,7 @@ class Imagemagick(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies("+ghostscript"):
             args.append("--with-gslib")
-            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share, "font")
+            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share.font)
             args.append("--with-gs-font-dir={0}".format(gs_font_dir))
         else:
             args.append("--without-gslib")

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -38,7 +38,7 @@ class Imagemagick(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies("+ghostscript"):
             args.append("--with-gslib")
-            gs_font_dir = join_path(spec["ghostscript-fonts"].prefix.share.font)
+            gs_font_dir = spec["ghostscript-fonts"].prefix.share.font
             args.append("--with-gs-font-dir={0}".format(gs_font_dir))
         else:
             args.append("--without-gslib")


### PR DESCRIPTION
Ghostscript adds about 75 dependencies to an installation of just imagemagick (97 without, 172 with Ghostscript). This adds a variant (defaulting to true for backward compatibility) that allows users to turn off Ghostscript support.