### PR TITLE
Remove CMakePackage.define alias from most packages

### DIFF
--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -60,7 +60,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
             env.append_flags("CXXFLAGS", "-no-ipo")
 
     def cmake_args(self):
-        define = CMakePackage.define
+        define = self.define
 
         vs = [
             "mpi",

--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -29,7 +29,7 @@ class FrontistrBase(CMakePackage):
     depends_on("trilinos@:12.18.1")
 
     def cmake_args(self):
-        define = CMakePackage.define
+        define = self.define
         cmake_args = [
             define("WITH_ML", True),
             define("REFINER_INCLUDE_PATH", self.spec["revocap-refiner"].prefix.include),

--- a/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
@@ -31,7 +31,7 @@ class FujitsuFrontistr(FrontistrBase):
         return url.format(version)
 
     def cmake_args(self):
-        define = CMakePackage.define
+        define = self.define
         args = super(FujitsuFrontistr, self).cmake_args()
         if self.spec.satisfies("%fj"):
             args.extend(

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -65,26 +65,23 @@ class Itk(CMakePackage):
     depends_on("zlib")
 
     def cmake_args(self):
-        force = CMakePackage.define
-        from_variant = self.define_from_variant
         use_mkl = "^mkl" in self.spec
-
         args = [
-            force("BUILD_SHARED_LIBS", True),
-            force("ITK_USE_SYSTEM_LIBRARIES", True),
-            force("ITK_USE_MKL", use_mkl),
-            from_variant("Module_ITKReview", "review"),
-            from_variant("Module_RTK", "rtk"),
-            from_variant("Module_ITKIOMINC", "minc"),
-            from_variant("Module_ITKIOTransformMINC", "minc"),
+            self.define("BUILD_SHARED_LIBS", True),
+            self.define("ITK_USE_SYSTEM_LIBRARIES", True),
+            self.define("ITK_USE_MKL", use_mkl),
+            self.define_from_variant("Module_ITKReview", "review"),
+            self.define_from_variant("Module_RTK", "rtk"),
+            self.define_from_variant("Module_ITKIOMINC", "minc"),
+            self.define_from_variant("Module_ITKIOTransformMINC", "minc"),
         ]
 
         if not use_mkl:
             args.extend(
                 [
-                    force("USE_FFTWD", True),
-                    force("USE_FFTWF", True),
-                    force("USE_SYSTEM_FFTW", True),
+                    self.define("USE_FFTWD", True),
+                    self.define("USE_FFTWF", True),
+                    self.define("USE_SYSTEM_FFTW", True),
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/libproxy/package.py
+++ b/var/spack/repos/builtin/packages/libproxy/package.py
@@ -28,11 +28,10 @@ class Libproxy(CMakePackage):
     depends_on("python@:3.6", type=("build", "run"), when="@:0.4.15 +python")
 
     def cmake_args(self):
-        from_variant = self.define_from_variant
         return [
-            from_variant("WITH_PERL", "perl"),
-            from_variant("WITH_PYTHON3", "python"),
-            CMakePackage.define("WITH_DOTNET", False),
-            CMakePackage.define("WITH_PYTHON2", False),
-            CMakePackage.define("WITH_VALA", False),
+            self.define_from_variant("WITH_PERL", "perl"),
+            self.define_from_variant("WITH_PYTHON3", "python"),
+            self.define("WITH_DOTNET", False),
+            self.define("WITH_PYTHON2", False),
+            self.define("WITH_VALA", False),
         ]

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -255,7 +255,7 @@ class LlvmAmdgpu(CMakePackage):
         # bootstraping the libcxx with the just built clang
         if self.spec.satisfies("@4.5.0:"):
             spec = self.spec
-            define = CMakePackage.define
+            define = self.define
             libcxxdir = "build-bootstrapped-libcxx"
             with working_dir(libcxxdir, create=True):
                 cmake_args = [

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -429,7 +429,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
         from_variant = self.define_from_variant
 
         python = spec["python"]
@@ -612,7 +612,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
     @run_after("install")
     def post_install(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
 
         # unnecessary if we build openmp via LLVM_ENABLE_RUNTIMES
         if "+cuda ~omp_as_runtime" in self.spec:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -574,7 +574,7 @@ class Llvm(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
         from_variant = self.define_from_variant
 
         python = spec["python"]

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -751,7 +751,7 @@ class Llvm(CMakePackage, CudaPackage):
     @run_after("install")
     def post_install(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
 
         # unnecessary if we build openmp via LLVM_ENABLE_RUNTIMES
         if "+cuda ~omp_as_runtime" in self.spec:

--- a/var/spack/repos/builtin/packages/mt-metis/package.py
+++ b/var/spack/repos/builtin/packages/mt-metis/package.py
@@ -23,11 +23,10 @@ class MtMetis(CMakePackage):
     variant("shared", default=True, description="Enable build of shared libraries")
 
     def cmake_args(self):
-        define = CMakePackage.define
         cmake_args = [
-            define("DOMLIB_PATH", "domlib"),
-            define("WILDRIVER_PATH", "wildriver"),
-            define("METIS_PATH", "metis"),
+            self.define("DOMLIB_PATH", "domlib"),
+            self.define("WILDRIVER_PATH", "wildriver"),
+            self.define("METIS_PATH", "metis"),
             self.define_from_variant("SHARED", "shared"),
         ]
         return cmake_args

--- a/var/spack/repos/builtin/packages/parmmg/package.py
+++ b/var/spack/repos/builtin/packages/parmmg/package.py
@@ -27,13 +27,12 @@ class Parmmg(CMakePackage):
     variant("pic", default=True, description="Build with position independent code")
 
     def cmake_args(self):
-        define = CMakePackage.define
         args = [
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            define("DOWNLOAD_MMG", False),
-            define("MMG_DIR", self.spec["mmg"].prefix),
-            define("DOWNLOAD_METIS", False),
-            define("METIS_DIR", self.spec["metis"].prefix),
+            self.define("DOWNLOAD_MMG", False),
+            self.define("MMG_DIR", self.spec["mmg"].prefix),
+            self.define("DOWNLOAD_METIS", False),
+            self.define("METIS_DIR", self.spec["metis"].prefix),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -218,7 +218,7 @@ class Phist(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
 
         if spec.satisfies("kernel_lib=builtin") and spec.satisfies("~mpi"):
             raise InstallError("~mpi not possible with kernel_lib=builtin!")

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -161,7 +161,7 @@ class Seacas(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         from_variant = self.define_from_variant
-        define = CMakePackage.define
+        define = self.define
 
         options = []
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -265,7 +265,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
         from_variant = self.define_from_variant
 
         # List of CMake arguments

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -74,7 +74,7 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
         cmake_args = []
 
         def append_define(*args):
-            cmake_args.append(CMakePackage.define(*args))
+            cmake_args.append(self.define(*args))
 
         def append_from_variant(*args):
             cmake_args.append(self.define_from_variant(*args))

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -522,7 +522,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         options = []
 
         spec = self.spec
-        define = CMakePackage.define
+        define = self.define
         define_from_variant = self.define_from_variant
 
         def _make_definer(prefix):

--- a/var/spack/repos/builtin/packages/vite/package.py
+++ b/var/spack/repos/builtin/packages/vite/package.py
@@ -29,13 +29,11 @@ class Vite(CMakePackage):
     variant("otf2", default=False, description="Support for OTF2 trace format")
 
     def cmake_args(self):
-        define = CMakePackage.define
-        from_variant = self.define_from_variant
         args = [
-            define("USE_QT5", True),
-            define("USE_OPENGL", True),
-            define("USE_VBO", False),
-            from_variant("VITE_ENABLE_OTF2", "otf2"),
-            from_variant("VITE_ENABLE_TAU", "tau"),
+            self.define("USE_QT5", True),
+            self.define("USE_OPENGL", True),
+            self.define("USE_VBO", False),
+            self.define_from_variant("VITE_ENABLE_OTF2", "otf2"),
+            self.define_from_variant("VITE_ENABLE_TAU", "tau"),
         ]
         return args


### PR DESCRIPTION
The first 4 commits are extracted from #30738 The last one goes through all the packages that are not reworked in #30738 and removes the alias. This is mainly needed to ensure backward compatibility once #30738 is merged, while it changes no behavior before that, and as such it is safe to merge before.

Modifications:
- [x] Do not alias `CMakePackage.define` in recipes, but use `self.define` instead