### PR TITLE
SDK: Remove conflicting variants from sensei propagation

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -115,11 +115,9 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
 
     dav_sdk_depends_on("veloc", when="+veloc")
 
-    propagate_to_sensei = [(v, v) for v in ["adios2", "ascent", "hdf5"]]
-    propagate_to_sensei.extend([("paraview", "catalyst"), ("visit", "libsim")])
-    dav_sdk_depends_on(
-        "sensei@4: ~vtkio +python", when="+sensei", propagate=dict(propagate_to_sensei)
-    )
+    # Skipping propagating ascent, catalyst(paraview), and libsim(visit) to sensei
+    # due to incomaptiblity between these variants in sensei.
+    dav_sdk_depends_on("sensei@4: ~vtkio +python", when="+sensei", propagate=["adios2", "hdf5"])
 
     # Fortran support with ascent is problematic on some Cray platforms so the
     # SDK is explicitly disabling it until the issues are resolved.


### PR DESCRIPTION
FYI: @eugeneswalker @wspear 

After talking this over in a team meeting, these extra variants are going to be left unspecified so long as they are incompatible with each other.