### PR TITLE
added a PoC for limiting reuse of specs (by target)

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -16,6 +16,8 @@ concretizer:
   # concretization. If `dependencies`, we'll only reuse dependencies but
   # give you a fresh concretization for your root specs.
   reuse: dependencies
+  reuse: true
+  # limit_target_reuse: [x86_64, x86_64_v2] # limit the arches the concretizer will use for concretization
   # Options that tune which targets are considered for concretization. The
   # concretization process is very sensitive to the number targets, and the time
   # needed to reach a solution increases noticeably with the number of targets

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -459,7 +459,7 @@ class ConfigSetAction(argparse.Action):
     """
 
     def __init__(
-        self, option_strings, dest, const, default=None, required=False, help=None, metavar=None
+            self, option_strings, dest, nargs=0, const=None, default=None, required=False, help=None, metavar=None
     ):
         # save the config option we're supposed to set
         self.config_path = dest
@@ -471,7 +471,7 @@ class ConfigSetAction(argparse.Action):
         super(ConfigSetAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
-            nargs=0,
+            nargs=nargs,
             const=const,
             default=default,
             required=required,
@@ -483,7 +483,11 @@ class ConfigSetAction(argparse.Action):
         # the const from the constructor or a value from the CLI.
         # Note that this is only called if the argument is actually
         # specified on the command line.
-        spack.config.set(self.config_path, self.const, scope="command_line")
+        if self.const:
+            spack.config.set(self.config_path, self.const, scope="command_line")
+        else:
+            if isinstance(self.default, list) and isinstance(values[0], str):
+                spack.config.set(self.config_path, values[0].split(","), scope="command_line")
 
 
 def add_concretizer_args(subparser):
@@ -523,6 +527,14 @@ def add_concretizer_args(subparser):
         const="dependencies",
         default=None,
         help="reuse installed dependencies only",
+    )
+    subgroup.add_argument(
+        "--limit-target-reuse",
+        action=ConfigSetAction,
+        dest="concretizer:limit_target_reuse",
+        nargs=1,
+        default=[],
+        help="limit reuse to specific target-architectures"
     )
 
 

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -15,18 +15,28 @@ properties = {
         "additionalProperties": False,
         "properties": {
             "reuse": {
-                "oneOf": [{"type": "boolean"}, {"type": "string", "enum": ["dependencies"]}]
+                "oneOf": [
+                    {"type": "boolean"},
+                    {"type": "string", "enum": ["dependencies"]},
+                ]
             },
             "enable_node_namespace": {"type": "boolean"},
+            "limit_target_reuse": {"type": "array"},
             "targets": {
                 "type": "object",
                 "properties": {
                     "host_compatible": {"type": "boolean"},
-                    "granularity": {"type": "string", "enum": ["generic", "microarchitectures"]},
+                    "granularity": {
+                        "type": "string",
+                        "enum": ["generic", "microarchitectures"],
+                    },
                 },
             },
             "unify": {
-                "oneOf": [{"type": "boolean"}, {"type": "string", "enum": ["when_possible"]}]
+                "oneOf": [
+                    {"type": "boolean"},
+                    {"type": "string", "enum": ["when_possible"]},
+                ]
             },
         },
     }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2710,6 +2710,7 @@ class Solver(object):
         # These properties are settable via spack configuration, and overridable
         # by setting them directly as properties.
         self.reuse = spack.config.get("concretizer:reuse", False)
+        self.limit_target_reuse = spack.config.get("concretizer:limit_target_reuse", [])
 
     @staticmethod
     def _check_input_and_extract_concrete_specs(specs):
@@ -2745,12 +2746,17 @@ class Solver(object):
                 # TODO: update mirror configuration so it can indicate that the
                 # TODO: source cache (or any mirror really) doesn't have binaries.
                 pass
-
         # If we only want to reuse dependencies, remove the root specs
         if self.reuse == "dependencies":
             reusable_specs = [
                 spec for spec in reusable_specs if not any(root in spec for root in specs)
             ]
+
+        print(self.limit_target_reuse)
+        if self.limit_target_reuse:
+            reusable_specs = [
+                s for s in reusable_specs if s.target in self.limit_target_reuse
+                ]
 
         return reusable_specs
 


### PR DESCRIPTION
So, this does, what I want in https://github.com/spack/spack/issues/32888. 

essentially if I do `spack spec --limit-target-reuse=x86_64,zen2  tar %gcc@12.2.0 target=zen2` the resulting spec will only try to reuse two architectures, when concretizing. This enables me to build different "stacks" in a clean way within one spack installation

It has some problems however:

1) I can't overwrite all scopes (=settings from the config-files) from the commandline (how would I do that)
2) I probably should extract the targets of the specs I want to build to add to the list of valid targets? 
3) this logic applies at least to compiler too and it's handled there already, how do you do this there?
4) is there any other place where this should better be/what does it need to integrate (except for tests)?