### PR TITLE
superlu-dist_crayPE update

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -71,7 +71,7 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
 
     patch("xl-611.patch", when="@:6.1.1 %xl")
     patch("xl-611.patch", when="@:6.1.1 %xl_r")
-    patch("superlu-cray-ftn-case.patch", when="@7.1.1 %cce")
+    patch("superlu-cray-ftn-case.patch", when="@7.1.1: %cce")
     patch("CMAKE_INSTALL_LIBDIR.patch", when="@7.0.0:7.2.0")
 
     def cmake_args(self):


### PR DESCRIPTION
This will apply a patch needed for crayfortran for versions of superlu-dist from 7.1.1 and newer.