### PR TITLE
pgplot: install rbg.txt and change PGPLOT_DIR

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -161,6 +161,8 @@ class Pgplot(MakefilePackage):
         install("libpgplot.a", prefix.lib)
         install("libpgplot.so", prefix.lib)
         install("grfont.dat", prefix.include)
+        mkdirp(prefix.lib + "/pgplot5")
+        install("rgb.txt", prefix.lib + "/pgplot5")
 
     @property
     def libs(self):
@@ -169,4 +171,4 @@ class Pgplot(MakefilePackage):
 
     def setup_run_environment(self, env):
         env.set("PGPLOT_FONT", self.prefix.include + "/grfont.dat")
-        env.set("PGPLOT_DIR", self.prefix)
+        env.set("PGPLOT_DIR", self.prefix.lib + "/pgplot5")


### PR DESCRIPTION
The file `rbg.txt` is needed for many PGPLOT application, such as the MESA stellar evolution code. This change installs the file to the `PGPLOT_DIR`, where the library expects it.

`PGPLOT_DIR` was previously set to the prefix itself, which is an odd place to install `rgb.txt`. This commit changes it to `lib/pgplot5`, following the convention used by Debian.