### PR TITLE
py-awkward: allow newer, fixed rapidjson versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -37,6 +37,6 @@ class PyAwkward(PythonPackage):
     depends_on("py-numpy@1.13.1:", type=("build", "run"))
     depends_on("py-pybind11", type=("build", "link"))
     depends_on("dlpack", when="@1.0.0:")
-    depends_on("rapidjson@:1.1.0")
+    depends_on("rapidjson")
     depends_on("cmake@3.13:", type="build")
     depends_on("py-wheel@0.36.0:", type="build", when="@:1.7.0")


### PR DESCRIPTION
Rapidjson was constrained due to a bug (see https://github.com/spack/spack/pull/29889) , but newer (although untagged) versions of rapidjson have since been added to spack (https://github.com/spack/spack/pull/29869). Tested the build of py-awkward with the latest, works fine.

@aandvalenzuela