### PR TITLE
py-torchmetrics: add v0.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchmetrics/package.py
+++ b/var/spack/repos/builtin/packages/py-torchmetrics/package.py
@@ -14,6 +14,7 @@ class PyTorchmetrics(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("0.10.0", sha256="990bafc7f76d7442894533771d0ba7492dbca2bbf2989fb32de7e9c68eb3d133")
     version("0.9.3", sha256="4ebfd2466021db26397636966ee1a195d3b340ba5d71bb258e764340dfc2476f")
     version("0.9.2", sha256="8178c9242e243318093d9b7237738a504535193d2006da6e58b0ed4003e318d2")
     version("0.9.0", sha256="3aa32ea575915b313d872d3460996c0f12a7bb37e6ce3da0e8d80865603b89f6")
@@ -31,4 +32,4 @@ class PyTorchmetrics(PythonPackage):
     depends_on("py-torch@1.3.1:", type=("build", "run"))
     depends_on("py-pydeprecate@0.3", when="@0.7:0.8", type=("build", "run"))
     depends_on("py-packaging", when="@0.3:", type=("build", "run"))
-    depends_on("py-typing-extensions", when="@0.9: ^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions", when="@0.9: ^python@:3.8", type=("build", "run"))


### PR DESCRIPTION
Successfully installs on macOS 12.6 (arm64) with Python 3.9.13 and Apple Clang 14.0.0.

https://github.com/Lightning-AI/metrics/releases/tag/v0.10.0