### PR TITLE
cuba: new package

### DIFF
--- a/var/spack/repos/builtin/packages/cuba/package.py
+++ b/var/spack/repos/builtin/packages/cuba/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Cuba(AutotoolsPackage):
+    """The Cuba library offers a choice of four independent routines for
+    multidimensional numerical integration: Vegas, Suave, Divonne, and
+    Cuhre."""
+
+    homepage = "https://feynarts.de/cuba/"
+    url = "https://feynarts.de/cuba/Cuba-4.2.2.tar.gz"
+
+    maintainers = ["wdconinc"]
+
+    version("4.2.2", sha256="8d9f532fd2b9561da2272c156ef7be5f3960953e4519c638759f1b52fe03ed52")
+
+    parallel = False


### PR DESCRIPTION
Cuba, https://feynarts.de/cuba/, is a library that offers a choice of four independent routines for multidimensional numerical integration: Vegas, Suave, Divonne, and Cuhre.

It is used as a dependency for several high energy and nuclear physics Monte Carlo event generators.

The Makefile build does not succeed when run in parallel.