### PR TITLE
Windows: fix bootstrap and package install failure

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -91,6 +91,14 @@ def _try_import_from_store(module, query_spec, query_info=None):
             os.path.join(candidate_spec.prefix, pkg.platlib),
         ]  # type: list[str]
         path_before = list(sys.path)
+
+        # Python 3.8+ on Windows does not search dependent DLLs in PATH,
+        # so we need to manually add it using os.add_dll_directory
+        # https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+        if sys.version_info[:2] >= (3, 8) and sys.platform == "win32":
+            if os.path.isdir(candidate_spec.prefix.bin):
+                os.add_dll_directory(candidate_spec.prefix.bin)  # novermin
+
         # NOTE: try module_paths first and last, last allows an existing version in path
         # to be picked up and used, possibly depending on something in the store, first
         # allows the bootstrap version to work when an incompatible version is in

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 
 from six import string_types, text_type
+from six.moves import shlex_quote
 
 import llnl.util.tty as tty
 
@@ -333,7 +334,7 @@ def which(*args, **kwargs):
         Executable: The first executable that is found in the path
     """
     exe = which_string(*args, **kwargs)
-    return Executable(exe) if exe else None
+    return Executable(shlex_quote(exe)) if exe else None
 
 
 class ProcessError(spack.error.SpackError):

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -64,6 +64,8 @@ class Clingo(CMakePackage):
         depends_on("py-cffi", type=("build", "run"), when="@5.5.0: platform=cray")
 
     patch("python38.patch", when="@5.3:5.4.0")
+    patch("size-t.patch", when="platform=windows")
+    patch("vs2022.patch", when="%msvc@19.30:")
 
     def patch(self):
         # Doxygen is optional but can't be disabled with a -D, so patch

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -64,7 +64,7 @@ class Clingo(CMakePackage):
         depends_on("py-cffi", type=("build", "run"), when="@5.5.0: platform=cray")
 
     patch("python38.patch", when="@5.3:5.4.0")
-    patch("size-t.patch", when="platform=windows")
+    patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/clingo/size-t.patch
+++ b/var/spack/repos/builtin/packages/clingo/size-t.patch
@@ -1,0 +1,22 @@
+diff --git a/libpyclingo/pyclingo.cc b/libpyclingo/pyclingo.cc
+index ec4a33c..88b6669 100644
+--- a/libpyclingo/pyclingo.cc
++++ b/libpyclingo/pyclingo.cc
+@@ -116,7 +116,7 @@ struct ObjectProtocoll {
+     Object call(char const *name, Args &&... args);
+     template <class... Args>
+     Object operator()(Args &&... args);
+-    ssize_t size();
++    Py_ssize_t size();
+     bool empty() { return size() == 0; }
+     Object getItem(Reference o);
+     Object getItem(char const *key);
+@@ -232,7 +232,7 @@ Object ObjectProtocoll<T>::operator()(Args &&... args) {
+     return PyObject_CallFunctionObjArgs(toPy_(), Reference(args).toPy()..., nullptr);
+ }
+ template <class T>
+-ssize_t ObjectProtocoll<T>::size() {
++Py_ssize_t ObjectProtocoll<T>::size() {
+     auto ret = PyObject_Size(toPy_());
+     if (PyErr_Occurred()) { throw PyException(); }
+     return ret;

--- a/var/spack/repos/builtin/packages/clingo/vs2022.patch
+++ b/var/spack/repos/builtin/packages/clingo/vs2022.patch
@@ -1,0 +1,18 @@
+diff --git a/libpyclingo/pyclingo.cc b/libpyclingo/pyclingo.cc
+index 88b6669..58e73bd 100644
+--- a/libpyclingo/pyclingo.cc
++++ b/libpyclingo/pyclingo.cc
+@@ -25,6 +25,13 @@
+ // NOTE: the python header has a linker pragma to link with python_d.lib
+ //       when _DEBUG is set which is not part of official python releases
+ #if defined(_MSC_VER) && defined(_DEBUG) && !defined(CLINGO_UNDEF__DEBUG)
++// Workaround for a VS 2022 issue.
++// NOTE: This workaround knowingly violates the Python.h include order requirement:
++// https://docs.python.org/3/c-api/intro.html#include-files
++#   include <yvals.h>
++# if _MSVC_STL_VERSION >= 143
++#   include <crtdefs.h>
++# endif
+ #undef _DEBUG
+ #include <Python.h>
+ #define _DEBUG


### PR DESCRIPTION
After #32905 is merged, I will make this PR ready.

This PR fixes various bugs on Windows:

- Building `clingo@spack` fails on Windows if using VS2022 and maybe also older MSVC versions. It's because
  - `ssize_t` is not defined in MSVC.
  - `#undef _DEBUG` in pybind's `Python.h` makes it fails to compile on VS2022. https://github.com/pybind/pybind11/pull/3497 https://github.com/KiruyaMomochi/clingo/pull/1
- Python 3.8+ on Windows does not search dependent DLLs in PATH leading `clingo` fails to import. We nend to manually add it using `os.add_dll_directory()`.
  - DLL search path in 3.8+ is limited. https://github.com/python/cpython/issues/87339
  - Since https://github.com/spack/spack/pull/31930 is merged, maybe a prettier way to do it is to symlink `<clingo-prefix>/bin/clingo.dll` to `<clingo-prefix>/Lib/site-packages/`?
- The command returned by `which` should be quoted on Windows. Otherwise, it may work, but not always.
  1. Python use `CreateProcess` API to create subprocess on Windows[^1], which tries to search `C:\Program` first, and then `C:\Program Files` if that fails.[^2]
  2. If `C:\Program` doesn't exist, it *looks* like it works, but if someone has a file or directory at `C:\Program`, everything will break.   
    <img width="587" alt="image" src="https://user-images.githubusercontent.com/65301509/193431165-c94e8fda-2e0b-4aae-bce6-05083289c785.png">
    <img width="564" alt="image" src="https://user-images.githubusercontent.com/65301509/193431168-1c7c73a2-dea7-412a-b7b0-6fcb19ec3d21.png">

[^1]: https://docs.python.org/3/library/subprocess.html#popen-constructor
[^2]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
