### PR TITLE
py-python-gitlab: add 3.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-gitlab/package.py
+++ b/var/spack/repos/builtin/packages/py-python-gitlab/package.py
@@ -12,6 +12,7 @@ class PyPythonGitlab(PythonPackage):
     homepage = "https://github.com/gpocentek/python-gitlab"
     pypi = "python-gitlab/python-gitlab-0.19.tar.gz"
 
+    version("3.9.0", sha256="5fc5e88f81f366e11851cb8b4b9a5b827491ce20ba7585446b74c9b097726ba3")
     version("2.10.1", sha256="7afa7d7c062fa62c173190452265a30feefb844428efc58ea5244f3b9fc0d40f")
     version("1.8.0", sha256="a6b03bc53f6e2e22b88d5ff9772b1bb360570ec82752f1def3d6eb60cda093e7")
     version("0.19", sha256="88b65591db7a10a0d9979797e4e654a113e2b93b3a559309f6092b27ab93934a")
@@ -19,7 +20,8 @@ class PyPythonGitlab(PythonPackage):
     version("0.17", sha256="f79337cd8b2343195b7ac0909e0483624d4235cca78fc76196a0ee4e109c9a70")
     version("0.16", sha256="2c50dc0bd3ed7c6b1edb6e556b0f0109493ae9dfa46e3bffcf3e5e67228d7d53")
 
-    depends_on("python@3.6:", when="@2.0.0:", type=("build", "run"))
+    depends_on("python@3.7:", when="@3:", type=("build", "run"))
+    depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-requests-toolbelt@0.9.1:", when="@2.6.0:", type=("build", "run"))
     depends_on("py-requests@2.25.0:", when="@2.10.1:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/python-gitlab/python-gitlab/tree/v3.9.0

I was not sure about the version needed for `py-requests`. In [setup.py](https://github.com/python-gitlab/python-gitlab/blob/v3.9.0/setup.py#L31) they request version 2.25.0 but in [requirements.txt](https://github.com/python-gitlab/python-gitlab/blob/v3.9.0/requirements.txt#L1) they want version 2.28.1. I now used the one in `setup.py` because this is the one used in py-python-gitlab@2.10.1 (there different versions were already requested in `setup.py` and `requirements.txt` as well)