### PR TITLE
Don't run bootstrap on package only PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,15 +73,15 @@ jobs:
       # setting environment variables from earlier steps: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       #
   bootstrap:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.bootstrap == 'true' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.bootstrap == 'false' }}
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/bootstrap.yml
   unit-tests:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'false' }}
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/unit_tests.yaml
   windows:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'false' }}
     needs: [ prechecks ]
     uses: ./.github/workflows/windows_python.yml
   all:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
             - 'lib/spack/**'
             - 'share/spack/**'
             - '.github/workflows/bootstrap.yml'
+            - '.github/workflows/ci.yaml'
             core:
             - './!(var/**)/**'
             packages:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,10 @@ jobs:
           # built-in repository or documentation
           filters: |
             bootstrap:
-            - '!var/spack/repos/builtin/**'
             - 'var/spack/repos/builtin/packages/clingo-bootstrap/**'
             - 'var/spack/repos/builtin/packages/clingo/**'
             - 'var/spack/repos/builtin/packages/python/**'
             - 'var/spack/repos/builtin/packages/re2c/**'
-            - '!lib/spack/docs/**'
             - 'lib/spack/**'
             - 'share/spack/**'
             - '.github/workflows/bootstrap.yml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,15 +73,15 @@ jobs:
       # setting environment variables from earlier steps: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       #
   bootstrap:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.bootstrap == 'false' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.bootstrap == 'true' }}
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/bootstrap.yml
   unit-tests:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'false' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
     needs: [ prechecks, changes ]
     uses: ./.github/workflows/unit_tests.yaml
   windows:
-    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'false' }}
+    if: ${{ github.repository == 'spack/spack' && needs.changes.outputs.core == 'true' }}
     needs: [ prechecks ]
     uses: ./.github/workflows/windows_python.yml
   all:


### PR DESCRIPTION
Currently we always run bootstrap jobs in CI, due to a possibly wrong translation from GitHub Action's path filters to `dorny/path-filters` action. Here we limit bootstrap jobs to PRs that modify core or packages involved in bootstrap.

Modifications:
- [x] Change the file paths used to determine if the `bootstrap` is run