### PR TITLE
py-torch-geometric: add v2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-geometric/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-geometric/package.py
@@ -18,7 +18,7 @@ class PyTorchGeometric(PythonPackage):
     your own), and helpful transforms, both for learning on arbitrary
     graphs as well as on 3D meshes or point clouds."""
 
-    homepage = "https://github.com/rusty1s/pytorch_geometric"
+    homepage = "https://github.com/pyg-team/pytorch_geometric"
     pypi = "torch-geometric/torch_geometric-2.1.0.post1.tar.gz"
 
     version(

--- a/var/spack/repos/builtin/packages/py-torch-geometric/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-geometric/package.py
@@ -19,39 +19,51 @@ class PyTorchGeometric(PythonPackage):
     graphs as well as on 3D meshes or point clouds."""
 
     homepage = "https://github.com/rusty1s/pytorch_geometric"
-    url = "https://github.com/rusty1s/pytorch_geometric/archive/1.6.0.tar.gz"
+    pypi = "torch-geometric/torch_geometric-2.1.0.post1.tar.gz"
 
-    version("1.6.3", sha256="1907c0f5eb7ab8f6f79a7e43703579b39b514501dd956ed0fc3d33210bcbb4c2")
-    version("1.6.0", sha256="7d5231cdcc2ebd4444f406cbf1537eb49bf90ab6f446eaf1b7af5cdbe105f3c9")
+    version("2.1.0.post1", sha256="32347402076ccf60fa50312825178f1e3e5ce5e7b3b3a8b2729ac699da24525d")
+    version("1.6.3", sha256="347f693bebcc8a621eda4867dafab91c04db5f596d7ed7ecb89b242f8ab5c6a1")
+    version("1.6.0", sha256="fbf43fe15421c9affc4fb361ba4db55cb9d3c64d0c29576bb58d332bf6d27fef")
 
     variant("cuda", default=False, description="Enable CUDA support")
 
+    # setup.py
+    depends_on("python@3.7:", when="@2:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pytest-runner", type="build")
-    depends_on("py-torch", type=("build", "run"))
-    depends_on("py-numpy", type=("build", "run"))
     depends_on("py-tqdm", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-networkx", type=("build", "run"))
-    depends_on("py-scikit-learn", type=("build", "run"))
-    depends_on("py-numba", type=("build", "run"))
-    depends_on("py-python-louvain", type=("build", "run"), when="@1.6.2:")
-    depends_on("py-requests", type=("build", "run"))
-    depends_on("py-pandas", type=("build", "run"))
-    depends_on("py-rdflib", type=("build", "run"))
-    depends_on("py-googledrivedownloader", type=("build", "run"))
-    depends_on("py-h5py~mpi", type=("build", "run"))
-    depends_on("py-ase", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"))
-    depends_on("py-torch-sparse+cuda", when="+cuda", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"))
+    depends_on("py-pyparsing", when="@2:", type=("build", "run"))
+
+    # README.md
     depends_on("py-torch-scatter+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch-cluster+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch-spline-conv+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch-sparse~cuda", when="~cuda", type=("build", "run"))
     depends_on("py-torch-scatter~cuda", when="~cuda", type=("build", "run"))
+    depends_on("py-torch-sparse+cuda", when="+cuda", type=("build", "run"))
+    depends_on("py-torch-sparse~cuda", when="~cuda", type=("build", "run"))
+
+    # Optional dependencies
+    depends_on("py-torch-cluster+cuda", when="+cuda", type=("build", "run"))
     depends_on("py-torch-cluster~cuda", when="~cuda", type=("build", "run"))
+    depends_on("py-torch-spline-conv+cuda", when="+cuda", type=("build", "run"))
     depends_on("py-torch-spline-conv~cuda", when="~cuda", type=("build", "run"))
+
+    # Undocumented dependencies
+    depends_on("py-torch", type=("build", "run"))
+
+    # Historic or optional dependencies
+    with when("@:1"):
+        depends_on("py-pytest-runner", type="build")
+        depends_on("py-networkx", type=("build", "run"))
+        depends_on("py-python-louvain", type=("build", "run"), when="@1.6.2:")
+        depends_on("py-numba", type=("build", "run"))
+        depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-rdflib", type=("build", "run"))
+        depends_on("py-googledrivedownloader", type=("build", "run"))
+        depends_on("py-h5py~mpi", type=("build", "run"))
+        depends_on("py-ase", type=("build", "run"))
 
     def setup_build_environment(self, env):
         if "+cuda" in self.spec:

--- a/var/spack/repos/builtin/packages/py-torch-geometric/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-geometric/package.py
@@ -39,6 +39,7 @@ class PyTorchGeometric(PythonPackage):
     depends_on("py-jinja2", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-pyparsing", when="@2:", type=("build", "run"))
+    depends_on("py-scikit-learn", type=("build", "run"))
 
     # README.md
     depends_on("py-torch-scatter+cuda", when="+cuda", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-torch-geometric/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-geometric/package.py
@@ -21,7 +21,9 @@ class PyTorchGeometric(PythonPackage):
     homepage = "https://github.com/rusty1s/pytorch_geometric"
     pypi = "torch-geometric/torch_geometric-2.1.0.post1.tar.gz"
 
-    version("2.1.0.post1", sha256="32347402076ccf60fa50312825178f1e3e5ce5e7b3b3a8b2729ac699da24525d")
+    version(
+        "2.1.0.post1", sha256="32347402076ccf60fa50312825178f1e3e5ce5e7b3b3a8b2729ac699da24525d"
+    )
     version("1.6.3", sha256="347f693bebcc8a621eda4867dafab91c04db5f596d7ed7ecb89b242f8ab5c6a1")
     version("1.6.0", sha256="fbf43fe15421c9affc4fb361ba4db55cb9d3c64d0c29576bb58d332bf6d27fef")
 


### PR DESCRIPTION
Successfully builds on macOS 12.6 (arm64) with Python 3.9.13 and Apple Clang 14.0.0.

@aweits @qwertos 