### PR TITLE
Make secondary namespaces accessible with clingo

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -679,6 +679,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         visited=None,
         missing=None,
         virtuals=None,
+        namespace_overrides=None,
     ):
         """Return dict of possible dependencies of this package.
 
@@ -693,6 +694,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             missing (dict or None): dict to populate with packages and their
                 *missing* dependencies.
             virtuals (set): if provided, populate with virtuals seen so far.
+            namespace_overrides (dict or None): full names of explicitly
+                mentioned specs. Here a namespace-override should be possible,
+                i.e. the "full"-name should be used as mapped herein!
 
         Returns:
             (dict): dictionary mapping dependency names to *their*
@@ -717,6 +721,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         visited = {} if visited is None else visited
         missing = {} if missing is None else missing
+        namespace_overrides = {} if namespace_overrides is None else namespace_overrides
 
         visited.setdefault(cls.name, set())
 
@@ -756,14 +761,16 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     continue
 
                 try:
-                    dep_cls = spack.repo.path.get_pkg_class(dep_name)
+                    dep_cls = spack.repo.path.get_pkg_class(
+                        namespace_overrides.get(dep_name, dep_name))
                 except spack.repo.UnknownPackageError:
                     # log unknown packages
                     missing.setdefault(cls.name, set()).add(dep_name)
                     continue
 
                 dep_cls.possible_dependencies(
-                    transitive, expand_virtuals, deptype, visited, missing, virtuals
+                    transitive, expand_virtuals, deptype, visited,
+                    missing, virtuals, namespace_overrides
                 )
 
         return visited

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2892,10 +2892,11 @@ class Spec(object):
 
         # take the best answer
         opt, i, answer = min(result.answers)
-        name = self.name
+        name = self.fullname
         # TODO: Consolidate this code with similar code in solve.py
         if self.virtual:
-            providers = [spec.name for spec in answer.values() if spec.package.provides(name)]
+            # use fullname to include namespaces when necessary. as we now put those in the final answer!
+            providers = [spec.fullname for spec in answer.values() if spec.package.provides(name)]
             name = providers[0]
 
         assert name in answer


### PR DESCRIPTION
My try at solving this: https://github.com/spack/spack/issues/33036

- spec'cing on the CLI: `spack  spec -N sne.py-torch-geometric+cuda ^py-torch-cluster ^py-torch cuda_arch=60 ^cuda+allow-unsupported-compilers` → this just uses the pytorch-geometric-package from the sne-secondary namespace
- unified concretization of envs with specs from secondary repos:
```
spack:
  # add package specs to the `specs` list
  specs:
  - py-torch cuda_arch=60
  - cuda+allow-unsupported-compilers
  - py-torch-geometric+cuda
  view: true
  concretizer:
    unify: true
```

Unclear to me are:
- should a patch for this also suppport `depends_on` with namespaces?
- it seems a lot of the problems around this arise around always using `spec.name` instead of `spec.fullname`. Might this be a more robust fix?
- in general because of the former this might lead to veeeery unintended side-effects.

So now that I've done this as PoC for the new concretizer, I would like to see whether this is integrateable. Imho this is a nice feature if you are a small installation and want to easily support fixes/extras/... for some packages in certain cases. 