### PR TITLE
remove shlex.split() preprocessing from the spec lexer/parser

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
+from typing import Callable, Dict, List, Tuple
 
 from six import string_types
 
@@ -39,19 +40,23 @@ class Token(object):
         return (self.type == other.type) and (self.value == other.value)
 
 
+_Lexicon = List['Tuple[str, Callable]']
+_Switches = Dict[str, List]
+
+
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
     __slots__ = "scanners", "mode", "switchbook"
 
     def __init__(self, lexicon_and_mode_switches):
-        self.scanners = []
-        self.switchbook = []
-        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
-            self.scanners.append(re.Scanner(lexicon))
-            self.switchbook.append(mode_switches_dict)
-
-        self.mode = 0
+        # type: (List[Tuple[str, _Lexicon, _Switches]]) -> None
+        self.scanners = {}      # type: Dict[str, _Lexicon]
+        self.switchbook = {}    # type: Dict[str, _Switches]
+        self.mode = lexicon_and_mode_switches[0][0]
+        for mode_name, lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners[mode_name] = re.Scanner(lexicon)  # type: ignore[attr-defined]
+            self.switchbook[mode_name] = mode_switches_dict
 
     def token(self, type, value=''):
         cur_scanner = self.scanners[self.mode]

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -6,7 +6,6 @@
 import abc
 import itertools
 import re
-import shlex
 import sys
 from textwrap import dedent
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
@@ -16,7 +15,6 @@ import six
 import llnl.util.tty as tty
 
 import spack.error
-import spack.util.path as sp
 
 
 class Token(object):
@@ -61,7 +59,7 @@ class Lexer(object):
         self.scanners = {}  # type: Dict[str, re.Scanner] # type: ignore[name-defined]
         self.switchbook = {}  # type: Dict[str, Dict[str, List[Any]]]
         self.original_mode = lexicon_and_mode_switches[0][0]  # type: str
-        self.mode = self.original_mode                        # type: str
+        self.mode = self.original_mode  # type: str
 
         # Convert the static description of the token id into a callback that executes
         # self.token(...) when the pattern is recognized. This particular construction is required
@@ -90,12 +88,12 @@ class Lexer(object):
         # type: (str) -> Iterable[Token]
         tty.debug(f"word: '{word}'")
         scanner = self.scanners[self.mode]
-        tty.debug(f'scanner: {[k for k, _ in scanner.lexicon]}')
+        tty.debug(f"scanner: {[k for k, _ in scanner.lexicon]}")
         mode_switches_dict = self.switchbook[self.mode]
-        tty.debug(f'mode_switches_dict: {mode_switches_dict}')
+        tty.debug(f"mode_switches_dict: {mode_switches_dict}")
 
         tokens, remainder = scanner.scan(word)
-        tty.debug(f'tokens1: {tokens}')
+        tty.debug(f"tokens1: {tokens}")
         tty.debug(f"remainder: '{remainder}'")
         remainder_was_consumed_by_next_mode = False
 
@@ -108,7 +106,7 @@ class Lexer(object):
                     tty.debug(f"other_mode: '{other_mode}'")
                     remainder_was_consumed_by_next_mode = True
                     already_matched = tokens[: i + 1]
-                    tty.debug(f'already_matched: {already_matched}')
+                    tty.debug(f"already_matched: {already_matched}")
                     input_for_next_recursion = word[word.index(t.value) + len(t.value) :]
                     tty.debug(f"input_for_next_recursion: '{input_for_next_recursion}'")
                     recursion_output = self._lex_word(input_for_next_recursion)
@@ -129,7 +127,7 @@ class Lexer(object):
 
     def lex(self, text):
         # type: (str) -> Iterator[Token]
-        tty.debug('LEX!!!!')
+        tty.debug("LEX!!!!")
         tty.debug(f"text: '{text}'")
         self.mode = self.original_mode
         try:

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -124,7 +124,7 @@ class Lexer(object):
                 for tok in self.lex_word(word):
                     yield tok
         except LexWordError as e:
-            raise six.raise_from(LexError(text, e), e)
+            raise six.raise_from(LexError(text, e), e)  # type: ignore[attr-defined]
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -44,32 +44,6 @@ class Token(object):
     def __eq__(self, other):
         return (self.type == other.type) and (self.value == other.value)
 
-    def _is_quoted(self):
-        # type: () -> bool
-        """Determine whether the value is a quoted string.
-
-        Raises a ValueError if the string does not have the same quotes on both sides."""
-        if self.value.startswith("'"):
-            assert self.value.endswith("'"), self.value
-            return True
-        if self.value.startswith('"'):
-            assert self.value.endswith('"'), self.value
-            return True
-        return False
-
-    def drop_quotes(self):
-        # type: () -> None
-        """???"""
-        if not self._is_quoted():
-            return
-        self.value = self.value[1:-1]
-
-    def normalize_whitespace(self):
-        # type: () -> None
-        """???"""
-        if not self._is_quoted():
-            self.value = self.value.replace(' ', '')
-
 
 _Lexicon = List["Tuple[str, Any]"]
 # FIXME: Generic types with more than one argument aren't yet accepted by our py2 mypy

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -121,7 +121,10 @@ class Parser(object):
 
     def push_tokens(self, iterable):
         """Adds all tokens in some iterable to the token stream."""
-        self.tokens = itertools.chain(iter(iterable), iter([self.next]), self.tokens)
+        self._push_token_stream(iter(iterable))
+
+    def _push_token_stream(self, stream):
+        self.tokens = itertools.chain(stream, iter([self.next]), self.tokens)
         self.gettok()
 
     def accept(self, id):
@@ -161,7 +164,8 @@ class Parser(object):
             text = sp.convert_to_posix_path(text)
             text = shlex.split(str(text))
         self.text = text
-        self.push_tokens(list(self.lexer.lex(text)))
+
+        self._push_token_stream(self.lexer.lex(text))
 
     @abc.abstractmethod
     def do_parse(self):

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -95,10 +95,13 @@ class Lexer(object):
                     # scan in other mode
                     self.mode = other_mode  # swap 0/1
                     remainder_was_used = True
-                    tokens = tokens[: i + 1] + self.lex_word(
-                        word[word.index(t.value) + len(t.value) :]
-                    )
+                    already_matched = tokens[: i + 1]
+                    input_for_next_recursion = word[word.index(t.value) + len(t.value) :]
+                    recursion_output = self.lex_word(input_for_next_recursion)
+                    tokens = already_matched + list(recursion_output)
                     break
+            if remainder_was_used:
+                break
 
         if remainder and not remainder_was_used:
             raise LexError("Invalid character", word, word.index(remainder))

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -7,6 +7,7 @@ import itertools
 import re
 import shlex
 import sys
+from textwrap import dedent
 
 from six import string_types
 
@@ -41,46 +42,43 @@ class Token(object):
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
-    __slots__ = "scanner0", "scanner1", "mode", "mode_switches_01", "mode_switches_10"
+    __slots__ = "scanners", "mode", "switchbook"
 
-    def __init__(self, lexicon0, mode_switches_01=[], lexicon1=[], mode_switches_10=[]):
-        self.scanner0 = re.Scanner(lexicon0)
-        self.mode_switches_01 = mode_switches_01
-        self.scanner1 = re.Scanner(lexicon1)
-        self.mode_switches_10 = mode_switches_10
+    def __init__(self, lexicon_and_mode_switches):
+        self.scanners = []
+        self.switchbook = []
+        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners.append(re.Scanner(lexicon))
+            self.switchbook.append(mode_switches_dict)
+
         self.mode = 0
 
-    def token(self, type, value=""):
-        if self.mode == 0:
-            return Token(type, value, self.scanner0.match.start(0), self.scanner0.match.end(0))
-        else:
-            return Token(type, value, self.scanner1.match.start(0), self.scanner1.match.end(0))
+    def token(self, type, value=''):
+        cur_scanner = self.scanners[self.mode]
+        return Token(type, value,
+                     cur_scanner.match.start(0),
+                     cur_scanner.match.end(0))
 
     def lex_word(self, word):
-        scanner = self.scanner0
-        mode_switches = self.mode_switches_01
-        if self.mode == 1:
-            scanner = self.scanner1
-            mode_switches = self.mode_switches_10
+        scanner = self.scanners[self.mode]
+        mode_switches_dict = self.switchbook[self.mode]
 
         tokens, remainder = scanner.scan(word)
-        remainder_used = 0
+        remainder_was_used = False
 
         for i, t in enumerate(tokens):
-            if t.type in mode_switches:
-                # Combine post-switch tokens with remainder and
-                # scan in other mode
-                self.mode = 1 - self.mode  # swap 0/1
-                remainder_used = 1
-                tokens = tokens[: i + 1] + self.lex_word(
-                    word[word.index(t.value) + len(t.value) :]
-                )
-                break
+            for other_mode, mode_switches in mode_switches_dict.items():
+                if t.type in mode_switches:
+                    # Combine post-switch tokens with remainder and
+                    # scan in other mode
+                    self.mode = other_mode  # swap 0/1
+                    remainder_was_used = True
+                    tokens = tokens[:i + 1] + self.lex_word(
+                        word[word.index(t.value) + len(t.value):])
+                    break
 
-        if remainder and not remainder_used:
-            msg = "Invalid character, '{0}',".format(remainder[0])
-            msg += " in '{0}' at index {1}".format(word, word.index(remainder))
-            raise LexError(msg, word, word.index(remainder))
+        if remainder and not remainder_was_used:
+            raise LexError("Invalid character", word, word.index(remainder))
 
         return tokens
 
@@ -161,7 +159,7 @@ class Parser(object):
 
 
 class ParseError(spack.error.SpackError):
-    """Raised when we don't hit an error while parsing."""
+    """Raised when we hit an error while parsing."""
 
     def __init__(self, message, string, pos):
         super(ParseError, self).__init__(message)
@@ -173,4 +171,11 @@ class LexError(ParseError):
     """Raised when we don't know how to lex something."""
 
     def __init__(self, message, string, pos):
-        super(LexError, self).__init__(message, string, pos)
+        bad_char = string[pos]
+        printed = dedent("""\
+        {0}: '{1}'
+        -------
+        {2}
+        {3}^
+        """).format(message, bad_char, string, pos * ' ')
+        super(LexError, self).__init__(printed, string, pos)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -9,7 +9,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Tuple
 
 import six
 
@@ -22,7 +22,7 @@ class Token(object):
 
     __slots__ = "type", "value", "start", "end"
 
-    def __init__(self, type, value='', start=0, end=0):
+    def __init__(self, type, value="", start=0, end=0):
         # type: (Any, str, int, int) -> None
         self.type = type
         self.value = value
@@ -43,7 +43,7 @@ class Token(object):
         return (self.type == other.type) and (self.value == other.value)
 
 
-_Lexicon = List['Tuple[str, Any]']
+_Lexicon = List["Tuple[str, Any]"]
 _Switches = Dict[str, List]
 
 
@@ -54,7 +54,7 @@ class Lexer(object):
 
     def __init__(self, lexicon_and_mode_switches):
         # type: (List[Tuple[str, _Lexicon, _Switches]]) -> None
-        self.scanners = {}    # type: Dict[str, re.Scanner] # type: ignore[name-defined]
+        self.scanners = {}  # type: Dict[str, re.Scanner] # type: ignore[name-defined]
         self.switchbook = {}  # type: Dict[str, _Switches]
         self.mode = lexicon_and_mode_switches[0][0]
         for mode_name, lexicon, mode_switches_dict in lexicon_and_mode_switches:
@@ -69,12 +69,10 @@ class Lexer(object):
             self.scanners[mode_name] = re.Scanner(transformed_lexicon)  # type: ignore[attr-defined] # noqa: E501
             self.switchbook[mode_name] = mode_switches_dict
 
-    def token(self, type, value=''):
+    def token(self, type, value=""):
         # type: (Any, str) -> Token
         cur_scanner = self.scanners[self.mode]
-        return Token(type, value,
-                     cur_scanner.match.start(0),
-                     cur_scanner.match.end(0))
+        return Token(type, value, cur_scanner.match.start(0), cur_scanner.match.end(0))
 
     def _transform_token_callback(self, tok):
         if tok is None:
@@ -97,8 +95,9 @@ class Lexer(object):
                     # scan in other mode
                     self.mode = other_mode  # swap 0/1
                     remainder_was_used = True
-                    tokens = tokens[:i + 1] + self.lex_word(
-                        word[word.index(t.value) + len(t.value):])
+                    tokens = tokens[: i + 1] + self.lex_word(
+                        word[word.index(t.value) + len(t.value) :]
+                    )
                     break
 
         if remainder and not remainder_was_used:
@@ -204,10 +203,12 @@ class LexError(ParseError):
 
     def __init__(self, message, string, pos):
         bad_char = string[pos]
-        printed = dedent("""\
+        printed = dedent(
+            """\
         {0}: '{1}'
         -------
         {2}
         {3}^
-        """).format(message, bad_char, string, pos * ' ')
+        """
+        ).format(message, bad_char, string, pos * " ")
         super(LexError, self).__init__(printed, string, pos)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -44,7 +44,7 @@ class Token(object):
 
 
 _Lexicon = List["Tuple[str, Any]"]
-_Switches = Dict[str, List]
+_Switches = "Dict[str, List[Any]]"
 
 
 class Lexer(object):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5004,45 +5004,57 @@ class SpecLexer(spack.parse.Lexer):
 
     """Parses tokens that make up spack specs."""
 
+    # TODO: Determine whether using >2 lexer modes would allow us to create
+    # a separate entry (likely defined the same as `spec_id_re` at first) to
+    # specifically match version strings, variant names, compiler dependency
+    # names (with '%').
     def __init__(self):
         # Spec strings require posix-style paths on Windows
         # because the result is later passed to shlex
-        filename_reg = (
-            r"[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
-            if not is_windows
-            else r"([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
-        )
-        super(SpecLexer, self).__init__(
-            [
-                (
-                    r"\@([\w.\-]*\s*)*(\s*\=\s*\w[\w.\-]*)?",
-                    lambda scanner, val: self.token(VER, val),
-                ),
-                (r"\:", lambda scanner, val: self.token(COLON, val)),
-                (r"\,", lambda scanner, val: self.token(COMMA, val)),
-                (r"\^", lambda scanner, val: self.token(DEP, val)),
-                (r"\+", lambda scanner, val: self.token(ON, val)),
-                (r"\-", lambda scanner, val: self.token(OFF, val)),
-                (r"\~", lambda scanner, val: self.token(OFF, val)),
-                (r"\%", lambda scanner, val: self.token(PCT, val)),
-                (r"\=", lambda scanner, val: self.token(EQ, val)),
+        filename_reg = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*' if not is_windows\
+            else r'([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
+        super(SpecLexer, self).__init__([
+            ([
+                # '^': dependency, or "AND":
+                (r'\^', lambda scanner, val: self.token(DEP,   val)),
+                # '@': begin a Version, VersionRange, or VersionList:
+                (r'\@', lambda scanner, val: self.token(AT,    val)),
+                # VersionRange syntax:
+                (r'\:', lambda scanner, val: self.token(COLON, val)),
+                # VersionList syntax:
+                (r'\,', lambda scanner, val: self.token(COMMA, val)),
+                # variant syntax:
+                (r'\+', lambda scanner, val: self.token(ON,    val)),
+                (r'\-', lambda scanner, val: self.token(OFF,   val)),
+                (r'\~', lambda scanner, val: self.token(OFF,   val)),
+                # Compiler dependency syntax:
+                (r'\%', lambda scanner, val: self.token(PCT,   val)),
+
+            # Filenames match before identifiers, so no initial filename
+            # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
+            (filename_reg,
+             lambda scanner, v: self.token(FILE, v)),
+                # This is *not* used in version string parsing.
+                (r'\=', lambda scanner, val: self.token(EQ,    val)),
+
                 # Filenames match before identifiers, so no initial filename
-                # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
-                (filename_reg, lambda scanner, v: self.token(FILE, v)),
+                # component is parsed as a spec (e.g., in subdir/spec.{yaml/json})
+                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
+                 lambda scanner, v: self.token(FILE, v)),
+
                 # Hash match after filename. No valid filename can be a hash
                 # (files end w/.yaml), but a hash can match a filename prefix.
-                (r"/", lambda scanner, val: self.token(HASH, val)),
+                (r'/', lambda scanner, val: self.token(HASH, val)),
+
                 # Identifiers match after filenames and hashes.
                 (spec_id_re, lambda scanner, val: self.token(ID, val)),
-                (r"\s+", lambda scanner, val: None),
-            ],
-            [EQ],
-            [
-                (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
-                (r"\s+", lambda scanner, val: None),
-            ],
-            [VAL],
-        )
+
+                # Gobble up all remaining whitespace between tokens.
+                (r'\s+', lambda scanner, val: None),
+            ], {1: [EQ]}),
+            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
+              (r'\s+', lambda scanner, val: None)],
+             {0: [VAL]})])
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5013,48 +5013,53 @@ class SpecLexer(spack.parse.Lexer):
         # because the result is later passed to shlex
         filename_reg = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*' if not is_windows\
             else r'([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
-        super(SpecLexer, self).__init__([
-            ([
-                # '^': dependency, or "AND":
-                (r'\^', lambda scanner, val: self.token(DEP,   val)),
-                # '@': begin a Version, VersionRange, or VersionList:
-                (r'\@', lambda scanner, val: self.token(AT,    val)),
-                # VersionRange syntax:
-                (r'\:', lambda scanner, val: self.token(COLON, val)),
-                # VersionList syntax:
-                (r'\,', lambda scanner, val: self.token(COMMA, val)),
-                # variant syntax:
-                (r'\+', lambda scanner, val: self.token(ON,    val)),
-                (r'\-', lambda scanner, val: self.token(OFF,   val)),
-                (r'\~', lambda scanner, val: self.token(OFF,   val)),
-                # Compiler dependency syntax:
-                (r'\%', lambda scanner, val: self.token(PCT,   val)),
-
-            # Filenames match before identifiers, so no initial filename
-            # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
-            (filename_reg,
-             lambda scanner, v: self.token(FILE, v)),
-                # This is *not* used in version string parsing.
-                (r'\=', lambda scanner, val: self.token(EQ,    val)),
-
-                # Filenames match before identifiers, so no initial filename
-                # component is parsed as a spec (e.g., in subdir/spec.{yaml/json})
-                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
-                 lambda scanner, v: self.token(FILE, v)),
-
-                # Hash match after filename. No valid filename can be a hash
-                # (files end w/.yaml), but a hash can match a filename prefix.
-                (r'/', lambda scanner, val: self.token(HASH, val)),
-
-                # Identifiers match after filenames and hashes.
-                (spec_id_re, lambda scanner, val: self.token(ID, val)),
-
-                # Gobble up all remaining whitespace between tokens.
-                (r'\s+', lambda scanner, val: None),
-            ], {1: [EQ]}),
-            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
-              (r'\s+', lambda scanner, val: None)],
-             {0: [VAL]})])
+        super(SpecLexer, self).__init__(
+            [
+                (
+                    "BEGIN_PHASE",
+                    [
+                        # '^': dependency, or "AND":
+                        (r"\^", lambda scanner, val: self.token(DEP, val)),
+                        # '@': begin a Version, VersionRange, or VersionList:
+                        (r"\@", lambda scanner, val: self.token(AT, val)),
+                        # VersionRange syntax:
+                        (r"\:", lambda scanner, val: self.token(COLON, val)),
+                        # VersionList syntax:
+                        (r"\,", lambda scanner, val: self.token(COMMA, val)),
+                        # variant syntax:
+                        (r"\+", lambda scanner, val: self.token(ON, val)),
+                        (r"\-", lambda scanner, val: self.token(OFF, val)),
+                        (r"\~", lambda scanner, val: self.token(OFF, val)),
+                        # Compiler dependency syntax:
+                        (r"\%", lambda scanner, val: self.token(PCT, val)),
+                        # This is *not* used in version string parsing.
+                        (r"\=", lambda scanner, val: self.token(EQ, val)),
+                        # Filenames match before identifiers, so no initial filename
+                        # component is parsed as a spec (e.g., in subdir/spec.yaml)
+                        (
+                            filename_reg,
+                            lambda scanner, v: self.token(FILE, v),
+                        ),
+                        # Hash match after filename. No valid filename can be a hash
+                        # (files end w/.yaml), but a hash can match a filename prefix.
+                        (r"/", lambda scanner, val: self.token(HASH, val)),
+                        # Identifiers match after filenames and hashes.
+                        (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                        # Gobble up all remaining whitespace between tokens.
+                        (r"\s+", lambda scanner, val: None),
+                    ],
+                    {"EQUALS_PHASE": [EQ]},
+                ),
+                (
+                    "EQUALS_PHASE",
+                    [
+                        (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
+                        (r"\s+", lambda scanner, val: None),
+                    ],
+                    {"BEGIN_PHASE": [VAL]},
+                ),
+            ]
+        )
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5000,14 +5000,15 @@ HASH, DEP, VER, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
 spec_id_re = r"\w[\w.-]*"
 
 
-_filename_re_base = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
-_windows_filename_prefix = r'([A-Za-z]:)*?'
+_filename_re_base = r"[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
+_windows_filename_prefix = r"([A-Za-z]:)*?"
 # Spec strings require posix-style paths on Windows
 # because the result is later passed to shlex.
-_windows_filename_re = f"{_windows_filename_prefix}{_filename_re_base}"
+_windows_filename_re = _windows_filename_prefix + _filename_re_base
 
 #: Regex for literal filenames.
 filename_reg = _windows_filename_re if is_windows else _filename_re_base
+
 
 class SpecLexer(spack.parse.Lexer):
 
@@ -5021,44 +5022,44 @@ class SpecLexer(spack.parse.Lexer):
         super(SpecLexer, self).__init__(
             [
                 (
-                    'BEGIN_PHASE',
+                    "BEGIN_PHASE",
                     [
-                        # '^': dependency, or "AND":
-                        (re.escape('^'), DEP),
                         # '@': begin a Version, VersionRange, or VersionList:
-                        (re.escape('@'), AT),
+                        (r"@([\w.\-]*\s*)*(\s*\=\s*\w[\w.\-]*)?", VER),
                         # VersionRange syntax:
-                        (re.escape(':'), COLON),
+                        (re.escape(":"), COLON),
                         # VersionList syntax:
-                        (re.escape(','), COMMA),
+                        (re.escape(","), COMMA),
+                        # '^': dependency, or "AND":
+                        (re.escape("^"), DEP),
                         # variant syntax:
-                        (re.escape('+'), ON),
-                        (re.escape('-'), OFF),
-                        (re.escape('~'), OFF),
+                        (re.escape("+"), ON),
+                        (re.escape("-"), OFF),
+                        (re.escape("~"), OFF),
                         # Compiler dependency syntax:
-                        (re.escape('%'), PCT),
+                        (re.escape("%"), PCT),
                         # This is *not* used in version string parsing.
-                        (re.escape('='), EQ),
+                        (re.escape("="), EQ),
                         # Filenames match before identifiers, so no initial filename
                         # component is parsed as a spec (e.g., in subdir/spec.yaml)
                         (filename_reg, FILE),
                         # Hash match after filename. No valid filename can be a hash
                         # (files end w/.yaml), but a hash can match a filename prefix.
-                        (re.escape('/'), HASH),
+                        (re.escape("/"), HASH),
                         # Identifiers match after filenames and hashes.
                         (spec_id_re, ID),
                         # Gobble up all remaining whitespace between tokens.
-                        (r'\s+', None),
+                        (r"\s+", None),
                     ],
-                    {'EQUALS_PHASE': [EQ]},
+                    {"EQUALS_PHASE": [EQ]},
                 ),
                 (
-                    'EQUALS_PHASE',
+                    "EQUALS_PHASE",
                     [
-                        (r'[\S].*', VAL),
-                        (r'\s+', None),
+                        (r"[\S].*", VAL),
+                        (r"\s+", None),
                     ],
-                    {'BEGIN_PHASE': [VAL]},
+                    {"BEGIN_PHASE": [VAL]},
                 ),
             ]
         )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5014,13 +5014,9 @@ _windows_filename_re = _windows_filename_prefix + _filename_re_base
 filename_reg = _windows_filename_re if is_windows else _filename_re_base
 
 #: Regex for any type of version, including single versions, ranges, and lists.
-version_regex = (
-    r"(?:[:]\s*)?"
-    r"{0}"
-    r"(?:[,:]+{0}|\s*[,:]\s+{1})*"
-    r"(?:\s*[:])?"
-    r"|:"
-).format(vn.MATCH_VERSION, vn.NO_EQUAL_VERSION)
+version_regex = (r"(?:[:]\s*)?" r"{0}" r"(?:[,:]+{0}|\s*[,:]\s+{1})*" r"(?:\s*[:])?" r"|:").format(
+    vn.MATCH_VERSION, vn.NO_EQUAL_VERSION
+)
 
 
 class SpecLexer(spack.parse.Lexer):
@@ -5115,7 +5111,7 @@ class SpecLexer(spack.parse.Lexer):
                     "DOUBLE_QUOTE_EQUALS_PHASE",
                     [
                         (re.escape('"'), DOUBLE_QUOTE),
-                        ("[^\\s,\"]+", VAL),
+                        ('[^\\s,"]+', VAL),
                         (re.escape(","), COMMA),
                         (r"\s+", None),
                     ],
@@ -5125,7 +5121,7 @@ class SpecLexer(spack.parse.Lexer):
                     "DOUBLE_QUOTE_VALUE_PHASE",
                     [
                         (re.escape('"'), DOUBLE_QUOTE),
-                        ("[^\"]*", VAL),
+                        ('[^"]*', VAL),
                     ],
                     {"BEGIN_PHASE": [DOUBLE_QUOTE]},
                 ),
@@ -5151,7 +5147,7 @@ class SpecLexer(spack.parse.Lexer):
                         (spec_id_re, VAL),
                         (r"\s+", None),
                     ],
-                    {"BEGIN_PHASE": [VAL]}
+                    {"BEGIN_PHASE": [VAL]},
                 ),
                 (
                     "COMPILER_PHASE",

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5019,42 +5019,39 @@ class SpecLexer(spack.parse.Lexer):
                     "BEGIN_PHASE",
                     [
                         # '^': dependency, or "AND":
-                        (r"\^", lambda scanner, val: self.token(DEP, val)),
+                        (r"\^", DEP),
                         # '@': begin a Version, VersionRange, or VersionList:
-                        (r"\@", lambda scanner, val: self.token(AT, val)),
+                        (r"\@", AT),
                         # VersionRange syntax:
-                        (r"\:", lambda scanner, val: self.token(COLON, val)),
+                        (r"\:", COLON),
                         # VersionList syntax:
-                        (r"\,", lambda scanner, val: self.token(COMMA, val)),
+                        (r"\,", COMMA),
                         # variant syntax:
-                        (r"\+", lambda scanner, val: self.token(ON, val)),
-                        (r"\-", lambda scanner, val: self.token(OFF, val)),
-                        (r"\~", lambda scanner, val: self.token(OFF, val)),
+                        (r"\+", ON),
+                        (r"\-", OFF),
+                        (r"\~", OFF),
                         # Compiler dependency syntax:
-                        (r"\%", lambda scanner, val: self.token(PCT, val)),
+                        (r"\%", PCT),
                         # This is *not* used in version string parsing.
-                        (r"\=", lambda scanner, val: self.token(EQ, val)),
+                        (r"\=", EQ),
                         # Filenames match before identifiers, so no initial filename
                         # component is parsed as a spec (e.g., in subdir/spec.yaml)
-                        (
-                            filename_reg,
-                            lambda scanner, v: self.token(FILE, v),
-                        ),
+                        (filename_reg, FILE),
                         # Hash match after filename. No valid filename can be a hash
                         # (files end w/.yaml), but a hash can match a filename prefix.
-                        (r"/", lambda scanner, val: self.token(HASH, val)),
+                        (r"/", HASH),
                         # Identifiers match after filenames and hashes.
-                        (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                        (spec_id_re, ID),
                         # Gobble up all remaining whitespace between tokens.
-                        (r"\s+", lambda scanner, val: None),
+                        (r"\s+", None),
                     ],
                     {"EQUALS_PHASE": [EQ]},
                 ),
                 (
                     "EQUALS_PHASE",
                     [
-                        (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
-                        (r"\s+", lambda scanner, val: None),
+                        (r"[\S].*", VAL),
+                        (r"\s+", None),
                     ],
                     {"BEGIN_PHASE": [VAL]},
                 ),

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4995,6 +4995,7 @@ class LazySpecCache(collections.defaultdict):
 
 #: These are possible token types in the spec grammar.
 HASH, DEP, VER, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
+#  0,   1,   2,     3,     4,  5,   6,   7,  8,  9,  10,   11
 
 #: Regex for fully qualified spec names. (e.g., builtin.hdf5)
 spec_id_re = r"\w[\w.-]*"

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -61,7 +61,7 @@ complex_dep1 = [
     Token(sp.DEP),
     Token(sp.ID, "_openmpi"),
     Token(sp.VER, "@"),
-    Token(sp.VAL, "1.2:1.4,1.6")
+    Token(sp.VAL, "1.2:1.4,1.6"),
 ]
 
 complex_dep1_space = [
@@ -142,7 +142,8 @@ class TestSpecSyntax(object):
         """Check that the provided spec parses to the provided token list."""
         spec = str(spec)
         lex_output = list(
-            tok for tok in sp.SpecLexer().lex(spec)
+            tok
+            for tok in sp.SpecLexer().lex(spec)
             if tok.type not in (sp.SINGLE_QUOTE, sp.DOUBLE_QUOTE)
         )
         assert len(tokens) == len(lex_output), "unexpected number of tokens"
@@ -225,8 +226,10 @@ class TestSpecSyntax(object):
             "mvapich_foo" " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug='2'" " ^stackwalker@8.1_1e"
         )
         self.check_parse(
-            "mvapich_foo" " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug='2'" " ^stackwalker@8.1_1e",
-            "mvapich_foo" " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2" " ^stackwalker@8.1_1e"
+            "mvapich_foo"
+            " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug='2'"
+            " ^stackwalker@8.1_1e",
+            "mvapich_foo" " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2" " ^stackwalker@8.1_1e",
         )
         self.check_parse(
             "mvapich_foo"
@@ -239,7 +242,7 @@ class TestSpecSyntax(object):
             " ^stackwalker@8.1_1e arch=test-redhat6-x86",
             "mvapich_foo"
             " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2"
-            " ^stackwalker@8.1_1e arch=test-redhat6-x86"
+            " ^stackwalker@8.1_1e arch=test-redhat6-x86",
         )
 
     def test_yaml_specs(self):
@@ -837,7 +840,7 @@ class TestSpecSyntax(object):
         self.check_parse(canonical, spacy_spec)
 
         canonical = (
-            'mvapich_foo debug=\'4\' '
+            "mvapich_foo debug='4' "
             "^_openmpi@1.2:1.4,1.6%intel@12.1:12.6+debug~qt_4 "
             "^stackwalker@8.1_1e"
         )
@@ -923,8 +926,11 @@ class TestSpecSyntax(object):
             ),
             (
                 [
-                    Token(sp.ID, "target"), Token(sp.EQ, "="),
-                    Token(sp.VAL, ":broadwell"), Token(sp.COMMA), Token(sp.VAL, "icelake"),
+                    Token(sp.ID, "target"),
+                    Token(sp.EQ, "="),
+                    Token(sp.VAL, ":broadwell"),
+                    Token(sp.COMMA),
+                    Token(sp.VAL, "icelake"),
                 ],
                 "target=:broadwell,icelake",
             ),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -151,7 +151,7 @@ class TestSpecSyntax(object):
     def check_lex(self, tokens, spec):
         """Check that the provided spec parses to the provided token list."""
         spec = shlex.split(str(spec))
-        lex_output = sp.SpecLexer().lex(spec)
+        lex_output = list(sp.SpecLexer().lex(spec))
         assert len(tokens) == len(lex_output), "unexpected number of tokens"
         for tok, spec_tok in zip(tokens, lex_output):
             if tok.type in (sp.ID, sp.VAL, sp.VER):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -910,6 +910,10 @@ class TestSpecSyntax(object):
         )
         self.check_parse(canonical, spacy_spec)
 
+    def test_kv_roundtrip(self):
+        canonical = Spec("a b='c d'")
+        assert Spec(str(canonical)) == canonical
+
     @pytest.mark.parametrize(
         "expected_tokens,spec_string",
         [

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -401,7 +401,7 @@ class AbstractVariant(object):
         return "{0.__name__}({1}, {2})".format(cls, repr(self.name), repr(self._original_value))
 
     def __str__(self):
-        return "{0}={1}".format(self.name, ",".join(str(x) for x in self.value))
+        return "{0}={1}".format(self.name, ",".join(repr(x) for x in self.value))
 
 
 class MultiValuedVariant(AbstractVariant):
@@ -443,7 +443,7 @@ class MultiValuedVariant(AbstractVariant):
         if self.name == "patches":
             values_str = ",".join(x[:7] for x in self.value)
         else:
-            values_str = ",".join(str(x) for x in self.value)
+            values_str = ",".join(repr(x) for x in self.value)
         return "{0}={1}".format(self.name, values_str)
 
 
@@ -460,7 +460,7 @@ class SingleValuedVariant(AbstractVariant):
         self._value = str(self._value[0])
 
     def __str__(self):
-        return "{0}={1}".format(self.name, self.value)
+        return "{0}={1!r}".format(self.name, self.value)
 
     @implicit_variant_conversion
     def satisfies(self, other):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -45,7 +45,10 @@ from spack.util.spack_yaml import syaml_dict
 __all__ = ["Version", "VersionRange", "VersionList", "ver"]
 
 # Valid version characters
-VALID_VERSION = re.compile(r"^[A-Za-z0-9_.-][=A-Za-z0-9_.-]*$")
+# There may be at most one '=' character within a version string.
+MATCH_VERSION = r"[A-Za-z0-9][A-Za-z0-9_.-]*(?:[=][A-Za-z0-9_.-]+)?"
+NO_EQUAL_VERSION = r"[0-9_][A-Za-z0-9_.-]*"
+VALID_VERSION = re.compile("^{0}$".format(MATCH_VERSION))
 
 # regex for a commit version
 COMMIT_VERSION = re.compile(r"^[a-f0-9]{40}$")
@@ -1178,6 +1181,7 @@ def _string_to_version(string):
         return VersionList(string.split(","))
 
     elif ":" in string:
+        tty.debug(f"string: '{string}'")
         s, e = string.split(":")
         start = Version(s) if s else None
         end = Version(e) if e else None


### PR DESCRIPTION
*This change is on top of #29093; see the diff against it at https://github.com/cosmicexplorer/spack/compare/arbitrary-lexer-modes...remove-shlex-lex-preprocessing?expand=1.*

### Problem

See discussion at https://github.com/spack/spack/pull/29093#issuecomment-1263714030. We currently call `shlex.split()` before lexing spec strings, and this is the main reason why calling `str()` on a spec instance often produces an unparseable string. We would like to be able to call e.g. `Spec(str(Spec('a b="c d"')))` and get the same spec. Unfortunately, on `develop` that produces the following:
```python
>>> Spec(str(Spec('a b="c d"')))
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/cosmicexplorer/tools/s1/lib/spack/spack/spec.py", line 1262, in __init__
    raise ValueError("More than one spec in string: " + spec_like)
ValueError: More than one spec in string: a b=c d
```

### Solution
- Build on the lexer refactoring from #29093 to define many new lexer modes to handle every part of the input string without relying on `shlex.split()`.
- Remove the call to `shlex.split()` in our spec parsing entry point, and move the work of interpreting quotes to the lexer.

### Result
```python
>>> Spec(str(Spec('a b="c d"')))
a b='c d'
```

As discussed in https://github.com/spack/spack/pull/29093#issuecomment-1267942948, this change induces a minor performance regression (this PR even more so than #29093). The regression seems very slight, so I'd like to ignore it, but we'd need to get consensus that this change is enough of a UX improvement to justify that.

It also may be possible to optimize this further; I have not focused on optimizing this approach at all yet.