### PR TITLE
pgplot: fix build failure when using +X

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -52,7 +52,7 @@ class Pgplot(MakefilePackage):
 
         libs = ""
         if "+X" in spec:
-            libs += " " + self.spec["X11"].libs.ld_flags
+            libs += " " + self.spec["libx11"].libs.ld_flags
         if "+png" in spec:
             libs += " " + self.spec["libpng"].libs.ld_flags
 
@@ -120,7 +120,7 @@ class Pgplot(MakefilePackage):
 
     def setup_build_environment(self, env):
         if "+X" in self.spec:
-            env.append_flags("LIBS", self.spec["X11"].libs.ld_flags)
+            env.append_flags("LIBS", self.spec["libx11"].libs.ld_flags)
         if "+png" in self.spec:
             env.append_flags("LIBS", self.spec["libpng"].libs.ld_flags)
 


### PR DESCRIPTION
The spec was using the wrong key to find the X11 library flags. It should be `libx11` instead of `X11`.