### PR TITLE
Update versions of the survey performance tool.

### DIFF
--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -33,7 +33,8 @@ class Survey(CMakePackage):
     maintainers = ["jgalarowicz"]
 
     version("master", branch="master")
-    version("1.0.5", branch="1.0.5")
+    version("1.0.6", branch="1.0.6")
+    version("1.0.5", tag="1.0.5")
     version("1.0.4", tag="1.0.4")
     version("1.0.3", tag="1.0.3")
     version("1.0.2", tag="1.0.2")


### PR DESCRIPTION
Update versions of the survey performance tool. Add a new version of survey (1.0.6) and turn branch 1.0.5 into tag 1.0.5.