### PR TITLE
Add hash hint to multi-spec message

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -291,17 +291,22 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
     elif first:
         return matching_specs[0]
 
-    elif len(matching_specs) > 1:
-        format_string = "{name}{@version}{%compiler}{arch=architecture}"
-        args = ["%s matches multiple packages." % spec, "Matching packages:"]
-        args += [
-            colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(format_string)
-            for s in matching_specs
-        ]
-        args += ["Use a more specific spec."]
-        tty.die(*args)
+    require_specific_spec(spec, matching_specs)
 
     return matching_specs[0]
+
+
+def require_specific_spec(spec, matching_specs):
+    if len(matching_specs) <= 1:
+        return
+
+    format_string = "{name}{@version}{%compiler}{arch=architecture}"
+    args = ["%s matches multiple packages." % spec, "Matching packages:"]
+    args += [
+        colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(format_string) for s in matching_specs
+    ]
+    args += ["Use a more specific spec (e.g., prepend '/' to the hash)."]
+    tty.die(*args)
 
 
 def gray_hash(spec, length):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -291,12 +291,12 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
     elif first:
         return matching_specs[0]
 
-    require_specific_spec(spec, matching_specs)
+    ensure_single_spec_or_die(spec, matching_specs)
 
     return matching_specs[0]
 
 
-def require_specific_spec(spec, matching_specs):
+def ensure_single_spec_or_die(spec, matching_specs):
     if len(matching_specs) <= 1:
         return
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -65,7 +65,7 @@ def disambiguate_in_view(specs, view):
             tty.die("Spec matches no installed packages.")
 
         matching_in_view = [ms for ms in matching_specs if ms in view_specs]
-        spack.cmd.require_specific_spec("Spec", matching_in_view)
+        spack.cmd.ensure_single_spec_or_die("Spec", matching_in_view)
 
         return matching_in_view[0] if matching_in_view else matching_specs[0]
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -35,7 +35,6 @@ YamlFilesystemView.
 """
 import llnl.util.tty as tty
 from llnl.util.link_tree import MergeConflictError
-from llnl.util.tty.color import colorize
 
 import spack.cmd
 import spack.environment as ev
@@ -66,16 +65,7 @@ def disambiguate_in_view(specs, view):
             tty.die("Spec matches no installed packages.")
 
         matching_in_view = [ms for ms in matching_specs if ms in view_specs]
-
-        if len(matching_in_view) > 1:
-            spec_format = "{name}{@version}{%compiler}{arch=architecture}"
-            args = ["Spec matches multiple packages.", "Matching packages:"]
-            args += [
-                colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(spec_format)
-                for s in matching_in_view
-            ]
-            args += ["Use a more specific spec."]
-            tty.die(*args)
+        spack.cmd.require_specific_spec("Spec", matching_in_view)
 
         return matching_in_view[0] if matching_in_view else matching_specs[0]
 

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -10,7 +10,7 @@ import pytest
 
 import spack.spec
 import spack.user_environment as uenv
-from spack.main import SpackCommand, SpackCommandError
+from spack.main import SpackCommand
 
 load = SpackCommand("load")
 unload = SpackCommand("unload")
@@ -115,10 +115,12 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
     install("libelf@0.8.12")
     install("libelf@0.8.13")
-    # Now there are two versions of libelf
-    with pytest.raises(SpackCommandError):
-        # This should cause an error due to multiple versions
-        load("--sh", "libelf")
+
+    # Now there are two versions of libelf, which should cause an error
+    out = load("--sh", "libelf", fail_on_error=False)
+    assert "matches multiple packages" in out
+    assert "Use a more specific spec" in out
+
     # Using --first should avoid the error condition
     load("--sh", "--first", "libelf")
 


### PR DESCRIPTION
Fixes #32540 (original request)

This PR adds the hash hint requested in #32540 .  It also does a little refactoring to make sure the two nearly identical messages are consistent.

Before this change:
```
$ spack load ginkgo
==> Error: ginkgo matches multiple packages.
  Matching packages:
    3rjdn3p ginkgo@1.4.0%gcc@8.3.1 arch=linux-rhel7-broadwell
    j4y2yfv ginkgo@1.4.0%gcc@8.3.1 arch=linux-rhel7-broadwell
  Use a more specific spec.
```

After:
```
$ spack load ginkgo
==> Error: ginkgo matches multiple packages.
  Matching packages:
    3rjdn3p ginkgo@1.4.0%gcc@8.3.1 arch=linux-rhel7-broadwell
    j4y2yfv ginkgo@1.4.0%gcc@8.3.1 arch=linux-rhel7-broadwell
  Use a more specific spec (e.g., prepend '/' to the hash).
```

Note the change simply adds `(e.g., prepend '/' to the hash)` to the hint.

@shahzebsiddiqui @adamjstewart 