### PR TITLE
py-tensorflow-metadata: add v1.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
@@ -19,16 +19,15 @@ class PyTensorflowMetadata(PythonPackage):
     # Only available as a wheel on PyPI
     url = "https://github.com/tensorflow/metadata/archive/refs/tags/v1.5.0.tar.gz"
 
-    version(
-        "1.5.0",
-        sha256="f0ec8aaf62fd772ef908efe4ee5ea3bc0d67dcbf10ae118415b7b206a1d61745",
-    )
+    version("1.10.0", sha256="e7aa81aa01433e2a75c11425affd55125b64f384baf96b71eeb3a88dca8cf2ae")
+    version("1.5.0", sha256="f0ec8aaf62fd772ef908efe4ee5ea3bc0d67dcbf10ae118415b7b206a1d61745")
 
     depends_on("bazel@0.24.1:", type="build")
     depends_on("python@3.7:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-absl-py@0.9:0.12", type=("build", "run"))
-    depends_on("py-googleapis-common-protos@1.52.0:1", type=("build", "run"))
+    depends_on("py-absl-py@0.9:1", when="@1.6:", type=("build", "run"))
+    depends_on("py-absl-py@0.9:0.12", when="@:1.5", type=("build", "run"))
+    depends_on("py-googleapis-common-protos@1.52:1", type=("build", "run"))
     depends_on("py-protobuf@3.13:3", type=("build", "run"))
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
Successfully builds on macOS 12.5.1 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.