### PR TITLE
compadre: new version 1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/compadre/package.py
+++ b/var/spack/repos/builtin/packages/compadre/package.py
@@ -15,16 +15,17 @@ class Compadre(CMakePackage):
     constitute the rows of some globally sparse matrix.
     """
 
-    homepage = "https://github.com/SNLComputation/compadre"
-    git = "https://github.com/SNLComputation/compadre.git"
-    url = "https://github.com/SNLComputation/compadre/archive/v1.3.0.tar.gz"
+    homepage = "https://github.com/sandialabs/compadre"
+    git = "https://github.com/sandialabs/compadre.git"
+    url = "https://github.com/sandialabs/compadre/archive/v1.3.0.tar.gz"
     maintainers = ["kuberry"]
 
-    version("master", branch="master", preferred=True)
+    version("master", branch="master")
+    version("1.5.0", "b7dd6020cc5a7969de817d5c7f6c5acceaad0f08dcfd3d7cacfa9f42e4c8b335")
+    version("1.4.1", "2e1e7d8e30953f76b6dc3a4c86ec8103d4b29447194cb5d5abb74b8e4099bdd9")
     version("1.3.0", "f711a840fd921e84660451ded408023ec3bcfc98fd0a7dc4a299bfae6ab489c2")
 
-    depends_on("kokkos@3.3.01:main")
-    depends_on("kokkos-kernels@3.3.01:main")
+    depends_on("kokkos-kernels@3.3.01:3.6")
     depends_on("cmake@3.13:", type="build")
 
     variant(
@@ -36,6 +37,13 @@ class Compadre(CMakePackage):
 
     variant("mpi", default=False, description="Enable MPI support")
     depends_on("mpi", when="+mpi")
+
+    # fixes duplicate symbol issue with static library build
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/sandialabs/Compadre/pull/286.patch?full_index=1",
+        sha256="e267b74f8ecb8dd23970848ed919d29b7d442f619ce80983e02a19f1d9582c61",
+        when="@1.5.0",
+    )
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
- url updates to indicate new home at https://github.com/sandialabs/compadre
- adds versions 1.4.1 and 1.5.0
- master branch is no longer the preferred version
- remove kokkos dependency which is redundant after requiring kokkos-kernels
