### PR TITLE
ncbi-toolkit: adding version 26_0_1

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
@@ -14,6 +14,13 @@ class NcbiToolkit(AutotoolsPackage):
     homepage = "https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/"
     url = "ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools++/CURRENT/ncbi_cxx--22_0_0.tar.gz"
 
+    # Per https://ncbi.github.io/cxx-toolkit/pages/ch_getcode_svn#ch_getcode_svn.external
+    # New versions are released on github
+    version(
+        "26_0_1",
+        sha256="aba79da5c8d0407ffc92b7831f4f8f8a8096a15e47a016ada81b6568f9d280cc",
+        url="https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release-26.0.1.tar.gz",
+    )
     version(
         "25_2_0",
         sha256="9f824a92750e64e7b9be98d82b84414ab4f7e5d73392dadbb87c94ff5ccf9111",
@@ -34,6 +41,8 @@ class NcbiToolkit(AutotoolsPackage):
 
     depends_on("boost@1.35.0:+test+log")
     depends_on("bzip2")
+    depends_on("cpio", type="build")
+    depends_on("diffutils", type="build")
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("libtiff")
@@ -46,6 +55,7 @@ class NcbiToolkit(AutotoolsPackage):
     depends_on("zlib")
     depends_on("samtools")
     depends_on("bamtools")
+    depends_on("berkeley-db")
 
     def configure_args(self):
         args = ["--without-sybase", "--without-fastcgi"]
@@ -87,6 +97,11 @@ class NcbiToolkit(AutotoolsPackage):
                         file_,
                     )
                     filter_file(r"(log_build_info\(ostr)\)", r"\1, true)", file_)
+
+        with working_dir(join_path("scripts", "common", "impl")):
+            files = ["if_diff.sh", "update_configurable.sh"]
+            for file in files:
+                filter_file("PATH=/bin:/usr/bin", "", file)
 
     def build(self, spec, prefix):
         with working_dir(join_path(glob("*MT64")[0], "build")):


### PR DESCRIPTION
Fetch: 0.08s.  Build: 57m 3.37s.  Total: 57m 3.45s. 

:|

Anyway, I missed the fact that new releases moved to github when I touched this last.

Per discussion in #29501 I've added berkeley-db as a dependency and verified that table2asn is built.

This recipe needs some attention, several scripts involved in the build and configure process hard code a /bin or /usr/bin path for executables, which is annoying with spack. Modern versions use cmake and make it easier to disable tests, which would likely improve build time. I don't have the time right now to give it the attention it deserves.