### PR TITLE
[py-pip] fix setup_dependent_package in py-pip

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -94,7 +94,7 @@ class PyPip(Package):
         python(*args)
 
     def setup_dependent_package(self, module, dependent_spec):
-        pip = self.spec["python"].command
+        pip = dependent_spec["python"].command
         pip.add_default_arg("-m")
         pip.add_default_arg("pip")
         setattr(module, "pip", pip)


### PR DESCRIPTION
This PR fixes a problem with the py-pip package: if python and py-pip are provided as external packages, the line that this PR changes will currently fail when installing packages that depend on py-pip.