### PR TITLE
py-flask: add 2.2.2 and fix dependencies for py-werkzeug and py-markupsafe

### DIFF
--- a/var/spack/repos/builtin/packages/py-flask/package.py
+++ b/var/spack/repos/builtin/packages/py-flask/package.py
@@ -11,7 +11,9 @@ class PyFlask(PythonPackage):
 
     homepage = "https://palletsprojects.com/p/flask/"
     pypi = "Flask/Flask-1.1.1.tar.gz"
+    git = "https://github.com/pallets/flask.git"
 
+    version("2.2.2", sha256="642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b")
     version("2.0.2", sha256="7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2")
     version("1.1.2", sha256="4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060")
     version("1.1.1", sha256="13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52")
@@ -20,15 +22,19 @@ class PyFlask(PythonPackage):
     version("0.12.1", sha256="9dce4b6bfbb5b062181d3f7da8f727ff70c1156cbb4024351eafd426deb5fb88")
     version("0.11.1", sha256="b4713f2bfb9ebc2966b8a49903ae0d3984781d5c878591cf2f7b484d28756b0e")
 
+    depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("python@2.7:2,3.5:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
 
+    depends_on("py-werkzeug@2.2.2:", when="@2.2.2:", type=("build", "run"))
     depends_on("py-werkzeug@2:", when="@2:", type=("build", "run"))
     depends_on("py-werkzeug@0.15:", type=("build", "run"))
     depends_on("py-jinja2@3:", when="@2:", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"))
     depends_on("py-itsdangerous@2:", when="@2:", type=("build", "run"))
     depends_on("py-itsdangerous@0.24:", type=("build", "run"))
+    depends_on("py-click@8:", when="@2.1:", type=("build", "run"))
     depends_on("py-click@7.1.2:", when="@2:", type=("build", "run"))
     depends_on("py-click@5.1:", type=("build", "run"))
+    depends_on("py-importlib-metadata@3.6:", when="@2.1: ^python@:3.9", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -12,8 +12,9 @@ class PyMarkupsafe(PythonPackage):
     implement automatic string escaping. It is used by Jinja 2, the
     Mako templating engine, the Pylons web framework and many more."""
 
-    homepage = "https://markupsafe.palletsprojects.com"
+    homepage = "https://palletsprojects.com/p/markupsafe"
     pypi = "MarkupSafe/MarkupSafe-1.1.1.tar.gz"
+    git = "https://github.com/pallets/markupsafe.git"
 
     version("2.1.1", sha256="7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b")
     version("2.0.1", sha256="594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a")
@@ -25,7 +26,7 @@ class PyMarkupsafe(PythonPackage):
     version("0.20", sha256="f6cf3bd233f9ea6147b21c7c02cac24e5363570ce4fd6be11dab9f499ed6a7d8")
     version("0.19", sha256="62fcc5d641df8b5ad271ebbd6b77a19cd92eceba1e1a990de4e96c867789f037")
 
-    depends_on("python@3.7:", when="@2.1.1:", type=("build", "run"))
+    depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-werkzeug/package.py
+++ b/var/spack/repos/builtin/packages/py-werkzeug/package.py
@@ -31,4 +31,3 @@ class PyWerkzeug(PythonPackage):
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-markupsafe@2.1.1:", when="@2.2:", type=("build", "run"))
-    depends_on("py-dataclasses", when="@2 ^python@:3.6", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-werkzeug/package.py
+++ b/var/spack/repos/builtin/packages/py-werkzeug/package.py
@@ -9,8 +9,9 @@ from spack.package import *
 class PyWerkzeug(PythonPackage):
     """The Swiss Army knife of Python web development"""
 
-    homepage = "https://werkzeug.palletsprojects.com"
+    homepage = "https://palletsprojects.com/p/werkzeug"
     pypi = "Werkzeug/Werkzeug-0.16.0.tar.gz"
+    git = "https://github.com/pallets/werkzeug.git"
 
     version("2.2.2", sha256="7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f")
     version("2.0.2", sha256="aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a")
@@ -25,8 +26,9 @@ class PyWerkzeug(PythonPackage):
     version("0.11.15", sha256="455d7798ac263266dbd38d4841f7534dd35ca9c3da4a8df303f8488f38f3bcc0")
     version("0.11.11", sha256="e72c46bc14405cba7a26bd2ce28df734471bc9016bc8b4cb69466c2c14c2f7e5")
 
-    depends_on("python@3.7:", when="@2.2.2:", type=("build", "run"))
+    depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@2:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-markupsafe@2.1.1:", when="@2.2.2:", type=("build", "run"))
+    depends_on("py-markupsafe@2.1.1:", when="@2.2:", type=("build", "run"))
+    depends_on("py-dataclasses", when="@2 ^python@:3.6", type=("build", "run"))


### PR DESCRIPTION
https://github.com/pallets/flask/tree/2.2.2
https://github.com/pallets/werkzeug/tree/2.2.2
https://github.com/pallets/markupsafe/tree/2.1.1