### PR TITLE
e4s ci: add chai +rocm

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -206,6 +206,7 @@ spack:
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm
   - caliper +rocm amdgpu_target=gfx90a
+  - chai ~benchmarks +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
@@ -244,7 +245,8 @@ spack:
   #- parsec +cuda cuda_arch=80                    # parsec/mca/device/cuda/transfer.c:168: multiple definition of `parsec_CUDA_d2h_max_flows';
 
   # ROCm failures
-  #- chai ~benchmarks +rocm amdgpu_target=gfx90a  # umpire: Target "blt_hip" INTERFACE_INCLUDE_DIRECTORIES property contains path: "/tmp/root/spack-stage/spack-stage-umpire-2022.03.1-by6rldnpdowaaoqgxkeqejwyx5uxo2sv/spack-src/HIP_CLANG_INCLUDE_PATH-NOTFOUND/.." which is prefixed in the source directory.
+  #- raja ~openmp +rocm amdgpu_target=gfx90a      # cmake: Could NOT find ROCPRIM (missing: ROCPRIM_INCLUDE_DIRS)
+  #- umpire +rocm amdgpu_target=gfx90a            # Target "blt_hip" INTERFACE_INCLUDE_DIRECTORIES property contains path: "/tmp/root/spack-stage/spack-stage-umpire-2022.03.1-by6rldnpdowaaoqgxkeqejwyx5uxo2sv/spack-src/HIP_CLANG_INCLUDE_PATH-NOTFOUND/.." which is prefixed in the source directory.
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s" }
 

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -112,6 +112,13 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
             self.spec.compiler.version,
         )
 
+    def initconfig_compiler_entries(self):
+        spec = self.spec
+        entries = super(Chai, self).initconfig_compiler_entries()
+        if "+rocm" in spec:
+            entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
+        return entries
+
     def initconfig_hardware_entries(self):
         spec = self.spec
         entries = super(Chai, self).initconfig_hardware_entries()


### PR DESCRIPTION
Hoping the merge of https://github.com/spack/spack/pull/32469 has fixed issue with `chai +rocm` in our CI environment.

FYI @wspear @davidbeckingsale 