### PR TITLE
Update the SHA for 5.2.1 release for mlirmiopen recipe.

### DIFF
--- a/var/spack/repos/builtin/packages/mlirmiopen/package.py
+++ b/var/spack/repos/builtin/packages/mlirmiopen/package.py
@@ -18,7 +18,7 @@ class Mlirmiopen(CMakePackage):
     maintainers = ["srekolam"]
 
     version("5.2.3", sha256="29e1c352d203622fa083432d5d368caccb53ba141119fbb7e8d5247d99854625")
-    version("5.2.1", sha256="912eed29ceff038ae537aeb2bc70abdef6d05f3143862c4efe3513e9e9ca2e8d")
+    version("5.2.1", sha256="9e305e05474076d84c78b7a796bca20b64c70ee3e2caa066c625216c5ee21d95")
     version("5.2.0", sha256="546121f203e7787d3501fbaf6673bdbeefbb39e0446b02c480454338362a1f01")
     version("5.1.3", sha256="936f92707ffe9a1973728503db6365bb7f14e5aeccfaef9f0924e54d25080c69")
     version("5.1.0", sha256="56dab11877295784cbb754c10bf2bd6535a3dfea31ec0b97ffe77b94115109dc")


### PR DESCRIPTION
This PR corrects the ChecksumError that is seen with 5.2.1 for mlirmiopen recipe
