### PR TITLE
Fix ROCm constraints for ginkgo@glu_experimental in HiOp

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -15,6 +15,7 @@ def hip_repair_options(options, spec):
         + glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
     )
 
+
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """
     Compiler agnostic metaprogramming library providing concepts,

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -10,11 +10,8 @@ from spack.package import *
 
 def hip_repair_options(options, spec):
     # there is only one dir like this, but the version component is unknown
-    options.append(
-        "-DHIP_CLANG_INCLUDE_PATH="
-        + glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
-    )
-
+    path = glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
+    options.append(cmake_cache_path("HIP_CLANG_INCLUDE_PATH", path))
 
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -10,9 +10,10 @@ from spack.package import *
 
 def hip_repair_options(options, spec):
     # there is only one dir like this, but the version component is unknown
-    path = glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
-    options.append(cmake_cache_path("HIP_CLANG_INCLUDE_PATH", path))
-
+    options.append(
+        "-DHIP_CLANG_INCLUDE_PATH="
+        + glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
+    )
 
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -13,6 +13,7 @@ def hip_repair_options(options, spec):
     path = glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0]
     options.append(cmake_cache_path("HIP_CLANG_INCLUDE_PATH", path))
 
+
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """
     Compiler agnostic metaprogramming library providing concepts,

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -62,15 +62,15 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%gcc@:5.2.9")
 
     # ROCm should work with this custom branch
-    with when(not '@glu_experimental'):
-      conflicts("+rocm", when="@:1.1.1")
+    with when(not "@glu_experimental"):
+        conflicts("+rocm", when="@:1.1.1")
 
     conflicts("+cuda", when="+rocm")
     conflicts("+openmp", when="+oneapi")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
     # ROCm should work with this custom branch
-    with when(not '@glu_experimental'):
+    with when(not "@glu_experimental"):
         conflicts("^hip@4.1.0:", when="@:1.3.0")
         conflicts("^hipblas@4.1.0:", when="@:1.3.0")
         conflicts("^hipsparse@4.1.0:", when="@:1.3.0")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -61,20 +61,16 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("%gcc@:5.2.9")
 
-    # ROCm should work with this custom branch
-    with when(not "@glu_experimental"):
-        conflicts("+rocm", when="@:1.1.1")
+    conflicts("+rocm", when="@:1.1.1")
 
     conflicts("+cuda", when="+rocm")
     conflicts("+openmp", when="+oneapi")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
-    # ROCm should work with this custom branch
-    with when(not "@glu_experimental"):
-        conflicts("^hip@4.1.0:", when="@:1.3.0")
-        conflicts("^hipblas@4.1.0:", when="@:1.3.0")
-        conflicts("^hipsparse@4.1.0:", when="@:1.3.0")
-        conflicts("^rocthrust@4.1.0:", when="@:1.3.0")
+    conflicts("^hip@4.1.0:", when="@:1.3.0")
+    conflicts("^hipblas@4.1.0:", when="@:1.3.0")
+    conflicts("^hipsparse@4.1.0:", when="@:1.3.0")
+    conflicts("^rocthrust@4.1.0:", when="@:1.3.0")
 
     # Skip smoke tests if compatible hardware isn't found
     patch("1.4.0_skip_invalid_smoke_tests.patch", when="@master")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -22,8 +22,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
-    version("glu", branch="glu")
-    version("glu_experimental", branch="glu_experimental")
+    version("1.5.0.glu", branch="glu")
+    version("1.5.0.glu_experimental", branch="glu_experimental")
     version("1.4.0", commit="f811917c1def4d0fcd8db3fe5c948ce13409e28e")  # v1.4.0
     version("1.3.0", commit="4678668c66f634169def81620a85c9a20b7cec78")  # v1.3.0
     version("1.2.0", commit="b4be2be961fd5db45c3d02b5e004d73550722e31")  # v1.2.0

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -24,7 +24,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     version("master", branch="master")
     version("1.5.0.glu", branch="glu")
     version("1.5.0.glu_experimental", branch="glu_experimental")
-    version("1.4.0", commit="f811917c1def4d0fcd8db3fe5c948ce13409e28e")  # v1.4.0
+    version("1.4.0", commit="f811917c1def4d0fcd8db3fe5c948ce13409e28e", preferred=True)  # v1.4.0
     version("1.3.0", commit="4678668c66f634169def81620a85c9a20b7cec78")  # v1.3.0
     version("1.2.0", commit="b4be2be961fd5db45c3d02b5e004d73550722e31")  # v1.2.0
     version("1.1.1", commit="08d2c5200d3c78015ac8a4fd488bafe1e4240cf5")  # v1.1.1

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -60,15 +60,21 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("intel-oneapi-dpl", when="+oneapi")
 
     conflicts("%gcc@:5.2.9")
-    conflicts("+rocm", when="@:1.1.1")
+
+    # ROCm should work with this custom branch
+    with when(not '@glu_experimental'):
+      conflicts("+rocm", when="@:1.1.1")
+
     conflicts("+cuda", when="+rocm")
     conflicts("+openmp", when="+oneapi")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
-    conflicts("^hip@4.1.0:", when="@:1.3.0")
-    conflicts("^hipblas@4.1.0:", when="@:1.3.0")
-    conflicts("^hipsparse@4.1.0:", when="@:1.3.0")
-    conflicts("^rocthrust@4.1.0:", when="@:1.3.0")
+    # ROCm should work with this custom branch
+    with when(not '@glu_experimental'):
+        conflicts("^hip@4.1.0:", when="@:1.3.0")
+        conflicts("^hipblas@4.1.0:", when="@:1.3.0")
+        conflicts("^hipsparse@4.1.0:", when="@:1.3.0")
+        conflicts("^rocthrust@4.1.0:", when="@:1.3.0")
 
     # Skip smoke tests if compatible hardware isn't found
     patch("1.4.0_skip_invalid_smoke_tests.patch", when="@master")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -60,9 +60,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("intel-oneapi-dpl", when="+oneapi")
 
     conflicts("%gcc@:5.2.9")
-
     conflicts("+rocm", when="@:1.1.1")
-
     conflicts("+cuda", when="+rocm")
     conflicts("+openmp", when="+oneapi")
 

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -113,7 +113,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("coinhsl+blas", when="+sparse")
     depends_on("metis", when="+sparse")
 
-    depends_on("ginkgo@glu_experimental", when="+ginkgo")
+    depends_on("ginkgo@1.5.0.glu_experimental", when="+ginkgo")
 
     conflicts(
         "+shared",


### PR DESCRIPTION
Not 100% sure if this syntax is correct, but this was what I needed to add to avoid conflicts and build successfully on ROCm 5.2.0.

Perhaps this is a case where expanding the spack core syntax would be beneficial, or at least including some useful documentation as I struggled to do this at first.