### PR TITLE
omega-h: add v9.34.13

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -24,6 +24,7 @@ class OmegaH(CMakePackage, CudaPackage):
         commit="e88912368e101d940f006019585701a704295ab0",
         git="https://github.com/SCOREC/omega_h.git",
     )
+    version("9.34.13", sha256="2eadfd6d634abc0b50396a82fd446f8f0b586ba6e64788c47827162c2aadec02")
     version("9.34.1", sha256="3a812da3b8df3e0e5d78055e91ad23333761bcd9ed9b2c8c13ee1ba3d702e46c")
     version("9.32.5", sha256="963a203e9117024cd48d829d82b8543cd9133477fdc15386113b594fdc3246d8")
     version("9.29.0", sha256="b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014")


### PR DESCRIPTION
Add new version: `omega-h@9.34.13`.

Hoping this new version will enable us to add `omega-h +cuda` to E4S CI:
* https://github.com/spack/spack/pull/32156

which is currently blocked because of:
* https://github.com/spack/spack/pull/32156#issuecomment-1223079213

@cwsmith @wspear