### PR TITLE
vtk: fix python bounds

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -61,14 +61,15 @@ class Vtk(CMakePackage):
     # We cannot build with both osmesa and qt in spack
     conflicts("+osmesa", when="+qt")
 
-    extends("python", when="+python")
-
-    # Acceptable python versions depend on vtk version
-    # We need vtk at least 8.0.1 for python@3,
-    # and at least 9.0 for python@3.8
-    depends_on("python@2.7:2.9", when="@:8.0 +python", type=("build", "run"))
-    depends_on("python@2.7:3.7", when="@8.0.1:8.9 +python", type=("build", "run"))
-    depends_on("python@2.7:", when="@9.0: +python", type=("build", "run"))
+    with when("+python"):
+        # Depend on any Python, add bounds below.
+        extends("python@2.7:", type=("build", "run"))
+        # Python 3 support from vtk 8
+        depends_on("python@:2", when="@:7", type=("build", "run"))
+        # Python 3.8 support from vtk 9
+        depends_on("python@:3.7", when="@:8", type=("build", "run"))
+        # Python 3.10 support from vtk 9.2
+        depends_on("python@:3.9", when="@:9.1", type=("build", "run"))
 
     # We need mpi4py if buidling python wrappers and using MPI
     depends_on("py-mpi4py", when="+python+mpi", type="run")


### PR DESCRIPTION
Currently the bounds look incorrect, comment says "We need vtk at least 8.0.1 for python@3," followed by `depends_on("python@2.7:2.9", when="@:8.0`, but then `when` includes 8.0.1.

This makes things  a bit tidier, and also adds a missing upperbound on Python 3.9, since 3.10 support is only available since VTK 9.2.0, see #33001 