### PR TITLE
Packages/py scipy

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -118,6 +118,15 @@ class PyScipy(PythonPackage):
             with open("setup.cfg", "w") as f:
                 f.write("[config_fc]\n")
                 f.write("fcompiler = fujitsu\n")
+        elif (self.spec.satisfies("%intel") or self.spec.satisfies("%oneapi")):
+            if self.spec.satisfies("target=x86:"):
+                with open("setup.cfg", "w") as f:
+                    f.write("[config_fc]\n")
+                    f.write("fcompiler = intel\n")
+            elif self.spec.satisfies("target=x86_64:"):
+                with open("setup.cfg", "w") as f:
+                    f.write("[config_fc]\n")
+                    f.write("fcompiler = intelem\n")
 
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -141,7 +141,7 @@ class PyScipy(PythonPackage):
         # https://github.com/scipy/scipy/issues/14935
         if (self.spec.satisfies('%intel ^py-pythran')
             or self.spec.satisfies('%oneapi ^py-pythran')):
-            if spec["py-pythran"].version < Version("0.12"):
+            if self.spec["py-pythran"].version < Version("0.12"):
                 env.set('SCIPY_USE_PYTHRAN', '0')
 
         # Pick up Blas/Lapack from numpy

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -118,7 +118,7 @@ class PyScipy(PythonPackage):
             with open("setup.cfg", "w") as f:
                 f.write("[config_fc]\n")
                 f.write("fcompiler = fujitsu\n")
-        elif (self.spec.satisfies("%intel") or self.spec.satisfies("%oneapi")):
+        elif self.spec.satisfies("%intel") or self.spec.satisfies("%oneapi"):
             if self.spec.satisfies("target=x86:"):
                 with open("setup.cfg", "w") as f:
                     f.write("[config_fc]\n")
@@ -139,10 +139,9 @@ class PyScipy(PythonPackage):
                 env.set("NPY_DISTUTILS_APPEND_FLAGS", "1")
 
         # https://github.com/scipy/scipy/issues/14935
-        if (self.spec.satisfies('%intel ^py-pythran')
-            or self.spec.satisfies('%oneapi ^py-pythran')):
+        if self.spec.satisfies("%intel ^py-pythran") or self.spec.satisfies("%oneapi ^py-pythran"):
             if self.spec["py-pythran"].version < Version("0.12"):
-                env.set('SCIPY_USE_PYTHRAN', '0')
+                env.set("SCIPY_USE_PYTHRAN", "0")
 
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -138,6 +138,12 @@ class PyScipy(PythonPackage):
             if self.spec.satisfies("^py-numpy@1.16:1.17"):
                 env.set("NPY_DISTUTILS_APPEND_FLAGS", "1")
 
+        # https://github.com/scipy/scipy/issues/14935
+        if (self.spec.satisfies('%intel ^py-pythran')
+            or self.spec.satisfies('%oneapi ^py-pythran')):
+            if spec["py-pythran"].version < Version("0.12"):
+                env.set('SCIPY_USE_PYTHRAN', '0')
+
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
 


### PR DESCRIPTION
This PR fixes the ability to build `py-scipy%intel` and `py-scipy%oneapi`.  Prior to this, the proper FORTRAN compiler was not detected/configured and defaulted to `gnu95`.

Fixes #32732