### PR TITLE
pfunit: Fix ~openmp for version 4

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -80,7 +80,6 @@ class Pfunit(CMakePackage):
             self.define_from_variant("BUILD_SHARED", "shared"),
             "-DCMAKE_Fortran_MODULE_DIRECTORY=%s" % spec.prefix.include,
             self.define_from_variant("BUILD_DOCS", "docs"),
-            self.define_from_variant("OPENMP", "openmp"),
             "-DMAX_RANK=%s" % spec.variants["max_array_rank"].value,
         ]
 
@@ -89,8 +88,10 @@ class Pfunit(CMakePackage):
 
         if spec.satisfies("@4.0.0:"):
             args.append("-DSKIP_MPI=%s" % ("YES" if "~mpi" in spec else "NO"))
+            args.append("-DSKIP_OPENMP=%s" % ("YES" if "~openmp" in spec else "NO"))
         else:
             args.append(self.define_from_variant("MPI", "mpi"))
+            args.append(self.define_from_variant("OPENMP", "openmp"))
 
         if spec.satisfies("+mpi"):
             args.extend(


### PR DESCRIPTION
This fixes a bug in building pFUnit 4 with OpenMP disabled.  The syntax for turning off OpenMP changed between versions 3 and 4 but the `package.py` didn't reflect this.  With this change, the OpenMP is handled in the same way as MPI, which does the right thing for both 3 and 4.

@citibeth
