### PR TITLE
py-bottleneck: add 1.3.5 and py-versioneer: add 0.26

### DIFF
--- a/var/spack/repos/builtin/packages/py-bottleneck/package.py
+++ b/var/spack/repos/builtin/packages/py-bottleneck/package.py
@@ -9,8 +9,10 @@ from spack.package import *
 class PyBottleneck(PythonPackage):
     """A collection of fast NumPy array functions written in Cython."""
 
+    homepage = "https://github.com/pydata/bottleneck"
     pypi = "Bottleneck/Bottleneck-1.0.0.tar.gz"
 
+    version("1.3.5", sha256="2c0d27afe45351f6f421893362621804fa7dea14fe29a78eaa52d4323f646de7")
     version("1.3.2", sha256="20179f0b66359792ea283b69aa16366419132f3b6cf3adadc0c48e2e8118e573")
     version("1.3.1", sha256="451586370462cb623d6ad604a545d1e97fb51d2ab5252b1ac57350a83e494a28")
     version("1.3.0", sha256="9d7814c61c31f42cfb4f26e050c2659c88a198f1398a9714174ae78347aad737")
@@ -18,4 +20,5 @@ class PyBottleneck(PythonPackage):
     version("1.0.0", sha256="8d9b7ad4fadf9648acc924a6ee522c7cb5b474e75faaad9d90dfd55e2805b495")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-versioneer", when="@1.3.3:", type="build")
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-versioneer/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer/package.py
@@ -10,12 +10,14 @@ class PyVersioneer(PythonPackage):
     """Versioneer is a tool to automatically update version strings by
     asking your version-control system about the current tree."""
 
-    homepage = "https://github.com/warner/python-versioneer"
-    url = "https://github.com/warner/python-versioneer/archive/0.18.tar.gz"
-    git = "https://github.com/warner/python-versioneer.git"
+    homepage = "https://github.com/python-versioneer/python-versioneer"
+    pypi = "versioneer/versioneer-0.26.tar.gz"
+    git = "https://github.com/python-versioneer/python-versioneer.git"
 
     maintainers = ["scemama"]
 
+    version("0.26", sha256="84fc729aa296d1d26645a8f62f178019885ff6f9a1073b29a4a228270ac5257b")
     version("0.18", sha256="cf895b67f5bc62d61c4837458069ded8f66b4e5764c19f7253c51ee27e8b3a99")
 
+    depends_on("python@3.6:", when="@0.19:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-versioneer/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer/package.py
@@ -17,7 +17,7 @@ class PyVersioneer(PythonPackage):
     maintainers = ["scemama"]
 
     version("0.26", sha256="84fc729aa296d1d26645a8f62f178019885ff6f9a1073b29a4a228270ac5257b")
-    version("0.18", sha256="cf895b67f5bc62d61c4837458069ded8f66b4e5764c19f7253c51ee27e8b3a99")
+    version("0.18", sha256="ead1f78168150011189521b479d3a0dd2f55c94f5b07747b484fd693c3fbf335")
 
     depends_on("python@3.6:", when="@0.19:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-versioneer/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer/package.py
@@ -19,5 +19,6 @@ class PyVersioneer(PythonPackage):
     version("0.26", sha256="84fc729aa296d1d26645a8f62f178019885ff6f9a1073b29a4a228270ac5257b")
     version("0.18", sha256="ead1f78168150011189521b479d3a0dd2f55c94f5b07747b484fd693c3fbf335")
 
+    depends_on("python@3.7:", when="@0.23:", type=("build", "run"))
     depends_on("python@3.6:", when="@0.19:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
switch `py-versioneer` to pypi

https://github.com/pydata/bottleneck/tree/v1.3.5
https://github.com/python-versioneer/python-versioneer/tree/0.26