### PR TITLE
Fix encoding issues with py-cylp

### DIFF
--- a/var/spack/repos/builtin/packages/py-cylp/package.py
+++ b/var/spack/repos/builtin/packages/py-cylp/package.py
@@ -9,9 +9,10 @@ from spack.package import *
 class PyCylp(PythonPackage):
     """A Python interface for CLP, CBC, and CGL.
 
-    CyLP is a Python interface to COIN-OR’s Linear and mixed-integer program
-    solvers (CLP, CBC, and CGL). CyLP’s unique feature is that you can use it
-    to alter the solution process of the solvers from within Python."""
+    CyLP is a Python interface to COIN-OR's Linear and mixed-integer program
+    solvers (CLP, CBC, and CGL). CyLP's unique feature is that you can use it
+    to alter the solution process of the solvers from within Python.
+    """
 
     homepage = "https://github.com/coin-or/cylp"
     pypi = "cylp/cylp-0.91.5.tar.gz"


### PR DESCRIPTION
fixes #32607

The package contains character that have encoding issues with Python 2.7.