### PR TITLE
GROMACS: update CMake version, and a couple more fixes

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -9,16 +9,15 @@ from spack.package import *
 
 
 class Gromacs(CMakePackage):
-    """GROMACS (GROningen MAchine for Chemical Simulations) is a molecular
-    dynamics package primarily designed for simulations of proteins, lipids
-    and nucleic acids. It was originally developed in the Biophysical
-    Chemistry department of University of Groningen, and is now maintained
-    by contributors in universities and research centers across the world.
+    """GROMACS is a molecular dynamics package primarily designed for simulations
+    of proteins, lipids and nucleic acids. It was originally developed in
+    the Biophysical Chemistry department of University of Groningen, and is now
+    maintained by contributors in universities and research centers across the world.
 
     GROMACS is one of the fastest and most popular software packages
     available and can run on CPUs as well as GPUs. It is free, open source
-    released under the GNU General Public License. Starting from version 4.6,
-    GROMACS is released under the GNU Lesser General Public License.
+    released under the GNU Lesser General Public License. Before the version 4.6,
+    GROMACS was released under the GNU General Public License.
     """
 
     homepage = "https://www.gromacs.org"
@@ -204,8 +203,9 @@ class Gromacs(CMakePackage):
     depends_on("cmake@2.8.8:3", type="build")
     depends_on("cmake@3.4.3:3", type="build", when="@2018:")
     depends_on("cmake@3.9.6:3", type="build", when="@2020")
-    depends_on("cmake@3.13.0:3", type="build", when="@2021:")
-    depends_on("cmake@3.16.0:3", type="build", when="@master")
+    depends_on("cmake@3.13.0:3", type="build", when="@2021")
+    depends_on("cmake@3.16.3:3", type="build", when="@2022:")
+    depends_on("cmake@3.18.4:3", type="build", when="@main")
     depends_on("cmake@3.16.0:3", type="build", when="%fj")
     depends_on("cuda", when="+cuda")
     depends_on("sycl", when="+sycl")
@@ -369,14 +369,13 @@ class Gromacs(CMakePackage):
         else:
             if "+cuda" in self.spec or "+opencl" in self.spec:
                 options.append("-DGMX_GPU:BOOL=ON")
+                if "+opencl" in self.spec:
+                    options.append("-DGMX_USE_OPENCL=ON")
             else:
                 options.append("-DGMX_GPU:BOOL=OFF")
 
         if "+cuda" in self.spec:
             options.append("-DCUDA_TOOLKIT_ROOT_DIR:STRING=" + self.spec["cuda"].prefix)
-
-        if "+opencl" in self.spec:
-            options.append("-DGMX_USE_OPENCL=on")
 
         if "+lapack" in self.spec:
             options.append("-DGMX_EXTERNAL_LAPACK:BOOL=ON")


### PR DESCRIPTION
- GROMACS is not an acronym (https://www.gromacs.org/about.html).
- GROMACS switched to LGPL a long time ago, so let's mention it first.
- CMake version required for `main` has been bumped to 3.18 (https://gitlab.com/gromacs/gromacs/-/merge_requests/3093)
- `-DGMX_USE_OPENCL` flag was used before 2021; for newer versions, `-DGMX_GPU=OpenCL` is enough.