### PR TITLE
update libflame for work with crayCC, craycc, ...

### DIFF
--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -70,7 +70,7 @@ class LibflameBase(AutotoolsPackage):
         # Libflame has a secondary dependency on BLAS,
         # but doesn't know which library name to expect:
         # https://github.com/flame/libflame/issues/24
-        config_args = ["LIBS=" + self.spec["blas"].libs.link_flags]
+        config_args = ["LIBS=" + self.spec["blas"].libs.ld_flags]
 
         if "+lapack2flame" in self.spec:
             config_args.append("--enable-lapack2flame")


### PR DESCRIPTION
update libflame for work with crayCC, craycc, crayftn compiler wrappers. These lightweight compiler drivers do not add the `-L<lib_path>` like the CC/cc/ftn compiler drivers do. I've made a slight change to add the lib directories.