### PR TITLE
py-eccodes: optionally hardcode path to libeccodes

### DIFF
--- a/var/spack/repos/builtin/packages/py-eccodes/hardcode-path.patch
+++ b/var/spack/repos/builtin/packages/py-eccodes/hardcode-path.patch
@@ -1,0 +1,18 @@
+--- a/gribapi/bindings.py
++++ b/gribapi/bindings.py
+@@ -25,14 +25,7 @@ __version__ = "1.5.0"
+ 
+ LOG = logging.getLogger(__name__)
+ 
+-try:
+-    import ecmwflibs as findlibs
+-except ImportError:
+-    import findlibs
+-
+-library_path = findlibs.find("eccodes")
+-if library_path is None:
+-    raise RuntimeError("Cannot find the ecCodes library")
++library_path = "@ECCODES_PATH@"
+ 
+ # default encoding for ecCodes strings
+ ENC = "ascii"

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 from spack.package import *
 
 
@@ -14,20 +12,42 @@ class PyEccodes(PythonPackage):
     homepage = "https://github.com/ecmwf/eccodes-python"
     pypi = "eccodes/eccodes-1.3.2.tar.gz"
 
+    version("1.5.0", sha256="e70c8f159140c343c215fd608ddf533be652ff05ad2ff17243c7b66cf92127fa")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
+
+    variant("hardcode-path", default=False, description="Hardcore path to the ecCodes library")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-attrs", type=("build", "run"))
     depends_on("py-cffi", type=("build", "run"))
-    depends_on("py-findlibs", type=("build", "run"))
-    depends_on("eccodes", type="run")
+    depends_on("py-findlibs", type=("build", "run"), when="~hardcode-path")
+    depends_on("eccodes@2.21.0:+shared", type="run")
+
+    # Hardcode path to libeccodes with value @ECCODES_PATH@ to be replaced with the real path to
+    # the library in the following patch method:
+    patch("hardcode-path.patch", when="+hardcode-path")
+
+    @when("+hardcode-path")
+    def patch(self):
+        filter_file(
+            "@ECCODES_PATH@",
+            self.spec["eccodes:c,shared"].libs.files[0],
+            "gribapi/bindings.py",
+            string=True,
+            backup=False,
+            ignore_absent=False,
+        )
 
     def setup_build_environment(self, env):
-        if sys.platform == "darwin":
-            env.prepend_path("DYLD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
-        else:
-            env.prepend_path("LD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
+        if "~hardcode-path" in self.spec:
+            eccodes_libs = self.spec["eccodes:c,shared"].libs
+            # ECCODES_HOME has the highest precedence when searching for the library with
+            # py-findlibs:
+            env.set("ECCODES_HOME", eccodes_libs.directories[0])
+            # but not if ecmwflibs (https://pypi.org/project/ecmwflibs/) is in the PYTHONPATH for
+            # whatever reason:
+            env.set("ECMWFLIBS_ECCODES", eccodes_libs.files[0])
 
     def setup_run_environment(self, env):
         self.setup_build_environment(env)


### PR DESCRIPTION
It is rather annoying that `py-eccodes` cannot find its runtime dependency without additional environment variables. This introduces variant `hardcode-path`. When the variant is disabled (default), the package depends on `py-findlibs`, which finds `libeccodes` at the runtime with the help of environment variables `ECCODES_HOME` and `ECMWFLIBS_ECCODES` (instead of much more general `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`, which are used currently). If the variant `hardcode-path` is enabled, the dependency on `py-findlibs` is dropped and the path to `libeccodes` is hardcoded into `py-eccodes` with a patch.

This also adds the most recent version of the package.