### PR TITLE
json-glib: add pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/json-glib/package.py
+++ b/var/spack/repos/builtin/packages/json-glib/package.py
@@ -39,6 +39,7 @@ class JsonGlib(MesonPackage):
 
     depends_on("glib")
     depends_on("gobject-introspection")
+    depends_on("pkgconfig", type="build")
 
     @when("@:1.5")
     def meson(self, spec, prefix):


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Apple Clang 12.0.0.

I found this dependency to be required to properly locate gobject-introspection.