### PR TITLE
Add pika 0.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -17,6 +17,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pika-org/pika.git"
     maintainers = ["msimberg", "albestro", "teonnik", "aurianer"]
 
+    version("0.8.0", sha256="058e82d7c8f95badabe52bbb4682d55aadf340d67ced1226c0673b4529adc182")
     version("0.7.0", sha256="e1bf978c88515f7af28ee47f98b795ffee521c15b39877ea4cfb405f31d507ed")
     version("0.6.0", sha256="cb4ebd7b92da39ec4df7b0d05923b94299d6ee2f2f49752923ffa2266ca76568")
     version("0.5.0", sha256="c43de7e92d04bea0ce59716756ef5f3a5a54f9e4affed872c1468632ad855f7c")
@@ -63,6 +64,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("git", type="build")
     depends_on("ninja", type="build")
     depends_on("cmake@3.18:", type="build")
+    depends_on("cmake@3.22:", when="@0.8:", type="build")
 
     conflicts("%gcc@:6")
     conflicts("%clang@:6")
@@ -83,6 +85,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda@11:", when="+cuda")
     depends_on("apex", when="+apex")
     depends_on("tracy-client", when="+tracy")
+    depends_on("hip@5.2:", when="@0.8: +rocm")
     depends_on("rocblas", when="+rocm")
     depends_on("hipblas", when="+rocm")
     depends_on("rocsolver", when="@0.5: +rocm")
@@ -129,8 +132,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
             self.define("HWLOC_ROOT", spec["hwloc"].prefix),
         ]
 
-        # HIP support requires compiling with hipcc
-        if "+rocm" in self.spec:
+        # HIP support requires compiling with hipcc for < 0.8.0
+        if "@:0.7 +rocm" in self.spec:
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
             if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]


### PR DESCRIPTION
- adds pika 0.8.0
- updates the cmake version requirement from 0.8.0 onwards
- constrains build with `hipcc` to only be applied for versions older than 0.8.0
- ~adds missing `hip` dependency for `+rocm` (it was always there implicitly because of hipblas/rocblas, but it should be an explicit dependency)~ (https://github.com/spack/spack/pull/32577#discussion_r966785597)
- constrains hip to at least 5.2.0 from pika 0.8.0 onwards