### PR TITLE
e4s: use ubuntu 20.04 image and %gcc@11.1.0

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -267,11 +267,11 @@ e4s-mac-protected-build:
 
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
-  image: ecpe4s/ubuntu22.04-runner-x86_64:2022-07-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
 
 e4s-protected-generate:
   extends: [ ".e4s", ".protected-generate"]
-  image: ecpe4s/ubuntu22.04-runner-x86_64:2022-07-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -15,7 +15,7 @@ spack:
 
   packages:
     all:
-      compiler: [gcc@11.2.0]
+      compiler: [gcc@11.1.0]
       providers:
         blas: [openblas]
         mpi: [mpich]
@@ -251,7 +251,7 @@ spack:
       - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
       - spack -d ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
 
-    image: ecpe4s/ubuntu22.04-runner-x86_64:2022-07-01
+    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
     
     broken-tests-packages:
       - gptune
@@ -423,7 +423,7 @@ spack:
             KUBERNETES_CPU_REQUEST: "500m"
             KUBERNETES_MEMORY_REQUEST: "500M"
 
-      - match: ['os=ubuntu22.04']
+      - match: ['os=ubuntu20.04']
         runner-attributes:
           tags: ["spack", "x86_64"]
           variables:
@@ -435,7 +435,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-      image: ecpe4s/ubuntu22.04-runner-x86_64:2022-07-01
+      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
       tags: ["spack", "public", "x86_64"]
 
     signing-job-attributes:


### PR DESCRIPTION
Downgrade runner image used for building E4S from Ubuntu 22.04 to Ubuntu 20.04
* `ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01`
* `%gcc@11.1.0`

FYI @wspear @kwryankrattiger 