### PR TITLE
Skip all tests using problematic fixture on python 2.7

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1188,6 +1188,9 @@ class TestConcretize(object):
             second_spec.concretize()
         assert first_spec.dag_hash() != second_spec.dag_hash()
 
+    @pytest.mark.skipif(
+         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+    )
     @pytest.mark.regression("20292")
     @pytest.mark.parametrize(
         "context",
@@ -1510,6 +1513,9 @@ class TestConcretize(object):
             s = Spec("python target=k10").concretized()
         assert s.satisfies("target=k10")
 
+    @pytest.mark.skipif(
+         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+    )
     @pytest.mark.regression("29201")
     def test_delete_version_and_reuse(self, mutable_database, repo_with_changing_recipe):
         """Test that we can reuse installed specs with versions not

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1189,7 +1189,7 @@ class TestConcretize(object):
         assert first_spec.dag_hash() != second_spec.dag_hash()
 
     @pytest.mark.skipif(
-         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+        sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
     )
     @pytest.mark.regression("20292")
     @pytest.mark.parametrize(
@@ -1514,7 +1514,7 @@ class TestConcretize(object):
         assert s.satisfies("target=k10")
 
     @pytest.mark.skipif(
-         sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
+        sys.version_info[:2] == (2, 7), reason="Fixture fails intermittently with Python 2.7"
     )
     @pytest.mark.regression("29201")
     def test_delete_version_and_reuse(self, mutable_database, repo_with_changing_recipe):


### PR DESCRIPTION
This is an extension of https://github.com/spack/spack/pull/32569 but for all tests using the problematic fixture (2 additional tests, 4 in total).

From one perspective, this could be said to "fix" https://github.com/spack/spack/issues/32470 (although I don't know the cause - why the fixture doesn't work with Python 2.7).

I ran into this error again as part of testing https://github.com/spack/spack/pull/32737.