### PR TITLE
r-gridextra: Fix the CRAN package name.

### DIFF
--- a/var/spack/repos/builtin/packages/r-gridextra/package.py
+++ b/var/spack/repos/builtin/packages/r-gridextra/package.py
@@ -12,7 +12,7 @@ class RGridextra(RPackage):
     Provides a number of user-level functions to work with "grid" graphics,
     notably to arrange multiple grid-based plots on a page, and draw tables."""
 
-    cran = "gridExtras"
+    cran = "gridExtra"
 
     version("2.3", sha256="81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b")
     version("2.2.1", sha256="44fe455a5bcdf48a4ece7a542f83e7749cf251dc1df6ae7634470240398c6818")


### PR DESCRIPTION
It seems like it was renamed from "gridExtras" to "gridExtra".