### PR TITLE
python2: work around lock issue

### DIFF
--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -220,6 +220,10 @@ def lock_path(lock_dir):
 
     yield lock_file
 
+    try:
+        lk.file_tracker.release_fh(lock_file)
+    except AssertionError:
+        pass
     if os.path.exists(lock_file):
         make_writable(lock_dir, lock_file)
         os.unlink(lock_file)

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -80,6 +80,10 @@ def test_lock_checks_group(tmpdir):
     gid = next((g for g in group_ids() if g != uid), None)
     if not gid:
         pytest.skip("user has no group with gid != uid")
+    try:
+        tmpdir.chown(uid, gid)
+    except OSError:
+        pytest.skip("chown not supported on target filesystem")
 
     # self-owned, another group
     tmpdir.chown(uid, gid)


### PR DESCRIPTION
Unit tests have been hanging with python2 on CI.  We have been keeping stale lock files in the lock registry, and looking them up by inode.  I am not entirely sure if this is the issue, but inodes are allowed to be reused immediately on removal, so it is possible we've been picking up state from previous tests in corner cases.  In the process of dealing with this I tracked down an occasional failure with tests using chown, caused by filesystems that only allow specific UIDs or GIDs to exist (tmpfs can do this), worked around that as well.

#hang