### PR TITLE
qmcpack: set python 3 executable explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -370,6 +370,7 @@ class Qmcpack(CMakePackage, CudaPackage):
         else:
             args.append("-DBUILD_PPCONVERT=0")
 
+        args.append(self.define("Python3_EXECUTABLE", self.spec["python"].command.path))
         return args
 
     # QMCPACK needs custom install method for the following reason:


### PR DESCRIPTION
Ported from #30738

Modifications:
- [x] set `Python3_EXECUTABLE` CMake argument