### PR TITLE
gitlab: cuda not compatible amazon linux 2

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -70,12 +70,6 @@ spack:
     # - intel-oneapi-compilers@2022.1
     # - nvhpc
 
-  - cuda_specs:
-    # Depends on ctffind which embeds fsincos (x86-specific asm) within code. Will not build on ARM
-    #- relion +cuda cuda_arch=70
-    - raja +cuda cuda_arch=70
-    - mfem +cuda cuda_arch=70
-
   - app_specs:
     - bwa
 # Depends on simde which requires newer compiler?
@@ -132,11 +126,6 @@ spack:
 
 
   specs:
-
-  - matrix:
-    - - $cuda_specs
-    - - $compiler
-    - - $target
 
   - matrix:
     - - $app_specs

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -30,18 +30,12 @@ spack:
     - ascent
     - blt
     - caliper
-    - caliper +cuda cuda_arch=70
     - camp
-    - camp +cuda
     - chai
-    - chai +cuda +raja
     - mfem
     - mfem +superlu-dist+petsc+sundials
-    - mfem +cuda cuda_arch=70 ^hypre+cuda
     - raja
-    - raja +cuda cuda_arch=70
     - umpire
-    - umpire +cuda
 
   - compiler:
     - '%gcc@7.3.1'


### PR DESCRIPTION
amazon linux 2 ships a glibc that is too old to work with cuda toolkit
for aarch64.

For example:

`libcurand.so.10.2.10.50` requires the symbol `logf@@GLIBC_2.27`, but
glibc is at 2.26.

So, these specs are removed.

That makes it possible to finally merge https://github.com/spack/spack/pull/31948 where the gitlab pipeline is failing because of this.