### PR TITLE
py-tensorflow: add v2.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -94,12 +94,12 @@ class PyKeras(PythonPackage):
         depends_on(
             "py-tensorflow@2.{}".format(minor_ver),
             type=("build", "run"),
-            when="@2.{}".format(minor_ver)
+            when="@2.{}".format(minor_ver),
         )
         depends_on(
             "py-tensorboard@2.{}".format(minor_ver),
             type=("build", "run"),
-            when="@2.{}".format(minor_ver)
+            when="@2.{}".format(minor_ver),
         )
     depends_on("py-theano", type=("build", "run"), when="@:2.0.7")
 

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -21,6 +21,7 @@ class PyKeras(PythonPackage):
     git = "https://github.com/keras-team/keras.git"
     url = "https://github.com/keras-team/keras/archive/refs/tags/v2.7.0.tar.gz"
 
+    version("2.10.0", sha256="b1d8d9358700f4a585455854a142d88cc987419c1638ef935b440842d593ad04")
     version("2.9.0", sha256="90226eaa0337573304f3e5ab44d4d9e3a65fe002776c5cbd0f65b738152c1084")
     version("2.8.0", sha256="5e777b0101d8385d3a90fc9056f1b2f6313f2c830d2e8181828b300c9229ec0c")
     version("2.7.0", sha256="7502746467ab15184e2e267f13fbb2c3f33ba24f8e02a097d229ba376dabaa04")
@@ -89,9 +90,17 @@ class PyKeras(PythonPackage):
     depends_on("py-scipy@0.14:", type=("build", "run"), when="@2.0.8:")
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
-    for ver in ["2.9", "2.8", "2.7", "2.6", "2.5"]:
-        depends_on("py-tensorflow@" + ver, type=("build", "run"), when="@" + ver)
-        depends_on("py-tensorboard@" + ver, type=("build", "run"), when="@" + ver)
+    for minor_ver in range(5, 11):
+        depends_on(
+            "py-tensorflow@2.{}".format(minor_ver),
+            type=("build", "run"),
+            when="@2.{}".format(minor_ver)
+        )
+        depends_on(
+            "py-tensorboard@2.{}".format(minor_ver),
+            type=("build", "run"),
+            when="@2.{}".format(minor_ver)
+        )
     depends_on("py-theano", type=("build", "run"), when="@:2.0.7")
 
     # Required dependencies not listed anywhere?

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -18,6 +18,11 @@ class PyTensorboard(PythonPackage):
     maintainers = ["aweits"]
 
     version(
+        "2.10.0",
+        sha256="76c91a5e8959cd2208cc32cb17a0cb002badabb66a06ac2af02a7810f49a59e3",
+        expand=False
+    )
+    version(
         "2.9.1",
         sha256="baa727f791776f9e5841d347127720ceed4bbd59c36b40604b95fb2ae6029276",
         expand=False,

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -20,7 +20,7 @@ class PyTensorboard(PythonPackage):
     version(
         "2.10.0",
         sha256="76c91a5e8959cd2208cc32cb17a0cb002badabb66a06ac2af02a7810f49a59e3",
-        expand=False
+        expand=False,
     )
     version(
         "2.9.1",

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -30,6 +30,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     maintainers = ["adamjstewart", "aweits"]
     import_modules = ["tensorflow"]
 
+    version("2.10.0", sha256="b5a1bb04c84b6fe1538377e5a1f649bb5d5f0b2e3625a3c526ff3a8af88633e8")
     version("2.9.2", sha256="8cd7ed82b096dc349764c3369331751e870d39c86e73bbb5374e1664a59dcdf7")
     version("2.9.1", sha256="6eaf86ead73e23988fe192da1db68f4d3828bcdd0f3a9dc195935e339c95dbdc")
     version("2.9.0", sha256="8087cb0c529f04a4bfe480e49925cd64a904ad16d8ec66b98e2aacdfd53c80ff")
@@ -155,13 +156,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     # https://github.com/tensorflow/tensorflow/issues/33374
     depends_on("python@:3.7", type=("build", "run"), when="@:2.1")
 
-    # TODO: Older versions of TensorFlow don't list the viable version range,
-    # just the minimum version of bazel that will work. The latest version of
-    # bazel doesn't seem to work, so for now we force them to use min version.
-    # Need to investigate further.
-
+    # See .bazelversion
+    depends_on("bazel@5.1.1", type="build", when="@2.10:")
     # See _TF_MIN_BAZEL_VERSION and _TF_MAX_BAZEL_VERSION in configure.py
-    depends_on("bazel@4.2.2:5.99.0", type="build", when="@2.9:")
+    depends_on("bazel@4.2.2:5.99.0", type="build", when="@2.9")
     depends_on("bazel@4.2.1:4.99.0", type="build", when="@2.8")
     depends_on("bazel@3.7.2:4.99.0", type="build", when="@2.7")
     depends_on("bazel@3.7.2:3.99.0", type="build", when="@2.5:2.6")
@@ -201,7 +199,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     depends_on("py-astunparse@1.6:", type=("build", "run"), when="@2.7:")
     depends_on("py-astunparse@1.6.3:1.6", type=("build", "run"), when="@2.4:2.6")
     depends_on("py-astunparse@1.6.3", type=("build", "run"), when="@2.2:2.3")
-    depends_on("py-flatbuffers@1.12:1", type=("build", "run"), when="@2.9:")
+    depends_on("py-flatbuffers@2:", type=("build", "run"), when="@2.10:")
+    depends_on("py-flatbuffers@1.12:1", type=("build", "run"), when="@2.9")
     depends_on("py-flatbuffers@1.12:", type=("build", "run"), when="@2.8")
     depends_on("py-flatbuffers@1.12:2", type=("build", "run"), when="@2.7")
     depends_on("py-flatbuffers@1.12", type=("build", "run"), when="@2.4:2.6")
@@ -249,8 +248,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     depends_on("py-numpy@1.11.0:1.14.5", type=("build", "run"), when="@0.11:1.3")
     depends_on("py-numpy@1.10.1:1.14.5", type=("build", "run"), when="@0.7.1:0.10 platform=darwin")
     depends_on("py-numpy@1.8.2:1.14.5", type=("build", "run"), when="@0.5:0.10")
-    depends_on("py-opt-einsum@3.3", type=("build", "run"), when="@2.4:2.6")
     depends_on("py-opt-einsum@2.3.2:", type=("build", "run"), when="@1.15:2.3,2.7:")
+    depends_on("py-opt-einsum@3.3", type=("build", "run"), when="@2.4:2.6")
     depends_on("py-packaging", type=("build", "run"), when="@2.9:")
     depends_on("py-protobuf@3.9.2:", type=("build", "run"), when="@2.3:")
     depends_on("py-protobuf@3.8.0:", type=("build", "run"), when="@2.1:2.2")
@@ -310,11 +309,8 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
         depends_on("py-grpcio@1.32", type=("build", "run"), when="@2.4")
         depends_on("py-grpcio@1.8.6:", type=("build", "run"), when="@1.6:2.3")
 
-    depends_on("py-tensorboard@2.9", type=("build", "run"), when="@2.9")
-    depends_on("py-tensorboard@2.8", type=("build", "run"), when="@2.8")
-    depends_on("py-tensorboard@2.7", type=("build", "run"), when="@2.7")
-    depends_on("py-tensorboard@2.6", type=("build", "run"), when="@2.6")
-    depends_on("py-tensorboard@2.5", type=("build", "run"), when="@2.5")
+    for minor_ver in range(5, 11):
+        depends_on("py-tensorboard@2.{}".format(minor_ver), type=("build", "run"), when="@2.{}".format(minor_ver))
     # TODO: is this still true? We now install tensorboard from wheel for all versions
     # depends_on('py-tensorboard', when='@:2.4')  # circular dep
     # depends_on('py-tensorflow-estimator')  # circular dep

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -310,7 +310,11 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
         depends_on("py-grpcio@1.8.6:", type=("build", "run"), when="@1.6:2.3")
 
     for minor_ver in range(5, 11):
-        depends_on("py-tensorboard@2.{}".format(minor_ver), type=("build", "run"), when="@2.{}".format(minor_ver))
+        depends_on(
+            "py-tensorboard@2.{}".format(minor_ver),
+            type=("build", "run"),
+            when="@2.{}".format(minor_ver),
+        )
     # TODO: is this still true? We now install tensorboard from wheel for all versions
     # depends_on('py-tensorboard', when='@:2.4')  # circular dep
     # depends_on('py-tensorflow-estimator')  # circular dep


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/releases/tag/v2.10.0

Fails to build on Apple M1 just like all previous releases, but hopefully builds on x86_64 for someone?

https://github.com/tensorflow/tensorflow/issues/57631