### PR TITLE
Remove mentions of "best-effort" matrix expansion in the docs

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -623,31 +623,6 @@ The following two Environment manifests are identical:
 Spec matrices can be used to install swaths of software across various
 toolchains.
 
-The concretization logic for spec matrices differs slightly from the
-rest of Spack. If a variant or dependency constraint from a matrix is
-invalid, Spack will reject the constraint and try again without
-it. For example, the following two Environment manifests will produce
-the same specs:
-
-.. code-block:: yaml
-
-   spack:
-     specs:
-       - matrix:
-           - [zlib, libelf, hdf5+mpi]
-           - [^mvapich2@2.2, ^openmpi@3.1.0]
-
-   spack:
-     specs:
-       - zlib
-       - libelf
-       - hdf5+mpi ^mvapich2@2.2
-       - hdf5+mpi ^openmpi@3.1.0
-
-This allows one to create toolchains out of combinations of
-constraints and apply them somewhat indiscriminately to packages,
-without regard for the applicability of the constraint.
-
 ^^^^^^^^^^^^^^^^^^^^
 Spec List References
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
closes #20340

This feature has been broken since clingo was introduced. Here we close the associated issue by removing mentions of the feature. This means that cross-products in spec matrices will never drop parts, based on whether something was solvable or not.

Modifications:
- [x] Remove mentions of "best-effort" matrix expansion from docs