### PR TITLE
Ginkgo: improve smoke testing

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -171,7 +171,11 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     def _build_test(self):
         cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
-        cmake_args = [self._cached_tests_src_dir]
+        cmake_args = [
+            "-DCMAKE_C_COMPILER={0}".format(self.compiler.cc),
+            "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
+            self._cached_tests_src_dir,
+        ]
 
         # Fix: For HIP tests, add the ARCH compilation flags when not present
         if "+rocm" in self.spec:

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -153,17 +153,50 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
                 )
         return args
 
-    @run_after("install")
-    def setup_build_tests(self):
-        """Build and install the smoke tests."""
-        # For now only 1.4.0 and later releases support this scheme.
-        if self.spec.satisfies("@:1.3.0"):
+
+    extra_install_tests = join_path('test', 'test_install')
+
+    @run_after('install')
+    def cache_test_sources(self):
+        self.cache_extra_test_sources(self.extra_install_tests)
+
+    @property
+    def _cached_tests_src_dir(self):
+        """The working directory for cached test sources."""
+        return join_path(self.test_suite.current_test_cache_dir,
+                self.extra_install_tests)
+
+    @property
+    def _cached_tests_work_dir(self):
+        """The working directory for cached test sources."""
+        return join_path(self._cached_tests_src_dir, 'build')
+
+    def _build_test(self):
+        cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
+        cmake_args = [ self._cached_tests_src_dir ]
+
+        # Fix: For HIP tests, add the ARCH compilation flags when not present
+        if "+rocm" in self.spec:
+            src_path = join_path(self._cached_tests_src_dir, "CMakeLists.txt")
+            cmakelists = open(src_path, "rt")
+            data = cmakelists.read()
+            data = data.replace('CLANG_OPTIONS "${GINKGO_PIC_OPTION}"',
+                    'CLANG_OPTIONS "${GINKGO_AMD_ARCH_FLAGS}" "${GINKGO_PIC_OPTION}"')
+            cmakelists.close()
+            cmakelists = open(src_path, "wt")
+            cmakelists.write(data)
+            cmakelists.close()
+
+        if not self.run_test(cmake_bin, options=cmake_args,
+                purpose="Generate the Makefile",
+                work_dir=self._cached_tests_work_dir):
+            print("Skipping Ginkgo test: failed to generate Makefile")
             return
-        with working_dir(self.build_directory):
-            make("test_install")
-        smoke_test_path = join_path(self.build_directory, "test", "test_install")
-        with working_dir(smoke_test_path):
-            make("install")
+
+        if not self.run_test("make", purpose="Build test software",
+                work_dir=self._cached_tests_work_dir):
+            print("Skipping Ginkgo test: failed to build test")
+            return
 
     def test(self):
         """Run the smoke tests."""
@@ -172,10 +205,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             print("SKIPPED: smoke tests not supported with this Ginkgo version.")
             return
 
-        # The installation process installs tests and associated data
-        # in a non-standard subdirectory. Consequently, those files must
-        # be manually copied to the test stage here.
-        install_tree(self.prefix.smoke_tests, self.test_suite.current_test_cache_dir)
+        self._build_test()
 
         # Perform the test(s) created by setup_build_tests.
         files = [
@@ -191,5 +221,5 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
                 skip_missing=True,
                 installed=False,
                 purpose="test: Running {0}".format(f),
-                work_dir=self.test_suite.current_test_cache_dir,
+                work_dir=self._cached_tests_work_dir,
             )


### PR DESCRIPTION
Cache the smoke test source, call CMake and build the smoke tests during the test.

There was a bug with the AMD smoke tests CMake code, which does not make use of the AMD architecture flags specified. This is fixed by a python `replace` call.

This addresses comments from @tldahlgren in #28412