### PR TITLE
build_environment: support prefix-map for install --source

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -60,6 +60,7 @@ import spack.paths
 import spack.platforms
 import spack.repo
 import spack.schema.environment
+import spack.spec
 import spack.store
 import spack.subprocess_context
 import spack.user_environment
@@ -275,7 +276,7 @@ def clean_environment():
     return env
 
 
-def set_compiler_environment_variables(pkg, env):
+def set_compiler_environment_variables(pkg, env, install_source=False):
     assert pkg.spec.concrete
     compiler = pkg.compiler
     spec = pkg.spec
@@ -347,6 +348,17 @@ def set_compiler_environment_variables(pkg, env):
         inject_flags[flag] = injf or []
         env_flags[flag] = envf or []
         build_system_flags[flag] = bsf or []
+
+    # Inject prefix map flags when installing from sources, this ensures
+    # that debuggers automatically pick up the sources from the install
+    # dir instead of the staging dir.
+    if install_source:
+        # Map <stage src dir> -> <install dir>/shared/pkg/src
+        source_map = spec.package.compiler.prefix_map_flag(
+            spec.package.stage.source_path, os.path.join(spec.prefix, "shared", spec.name, "src")
+        )
+        if source_map:
+            inject_flags["cppflags"].append(source_map)
 
     # Place compiler flags as specified by flag_handler
     for flag in spack.spec.FlagMap.valid_compiler_flags():
@@ -791,7 +803,7 @@ def load_external_modules(pkg):
             load_module(external_module)
 
 
-def setup_package(pkg, dirty, context="build"):
+def setup_package(pkg, dirty, install_source=False, context="build"):
     """Execute all environment setup routines."""
     if context not in ["build", "test"]:
         raise ValueError("'context' must be one of ['build', 'test'] - got: {0}".format(context))
@@ -806,7 +818,7 @@ def setup_package(pkg, dirty, context="build"):
     # setup compilers for build contexts
     need_compiler = context == "build" or (context == "test" and pkg.test_requires_compiler)
     if need_compiler:
-        set_compiler_environment_variables(pkg, env_mods)
+        set_compiler_environment_variables(pkg, env_mods, install_source)
         set_wrapper_variables(pkg, env_mods)
 
     env_mods.extend(modifications_from_dependencies(pkg.spec, context, custom_mods_only=False))
@@ -1081,7 +1093,10 @@ def _setup_pkg_and_run(
         if not kwargs.get("fake", False):
             kwargs["unmodified_env"] = os.environ.copy()
             kwargs["env_modifications"] = setup_package(
-                pkg, dirty=kwargs.get("dirty", False), context=context
+                pkg,
+                dirty=kwargs.get("dirty", False),
+                context=context,
+                install_source=kwargs.get("install_source", False),
             )
         return_value = function(pkg, kwargs)
         child_pipe.send(return_value)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -270,6 +270,12 @@ class Compiler(object):
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3"]
 
+    def prefix_map_flag(self, old, new):
+        """When sources are relocated from the stage -> install dir
+        this flag can be injected to ensure debuggers can locate
+        sources in the new dir."""
+        return ""
+
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv = None  # type: str
     # Name of module used to switch versions of this compiler

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -149,6 +149,13 @@ class Clang(Compiler):
     def fc_pic_flag(self):
         return "-fPIC"
 
+    def prefix_map_flag(self, old, new):
+        if self.real_version < ver("10"):
+            flag = "-fdebug-prefix-map={}={}"
+        else:
+            flag = "-ffile-prefix-map={}={}"
+        return flag.format(old, new)
+
     required_libs = ["libclang"]
 
     @classmethod

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -128,6 +128,13 @@ class Gcc(spack.compiler.Compiler):
     def fc_pic_flag(self):
         return "-fPIC"
 
+    def prefix_map_flag(self, old, new):
+        if self.real_version < ver("8"):
+            flag = "-fdebug-prefix-map={}={}"
+        else:
+            flag = "-ffile-prefix-map={}={}"
+        return flag.format(old, new)
+
     required_libs = ["libgcc", "libgfortran"]
 
     @classmethod


### PR DESCRIPTION
Attempt to close #9741

More of a proof of concept for now, but the idea is to automatically replace
absolute paths pointing into the stage dir with the actual absolute path of the
sources in the install dir, when installed with `spack install --source`.

Notice though that in many cases binaries contain relative paths, and that
users still need to start gdb with something along the lines of:

```console
gdb> directory <install prefix>/share/<pkg name>/src
```