### PR TITLE
pango: harfbuzz+coretext required on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -13,6 +13,7 @@ class Harfbuzz(MesonPackage):
     url = "https://github.com/harfbuzz/harfbuzz/releases/download/2.9.1/harfbuzz-2.9.1.tar.xz"
     git = "https://github.com/harfbuzz/harfbuzz.git"
 
+    version("5.1.0", sha256="2edb95db668781aaa8d60959d21be2ff80085f31b12053cdd660d9a50ce84f05")
     version("4.2.1", sha256="bd17916513829aeff961359a5ccebba6de2f4bf37a91faee3ac29c120e3d7ee1")
     version("4.1.0", sha256="f7984ff4241d4d135f318a93aa902d910a170a8265b7eaf93b5d9a504eed40c8")
     version("4.0.1", sha256="98f68777272db6cd7a3d5152bac75083cd52a26176d87bc04c8b3929d33bce49")
@@ -57,6 +58,7 @@ class Harfbuzz(MesonPackage):
     )
 
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
+    variant("coretext", default=False, when="platform=darwin", description="Enable CoreText shaper backend on macOS")
 
     depends_on("pkgconfig", type="build")
     depends_on("glib")
@@ -109,6 +111,11 @@ class Harfbuzz(MesonPackage):
             "-Dgraphite2=" + ("enabled" if self.spec.satisfies("+graphite2") else "disabled")
         )
 
+        if "+coretext" in self.spec:
+            args.append("-Dcoretext=enabled")
+        elif "~coretet" in self.spec:
+            args.append("-Dcoretext=disabled")
+
         return args
 
     @when("@:2.9")
@@ -123,6 +130,11 @@ class Harfbuzz(MesonPackage):
         args.append("GTKDOC_MKPDF={0}".format(true))
         args.append("GTKDOC_REBASE={0}".format(true))
         args.extend(self.with_or_without("graphite2"))
+
+        if "+coretext" in self.spec:
+            args.append("--with-coretext")
+        elif "~coretet" in self.spec:
+            args.append("--without-coretext")
 
         return args
 

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -118,7 +118,7 @@ class Harfbuzz(MesonPackage):
 
         if "+coretext" in self.spec:
             args.append("-Dcoretext=enabled")
-        elif "~coretet" in self.spec:
+        elif "~coretext" in self.spec:
             args.append("-Dcoretext=disabled")
 
         return args
@@ -138,7 +138,7 @@ class Harfbuzz(MesonPackage):
 
         if "+coretext" in self.spec:
             args.append("--with-coretext")
-        elif "~coretet" in self.spec:
+        elif "~coretext" in self.spec:
             args.append("--without-coretext")
 
         return args

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -58,7 +58,12 @@ class Harfbuzz(MesonPackage):
     )
 
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
-    variant("coretext", default=False, when="platform=darwin", description="Enable CoreText shaper backend on macOS")
+    variant(
+        "coretext",
+        default=False,
+        when="platform=darwin",
+        description="Enable CoreText shaper backend on macOS",
+    )
 
     depends_on("pkgconfig", type="build")
     depends_on("glib")

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -55,6 +55,7 @@ class Pango(MesonPackage):
 
     depends_on("pkgconfig@0.9.0:", type="build")
     depends_on("harfbuzz")
+    depends_on("harfbuzz+coretext", when="platform=darwin")
     depends_on("cairo+ft+fc")
     depends_on("cairo~X", when="~X")
     depends_on("cairo+X", when="+X")


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Apple Clang 12.0.0.

Without this change, the pango build was failing with:
```
../spack-src/pango/pangocoretext.c:27:10: fatal error: 'hb-coretext.h' file not found
```