### PR TITLE
py-interface-meta: add 1.3.0 (incl new dependency packages)

### DIFF
--- a/var/spack/repos/builtin/packages/py-dunamai/package.py
+++ b/var/spack/repos/builtin/packages/py-dunamai/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDunamai(PythonPackage):
+    """Dynamic version generation."""
+
+    homepage = "https://github.com/mtkennerly/dunamai"
+    pypi = "dunamai/dunamai-1.13.1.tar.gz"
+
+    version("1.13.1", sha256="49597bdf653bdacdeb51ec6e0f1d4d2327309376fc83e6f1d42af6e29600515f")
+
+    depends_on("python@3.5:3", type=("build", "run"))
+    depends_on("py-poetry-core@1:", type="build")
+
+    depends_on("py-packaging@20.9:", type=("build", "run"))
+    depends_on("py-importlib-metadata@1.6:", when="^pyhton@:3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-interface-meta/package.py
+++ b/var/spack/repos/builtin/packages/py-interface-meta/package.py
@@ -13,8 +13,12 @@ class PyInterfaceMeta(PythonPackage):
     homepage = "https://github.com/matthewwardrop/interface_meta"
     pypi = "interface_meta/interface_meta-1.2.4.tar.gz"
 
+    version("1.3.0", sha256="8a4493f8bdb73fb9655dcd5115bc897e207319e36c8835f39c516a2d7e9d79a1")
     version("1.2.4", sha256="4c7725dd4b80f97b7eecfb26023e1a8a7cdbb6d6a7207a8e93f9d4bfef9ee566")
 
+    depends_on("python@3.7:3", when="@1.3:", type=("build", "run"))
     depends_on("python@3.4:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setupmeta", type="build")
+    depends_on("py-poetry-core@1:", when="@1.3:", type="build")
+    depends_on("py-poetry-dynamic-versioning", when="@1.3:", type="build")
+    depends_on("py-setuptools", when="@:1.2", type="build")
+    depends_on("py-setupmeta", when="@:1.2", type="build")

--- a/var/spack/repos/builtin/packages/py-poetry-dynamic-versioning/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-dynamic-versioning/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPoetryDynamicVersioning(PythonPackage):
+    """Plugin for Poetry to enable dynamic versioning based on VCS tags."""
+
+    homepage = "https://github.com/mtkennerly/poetry-dynamic-versioning"
+    pypi = "poetry-dynamic-versioning/poetry-dynamic-versioning-0.19.0.tar.gz"
+
+    version("0.19.0", sha256="a11a7eba6e7be167c55a1dddec78f52b61a1832275c95519ad119c7a89a7f821")
+
+    depends_on("python@3.7:3", type=("build", "run"))
+    depends_on("py-poetry-core@1:", type="build")
+
+    depends_on("py-dunamai@1.12:2", type=("build", "run"))
+    depends_on("py-tomlkit@0.4:", type=("build", "run"))
+    depends_on("py-jinja2@2.11.1:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-poetry-dynamic-versioning/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-dynamic-versioning/package.py
@@ -17,6 +17,6 @@ class PyPoetryDynamicVersioning(PythonPackage):
     depends_on("python@3.7:3", type=("build", "run"))
     depends_on("py-poetry-core@1:", type="build")
 
-    depends_on("py-dunamai@1.12:2", type=("build", "run"))
+    depends_on("py-dunamai@1.12:1", type=("build", "run"))
     depends_on("py-tomlkit@0.4:", type=("build", "run"))
     depends_on("py-jinja2@2.11.1:3", type=("build", "run"))


### PR DESCRIPTION
https://github.com/matthewwardrop/interface_meta/tree/v1.3.0
https://github.com/mtkennerly/poetry-dynamic-versioning/tree/v0.19.0
https://github.com/mtkennerly/dunamai/tree/v1.13.1

`py-poetry-dynamic-versioning` has an (optional) dependency on `py-poetry` but adding it results in an error
```
Error: Cyclic dependency detected between 'py-poetry-plugin-export' and 'py-poetry'
```
Installation (including `--test=root`) seems to work without it.