### PR TITLE
root: make X11 really optional on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 from spack.package import *
 
@@ -19,7 +18,7 @@ class AppleGl(Package):
 
     version("4.1.0")
 
-    provides("gl@4.1", when=sys.platform == "darwin")
+    provides("gl@4.1")
 
     # Only supported on 'platform=darwin' and compiler=apple-clang
     conflicts("platform=linux")

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -1,0 +1,58 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class AppleGl(Package):
+    """Shim package for the core OpenGL library from Apple"""
+
+    homepage = "https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_intro/opengl_intro.html"
+
+    maintainers = ["aphecetche"]
+
+    has_code = False
+
+    version("4.1.0")
+
+    provides("gl@4.1", when=sys.platform == "darwin")
+
+    # Only supported on 'platform=darwin' and compiler=apple-clang
+    conflicts("platform=linux")
+    conflicts("platform=cray")
+    conflicts("%gcc")
+    conflicts("%clang")
+
+    phases = []
+
+    sdk_base = (
+        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
+        "Developer/SDKs/MacOSX"
+    )
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # we try to setup a build environment with enough hints
+        # for the build system to pick up on the Apple framework version
+        # of OpenGL.
+        # - for a cmake build we actually needs nothing at all as
+        # find_package(OpenGL) will do the right thing
+        # - for the rest of the build systems we'll assume that
+        # setting the C_INCLUDE_PATH will be enough for the compilation phase
+        # and *** for the link phase.
+        env.prepend_path("C_INCLUDE_PATH", self.sdk_base)
+
+    @property
+    def headers(self):
+        return HeaderList(
+            "{}.sdk/System/Library/Frameworks/OpenGL.framework/Headers".format(self.sdk_base)
+        )
+
+    @property
+    def libs(self):
+        return LibraryList(
+            "{}.sdk/System/Library/Frameworks/OpenGL.framework".format(self.sdk_base)
+        )

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -1,0 +1,58 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class AppleGlu(Package):
+    """Shim package for Apple implementation of OpenGL Utility Libray (GLU)"""
+
+    homepage = ""
+
+    maintainers = ["aphecetche"]
+
+    has_code = False
+
+    version("1.3.0")
+
+    provides("glu@1.3", when=sys.platform == "darwin")
+
+    # Only supported on 'platform=darwin' and compiler=apple-clang
+    conflicts("platform=linux")
+    conflicts("platform=cray")
+    conflicts("%gcc")
+    conflicts("%clang")
+
+    phases = []
+
+    sdk_base = (
+        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
+        "Developer/SDKs/MacOSX"
+    )
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # we try to setup a build environment with enough hints
+        # for the build system to pick up on the Apple framework version
+        # of OpenGL.
+        # - for a cmake build we actually needs nothing at all as
+        # find_package(OpenGL) will do the right thing
+        # - for the rest of the build systems we'll assume that
+        # setting the C_INCLUDE_PATH will be enough for the compilation phase
+        # and *** for the link phase.
+        env.prepend_path("C_INCLUDE_PATH", self.sdk_base)
+
+    @property
+    def headers(self):
+        return HeaderList(
+            "{}.sdk/System/Library/Frameworks/OpenGL.framework/Headers".format(self.sdk_base)
+        )
+
+    @property
+    def libs(self):
+        return LibraryList(
+            "{}.sdk/System/Library/Frameworks/OpenGL.framework".format(self.sdk_base)
+        )

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 from spack.package import *
 
@@ -19,7 +18,7 @@ class AppleGlu(Package):
 
     version("1.3.0")
 
-    provides("glu@1.3", when=sys.platform == "darwin")
+    provides("glu@1.3")
 
     # Only supported on 'platform=darwin' and compiler=apple-clang
     conflicts("platform=linux")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -214,12 +214,8 @@ class Root(CMakePackage):
     depends_on("ftgl@2.4.0:", when="+opengl")
     depends_on("glew", when="+opengl")
     depends_on("gl2ps", when="+opengl")
-    if sys.platform != "darwin":
-        depends_on("gl", when="+x+opengl")
-        depends_on("glu", when="+x+opengl")
-    else:
-        depends_on("gl", when="+opengl")
-        depends_on("glu", when="+opengl")
+    depends_on("gl", when="+opengl")
+    depends_on("glu", when="+opengl")
 
     # Qt4
     depends_on("qt@:4", when="+qt4")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -211,11 +211,15 @@ class Root(CMakePackage):
     depends_on("libsm", when="+x")
 
     # OpenGL
-    depends_on("ftgl@2.4.0:", when="+x+opengl")
-    depends_on("glew", when="+x+opengl")
-    depends_on("gl", when="+x+opengl")
-    depends_on("glu", when="+x+opengl")
-    depends_on("gl2ps", when="+x+opengl")
+    depends_on("ftgl@2.4.0:", when="+opengl")
+    depends_on("glew", when="+opengl")
+    depends_on("gl2ps", when="+opengl")
+    if sys.platform != "darwin":
+        depends_on("gl", when="+x+opengl")
+        depends_on("glu", when="+x+opengl")
+    else:
+        depends_on("gl", when="+opengl")
+        depends_on("glu", when="+opengl")
 
     # Qt4
     depends_on("qt@:4", when="+qt4")
@@ -287,7 +291,8 @@ class Root(CMakePackage):
     conflicts("target=ppc64le:", when="@:6.24")
 
     # Incompatible variants
-    conflicts("+opengl", when="~x", msg="OpenGL requires X")
+    if sys.platform != "darwin":
+        conflicts("+opengl", when="~x", msg="OpenGL requires X")
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")
     conflicts("+tmva", when="~mlp", msg="TVMA requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
@@ -430,8 +435,11 @@ class Root(CMakePackage):
 
         # Options related to ROOT's ability to download and build its own
         # dependencies. Per Spack convention, this should generally be avoided.
+
+        afterimage_enabled = "+x" if "platform=darwin" not in self.spec else True
+
         options += [
-            define_from_variant("builtin_afterimage", "x"),
+            define("builtin_afterimage", afterimage_enabled),
             define("builtin_cfitsio", False),
             define("builtin_davix", False),
             define("builtin_fftw3", False),
@@ -604,7 +612,7 @@ class Root(CMakePackage):
             add_include_path("fontconfig")
             add_include_path("libx11")
             add_include_path("xproto")
-        if "+opengl" in spec:
+        if "+opengl" in spec and "platform=darwin" not in spec:
             add_include_path("glew")
             add_include_path("mesa-glu")
         if "platform=darwin" in spec:

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -432,7 +432,7 @@ class Root(CMakePackage):
         # Options related to ROOT's ability to download and build its own
         # dependencies. Per Spack convention, this should generally be avoided.
 
-        afterimage_enabled = "+x" if "platform=darwin" not in self.spec else True
+        afterimage_enabled = ("+x" in self.spec) if "platform=darwin" not in self.spec else True
 
         options += [
             define("builtin_afterimage", afterimage_enabled),


### PR DESCRIPTION
This is an attempt to get Root compiled with OpenGL but without requiring X11 on macOS.

Note that this is my first Spack PR... Hopefully I've correctly read the [contribution guide]( https://spack.readthedocs.io/en/latest/contribution_guide.html) though. You'll let me know :wink: 

Note also that I have some other changes in the root recipe that I'd like to propose (in other PRs) to "activate" two more variants : arrow and monalisa. I assumed it would be better to stage the modifications, but I can of course propose a combined PR if preferred.  