### PR TITLE
Docs: Getting Started Dependencies

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -127,6 +127,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinx_design",
     "sphinxcontrib.programoutput",
 ]
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -40,7 +40,12 @@ A build matrix showing which packages are working on which systems is shown belo
 
       .. note::
 
-         TODO
+         yum update -y
+         yum install -y epel-release
+         yum update -y
+         yum --enablerepo epel groupinstall -y "Development Tools"
+         yum --enablerepo epel install -y curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute make patch python3 python3-pip python3-setuptools unzip
+         python3 -m pip install boto3
 
    .. tab-item:: macOS Brew
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -34,7 +34,7 @@ A build matrix showing which packages are working on which systems is shown belo
       .. code-block:: console
 
          apt update
-         apt install build-essential ca-certificates coreutils curl environment-modules gcc gfortran g++ git gpg lsb-release python3 unzip zip
+         apt install build-essential ca-certificates coreutils curl environment-modules gfortran git gpg lsb-release python3 python3-distutils python3-venv unzip zip
 
    .. tab-item:: RHEL
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -23,8 +23,31 @@ be present on the machine where Spack is run:
 These requirements can be easily installed on most modern Linux systems;
 on macOS, XCode is required.  Spack is designed to run on HPC
 platforms like Cray.  Not all packages should be expected
-to work on all platforms.  A build matrix showing which packages are
-working on which systems is planned but not yet available.
+to work on all platforms.
+
+A build matrix showing which packages are working on which systems is shown below.
+
+.. tab-set::
+
+   .. tab-item:: Debian/Ubuntu
+
+      .. code-block:: console
+
+         apt update
+         apt install build-essential ca-certificates coreutils curl environment-modules gcc gfortran g++ git gpg lsb-release python3 unzip zip
+
+   .. tab-item:: RHEL
+
+      .. note::
+
+         TODO
+
+   .. tab-item:: macOS Brew
+
+      .. code-block:: console
+
+         brew update
+         brew install curl gcc git gnupg zip
 
 ------------
 Installation

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -3,6 +3,7 @@
 
 sphinx>=3.4,!=4.1.2,!=5.1.0
 sphinxcontrib-programoutput
+sphinx-design
 sphinx-rtd-theme
 python-levenshtein
 # Restrict to docutils <0.17 to workaround a list rendering issue in sphinx.

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -18,6 +18,7 @@ spack:
   - "py-sphinx@3.4:4.1.1,4.1.3:"
   - py-sphinxcontrib-programoutput
   - py-docutils@:0.16
+  - py-sphinx-design
   - py-sphinx-rtd-theme
   # VCS
   - git


### PR DESCRIPTION
Finally document what one needs to install to use Spack on Linux and Mac :-)

With <3 for minimal container users (e.g., issues like #32479) and my colleagues with their fancy Macs.
![Screenshot from 2022-09-01 12-03-42](https://user-images.githubusercontent.com/1353258/187992651-6aa20653-8337-4417-9233-309ea8a16e09.png)
