### PR TITLE
py-tokenize-rt: add missing setuptools dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-tokenize-rt/package.py
+++ b/var/spack/repos/builtin/packages/py-tokenize-rt/package.py
@@ -15,3 +15,4 @@ class PyTokenizeRt(PythonPackage):
     version("4.2.1", sha256="0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94")
 
     depends_on("python@3.6.1:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Apple Clang 12.0.0.

Build fails without a build backend.