### PR TITLE
[rocksdb] Added rtti variant

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -34,6 +34,7 @@ class Rocksdb(MakefilePackage):
     variant("zstd", default=False, description="Enable zstandard compression support")
     variant("tbb", default=False, description="Enable Intel TBB support")
     variant("werror", default=False, description="Build with -Werror")
+    variant("rtti", default=False, description="Build with RTTI")
 
     depends_on("bzip2", when="+bz2")
     depends_on("gflags")
@@ -96,6 +97,9 @@ class Rocksdb(MakefilePackage):
 
         if "~werror" in self.spec:
             env["DISABLE_WARNING_AS_ERROR"] = "1"
+
+        if '+rtti' in self.spec:
+            env["USE_RTTI"] = "1"
 
         if self.spec.satisfies("@6.13.2:"):
             env["PREFIX"] = self.spec.prefix

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -98,7 +98,7 @@ class Rocksdb(MakefilePackage):
         if "~werror" in self.spec:
             env["DISABLE_WARNING_AS_ERROR"] = "1"
 
-        if '+rtti' in self.spec:
+        if "+rtti" in self.spec:
             env["USE_RTTI"] = "1"
 
         if self.spec.satisfies("@6.13.2:"):


### PR DESCRIPTION
This PR adds the `rtti` variant in rocksdb. This is needed when subclassing some rocksdb classes (e.g. Logger), and can be enabled via the `USE_RTTI` environment variable when calling `make`.