### PR TITLE
Skip test which fails randomly on Python 2.7

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1529,8 +1529,8 @@ class TestConcretize(object):
 
     @pytest.mark.regression("29201")
     @pytest.mark.skipif(
-         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
-     )
+        sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+    )
     def test_installed_version_is_selected_only_for_reuse(
         self, mutable_database, repo_with_changing_recipe
     ):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1528,6 +1528,9 @@ class TestConcretize(object):
         assert root.dag_hash() == new_root.dag_hash()
 
     @pytest.mark.regression("29201")
+    @pytest.mark.skipif(
+         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+     )
     def test_installed_version_is_selected_only_for_reuse(
         self, mutable_database, repo_with_changing_recipe
     ):


### PR DESCRIPTION
Skip test which fails randomly when using Python 2.7 to run Spack.

See: https://github.com/spack/spack/issues/32470
This copies the approach used in https://github.com/spack/spack/pull/32526.

@alalazo based on the wording of the skip message, should this actually apply to all tests using the `repo_with_changing_recipe` fixture?