### PR TITLE
lmod change family arch dir to arch dir

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -239,7 +239,7 @@ class LmodFileLayout(BaseFileLayout):
         if arch_folder_conf:
             # include an arch specific folder between root and filename
             arch_folder = "-".join(
-                [str(self.spec.platform), str(self.spec.os), str(self.spec.target.family)]
+                [str(self.spec.platform), str(self.spec.os), str(self.spec.target)]
             )
             return os.path.join(self.dirname(), arch_folder)
         return self.dirname()


### PR DESCRIPTION
With lmod I get name conflicts for modules in different architecture because the directory structure is family based.
```
==> Error: Name clashes detected in module files:

file: /modules/spack-0.18.1/share/spack/lmod/linux-ubuntu20.04-x86_64/Core/zlib/1.2.12.lua
spec: zlib@1.2.12%gcc@9.4.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu20.04-x86_64
spec: zlib@1.2.12%gcc@9.4.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu20.04-x86_64_v3
spec: zlib@1.2.12%gcc@9.4.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu20.04-x86_64_v4
```
With this little change it makes directories for each generic architecture.