### PR TITLE
Install: Add use-buildcache option to install

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -32,48 +32,37 @@ section = "build"
 level = "short"
 
 
-def parse_use_buildcache(args):
-    bc_parsed = {}
+# Pass in the value string passed to use-buildcache and get back
+# the package and dependencies values.
+def parse_use_buildcache(opt):
     bc_keys = ["package:", "dependencies:", ""]
     bc_values = ["only", "never", "auto"]
-    kv_list = re.findall("([a-z]+:)?([a-z]+)", args)
+    kv_list = re.findall("([a-z]+:)?([a-z]+)", opt)
 
     # Verify keys and values
     bc_map = {k: v for k, v in kv_list if k in bc_keys and v in bc_values}
     if not len(kv_list) == len(bc_map):
-        unrecognized_args = [(k, v) for k, v in kv_list if k not in bc_keys or v not in bc_values]
-        tty.error("Unrecognized arguments passed to use-buildcache: %s" % unrecognized_args)
+        tty.error("Unrecognized arguments passed to use-buildcache")
         tty.error(
             "Expected: --use-buildcache "
             "[[auto|only|never],[package:[auto|only|never]],[dependencies:[auto|only|never]]]"
         )
         exit(1)
 
-    bc_parsed["package"] = "auto"
-    bc_parsed["dependencies"] = "auto"
-    if "" in bc_map:
-        bc_parsed["package"] = bc_map[""]
-        bc_parsed["dependencies"] = bc_map[""]
-    if "package:" in bc_map:
-        bc_parsed["package"] = bc_map["package:"]
-    if "dependencies:" in bc_map:
-        bc_parsed["dependencies"] = bc_map["dependencies:"]
+    for _group in ["package:", "dependencies:"]:
+        if _group not in bc_map:
+            if "" in bc_map:
+                bc_map[_group] = bc_map[""]
+            else:
+                bc_map[_group] = "auto"
 
-    return bc_parsed
+    return bc_map["package:"], bc_map["dependencies:"]
 
 
-def args_use_cache(args, use_buildcache):
+# Determine value of cache flag
+def cache_opt(default_opt, use_buildcache):
     if use_buildcache == "auto":
-        return args.use_cache
-    elif use_buildcache == "only":
-        return True
-    elif use_buildcache == "never":
-        return False
-
-
-def args_cache_only(args, use_buildcache):
-    if use_buildcache == "auto":
-        return args.cache_only
+        return default_opt
     elif use_buildcache == "only":
         return True
     elif use_buildcache == "never":
@@ -85,7 +74,7 @@ def install_kwargs_from_args(args):
     to the package installer.
     """
 
-    cache_ops = parse_use_buildcache(args.use_buildcache)
+    pkg_use_bc, dep_use_bc = parse_use_buildcache(args.use_buildcache)
 
     return {
         "fail_fast": args.fail_fast,
@@ -96,10 +85,10 @@ def install_kwargs_from_args(args):
         "verbose": args.verbose or args.install_verbose,
         "fake": args.fake,
         "dirty": args.dirty,
-        "package_use_cache": args_use_cache(args, cache_ops["package"]),
-        "package_cache_only": args_cache_only(args, cache_ops["package"]),
-        "dependencies_use_cache": args_use_cache(args, cache_ops["dependencies"]),
-        "dependencies_cache_only": args_cache_only(args, cache_ops["dependencies"]),
+        "package_use_cache": cache_opt(args.use_cache, pkg_use_bc),
+        "package_cache_only": cache_opt(args.cache_only, pkg_use_bc),
+        "dependencies_use_cache": cache_opt(args.use_cache, dep_use_bc),
+        "dependencies_cache_only": cache_opt(args.cache_only, dep_use_bc),
         "include_build_deps": args.include_build_deps,
         "explicit": True,  # Use true as a default for install command
         "stop_at": args.until,
@@ -181,7 +170,15 @@ the dependencies""",
         "--use-buildcache",
         dest="use_buildcache",
         default="package:auto,dependencies:auto",
-        help="finer grain control over which packages to check mirrors for",
+        help="""select the mode of buildcache for the 'package' and 'dependencies'.
+Available modes are 'auto', 'only', and 'never'.
+'auto' will utilize the default behavior, similar to --use-cache
+'only' will enable --cache-only,
+'never' will enable --no-cache
+
+ex.
+--use-buildcache package:only,dependencies:never
+""",
     )
 
     subparser.add_argument(

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -170,14 +170,12 @@ the dependencies""",
         "--use-buildcache",
         dest="use_buildcache",
         default="package:auto,dependencies:auto",
+        metavar="[{auto,only,never},][package:{auto,only,never},][dependencies:{auto,only,never}]",
         help="""select the mode of buildcache for the 'package' and 'dependencies'.
-Available modes are 'auto', 'only', and 'never'.
-'auto' will utilize the default behavior, similar to --use-cache
-'only' will enable --cache-only,
-'never' will enable --no-cache
-
-ex.
---use-buildcache package:only,dependencies:never
+Default: package:auto,dependencies:auto
+- `auto` behaves like --use-cache
+- `only` behaves like --cache-only
+- `never` behaves like --no-cache
 """,
     )
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2220,10 +2220,10 @@ class BuildTask(object):
     @property
     def explicit(self):
         """The package was explicitly requested by the user."""
-        return self.is_package and self.request.install_args.get("explicit", True)
+        return self.is_root and self.request.install_args.get("explicit", True)
 
     @property
-    def is_package(self):
+    def is_root(self):
         """The package was requested directly, but may or may not be explicit
         in an environment."""
         return self.pkg == self.request.pkg
@@ -2231,7 +2231,7 @@ class BuildTask(object):
     @property
     def use_cache(self):
         _use_cache = True
-        if self.is_package:
+        if self.is_root:
             return self.request.install_args.get("package_use_cache", _use_cache)
         else:
             return self.request.install_args.get("dependencies_use_cache", _use_cache)
@@ -2239,7 +2239,7 @@ class BuildTask(object):
     @property
     def cache_only(self):
         _cache_only = False
-        if self.is_package:
+        if self.is_root:
             return self.request.install_args.get("package_cache_only", _cache_only)
         else:
             return self.request.install_args.get("dependencies_cache_only", _cache_only)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1184,12 +1184,12 @@ class PackageInstaller(object):
 
         explicit = task.explicit
         install_args = task.request.install_args
-        if task.dependency:
-            cache_only = install_args.get("dependencies_cache_only")
-            use_cache = install_args.get("dependencies_use_cache")
-        else:
+        if task.is_package:
             cache_only = install_args.get("package_cache_only")
             use_cache = install_args.get("package_use_cache")
+        else:
+            cache_only = install_args.get("dependencies_cache_only")
+            use_cache = install_args.get("dependencies_use_cache")
         tests = install_args.get("tests")
         unsigned = install_args.get("unsigned")
 
@@ -2224,12 +2224,13 @@ class BuildTask(object):
     @property
     def explicit(self):
         """The package was explicitly requested by the user."""
-        return self.pkg == self.request.pkg and self.request.install_args.get("explicit", True)
+        return self.is_package and self.request.install_args.get("explicit", True)
 
     @property
-    def dependency(self):
-        """The package is a dependency requested by another package."""
-        return not self.explicit
+    def is_package(self):
+        """The package was requested directly, but may or may not be explicit
+        in an environment."""
+        return self.pkg == self.request.pkg
 
     @property
     def key(self):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1184,12 +1184,8 @@ class PackageInstaller(object):
 
         explicit = task.explicit
         install_args = task.request.install_args
-        if task.is_package:
-            cache_only = install_args.get("package_cache_only")
-            use_cache = install_args.get("package_use_cache")
-        else:
-            cache_only = install_args.get("dependencies_cache_only")
-            use_cache = install_args.get("dependencies_use_cache")
+        cache_only = task.cache_only
+        use_cache = task.use_cache
         tests = install_args.get("tests")
         unsigned = install_args.get("unsigned")
 
@@ -2233,6 +2229,22 @@ class BuildTask(object):
         return self.pkg == self.request.pkg
 
     @property
+    def use_cache(self):
+        _use_cache = True
+        if self.is_package:
+            return self.request.install_args.get("package_use_cache", _use_cache)
+        else:
+            return self.request.install_args.get("dependencies_use_cache", _use_cache)
+
+    @property
+    def cache_only(self):
+        _cache_only = False
+        if self.is_package:
+            return self.request.install_args.get("package_cache_only", _cache_only)
+        else:
+            return self.request.install_args.get("dependencies_cache_only", _cache_only)
+
+    @property
     def key(self):
         """The key is the tuple (# uninstalled dependencies, sequence)."""
         return (self.priority, self.sequence)
@@ -2321,8 +2333,8 @@ class BuildRequest(object):
             ("install_deps", True),
             ("install_package", True),
             ("install_source", False),
-            ("packages_cache_only", False),
-            ("packages_use_cache", True),
+            ("package_cache_only", False),
+            ("package_use_cache", True),
             ("keep_prefix", False),
             ("keep_stage", False),
             ("restage", False),

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1099,10 +1099,9 @@ def test_install_use_buildcache(
     mock_packages,
     mock_fetch,
     mock_archive,
-    mutable_config,
     mock_binary_index,
     tmpdir,
-    install_mockery,
+    install_mockery_mutable_config,
 ):
     """
     Make sure installing with use-buildcache behaves correctly.

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1133,9 +1133,9 @@ def test_install_use_buildcache(
             "--no-check-signature", "--use-buildcache", opt, package_name, fail_on_error=True
         )
 
-        parsed = spack.cmd.install.parse_use_buildcache(opt)
-        validate(parsed["dependencies"], out, dependency_name)
-        validate(parsed["package"], out, package_name)
+        pkg_opt, dep_opt = spack.cmd.install.parse_use_buildcache(opt)
+        validate(dep_opt, out, dependency_name)
+        validate(pkg_opt, out, package_name)
 
         # Clean up installed packages
         uninstall("-y", "-a")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1188,7 +1188,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -U --fresh --reuse"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -U --fresh --reuse"
     else
         _all_packages
     fi


### PR DESCRIPTION
Allow differentiating between top level packages and dependencies when determining whether to install from the cache or not.

@scottwittenburg 

Implements this [feature request](https://github.com/spack/spack/issues/29695).