### PR TITLE
Add libraqm package; enable in py-pillow

### DIFF
--- a/var/spack/repos/builtin/packages/libraqm/package.py
+++ b/var/spack/repos/builtin/packages/libraqm/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libraqm(MesonPackage):
+    """Raqm is a small library that encapsulates the logic for complex text layout and provides a convenient API."""
+
+    homepage = "https://github.com/HOST-Oman/libraqm"
+    url      = "https://github.com/HOST-Oman/libraqm/releases/download/v0.9.0/raqm-0.9.0.tar.xz"
+    git      = "https://github.com/HOST-Oman/libraqm.git"
+
+    version('0.9.0', tag="v0.9.0")
+
+    depends_on("freetype")
+    depends_on("harfbuzz")

--- a/var/spack/repos/builtin/packages/libraqm/package.py
+++ b/var/spack/repos/builtin/packages/libraqm/package.py
@@ -10,10 +10,10 @@ class Libraqm(MesonPackage):
     """Raqm is a small library that encapsulates the logic for complex text layout and provides a convenient API."""
 
     homepage = "https://github.com/HOST-Oman/libraqm"
-    url      = "https://github.com/HOST-Oman/libraqm/releases/download/v0.9.0/raqm-0.9.0.tar.xz"
-    git      = "https://github.com/HOST-Oman/libraqm.git"
+    url = "https://github.com/HOST-Oman/libraqm/releases/download/v0.9.0/raqm-0.9.0.tar.xz"
+    git = "https://github.com/HOST-Oman/libraqm.git"
 
-    version('0.9.0', tag="v0.9.0")
+    version("0.9.0", sha256="9ed6fdf41da6391fc9bf7038662cbe412c330aa6eb22b19704af2258e448107c")
 
     depends_on("freetype")
     depends_on("harfbuzz")

--- a/var/spack/repos/builtin/packages/libraqm/package.py
+++ b/var/spack/repos/builtin/packages/libraqm/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Libraqm(MesonPackage):
-    """Raqm is a small library that encapsulates the logic for complex text layout and provides a convenient API."""
+    """Raqm provides a convenient API for the logic of complex text layout."""
 
     homepage = "https://github.com/HOST-Oman/libraqm"
     url = "https://github.com/HOST-Oman/libraqm/releases/download/v0.9.0/raqm-0.9.0.tar.xz"

--- a/var/spack/repos/builtin/packages/libraqm/package.py
+++ b/var/spack/repos/builtin/packages/libraqm/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Libraqm(MesonPackage):

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -25,7 +25,7 @@ class PyPillowBase(PythonPackage):
     variant("jpeg2000", default=False, description="JPEG 2000 functionality")
     variant("imagequant", when="@3.3:", default=False, description="Improved color quantization")
     variant("xcb", when="@7.1:", default=False, description="X11 screengrab support")
-    variant("raqm", when="@8.4.0:", default=False, description="RAQM support")
+    variant("raqm", when="@8.2:", default=False, description="RAQM support")
 
     # Required dependencies
     # https://pillow.readthedocs.io/en/latest/installation.html#notes
@@ -55,6 +55,9 @@ class PyPillowBase(PythonPackage):
     depends_on("libxcb", when="+xcb")
     depends_on("libraqm", when="+raqm")
 
+    # Conflicting options
+    conflicts("+raqm", when="~freetype")
+
     def patch(self):
         """Patch setup.py to provide library and include directories
         for dependencies."""
@@ -72,7 +75,7 @@ class PyPillowBase(PythonPackage):
 
         def variant_to_cfg(variant):
             able = "enable" if "+" + variant in self.spec else "disable"
-            return "{0}-{1}=1\n".format(able, variant)
+            return "{0}_{1}=1\n".format(able, variant)
 
         with open("setup.cfg", "a") as setup:
             setup.write("[build_ext]\n")

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -25,6 +25,7 @@ class PyPillowBase(PythonPackage):
     variant("jpeg2000", default=False, description="JPEG 2000 functionality")
     variant("imagequant", when="@3.3:", default=False, description="Improved color quantization")
     variant("xcb", when="@7.1:", default=False, description="X11 screengrab support")
+    variant('raqm', default=False, description='RAQM support')
 
     # Required dependencies
     # https://pillow.readthedocs.io/en/latest/installation.html#notes
@@ -52,6 +53,7 @@ class PyPillowBase(PythonPackage):
     depends_on("openjpeg", when="+jpeg2000")
     depends_on("libimagequant", when="+imagequant")
     depends_on("libxcb", when="+xcb")
+    depends_on('libraqm', when='+raqm')
 
     def patch(self):
         """Patch setup.py to provide library and include directories

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -25,7 +25,7 @@ class PyPillowBase(PythonPackage):
     variant("jpeg2000", default=False, description="JPEG 2000 functionality")
     variant("imagequant", when="@3.3:", default=False, description="Improved color quantization")
     variant("xcb", when="@7.1:", default=False, description="X11 screengrab support")
-    variant("raqm", default=False, description="RAQM support")
+    variant("raqm", when="@8.4.0:", default=False, description="RAQM support")
 
     # Required dependencies
     # https://pillow.readthedocs.io/en/latest/installation.html#notes

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -25,7 +25,7 @@ class PyPillowBase(PythonPackage):
     variant("jpeg2000", default=False, description="JPEG 2000 functionality")
     variant("imagequant", when="@3.3:", default=False, description="Improved color quantization")
     variant("xcb", when="@7.1:", default=False, description="X11 screengrab support")
-    variant('raqm', default=False, description='RAQM support')
+    variant("raqm", default=False, description="RAQM support")
 
     # Required dependencies
     # https://pillow.readthedocs.io/en/latest/installation.html#notes
@@ -53,7 +53,7 @@ class PyPillowBase(PythonPackage):
     depends_on("openjpeg", when="+jpeg2000")
     depends_on("libimagequant", when="+imagequant")
     depends_on("libxcb", when="+xcb")
-    depends_on('libraqm', when='+raqm')
+    depends_on("libraqm", when="+raqm")
 
     def patch(self):
         """Patch setup.py to provide library and include directories


### PR DESCRIPTION
Now Pillow can render OTF fonts with ligatures and glyph substitutions correctly. Must be built with:
```
spack install py-pillow+freetype+raqm
```