### PR TITLE
libcroco does not respect gtk-doc configure flag, so removing variant

### DIFF
--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -15,9 +15,11 @@ class Libcroco(AutotoolsPackage):
     version("0.6.13", sha256="767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4")
     version("0.6.12", sha256="ddc4b5546c9fb4280a5017e2707fbd4839034ed1aba5b7d4372212f34f84f860")
 
-    # libcroco has a --enable-gtk-doc configure flag that appears to be ignored     # as of version 0.6.13. Until that flag is honored, the +doc variant is a
-    # no-op
-    #variant("doc", default=False, description="Build documentation with gtk-doc")
+    # libcroco has a --enable-gtk-doc configure flag that appears to be
+    # ignored as of version 0.6.13. Until that flag is honored, the +doc
+    # variant is a no-op
+    # variant("doc", default=False,
+    #         description="Build documentation with gtk-doc")
 
     depends_on("glib")
     depends_on("libxml2")

--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -19,12 +19,10 @@ class Libcroco(AutotoolsPackage):
 
     depends_on("glib")
     depends_on("libxml2")
-    depends_on("gtk-doc", type="build", when="+doc")
+    depends_on("gtk-doc", type="build")
     depends_on("pkgconfig", type="build")
 
     def configure_args(self):
-        args = ["--enable-gtk-doc=" + ("yes" if self.spec.variants["doc"].value else "no")]
         # macOS ld does not support this flag
         # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb
-        args.append("--disable-Bsymbolic")
-        return args
+        return ["--disable-Bsymbolic"]

--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -15,7 +15,9 @@ class Libcroco(AutotoolsPackage):
     version("0.6.13", sha256="767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4")
     version("0.6.12", sha256="ddc4b5546c9fb4280a5017e2707fbd4839034ed1aba5b7d4372212f34f84f860")
 
-    variant("doc", default=False, description="Build documentation with gtk-doc")
+    # libcroco has a --enable-gtk-doc configure flag that appears to be ignored     # as of version 0.6.13. Until that flag is honored, the +doc variant is a
+    # no-op
+    #variant("doc", default=False, description="Build documentation with gtk-doc")
 
     depends_on("glib")
     depends_on("libxml2")


### PR DESCRIPTION
The libcroco configure script was not respecting --enable-gtk-doc=no and thus depends on gtk-doc regardless of that flag. Until this is fixed upsream, it seems like the +doc variant is the only option and thus, this PR removes the variant and depends on gtk-doc without condition.