### PR TITLE
root: determine_variants cxxstd=20 support

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -334,6 +334,8 @@ class Root(CMakePackage):
             v.append("cxxstd=14")
         elif "cxx17" in f:
             v.append("cxxstd=17")
+        elif "cxx20" in f:
+            v.append("cxxstd=20")
 
         # helper function: check if featurename is in features, and if it is,
         # append variantname to variants. featurename may be a list/tuple, in


### PR DESCRIPTION
This is somewhat ahead of reality, but once/when external ROOT installs with cxxstd=20 are common, we will need this to pick up the correct variant. I just happened to run across this and figured a PR was in order.

Maintainers: @HadrienG2  @chissg  @drbenmorgan  @vvolkl