### PR TITLE
estarlight, dpmjet: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -35,4 +35,3 @@ class Dpmjet(MakefilePackage):
         install_tree("bin", prefix.bin)
         install_tree("lib", prefix.lib)
         install_tree("include", prefix.include)
-        pass

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -29,7 +29,6 @@ class Dpmjet(MakefilePackage):
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter(r"install: \$\(pylib\)", "install:")
-        pass
 
     def install(self, spec, prefix):
         install_tree("bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -18,6 +18,8 @@ class Dpmjet(MakefilePackage):
 
     maintainers = ["wdconinc"]
 
+    version("19.3.5", sha256="5a546ca20f86abaecda1828eb5b577aee8a532dffb2c5e7244667d5f25777909")
+    version("19.3.4", sha256="646f520aa67ef6355c45cde155a5dd55f7c9d661314358a7668f6ff472f5d5f9")
     version("19.3.3", sha256="4f449a36b48ff551beb4303d66bac18bebc52dbcac907f84ab7716c914ad6d8a")
     version("19.2.0", sha256="0f5c1af4419e1a8fa4b46cc24ae1da98abe5c119064275e1848538fe033f02cc")
     version("19.1.3", sha256="f2f7f9eee0fcd1e2770382fa6e3491418607e33de2272e04b6d75ebc97640474")

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Dpmjet(MakefilePackage):
+    """DPMJET-III is a Monte Carlo event generator for hadron, photon
+    and nuclear collisions."""
+
+    homepage = "https://github.com/DPMJET/DPMJET"
+    url = "https://github.com/DPMJET/DPMJET/archive/refs/tags/v19.3.3.zip"
+    list_url = "https://github.com/DPMJET/DPMJET/tags"
+    git = "https://github.com/DPMJET/DPMJET.git"
+
+    maintainers = ["wdconinc"]
+
+    version("19.3.3", sha256="4f449a36b48ff551beb4303d66bac18bebc52dbcac907f84ab7716c914ad6d8a")
+    version("19.2.0", sha256="0f5c1af4419e1a8fa4b46cc24ae1da98abe5c119064275e1848538fe033f02cc")
+    version("19.1.3", sha256="f2f7f9eee0fcd1e2770382fa6e3491418607e33de2272e04b6d75ebc97640474")
+
+    depends_on("python@3:")
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter(r"install: \$\(pylib\)", "install:")
+        pass
+
+    def install(self, spec, prefix):
+        install_tree("bin", prefix.bin)
+        install_tree("lib", prefix.lib)
+        pass

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -32,4 +32,5 @@ class Dpmjet(MakefilePackage):
     def install(self, spec, prefix):
         install_tree("bin", prefix.bin)
         install_tree("lib", prefix.lib)
+        install_tree("include", prefix.include)
         pass

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Estarlight(CMakePackage):
+    """Monte Carlo event generator for coherent vector meson photo- and electro-
+    production in electron-ion collisions."""
+
+    homepage = "https://github.com/eic/estarlight"
+    url      = "https://github.com/eic/estarlight/archive/refs/tags/v1.0.0.zip"
+    list_url = "https://github.com/eic/estarlight/releases"
+    git      = "https://github.com/eic/estarlight.git"
+
+    maintainers = ['wdconinc']
+
+    tags = ['eic']
+
+    version('master', branch='master')
+    version('1.0.0', sha256='a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4')
+
+    variant('hepmc3', default=True, description='Support HepMC3 writing')
+    variant('doxygen', default=False, description='Build documentation')
+    variant('pythia8', default=False, description='Use Pythia8 for parton showers')
+    variant('pythia6', default=False, description='Use Pythia6 for parton showers')
+    variant('dpmjet', default=False, description='Use dpmjet for jets')
+
+    depends_on('hepmc3', when='+hepmc3')
+    depends_on('doxygen', when='+doxygen')
+    depends_on('pythia8', when='+pythia8')
+    depends_on('pythia6', when='+pythia6')
+    depends_on('dpmjet', when='+dpmjet')
+
+    def cmake_args(self):
+        args = []
+        return args
+

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -19,7 +19,7 @@ class Estarlight(CMakePackage):
     maintainers = ["wdconinc"]
 
     version("master", branch="master")
-    version("1.0.0", sha256="a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4")
+    version("1.0.1", sha256="b43c1dd3663d8f325f30b17dd7cf4b49f2eb8ceeed7319c5aabebec8676279fd")
 
     variant("dpmjet", default=False, description="Use dpmjet for jets")
     variant("hepmc3", default=False, description="Support HepMC3 writing")

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -12,24 +12,24 @@ class Estarlight(CMakePackage):
     production in electron-ion collisions."""
 
     homepage = "https://github.com/eic/estarlight"
-    url      = "https://github.com/eic/estarlight/archive/refs/tags/v1.0.0.zip"
+    url = "https://github.com/eic/estarlight/archive/refs/tags/v1.0.0.zip"
     list_url = "https://github.com/eic/estarlight/releases"
-    git      = "https://github.com/eic/estarlight.git"
+    git = "https://github.com/eic/estarlight.git"
 
-    maintainers = ['wdconinc']
+    maintainers = ["wdconinc"]
 
-    version('master', branch='master')
-    version('1.0.0', sha256='a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4')
+    version("master", branch="master")
+    version("1.0.0", sha256="a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4")
 
-    variant('dpmjet', default=False, description='Use dpmjet for jets')
-    variant('hepmc3', default=False, description='Support HepMC3 writing')
-    variant('pythia6', default=False, description='Use Pythia6 for parton showers')
-    variant('pythia8', default=False, description='Use Pythia8 for parton showers')
+    variant("dpmjet", default=False, description="Use dpmjet for jets")
+    variant("hepmc3", default=False, description="Support HepMC3 writing")
+    variant("pythia6", default=False, description="Use Pythia6 for parton showers")
+    variant("pythia8", default=False, description="Use Pythia8 for parton showers")
 
-    depends_on('dpmjet', when='+dpmjet')
-    depends_on('hepmc3', when='+hepmc3')
-    depends_on('pythia6', when='+pythia6')
-    depends_on('pythia8', when='+pythia8')
+    depends_on("dpmjet", when="+dpmjet")
+    depends_on("hepmc3", when="+hepmc3")
+    depends_on("pythia6", when="+pythia6")
+    depends_on("pythia8", when="+pythia8")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -21,19 +21,21 @@ class Estarlight(CMakePackage):
     version('master', branch='master')
     version('1.0.0', sha256='a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4')
 
-    variant('hepmc3', default=True, description='Support HepMC3 writing')
-    variant('doxygen', default=False, description='Build documentation')
-    variant('pythia8', default=False, description='Use Pythia8 for parton showers')
-    variant('pythia6', default=False, description='Use Pythia6 for parton showers')
     variant('dpmjet', default=False, description='Use dpmjet for jets')
+    variant('hepmc3', default=False, description='Support HepMC3 writing')
+    variant('pythia6', default=False, description='Use Pythia6 for parton showers')
+    variant('pythia8', default=False, description='Use Pythia8 for parton showers')
 
-    depends_on('hepmc3', when='+hepmc3')
-    depends_on('doxygen', when='+doxygen')
-    depends_on('pythia8', when='+pythia8')
-    depends_on('pythia6', when='+pythia6')
     depends_on('dpmjet', when='+dpmjet')
+    depends_on('hepmc3', when='+hepmc3')
+    depends_on('pythia6', when='+pythia6')
+    depends_on('pythia8', when='+pythia8')
 
     def cmake_args(self):
-        args = []
+        args = [
+            self.define_from_variant("ENABLE_DPMJET", "dpmjet"),
+            self.define_from_variant("ENABLE_HEPMC3", "hepmc3"),
+            self.define_from_variant("ENABLE_PYTHIA6", "pythia6"),
+            self.define_from_variant("ENABLE_PYTHIA", "pythia8"),
+        ]
         return args
-

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -13,7 +13,7 @@ class Estarlight(CMakePackage):
 
     homepage = "https://github.com/eic/estarlight"
     url = "https://github.com/eic/estarlight/archive/refs/tags/v1.0.0.zip"
-    list_url = "https://github.com/eic/estarlight/releases"
+    list_url = "https://github.com/eic/estarlight/tags"
     git = "https://github.com/eic/estarlight.git"
 
     maintainers = ["wdconinc"]

--- a/var/spack/repos/builtin/packages/estarlight/package.py
+++ b/var/spack/repos/builtin/packages/estarlight/package.py
@@ -18,8 +18,6 @@ class Estarlight(CMakePackage):
 
     maintainers = ['wdconinc']
 
-    tags = ['eic']
-
     version('master', branch='master')
     version('1.0.0', sha256='a963bd4e08218767030ddadb7ad72d8d93f2468dfdce309abf566e87326c81f4')
 


### PR DESCRIPTION
Two new monte carlo event generators in nuclear/hadronic/high energy physics:
- [DPMJET](https://github.com/DPMJET/DPMJET), used in fluka and others,
- [estarlight](https://github.com/eic/estarlight): an electron-hadron extension of [starlight](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/starlight/package.py) (already in spack, but this package is a separate code base that does not link against the starlight package).

Sufficient for draft PR but the following is still TODO:
- [X] dpmjet: waiting for bugfix which avoids the need for the `pylib` filter
  - This will not be addressed upstream. The filter works for all included versions.
- [X] estarlight: waiting for 1.0.1 release with one remaining bugfix for gcc@10: