### PR TITLE
tree: add 2.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/tree/package.py
+++ b/var/spack/repos/builtin/packages/tree/package.py
@@ -26,7 +26,7 @@ class Tree(Package):
 
     @when("@2:")
     def install(self, spec, prefix):
-        make("install", "PREFIX=%s" % prefix)
+        make("install", "PREFIX=%s" % prefix, "CFLAGS=-std=c99")
 
     @when("@:1")
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/tree/package.py
+++ b/var/spack/repos/builtin/packages/tree/package.py
@@ -26,7 +26,13 @@ class Tree(Package):
 
     @when("@2:")
     def install(self, spec, prefix):
-        make("install", "PREFIX=%s" % prefix, "CFLAGS=-std=c99")
+        make(
+            "PREFIX=%s" % prefix,
+            "CC=%s" % spack_cc,
+            "CFLAGS=-O3 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=c99",
+            "LDFLAGS=-s",
+            "install",
+        )
 
     @when("@:1")
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/tree/package.py
+++ b/var/spack/repos/builtin/packages/tree/package.py
@@ -19,6 +19,7 @@ class Tree(Package):
     homepage = "http://mama.indstate.edu/users/ice/tree/"
     url = "http://mama.indstate.edu/users/ice/tree/src/tree-1.7.0.tgz"
 
+    version("2.0.3", sha256="ba14e77b5f9dc7f8250c3f702ec5b6be2f93cd0fa87311bab3239676866a3b1d")
     version("2.0.2", sha256="7d693a1d88d3c4e70a73e03b8dbbdc12c2945d482647494f2f5bd83a479eeeaf")
     version("1.8.0", sha256="715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2")
     version("1.7.0", sha256="6957c20e82561ac4231638996e74f4cfa4e6faabc5a2f511f0b4e3940e8f7b12")


### PR DESCRIPTION
When I tried to compile `tree` in the past, it failed with `error: 'for' loop initial declarations are only allowed in C99 mode`. I needed to add `CFLAGS=-O3 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=c99` to use both the existing values from the Makefile and the new flag `-std=c99`. I felt this was too hacky to upstream. `tree` v2.0.3 now appends the environment-set `CFLAGS` to its own copy instead of overriding its own, so I feel much more comfortable upstreaming it.