### PR TITLE
Doc: `lsb-release`

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -44,7 +44,7 @@ A build matrix showing which packages are working on which systems is shown belo
          yum install -y epel-release
          yum update -y
          yum --enablerepo epel groupinstall -y "Development Tools"
-         yum --enablerepo epel install -y curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute make patch python3 python3-pip python3-setuptools unzip
+         yum --enablerepo epel install -y curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute redhat-lsb-core make patch python3 python3-pip python3-setuptools unzip
          python3 -m pip install boto3
 
    .. tab-item:: macOS Brew

--- a/lib/spack/docs/tables/system_prerequisites.csv
+++ b/lib/spack/docs/tables/system_prerequisites.csv
@@ -11,6 +11,7 @@ bzip2, , , Compress/Decompress archives
 xz, , , Compress/Decompress archives
 zstd, , Optional, Compress/Decompress archives
 file, , , Create/Use Buildcaches
+lsb-release, , , Linux: identify operating system version
 gnupg2, , , Sign/Verify Buildcaches
 git, , , Manage Software Repositories
 svn, , Optional, Manage Software Repositories


### PR DESCRIPTION
Without the `lsb-release` tool installed, Spack cannot identify the Ubuntu/Debian version.

Debian unstable/sid (system of a colleague)
```
      operating_system: debianunstable
```
or (me in docker, default no `lsb-release` installed)
```
      operating_system: debian
```