### PR TITLE
rocfft test require rocm-openmp-extras instead llvm-amdgpu +opemnp

### DIFF
--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -96,7 +96,7 @@ class Rocfft(CMakePackage):
     depends_on("googletest@1.10.0:", type="test")
     depends_on("fftw@3.3.8:", type="test")
     depends_on("boost@1.64.0: +program_options", type="test")
-    depends_on("llvm-amdgpu +openmp", type="test")
+    depends_on("rocm-openmp-extras", type="test")
 
     def check(self):
         exe = join_path(self.build_directory, "clients", "staging", "rocfft-test")


### PR DESCRIPTION
test depends on llvm-amdgpu +openmp which is failing.
It can depend on rocm-openmp-extras with the latest changes.