### PR TITLE
py-annexremote: add 1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-annexremote/package.py
+++ b/var/spack/repos/builtin/packages/py-annexremote/package.py
@@ -12,7 +12,9 @@ class PyAnnexremote(PythonPackage):
     homepage = "https://github.com/Lykos153/AnnexRemote"
     pypi = "annexremote/annexremote-1.5.0.tar.gz"
 
+    version("1.6.0", sha256="779a43e5b1b4afd294761c6587dee8ac68f453a5a8cc40f419e9ca777573ae84")
     version("1.5.0", sha256="92f32b6f5461cbaeefe0c60b32f9c1e0c1dbe4e57b8ee425affb56f4060f64ef")
 
+    depends_on("python@3:", when="@1.6:", type="build")
     depends_on("py-setuptools", type="build")
-    depends_on("py-future", type=("build", "run"))
+    depends_on("py-future", when="@:1.5", type=("build", "run"))


### PR DESCRIPTION
https://github.com/Lykos153/AnnexRemote/tree/v1.6.0

the python 3 requirement comes from the prerequisites section in the README.md