### PR TITLE
shell.py: fix undefined variable in csh deactivate

### DIFF
--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -65,8 +65,8 @@ def deactivate_header(shell):
     if shell == "csh":
         cmds += "unsetenv SPACK_ENV;\n"
         cmds += "if ( $?SPACK_OLD_PROMPT ) "
-        cmds += 'set prompt="$SPACK_OLD_PROMPT" && '
-        cmds += "unsetenv SPACK_OLD_PROMPT;\n"
+        cmds += '    eval \'set prompt="$SPACK_OLD_PROMPT" &&'
+        cmds += "          unsetenv SPACK_OLD_PROMPT';\n"
         cmds += "unalias despacktivate;\n"
     elif shell == "fish":
         cmds += "set -e SPACK_ENV;\n"


### PR DESCRIPTION
This commit fixes #27027.

The root cause of the issue is that the `SPACK_OLD_PROMPT` variable was evaluated in string interpolation regardless of whether the guard condition above evaluates to true or false. This commit uses the `eval` keyword to defer evaluation until the command is executed.

Tested as follows:
```
~/spack/ # source share/spack/setup-env.csh 
~/spack/ # spack env create myenv
~/spack/ # spack env activate myenv
~/spack/ # spack env deactivate
~/spack/ # spack env activate -p myenv
[myenv] ~/spack/ # spack env deactivate
~/spack/ #
```
Note that `SPACK_OLD_PROMPT: Undefined variable.` no longer appears.

Please also note that the suggested fix in #27027 of using back-ticks to enclose the two commands does not work for the case where the prompt flag (`-p`) is specified during environment activation.