### PR TITLE
geant4-vmc: unset MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-vmc/package.py
+++ b/var/spack/repos/builtin/packages/geant4-vmc/package.py
@@ -36,3 +36,7 @@ class Geant4Vmc(CMakePackage):
     depends_on("cmake@3.3:", type="build")
     depends_on("geant4")
     depends_on("vmc")
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("platform=darwin"):
+            env.unset("MACOSX_DEPLOYMENT_TARGET")


### PR DESCRIPTION
I've noticed lately (possibly after the upgrade to Xcode 14 ?) that I need to unset this env variable otherwise I get failed builds (in a number of packages) with error : 
```
error: invalid version number in 'MACOSX_DEPLOYMENT_TARGET=12.0'
```

I'm not so sure the fix is a really good one, but pragmatically it works :wink: 
maybe @adamjstewart can comment further on the validity / limits of the fix ?