### PR TITLE
Match protobuf to py-protobuf version

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -15,7 +15,11 @@ class Protobuf(Package):
     homepage = "https://developers.google.com/protocol-buffers"
     url = "https://github.com/protocolbuffers/protobuf/archive/v3.18.0.tar.gz"
 
-    version("21.1", sha256="f1a83673cbcaff6346a8fba87a9c02c0f943a4a696b6c7d1b71586d97609db12")
+    version("3.21.5", sha256="d7d204a59fd0d2d2387bd362c2155289d5060f32122c4d1d922041b61191d522")
+    version("3.21.4", sha256="85d42d4485f36f8cec3e475a3b9e841d7d78523cd775de3a86dba77081f4ca25")
+    version("3.21.3", sha256="c29d8b4b79389463c546f98b15aa4391d4ed7ec459340c47bffe15db63eb9126")
+    version("3.21.2", sha256="66e1156ac78290db81335c79d1fc5a54123ebb62a43eb2e5b42a44ca23087517")
+    version("3.21.1", sha256="a295dd3b9551d3e2749a9969583dea110c6cdcc39d02088f7c7bb1100077e081")
     version("3.20.1", sha256="8b28fdd45bab62d15db232ec404248901842e5340299a57765e48abe8a80d930")
     version("3.20.0", sha256="b07772d38ab07e55eca4d50f4b53da2d998bb221575c60a4f81100242d4b4889")
     version("3.19.4", sha256="3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -19,6 +19,7 @@ class PyProtobuf(PythonPackage):
 
     variant("cpp", default=False, description="Enable the cpp implementation")
 
+    version("4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a")
     version("3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9")
     version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
     version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")
@@ -73,14 +74,20 @@ class PyProtobuf(PythonPackage):
     depends_on("py-unittest2", when="@3: ^python@:2", type=("build", "run"))
 
     # Setup dependencies for protobuf to use the same minor version as py-protobuf
+    # Handle mapping the 4.x release to the protobuf 3.x releases
+    for ver in list(range(21, 22)):
+        depends_on(
+            "protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
+            type=("build", "run"),
+            when="+cpp @4." + str(ver) + ".0:4." + str(ver) + ".99")
     # Handle the 3.x series releases
-    for ver in list(range(1, 20)):
-        depends_on("protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
-                   type=("build", "run"),
-                   when="+cpp @3." + str(ver) + ".0:3." + str(ver) + ".99")
+    for ver in list(range(1, 21)):
+        depends_on(
+            "protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
+            type=("build", "run"),
+            when="+cpp @3." + str(ver) + ".0:3." + str(ver) + ".99")
     # Handle the 2.x series releases
-    depends_on("protobuf@2.0.0:2.99.99", type=("build", "run"),
-               when="+cpp @2.0.0:2.99.99")
+    depends_on("protobuf@2.0.0:2.99.99", type=("build", "run"), when="+cpp @2.0.0:2.99.99")
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -23,7 +23,8 @@ class PyProtobuf(PythonPackage):
     version(
         "3.20.1",
         sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9",
-        preferred=True)
+        preferred=True
+    )
     version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
     version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")
     version("3.19.3", sha256="d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -20,7 +20,10 @@ class PyProtobuf(PythonPackage):
     variant("cpp", default=False, description="Enable the cpp implementation")
 
     version("4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a")
-    version("3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9")
+    version(
+        "3.20.1",
+        sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9",
+        preferred=True)
     version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
     version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")
     version("3.19.3", sha256="d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907")
@@ -81,7 +84,7 @@ class PyProtobuf(PythonPackage):
     for ver in list(range(1, 21)):
         depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
-    depends_on("protobuf@2", type=("build", "run"), when="+cpp @2")
+    depends_on("protobuf@2.", type=("build", "run"), when="+cpp @2.")
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -80,14 +80,14 @@ class PyProtobuf(PythonPackage):
     # Setup dependencies for protobuf to use the same minor version as py-protobuf
     # Handle mapping the 4.x release to the protobuf 3.x releases
     for ver in list(range(21, 22)):
-        depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @4." + str(ver))
+        depends_on("protobuf@3." + str(ver), when="+cpp @4." + str(ver))
     # Handle the 3.x series releases
     for ver in list(range(1, 8)) + list(range(9, 21)):
-        depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @3." + str(ver))
+        depends_on("protobuf@3." + str(ver), when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
     for ver in list(range(3, 7)):
         if ver == 5:
-            depends_on("protobuf@2." + str(ver), type=("build", "run"), when="+cpp @2." + str(ver))
+            depends_on("protobuf@2." + str(ver), when="+cpp @2." + str(ver))
         else:
             conflicts("+cpp", when="@2." + str(ver))
 

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -23,7 +23,7 @@ class PyProtobuf(PythonPackage):
     version(
         "3.20.1",
         sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9",
-        preferred=True
+        preferred=True,
     )
     version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
     version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -77,17 +77,17 @@ class PyProtobuf(PythonPackage):
     # Handle mapping the 4.x release to the protobuf 3.x releases
     for ver in list(range(21, 22)):
         depends_on(
-            "protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
+            "protobuf@3." + str(ver),
             type=("build", "run"),
-            when="+cpp @4." + str(ver) + ".0:4." + str(ver) + ".99")
+            when="+cpp @4." + str(ver))
     # Handle the 3.x series releases
     for ver in list(range(1, 21)):
         depends_on(
-            "protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
+            "protobuf@3." + str(ver),
             type=("build", "run"),
-            when="+cpp @3." + str(ver) + ".0:3." + str(ver) + ".99")
+            when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
-    depends_on("protobuf@2.0.0:2.99.99", type=("build", "run"), when="+cpp @2.0.0:2.99.99")
+    depends_on("protobuf@2", type=("build", "run"), when="+cpp @2")
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -82,11 +82,14 @@ class PyProtobuf(PythonPackage):
     for ver in list(range(21, 22)):
         depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @4." + str(ver))
     # Handle the 3.x series releases
-    for ver in list(range(1, 21)):
+    for ver in list(range(1, 8)) + list(range(9, 21)):
         depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
     for ver in list(range(3, 7)):
-        depends_on("protobuf@2." + str(ver), type=("build", "run"), when="+cpp @2." + str(ver))
+        if ver == 5:
+            depends_on("protobuf@2." + str(ver), type=("build", "run"), when="+cpp @2." + str(ver))
+        else:
+            conflicts("+cpp", when="@2." + str(ver))
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -76,16 +76,10 @@ class PyProtobuf(PythonPackage):
     # Setup dependencies for protobuf to use the same minor version as py-protobuf
     # Handle mapping the 4.x release to the protobuf 3.x releases
     for ver in list(range(21, 22)):
-        depends_on(
-            "protobuf@3." + str(ver),
-            type=("build", "run"),
-            when="+cpp @4." + str(ver))
+        depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @4." + str(ver))
     # Handle the 3.x series releases
     for ver in list(range(1, 21)):
-        depends_on(
-            "protobuf@3." + str(ver),
-            type=("build", "run"),
-            when="+cpp @3." + str(ver))
+        depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
     depends_on("protobuf@2", type=("build", "run"), when="+cpp @2")
 

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -71,7 +71,16 @@ class PyProtobuf(PythonPackage):
     depends_on("py-six@1.9:", when="@3:", type=("build", "run"))
     depends_on("py-ordereddict", when="@3: ^python@:2", type=("build", "run"))
     depends_on("py-unittest2", when="@3: ^python@:2", type=("build", "run"))
-    depends_on("protobuf", when="+cpp")
+
+    # Setup dependencies for protobuf to use the same minor version as py-protobuf
+    # Handle the 3.x series releases
+    for ver in list(range(1, 20)):
+        depends_on("protobuf@3." + str(ver) + ".0:3." + str(ver) + ".99",
+                   type=("build", "run"),
+                   when="+cpp @3." + str(ver) + ".0:3." + str(ver) + ".99")
+    # Handle the 2.x series releases
+    depends_on("protobuf@2.0.0:2.99.99", type=("build", "run"),
+               when="+cpp @2.0.0:2.99.99")
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -20,7 +20,7 @@ class PyProtobuf(PythonPackage):
     variant("cpp", default=False, description="Enable the cpp implementation")
 
     version("4.21.5", sha256="eb1106e87e095628e96884a877a51cdb90087106ee693925ec0a300468a9be3a")
-    version("3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9")
+    version("3.20.1", sha256="adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9", preferred=True)
     version("3.20.0", sha256="71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702")
     version("3.19.4", sha256="9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a")
     version("3.19.3", sha256="d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -85,7 +85,8 @@ class PyProtobuf(PythonPackage):
     for ver in list(range(1, 21)):
         depends_on("protobuf@3." + str(ver), type=("build", "run"), when="+cpp @3." + str(ver))
     # Handle the 2.x series releases
-    depends_on("protobuf@2.", type=("build", "run"), when="+cpp @2.")
+    for ver in list(range(3, 7)):
+        depends_on("protobuf@2." + str(ver), type=("build", "run"), when="+cpp @2." + str(ver))
 
     @property
     def build_directory(self):


### PR DESCRIPTION
Fixed the py-protobuf recipe so that when cpp support is require so
that it uses the same major and minor version range for the protobuf
package.