### PR TITLE
[WIP] e4s ci: map kokkos+rocm to mi200 for post-install spack test

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -260,6 +260,13 @@ spack:
 
     mappings:
       - match:
+          - kokkos +rocm amdgpu_target=gfx90a
+        runner-attributes:
+          tags: [ "uo-gilgamesh-docker-rocm", "gfx90a" ]
+          variables:
+            CI_JOB_SIZE: large
+
+      - match:
           - hipblas
           - llvm
           - llvm-amdgpu


### PR DESCRIPTION
Map `kokkos +rocm` to special Docker Executor runner that has MI200 mapped in so that its post-install `spack test` can exercise the GPU.

FYI @wspear @tldahlgren @scottwittenburg 