### PR TITLE
bootstrap: don't do relocation logic on binary patchelf

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1600,7 +1600,9 @@ def _extract_inner_tarball(spec, filename, extract_to, unsigned, remote_checksum
     return tarfile_path
 
 
-def extract_tarball(spec, download_result, allow_root=False, unsigned=False, force=False):
+def extract_tarball(
+    spec, download_result, allow_root=False, unsigned=False, force=False, relocate=True
+):
     """
     extract binary tarball for given package into install area
     """
@@ -1696,7 +1698,8 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
     os.remove(specfile_path)
 
     try:
-        relocate_package(spec, allow_root)
+        if relocate:
+            relocate_package(spec, allow_root)
     except Exception as e:
         shutil.rmtree(spec.prefix)
         raise e
@@ -1715,7 +1718,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         _delete_staged_downloads(download_result)
 
 
-def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None):
+def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None, relocate=True):
     """Install the root node of a concrete spec from a buildcache.
 
     Checking the sha256 sum of a node before installation is usually needed only
@@ -1731,6 +1734,7 @@ def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None
             local store
         sha256 (str): optional sha256 of the binary package, to be checked
             before installation
+        relocate (bool): enable relocation logic for this binary package
     """
     # Early termination
     if spec.external or spec.virtual:
@@ -1758,7 +1762,7 @@ def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None
     # don't print long padded paths while extracting/relocating binaries
     with spack.util.path.filter_padding():
         tty.msg('Installing "{0}" from a buildcache'.format(spec.format()))
-        extract_tarball(spec, download_result, allow_root, unsigned, force)
+        extract_tarball(spec, download_result, allow_root, unsigned, force, relocate)
         spack.hooks.post_install(spec)
         spack.store.db.add(spec, spack.store.layout)
 

--- a/share/spack/bootstrap/github-actions-v0.3/patchelf.json
+++ b/share/spack/bootstrap/github-actions-v0.3/patchelf.json
@@ -8,7 +8,8 @@
           "8c6a28cbe8133d719be27ded11159f0aa2c97ed1d0881119ae0ebd71f8ccc755"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=aarch64"
+      "spec": "patchelf@0.13: %gcc platform=linux target=aarch64",
+      "relocatable": true
     },
     {
       "binaries": [
@@ -18,7 +19,8 @@
           "1d4ea9167fb8345a178c1352e0377cc37ef2b421935cf2b48fb6fa03a94fca3d"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=ppc64le"
+      "spec": "patchelf@0.13: %gcc platform=linux target=ppc64le",
+      "relocatable": true
     },
     {
       "binaries": [
@@ -28,7 +30,8 @@
           "833df21b20eaa7999ac4c5779ae26aa90397d9027aebaa686a428589befda693"
         ]
       ],
-      "spec": "patchelf@0.13: %gcc platform=linux target=x86_64"
+      "spec": "patchelf@0.13: %gcc platform=linux target=x86_64",
+      "relocatable": true
     }
   ]
 }


### PR DESCRIPTION
Currently Spack implements the relocation logic for patchelf itself in a curious way:

1. `cp patchelf patchelf.bak`
2. `patchelf.bak --set-rpath ... patchelf`
3. `rm patchelf.bak`

The fact that this works at all means that `patchelf` is relocatable software
to start with.

That simply means we should skip relocation of patchelf during bootstrap, to
break the recursion where patchelf is required to bootstrap patchelf.

This PR informs the installer to not relocate patchelf.

