### PR TITLE
autotools: Filter libtools when building with dpcpp

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -307,9 +307,7 @@ To resolve this problem, please try the following:
             fs.filter_file(
                 r"^(predep_objects=.*)/tmp/conftest-[0-9A-Fa-f]+\.o", r"\1", libtool_path
             )
-            fs.filter_file(
-                r"^(predep_objects=.*)/tmp/a-[0-9A-Fa-f]+\.o", r"\1", libtool_path
-            )
+            fs.filter_file(r"^(predep_objects=.*)/tmp/a-[0-9A-Fa-f]+\.o", r"\1", libtool_path)
 
     @property
     def configure_directory(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -301,9 +301,11 @@ To resolve this problem, please try the following:
             ]
             for o in objfile:
                 fs.filter_file(rehead + o, "", libtool_path)
+        # Hack to filter out spurious predp_objects when building with
+        # Intel dpcpp; see issue #32863
         if self.spec.satisfies("%dpcpp"):
-            fs.filter_file("/tmp/conftest-[0-9A-Fa-f]+.o", "", libtool_path)
-            fs.filter_file("/tmp/a-[0-9A-Fa-f]+.o", "", libtool_path)
+            fs.filter_file(r"^(predep_objects=.*)/tmp/conftest-[0-9A-Fa-f]+\.o", r"\1", libtool_path)
+            fs.filter_file(r"^(predep_objects=.*)/tmp/a-[0-9A-Fa-f]+\.o", r"\1", libtool_path)
 
     @property
     def configure_directory(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -266,7 +266,8 @@ To resolve this problem, please try the following:
     def _do_patch_libtool(self):
         """If configure generates a "libtool" script that does not correctly
         detect the compiler (and patch_libtool is set), patch in the correct
-        flags for the Arm, Clang/Flang, Fujitsu and NVHPC compilers."""
+        flags for the Arm, Clang/Flang, Fujitsu and NVHPC compilers. Also
+        filter out spurious predep_objects for Intel dpcpp builds."""
 
         # Exit early if we are required not to patch libtool
         if not self.patch_libtool:
@@ -300,6 +301,9 @@ To resolve this problem, please try the following:
             ]
             for o in objfile:
                 fs.filter_file(rehead + o, "", libtool_path)
+        if self.spec.satisfies("%dpcpp"):
+            fs.filter_file("/tmp/conftest-[0-9A-Fa-f]+.o", "", libtool_path)
+            fs.filter_file("/tmp/a-[0-9A-Fa-f]+.o", "", libtool_path)
 
     @property
     def configure_directory(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -304,8 +304,12 @@ To resolve this problem, please try the following:
         # Hack to filter out spurious predp_objects when building with
         # Intel dpcpp; see issue #32863
         if self.spec.satisfies("%dpcpp"):
-            fs.filter_file(r"^(predep_objects=.*)/tmp/conftest-[0-9A-Fa-f]+\.o", r"\1", libtool_path)
-            fs.filter_file(r"^(predep_objects=.*)/tmp/a-[0-9A-Fa-f]+\.o", r"\1", libtool_path)
+            fs.filter_file(
+                r"^(predep_objects=.*)/tmp/conftest-[0-9A-Fa-f]+\.o", r"\1", libtool_path
+            )
+            fs.filter_file(
+                r"^(predep_objects=.*)/tmp/a-[0-9A-Fa-f]+\.o", r"\1", libtool_path
+            )
 
     @property
     def configure_directory(self):


### PR DESCRIPTION
Due to a [known issue](https://community.intel.com/t5/Intel-oneAPI-Data-Parallel-C/dpcpp-and-GNU-Autotools/m-p/1296985) with dpcpp, autotool-based builds that try to use it will fail; see #32863. This pull request modifies the Autotools package class to filter spurious object files out of the libtool script, as is already done to address issues with other compilers.