### PR TITLE
wonton: Fix exported CMake config to not break host codes

### DIFF
--- a/var/spack/repos/builtin/packages/wonton/fix-cmake-config-r3d.patch
+++ b/var/spack/repos/builtin/packages/wonton/fix-cmake-config-r3d.patch
@@ -1,0 +1,23 @@
+--- wonton-1.3.3-orig/wonton/intersect/r3d/config/r3dConfig.cmake.in	2021-03-29 03:04:15.000000000 -0600
++++ wonton-1.3.3/wonton/intersect/r3d/config/r3dConfig.cmake.in	2022-09-21 16:17:20.875412000 -0600
+@@ -2,9 +2,6 @@
+ # R3D configuration file template
+ #-----------------------------------------------------------------------------
+ 
+-# Compiler Definitions
+-set(CMAKE_C_COMPILER @CMAKE_C_COMPILER@ CACHE FILEPATH "C Compiler used for compiling R3D")
+-
+ # R3D installation path
+ set(r3d_ROOT @CMAKE_INSTALL_PREFIX@ CACHE PATH "Path to R3D installation")
+ 
+@@ -22,10 +19,6 @@
+   cmake_policy(SET CMP0074 NEW)  # find_package honors Pkg_ROOT variables 
+ endif ()
+ 
+-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+-  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)  # search for PkgConfig.cmake files first
+-endif ()
+-
+ 
+ #
+ # Import R3D targets

--- a/var/spack/repos/builtin/packages/wonton/fix-cmake-config.patch
+++ b/var/spack/repos/builtin/packages/wonton/fix-cmake-config.patch
@@ -1,0 +1,32 @@
+--- wonton-1.2.11-orig/cmake/wontonConfig.cmake.in	2021-01-20 13:25:56.000000000 -0700
++++ wonton-1.2.11/cmake/wontonConfig.cmake.in	2022-09-12 16:28:11.104950000 -0600
+@@ -12,10 +12,6 @@
+ set(WONTON_VERSION_MINOR @WONTON_VERSION_PATCH@ CACHE STRING "Patch version of WONTON")
+ 
+ 
+-# Compiler Definitions
+-set(CMAKE_C_COMPILER @CMAKE_C_COMPILER@ CACHE FILEPATH "C Compiler used for compiling WONTON")
+-set(CMAKE_CXX_COMPILER @CMAKE_CXX_COMPILER@ CACHE FILEPATH "CXX Compiler used for compiling WONTON")
+-
+ # Wonton installation path
+ set(WONTON_ROOT @CMAKE_INSTALL_PREFIX@ CACHE PATH "Path to Wonton installation")
+ 
+@@ -65,6 +61,7 @@
+ endif ()
+ 
+ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
++  set(SAVED_CMAKE_FIND_PACKAGE_PREFER_CONFIG "${CMAKE_FIND_PACKAGE_PREFER_CONFIG}")
+   set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)  # search for PkgConfig.cmake files first
+ endif ()
+ 
+@@ -135,6 +132,10 @@
+ # Restore original CMAKE_MODULE_PATH
+ set(CMAKE_MODULE_PATH ${SAVED_CMAKE_MODULE_PATH})
+ 
++if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
++  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG "${SAVED_CMAKE_FIND_PACKAGE_PREFER_CONFIG}")
++endif ()
++
+ #
+ # Import wonton targets
+ #

--- a/var/spack/repos/builtin/packages/wonton/package.py
+++ b/var/spack/repos/builtin/packages/wonton/package.py
@@ -76,6 +76,11 @@ class Wonton(CMakePackage):
     depends_on("kokkos +openmp", when="+kokkos +openmp")
     depends_on("kokkos +cuda", when="+kokkos +cuda")
 
+    # Wonton-provided CMake config files contain some settings that
+    # can break host codes; these patches fix that
+    patch("fix-cmake-config.patch", when="@1.2.0:1.3.3")
+    patch("fix-cmake-config-r3d.patch", when="@1.3.0:1.3.3")
+
     def cmake_args(self):
         options = []
         if "+mpi" in self.spec:


### PR DESCRIPTION
As written, Wonton 1.2.0 and later export CMake config files containing a few settings that can break host codes.  This MR adds patches to remove and/or scope the offending lines.

@raovgarimella please review.  @clellsolomon @junghans FYI.
