### PR TITLE
encode development requirements in pyproject.toml

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -49,52 +49,8 @@ spack_prefix = os.path.dirname(os.path.dirname(spack_file))
 spack_lib_path = os.path.join(spack_prefix, "lib", "spack")
 sys.path.insert(0, spack_lib_path)
 
-# Add external libs
-spack_external_libs = os.path.join(spack_lib_path, "external")
-
-if sys.version_info[:2] <= (2, 7):
-    sys.path.insert(0, os.path.join(spack_external_libs, "py2"))
-
-sys.path.insert(0, spack_external_libs)
-
-# Here we delete ruamel.yaml in case it has been already imported from site
-# (see #9206 for a broader description of the issue).
-#
-# Briefly: ruamel.yaml produces a .pth file when installed with pip that
-# makes the site installed package the preferred one, even though sys.path
-# is modified to point to another version of ruamel.yaml.
-if "ruamel.yaml" in sys.modules:
-    del sys.modules["ruamel.yaml"]
-
-if "ruamel" in sys.modules:
-    del sys.modules["ruamel"]
-
-# The following code is here to avoid failures when updating
-# the develop version, due to spurious argparse.pyc files remaining
-# in the libs/spack/external directory, see:
-# https://github.com/spack/spack/pull/25376
-# TODO: Remove in v0.18.0 or later
-try:
-    import argparse
-except ImportError:
-    argparse_pyc = os.path.join(spack_external_libs, "argparse.pyc")
-    if not os.path.exists(argparse_pyc):
-        raise
-    try:
-        os.remove(argparse_pyc)
-        import argparse  # noqa: F401
-    except Exception:
-        msg = (
-            "The file\n\n\t{0}\n\nis corrupted and cannot be deleted by Spack. "
-            "Either delete it manually or ask some administrator to "
-            "delete it for you."
-        )
-        print(msg.format(argparse_pyc))
-        sys.exit(1)
-
-
-import spack.main  # noqa: E402
+from spack_installable.main import main  # noqa: E402
 
 # Once we've set up the system path, run the spack main method
 if __name__ == "__main__":
-    sys.exit(spack.main.main())
+    sys.exit(main())

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -3,11 +3,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#: (major, minor, micro, dev release) tuple
-spack_version_info = (0, 19, 0, "dev0")
-
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-spack_version = ".".join(str(s) for s in spack_version_info)
+__version__ = "0.19.0.dev0"
+spack_version = __version__
+
+def __try_int(v):
+    try:
+        return int(v)
+    except:
+        return v
+
+#: (major, minor, micro, dev release) tuple
+spack_version_info = tuple([__try_int(v) for v in __version__.split(".")])
+
 
 __all__ = ["spack_version_info", "spack_version"]
-__version__ = spack_version

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -7,11 +7,13 @@
 __version__ = "0.19.0.dev0"
 spack_version = __version__
 
+
 def __try_int(v):
     try:
         return int(v)
-    except:
+    except ValueError:
         return v
+
 
 #: (major, minor, micro, dev release) tuple
 spack_version_info = tuple([__try_int(v) for v in __version__.split(".")])

--- a/lib/spack/spack_installable/main.py
+++ b/lib/spack/spack_installable/main.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from os.path import dirname as dn
+
+
+def main(argv=None):
+    # Find spack's location and its prefix.
+    this_file = os.path.realpath(os.path.expanduser(__file__))
+    spack_prefix = dn(dn(dn(dn(this_file))))
+
+    # Allow spack libs to be imported in our scripts
+    spack_lib_path = os.path.join(spack_prefix, "lib", "spack")
+    sys.path.insert(0, spack_lib_path)
+
+    # Add external libs
+    spack_external_libs = os.path.join(spack_lib_path, "external")
+
+    if sys.version_info[:2] <= (2, 7):
+        sys.path.insert(0, os.path.join(spack_external_libs, "py2"))
+
+    sys.path.insert(0, spack_external_libs)
+    # Here we delete ruamel.yaml in case it has been already imported from site
+    # (see #9206 for a broader description of the issue).
+    #
+    # Briefly: ruamel.yaml produces a .pth file when installed with pip that
+    # makes the site installed package the preferred one, even though sys.path
+    # is modified to point to another version of ruamel.yaml.
+    if "ruamel.yaml" in sys.modules:
+        del sys.modules["ruamel.yaml"]
+
+    if "ruamel" in sys.modules:
+        del sys.modules["ruamel"]
+
+    # The following code is here to avoid failures when updating
+    # the develop version, due to spurious argparse.pyc files remaining
+    # in the libs/spack/external directory, see:
+    # https://github.com/spack/spack/pull/25376
+    # TODO: Remove in v0.18.0 or later
+    try:
+        import argparse  # noqa: F401
+    except ImportError:
+        argparse_pyc = os.path.join(spack_external_libs, "argparse.pyc")
+        if not os.path.exists(argparse_pyc):
+            raise
+        try:
+            os.remove(argparse_pyc)
+            import argparse  # noqa: F401
+        except Exception:
+            msg = (
+                "The file\n\n\t{0}\n\nis corrupted and cannot be deleted by Spack. "
+                "Either delete it manually or ask some administrator to "
+                "delete it for you."
+            )
+            print(msg.format(argparse_pyc))
+            sys.exit(1)
+
+    import spack.main  # noqa: E402
+
+    sys.exit(spack.main.main(argv))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ include = [
 ]
 
 [tool.hatch.envs.default]
-detached = true
 features = [
   "dev",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies=[
 ]
 dynamic = ["version"]
 
+[project.scripts]
+spack = "lib.spack.spack_installable.main:main"
+
 [tool.hatch.version]
 path = "lib/spack/spack/__init__.py"
 
@@ -33,6 +36,22 @@ ci = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+include = [
+  "/bin",
+  "/etc",
+  "/lib",
+  "/share",
+  "/var",
+  "CITATION.cff",
+  "COPYRIGHT",
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "NOTICE",
+  "README.md",
+  "SECURITY.md",
+]
 
 [tool.hatch.envs.default]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="spack"
-version="0"
+version="0.19.0.dev0"
 description="The spack package manager"
 dependencies=[
   "six",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,54 @@
+[project]
+name="spack"
+version="0"
+description="The spack package manager"
+dependencies=[
+  "six",
+  "types-six",
+  "setuptools",
+  "clingo",
+]
+packages = []
+
+[project.optional-dependencies]
+dev = [
+  "pip>=21.3",
+  "pytest",
+  "pytest-xdist",
+  "setuptools",
+  "click==8.0.2",
+  'black==21.12b0',
+  "mypy",
+  "isort",
+  "flake8",
+  "vermin",
+]
+ci = [
+  "pytest-cov",
+  "codecov[toml]",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.envs.default]
+detached = true
+features = [
+  "dev",
+]
+
+[tool.hatch.envs.default.scripts]
+spack = "./bin/spack"
+style = "./bin/spack style"
+test = "./bin/spack unit-test"
+
+[tool.hatch.envs.ci]
+features = [
+  "dev",
+  "ci",
+]
+
 [tool.black]
 line-length = 99
 target-version = ['py27', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,16 @@
 [project]
 name="spack"
-version="0.19.0.dev0"
 description="The spack package manager"
 dependencies=[
+  "clingo",
+  "setuptools",
   "six",
   "types-six",
-  "setuptools",
-  "clingo",
 ]
-packages = []
+dynamic = ["version"]
+
+[tool.hatch.version]
+path = "lib/spack/spack/__init__.py"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Add a `project` block to the toml config along with development and CI dependencies and a minimal `build-system` block, doing basically nothing, so that spack can be bootstrapped to a full development environment with:

```shell
$ hatch shell
```

or for a minimal environment without hatch:

```shell
$ python3 -m venv venv
$ source venv/bin/activate
$ python3 -m pip install --upgrade pip
$ python3 -m pip install -e '.[dev]'
```

This means we can re-use the requirements list throughout the workflow yaml files and otherwise maintain this list in *one place* rather than several disparate ones.  We may be stuck with a couple more temporarily to continue supporting python2.7, but aside from that it's less places to get out of sync and a couple new bootstrap options.