### PR TITLE
acts: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -12,8 +12,9 @@ class ActsDd4hep(CMakePackage):
     homepage = "https://github.com/acts-project/acts-dd4hep"
     url = "https://github.com/acts-project/acts-dd4hep/archive/refs/tags/v1.0.0.tar.gz"
 
-    maintainers = ["HadrianG2", "wdconinc"]
+    maintainers = ["HadrienG2", "wdconinc"]
 
+    version("1.0.1", sha256="e40f34ebc30b3c33a6802c9d94136e65072d8dcee0b7db57a645f08a64ea5334")
     version("1.0.0", sha256="991f996944c88efa837880f919239e50d12c5c9361e220bc9422438dd608308c")
 
     depends_on("dd4hep@1.11: +dddetectors")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,7 +39,11 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("20.2.0", commit="7750c1d24714314e8de716b92ebcd4a92cc4e303", submodules=True)
+    version("20.1.0", commit="be36226fb1be88d7be7c9b17a1c1f6e76ff0e006", submodules=True)
     version("20.0.0", commit="3740e6cdbfb1f75d8e481686acdfa5b16d3c41a3", submodules=True)
+    version("19.9.0", commit="b655e18929ae0ccb6926d8e217b1b3fc02978d35", submodules=True)
+    version("19.8.0", commit="7582072dbaa70802264f20b392de4313afd25667", submodules=True)
     version("19.7.0", commit="03cf7a3ae74b632b3f89416dc27cc993c9ae4628", submodules=True)
     version("19.6.0", commit="333082914e6a51b381abc1cf52856829e3eb7890", submodules=True)
     version("19.5.0", commit="bf9f0270eadd8e78d283557b7c9070b80dece4a7", submodules=True)

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -366,7 +366,7 @@ class Acts(CMakePackage, CudaPackage):
             if cuda_arch != "none":
                 args.append("-DCUDA_FLAGS=-arch=sm_{0}".format(cuda_arch[0]))
 
-        if spec.satisfies("@19 +dd4hep"):
+        if spec.satisfies("@19:20.2 +dd4hep"):
             args.append("-DACTS_USE_SYSTEM_ACTSDD4HEP=ON")
 
         if spec.satisfies("@:16"):

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -201,18 +201,6 @@ class Acts(CMakePackage, CudaPackage):
         description="Build the SyCL plugin",
         when="@1:",
     )
-    variant(
-        "tbb",
-        default=True,
-        description="Build the examples with Threading Building Blocks library",
-        when="@19.8:19 +examples",
-    )
-    variant(
-        "tbb",
-        default=True,
-        description="Build the examples with Threading Building Blocks library",
-        when="@20.1: +examples",
-    )
     variant("tgeo", default=False, description="Build the TGeo plugin", when="+identification")
 
     # Variants that only affect Acts examples for now
@@ -251,6 +239,18 @@ class Acts(CMakePackage, CudaPackage):
         default=False,
         description="Build ActSVG display plugin",
         when="@20.1:",
+    )
+    variant(
+        "tbb",
+        default=True,
+        description="Build the examples with Threading Building Blocks library",
+        when="@19.8:19 +examples",
+    )
+    variant(
+        "tbb",
+        default=True,
+        description="Build the examples with Threading Building Blocks library",
+        when="@20.1: +examples",
     )
     variant("analysis", default=False, description="Build analysis applications in the examples")
 

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,9 +39,11 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("20.3.0", commit="b1859b322744cb033328fd57d9e74fb5326aa56b", submodules=True)
     version("20.2.0", commit="7750c1d24714314e8de716b92ebcd4a92cc4e303", submodules=True)
     version("20.1.0", commit="be36226fb1be88d7be7c9b17a1c1f6e76ff0e006", submodules=True)
     version("20.0.0", commit="3740e6cdbfb1f75d8e481686acdfa5b16d3c41a3", submodules=True)
+    version("19.10.0", commit="2d07f60eb2280a46af1085600ec8327679bbb630", submodules=True)
     version("19.9.0", commit="b655e18929ae0ccb6926d8e217b1b3fc02978d35", submodules=True)
     version("19.8.0", commit="7582072dbaa70802264f20b392de4313afd25667", submodules=True)
     version("19.7.0", commit="03cf7a3ae74b632b3f89416dc27cc993c9ae4628", submodules=True)

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -232,10 +232,17 @@ class Acts(CMakePackage, CudaPackage):
         description="Build python bindings for the examples",
         when="@14: +examples",
     )
+    variant(
+        "svg",
+        default=False,
+        description="Build ActSVG display plugin",
+        when="@20.1:",
+    )
     variant("analysis", default=False, description="Build analysis applications in the examples")
 
     # Build dependencies
     depends_on("acts-dd4hep", when="@19 +dd4hep")
+    depends_on("actsvg", when="@20.1: +svg")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")
     depends_on("boost @1.62:1.69 +program_options +test", when="@:0.10.3")
@@ -325,6 +332,7 @@ class Acts(CMakePackage, CudaPackage):
             enable_cmake_variant("MEMORY_PROFILING", "profilemem"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             example_cmake_variant("PYTHON_BINDINGS", "python"),
+            plugin_cmake_variant("ACTSVG", "svg"),
             plugin_cmake_variant("SYCL", "sycl"),
             plugin_cmake_variant("TGEO", "tgeo"),
             cmake_variant(unit_tests_label, "unit_tests"),
@@ -356,6 +364,10 @@ class Acts(CMakePackage, CudaPackage):
 
         if spec.satisfies("@18: +python"):
             args.append("-DACTS_USE_SYSTEM_PYBIND11=ON")
+
+        if spec.satisfies("@20.1: +svg"):
+            args.append("-DACTS_SETUP_ACTSVG=ON")
+            args.append("-DACTS_USE_SYSTEM_ACTSVG=ON")
 
         if "root" in spec:
             cxxstd = spec["root"].variants["cxxstd"].value

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -300,9 +300,9 @@ class Acts(CMakePackage, CudaPackage):
             enabled = spec.satisfies(spack_variant)
             return "-DACTS_ENABLE_{0}={1}".format(cmake_label, enabled)
 
-        def example_cmake_variant(cmake_label, spack_variant):
+        def example_cmake_variant(cmake_label, spack_variant, type="BUILD"):
             enabled = spec.satisfies("+examples +" + spack_variant)
-            return "-DACTS_BUILD_EXAMPLES_{0}={1}".format(cmake_label, enabled)
+            return "-DACTS_{0}_EXAMPLES_{1}={2}".format(type, cmake_label, enabled)
 
         def plugin_label(plugin_name):
             if spec.satisfies("@0.33:"):
@@ -349,6 +349,7 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("ACTSVG", "svg"),
             plugin_cmake_variant("SYCL", "sycl"),
             plugin_cmake_variant("TGEO", "tgeo"),
+            example_cmake_variant("TBB", "tbb", "USE"),
             cmake_variant(unit_tests_label, "unit_tests"),
         ]
 

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -201,6 +201,18 @@ class Acts(CMakePackage, CudaPackage):
         description="Build the SyCL plugin",
         when="@1:",
     )
+    variant(
+        "tbb",
+        default=True,
+        description="Build the examples with Threading Building Blocks library",
+        when="@19.8:19 +examples",
+    )
+    variant(
+        "tbb",
+        default=True,
+        description="Build the examples with Threading Building Blocks library",
+        when="@20.1: +examples",
+    )
     variant("tgeo", default=False, description="Build the TGeo plugin", when="+identification")
 
     # Variants that only affect Acts examples for now
@@ -262,7 +274,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("gperftools", when="+profilemem")
     depends_on("hepmc3 @3.2.1:", when="+hepmc3")
     depends_on("heppdt", when="+hepmc3 @:4.0")
-    depends_on("intel-tbb @2020.1:", when="+examples")
+    depends_on("intel-tbb @2020.1:", when="+examples +tbb")
     depends_on("nlohmann-json @3.9.1:", when="@0.14: +json")
     depends_on("pythia8", when="+pythia8")
     depends_on("python", when="+python")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -330,6 +330,7 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("CUDA", "cuda"),
             plugin_cmake_variant("DD4HEP", "dd4hep"),
             example_cmake_variant("DD4HEP", "dd4hep"),
+            plugin_cmake_variant("DIGITIZATION", "digitization"),
             example_cmake_variant("EDM4HEP", "edm4hep"),
             cmake_variant("EXAMPLES", "examples"),
             cmake_variant("FATRAS", "fatras"),
@@ -358,30 +359,34 @@ class Acts(CMakePackage, CudaPackage):
         if spec.satisfies("@19.4.0:"):
             args.append("-DACTS_ENABLE_LOG_FAILURE_THRESHOLD=ON")
 
-        if spec.satisfies("+autodiff"):
-            args.append("-DACTS_USE_SYSTEM_AUTODIFF=ON")
+        # Use dependencies provided by spack
+        if spec.satisfies("@20.3:"):
+            args.append("-DACTS_USE_SYSTEM_LIBS=ON")
+        else:
+            if spec.satisfies("+autodiff"):
+                args.append("-DACTS_USE_SYSTEM_AUTODIFF=ON")
+
+            if spec.satisfies("@19:20.2 +dd4hep"):
+                args.append("-DACTS_USE_SYSTEM_ACTSDD4HEP=ON")
+
+            if spec.satisfies("@0.33: +json"):
+                args.append("-DACTS_USE_SYSTEM_NLOHMANN_JSON=ON")
+            elif spec.satisfies("@0.14.0:0.32 +json"):
+                args.append("-DACTS_USE_BUNDLED_NLOHMANN_JSON=OFF")
+
+            if spec.satisfies("@18: +python"):
+                args.append("-DACTS_USE_SYSTEM_PYBIND11=ON")
+
+            if spec.satisfies("@20.1: +svg"):
+                args.append("-DACTS_USE_SYSTEM_ACTSVG=ON")
+
+            if spec.satisfies("@14: +vecmem"):
+                args.append("-DACTS_USE_SYSTEM_VECMEM=ON")
 
         if "+cuda" in spec:
             cuda_arch = spec.variants["cuda_arch"].value
             if cuda_arch != "none":
                 args.append("-DCUDA_FLAGS=-arch=sm_{0}".format(cuda_arch[0]))
-
-        if spec.satisfies("@19:20.2 +dd4hep"):
-            args.append("-DACTS_USE_SYSTEM_ACTSDD4HEP=ON")
-
-        if spec.satisfies("@:16"):
-            args.append(plugin_cmake_variant("DIGITIZATION", "digitization"))
-
-        if spec.satisfies("@0.33: +json"):
-            args.append("-DACTS_USE_SYSTEM_NLOHMANN_JSON=ON")
-        elif spec.satisfies("@0.14.0: +json"):
-            args.append("-DACTS_USE_BUNDLED_NLOHMANN_JSON=OFF")
-
-        if spec.satisfies("@18: +python"):
-            args.append("-DACTS_USE_SYSTEM_PYBIND11=ON")
-
-        if spec.satisfies("@20.1: +svg"):
-            args.append("-DACTS_USE_SYSTEM_ACTSVG=ON")
 
         if "root" in spec:
             cxxstd = spec["root"].variants["cxxstd"].value

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -381,7 +381,6 @@ class Acts(CMakePackage, CudaPackage):
             args.append("-DACTS_USE_SYSTEM_PYBIND11=ON")
 
         if spec.satisfies("@20.1: +svg"):
-            args.append("-DACTS_SETUP_ACTSVG=ON")
             args.append("-DACTS_USE_SYSTEM_ACTSVG=ON")
 
         if "root" in spec:

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -244,13 +244,7 @@ class Acts(CMakePackage, CudaPackage):
         "tbb",
         default=True,
         description="Build the examples with Threading Building Blocks library",
-        when="@19.8:19 +examples",
-    )
-    variant(
-        "tbb",
-        default=True,
-        description="Build the examples with Threading Building Blocks library",
-        when="@20.1: +examples",
+        when="@19.8:19,20.1: +examples",
     )
     variant("analysis", default=False, description="Build analysis applications in the examples")
 

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -20,8 +20,16 @@ class Actsvg(CMakePackage):
 
     version("0.4.22", sha256="a535dc80b309033c45a8521c01b5ea6cd82c1fc8c89661d112de8879d68be790")
 
-    variant("examples", default=False, description="Build the example applications",)
-    variant("meta", default=True, description="Build the meta level interface",)
+    variant(
+        "examples",
+        default=False,
+        description="Build the example applications",
+    )
+    variant(
+        "meta",
+        default=True,
+        description="Build the meta level interface",
+    )
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -18,7 +18,7 @@ class Actsvg(CMakePackage):
 
     maintainers = ["HadrienG2", "wdconinc"]
 
-    version("0.4.22", sha256="a535dc80b309033c45a8521c01b5ea6cd82c1fc8c89661d112de8879d68be790")
+    version("0.4.26", sha256="a1dfad15b616cac8191a355c1a87544571c36349400e3de56b9e5be6fa73714c")
 
     variant(
         "examples",
@@ -30,7 +30,7 @@ class Actsvg(CMakePackage):
         default=True,
         description="Build the meta level interface",
     )
-    
+
     depends_on("boost +program_options", type="test")
     depends_on("boost +program_options", when="+examples")
     depends_on("googletest", when="+examples")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -30,6 +30,10 @@ class Actsvg(CMakePackage):
         default=True,
         description="Build the meta level interface",
     )
+    
+    depends_on("boost +program_options", type="test")
+    depends_on("boost +program_options", when="+examples")
+    depends_on("googletest", when="+examples")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Actsvg(CMakePackage):
+    """An SVG based C++17 plotting library for ACTS detectors and
+    surfaces."""
+
+    homepage = "https://github.com/acts-project/actsvg"
+    url = "https://github.com/acts-project/actsvg/archive/refs/tags/v0.4.22.zip"
+    list_url = "https://github.com/acts-project/actsvg/releases"
+    git = "https://github.com/acts-project/actsvg.git"
+
+    maintainers = ["HadrienG2", "wdconinc"]
+
+    version("0.4.22", sha256="a535dc80b309033c45a8521c01b5ea6cd82c1fc8c89661d112de8879d68be790")
+
+    variant("examples", default=False, description="Build the example applications",)
+    variant("meta", default=True, description="Build the meta level interface",)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("ACTSVG_BUILD_EXAMPLES", "examples"),
+            self.define_from_variant("ACTSVG_BUILD_META", "meta"),
+            self.define("ACTSVG_BUILD_TESTING", self.run_tests),
+        ]
+        return args


### PR DESCRIPTION
In the **20.x release line**, these are the changes, https://github.com/acts-project/acts/compare/v20.0.0...v20.3.0
- [x] `option(ACTS_SETUP_ACTSVG "Build ActSVG display plugin" OFF)` introduced in v20.1.0
- [x] `option(ACTS_USE_SYSTEM_ACTSVG "Use the ActSVG system library" OFF)` introduced in v20.1.0
- [x] `option(ACTS_BUILD_PLUGIN_ACTSVG "Build SVG display plugin" OFF)` introduced in v20.1.0
- [x] `option(ACTS_USE_EXAMPLES_TBB "Use Threading Building Blocks library in examples" ON)` introduced in v20.1.0
- [ ] ~~`option(ACTS_EXATRKX_ENABLE_ONNX "Build the Onnx backend for the exatrkx plugin" OFF)` introduced in v20.2.0~~
  - missing dependencies `OnnxRuntime` and `cugraph`
- [ ] ~~`option(ACTS_EXATRKX_ENABLE_TORCH "Build the torchscript backend for the exatrkx plugin" ON)` introduced in v20.2.0~~
  - missing dependencies `TorchScatter`
- [x] `option(ACTS_USE_SYSTEM_LIBS "Use system libraries by default" OFF)` introduced in v20.3.0
- [x] `option(ACTS_USE_SYSTEM_ACTSDD4HEP "Use the ActsDD4hep glue library..." OFF)` removed in v20.3.0

In the **19.x release line**, these are the changes: https://github.com/acts-project/acts/compare/v19.7.0...v19.10.0
- [x] `option(ACTS_USE_EXAMPLES_TBB "Use Threading Building Blocks library in examples" ON)` introduced in v19.8.0
- [ ] ~~`option(ACTS_EXATRKX_ENABLE_ONNX "Build the Onnx backend for the exatrkx plugin" OFF)` introduced in v19.10.0~~
  - missing dependencies `OnnxRuntime` and `cugraph`
- [ ] ~~`option(ACTS_EXATRKX_ENABLE_TORCH "Build the torchscript backend for the exatrkx plugin" ON)` introduced in v19.10.0~~
  - missing dependencies `TorchScatter`
- [ ] ~~`option(ACTS_USE_SYSTEM_LIBS "Use system libraries by default" OFF)` introduced in v19.10.0~~
  - for simplicity sake in the package.py, choosing to ignore this for the 19.x backport series