### PR TITLE
[WIP] Accelerate (and simplify) buildcache relocation

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1494,7 +1494,7 @@ def relocate_package(spec, allow_root):
     # If we are not installing back to the same install tree do the relocation
     if old_prefix != new_prefix:
         files_to_relocate = [
-            os.path.join(workdir, filename) for filename in buildinfo.get("relocate_binaries")
+            os.path.join(workdir, filename) for filename in buildinfo["relocate_binaries"]
         ]
         # If the buildcache was not created with relativized rpaths
         # do the relocation of path in binaries
@@ -1509,37 +1509,12 @@ def relocate_package(spec, allow_root):
                 old_prefix,
                 new_prefix,
             )
-        if "elf" in platform.binary_formats:
-            relocate.relocate_elf_binaries(
-                files_to_relocate,
-                old_layout_root,
-                new_layout_root,
-                prefix_to_prefix_bin,
-                rel,
-                old_prefix,
-                new_prefix,
-            )
-            # Relocate links to the new install prefix
-            links = [link for link in buildinfo.get("relocate_links", [])]
-            relocate.relocate_links(links, old_layout_root, old_prefix, new_prefix)
-
-        # For all buildcaches
+        # Relocate links to the new install prefix
+        relocate.relocate_links(
+            buildinfo.get("relocate_links", []), old_layout_root, old_prefix, new_prefix
+        )
         # relocate the install prefixes in text files including dependencies
         relocate.relocate_text(text_names, prefix_to_prefix_text)
-
-        paths_to_relocate = [old_prefix, old_layout_root]
-        paths_to_relocate.extend(prefix_to_hash.keys())
-        files_to_relocate = list(
-            filter(
-                lambda pathname: not relocate.file_is_relocatable(
-                    pathname, paths_to_relocate=paths_to_relocate
-                ),
-                map(
-                    lambda filename: os.path.join(workdir, filename),
-                    buildinfo["relocate_binaries"],
-                ),
-            )
-        )
         # relocate the install prefixes in binary files including dependencies
         relocate.relocate_text_bin(files_to_relocate, prefix_to_prefix_bin)
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -758,6 +758,8 @@ def relocate_text(files, prefixes, concurrency=32):
         prefixes (OrderedDict): String prefixes which need to be changed
         concurrency (int): Preferred degree of parallelism
     """
+    if len(files) == 0:
+        return
 
     # This now needs to be handled by the caller in all cases
     # orig_sbang = '#!/bin/bash {0}/bin/sbang'.format(orig_spack)
@@ -781,7 +783,7 @@ def relocate_text(files, prefixes, concurrency=32):
     for filename in files:
         args.append((filename, compiled_prefixes))
 
-    tp = multiprocessing.pool.Pool(processes=concurrency)
+    tp = multiprocessing.pool.Pool(processes=min(concurrency, len(files)))
     chunksize = max(math.floor(len(files) / concurrency / 5), 1)
     try:
         tp.map(_replace_prefix_text, args, chunksize)
@@ -803,6 +805,9 @@ def relocate_text_bin(binaries, prefixes, concurrency=32):
     Raises:
       BinaryTextReplaceError: when the new path is longer than the old path
     """
+    if len(binaries) == 0:
+        return
+
     byte_prefixes = collections.OrderedDict({})
 
     for orig_prefix, new_prefix in prefixes.items():
@@ -824,7 +829,7 @@ def relocate_text_bin(binaries, prefixes, concurrency=32):
     for binary in binaries:
         args.append((binary, byte_prefixes))
 
-    tp = multiprocessing.pool.Pool(processes=concurrency)
+    tp = multiprocessing.pool.Pool(processes=min(concurrency, len(binaries)))
     chunksize = max(math.floor(len(binaries) / concurrency / 5), 1)
     try:
         tp.map(_replace_prefix_bin, args, chunksize)


### PR DESCRIPTION
**REWRITTEN FOR BETTER EXPLAINATION**

Unpacking and relocating packages that come out of a buildcache is a significant bottleneck for CI jobs since they always start from a clean install. This PR speeds up the relocation step, for an overall speedup of ~2.9x installing LLVM (not including dependencies) from cache. With this, the main bottleneck is now the unpacking step (`tarfile.extractall`).

The main culprit is `patchelf`, which is very slow for unknown reasons. https://github.com/spack/spack/pull/27610 reimplements a limited feature set of `patchelf` in native Python. This PR takes the more aggressive (and faster, and simpler) approach of, "just use string replacement!"

This approach is already implemented in `relocate_text_bin` to support buildcaches created with `-a/--allow-root` (i.e. from `spack ci`), so this patch primarily removes the `patchelf` pass (`relocate_elf_binaries`). This works (and works well) because:
 - The RPATH/RUNPATH is always stored as a null-terminated strings, just like a path in the bss would be stored. No special handling is required by the ELF format, `relocate_text_bin` will recognize and replace it just fine.
 - `relocate_text_bin` inserts padding made up of `os.sep` to fill in the gap, `patchelf` does not add padding. RPATH/RUNPATH is only used when loading binaries and the path-manipulation code is highly optimized, performance will not be hurt.
 - Binaries need to be fit in the system memory to be usable in practice. Loading the entire file and using Python's optimized native `bytes.replace` method should always be possible without running out of memory.

Additionally, this PR optimizes `relocate_text_bin` to use a process-`Pool` instead of a `ThreadPool` for concurrency. This avoids serialization from GIL contention between threads.

We (the HPCToolkit folks) have been using this patch in our own CI for a few weeks now with no known issues, so I think this is safe to consider more seriously.

Known issues and concerns:
 - The original implementation allowed a case where the new prefix could be longer than the old prefix, if the prefix was only used in the RPATHs and nowhere else. This new implementation does not (currently) fall back to `patchelf` in this case, which is the primary reason the `clingo` checks fail. This could be avoided by fixing https://github.com/alalazo/spack-bootstrap-mirrors/issues/10.
 - The original implementation passed `--force-rpath` to `patchelf` to ensure RPATHs were used (instead of RUNPATHs). This PR removes that logic, instead using whichever the buildcache was generated with. Fixing this requires minimally parsing the ELF which will slow down the relocation. Alternatively, this could become almost moot with https://github.com/spack/spack/pull/31948.
 - The `relocate_text_bin` code path has a latent bug where, if the projection in the "new" case differs from the original, it may not relocate properly (the layout root is replaced but not the projection suffix). Using it for RPATHs makes this bug much more obvious.