### PR TITLE
Improve lexing error

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -78,7 +78,9 @@ class Lexer(object):
                 break
 
         if remainder and not remainder_used:
-            raise LexError("Invalid character", word, word.index(remainder))
+            msg = "Invalid character, '{0}',".format(remainder[0])
+            msg += " in '{0}' at index {1}".format(word, word.index(remainder))
+            raise LexError(msg, word, word.index(remainder))
 
         return tokens
 


### PR DESCRIPTION
With the following badly formed line in a package:

```
dep = "foo"
depends_on("{0}+debug".format(dep), when="+{0}+debug")
```

Notice the lack of the `.format(dep)` at the end of the when parameter.

The correct line should have been the following but it was hard to track down due to the amount of changes I made.

```
depends_on("{0}+debug".format(dep), when="+{0}+debug".format(dep))
```

You get the following error message when you run `spack spec ...`:

```
==> Error: Invalid character
```

This improves the error message to the following:

```
==> Error: Invalid character, '{', in '+{0}+debug' at index 1
```