### PR TITLE
Fix a `depends_on` version for `fenics-dolfinx`

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -82,7 +82,7 @@ class FenicsDolfinx(CMakePackage):
     depends_on("py-fenics-ffcx@0.1.0", type=("build", "run"), when="@0.1.0")
 
     depends_on("fenics-basix@main", when="@main")
-    depends_on("fenics-basix@0.5.1:0.5", when="@0.5.1:0.5")
+    depends_on("fenics-basix@0.5.1:0.5", when="@0.5.0:0.5")
     depends_on("fenics-basix@0.4.2", when="@0.4.1")
     depends_on("fenics-basix@0.3.0", when="@0.3.0")
     depends_on("fenics-basix@0.2.0", when="@0.2.0")


### PR DESCRIPTION
`depends_on` syntax missed a version.