### PR TITLE
Octopus: update to version 12.0 

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -20,6 +20,7 @@ class Octopus(Package, CudaPackage):
 
     maintainers = ["fangohr", "RemiLacroix-IDRIS"]
 
+    version("12.0", sha256="70beaf08573d394a766f10346a708219b355ad725642126065d12596afbc0dcc")
     version("11.4", sha256="73bb872bff8165ddd8efc5b891f767cb3fe575b5a4b518416c834450a4492da7")
     version("11.3", sha256="0c98417071b5e38ba6cbdd409adf917837c387a010e321c0a7f94d9bd9478930")
     version("11.1", sha256="d943cc2419ca409dda7459b7622987029f2af89984d0d5f39a6b464c3fc266da")


### PR DESCRIPTION
Enable use of latest version of Octopus (12.0)

Release notes:
https://www.octopus-code.org/documentation/main/releases/octopus-12/