### PR TITLE
Attempt at patching phist find mpi heuristic for updated phist version

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -192,7 +192,7 @@ class Phist(CMakePackage):
     # the phist repo came with it's own FindMPI.cmake before, which may cause some other
     # MPI installation to be used than the one spack wants.
     def patch(self):
-        if self.spec.satisfies("@1.9.6"):
+        if self.spec.satisfies("@1.9.6:"):
             filter_file("USE mpi", "use mpi_f08", "src/kernels/builtin/crsmat_module.F90")
             # filter_file('use mpi', 'use mpi_f08', -> Needs more fixes
             #            'fortran_bindings/phist_testing.F90')


### PR DESCRIPTION
This is a tentative fix for the current Gitlab CI issues plaguing develop where phist fails due to GCC complaining about a type mismatch in some calls to MPI.

This solve is based on a previous issue with phist, where its bundled findMPI.cmake is conflicting with Spack derived MPI location determination.