### PR TITLE
py-pyfr: add v1.15.0, explicitly set env variables for dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -20,7 +20,7 @@ class Libxsmm(MakefilePackage):
 
     maintainers = ["hfp"]
 
-    version("master", branch="master")
+    version("main", branch="main")
     version("1.17", sha256="8b642127880e92e8a75400125307724635ecdf4020ca4481e5efe7640451bb92")
     version("1.16.3", sha256="e491ccadebc5cdcd1fc08b5b4509a0aba4e2c096f53d7880062a66b82a0baf84")
     version("1.16.2", sha256="bdc7554b56b9e0a380fc9c7b4f4394b41be863344858bc633bc9c25835c4c64e")

--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -17,6 +17,7 @@ class PyGimmik(PythonPackage):
 
     maintainers = ["MichaelLaufer"]
 
+    version("3.0", sha256="45c2da7acff3201b7796ba731e4be7f3b4f39469ff1f1bc0ddf4f19c4a6af010")
     version("2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1")
     version("2.2", sha256="9144640f94aab92f9c5dfcaf16885a79428ab97337cf503a4b2dddeb870f3cf0")
 

--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -21,8 +21,8 @@ class PyGimmik(PythonPackage):
     version("2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1")
     version("2.2", sha256="9144640f94aab92f9c5dfcaf16885a79428ab97337cf503a4b2dddeb870f3cf0")
 
-    depends_on("python@3.8", when="@:2.3" type=("build", "run"))
-    depends_on("python@3.9:", when="@3.0:" type=("build", "run"))
+    depends_on("python@3.8", when="@:2.3", type=("build", "run"))
+    depends_on("python@3.9:", when="@3.0:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-mako", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -21,7 +21,8 @@ class PyGimmik(PythonPackage):
     version("2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1")
     version("2.2", sha256="9144640f94aab92f9c5dfcaf16885a79428ab97337cf503a4b2dddeb870f3cf0")
 
-    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.8", when="@:2.3" type=("build", "run"))
+    depends_on("python@3.9:", when="@3.0:" type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-mako", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -7,7 +7,7 @@
 from spack.package import *
 
 
-class PyPyfr(PythonPackage):
+class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     """PyFR is an open-source Python based framework for solving
     advection-diffusion type problems on streaming architectures
     using the Flux Reconstruction approach of Huynh."""
@@ -22,6 +22,10 @@ class PyPyfr(PythonPackage):
     version("master", branch="master")
 
     # pypi releases
+    version(
+        "1.15.0",
+        sha256="6a634b9d32447f45d3c24c9de0ed620a0a0a781be7cc5e57b1c1bf44a4650d8d",
+    )
     version(
         "1.14.0",
         sha256="ebf40ce0896cce9ac802e03fd9430b5be30ea837c31224531a6d5fd68f820766",
@@ -41,8 +45,8 @@ class PyPyfr(PythonPackage):
     # Required dependencies
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-gimmik@2.2:2", type=("build", "run"))
-    depends_on("py-gimmik@2.3:2", when="@1.14.0:", type=("build", "run"))
+    depends_on("py-gimmik@2.3:2", when="@:1.14.0", type=("build", "run"))
+    depends_on("py-gimmik@3:", when="@:1.15.0", type=("build", "run"))
     depends_on("py-h5py@2.10:", type=("build", "run"))
     depends_on("py-mako@1.0.0:", type=("build", "run"))
     depends_on("py-mpi4py@3.1.0:", type=("build", "run"))
@@ -52,7 +56,48 @@ class PyPyfr(PythonPackage):
 
     # Optional dependencies
     depends_on("py-scipy", when="+scipy", type=("build", "run"))
+    depends_on("metis@5.0:", when="+metis", type=("run"))
     depends_on("scotch@6.0:", when="+scotch", type=("run"))
     depends_on("cuda@8.0:", when="+cuda", type=("run"))
-    depends_on("rocblas@4.5.0:", when="+hip", type=("run"))
-    depends_on("libxsmm@1.18:+shared blas=0 +large_jit_buffer", when="+libxsmm", type=("run"))
+    depends_on("rocblas@5.2.0:", when="+hip", type=("run"))
+    depends_on("libxsmm@1.18:+shared blas=0", when="+libxsmm", type=("run"))
+
+    # Conflicts for compilers not supporting OpenMP 5.1+ from v1.15.0:
+    conflicts("%gcc@:11", when="@1.15.0: +libxsmm", msg="OpenMP 5.1+ supported compiler required!")
+
+    # Explicitly set library path for dependencies
+    def setup_run_environment(self, env):
+        if "+metis" in self.spec:
+            lib_path = find_libraries(
+                    "libmetis", root=self.spec["metis"].prefix.lib, recursive=False
+                )
+            env.set("PYFR_METIS_LIBRARY_PATH", lib_path[0])
+        
+        if "+scotch" in self.spec:
+            lib_path = find_libraries(
+                    "libscotch", root=self.spec["scotch"].prefix.lib, recursive=False
+                )
+            env.set("PYFR_SCOTCH_LIBRARY_PATH", lib_path[0])
+        
+        if "+libxsmm" in self.spec:
+            lib_path = find_libraries(
+                    "libxsmm", root=self.spec["libxsmm"].prefix.lib, recursive=False
+                )
+            env.set("PYFR_XSMM_LIBRARY_PATH", lib_path[0])
+        
+        if "+cuda" in self.spec:
+            lib_path = find_libraries(
+                    "libcublas", root=self.spec["cuda"].prefix, recursive=True
+                )
+            env.set("PYFR_CUBLAS_LIBRARY_PATH", lib_path[0])
+
+        if "+hip" in self.spec:
+            lib_path = find_libraries(
+                    "libamdhip64", root=self.spec["hip"].prefix, recursive=True
+                )
+            env.set("PYFR_AMDHIP64_LIBRARY_PATH", lib_path[0])
+
+            lib_path = find_libraries(
+                    "librocblas", root=self.spec["rocblas"].prefix, recursive=True
+                )
+            env.set("PYFR_ROCBLAS_LIBRARY_PATH", lib_path[0])

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -69,36 +69,36 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     # Explicitly set library path for dependencies
     def setup_run_environment(self, env):
         if "+metis" in self.spec:
-            lib_path = find_libraries(
-                    "libmetis", root=self.spec["metis"].prefix.lib, recursive=False
-                )
-            env.set("PYFR_METIS_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["metis"].libs.directories[0], "libmetis.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_METIS_LIBRARY_PATH", lib_path)
 
         if "+scotch" in self.spec:
-            lib_path = find_libraries(
-                    "libscotch", root=self.spec["scotch"].prefix.lib, recursive=False
-                )
-            env.set("PYFR_SCOTCH_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["scotch"].libs.directories[0], "libscotch.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_SCOTCH_LIBRARY_PATH", lib_path)
 
         if "+libxsmm" in self.spec:
-            lib_path = find_libraries(
-                    "libxsmm", root=self.spec["libxsmm"].prefix.lib, recursive=False
-                )
-            env.set("PYFR_XSMM_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["libxsmm"].libs.directories[0], "libxsmm.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_XSMM_LIBRARY_PATH", lib_path)
 
         if "+cuda" in self.spec:
-            lib_path = find_libraries(
-                    "libcublas", root=self.spec["cuda"].prefix, recursive=True
-                )
-            env.set("PYFR_CUBLAS_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["cuda"].libs.directories[0], "libcublas.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_CUBLAS_LIBRARY_PATH", lib_path)
 
         if "+hip" in self.spec:
-            lib_path = find_libraries(
-                    "libamdhip64", root=self.spec["hip"].prefix, recursive=True
-                )
-            env.set("PYFR_AMDHIP64_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["hip"].libs.directories[0], "libamdhip64.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_AMDHIP64_LIBRARY_PATH", lib_path)
 
-            lib_path = find_libraries(
-                    "librocblas", root=self.spec["rocblas"].prefix, recursive=True
-                )
-            env.set("PYFR_ROCBLAS_LIBRARY_PATH", lib_path[0])
+            lib_path = join_path(
+                self.spec["rocblas"].libs.directories[0], "librocblas.{0}".format(dso_suffix)
+            )
+            env.set("PYFR_ROCBLAS_LIBRARY_PATH", lib_path)

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -58,7 +58,8 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-scipy", when="+scipy", type=("build", "run"))
     depends_on("metis@5.0:", when="+metis", type=("run"))
     depends_on("scotch@6.0:", when="+scotch", type=("run"))
-    depends_on("cuda@8.0: +allow-unsupported-compilers", when="+cuda", type=("run"))
+    depends_on("cuda@8.0: +allow-unsupported-compilers", when="@:1.14.0 +cuda", type=("run"))
+    depends_on("cuda@11.4.0: +allow-unsupported-compilers", when="@1.15.0: +cuda", type=("run"))
     depends_on("rocblas@5.2.0:", when="+hip", type=("run"))
     depends_on("libxsmm@1.18:+shared blas=0", when="+libxsmm", type=("run"))
 

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -46,7 +46,7 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-gimmik@2.3:2", when="@:1.14.0", type=("build", "run"))
-    depends_on("py-gimmik@3:", when="@1.15.0:", type=("build", "run"))
+    depends_on("py-gimmik@3", when="@1.15.0:", type=("build", "run"))
     depends_on("py-h5py@2.10:", type=("build", "run"))
     depends_on("py-mako@1.0.0:", type=("build", "run"))
     depends_on("py-mpi4py@3.1.0:", type=("build", "run"))
@@ -73,19 +73,19 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
                     "libmetis", root=self.spec["metis"].prefix.lib, recursive=False
                 )
             env.set("PYFR_METIS_LIBRARY_PATH", lib_path[0])
-        
+
         if "+scotch" in self.spec:
             lib_path = find_libraries(
                     "libscotch", root=self.spec["scotch"].prefix.lib, recursive=False
                 )
             env.set("PYFR_SCOTCH_LIBRARY_PATH", lib_path[0])
-        
+
         if "+libxsmm" in self.spec:
             lib_path = find_libraries(
                     "libxsmm", root=self.spec["libxsmm"].prefix.lib, recursive=False
                 )
             env.set("PYFR_XSMM_LIBRARY_PATH", lib_path[0])
-        
+
         if "+cuda" in self.spec:
             lib_path = find_libraries(
                     "libcublas", root=self.spec["cuda"].prefix, recursive=True

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -66,39 +66,11 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     # Conflicts for compilers not supporting OpenMP 5.1+ from v1.15.0:
     conflicts("%gcc@:11", when="@1.15.0: +libxsmm", msg="OpenMP 5.1+ supported compiler required!")
 
-    # Explicitly set library path for dependencies
+    # Explicitly add dependencies to PYFR_LIBRARY_PATH environment variable
     def setup_run_environment(self, env):
-        if "+metis" in self.spec:
-            lib_path = join_path(
-                self.spec["metis"].libs.directories[0], "libmetis.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_METIS_LIBRARY_PATH", lib_path)
-
-        if "+scotch" in self.spec:
-            lib_path = join_path(
-                self.spec["scotch"].libs.directories[0], "libscotch.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_SCOTCH_LIBRARY_PATH", lib_path)
-
-        if "+libxsmm" in self.spec:
-            lib_path = join_path(
-                self.spec["libxsmm"].libs.directories[0], "libxsmm.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_XSMM_LIBRARY_PATH", lib_path)
-
-        if "+cuda" in self.spec:
-            lib_path = join_path(
-                self.spec["cuda"].libs.directories[0], "libcublas.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_CUBLAS_LIBRARY_PATH", lib_path)
-
-        if "+hip" in self.spec:
-            lib_path = join_path(
-                self.spec["hip"].libs.directories[0], "libamdhip64.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_AMDHIP64_LIBRARY_PATH", lib_path)
-
-            lib_path = join_path(
-                self.spec["rocblas"].libs.directories[0], "librocblas.{0}".format(dso_suffix)
-            )
-            env.set("PYFR_ROCBLAS_LIBRARY_PATH", lib_path)
+        deps = ["metis", "scotch", "libxsmm", "cuda", "hip", "rocblas"]
+        pyfr_library_path = []
+        for dep in deps:
+            if "+{}".format(dep) in self.spec:
+                pyfr_library_path.extend(self.spec[dep].libs.directories)
+        env.set("PYFR_LIBRARY_PATH", ":".join(pyfr_library_path))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -46,7 +46,7 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-gimmik@2.3:2", when="@:1.14.0", type=("build", "run"))
-    depends_on("py-gimmik@3:", when="@:1.15.0", type=("build", "run"))
+    depends_on("py-gimmik@3:", when="@1.15.0:", type=("build", "run"))
     depends_on("py-h5py@2.10:", type=("build", "run"))
     depends_on("py-mako@1.0.0:", type=("build", "run"))
     depends_on("py-mpi4py@3.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -58,7 +58,7 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-scipy", when="+scipy", type=("build", "run"))
     depends_on("metis@5.0:", when="+metis", type=("run"))
     depends_on("scotch@6.0:", when="+scotch", type=("run"))
-    depends_on("cuda@8.0:", when="+cuda", type=("run"))
+    depends_on("cuda@8.0: +allow-unsupported-compilers", when="+cuda", type=("run"))
     depends_on("rocblas@5.2.0:", when="+hip", type=("run"))
     depends_on("libxsmm@1.18:+shared blas=0", when="+libxsmm", type=("run"))
 


### PR DESCRIPTION
Explicit library paths to external libs added due to #28354 .
OpenMP v5.1 compiler support now required for Libxsmm (OpenMP) backend, might be possible to remove this restriction as PyFR compilation is JIT. Either way, an OpenMP virtual dependency would surely be helpful.

#### Also changed:
* `py-gimmik` version updated to v3.0
* `libxsmm` updated main branch name (needed by PyFR until v2 arrives)

@FreddieWitherden
