### PR TITLE
Set CMAKE_HIP_ARCHITECTURES with the value of amdgpu_target

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -142,11 +142,11 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
         ]
 
         # HIP support requires compiling with hipcc for < 0.8.0
-        if "@:0.7 +rocm" in self.spec:
+        if self.spec.satisfies("@:0.7 +rocm"):
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
             if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]
-        if "@0.8: +rocm" in self.spec:
+        if self.spec.satisfies("@0.8: +rocm"):
             rocm_archs = spec.variants["amdgpu_target"].value
             rocm_archs = ";".join(rocm_archs)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", rocm_archs))

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -146,5 +146,9 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
             if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]
+        if "@0.8: +rocm" in self.spec:
+            rocm_archs = spec.variants['amdgpu_target'].value
+            rocm_archs = ";".join(rocm_archs)
+            args.append(self.define("CMAKE_HIP_ARCHITECTURES", rocm_archs))
 
         return args

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -147,7 +147,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]
         if "@0.8: +rocm" in self.spec:
-            rocm_archs = spec.variants['amdgpu_target'].value
+            rocm_archs = spec.variants["amdgpu_target"].value
             rocm_archs = ";".join(rocm_archs)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", rocm_archs))
 


### PR DESCRIPTION
Since we use `enable_language(HIP)` in pika, the architectures were not properly forwarded