### PR TITLE
intel-oneapi-compilers-classic: extend setup_run_environment with the one from intel-oneapi-compilers

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -38,6 +38,9 @@ class IntelOneapiCompilersClassic(Package):
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file."""
         oneapi_pkg = self.spec["intel-oneapi-compilers"].package
+
+        oneapi_pkg.setup_run_environment(env)
+
         bin_prefix = oneapi_pkg.component_prefix.linux.bin.intel64
         env.set("CC", bin_prefix.icc)
         env.set("CXX", bin_prefix.icpc)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -36,26 +36,10 @@ class IntelOneapiCompilersClassic(Package):
         depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")
 
     def setup_run_environment(self, env):
-        """Adds environment variables to the generated module file.
-
-        These environment variables come from running:
-
-        .. code-block:: console
-
-           $ source {prefix}/{component}/{version}/env/vars.sh
-
-        and from setting CC/CXX/F77/FC
-        """
-
-        bin = join_path(
-            self.spec["intel-oneapi-compilers"].prefix,
-            "compiler",
-            self.spec["intel-oneapi-compilers"].version,
-            "linux",
-            "bin",
-            "intel64",
-        )
-        env.set("CC", join_path(bin, "icc"))
-        env.set("CXX", join_path(bin, "icpc"))
-        env.set("F77", join_path(bin, "ifort"))
-        env.set("FC", join_path(bin, "ifort"))
+        """Adds environment variables to the generated module file."""
+        oneapi_pkg = self.spec["intel-oneapi-compilers"].package
+        bin_prefix = oneapi_pkg.component_prefix.linux.bin.intel64
+        env.set("CC", bin_prefix.icc)
+        env.set("CXX", bin_prefix.icpc)
+        env.set("F77", bin_prefix.ifort)
+        env.set("FC", bin_prefix.ifort)


### PR DESCRIPTION
Currently, we don't get the expected environment setup after loading the `intel-oneapi-compilers-classic` **TCL** module:
```console
$ module load intel-oneapi-compilers-classic
$ icc --version
bash: icc: command not found
$ man icc
No manual entry for icc
```
This happens because `tcl` modules are not configured to autoload dependencies by default (in contrast to `lmod` modules). On the one hand, this can be solved with a configuration file (plus an optional fixup from #32853). On the other hand, the whole purpose of `intel-oneapi-compilers-classic` is to provide the users with a module file that works. So, I am not so sure about this really. To add more value to it, we could filter out environment modifications done by `intel-oneapi-compilers` that are not relevant for `intel-oneapi-compilers-classic` (and vice versa).

If the main idea of this PR is not accepted, I can remove one line and keep only the refactoring.