### PR TITLE
gdk-pixbuf: only build tests when requested

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -91,6 +91,9 @@ class GdkPixbuf(Package):
     def install(self, spec, prefix):
         with working_dir("spack-build", create=True):
             meson_args = std_meson_args + ["-Dman={0}".format("+man" in spec)]
+            # Only build tests when requested
+            if self.version >= Version("2.42.9"):
+                meson_args += ["-Dtests={0}".format(self.run_tests)]
             # Based on suggestion by luigi-calori and the fixup shown by lee218llnl:
             # https://github.com/spack/spack/pull/27254#issuecomment-974464174
             if "+x11" in spec:


### PR DESCRIPTION
The building of tests is optional [as of 2.42.9](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/801eef111df624f4377baed9a90c94b6a2d4340c). This applies this option in the build.

The reason the option was added is to deal with test build failures in sandboxed environments and with certain glibc versions (caused by glib gresources, in fact). For example, with the latest version glibc and in the latest version of docker these tests [cannot be built](https://github.com/moby/moby/issues/43595).