### PR TITLE
octave: fix missing include <ctime>

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -107,6 +107,13 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     depends_on("suite-sparse", when="+suitesparse")
     depends_on("zlib", when="+zlib")
 
+    # to fix https://savannah.gnu.org/bugs/?62750
+    patch(
+        "https://hg.savannah.gnu.org/hgweb/octave/raw-rev/8245e773bb5b",
+        sha256="ae786fe9177066c41d414a93009f6769296e63a5d34f407f55bb71344d02f803",
+        when="@7.1.0",
+    )
+
     def patch(self):
         # Filter mkoctfile.in.cc to use underlying compilers and not
         # Spack compiler wrappers. We are patching the template file


### PR DESCRIPTION
I could not install octave due to [this bug](https://savannah.gnu.org/bugs/?62750).

This PR adds the patch to fix it.