### PR TITLE
Enable adios2+cuda for ecp-data-vis-sdk +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -99,7 +99,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on(
         "adios2+shared+mpi+python+blosc+sst+ssc+dataman",
         when="+adios2",
-        propagate=["hdf5", "sz", "zfp", "fortran"],
+        propagate=["cuda", "hdf5", "sz", "zfp", "fortran"] + cuda_arch_variants,
     )
 
     dav_sdk_depends_on("darshan-runtime+mpi", when="+darshan", propagate=["hdf5"])


### PR DESCRIPTION
Tested in both e4s container and on perlmutter.

CC @kwryankrattiger.