### PR TITLE
claw: enable building with oneapi and nag+gcc@10:

### DIFF
--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -61,9 +63,12 @@ class Claw(CMakePackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
+            compiler_spec = self.spec.compiler
+            if spack.compilers.is_mixed_toolchain(self.compiler):
+                compiler_spec = self._get_real_compiler_spec("cc") or compiler_spec
             if any(
                 [
-                    self.spec.compiler.satisfies(s)
+                    compiler_spec.satisfies(s)
                     for s in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:", "oneapi"]
                 ]
             ):
@@ -77,3 +82,25 @@ class Claw(CMakePackage):
         args = ["-DOMNI_CONF_OPTION=--with-libxml2=%s" % self.spec["libxml2"].prefix]
 
         return args
+
+    def _get_real_compiler_spec(self, language):
+        lang_compiler = getattr(self.compiler, language)
+
+        if not lang_compiler:
+            return None
+
+        for compiler_name in spack.compilers.supported_compilers():
+            compiler_cls = spack.compilers.class_for_compiler_name(compiler_name)
+            lang_version_fn = getattr(compiler_cls, "{0}_version".format(language))
+            for regexp in compiler_cls.search_regexps(language):
+                if regexp.match(os.path.basename(lang_compiler)):
+                    try:
+                        detected_version = lang_version_fn(lang_compiler)
+                        if detected_version:
+                            compiler_version = Version(detected_version)
+                            if compiler_version != Version("unknown"):
+                                return spack.spec.CompilerSpec(compiler_name, compiler_version)
+                    except Exception:
+                        continue
+
+        return None

--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -64,7 +64,7 @@ class Claw(CMakePackage):
             if any(
                 [
                     self.spec.compiler.satisfies(s)
-                    for s in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:"]
+                    for s in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:", "oneapi"]
                 ]
             ):
                 # https://gcc.gnu.org/gcc-10/porting_to.html


### PR DESCRIPTION
1. Enable building with `%oneapi` (I am not aware of the version that would not need the `-fcommon` flag).
2. Enable building with `%nag` that is mixed with `gcc@10:`. To support this case, we have to detect the real version of `gcc`, which is implemented in `_get_real_compiler_spec`.