### PR TITLE
dtc:fix build error with clang or Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/dtc/package.py
+++ b/var/spack/repos/builtin/packages/dtc/package.py
@@ -27,6 +27,7 @@ class Dtc(MakefilePackage):
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX =.*", "PREFIX = %s" % prefix)
-        if self.spec.satisfies('%clang') or self.spec.satisfies('%fj'):
-            makefile.filter(r'WARNINGS = -Wall',
-                            'WARNINGS = -Wall -Wno-unused-command-line-argument')
+        if self.spec.satisfies("%clang") or self.spec.satisfies("%fj"):
+            makefile.filter(
+                r"WARNINGS = -Wall", "WARNINGS = -Wall -Wno-unused-command-line-argument"
+            )

--- a/var/spack/repos/builtin/packages/dtc/package.py
+++ b/var/spack/repos/builtin/packages/dtc/package.py
@@ -27,3 +27,6 @@ class Dtc(MakefilePackage):
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX =.*", "PREFIX = %s" % prefix)
+        if self.spec.satisfies('%clang') or self.spec.satisfies('%fj'):
+            makefile.filter(r'WARNINGS = -Wall',
+                            'WARNINGS = -Wall -Wno-unused-command-line-argument')


### PR DESCRIPTION
An error occurred due to the '-werror' option when built with the Clang or Fujitsu compiler.
"error: -Wl,--disable-new-dtags: 'linker' input unused [-Werror,-Wunused-command-line-argument]"