### PR TITLE
python: don't accidentally link to system db libs

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -791,7 +791,7 @@ class Python(Package):
 
         if "+dbm" in spec:
             # Default order is ndbm:gdbm:bdb
-            config_args.append("--with-dbmliborder=gdbm:bdb:ndbm")
+            config_args.append("--with-dbmliborder=gdbm")
         else:
             config_args.append("--with-dbmliborder=")
 


### PR DESCRIPTION
Avoid that Python looks for system `ndbm` / `berkeley-db`

Currently Spack builds

```
<prefix>/lib/python3.9/lib-dynload/_dbm.cpython-39-x86_64-linux-gnu.so
```

Which links to system `berkeley-db` on my system
