### PR TITLE
gmake: add 4.3.90 alpha release

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -76,17 +76,8 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         args = []
-
-        if "+guile" in self.spec:
-            args.append("--with-guile")
-        else:
-            args.append("--without-guile")
-
-        if "+nls" in self.spec:
-            args.append("--enable-nls")
-        else:
-            args.append("--disable-nls")
-
+        args.extend(self.with_or_without('guile'))
+        args.extend(self.with_or_without('nls'))
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -16,9 +16,29 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/make/"
     gnu_mirror_path = "make/make-4.2.1.tar.gz"
 
-    version("4.3", sha256="e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19")
-    version("4.2.1", sha256="e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7")
-    version("4.0", sha256="fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69")
+    # Alpha releases
+    version(
+        "4.3.90",
+        url="http://alpha.gnu.org/gnu/make/make-4.3.90.tar.gz",
+        sha256="b85021da86c3ceaa104151ac1f4af3c811f5f2f61cd383f0de739aa5b2f98c7d",
+    )
+
+    # Stable releases
+    version(
+        "4.3",
+        sha256="e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19",
+        preferred=True,
+    )
+    version(
+        "4.2.1",
+        sha256="e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7",
+        preferred=True,
+    )
+    version(
+        "4.0",
+        sha256="fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69",
+        preferred=True,
+    )
 
     variant("guile", default=False, description="Support GNU Guile for embedded scripting")
     variant("nls", default=True, description="Enable Native Language Support")

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -15,7 +15,7 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/make/"
     gnu_mirror_path = "make/make-4.2.1.tar.gz"
-    maintainers = ['haampie']
+    maintainers = ["haampie"]
 
     # Alpha releases
     version(
@@ -76,8 +76,8 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         args = []
-        args.extend(self.with_or_without('guile'))
-        args.extend(self.with_or_without('nls'))
+        args.extend(self.with_or_without("guile"))
+        args.extend(self.with_or_without("nls"))
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -15,6 +15,7 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/make/"
     gnu_mirror_path = "make/make-4.2.1.tar.gz"
+    maintainers = ['haampie']
 
     # Alpha releases
     version(


### PR DESCRIPTION
GNU Make 4.3.90 supports jobserver through fifo, so it's nice to add the
alpha release to Spack already.
