### PR TITLE
llvm: fix detection of LLDB_PYTHON_EXE_RELATIVE_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/D133513.diff
+++ b/var/spack/repos/builtin/packages/llvm/D133513.diff
@@ -1,0 +1,29 @@
+Index: lldb/bindings/python/get-python-config.py
+===================================================================
+--- lldb/bindings/python/get-python-config.py
++++ lldb/bindings/python/get-python-config.py
+@@ -44,15 +44,21 @@
+     elif args.variable_name == "LLDB_PYTHON_EXE_RELATIVE_PATH":
+         tried = list()
+         exe = sys.executable
+-        prefix = os.path.realpath(sys.prefix)
++        prefix = sys.prefix
+         while True:
+             try:
+                 print(relpath_nodots(exe, prefix))
+                 break
+             except ValueError:
+                 tried.append(exe)
+-                if os.path.islink(exe):
+-                    exe = os.path.join(os.path.realpath(os.path.dirname(exe)), os.readlink(exe))
++                real_exe_dirname = os.path.realpath(os.path.dirname(exe))
++                real_prefix = os.path.realpath(prefix)
++                if prefix != real_prefix:
++                    prefix = real_prefix
++                    exe = os.path.join(real_exe_dirname, os.path.basename(exe))
++                    continue
++                elif os.path.islink(exe):
++                    exe = os.path.join(real_exe_dirname, os.readlink(exe))
+                     continue
+                 else:
+                     print("Could not find a relative path to sys.executable under sys.prefix", file=sys.stderr)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -377,6 +377,12 @@ class Llvm(CMakePackage, CudaPackage):
         when="@8:11",
     )
 
+    # fix detection of LLDB_PYTHON_EXE_RELATIVE_PATH
+    # see https://reviews.llvm.org/D133513
+    # TODO: adjust version constraint and switch to fetching from the upstream GitHub repo
+    #  when/if the bugfix is merged
+    patch("D133513.diff", level=0, when="@14:15+lldb+python")
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #


### PR DESCRIPTION
There are problems when installing `llvm@14:+lldb+python` using Python installed to a symlinked directory (see https://reviews.llvm.org/D133513). This applies a patch that fixes the issue.