### PR TITLE
`find`/`list`: display package counts last

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -203,7 +203,16 @@ def setup_env(env):
     return decorator, added, roots, removed
 
 
-def display_env(env, args, decorator):
+def display_env(env, args, decorator, results):
+    """Display extra find output when running in an environment.
+
+    Find in an environment outputs 2 or 3 sections:
+
+    1. Root specs
+    2. Concretized roots (if asked for with -c)
+    3. Installed specs
+
+    """
     tty.msg("In environment %s" % env.name)
 
     if not env.user_specs:
@@ -233,6 +242,12 @@ def display_env(env, args, decorator):
         tty.msg("Concretized roots")
         cmd.display_specs(env.specs_by_hash.values(), args, decorator=decorator)
         print()
+
+    # Display a header for the installed packages section IF there are installed
+    # packages. If there aren't any, we'll just end up printing "0 installed packages"
+    # later.
+    if results:
+        tty.msg("Installed packages")
 
 
 def find(parser, args):
@@ -286,10 +301,11 @@ def _find(parser, args):
     else:
         if not args.format:
             if env:
-                display_env(env, args, decorator)
+                display_env(env, args, decorator, results)
 
+        cmd.display_specs(results, args, decorator=decorator, all_headers=True)
+
+        # print number of installed packages last (as the list may be long)
         if sys.stdout.isatty() and args.groups:
             pkg_type = "loaded" if args.loaded else "installed"
             spack.cmd.print_how_many_pkgs(results, pkg_type)
-
-        cmd.display_specs(results, args, decorator=decorator, all_headers=True)

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -122,9 +122,9 @@ def filter_by_name(pkgs, args):
 @formatter
 def name_only(pkgs, out):
     indent = 0
-    if out.isatty():
-        tty.msg("%d packages." % len(pkgs))
     colify(pkgs, indent=indent, output=out)
+    if out.isatty():
+        tty.msg("%d packages" % len(pkgs))
 
 
 def github_url(pkg):

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+from textwrap import dedent
 
 import pytest
 
@@ -126,6 +127,19 @@ def test_namespaces_shown_correctly(database):
 
     out = find("--namespace")
     assert "builtin.mock.zmpi" in out
+
+
+@pytest.mark.db
+def test_find_cli_output_format(database, mock_tty_stdout):
+    out = find("zmpi")
+    assert out.endswith(
+        dedent(
+            """\
+    zmpi@1.0
+    ==> 1 installed package
+    """
+        )
+    )
 
 
 def _check_json_output(spec_list):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from textwrap import dedent
+
 from spack.main import SpackCommand
 
 list = SpackCommand("list")
@@ -12,6 +14,16 @@ def test_list():
     output = list()
     assert "cloverleaf3d" in output
     assert "hdf5" in output
+
+
+def test_list_cli_output_format(mock_tty_stdout):
+    out = list("mpileaks")
+    assert out == dedent(
+        """\
+    mpileaks
+    ==> 1 packages
+    """
+    )
 
 
 def test_list_filter(mock_packages):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1764,3 +1764,8 @@ def mock_spider_configs(mock_config_data, monkeypatch):
     monkeypatch.setattr(spack.util.web, "spider", _spider)
 
     yield
+
+
+@pytest.fixture(scope="function")
+def mock_tty_stdout(monkeypatch):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)


### PR DESCRIPTION
We have over 6,600 packages now, and `spack list` still displays the number of packages before it lists them all. This is useless for large sets of results (e.g., with no args) as the number has scrolled way off the screen before you can see it. The same is true for `spack find` with large installations.

This PR changes `spack find` and `spack list` so that they display the package count last.

## `spack list`
Before:

```console
> spack list hdf
==> 17 packages
hdf       hdf5          hdf5-vol-async                 hdf5-vol-log  r-hdf5array  r-rhdf5filters
hdf-eos2  hdf5-blosc    hdf5-vol-cache                 hdfview       r-hdf5r      r-rhdf5lib
hdf-eos5  hdf5-vfd-gds  hdf5-vol-external-passthrough  py-hdfs       r-rhdf5
```

After:

```console
> spack list hdf
hdf       hdf5          hdf5-vol-async                 hdf5-vol-log  r-hdf5array  r-rhdf5filters
hdf-eos2  hdf5-blosc    hdf5-vol-cache                 hdfview       r-hdf5r      r-rhdf5lib
hdf-eos5  hdf5-vfd-gds  hdf5-vol-external-passthrough  py-hdfs       r-rhdf5
==> 17 packages
```

## `spack find`

Before:
```console
> spack find -x
==> 35 installed packages
-- darwin-bigsur-skylake / apple-clang@12.0.5 -------------------
berkeley-db@18.1.40  coreutils@8.32  git@2.31.1       python@3.8.11  zlib@1.2.11
clingo@5.5.0         diffutils@3.8   graphviz@2.47.2  python@3.8.11
cmake@3.21.1         emacs@27.2      py-pip@21.1.2    sqlite@3.35.5

-- darwin-bigsur-skylake / apple-clang@13.0.0 -------------------
zlib@1.2.12

-- darwin-monterey-m1 / apple-clang@13.1.6 ----------------------
clingo@5.5.2   emacs@28.1   graphviz@2.49.0      py-pandas@1.4.3     py-pytest@6.2.5
cloc@1.90      gcc@11.3.0   py-black@21.12b0     py-pip@22.1.2       python@3.9.13
cmake@3.23.3   git@2.37.0   py-matplotlib@3.5.3  py-pygithub@1.55    sqlite@3.38.5
coreutils@9.1  gnupg@2.3.7  py-numpy@1.23.2      py-pygments@2.13.0

-- test-debian6-core2 / gcc@4.5.0 -------------------------------
c@1.0  c@1.0
```

After:
```console
> spack find -x
-- darwin-bigsur-skylake / apple-clang@12.0.5 -------------------
berkeley-db@18.1.40  coreutils@8.32  git@2.31.1       python@3.8.11  zlib@1.2.11
clingo@5.5.0         diffutils@3.8   graphviz@2.47.2  python@3.8.11
cmake@3.21.1         emacs@27.2      py-pip@21.1.2    sqlite@3.35.5

-- darwin-bigsur-skylake / apple-clang@13.0.0 -------------------
zlib@1.2.12

-- darwin-monterey-m1 / apple-clang@13.1.6 ----------------------
clingo@5.5.2   emacs@28.1   graphviz@2.49.0      py-pandas@1.4.3     py-pytest@6.2.5
cloc@1.90      gcc@11.3.0   py-black@21.12b0     py-pip@22.1.2       python@3.9.13
cmake@3.23.3   git@2.37.0   py-matplotlib@3.5.3  py-pygithub@1.55    sqlite@3.38.5
coreutils@9.1  gnupg@2.3.7  py-numpy@1.23.2      py-pygments@2.13.0

-- test-debian6-core2 / gcc@4.5.0 -------------------------------
c@1.0  c@1.0
==> 35 installed packages
```

## `spack find` in an environment
Before: 

```console
> spack -e default find tar
==> In environment default
==> Root specs
clingo  coreutils  git       py-black@:21.12b0  py-pandas    py-pygments  sqlite
cloc    emacs      gnupg     py-matplotlib      py-pip       py-pytest
cmake   gcc        graphviz  py-numpy           py-pygithub  python

==> 1 installed package
-- darwin-monterey-m1 / apple-clang@13.1.6 ----------------------
tar@1.34
```

After:
```console
> spack -e default find tar
==> In environment default
==> Root specs
clingo  coreutils  git       py-black@:21.12b0  py-pandas    py-pygments  sqlite
cloc    emacs      gnupg     py-matplotlib      py-pip       py-pytest
cmake   gcc        graphviz  py-numpy           py-pygithub  python

==> Installed packages
-- darwin-monterey-m1 / apple-clang@13.1.6 ----------------------
tar@1.34
==> 1 installed package
```

## `spack find` in an empty environment

Before and after are the same:
```console
> spack -e empty find
==> In environment x
==> No root specs
==> 0 installed packages
```