### PR TITLE
py-pyproj: add v3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -14,8 +14,6 @@ class PyBasemap(PythonPackage):
     homepage = "https://matplotlib.org/basemap/"
 
     version("1.2.1", sha256="3fb30424f18cd4ffd505e30fd9c810ae81b999bb92f950c76553e1abc081faa7")
-    version("1.2.0", sha256="bd5bf305918a2eb675939873b735238f9e3dfe6b5c290e37c41e5b082ff3639a")
-    version("1.0.7", sha256="e07ec2e0d63b24c9aed25a09fe8aff2598f82a85da8db74190bac81cbf104531")
 
     # Per Github issue #3813, setuptools is required at runtime in order
     # to make mpl_toolkits a namespace package that can span multiple
@@ -23,7 +21,6 @@ class PyBasemap(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-numpy@1.2.1:", type=("build", "run"))
     depends_on("py-matplotlib@1.0.0:3.0.0,3.0.2:", type=("build", "run"))
-    depends_on("py-pyproj@1.9.3:1", type=("build", "run"), when="@:1.2.0")
     # 1.2.1 is PROJ6 compatible
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=939022
     depends_on("py-pyproj@1.9.3:", type=("build", "run"), when="@1.2.1:")

--- a/var/spack/repos/builtin/packages/py-pyproj/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproj/package.py
@@ -16,6 +16,7 @@ class PyPyproj(PythonPackage):
 
     maintainers = ["citibeth", "adamjstewart"]
 
+    version("3.4.0", sha256="a708445927ace9857f52c3ba67d2915da7b41a8fdcd9b8f99a4c9ed60a75eb33")
     version("3.1.0", sha256="67b94f4e694ae33fc90dfb7da0e6b5ed5f671dd0acc2f6cf46e9c39d56e16e1a")
     version("3.0.1", sha256="bfbac35490dd17f706700673506eeb8170f8a2a63fb5878171d4e6eef242d141")
     version("3.0.0", sha256="539e320d06e5441edadad2e2ab276e1877445eca384fc1c056b5501453d433c2")
@@ -23,41 +24,32 @@ class PyPyproj(PythonPackage):
     version("2.6.0", sha256="977542d2f8cf2981cf3ad72cedfebcd6ac56977c7aa830d9b49fa7888b56e83d")
     version("2.2.0", sha256="0a4f793cc93539c2292638c498e24422a2ec4b25cb47545addea07724b2a56e5")
     version("2.1.3", sha256="99c52788b01a7bb9a88024bf4d40965c0a66a93d654600b5deacf644775f424d")
-    version(
-        "1.9.6",
-        sha256="e0c02b1554b20c710d16d673817b2a89ff94738b0b537aead8ecb2edc4c4487b",
-        deprecated=True,
-    )
-    version(
-        "1.9.5.1",
-        sha256="53fa54c8fa8a1dfcd6af4bf09ce1aae5d4d949da63b90570ac5ec849efaf3ea8",
-        deprecated=True,
-    )
 
-    # In setup.cfg and setup.py
+    # In pyproject.toml
+    depends_on("py-setuptools@61:", when="@3.4:", type="build")
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cython@0.28.4:", when="@2:", type="build")
+
+    # In setup.cfg
+    depends_on("python@3.8:", when="@3.3:", type=("build", "link", "run"))
     depends_on("python@3.7:", when="@3.1:", type=("build", "link", "run"))
     depends_on("python@3.6:", when="@3.0:", type=("build", "link", "run"))
     depends_on("python@3.5:", when="@2.3:", type=("build", "link", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@2.2:", type=("build", "link", "run"))
     depends_on("python@2.6:2.8,3.3:", type=("build", "link", "run"))
-
-    # In setup.py
-    # https://pyproj4.github.io/pyproj/stable/installation.html#installing-from-source
-    depends_on("proj")
-    depends_on("proj@7.2:", when="@3.0.1:")
-    depends_on("proj@7.2.0:7.2", when="@3.0.0")
-    depends_on("proj@6.2:7.0", when="@2.4:2.6")
-    depends_on("proj@6.1:7.0", when="@2.2:2.3")
-    depends_on("proj@6.0:6", when="@2.0:2.1")
-    depends_on("proj@:5.2", when="@:1.9")
-
-    # In setup.py
-    depends_on("py-setuptools", type="build")
     depends_on("py-certifi", when="@3.0:", type=("build", "run"))
-    depends_on("py-aenum", when="@2.2.0:2.2 ^python@:3.5", type=("build", "run"))
+    depends_on("py-aenum", when="@2.2 ^python@:3.5", type=("build", "run"))
 
-    # In pyproject.toml
-    depends_on("py-cython@0.28.4:", when="@2.0:")
+    # https://pyproj4.github.io/pyproj/stable/installation.html#installing-from-source
+    depends_on("proj@8.2:", when="@3.4:")
+    depends_on("proj@8.0:9.1", when="@3.3")
+    depends_on("proj@7.2:9.1", when="@3.0.1:3.2")
+    depends_on("proj@7.2", when="@3.0.0")
+    depends_on("proj@6.2:7", when="@2.4:2.6")
+    depends_on("proj@6.1:7", when="@2.2:2.3")
+    depends_on("proj@6.0:7", when="@2.0:2.1")
+    depends_on("proj@:5.2", when="@:1.9")
+    depends_on("proj")
 
     def setup_build_environment(self, env):
         # https://pyproj4.github.io/pyproj/stable/installation.html#pyproj-build-environment-variables


### PR DESCRIPTION
Successfully builds on macOS 12.5.1 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/pyproj4/pyproj/releases/tag/3.4.0