### PR TITLE
gaudi: @:36 fails to build with fmt@9:

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -65,6 +65,7 @@ class Gaudi(CMakePackage):
     depends_on("cmake", type="build")
     depends_on("cppgsl")
     depends_on("fmt", when="@33.2:")
+    depends_on("fmt@:8", when="@:36.7")
     depends_on("intel-tbb")
     depends_on("uuid")
     depends_on("nlohmann-json", when="@35.0:")


### PR DESCRIPTION
Since fmt@9.0.0 and 9.1.0 were [added](https://github.com/spack/spack/commit/6c4acfbf83372f76fe69aa7b959f257b6a1e8410) to spack a few days ago, gaudi fails to compile with default concretization. Since gaudi developers are usually paying attention to new versions of dependencies, I'm going to assume (perhaps optimistically) that the next bugfix version of gaudi will fix this (even though the issue has not been reported yet to Gaudi; I posted on the [key4hep public mirror](https://github.com/key4hep/Gaudi/issues/1)).

