### PR TITLE
add ability to disable werror for rocksdb

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -33,6 +33,7 @@ class Rocksdb(MakefilePackage):
     variant("zlib", default=True, description="Enable zlib compression support")
     variant("zstd", default=False, description="Enable zstandard compression support")
     variant("tbb", default=False, description="Enable Intel TBB support")
+    variant("werror", default=False, description="Build with -Werror")
 
     depends_on("bzip2", when="+bz2")
     depends_on("gflags")
@@ -92,6 +93,9 @@ class Rocksdb(MakefilePackage):
 
         env["CFLAGS"] = " ".join(cflags)
         env["PLATFORM_FLAGS"] = " ".join(ldflags)
+
+        if "+werror" not in self.spec:
+            env["DISABLE_WARNING_AS_ERROR"] = "1"
 
         if self.spec.satisfies("@6.13.2:"):
             env["PREFIX"] = self.spec.prefix

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -94,7 +94,7 @@ class Rocksdb(MakefilePackage):
         env["CFLAGS"] = " ".join(cflags)
         env["PLATFORM_FLAGS"] = " ".join(ldflags)
 
-        if "+werror" not in self.spec:
+        if "~werror" in self.spec:
             env["DISABLE_WARNING_AS_ERROR"] = "1"
 
         if self.spec.satisfies("@6.13.2:"):


### PR DESCRIPTION
The default `-Werror` in the package causes build failures on newer versions of GCC.