### PR TITLE
feature: Add -x|--explicit option to 'spack test run'

### DIFF
--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -467,7 +467,7 @@ def test_affected_specs_on_first_concretization(mutable_mock_env_path, config):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script ot supported on Windows"
+    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_process_command(tmpdir):
     repro_dir = tmpdir.join("repro_dir").strpath
@@ -479,7 +479,7 @@ def test_ci_process_command(tmpdir):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script ot supported on Windows"
+    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_process_command_fail(tmpdir, monkeypatch):
     import subprocess
@@ -526,7 +526,7 @@ def test_ci_run_standalone_tests_missing_requirements(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script ot supported on Windows"
+    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_junit(
     tmpdir, working_env, config, mock_packages, mock_test_stage, capfd
@@ -547,7 +547,7 @@ def test_ci_run_standalone_tests_not_installed_junit(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script ot supported on Windows"
+    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_cdash(
     tmpdir, working_env, config, mock_packages, mock_test_stage, capfd

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1742,7 +1742,7 @@ _spack_test() {
 _spack_test_run() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --externals --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
+        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --externals -x --explicit --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
     else
         _installed_packages
     fi


### PR DESCRIPTION
@wspear 

This PR adds the ability to run `spack test run --explicit [spec(s)]` to run stand-alone tests for only the explicitly installed spec(s).

```
$ spack test run -h
usage: spack test run [-hx] [--alias ALIAS] [--fail-fast] [--fail-first]
                      [--externals] [--keep-stage]
                      [--log-format {None,junit,cdash}] [--log-file LOG_FILE]
                      [--help-cdash] [--clean | --dirty]
                      ...

Run tests for the specified installed packages.

    If no specs are listed, run tests for all packages in the current
    environment or all installed packages if there is no active environment.
    

positional arguments:
  installed_specs       one or more installed package specs

optional arguments:
  --alias ALIAS         Provide an alias for this test-suite for subsequent access.
  --clean               unset harmful variables in the build environment (default)
  --dirty               preserve user environment in spack's build environment (danger!)
  --externals           Test packages that are externally installed.
  --fail-fast           Stop tests for each package after the first failure.
  --fail-first          Stop after the first failed package.
  --help-cdash          Show usage instructions for CDash reporting
  --keep-stage          Keep testing directory for debugging
  --log-file LOG_FILE   filename for the log file. if not passed a default will be used
  --log-format {None,junit,cdash}
                        format to be used for log files
  -h, --help            show this help message and exit
  -x, --explicit        Only test packages that are explicitly installed.
  ```