### PR TITLE
CMB/SMTK packages

### DIFF
--- a/var/spack/repos/builtin/packages/modelbuilder/package.py
+++ b/var/spack/repos/builtin/packages/modelbuilder/package.py
@@ -1,0 +1,72 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install modelbuilder
+#
+# You can edit this file again by typing:
+#
+#     spack edit modelbuilder
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+from spack.package import *
+
+
+class Modelbuilder(CMakePackage):
+    """Modelbuilder is an open-source ParaView Client
+    with Simulation pre-processing workflow tools.
+    """
+
+    homepage = "https://www.computationalmodelbuilder.org"
+    url = "https://gitlab.kitware.com/cmb/cmb"
+    git = "https://gitlab.kitware.com/cmb/cmb.git"
+
+    maintainers = ["kwryankrattiger"]
+
+    version("master", branch="master")
+
+    releases = [
+        "22.04.0",
+        "21.12.0",
+        "21.07.0",
+        "21.05.0",
+    ]
+    for ver in releases:
+        version(ver, branch="v{0}".format(ver), submodules=False)
+
+    variant("doc", default=False, description="Build documentation.")
+    variant("python", default=True, description="Enable built-in Python shell.")
+    variant("remote", default=False, description="Enable remote rendering support.")
+    variant("shared", default=True, description="Build with shared libs.")
+    variant("smtk", default=True, description="Enable Built-in SMTK plugins.")
+
+    depends_on("smtk +paraview +qt", when="+smtk")
+    depends_on("smtk +shared", when="+smtk +shared")
+    depends_on("paraview +qt")
+    depends_on("paraview +shared", when="+shared")
+    depends_on("paraview +python3", when="+python")
+    depends_on("python@3:", when="+python")
+    depends_on("qt@5: +gui")
+    depends_on("py-sphinx", when="+doc")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("cmb_enable_pythonshell", "python"),
+            self.define_from_variant("cmb_enable_multiservers", "remote"),
+            self.define_from_variant("cmb_enable_documentation", "doc"),
+            # self.define_from_variant("cmb_enable_objectpicking", "smtk"),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/modelbuilder/package.py
+++ b/var/spack/repos/builtin/packages/modelbuilder/package.py
@@ -5,24 +5,6 @@
 
 from spack.package import *
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install modelbuilder
-#
-# You can edit this file again by typing:
-#
-#     spack edit modelbuilder
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-from spack.package import *
-
 
 class Modelbuilder(CMakePackage):
     """Modelbuilder is an open-source ParaView Client

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -84,6 +84,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         description="Enable Catalyst 2 (libcatalyst) implementation",
         when="@5.10:",
     )
+    variant("gdal", default=False, description="Enable GDAL support")
+    variant("smtk_extensions", default=False, description="Enable components required by CMB/SMTK")
+    variant("visitbridge", default=False, description="Enable VisItBridge Support")
 
     variant(
         "advanced_debug",
@@ -186,8 +189,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("expat")
     depends_on("eigen@3:")
     depends_on("freetype")
-    # depends_on('hdf5+mpi', when='+mpi')
-    # depends_on('hdf5~mpi', when='~mpi')
+    depends_on("gdal@3.5.1", when="+gdal")
     depends_on("hdf5+hl+mpi", when="+hdf5+mpi")
     depends_on("hdf5+hl~mpi", when="+hdf5~mpi")
     depends_on("hdf5@1.10:", when="+hdf5 @5.10:")
@@ -610,5 +612,38 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         if "+libcatalyst" in spec:
             cmake_args.append("-DVTK_MODULE_ENABLE_ParaView_InSitu=YES")
             cmake_args.append("-DPARAVIEW_ENABLE_CATALYST=YES")
+
+        if "+gdal" in spec:
+            cmake_args.extend(
+                [
+                    self.define("PARAVIEW_ENABLE_GDAL", "YES"),
+                ]
+            )
+            # SMTK needs geovis to enable gdal
+            if "+smtk_extensions" in spec:
+                cmake_args.extend(
+                    [
+                        self.define("VTK_MODULE_ENABLE_VTK_GeovisCore", "YES"),
+                    ]
+                )
+
+        if "+smtk_extensions" in spec:
+            cmake_args.extend(
+                [
+                    self.define("VTK_MODULE_ENABLE_VTK_ViewsInfovis", "YES"),
+                    self.define("VTK_MODULE_ENABLE_VTK_RenderingGL2PSOpenGL2", "YES"),
+                    self.define("VTK_MODULE_ENABLE_VTK_DomainsChemistryOpenGL2", "YES"),
+                    self.define("PARAVIEW_BUILD_LEGACY_REMOVE", "OFF"),
+                    self.define("PARAVIEW_UNIFIED_INSTALL_TREE", "OFF"),
+                ]
+            )
+
+        if "+visitbridge" in spec:
+            cmake_args.extend(
+                [
+                    self.define("PARAVIEW_ENABLE_VISITBRIDGE", "ON"),
+                    self.define("VISIT_BUILD_READER_Silo", "ON"),
+                ]
+            )
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -86,7 +86,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant("gdal", default=False, description="Enable GDAL support")
     variant("smtk_extensions", default=False, description="Enable components required by CMB/SMTK")
-    variant("visitbridge", default=False, description="Enable VisItBridge Support")
 
     variant(
         "advanced_debug",
@@ -394,8 +393,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES:BOOL=%s" % includes,
             "-DBUILD_TESTING:BOOL=OFF",
             "-DOpenGL_GL_PREFERENCE:STRING=LEGACY",
-            self.define_from_variant("PARAVIEW_ENABLE_VISITBRIDGE", "visitbridge"),
-            self.define_from_variant("VISIT_BUILD_READER_Silo", "visitbridge"),
         ]
 
         if spec.satisfies("@5.11:"):

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -19,8 +19,21 @@ class Pegtl(CMakePackage):
     git = "https://github.com/taocpp/PEGTL.git"
 
     version("master", branch="master")
-    version("3.2.0", sha256="91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56")
-    version("2.8.3", sha256="370afd0fbe6d73c448a33c10fbe4a7254f92077f5a217317d0a32a9231293015")
+    version(
+        "3.2.0",
+        sha256="91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56",
+        preferred=True,
+    )
+    version(
+        "2.8.3",
+        sha256="370afd0fbe6d73c448a33c10fbe4a7254f92077f5a217317d0a32a9231293015",
+        preferred=True,
+    )
+    version(
+        "2.7.1",
+        sha256="98f61699a3a4b83a787e9176c6ef340500f5b1a8c930fb024ae49f8b9e1394b6",
+        preferred=True,
+    )
     version("2.1.4", sha256="d990dccc07b4d9ba548326d11c5c5e34fa88b34fe113cb5377da03dda29f23f2")
     version("2.0.0", sha256="5aae0505077e051cae4d855c38049cc6cf71103a6cc8d0ddef01a576e8a60cc0")
 
@@ -30,7 +43,7 @@ class Pegtl(CMakePackage):
     # Ref: https://bugs.gentoo.org/733678
     patch_url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/pegtl/files/pegtl-2.8.3-gcc-10.patch"
     patch_checksum = "fc40b0c7390f8c0473f2cb4821bda7a5e107f93ca9d2fafeff2065445bb39981"
-    patch(patch_url, sha256=patch_checksum, level=0, when="@2.1.4:2.8.3")
+    patch(patch_url, sha256=patch_checksum, when="@2.1.4:2.8.3")
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/smtk-occt-session/package.py
+++ b/var/spack/repos/builtin/packages/smtk-occt-session/package.py
@@ -5,24 +5,6 @@
 
 from spack.package import *
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install smtk-occt-session
-#
-# You can edit this file again by typing:
-#
-#     spack edit smtk-occt-session
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-from spack.package import *
-
 
 class SmtkOcctSession(CMakePackage):
     """SMTK Plugin for working with Models using OpenCascade"""

--- a/var/spack/repos/builtin/packages/smtk-occt-session/package.py
+++ b/var/spack/repos/builtin/packages/smtk-occt-session/package.py
@@ -1,0 +1,63 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install smtk-occt-session
+#
+# You can edit this file again by typing:
+#
+#     spack edit smtk-occt-session
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+from spack.package import *
+
+
+class SmtkOcctSession(CMakePackage):
+    """SMTK Plugin for working with Models using OpenCascade"""
+
+    homepage = "https://www.computationalmodelbuilder.org/"
+    url = "https://gitlab.kitware.com/cmb/plugins/opencascade-session"
+    git = "https://gitlab.kitware.com/cmb/plugins/opencascade-session.git"
+
+    maintainers = ["kwryankrattiger"]
+
+    # Versions
+    version("master", branch="master", submodules=False)
+    version("2022.08.11", commit="797488203e073b3fccc0cdf038c11e1f347ab858", submodules=False)
+
+    # Variants
+    variant("enable_by_default", default=False, description="Enable plugin by default")
+    variant("testing", default=False, description="Enable testing")
+
+    # Dependencies
+    depends_on("smtk")
+    depends_on("opencascade@7.4.0p1")
+    depends_on("boost +filesystem")
+    depends_on("nlohmann-json")
+
+    # Cannot have VTK and ParaView in the same stack
+    depends_on("opencascade ~vtk", when="^smtk +paraview")
+
+    def setup_run_environment(self, env):
+        if "smtk +paraview" in self.spec and "+enable_by_default" in self.spec:
+            for config_file in find(self.prefix, "smtk.opencascadesession.xml"):
+                env.prepend_path("PV_PLUGIN_CONFIG_FILE", config_file)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("OPENCASCADE_ENABLE_TESTING", "testing"),
+            self.define("OCCT_DIR", self.spec["opencascade"].prefix),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
+++ b/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
@@ -5,24 +5,6 @@
 
 from spack.package import *
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install smtk-rgg-session
-#
-# You can edit this file again by typing:
-#
-#     spack edit smtk-rgg-session
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-from spack.package import *
-
 
 class SmtkRggSession(CMakePackage):
     """FIXME: Put a proper description of your package here."""
@@ -52,7 +34,7 @@ class SmtkRggSession(CMakePackage):
     depends_on("python@3:", when="+python")
 
     def setup_run_environment(self, env):
-        if "smtk +paraview" in self.spec and "+enable_by_default" in self.spec:
+        if "+enable_by_default" in self.spec:
             for config_file in find(self.prefix, "smtk.rggsession.xml"):
                 env.prepend_path("PV_PLUGIN_CONFIG_FILE", config_file)
 

--- a/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
+++ b/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
@@ -1,0 +1,64 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install smtk-rgg-session
+#
+# You can edit this file again by typing:
+#
+#     spack edit smtk-rgg-session
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+from spack.package import *
+
+
+class SmtkRggSession(CMakePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.computationalmodelbuilder.org/"
+    url = "https://gitlab.kitware.com/cmb/plugins/rgg-session"
+    git = "https://gitlab.kitware.com/cmb/plugins/rgg-session.git"
+
+    maintainers = ["kwryankrattiger"]
+    tags = ["cmb"]
+
+    # Versions
+    version("master", branch="master", submodules=False)
+    version("2022.05.30", commit="f5ad1999323a9dd83ce5b3ee81dd3f9913d813dd", submodules=False)
+
+    # Variants
+    variant("python", default=True, description="Enable python wrappings")
+    variant("enable_by_default", default=False, description="Enable plugin by default")
+
+    # Dependencies
+    depends_on("smtk +paraview +qt")
+    depends_on("boost@1.64.0 +filesystem")
+    depends_on("qt +gui")
+
+    extends("python", when="+python")
+    depends_on("python@3:", when="+python")
+
+    def setup_run_environment(self, env):
+        if "smtk +paraview" in self.spec and "+enable_by_default" in self.spec:
+            for config_file in find(self.prefix, "smtk.rggsession.xml"):
+                env.prepend_path("PV_PLUGIN_CONFIG_FILE", config_file)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("RGG_ENABLE_PYTHON_WRAPPING", "python"),
+            self.define_from_variant("ENABLE_PLUGIN_BY_DEFAULT", "enable_by_default"),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
+++ b/var/spack/repos/builtin/packages/smtk-rgg-session/package.py
@@ -7,9 +7,8 @@ from spack.package import *
 
 
 class SmtkRggSession(CMakePackage):
-    """FIXME: Put a proper description of your package here."""
+    """SMTK Plugin for working with RGG Reactor Models"""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://www.computationalmodelbuilder.org/"
     url = "https://gitlab.kitware.com/cmb/plugins/rgg-session"
     git = "https://gitlab.kitware.com/cmb/plugins/rgg-session.git"
@@ -27,7 +26,7 @@ class SmtkRggSession(CMakePackage):
 
     # Dependencies
     depends_on("smtk +paraview +qt")
-    depends_on("boost@1.64.0 +filesystem")
+    depends_on("boost@1.64: +filesystem")
     depends_on("qt +gui")
 
     extends("python", when="+python")

--- a/var/spack/repos/builtin/packages/smtk/package.py
+++ b/var/spack/repos/builtin/packages/smtk/package.py
@@ -1,0 +1,170 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.We've put "FIXME"
+# next to all the things you 'll want to change. Once you' ve handled
+# them, you can save this file and test your package like this:
+#
+# spack install smtk
+#
+# You can edit this file again by typing:
+#
+# spack edit smtk
+#
+# See the Spack documentation for more information on packaging.
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+from spack.package import *
+
+
+class Smtk(CMakePackage):
+    """SMTK is an open-source, multi-platform Simulation Modeling
+    Toolkit. This package includes libraries and plugins for
+    working with CAD and other types of models used in simulation
+    set up.
+    """
+
+    homepage = "https://www.computationalmodelbuilder.org/"
+    url = "https://gitlab.kitware.com/cmb/smtk"
+    git = "https://gitlab.kitware.com/cmb/smtk.git"
+
+    maintainers = ["kwryankrattiger"]
+    tags = ["cmb"]
+
+    version("master", branch="master", submodules=True)
+
+    releases = [
+        "22.08.0",
+        "22.07.00",
+        "22.05.0",
+        "22.04.0",
+        "22.02.0",
+        "21.12.0",
+        "21.11.0",
+        "21.10.0",
+        "21.09.0",
+        "21.07.0",
+        "21.05.0",
+        "21.04.0",
+    ]
+
+    for ver in releases:
+        version(ver, branch="v{0}".format(ver), submodules=True)
+
+    variant("shared", default=True, description="Build using shared libraries.")
+    variant("paraview", default=True, description="Enable ParaView extensions.")
+    variant("vtk", default=False, description="Enable VTK extensions.")
+    variant("gdal", default=False, description="Enable GDal extensions.")
+    variant("python", default=True, description="Enable Python wrappings.")
+    variant("qt", default=True, description="Enable Qt extensions", when="+paraview")
+    variant("doc", default=False, description="Build documentation")
+
+    boost_libraries = [
+        "+atomic",
+        "+chrono",
+        "+date_time",
+        "+filesystem",
+        "+iostreams",
+        "+log",
+        "+program_options",
+        "+serialization",
+        "+system",
+        "+thread",
+        "+timer",
+    ]
+    with when("%gcc@:4.9"):
+        boost_libraries.append("+regex")
+    depends_on("boost@1.64: " + " ".join(boost_libraries))
+    depends_on("eigen")
+    depends_on("hdf5")
+    depends_on("libarchive")
+    depends_on("moab ~mpi ~parmetis")
+    depends_on("netcdf-c")
+    depends_on("nlohmann-json")
+    depends_on("pegtl@2:2.7.1")
+
+    depends_on("gdal@3.5.1", when="+gdal")
+
+    depends_on("paraview +smtk_extensions +visitbridge ~mpi build_edition=canonical", when="+paraview")
+    depends_on("paraview +qt", when="+paraview +qt")
+    depends_on("paraview ~qt", when="+paraview ~qt")
+    depends_on("paraview +gdal", when="+paraview +gdal")
+    depends_on("paraview ~gdal", when="+paraview ~gdal")
+    depends_on("paraview +python3", when="+paraview +python")
+    depends_on("paraview ~python3", when="+paraview ~python")
+    depends_on("paraview +shared", when="+paraview +shared")
+    depends_on("paraview ~shared", when="+paraview ~shared")
+    depends_on("paraview@5.9", when="@21:21.09")
+    depends_on("paraview@5.10", when="@21.10:22.02")
+    depends_on("paraview@5.11", when="@22.04:")
+
+    extends("python", when="+python")
+    depends_on("python@3.6:", when="+python")
+    depends_on("py-pybind11", when="+python")
+    depends_on("py-matplotlib", when="+python")
+
+    depends_on("py-sphinx", type="build", when="+doc")
+    depends_on("doxygen", type="build", when="+doc")
+
+    depends_on("qt@5:", when="+qt")
+
+    depends_on("vtk@9:", when="+vtk ~paraview")
+
+    # Conflicts
+    conflicts("+paraview", when="~vtk", msg="SMTK with ParaView support implies VTK support")
+
+    # Patches
+    patch("smtk-common-boost-regex.patch", when="@:22.08")
+
+    def cmake_args(self):
+        spec = self.spec
+
+        cmake_args = [
+            self.define("SMTK_UNIFIED_INSTALL_TREE", True),
+            self.define("SMTK_RELOCATABLE_INSTALL", False),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", False),
+            self.define("SMTK_ENABLE_OPERATION_THREADS", False),
+            # Set CMAKE_INSTALL_LIBDIR to "lib" for to
+            # override OS - specific libdirs that GNUInstallDirs.cmake would otherwise
+            # set.
+            self.define("CMAKE_INSTALL_LIBDIR", "lib"),
+            self.define("SMTK_RELOCATABLE_INSTALL", True),
+            self.define("BUILD_TESTING", False),
+            self.define("SMTK_ENABLE_APPLICATIONS", False),
+            self.define("SMTK_ENABLE_TESTING", False),
+            self.define_from_variant("SMTK_ENABLE_GDAL_SUPPORT", "gdal"),
+            self.define_from_variant("SMTK_ENABLE_QT_SUPPORT", "qt"),
+            self.define("SMTK_QT_VERSION", "5"),
+            self.define_from_variant("SMTK_ENABLE_PARAVIEW_SUPPORT", "paraview"),
+            self.define_from_variant("SMTK_ENABLE_EXODUS_SESSION", "paraview"),
+            self.define_from_variant("SMTK_ENABLE_PYTHON_WRAPPING", "python"),
+            self.define_from_variant("SMTK_ENABLE_MATPLOTLIB", "python"),
+            self.define("SMTK_USE_PYBIND11", "python"),
+            self.define("PYBIND11_INSTALL", "python"),
+            self.define("SMTK_PYTHON_VERSION", "3"),
+            self.define("SMTK_ENABLE_PROJECT_UI", True),
+            self.define("SMTK_USE_SYSTEM_MOAB", True),
+            # This should be off by default because vtkCmbMoabReader in discrete
+            # session may only be needed for debugging purpose
+            self.define("SMTK_ENABLE_MOAB_DISCRETE_READER", False),
+        ]
+
+        if "+paraview" in spec or "+vtk" in spec:
+            cmake_args.append(self.define("SMTK_ENABLE_VTK_SUPPORT", True))
+
+        if "+doc" in spec:
+            cmake_args.append(self.define("SMTK_BUILD_DOCUMENTATION", "always"))
+        else:
+            cmake_args.append(self.define("SMTK_BUILD_DOCUMENTATION", "never"))
+
+        return cmake_args
+
+    # def install_plugins(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/smtk/package.py
+++ b/var/spack/repos/builtin/packages/smtk/package.py
@@ -5,24 +5,6 @@
 
 from spack.package import *
 
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.We've put "FIXME"
-# next to all the things you 'll want to change. Once you' ve handled
-# them, you can save this file and test your package like this:
-#
-# spack install smtk
-#
-# You can edit this file again by typing:
-#
-# spack edit smtk
-#
-# See the Spack documentation for more information on packaging.
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-from spack.package import *
-
 
 class Smtk(CMakePackage):
     """SMTK is an open-source, multi-platform Simulation Modeling
@@ -92,7 +74,9 @@ class Smtk(CMakePackage):
 
     depends_on("gdal@3.5.1", when="+gdal")
 
-    depends_on("paraview +smtk_extensions +visitbridge ~mpi build_edition=canonical", when="+paraview")
+    depends_on(
+        "paraview +smtk_extensions +visitbridge ~mpi build_edition=canonical", when="+paraview"
+    )
     depends_on("paraview +qt", when="+paraview +qt")
     depends_on("paraview ~qt", when="+paraview ~qt")
     depends_on("paraview +gdal", when="+paraview +gdal")

--- a/var/spack/repos/builtin/packages/smtk/smtk-common-boost-regex.patch
+++ b/var/spack/repos/builtin/packages/smtk/smtk-common-boost-regex.patch
@@ -1,0 +1,12 @@
+diff --git a/smtk/attribute/FileItemDefinition.cxx b/smtk/attribute/FileItemDefinition.cxx
+index 32ca22a7d..ff0cd19b0 100644
+--- a/smtk/attribute/FileItemDefinition.cxx
++++ b/smtk/attribute/FileItemDefinition.cxx
+@@ -17,7 +17,6 @@
+ // We use either STL regex or Boost regex, depending on support. These flags
+ // correspond to the equivalent logic used to determine the inclusion of Boost's
+ // regex library.
+-#define USE_BOOST_REGEX
+ #if !defined(USE_BOOST_REGEX) &&                                                                   \
+   (defined(SMTK_CLANG) ||                                                                          \
+    (defined(SMTK_GCC) && __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)) ||                \


### PR DESCRIPTION
@mathstuf @vicentebolea

I am adding packages for CMB/SMTK and had to extend the ParaView recipe to include visitbridge and some other stuff for smtk to be happy.

I think I may want to make `SMTKPlugin` package that adds the `enable_by_default` option and handles adding them to the `PV_PLUGIN_CONFIG_FILE`

This should also resolve #32493 , although I may make that a separate PR.