### PR TITLE
cgal: depends on for older versions

### DIFF
--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -52,8 +52,8 @@ class Cgal(CMakePackage):
     depends_on("cmake@2.8.11:", type="build")
 
     # Essential Third Party Libraries
-    depends_on("boost+exception+math+random+container", when='@5.0:')
-    depends_on('boost+thread+system', when='@:5.0')
+    depends_on("boost+exception+math+random+container", when="@5.0:")
+    depends_on("boost+thread+system", when="@:5.0")
     depends_on("gmp")
     depends_on("mpfr")
 

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -52,7 +52,8 @@ class Cgal(CMakePackage):
     depends_on("cmake@2.8.11:", type="build")
 
     # Essential Third Party Libraries
-    depends_on("boost+exception+math+random+container")
+    depends_on("boost+exception+math+random+container", when='@5.0:')                                                                                                                                                                         
+    depends_on('boost+thread+system', when='@:5.0')
     depends_on("gmp")
     depends_on("mpfr")
 

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -52,7 +52,7 @@ class Cgal(CMakePackage):
     depends_on("cmake@2.8.11:", type="build")
 
     # Essential Third Party Libraries
-    depends_on("boost+exception+math+random+container", when='@5.0:')                                                                                                                                                                         
+    depends_on("boost+exception+math+random+container", when='@5.0:')
     depends_on('boost+thread+system', when='@:5.0')
     depends_on("gmp")
     depends_on("mpfr")


### PR DESCRIPTION
It seems that some recent change to `cgal` dependencies is incompatible with older versions. This solves the issue for @4.12, at least.
Not addressed here, but it would also seem that cgal@4.12 won't compile with option `+headers_only`.