### PR TITLE
py-py2cairo: only supports Python 2

### DIFF
--- a/var/spack/repos/builtin/packages/py-py2cairo/package.py
+++ b/var/spack/repos/builtin/packages/py-py2cairo/package.py
@@ -16,7 +16,7 @@ class PyPy2cairo(WafPackage):
 
     extends("python")
 
-    depends_on("python", type=("build", "run"))
+    depends_on("python@2", type=("build", "run"))
     depends_on("cairo@1.10.0:")
     depends_on("pixman")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
From what I can tell from the [homepage](https://cairographics.org/pycairo/), it seems like py2cairo only supports Python 2 while pycairo supports 2 and 3 (recently only 3). So py2cairo should be added to the list of packages to remove once we remove Python 2 support. Note that older versions of pygobject and all versions of pygtk depend on py2cairo and will be removed as well.