### PR TITLE
py-sphinx: add v5.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-colorama/package.py
+++ b/var/spack/repos/builtin/packages/py-colorama/package.py
@@ -12,6 +12,7 @@ class PyColorama(PythonPackage):
     homepage = "https://github.com/tartley/colorama"
     pypi = "colorama/colorama-0.3.7.tar.gz"
 
+    version("0.4.5", sha256="e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4")
     version("0.4.4", sha256="5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b")
     version("0.4.1", sha256="05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d")
     version("0.3.7", sha256="e043c8d32527607223652021ff648fbb394d5e19cba9f1a698670b338c9d782b")

--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -13,6 +13,7 @@ class PyFlitCore(PythonPackage):
     pypi = "flit-core/flit_core-3.3.0.tar.gz"
     maintainers = ["takluyver"]
 
+    version("3.7.1", sha256="14955af340c43035dbfa96b5ee47407e377ee337f69e70f73064940d27d0a44f")
     version("3.6.0", sha256="5892962ab8b8ea945835b3a288fe9dd69316f1903d5288c3f5cafdcdd04756ad")
     version("3.5.1", sha256="3083720351a6cb00e0634a1ec0e26eae7b273174c3c6c03d5b597a14203b282e")
     version("3.5.0", sha256="2db800d33ff41e4c6e7c1b594666cb2a11553024106655272c7245933b1d75bd")
@@ -23,10 +24,13 @@ class PyFlitCore(PythonPackage):
     version("3.0.0", sha256="a465052057e2d6d957e6850e9915245adedfc4fd0dd5737d0791bf3132417c2d")
     version("2.3.0", sha256="a50bcd8bf5785e3a7d95434244f30ba693e794c5204ac1ee908fc07c4acdbf80")
 
-    # Dependencies listed in flit_core/build_thyself.py
+    # pyproject.toml
+    depends_on("python@3.7:", when="@3.7:", type=("build", "run"))
     depends_on("python@3.6:", when="@3.4:", type=("build", "run"))
     depends_on("python@3.4:", when="@3:", type=("build", "run"))
     depends_on("python@2.7,3.4:", type=("build", "run"))
+
+    # flit_core/build_thyself.py
     depends_on("py-tomli", when="@3.4:3.5", type="run")
     depends_on("py-toml", when="@3.1:3.3", type="run")
     depends_on("py-pytoml", when="@:3.0", type="run")

--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -25,7 +25,6 @@ class PyFlitCore(PythonPackage):
     version("2.3.0", sha256="a50bcd8bf5785e3a7d95434244f30ba693e794c5204ac1ee908fc07c4acdbf80")
 
     # pyproject.toml
-    depends_on("python@3.7:", when="@3.7:", type=("build", "run"))
     depends_on("python@3.6:", when="@3.4:", type=("build", "run"))
     depends_on("python@3.4:", when="@3:", type=("build", "run"))
     depends_on("python@2.7,3.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -14,6 +14,7 @@ class PySphinx(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("5.2.0", sha256="1790c2098937dcfa7871c9d102c24eccd4a8b883b67c5c1e26892fb52d102542")
     version("5.1.1", sha256="ba3224a4e206e1fbdecf98a4fae4992ef9b24b85ebf7b584bb340156eaf08d89")
     version("5.1.0", sha256="7893d10d9d852c16673f9b1b7e9eda1606b420b7810270294d6e4b44c0accacc")
     version("5.0.2", sha256="b18e978ea7565720f26019c702cd85c84376e948370f1cd43d60265010e1c7b0")
@@ -54,17 +55,16 @@ class PySphinx(PythonPackage):
 
     extends("python", ignore="bin/(pybabel|pygmentize)")
 
-    # See here for upstream list of dependencies:
-    # https://github.com/sphinx-doc/sphinx/blob/master/setup.py
-    # See http://www.sphinx-doc.org/en/stable/changes.html for when each
-    # dependency was added or removed.
+    depends_on("py-flit-core@3.7:", when="@5.2:", type="build")
+    depends_on("py-setuptools", when="@4.4:5.1", type="build")
+    depends_on("py-setuptools", when="@:4.3", type=("build", "run"))
+
     depends_on("python@3.7:", when="@6:", type=("build", "run"))
     depends_on("python@3.6:", when="@4.3:5", type=("build", "run"))
     depends_on("python@3.6:3.9", when="@4:4.2", type=("build", "run"))
     depends_on("python@3.5:3.9", when="@2:3", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:3.9", when="@:1", type=("build", "run"))
 
-    depends_on("py-sphinxcontrib-websupport", when="@1.6:1", type=("build", "run"))
     depends_on("py-sphinxcontrib-applehelp", when="@2:", type=("build", "run"))
     depends_on("py-sphinxcontrib-devhelp", when="@2:", type=("build", "run"))
     depends_on("py-sphinxcontrib-jsmath", when="@2:", type=("build", "run"))
@@ -73,24 +73,32 @@ class PySphinx(PythonPackage):
     depends_on("py-sphinxcontrib-serializinghtml@1.1.5:", when="@4.1.1:", type=("build", "run"))
     depends_on("py-sphinxcontrib-serializinghtml", when="@2:", type=("build", "run"))
     depends_on("py-sphinxcontrib-qthelp", when="@2:", type=("build", "run"))
-    depends_on("py-six@1.5:", when="@:1", type=("build", "run"))
-    depends_on("py-jinja2@2.3:", type=("build", "run"))
+    depends_on("py-jinja2@3:", when="@5.2:", type=("build", "run"))
     depends_on("py-jinja2@2.3:2", when="@:4.0.1", type=("build", "run"))
-    depends_on("py-pygments@2.0:", type=("build", "run"))
+    depends_on("py-jinja2@2.3:", type=("build", "run"))
+    depends_on("py-pygments@2.12:", when="@5.2:", type=("build", "run"))
+    depends_on("py-pygments@2:", type=("build", "run"))
     depends_on("py-docutils@0.14:0.19", when="@5.1:", type=("build", "run"))
     depends_on("py-docutils@0.14:0.18", when="@5.0", type=("build", "run"))
     depends_on("py-docutils@0.14:0.17", when="@4", type=("build", "run"))
     depends_on("py-docutils@0.12:0.16", when="@:3", type=("build", "run"))
+    depends_on("py-snowballstemmer@2:", when="@5.2:", type=("build", "run"))
     depends_on("py-snowballstemmer@1.1:", type=("build", "run"))
+    depends_on("py-babel@2.9:", when="@5.2:", type=("build", "run"))
     depends_on("py-babel@1.3:", type=("build", "run"))
     depends_on("py-alabaster@0.7", type=("build", "run"))
+    depends_on("py-imagesize@1.3:", when="@5.2:", type=("build", "run"))
     depends_on("py-imagesize", when="@1.4:", type=("build", "run"))
     depends_on("py-requests@2.5.0:", type=("build", "run"))
-    depends_on("py-setuptools", when="@:4.3", type=("build", "run"))
-    depends_on("py-setuptools", when="@4.4:", type="build")
-    depends_on("py-sphinx-rtd-theme@0.1:", when="@:1.3", type=("build", "run"))
+    depends_on("py-packaging@21:", when="@5.2:", type=("build", "run"))
     depends_on("py-packaging", when="@1.7:", type=("build", "run"))
+    depends_on("py-importlib-metadata@4.8:", when="@5.2: ^python@:3.9", type=("build", "run"))
     depends_on("py-importlib-metadata@4.4:", when="@4.4: ^python@:3.9", type=("build", "run"))
-    depends_on("py-typing", when="@1.6.1", type=("build", "run"))
-    depends_on("py-typing", when="@1.6.2:^python@2.7:3.4", type=("build", "run"))
+    depends_on("py-colorama@0.4.5:", when="@5.2: platform=windows", type=("build", "run"))
     depends_on("py-colorama@0.3.5:", when="platform=windows", type=("build", "run"))
+
+    depends_on("py-sphinxcontrib-websupport", when="@1.6:1", type=("build", "run"))
+    depends_on("py-six@1.5:", when="@:1", type=("build", "run"))
+    depends_on("py-sphinx-rtd-theme@0.1:", when="@:1.3", type=("build", "run"))
+    depends_on("py-typing", when="@1.6.2:^python@2.7:3.4", type=("build", "run"))
+    depends_on("py-typing", when="@1.6.1", type=("build", "run"))


### PR DESCRIPTION
Successfully installs on macOS 12.6 (arm64) with Python 3.9.13 and Apple Clang 14.0.0.

https://www.sphinx-doc.org/en/master/changes.html