### PR TITLE
rvs binary path updated for 5.2 rocm release

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -146,9 +146,13 @@ class RocmValidationSuite(CMakePackage):
         depends_on("hip-rocclr@" + ver, when="@" + ver)
 
     def patch(self):
-        if "@4.5.0:" in self.spec:
+        if "@4.5.0:5.1" in self.spec:
             filter_file(
                 "@ROCM_PATH@/rvs", self.spec.prefix.rvs, "rvs/conf/deviceid.sh.in", string=True
+            )
+        elif "@5.2.0:" in self.spec:
+            filter_file(
+                "@ROCM_PATH@/bin", self.spec.prefix.rvs, "rvs/conf/deviceid.sh.in", string=True
             )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -152,7 +152,7 @@ class RocmValidationSuite(CMakePackage):
             )
         elif "@5.2.0:" in self.spec:
             filter_file(
-                "@ROCM_PATH@/bin", self.spec.prefix.rvs, "rvs/conf/deviceid.sh.in", string=True
+                "@ROCM_PATH@/bin", self.spec.prefix.bin, "rvs/conf/deviceid.sh.in", string=True
             )
 
     def cmake_args(self):


### PR DESCRIPTION
rvs binary has been moved to bin directory by below commit from 5.2.0 release.
https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/commit/bb949c4fd7773cb6d5cb07fc0776053d8905a627#diff-8d3eab83afad587863b92cd82c66db2b5c40ecdc9d7d5b882c0e52c2494c0370