### PR TITLE
pbbam: switching to meson, adding version 2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/pbbam/package.py
+++ b/var/spack/repos/builtin/packages/pbbam/package.py
@@ -4,46 +4,43 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
-class Pbbam(CMakePackage):
+class Pbbam(MesonPackage):
     """The pbbam software package provides components to create, query,
     & edit PacBio BAM files and associated indices.
     These components include a core C++ library,
     bindings for additional languages, and command-line utilities."""
 
     homepage = "https://github.com/PacificBiosciences/pbbam"
-    url = "https://github.com/PacificBiosciences/pbbam/archive/0.18.0.tar.gz"
+    url = "https://github.com/PacificBiosciences/pbbam/archive/refs/tags/0.18.0.tar.gz"
+    maintainers = ["snehring"]
 
+    version(
+        "2.1.0",
+        sha256="605944f09654d964ce12c31d67e6766dfb1513f730ef5d4b74829b2b84dd464f",
+        url="https://github.com/PacificBiosciences/pbbam/archive/refs/tags/v2.1.0.tar.gz",
+    )
     version("0.18.0", sha256="45286e5f7deb7ff629e0643c8a416155915aec7b85d54c60b5cdc07f4d7b234a")
 
     depends_on("zlib")
     depends_on("boost@1.55.0:")
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
     depends_on("htslib@1.3.1:")
-    depends_on("doxygen+graphviz")
+    # newer versions require C17
+    conflicts("%gcc@:7.5.0", when="@2.1.0:")
+    conflicts("%clang@:6.0.1", when="@2.1.0:")
 
-    conflicts("%gcc@:5.2.0")
-
-    def cmake_args(self):
+    def meson_args(self):
         options = []
         if self.run_tests:
-            options.append("-DPacBioBAM_build_tests:BOOL=ON")
+            options.append("-Dtests=true")
         else:
-            options.append("-DPacBioBAM_build_tests:BOOL=OFF")
+            options.append("-Dtests=false")
 
         return options
 
-    def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            install_tree("bin", prefix.bin)
-            install_tree("lib", prefix.lib)
-            install_tree("pbbam", prefix.include.pbbam)
+    def setup_build_environment(self, env):
+        env.set("BOOST_ROOT", self.spec["boost"].prefix)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set("PacBioBAM_LIBRARIES", self.prefix.lib)


### PR DESCRIPTION
At some point pbbam switched fully to meson. The good news is the original version we had packaged also works with meson, so we've got the rare case of switching a build system not being super annoying!

Boost without any variants seems to provide what it requires.

I also winnowed the dependencies a bit.