### PR TITLE
Fixup errors introduced by Clingo Pr

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -658,7 +658,7 @@ def _add_externals_if_missing():
         spack.repo.path.get_pkg_class("gawk"),
     ]
     if is_windows:
-        search_list.extend(spack.repo.path.get_pkg_class("winbison"))
+        search_list.append(spack.repo.path.get_pkg_class("winbison"))
     detected_packages = spack.detection.by_executable(search_list)
     spack.detection.update_configuration(detected_packages, scope="bootstrap")
 

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -28,6 +28,8 @@ class Re2c(Package):
 
     phases = ["configure", "build", "install"]
 
+    depends_on("cmake", when="platform=windows")
+
     @property
     def make_tool(self):
         if is_windows:


### PR DESCRIPTION
re2c depends on cmake on Windows

Winbison properly added to bootstrap package search list