### PR TITLE
simgrid: add variant and remove flag

### DIFF
--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -116,6 +116,7 @@ class Simgrid(CMakePackage):
     variant("smpi", default=True, description="SMPI provides MPI")
     variant("examples", default=False, description="Install examples")
     variant("mc", default=False, description="Model checker")
+    variant("msg", default=False, description="Enables the old MSG interface")
 
     # does not build correctly with some old compilers -> rely on packages
     depends_on("boost@:1.69.0", when="@:3.21")
@@ -145,7 +146,8 @@ class Simgrid(CMakePackage):
             args.append("-Denable_documentation=OFF")
         if spec.satisfies("+mc"):
             args.append("-Denable_model-checking=ON")
-
+        if spec.satisfies("+msg"):
+            args.append("-Denable_msg=ON")
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -132,7 +132,7 @@ class Simgrid(CMakePackage):
 
         if self.spec.satisfies("+smpi"):
             self.spec.smpicc = join_path(self.prefix.bin, "smpicc")
-            self.spec.smpicxx = join_path(self.prefix.bin, "smpicxx -std=c++11")
+            self.spec.smpicxx = join_path(self.prefix.bin, "smpicxx")
             self.spec.smpifc = join_path(self.prefix.bin, "smpif90")
             self.spec.smpif77 = join_path(self.prefix.bin, "smpiff")
 


### PR DESCRIPTION
Updates package simgrid:
- add a new variant for the old msg interface
- remove a flag from the compiler path