### PR TITLE
variant: allow for conditional booleans

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -886,12 +886,12 @@ class Value(object):
         return hash(self.value)
 
     def __eq__(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, six.string_types) or isinstance(other, bool):
             return self.value == other
         return self.value == other.value
 
     def __lt__(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, six.string_types) or isinstance(other, bool):
             return self.value < other
         return self.value < other.value
 


### PR DESCRIPTION
Currently, we have the following in the `llvm` package:
https://github.com/spack/spack/blob/80389911cce2daae5b0e4df069a3be9575954dc3/var/spack/repos/builtin/packages/llvm/package.py#L210-L212
What it means is that we can't have `llvm~clang+z3`:
```console
$ spack spec llvm~clang+z3
==> Error: Cannot set variant 'z3' for package 'llvm' because the variant condition cannot be satisfied for the given spec
```
Good. Now, what about `llvm~clang~z3`? As a user, I would expect it to be possible but it is not:
```console
$ spack spec llvm~clang~z3
==> Error: Cannot set variant 'z3' for package 'llvm' because the variant condition cannot be satisfied for the given spec
```

With the modifications from this PR, it is possible to declare the `z3` variant differently:
```python
variant(
    "z3",
    values=(conditional(True, when="+clang @8:"), False),
    default=False,
    description="Use Z3 for the clang static analyzer",
)
```
And it looks like we can have the expected behaviour. We still get an error for `llvm~clang+z3` (with a different message though):
```console
$ spack spec llvm~clang+z3
==> Error: 'llvm' required multiple values for single-valued variant 'clang'
    Requested '~clang' and '+clang'
```
And we can also explicitly disable `z3`:
```console
$ spack spec llvm~clang~z3
Input spec
--------------------------------
llvm~clang~z3

Concretized
--------------------------------
llvm@14.0.6%gcc@10.2.1~clang~cuda+gold~ipo~link_llvm_dylib+lld+llvm_dylib~mlir~omp_debug~omp_tsan+polly~python~split_dwarf~z3 build_type=Release patches=6379168,d85ef51,f920173 shlib_symbol_version=none targets=none version_suffix=none arch=linux-debian11-skylake
...
```

> _NOTE:_ The order of the values is important:
> ```python
> variant(..., values=(True, False), default=False,...)
> ```
> seems to be the same as
> ```python
> variant(..., values=None, default=False,...)
> ```
> but if we swap the order of `values`, i.e.
> ```python
> variant(..., values=(False, True), default=False,...)
> ```
> we get:
> ```console
> $ spack spec llvm+z3
> ==> Error: invalid values for variant "z3" in package "llvm": ['True']
> $ spack spec llvm~z3
> ==> Error: invalid values for variant "z3" in package "llvm": ['False']
> ```
> The same problem is when `values` has a `conditional` as above, i.e.:
> ```python
> variant(..., values=(False, conditional(True, when="+clang @8:")), default=False,...)
> ```
> It might be worth fixing too.

@alalazo 