### PR TITLE
py-cartopy: add v0.21.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cartopy/package.py
+++ b/var/spack/repos/builtin/packages/py-cartopy/package.py
@@ -14,6 +14,7 @@ class PyCartopy(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("0.21.0", sha256="ce1d3a28a132e94c89ac33769a50f81f65634ab2bd40556317e15bd6cad1ce42")
     version("0.20.3", sha256="0d60fa2e2fbd77c4d1f6b1f9d3b588966147f07c1b179d2d34570ac1e1b49006")
     version("0.20.2", sha256="4d08c198ecaa50a6a6b109d0f14c070e813defc046a83ac5d7ab494f85599e35")
     version("0.20.1", sha256="91f87b130e2574547a20cd634498df97d797abd12dcfd0235bc0cdbcec8b05e3")
@@ -33,39 +34,40 @@ class PyCartopy(PythonPackage):
     )
     variant("plotting", default=False, description="Add plotting functionality")
 
-    # setup.py
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
-    depends_on("python@3.5:", when="@0.19:", type=("build", "run"))
-    depends_on("python@3.7:", when="@0.20:", type=("build", "run"))
-    depends_on("geos@3.3.3:")
-    depends_on("geos@3.7.2:", when="@0.20:")
-    depends_on("proj@4.9:5", when="@:0.16")
-    depends_on("proj@4.9:7", when="@0.17:0.19")
-    depends_on("proj@8:", when="@0.20:")
-
     # pyproject.toml
-    depends_on("py-setuptools@0.7.2:", type="build")
     depends_on("py-setuptools@40.6:", when="@0.19:", type="build")
-    depends_on("py-cython", type="build")
-    depends_on("py-cython@0.15.1:", when="@0.17:", type="build")
-    depends_on("py-cython@0.28:", when="@0.18:", type="build")
-    depends_on("py-cython@0.29.2:", when="@0.19:", type="build")
+    depends_on("py-setuptools@0.7.2:", type="build")
     depends_on("py-cython@0.29.13:", when="@0.20:", type="build")
-    depends_on("py-setuptools-scm", when="@0.19:", type="build")
+    depends_on("py-cython@0.29.2:", when="@0.19:", type="build")
+    depends_on("py-cython@0.28:", when="@0.18:", type="build")
+    depends_on("py-cython@0.15.1:", when="@0.17:", type="build")
+    depends_on("py-cython", type="build")
     depends_on("py-setuptools-scm@7:", when="@0.20.3:", type="build")
+    depends_on("py-setuptools-scm", when="@0.19:", type="build")
     depends_on("py-setuptools-scm-git-archive", when="@0.19:0.20.2", type="build")
 
+    # setup.py
+    depends_on("python@3.8:", when="@0.21:", type=("build", "run"))
+    depends_on("python@3.7:", when="@0.20:", type=("build", "run"))
+    depends_on("python@3.5:", when="@0.19:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
+    depends_on("geos@3.7.2:", when="@0.20:")
+    depends_on("geos@3.3.3:")
+    depends_on("proj@8:", when="@0.20")
+    depends_on("proj@4.9:7", when="@0.17:0.19")
+    depends_on("proj@4.9:5", when="@:0.16")
+
     # requirements/default.txt
-    depends_on("py-numpy@1.6:", type=("build", "run"))
-    depends_on("py-numpy@1.10:", when="@0.17:", type=("build", "run"))
-    depends_on("py-numpy@1.13.3:", when="@0.19:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@0.20:", type=("build", "run"))
+    depends_on("py-numpy@1.13.3:", when="@0.19:", type=("build", "run"))
+    depends_on("py-numpy@1.10:", when="@0.17:", type=("build", "run"))
+    depends_on("py-numpy@1.6:", type=("build", "run"))
     depends_on("py-matplotlib@3.1:", when="@0.20:", type=("build", "run"))
-    depends_on("py-shapely@1.5.6:", type=("build", "run"))
-    depends_on("py-shapely@1.6.4:", when="@0.20:", type=("build", "run"))
-    depends_on("py-pyshp@1.1.4:", type=("build", "run"))
-    depends_on("py-pyshp@2:", when="@0.19:", type=("build", "run"))
+    depends_on("py-shapely@1.6.4:1", when="@0.20:", type=("build", "run"))
+    depends_on("py-shapely@1.5.6:1", type=("build", "run"))
     depends_on("py-pyshp@2.1:", when="@0.20:", type=("build", "run"))
+    depends_on("py-pyshp@2:", when="@0.19:", type=("build", "run"))
+    depends_on("py-pyshp@1.1.4:", type=("build", "run"))
     depends_on("py-pyproj@3:", when="@0.20:", type=("build", "run"))
     depends_on("py-six@1.3:", when="@:0.18", type=("build", "run"))
     depends_on("py-futures", when="@0.18 ^python@2.7", type=("build", "run"))
@@ -77,21 +79,21 @@ class PyCartopy(PythonPackage):
 
     # requirements/ows.txt
     with when("+ows"):
-        depends_on("py-owslib@0.8.11:", type="run")
         depends_on("py-owslib@0.18:", when="@0.20:", type="run")
-        depends_on("pil@1.7.8:", type="run")
+        depends_on("py-owslib@0.8.11:", type="run")
         depends_on("pil@6.1:", when="@0.20:", type="run")
+        depends_on("pil@1.7.8:", type="run")
 
     # requirements/plotting.txt
     with when("+plotting"):
-        depends_on("py-matplotlib@1.3:", when="@0.16", type="run")
-        depends_on("py-matplotlib@1.5.1:", when="@0.17:0.19", type="run")
-        depends_on("gdal@1.10:+python", type="run")
         depends_on("gdal@2.3.2:+python", when="@0.20:", type="run")
-        depends_on("pil@1.7.8:", type="run")
+        depends_on("gdal@1.10:+python", type="run")
         depends_on("pil@6.1:", when="@0.20:", type="run")
-        depends_on("py-scipy@0.10:", type="run")
+        depends_on("pil@1.7.8:", type="run")
         depends_on("py-scipy@1.3.1:", when="@0.20:", type="run")
+        depends_on("py-scipy@0.10:", type="run")
+        depends_on("py-matplotlib@1.5.1:", when="@0.17:0.19", type="run")
+        depends_on("py-matplotlib@1.3:", when="@0.16", type="run")
 
     patch("proj6.patch", when="@0.17.0")
 


### PR DESCRIPTION
Successfully builds on macOS 12.5.1 (arm64) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/SciTools/cartopy/releases/tag/v0.21.0