### PR TITLE
Apply setup_dependent_package to superclass packages that are not shared

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -775,6 +775,15 @@ def parent_class_modules(cls):
     return result
 
 
+def nonshared_parents(cls):
+    """Return list with cls and all superclasses that define a Package
+       class object with the same name (so excludes superclasses like
+       PackageBase).
+    """
+    all_parents = parent_class_modules(cls)
+    return list(x for x in all_parents if getattr(x, cls.__name__, None))
+
+
 def load_external_modules(pkg):
     """Traverse a package's spec DAG and load any external modules.
 
@@ -994,7 +1003,8 @@ def modifications_from_dependencies(
             if set_package_py_globals:
                 set_module_variables_for_package(dpkg)
             # Allow dependencies to modify the module
-            dpkg.setup_dependent_package(spec.package.module, spec)
+            for module in nonshared_parents(spec.package.__class__):
+                dpkg.setup_dependent_package(module, spec)
             if context == "build":
                 dpkg.setup_dependent_build_environment(env, spec)
             else:


### PR DESCRIPTION
If you have a package in the builtin repo like:

```
class Foo(Package):
    depends_on(cmake)

    def install():
        cmake(...)
```

and a custom package repository which extends that package like:

```
class Foo(builtin.Foo):
    ...
```

this will fail as of https://github.com/spack/spack/commit/b9e57006c98c5ea3836a33a55a41a516e52f3e4b#diff-a493ca2ca45c40f1a67e6ef60fe57654cb2077e3d20b50ceee9b85d0ec16c8e3 because `build_environment` only ensures that the subclass module has a `cmake` attribute defined.

This retrieves all packages in the inheritance DAG for the installed package, but excludes "shared" superclasses like `PackageBase`. This assumes that all packages in this inheritance hierarchy would have the same class name (e.g. in this case they would all be called `Foo`. I couldn't quickly think of a better criteria but other possible criteria is to only retrieve package superclasses if they are defined in a repo (this would cause problems if users created packages in their repo for the sole purpose of sharing amongst other packages).