### PR TITLE
New python package support:  py-river

### DIFF
--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRiver(PythonPackage):
+    """River is a Python library for online machine learning. It aims to be the most
+	user-friendly library for doing machine learning on streaming data. River is
+	the result of a merge between creme and scikit-multiflow."""
+
+    homepage = "https://riverml.xyz/0.13.0/"
+    pypi     = "river/river-0.13.0.tar.gz"
+
+    version('0.13.0', sha256='9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340')
+
+    depends_on('python@3.8:', type='build')
+    depends_on('py-numpy@1.18.5:')
+    depends_on('py-pandas@1.3:')
+    depends_on('py-python-dateutil@2.8.1:')
+    depends_on('py-six@1.5:')
+    depends_on('py-pytz@2020.1:')
+    depends_on('py-scipy@1.5:')

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -16,7 +16,7 @@ class PyRiver(PythonPackage):
 
     version('0.13.0', sha256='9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340')
 
-    depends_on('python@3.8:', type='build')
+    depends_on('python@3.8:',type='build')
     depends_on('py-numpy@1.18.5:')
     depends_on('py-pandas@1.3:')
     depends_on('py-python-dateutil@2.8.1:')

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -20,7 +20,7 @@ class PyRiver(PythonPackage):
     depends_on("py-cython", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-rust", type="build")
-    
+
     # setup.py
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-numpy@1.22:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -16,10 +16,13 @@ class PyRiver(PythonPackage):
 
     version("0.13.0", sha256="9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340")
 
-    depends_on("python@3.8:", type="build")
-    depends_on("py-numpy@1.18.5:")
-    depends_on("py-pandas@1.3:")
-    depends_on("py-python-dateutil@2.8.1:")
-    depends_on("py-six@1.5:")
-    depends_on("py-pytz@2020.1:")
-    depends_on("py-scipy@1.5:")
+    # pyproject.toml
+    depends_on("py-cython", type="build")
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-rust", type="build")
+    
+    # setup.py
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-numpy@1.22:", type=("build", "run"))
+    depends_on("py-scipy@1.5:", type=("build", "run"))
+    depends_on("py-pandas@1.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -8,8 +8,8 @@ from spack.package import *
 
 class PyRiver(PythonPackage):
     """River is a Python library for online machine learning. It aims to be the most
-        user-friendly library for doing machine learning on streaming data. River is
-        the result of a merge between creme and scikit-multiflow."""
+    user-friendly library for doing machine learning on streaming data. River is the
+    result of a merge between creme and scikit-multiflow."""
 
     homepage = "https://riverml.xyz/0.13.0/"
     pypi = "river/river-0.13.0.tar.gz"

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -8,15 +8,15 @@ from spack.package import *
 
 class PyRiver(PythonPackage):
     """River is a Python library for online machine learning. It aims to be the most
-	user-friendly library for doing machine learning on streaming data. River is
-	the result of a merge between creme and scikit-multiflow."""
+        user-friendly library for doing machine learning on streaming data. River is
+        the result of a merge between creme and scikit-multiflow."""
 
     homepage = "https://riverml.xyz/0.13.0/"
-    pypi     = "river/river-0.13.0.tar.gz"
+    pypi = "river/river-0.13.0.tar.gz"
 
     version('0.13.0', sha256='9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340')
 
-    depends_on('python@3.8:',type='build')
+    depends_on('python@3.8:', type='build')
     depends_on('py-numpy@1.18.5:')
     depends_on('py-pandas@1.3:')
     depends_on('py-python-dateutil@2.8.1:')

--- a/var/spack/repos/builtin/packages/py-river/package.py
+++ b/var/spack/repos/builtin/packages/py-river/package.py
@@ -14,12 +14,12 @@ class PyRiver(PythonPackage):
     homepage = "https://riverml.xyz/0.13.0/"
     pypi = "river/river-0.13.0.tar.gz"
 
-    version('0.13.0', sha256='9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340')
+    version("0.13.0", sha256="9d068b7a9db32302fbd581af81315681dfe61774a5d777fb3d5982d3c3061340")
 
-    depends_on('python@3.8:', type='build')
-    depends_on('py-numpy@1.18.5:')
-    depends_on('py-pandas@1.3:')
-    depends_on('py-python-dateutil@2.8.1:')
-    depends_on('py-six@1.5:')
-    depends_on('py-pytz@2020.1:')
-    depends_on('py-scipy@1.5:')
+    depends_on("python@3.8:", type="build")
+    depends_on("py-numpy@1.18.5:")
+    depends_on("py-pandas@1.3:")
+    depends_on("py-python-dateutil@2.8.1:")
+    depends_on("py-six@1.5:")
+    depends_on("py-pytz@2020.1:")
+    depends_on("py-scipy@1.5:")


### PR DESCRIPTION
Adding support to [River ](https://github.com/online-ml/river), a python package for developing online machine learning models. 