### PR TITLE
tcl module template: automatically unload automatically loaded modules

### DIFF
--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -113,7 +113,7 @@ class TestTcl(object):
         assert len([x for x in content if x.startswith("prepend-path CMAKE_PREFIX_PATH")]) == 0
         assert len([x for x in content if 'setenv FOO "foo"' in x]) == 0
         assert len([x for x in content if "unsetenv BAR" in x]) == 0
-        assert len([x for x in content if "is-loaded foo/bar" in x]) == 1
+        assert len([x for x in content if "is-loaded 'foo/bar'" in x]) == 1
         assert len([x for x in content if "module load foo/bar" in x]) == 1
         assert len([x for x in content if "setenv LIBDWARF_ROOT" in x]) == 1
 

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -23,7 +23,7 @@ proc ModulesHelp { } {
 
 {% block autoloads %}
 {% for module in autoload %}
-if {{ '{' }} [ module-info mode load ] && ![ is-loaded {{ module }} ] {{ '}' }} {{ '{' }}
+if {{ '{' }} ![ is-loaded '{{ module }}' ] {{ '}' }} {{ '{' }}
 {% if verbose %}
     puts stderr "Autoloading {{ module }}"
 {% endif %}


### PR DESCRIPTION
I think I could simply provide Spack with my own template but I decided to share this.

Currently, a tcl module `foo/1.2.3` that is configured to autoload module `bar/4.5.6` contains the following lines:
```tcl
if { [ module-info mode load ] && ![ is-loaded bar/4.5.6 ] } {
    module load bar/4.5.6
}
```
The annoying thing is that if `bar` is loaded automatically when loading `foo` it does not get unloaded automatically when unloading `foo`:
```console
$ module list
No Modulefiles Currently Loaded.
$ module load foo/1.2.3
Loading foo/1.2.3
  Loading requirement: bar/4.5.6
$ module unload foo/1.2.3
$ module list
Currently Loaded Modulefiles:
 1) bar/4.5.6
```

This PR changes the template so that `foo/1.2.3` now contains the following (the single quotes around `bar/4.5.6` are important):
```tcl
if { ![ is-loaded 'bar/4.5.6' ] } {
    module load bar/4.5.6
}
```
And we get the following behaviour:
```console
$ module list
No Modulefiles Currently Loaded.
$ module load foo/1.2.3
Loading foo/1.2.3
  Loading requirement: bar/4.5.6
$ module unload foo/1.2.3
Unloading foo/1.2.3
  Unloading useless requirement: bar/4.5.6
$ module list
No Modulefiles Currently Loaded.
```
Also note that if `bar` is loaded manually, it does not get unloaded automatically:
```console
$ module list
No Modulefiles Currently Loaded.
$ module load bar/4.5.6
$ module load foo/1.2.3
$ module unload foo/1.2.3
$ module list
Currently Loaded Modulefiles:
 1) bar/4.5.6
```

I don't understand the reason for having `[ module-info mode load ]` introduced in d163be6 but if it wasn't for it, the only change of this PR would be adding the single quotes.