### PR TITLE
Remove "tut" from the "build-systems" pipeline

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -16,7 +16,6 @@ spack:
     - default_specs:
       - lz4  # MakefilePackage
       - mpich~fortran  # AutotoolsPackage
-      - tut  # WafPackage
       - py-setuptools  # PythonPackage
       - openjpeg  # CMakePackage
       - r-rcpp  # RPackage

--- a/var/spack/repos/builtin/packages/py-pkgutil-resolve-name/package.py
+++ b/var/spack/repos/builtin/packages/py-pkgutil-resolve-name/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class PyPkgutilResolveName(PythonPackage):
-    """Resolve a name to an object. A backport of Python 3.9’s `pkgutil.resolve_name`"""
+    """Resolve a name to an object. A backport of Python 3.9 `pkgutil.resolve_name`"""
 
     homepage = "https://github.com/graingert/pkgutil-resolve-name"
     pypi = "pkgutil_resolve_name/pkgutil_resolve_name-1.3.10.tar.gz"


### PR DESCRIPTION
PR #32615 deprecated Python versions up to 3.6.X. Since the "build-systems" pipeline requires Python 3.6.15 to build `tut`, it will fail on the first rebuild that involves Python. The `tut` package is meant to perform an end-to-end test of the `Waf` build-system, which is scarcely used. The fix therefore is just to remove it from the pipeline.

Modifications:
- [x] Remove `tut` from the "build-systems" Gitlab pipeline
- [x] Remove a UTF-8 character that breaks Python 2.7 CI in `develop` (introduced in #32776) 