### PR TITLE
Add a warning on Python 2.7 deprecation

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -547,6 +547,11 @@ def setup_main_options(args):
     # Assign a custom function to show warnings
     warnings.showwarning = send_warning_to_tty
 
+    if sys.version_info[:2] == (2, 7):
+        msg = ("Running Spack using Python v2.7 is deprecated and support for it will be "
+               " removed after the Spack v0.19 release series.")
+        warnings.warn(msg)
+
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -548,11 +548,10 @@ def setup_main_options(args):
     warnings.showwarning = send_warning_to_tty
 
     if sys.version_info[:2] == (2, 7):
-        msg = (
-            "Running Spack using Python v2.7 is deprecated and support for it will be "
-            " removed in Spack v0.20, use Python v3.6+ instead."
+        warnings.warn(
+            "Python 2.7 support is deprecated and will be removed in Spack v0.20.\n"
+            "    Please move to Python 3.6 or higher."
         )
-        warnings.warn(msg)
 
     # Set up environment based on args.
     tty.set_verbose(args.verbose)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -548,8 +548,10 @@ def setup_main_options(args):
     warnings.showwarning = send_warning_to_tty
 
     if sys.version_info[:2] == (2, 7):
-        msg = ("Running Spack using Python v2.7 is deprecated and support for it will be "
-               " removed after the Spack v0.19 release series.")
+        msg = (
+            "Running Spack using Python v2.7 is deprecated and support for it will be "
+            " removed after the Spack v0.19 release series."
+        )
         warnings.warn(msg)
 
     # Set up environment based on args.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -550,7 +550,7 @@ def setup_main_options(args):
     if sys.version_info[:2] == (2, 7):
         msg = (
             "Running Spack using Python v2.7 is deprecated and support for it will be "
-            " removed after the Spack v0.19 release series."
+            " removed in Spack v0.20."
         )
         warnings.warn(msg)
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -550,7 +550,7 @@ def setup_main_options(args):
     if sys.version_info[:2] == (2, 7):
         msg = (
             "Running Spack using Python v2.7 is deprecated and support for it will be "
-            " removed in Spack v0.20."
+            " removed in Spack v0.20, use Python v3.6+ instead."
         )
         warnings.warn(msg)
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -22,6 +22,9 @@ parser = spack.main.make_argument_parser()
 spack.main.add_all_commands(parser)
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] == (2, 7), reason="Fails as the output contains a warning on Python 2.7"
+)
 def test_names():
     """Test default output of spack commands."""
     out1 = commands().strip().split("\n")


### PR DESCRIPTION
We decided to remove support for running under Python 2.7 after the 0.19 release series. This PR adds a warning message to inform users.