### PR TITLE
Allow conditional variants as first values in a variant directive

### DIFF
--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -2,13 +2,12 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import numbers
 
 import pytest
 
 import spack.error
+import spack.variant
 from spack.variant import (
     BoolValuedVariant,
     DuplicateVariantError,
@@ -737,3 +736,11 @@ def test_disjoint_set_fluent_methods():
         assert "none" not in d
         assert "none" not in [x for x in d]
         assert "none" not in d.feature_values
+
+
+@pytest.mark.regression("32694")
+@pytest.mark.parametrize("other", [True, False])
+def test_conditional_value_comparable_to_bool(other):
+    value = spack.variant.Value("98", when="@1.0")
+    comparison = value == other
+    assert comparison is False

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -886,7 +886,7 @@ class Value(object):
         return hash(self.value)
 
     def __eq__(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, (six.string_types, bool)):
             return self.value == other
         return self.value == other.value
 


### PR DESCRIPTION
fixes #32694 

When a conditional variant value is compared to a Boolean value, to check if we are dealing with a `BoolValuedVariant`, Spack fails and raise an exception. This PR fixes that issue.