### PR TITLE
amdblis: symlink libblis-mt to libblis

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
 from spack.package import *
 from spack.pkg.builtin.blis import BlisBase
 
@@ -62,3 +64,11 @@ class Amdblis(BlisBase):
             config_args.append("auto")
 
         return config_args
+
+    @run_after("install")
+    def create_symlink(self):
+        with working_dir(self.prefix.lib):
+            if os.path.isfile("libblis-mt.a"):
+                os.symlink("libblis-mt.a", "libblis.a")
+            if os.path.isfile("libblis-mt.so"):
+                os.symlink("libblis-mt.so", "libblis.so")


### PR DESCRIPTION
`amdblis threads=openmp` installs `libblis-mt.so` instead of `libblis.so`.
CMake's FindBLAS currently looks for `libblis.so` only (https://gitlab.kitware.com/cmake/cmake/-/issues/23605) so I'm adding a symlink for compatibility.