### PR TITLE
serialbox: patch to add missing include directives

### DIFF
--- a/var/spack/repos/builtin/packages/serialbox/missing_includes.patch
+++ b/var/spack/repos/builtin/packages/serialbox/missing_includes.patch
@@ -1,0 +1,11 @@
+--- a/src/serialbox-c/FortranWrapper.cpp
++++ b/src/serialbox-c/FortranWrapper.cpp
+@@ -12,6 +12,8 @@
+  *
+ \*===------------------------------------------------------------------------------------------===*/
+ 
++#include <array>
++
+ #include "serialbox-c/FortranWrapper.h"
+ #include "serialbox-c/FieldMetainfo.h"
+ #include "serialbox-c/Metainfo.h"

--- a/var/spack/repos/builtin/packages/serialbox/package.py
+++ b/var/spack/repos/builtin/packages/serialbox/package.py
@@ -63,6 +63,10 @@ class Serialbox(CMakePackage):
     patch("nag/examples.patch", when="@2.3.1:%nag+fortran+examples")
     patch("nag/ftg.patch", when="@2.3.1:%nag+ftg")
 
+    # Add missing include directives
+    # (part of https://github.com/GridTools/serialbox/pull/259):
+    patch("missing_includes.patch", when="@:2.6.1+c")
+
     conflicts(
         "+ftg",
         when="~fortran",


### PR DESCRIPTION
This adds missing include directive, which is critical with more recent compilers (using more recent versions of the standard library).