### PR TITLE
GCC: Apple Silicon support for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -317,11 +317,11 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     #   on XCode 12.5
     conflicts("+bootstrap", when="@:11.1 %apple-clang@12.0.5")
 
-    # aarch64/M1 is supported in GCC 12+
+    # aarch64/M1 is supported in GCC 11.3-12.2
     conflicts(
-        "@:11.2,11.3.1:",
+        "@:11.2,12.3:",
         when="target=aarch64: platform=darwin",
-        msg="Only GCC 11.3.0 supports macOS M1 (aarch64)",
+        msg="Only GCC 11.3-12.2 support macOS M1 (aarch64)",
     )
 
     # Newer binutils than RHEL's is required to run `as` on some instructions
@@ -370,6 +370,17 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             "https://raw.githubusercontent.com/Homebrew/formula-patches/22dec3fc/gcc/gcc-11.3.0-arm.diff",
             sha256="e02006b7ec917cc1390645d95735a6a866caed0dfe506d5bef742f7862cab218",
             when="@11.3.0 target=aarch64:",
+        )
+        # https://github.com/iains/gcc-12-branch
+        patch(
+            "https://raw.githubusercontent.com/Homebrew/formula-patches/76677f2b/gcc/gcc-12.1.0-arm.diff",
+            sha256="a000f1d9cb1dd98c7c4ef00df31435cd5d712d2f9d037ddc044f8bf82a16cf35",
+            when="@12.1.0 target=aarch64:",
+        )
+        patch(
+            "https://raw.githubusercontent.com/Homebrew/formula-patches/1d184289/gcc/gcc-12.2.0-arm.diff",
+            sha256="a7843b5c6bf1401e40c20c72af69c8f6fc9754ae980bb4a5f0540220b3dcb62d",
+            when="@12.2.0 target=aarch64:",
         )
         conflicts("+bootstrap", when="@11.3.0 target=aarch64:")
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -331,6 +331,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     # GCC 11 requires GCC 4.8 or later (https://gcc.gnu.org/gcc-11/changes.html)
     conflicts("%gcc@:4.7", when="@11:")
 
+    # https://github.com/iains/gcc-12-branch/issues/6
+    conflicts("%apple-clang@14:")
+
     if sys.platform == "darwin":
         # Fix parallel build on APFS filesystem
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797


### PR DESCRIPTION
Added the same patches used by Homebrew for newer versions of GCC.

Unfortunately, none of these patches seem to work for the recently released Apple Clang 14.0.0. I see the following error message for all 3 patched versions:
```
ld: Assertion failed: (_file->_atomsArrayCount == computedAtomCount && "more atoms allocated than expected"), function parse, file macho_relocatable_file.cpp, line 2061.
collect2: error: ld returned 1 exit status
make[6]: *** [libstdc++.la] Error 1
make[5]: *** [all-recursive] Error 1
make[4]: *** [all-recursive] Error 1
make[3]: *** [all] Error 2
make[2]: *** [all-stage1-target-libstdc++-v3] Error 2
make[1]: *** [stage1-bubble] Error 2
make: *** [all] Error 2
```
Any ideas how to solve this?