### PR TITLE
remove x86_64 option from intel compiler

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -82,13 +82,6 @@
             "flags": "-march={name} -mtune=generic"
           }
         ],
-        "intel": [
-          {
-            "versions": ":",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic"
-          }
-        ],
         "oneapi": [
           {
             "versions": ":",


### PR DESCRIPTION
`x86-64` is nowhere in [the intel classic compiler manual section on the `march` flag](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/code-generation-options/march.html). 

```
/modules/spack-0.18.1/lib/spack/env/intel/icc -fPIC -O2 -D_LARGEFILE64_SOURCE=1  -c -o adler32.o adler32.c
icc: command line warning #10148: option '-march=x86-64' not supported
```
The compiler above was supposed to be my `intel-oneapi-compilers` package, I'm assuming that `lib/spack/env/intel/icc` is some kind of wrapper script.
the modules I made like this (according to the manual) actually got compiled for a Pentium 4.

This should definitely be fact checked on a system that isn't mine.