### PR TITLE
Avoid `xxmr2d:out of memory` error for scalapack-2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/mr2d_malloc-memory.patch
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/mr2d_malloc-memory.patch
@@ -1,0 +1,4 @@
+108c108
+< mr2d_malloc(Int n)
+---
+> mr2d_malloc(long long n)

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -44,6 +44,9 @@ class ScalapackBase(CMakePackage):
         sha256="072b006e485f0ca4cba56096912a986e4d3da73aae51c2205928aa5eb842cefd",
         when="@2.2.0",
     )
+    # In file `scalapack-2.2.0/REDIST/SRC/pgemraux.c`, change variable n type from `Int` to `long long`,
+    # so that `xxmr2d:out of memory` can be avoid
+    patch("mr2d_malloc-memory.patch", when='@2.2.0')
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -46,7 +46,7 @@ class ScalapackBase(CMakePackage):
     )
     # In file `scalapack-2.2.0/REDIST/SRC/pgemraux.c`, change variable n type from `Int` to `long long`,
     # so that `xxmr2d:out of memory` can be avoid
-    patch("mr2d_malloc-memory.patch", when='@2.2.0')
+    patch("mr2d_malloc-memory.patch", when="@2.2.0")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -44,7 +44,8 @@ class ScalapackBase(CMakePackage):
         sha256="072b006e485f0ca4cba56096912a986e4d3da73aae51c2205928aa5eb842cefd",
         when="@2.2.0",
     )
-    # In file `scalapack-2.2.0/REDIST/SRC/pgemraux.c`, change variable n type from `Int` to `long long`,
+    # In file `scalapack-2.2.0/REDIST/SRC/pgemraux.c`,
+    # change variable n type from `Int` to `long long`,
     # so that `xxmr2d:out of memory` can be avoid
     patch("mr2d_malloc-memory.patch", when="@2.2.0")
 


### PR DESCRIPTION
In file `scalapack-2.2.0/REDIST/SRC/pgemraux.c`, change variable n type from `Int` to `long long`,  so that `xxmr2d:out of memory` can be avoid.

The created patch file was simply generated by:

$ diff `old_pgemraux.c` `new_pgemraux.c`

Further modification may be made to complete this fix.