### PR TITLE
dd4hep: new version 1.23

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -24,6 +24,7 @@ class Dd4hep(CMakePackage):
     tags = ["hep"]
 
     version("master", branch="master")
+    version("1.23", sha256="64e4f213e500147e4067301b03143b872381e2ae33710cb6eea8c578529dd596")
     version("1.22", sha256="0e729b8897b7a9c348bc3304c63d4efd1a88e032a2ff5a8c4daf6c927fd7f8ee")
     version("1.21", sha256="0f9fe9784bf28fa20ce5555ff074430da430e9becc2566fe11e27c4904a51c94")
     version("1.20.2", sha256="3dab7a300f749452791e160db9394180b65533e91b1b628e568da72ca79b211a")


### PR DESCRIPTION
Release notes at https://github.com/AIDASoft/DD4hep/releases/tag/v01-23. Nothing that would impact the spack build.