### PR TITLE
Installer: Replace missed instance of cache_only

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2355,9 +2355,14 @@ class BuildRequest(object):
         Returns:
             tuple: required dependency type(s) for the package
         """
+        cache_only = self.install_args.get("package_cache_only")
+        # This is likely never true, but check it to be safe
+        if not pkg.name == self.pkg.name:
+            cache_only = self.install_args.get("dependencies_cache_only")
+
         deptypes = ["link", "run"]
         include_build_deps = self.install_args.get("include_build_deps")
-        if not self.install_args.get("cache_only") or include_build_deps:
+        if not cache_only or include_build_deps:
             deptypes.append("build")
         if self.run_tests(pkg):
             deptypes.append("test")


### PR DESCRIPTION
@scottwittenburg I missed this instance when doing the use-buildcache option

@alalazo @tgamblin FYI