### PR TITLE
patch etsf-io tests

### DIFF
--- a/var/spack/repos/builtin/packages/etsf-io/package.py
+++ b/var/spack/repos/builtin/packages/etsf-io/package.py
@@ -25,6 +25,9 @@ class EtsfIo(Package):
     depends_on("netcdf-fortran")
     depends_on("hdf5+mpi~cxx", when="+mpi")  # required for NetCDF-4 support
 
+    patch("tests_module.patch")
+    patch("tests_init.patch")
+
     def install(self, spec, prefix):
         options = ["--prefix=%s" % prefix]
         oapp = options.append
@@ -48,3 +51,24 @@ class EtsfIo(Package):
         make()
         make("check")
         make("install")
+
+    def test(self):
+        """Run this smoke test when requested explicitly"""
+
+        # Test is to run "etsf_io --help"
+        spec = self.spec
+        exe = join_path(spec["etsf-io"].prefix.bin, "etsf_io")
+        options = ["--help"]
+        purpose = "Check etsf_io can execute (--help)"
+        expected = ["Usage: etsf_io"]
+
+        self.run_test(
+            exe,
+            options=options,
+            expected=expected,
+            status=[0],
+            installed=False,
+            purpose=purpose,
+            skip_missing=False,
+            work_dir=None,
+        )

--- a/var/spack/repos/builtin/packages/etsf-io/tests_init.patch
+++ b/var/spack/repos/builtin/packages/etsf-io/tests_init.patch
@@ -1,0 +1,14 @@
+--- etsf-io/tests/group_level/tests_init.f90.orig	2022-06-13 21:38:17.550243223 +0200
++++ etsf-io/tests/group_level/tests_init.f90	2022-06-13 21:35:32.735709916 +0200
+@@ -20,9 +20,9 @@
+     type(etsf_io_low_error), intent(in) :: error
+     
+     if (lstat) then
+-      write(*, "(A,A,A,A)") "== ", name, repeat(" ", 68 - len(name)), "OK     =="
++      write(*, "(A,A,A,A)") "== ", name, repeat(" ", 88 - len(name)), "OK     =="
+     else
+-      write(*, "(A,A,A,A)") "== ", name, repeat(" ", 68 - len(name)), "Failed =="
++      write(*, "(A,A,A,A)") "== ", name, repeat(" ", 88 - len(name)), "Failed =="
+       call etsf_io_low_error_handle(error)
+     end if
+   end subroutine tests_write_status

--- a/var/spack/repos/builtin/packages/etsf-io/tests_module.patch
+++ b/var/spack/repos/builtin/packages/etsf-io/tests_module.patch
@@ -1,0 +1,21 @@
+--- etsf-io/tests/group_level/tests_module.f90.orig	2022-06-13 21:28:19.013027453 +0200
++++ etsf-io/tests/group_level/tests_module.f90	2022-06-13 21:34:27.062699770 +0200
+@@ -85,7 +85,7 @@
+     character(len = *), parameter :: me = "check_read_nD"
+     integer, allocatable :: int_array(:)
+     double precision, allocatable :: dbl_array(:)
+-    character(len = 256), allocatable :: strings(:)
++    character(len = dims(1)), allocatable :: strings(:)
+ 
+     ! Allocate temporary read space
+     if (type == "integer") then
+@@ -370,8 +370,8 @@
+   end subroutine allocate_str_1D
+ 
+   subroutine check_mem_str_0D(string, length, varname, lstat, error_data)
+-    character(len = length), intent(in) :: string
+     integer, intent(in) :: length
++    character(len = length), intent(in) :: string
+     character(len = *), intent(in) :: varname
+     logical, intent(out) :: lstat
+     type(etsf_io_low_error), intent(inout) :: error_data


### PR DESCRIPTION
The package currently fails to install as the package fails at the `make check` phase.
The PR includes two patches to get the package working.
Both these patches are being applied to the etsf_io testing system and not the library itself.
Patches from meisam.tabriz@mpcdf.mpg.de and smoke tests from @fangohr 
I am only sending the PR with their permission. 

