### PR TITLE
py-eccodes: add version 1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -21,7 +21,7 @@ class PyEccodes(PythonPackage):
     depends_on("py-attrs", type=("build", "run"))
     depends_on("py-cffi", type=("build", "run"))
     depends_on("py-findlibs", type=("build", "run"))
-    depends_on("eccodes", type="run")
+    depends_on("eccodes@2.21.0:+shared", type="run")
 
     def setup_build_environment(self, env):
         if sys.platform == "darwin":

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -14,6 +14,7 @@ class PyEccodes(PythonPackage):
     homepage = "https://github.com/ecmwf/eccodes-python"
     pypi = "eccodes/eccodes-1.3.2.tar.gz"
 
+    version("1.5.0", sha256="e70c8f159140c343c215fd608ddf533be652ff05ad2ff17243c7b66cf92127fa")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -24,10 +24,11 @@ class PyEccodes(PythonPackage):
     depends_on("eccodes@2.21.0:+shared", type="run")
 
     def setup_build_environment(self, env):
-        if sys.platform == "darwin":
-            env.prepend_path("DYLD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
-        else:
-            env.prepend_path("LD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
+        eccodes_libs = self.spec["eccodes:c,shared"].libs
+        # ECCODES_HOME has the highest precedence when searching for the library with py-findlibs:
+        env.set("ECCODES_HOME", eccodes_libs.directories[0])
+        # but not if ecmwflibs (https://pypi.org/project/ecmwflibs/) is in the PYTHONPATH:
+        env.set("ECMWFLIBS_ECCODES", eccodes_libs.files[0])
 
     def setup_run_environment(self, env):
         self.setup_build_environment(env)


### PR DESCRIPTION
This is #32728 (which I would like to keep for now) minus the hack:

* add constraints on the runtime dependency `eccodes`;
* set less general environment variables that enable location of `libeccodes`;
* add version `1.5.0`.