### PR TITLE
Add skip_import to PythonPackage and use it in py-nilearn

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -582,6 +582,19 @@ libraries. Make sure not to add modules/packages containing the word
 "test", as these likely won't end up in the installation directory,
 or may require test dependencies like pytest to be installed.
 
+Instead of defining the ``import_modules`` explicity, only the subset
+of module names to be skipped can be defined by using ``skip_modules``.
+If a defined module has submodules, they are skipped as well, e.g.,
+in case the ``plotting`` modules should be excluded from the
+automatically detected ``import_modules`` ``['nilearn', 'nilearn.surface',
+'nilearn.plotting', 'nilearn.plotting.data']`` set:
+
+.. code-block:: python
+
+        skip_modules = ['nilearn.plotting']
+
+This will set ``import_modules`` to ``['nilearn', 'nilearn.surface']``
+
 Import tests can be run during the installation using ``spack install
 --test=root`` or at any time after the installation using
 ``spack test run``.

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -138,11 +138,27 @@ class PythonPackage(PackageBase):
                     path.replace(root + os.sep, "", 1).replace(".py", "").replace("/", ".")
                 )
 
-        modules = [mod for mod in modules if re.match("[a-zA-Z0-9._]+$", mod)]
+        modules = [
+            mod
+            for mod in modules
+            if re.match("[a-zA-Z0-9._]+$", mod) and not any(map(mod.startswith, self.skip_modules))
+        ]
 
         tty.debug("Detected the following modules: {0}".format(modules))
 
         return modules
+
+    @property
+    def skip_modules(self):
+        """Names of modules that should be skipped when running tests.
+
+        These are a subset of import_modules. If a module has submodules,
+        they are skipped as well (meaning a.b is skipped if a is contained).
+
+        Returns:
+            list: list of strings of module names
+        """
+        return []
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/py-nilearn/package.py
+++ b/var/spack/repos/builtin/packages/py-nilearn/package.py
@@ -28,13 +28,22 @@ class PyNilearn(PythonPackage):
 
     variant("plotting", default=False, description="Enable plotting functionalities")
 
+    depends_on("py-joblib@0.15:", when="@0.9.1:", type=("build", "run"))
+    depends_on("py-joblib@0.12:", when="@0.7:", type=("build", "run"))
+    depends_on("py-joblib@0.11:", when="@0.6:", type=("build", "run"))
+    depends_on("py-lxml", when="@0.9.1:", type=("build", "run"))
+    depends_on("py-nibabel@3:", when="@0.9.1:", type=("build", "run"))
+    depends_on("py-nibabel@2.5:", when="@0.8:", type=("build", "run"))
+    depends_on("py-nibabel@2.0.2:", type=("build", "run"))
+    depends_on("py-numpy@1.18:", when="@0.9.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@0.8:", type=("build", "run"))
     depends_on("py-numpy@1.11:", when="@0.5:", type=("build", "run"))
     depends_on("py-numpy@1.6.1:", type=("build", "run"))
-    depends_on("py-scipy@1.2:", when="@0.8:", type=("build", "run"))
-    depends_on("py-scipy@0.19:", when="@0.6:", type=("build", "run"))
-    depends_on("py-scipy@0.17:", when="@0.5:", type=("build", "run"))
-    depends_on("py-scipy@0.14:", type=("build", "run"))
+    depends_on("py-pandas@1:", when="@0.9.1:", type=("build", "run"))
+    depends_on("py-pandas@0.24.0:", when="@0.8:", type=("build", "run"))
+    depends_on("py-pandas@0.18.0:", when="@0.7:", type=("build", "run"))
+    depends_on("py-requests@2:", when="@0.7:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.22:", when="@0.9.1:", type=("build", "run"))
     depends_on("py-scikit-learn@0.21:", when="@0.8:", type=("build", "run"))
     depends_on("py-scikit-learn@0.19:", when="@0.7:", type=("build", "run"))
     # sklearn.linear_model.base was deprecated in py-scikit.learn@0.24
@@ -42,18 +51,18 @@ class PyNilearn(PythonPackage):
     # older py-nilearn versions use import sklearn.external.joblib which was
     # deprecated in py-scikit-learn@0.23:
     depends_on("py-scikit-learn@0.15:0.22", when="@:0.5", type=("build", "run"))
-    depends_on("py-joblib@0.12:", when="@0.7:", type=("build", "run"))
-    depends_on("py-joblib@0.11:", when="@0.6:", type=("build", "run"))
-    depends_on("py-nibabel@2.5:", when="@0.8:", type=("build", "run"))
-    depends_on("py-nibabel@2.0.2:", type=("build", "run"))
-    depends_on("py-pandas@0.24.0:", when="@0.8:", type=("build", "run"))
-    depends_on("py-pandas@0.18.0:", when="@0.7:", type=("build", "run"))
-    depends_on("py-requests@2:", when="@0.7:", type=("build", "run"))
+    depends_on("py-scipy@1.5:", when="@0.9.1:", type=("build", "run"))
+    depends_on("py-scipy@1.2:", when="@0.8:", type=("build", "run"))
+    depends_on("py-scipy@0.19:", when="@0.6:", type=("build", "run"))
+    depends_on("py-scipy@0.17:", when="@0.5:", type=("build", "run"))
+    depends_on("py-scipy@0.14:", type=("build", "run"))
 
-    depends_on("py-matplotlib@2.0:", when="@0.6: +plotting", type=("build", "run"))
+    depends_on("py-matplotlib@3:", when="@0.9.1: +plotting", type=("build", "run"))
+    depends_on("py-matplotlib@2:", when="@0.6: +plotting", type=("build", "run"))
     # older py-nilearn versions use matplotlib.cm.revcmap which was deprecated
     # in py-matplotlib@3.4:
-    depends_on("py-matplotlib@1.1.1:3.3", when="@:0.6 +plotting", type=("build", "run"))
+    depends_on("py-matplotlib@1.5.1:3.3", when="@:0.5 +plotting", type=("build", "run"))
+    depends_on("py-matplotlib@1.1.1:3.3", when="0.4.2 +plotting", type=("build", "run"))
 
     @property
     def skip_modules(self):

--- a/var/spack/repos/builtin/packages/py-nilearn/package.py
+++ b/var/spack/repos/builtin/packages/py-nilearn/package.py
@@ -11,7 +11,10 @@ class PyNilearn(PythonPackage):
 
     homepage = "https://nilearn.github.io/"
     pypi = "nilearn/nilearn-0.7.1.tar.gz"
+    git = "https://github.com/nilearn/nilearn"
 
+    version("0.9.2", sha256="8da8d3835d92cd7b8a6cc92455a489d7e7f5994cf64fc71bce653e362773b9e4")
+    version("0.9.0", sha256="f9c8e30adef51489910aec7724b5699de178427d3ae63873dad9b23dd321fe76")
     version("0.8.1", sha256="a0489940855130f35bbc4cac0750479a6f82025215ea7b1d778faca064219298")
     version("0.8.0", sha256="f2d3dc81005f829f3a183efa6c90d698ea6818c06264d2e3f03e805c4340febb")
     version("0.7.1", sha256="8b1409a5e1f0f6d1a1f02555c2f11115a2364f45f1e57bcb5fb3c9ea11f346fa")
@@ -53,29 +56,10 @@ class PyNilearn(PythonPackage):
     depends_on("py-matplotlib@1.1.1:3.3", when="@:0.6 +plotting", type=("build", "run"))
 
     @property
-    def import_modules(self):
-        modules = [
-            "nilearn",
-            "nilearn.connectome",
-            "nilearn.datasets",
-            "nilearn.decoding",
-            "nilearn.decomposition",
-            "nilearn.image",
-            "nilearn.input_data",
-            "nilearn.masking",
-            "nilearn.mass_univariate",
-            "nilearn.regions",
-            "nilearn.signal",
-            "nilearn.surface",
-        ]
+    def skip_modules(self):
+        modules = []
 
-        if self.spec.satisfies("@0.6:"):
-            modules.append("nilearn.externals")
-
-        if self.spec.satisfies("@0.7:"):
-            modules.append("nilearn.glm")
-
-        if "+plotting" in self.spec:
+        if self.spec.satisfies("~plotting"):
             modules.append("nilearn.plotting")
             if self.spec.satisfies("@0.7:"):
                 modules.append("nilearn.reporting")


### PR DESCRIPTION
A while ago we discussed to add `skip_import` functionality to the `PythonPackage` (see #29175). Instead of explicitly defining `import_modules` for each version or variant, this enables to use the automatic detected modules and ignores certain ones.

For the `py-nilearn` example using `import_modules` would mean:

```
    @property
    def import_modules(self):
        modules = [
            'nilearn',
            'nilearn.connectome',
            'nilearn.datasets',
            'nilearn.decoding',
            'nilearn.decomposition',
            'nilearn.image',
            'nilearn.input_data',
            'nilearn.masking',
            'nilearn.mass_univariate',
            'nilearn.regions',
            'nilearn.signal',
            'nilearn.surface',
        ]

        if self.spec.satisfies('@0.6:'):
            modules.append('nilearn.externals')

        if self.spec.satisfies('@0.7:'):
            modules.append('nilearn.glm')

        if '+plotting' in self.spec:
            modules.append('nilearn.plotting')
            if self.spec.satisfies('@0.7:'):
                modules.append('nilearn.reporting')

        return modules
```

whereas with `skip_modules` this can be reduced to
```
    @property
    def skip_modules(self):
        modules = []

        if self.spec.satisfies("~plotting"):
            modules.append("nilearn.plotting")
            if self.spec.satisfies("@0.7:"):
                modules.append("nilearn.reporting")

        return modules
```
ping @adamjstewart 