### PR TITLE
Support for building Pmix with Debian/Ubuntu external dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -146,6 +146,11 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
         url = "https://download.open-mpi.org/release/hwloc/v{0}/hwloc-{1}.tar.gz"
         return url.format(version.up_to(2), version)
 
+    @property
+    def libs(self):
+        libs = find_libraries("libhwloc", root=self.prefix, shared=True, recursive=True)
+        return LibraryList(libs)
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -49,6 +49,11 @@ class Libevent(AutotoolsPackage):
 
         return url.format(version)
 
+    @property
+    def libs(self):
+        libs = find_libraries("libevent", root=self.prefix, shared=True, recursive=True)
+        return LibraryList(libs)
+
     def configure_args(self):
         spec = self.spec
         configure_args = []

--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -103,7 +103,7 @@ class Pmix(AutotoolsPackage):
         tgt_libpath = ""
         dir_list = spec[pkg_name].libs
         for entry in dir_list:
-            if path_match_str=="" or (path_match_str!="" and path_match_str in entry):
+            if path_match_str == "" or (path_match_str != "" and path_match_str in entry):
                 tgt_libpath = entry
                 break
         path_list = tgt_libpath.split(os.sep)
@@ -118,12 +118,17 @@ class Pmix(AutotoolsPackage):
         config_args.append("--with-libevent=" + spec["libevent"].prefix)
         config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
 
+        # As of 09/22/22 pmix build does not detect the hwloc version
+        # for 32-bit architecture correctly. Since, we have only been
+        # able to test on 64-bit architecture, we are keeping this
+        # check for "64" in place. We will need to re-visit this when we
+        # have the fix in Pmix for 32-bit library version detection
         if "64" in platform.machine():
             if spec["libevent"].external_path:
-                dep_libpath = self.find_external_lib_path("libevent","64")
+                dep_libpath = self.find_external_lib_path("libevent", "64")
                 config_args.append("--with-libevent-libdir=" + dep_libpath)
             if spec["hwloc"].external_path:
-                dep_libpath = self.find_external_lib_path("hwloc","64")
+                dep_libpath = self.find_external_lib_path("hwloc", "64")
                 config_args.append("--with-hwloc-libdir=" + dep_libpath)
 
         config_args.extend(self.enable_or_disable("python-bindings", variant="python"))

--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -3,11 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import re
 import platform
-import spack.platforms
 
-import llnl.util.filesystem as filesystem
 from spack.package import *
 
 
@@ -101,18 +98,17 @@ class Pmix(AutotoolsPackage):
         perl = which("perl")
         perl("./autogen.pl")
 
-    def find_external_lib_path(self, lib_name, pkg_name, path_match_str=""):
+    def find_external_lib_path(self, pkg_name, path_match_str=""):
         spec = self.spec
         tgt_libpath = ""
-        dir_list = filesystem.find_libraries(lib_name, spec[pkg_name].external_path, True, True)
+        dir_list = spec[pkg_name].libs
         for entry in dir_list:
-            if lib_name in entry:
-                if path_match_str=="" or (path_match_str!="" and path_match_str in entry):
-                    tgt_libpath = entry
-                    break
-        path_list = tgt_libpath.split('/')
+            if path_match_str=="" or (path_match_str!="" and path_match_str in entry):
+                tgt_libpath = entry
+                break
+        path_list = tgt_libpath.split(os.sep)
         del path_list[-1]
-        return '/'.join(path_list)
+        return (os.sep).join(path_list)
 
     def configure_args(self):
         spec = self.spec
@@ -121,16 +117,13 @@ class Pmix(AutotoolsPackage):
 
         config_args.append("--with-libevent=" + spec["libevent"].prefix)
         config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
-        host_platform = spack.platforms.host()
-        host_os = host_platform.operating_system("default_os")
 
-        if platform.machine()=="x86_64" and  \
-                re.search('ubuntu', str(host_os), re.IGNORECASE):
+        if "64" in platform.machine():
             if spec["libevent"].external_path:
-                dep_libpath = self.find_external_lib_path("libevent","libevent","64")
+                dep_libpath = self.find_external_lib_path("libevent","64")
                 config_args.append("--with-libevent-libdir=" + dep_libpath)
             if spec["hwloc"].external_path:
-                dep_libpath = self.find_external_lib_path("libhwloc","hwloc","64")
+                dep_libpath = self.find_external_lib_path("hwloc","64")
                 config_args.append("--with-hwloc-libdir=" + dep_libpath)
 
         config_args.extend(self.enable_or_disable("python-bindings", variant="python"))


### PR DESCRIPTION
Debian like distros use multiarch implementation spec
https://wiki.ubuntu.com/MultiarchSpec
Instead of being limited to /usr/lib64, architecture based lib directories are used. For instance, under ubuntu a library package on x86_64 installs binaries under /usr/lib/x86_64-linux-gnu. Building pmix with external dependencies like hwloc or libevent fail as with prefix set to /usr, that prefix works for headers and binaries but does not work for libraries. The default location for library /usr/lib64 does not hold installed binaries. Pmix build options --with-libevent and --with-libhwloc allow us to specify dependent library locations. This commit is an effort to highlight and resolve such an issue when a users want to use Debian like distro library packages and use spack to build pmix. There maybe other packages that might be impacted in a similar way.