### PR TITLE
Include exception info related to url retrieval in debug messages

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -338,6 +338,7 @@ class URLFetchStrategy(FetchStrategy):
         errors = []
         for url in self.candidate_urls:
             if not web_util.url_exists(url, self.curl):
+                tty.debug("URL does not exist: " + url)
                 continue
 
             try:

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -444,7 +444,8 @@ def url_exists(url, curl=None):
     try:
         read_from_url(url)
         return True
-    except (SpackWebError, URLError):
+    except (SpackWebError, URLError) as e:
+        tty.debug("Failure reading URL: " + str(e))
         return False
 
 


### PR DESCRIPTION
... which otherwise would be swallowed

I was speaking to a user who got a series of fetch errors without any elaboration when their CA configuration was not sufficient to retrieve an HTTPS link. I think some output for these exceptions would have been useful to identify that.