### PR TITLE
fix cmake cache package handling for hip workaround

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -16,6 +16,16 @@ def hip_repair_options(options, spec):
     )
 
 
+def hip_repair_cache(options, spec):
+    # there is only one dir like this, but the version component is unknown
+    options.append(
+        cmake_cache_path(
+            "HIP_CLANG_INCLUDE_PATH",
+            glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0],
+        )
+    )
+
+
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """
     Compiler agnostic metaprogramming library providing concepts,

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -6,7 +6,7 @@
 import socket
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_repair_options
+from spack.pkg.builtin.camp import hip_repair_cache
 
 
 class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
@@ -125,7 +125,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
-            hip_repair_options(entries, spec)
+            hip_repair_cache(entries, spec)
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ",".join(archs)

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -9,7 +9,7 @@ import socket
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_repair_options
+from spack.pkg.builtin.camp import hip_repair_cache
 
 
 class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
@@ -188,7 +188,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
-            hip_repair_options(entries, spec)
+            hip_repair_cache(entries, spec)
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ",".join(archs)


### PR DESCRIPTION
If this works, it should fix raja, umpire, and the camp support functions for the hip workaround.


Fixes #32830