### PR TITLE
must: Fix incorrect cmake argument in MPI error detection tool  build

### DIFF
--- a/var/spack/repos/builtin/packages/must/package.py
+++ b/var/spack/repos/builtin/packages/must/package.py
@@ -101,6 +101,6 @@ class Must(CMakePackage):
             cmake_args.extend(["-DUSE BACKWARD=Off"])
         else:
             if spec.satisfies("+backward"):
-                cmake_args.extend(["-DSUSE BACKWARD=On"])
+                cmake_args.extend(["-DUSE BACKWARD=On"])
 
         return cmake_args


### PR DESCRIPTION
Fix a typo error in the cmake arguments to the must MPI error detection tool build.