### PR TITLE
charliecloud: use bash for autoreconf

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -56,7 +56,7 @@ class Charliecloud(AutotoolsPackage):
     depends_on("bats@0.4.0", type="test")
 
     def autoreconf(self, spec, prefix):
-        which("sh")("autogen.sh")
+        which("bash")("autogen.sh")
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Potentially addresses #32002.

Fixes https://github.com/spack/spack/issues/32002