### PR TITLE
Package updates for slate, lapackpp, and blaspp

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -20,6 +20,9 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
+        "2022.07.00", sha256="796277859bc1bd9c0aeb0cb170a1e259765c0a86af49b20afa0ffcbabc3e207e"
+    )
+    version(
         "2022.05.00", sha256="696277859bc1bd9c0aeb0cb170a1e259765c0a86af49b20afa0ffcbabc3e207e"
     )
     version(

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -20,7 +20,7 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
-        "2022.07.00", sha256="796277859bc1bd9c0aeb0cb170a1e259765c0a86af49b20afa0ffcbabc3e207e"
+        "2022.07.00", sha256="566bd644f0364caffde6669e0f86514658eb06ca3d252a4fe67203921a875481"
     )
     version(
         "2022.05.00", sha256="696277859bc1bd9c0aeb0cb170a1e259765c0a86af49b20afa0ffcbabc3e207e"

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -58,6 +58,8 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("blas")
     depends_on("lapack")
+    depends_on("rocblas", when="+rocm")
+    depends_on("rocsolver", when="+rocm")
 
     conflicts("+rocm", when="+cuda", msg="LAPACK++ can only support one GPU backend at a time")
 

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -59,13 +59,23 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blas")
     depends_on("lapack")
 
+    conflicts("+rocm", when="+cuda", msg="LAPACK++ can only support one GPU backend at a time")
+
     def cmake_args(self):
         spec = self.spec
+
+        backend = "none"
+        if self.version >= Version("2022.07.00"):
+            if "+cuda" in spec:
+                backend = "cuda"
+            if "+rocm" in spec:
+                backend = "hip"
 
         args = [
             "-DBUILD_SHARED_LIBS=%s" % ("+shared" in spec),
             "-Dbuild_tests=%s" % self.run_tests,
             "-DLAPACK_LIBRARIES=%s" % spec["lapack"].libs.joined(";"),
+            "-Dgpu_backend=%s" % backend,
         ]
 
         if spec["blas"].name == "cray-libsci":

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -32,7 +32,7 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
-        "2022.07.00", sha256="40f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
+        "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
     )
     version(
         "2022.05.00", sha256="d0f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -31,9 +31,10 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ["teonnik", "Sely85", "G-Ragghianti", "mgates3"]
 
     version("master", branch="master")
-    version(
-        "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
-    )
+    version("2022.07.00", git="https://github.com/G-Ragghianti/lapackpp")
+    #version(
+    #    "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
+    #)
     version(
         "2022.05.00", sha256="d0f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
     )

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -11,6 +11,7 @@ from spack.package import *
 _versions = [
     # LAPACK++,     BLAS++
     ["master", "master"],
+    ["2022.07.00", "2022.07.00"],
     ["2022.05.00", "2022.05.00"],
     ["2020.10.00", "2020.10.00"],
     ["2020.10.01", "2020.10.01"],
@@ -19,7 +20,7 @@ _versions = [
 ]
 
 
-class Lapackpp(CMakePackage):
+class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     """LAPACK++: C++ API for the LAPACK Linear Algebra Package. Developed
     by the Innovative Computing Laboratory at the University of Tennessee,
     Knoxville."""
@@ -30,6 +31,9 @@ class Lapackpp(CMakePackage):
     maintainers = ["teonnik", "Sely85", "G-Ragghianti", "mgates3"]
 
     version("master", branch="master")
+    version(
+        "2022.07.00", sha256="40f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
+    )
     version(
         "2022.05.00", sha256="d0f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
     )

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -57,6 +57,12 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     for (lpp_ver, bpp_ver) in _versions:
         depends_on("blaspp@" + bpp_ver, when="@" + lpp_ver)
 
+    depends_on("blaspp ~cuda", when="~cuda")
+    depends_on("blaspp +cuda", when="+cuda")
+    depends_on("blaspp ~rocm", when="~rocm")
+    for val in ROCmPackage.amdgpu_targets:
+        depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+
     depends_on("blas")
     depends_on("lapack")
     depends_on("rocblas", when="+rocm")

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -31,10 +31,9 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ["teonnik", "Sely85", "G-Ragghianti", "mgates3"]
 
     version("master", branch="master")
-    version("2022.07.00", git="https://github.com/G-Ragghianti/lapackpp")
-    #version(
-    #    "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
-    #)
+    version(
+        "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
+    )
     version(
         "2022.05.00", sha256="d0f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
     )

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -25,7 +25,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
-        "2022.07.00", sha256="5da23f3c3c51fde65120f80df2b2f703aee1910389c08f971804aa77d11ac027"
+        "2022.07.00", sha256="176db81aef44b1d498a37c67b30aff88d4025770c9200e19ceebd416e4101327"
     )
     version(
         "2022.06.00", sha256="4da23f3c3c51fde65120f80df2b2f703aee1910389c08f971804aa77d11ac027"
@@ -60,7 +60,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     for val in ROCmPackage.amdgpu_targets:
         depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
     depends_on("lapackpp@2022.07.00", when="@2022.07.00:")
-    depends_on("lapackpp@2022.05.00", when="@2022.05.00:")
+    depends_on("lapackpp@2022.05.00:", when="@2022.05.00:")
     depends_on("lapackpp@2021.04.00:", when="@2021.05.01:")
     depends_on("lapackpp@2020.10.02", when="@2020.10.00")
     depends_on("lapackpp@master", when="@master")

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -57,8 +57,12 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blaspp ~cuda", when="~cuda")
     depends_on("blaspp +cuda", when="+cuda")
     depends_on("blaspp ~rocm", when="~rocm")
+    depends_on("lapackpp ~cuda", when="~cuda")
+    depends_on("lapackpp +cuda", when="+cuda")
+    depends_on("lapackpp ~rocm", when="~rocm")
     for val in ROCmPackage.amdgpu_targets:
         depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+        depends_on("lapackpp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
     depends_on("lapackpp@2022.07.00", when="@2022.07.00:")
     depends_on("lapackpp@2022.05.00:", when="@2022.05.00:")
     depends_on("lapackpp@2021.04.00:", when="@2021.05.01:")

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -25,6 +25,9 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
+        "2022.07.00", sha256="5da23f3c3c51fde65120f80df2b2f703aee1910389c08f971804aa77d11ac027"
+    )
+    version(
         "2022.06.00", sha256="4da23f3c3c51fde65120f80df2b2f703aee1910389c08f971804aa77d11ac027"
     )
     version(
@@ -56,6 +59,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blaspp ~rocm", when="~rocm")
     for val in ROCmPackage.amdgpu_targets:
         depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+    depends_on("lapackpp@2022.07.00", when="@2022.07.00:")
     depends_on("lapackpp@2022.05.00", when="@2022.05.00:")
     depends_on("lapackpp@2021.04.00:", when="@2021.05.01:")
     depends_on("lapackpp@2020.10.02", when="@2020.10.00")


### PR DESCRIPTION
These package updates correspond to SLATE release 2022-07-00.  The major change is the inclusion of HIP and CUDA support in lapackpp.