### PR TITLE
libcatalyst: use git instead of fixed urls

### DIFF
--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -11,14 +11,12 @@ class Libcatalyst(CMakePackage):
     scientific data producers) to analyze and visualize data in situ."""
 
     homepage = "https://gitlab.kitware.com/paraview/catalyst"
-    url = "https://gitlab.kitware.com/paraview/catalyst/-/archive/{0}/catalyst-{0}.tar.bz2"
+    git = "https://gitlab.kitware.com/paraview/catalyst.git"
 
     maintainers = ["mathstuf"]
 
     # master as of 2021-05-12
-    version(
-        "2021-05-12", sha256="5a01f12b271d9d9e9b89f31d45a5f4b8426904483639d38754893adfd3547bab"
-    )
+    version("2021-05-12", commit="8456ccd6015142b5a7705f79471361d4f5644fa7")
 
     variant("mpi", default=False, description="Enable MPI support")
     variant("python3", default=False, description="Enable Python3 support")
@@ -27,10 +25,6 @@ class Libcatalyst(CMakePackage):
 
     # TODO: catalyst doesn't support an external conduit
     # depends_on('conduit')
-
-    def url_for_version(self, version):
-        _urlfmt = self.url
-        return _urlfmt.format(version)
 
     def cmake_args(self):
         """Populate cmake arguments for libcatalyst."""


### PR DESCRIPTION
I had difficulties custom installing specific versions of Catalyst, here I change URL to git to be able to install commit at wish.

    The issue is that we are not not able to install (Fetch URL error) any
    version of catalyst other than the specified in the spack package.py.
    This very version is accessible only because it is cached by Spack. The
    real URL does not exist anymore, I believe the reason is that there used
    to be a tag in catalyst that does not exist anymore.