### PR TITLE
VTK-m: Update gcc 11 conflict after patch

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -85,7 +85,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.18:", when="+rocm", type="build")  # CMake >= 3.18
 
     conflicts("%gcc@:4.10", msg="vtk-m requires gcc >= 5. Please install a newer version")
-    conflicts("%gcc@11:", when="@:1.7", msg="vtk-m v1.8 provides updates for gcc >= 11")
+    conflicts("%gcc@11:", when="@:1.5.2", msg="DIY has a issue building with gcc 11")
 
     depends_on("cuda@10.1.0:", when="+cuda_native")
     depends_on("tbb", when="+tbb")


### PR DESCRIPTION
#32059 was fixed using #32465 for all patched versions.

FYI: @eugeneswalker @wspear @vicentebolea 