### PR TITLE
install sources after package install() runs

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1872,10 +1872,14 @@ class BuildProcessInstaller(object):
             if self.fake:
                 _do_fake_install(self.pkg)
             else:
+                self._real_install()
+
+                # Run package's install() method before installing sources. This means package
+                # install scripts that don't expect <prefix>/share to exist yet won't fail. See
+                # https://github.com/spack/spack/pull/32953 for where installing sources first may
+                # cause breakages.
                 if self.install_source:
                     self._install_source()
-
-                self._real_install()
 
             # Stop the timer and save results
             self.timer.stop()

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -185,6 +185,13 @@ def test_install_with_source(mock_packages, mock_archive, mock_fetch, config, in
     )
 
 
+@pytest.mark.regression("32948")
+@pytest.mark.disable_clean_stage_check
+def test_install_source_mkdir(mock_packages, mock_archive, mock_fetch, config, install_mockery):
+    """Verify that a package's install() method is allowed to assume share/ is not yet created."""
+    install("--source", "--keep-stage", "trivial-install-test-package+mkdir-share-dir")
+
+
 def test_install_env_variables(mock_packages, mock_archive, mock_fetch, config, install_mockery):
     spec = Spec("libdwarf")
     spec.concretize()

--- a/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
@@ -12,14 +12,14 @@ class TrivialInstallTestPackage(Package):
     homepage = "http://www.example.com/trivial_install"
     url = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    variant('mkdir-share-dir', default=False)
+    variant("mkdir-share-dir", default=False)
 
     version("1.0", "0123456789abcdef0123456789abcdef")
 
     def install(self, spec, prefix):
         touch(join_path(prefix, "an_installation_file"))
 
-        if '+mkdir-share-dir' in spec:
+        if "+mkdir-share-dir" in spec:
             share = join_path(prefix, "share")
             # mkdir() will fail if <prefix>/share/ already exists, which it will if the package
             # sources were installed (in <prefix>/share/pkg/src) before this install() is run.

--- a/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
@@ -12,7 +12,15 @@ class TrivialInstallTestPackage(Package):
     homepage = "http://www.example.com/trivial_install"
     url = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
+    variant('mkdir-share-dir', default=False)
+
     version("1.0", "0123456789abcdef0123456789abcdef")
 
     def install(self, spec, prefix):
         touch(join_path(prefix, "an_installation_file"))
+
+        if '+mkdir-share-dir' in spec:
+            share = join_path(prefix, "share")
+            # mkdir() will fail if <prefix>/share/ already exists, which it will if the package
+            # sources were installed (in <prefix>/share/pkg/src) before this install() is run.
+            mkdir(share)


### PR DESCRIPTION
### Problem

See the bugfix in #32953. `ca-certificates-mozilla` called `mkdir()` assuming that `<prefix>/share/` would not exist already, which fails if `spack install --source ca-certificates-mozilla` is used, since we currently install package sources into the prefix (at `<prefix>/share/pkg/src/`) *before* installing the package itself. As described in #32948, this means an attempt to install some *different* package with `--source` will fail if any of its transitive deps make the mistake of assuming an empty install prefix in their `install()` method.

### Solution
- Switch installing sources to run *after* the package's `install()` method.
    - `BuildProcessInstaller._install_source()` uses `fs.install_tree()`, which does not break if the target directory exists already.
    - This allows package `install()` methods to use either `mkdir()` or `mkdirp()` without worrying about the implementation detail of when spack installs sources.

### Result
#32948 shouldn't occur for any other packages.