### PR TITLE
py-blis: fix environment settings

### DIFF
--- a/var/spack/repos/builtin/packages/py-blis/package.py
+++ b/var/spack/repos/builtin/packages/py-blis/package.py
@@ -18,3 +18,7 @@ class PyBlis(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.15:", type=("build", "run"))
+
+    def setup_build_environment(self, env):
+        env.set("BLIS_COMPILER", self.compiler.cc)
+        env.set("BLIS_ARCH", "generic")

--- a/var/spack/repos/builtin/packages/py-blis/package.py
+++ b/var/spack/repos/builtin/packages/py-blis/package.py
@@ -20,5 +20,5 @@ class PyBlis(PythonPackage):
     depends_on("py-numpy@1.15:", type=("build", "run"))
 
     def setup_build_environment(self, env):
-        env.set("BLIS_COMPILER", self.compiler.cc)
+        env.set("BLIS_COMPILER", spack_cc)
         env.set("BLIS_ARCH", "generic")


### PR DESCRIPTION
Error occur when compiling with a compiler other than GCC, or on a platform other than x86_64. The reason is that two environment variables are not set.
-  BLIS_COMPILER
-  BLIS_ARCH