### PR TITLE
[WIP] "spack find -c": show concretized-but-not-installed specs

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -88,7 +88,7 @@ class ConstraintAction(argparse.Action):
                 # This is fast for already-concrete specs
                 specs[s.dag_hash()] = s
 
-        if kwargs.get('show_concretized', False):
+        if kwargs.get("show_concretized", False):
             for qspec in qspecs:
                 for user_spec, spec in env.concretized_specs():
                     for dep_spec in spec.traverse():

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -79,12 +79,12 @@ class ConstraintAction(argparse.Action):
 
         # return everything for an empty query.
         if not qspecs:
-            return spack.store.db.query(q_args)
+            return spack.store.db.query(**q_args)
 
         # Return only matching stuff otherwise.
         specs = {}
         for spec in qspecs:
-            for s in spack.store.db.query(spec, q_args):
+            for s in spack.store.db.query(spec, **q_args):
                 # This is fast for already-concrete specs
                 specs[s.dag_hash()] = s
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -254,6 +254,7 @@ def find(parser, args):
 
 def _find(parser, args):
     q_args = query_arguments(args)
+    q_args['show_concretized'] = args.show_concretized
     results = args.specs(**q_args)
 
     env = ev.active_environment()

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -254,7 +254,7 @@ def find(parser, args):
 
 def _find(parser, args):
     q_args = query_arguments(args)
-    q_args['show_concretized'] = args.show_concretized
+    q_args["show_concretized"] = args.show_concretized
     results = args.specs(**q_args)
 
     env = ev.active_environment()


### PR DESCRIPTION
If you run `spack find -c`, it will show you all the concretized roots.

However, if your env is not installed, you currently cannot use `spack find <query_spec>` to query environment specs (i.e. the query spec is not used to pull uninstalled-but-concretized specs from the env). This is primarily useful if you are trying to understand how matrix specifications are expanded in combination with `unify` directives (so for example your environment tries to build several instances of the same package with different `mpi`s and compilers).

I'm calling this WIP because `spack find` output currently assumes everything returned by the query has been installed:

```
==> 16 installed packages
```

and also because passing `show_concretized` is handled awkwardly (I want to make sure the semantics are acceptable and then I'll refactor).