### PR TITLE
py-cdo: add version 1.5.6, deprecate 1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-cdo/package.py
+++ b/var/spack/repos/builtin/packages/py-cdo/package.py
@@ -12,10 +12,21 @@ class PyCdo(PythonPackage):
 
     pypi = "cdo/cdo-1.3.2.tar.gz"
 
-    version("1.3.2", sha256="9f78879d90d14134f2320565016d0d371b7dfe7ec71110fd313868ec1db34aee")
+    maintainers = ["Try2Code", "skosukhin"]
 
-    depends_on("cdo")
+    version("1.5.6", sha256="fec1a75382f01b3c9c368e8f143d98b12323e06975663f87d9b60c739ae1d335")
+    version(
+        "1.3.2",
+        sha256="9f78879d90d14134f2320565016d0d371b7dfe7ec71110fd313868ec1db34aee",
+        deprecated=True,
+    )
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-netcdf4", type=("build", "run"))
+    depends_on("cdo+netcdf", type="run")
+    depends_on("py-netcdf4", type="run")
+    depends_on("py-scipy", type="run", when="@:1.4")
+    depends_on("py-xarray", type="run", when="@1.3.4:")
+    depends_on("py-six", type="run", when="@1.3.3:")
+
+    def setup_run_environment(self, env):
+        env.set("CDO", self.spec["cdo"].prefix.bin.cdo)

--- a/var/spack/repos/builtin/packages/py-cdo/package.py
+++ b/var/spack/repos/builtin/packages/py-cdo/package.py
@@ -21,6 +21,8 @@ class PyCdo(PythonPackage):
         deprecated=True,
     )
 
+    depends_on("python@2.7:", type=("build", "run"))
+
     depends_on("py-setuptools", type="build")
     depends_on("cdo+netcdf", type="run")
     depends_on("py-netcdf4", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-cdo/package.py
+++ b/var/spack/repos/builtin/packages/py-cdo/package.py
@@ -23,10 +23,10 @@ class PyCdo(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("cdo+netcdf", type="run")
-    depends_on("py-netcdf4", type="run")
-    depends_on("py-scipy", type="run", when="@:1.4")
-    depends_on("py-xarray", type="run", when="@1.3.4:")
-    depends_on("py-six", type="run", when="@1.3.3:")
+    depends_on("py-netcdf4", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"), when="@:1.4")
+    depends_on("py-xarray", type=("build", "run"), when="@1.3.4:")
+    depends_on("py-six", type=("build", "run"), when="@1.3.3:")
 
     def setup_run_environment(self, env):
         env.set("CDO", self.spec["cdo"].prefix.bin.cdo)


### PR DESCRIPTION
* add latest version `1.5.6`
* deprecate very old `1.3.2` (the only one we currently have)
* update dependencies
* setup runtime environment
* add maintainers (@Try2Code, please, confirm here that you agree to be on the list)