### PR TITLE
graphite2: fix build on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/graphite2/package.py
+++ b/var/spack/repos/builtin/packages/graphite2/package.py
@@ -17,8 +17,15 @@ class Graphite2(CMakePackage):
     )
     url = "https://github.com/silnrsi/graphite/releases/download/1.3.13/graphite2-1.3.13.tgz"
 
+    version("1.3.14", sha256="f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d")
     version("1.3.13", sha256="dd63e169b0d3cf954b397c122551ab9343e0696fb2045e1b326db0202d875f06")
 
     depends_on("python@3.6:", type="test")
 
     patch("regparm.patch")
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Apple Clang 12.0.0.

### Before
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/apple-clang-12.0.0/graphite2-1.3.14-u2dldeabc5hd34v4m33mvn2faqhcvvav/lib/libgraphite2.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/apple-clang-12.0.0/graphite2-1.3.14-u2dldeabc5hd34v4m33mvn2faqhcvvav/lib/libgraphite2.dylib:
	libgraphite2.3.dylib (compatibility version 3.0.0, current version 3.2.1)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```
### After
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/apple-clang-12.0.0/graphite2-1.3.14-xxprtcxgjw3ge4equ5oxxfkftd7y4r47/lib/libgraphite2.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/apple-clang-12.0.0/graphite2-1.3.14-xxprtcxgjw3ge4equ5oxxfkftd7y4r47/lib/libgraphite2.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-ivybridge/apple-clang-12.0.0/graphite2-1.3.14-xxprtcxgjw3ge4equ5oxxfkftd7y4r47/lib/libgraphite2.dylib (compatibility version 3.0.0, current version 3.2.1)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```