### PR TITLE
exodusii: add fortran variant

### DIFF
--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -56,6 +56,7 @@ class Exodusii(CMakePackage):
     version("master", branch="master")
 
     variant("mpi", default=True, description="Enables MPI parallelism.")
+    variant("fortran", default=False, description="Build exodus Fortran wrapper libraries.")
 
     depends_on("cmake@2.8.11:", type="build")
     depends_on("mpi", when="+mpi")
@@ -88,6 +89,16 @@ class Exodusii(CMakePackage):
             "-DCMAKE_C_COMPILER={0}".format(cc_path),
             "-DCMAKE_CXX_COMPILER={0}".format(cxx_path),
         ]
+        if "+fortran" in spec:
+            fc_path = spec["mpi"].mpifc if "+mpi" in spec else self.compiler.f90
+            options.extend(
+                [
+                    "-DSEACASProj_ENABLE_Fortran:BOOL=ON",
+                    "-DCMAKE_Fortran_COMPILER={0}".format(fc_path),
+                    "-DSEACASProj_ENABLE_SEACASExodus_for:BOOL=ON",
+                    "-DSEACASProj_ENABLE_SEACASExoIIv2for32:BOOL=ON"
+                ]
+            )
         # Python #
         # Handle v2016 separately because of older tribits
         if spec.satisfies("@:2016-08-09"):

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -56,7 +56,7 @@ class Exodusii(CMakePackage):
     version("master", branch="master")
 
     variant("mpi", default=True, description="Enables MPI parallelism.")
-    variant("fortran", default=False, description="Build exodus Fortran wrapper libraries.")
+    variant("fortran", default=False, description="Build Fortran wrapper libraries.")
 
     depends_on("cmake@2.8.11:", type="build")
     depends_on("mpi", when="+mpi")
@@ -96,7 +96,7 @@ class Exodusii(CMakePackage):
                     "-DSEACASProj_ENABLE_Fortran:BOOL=ON",
                     "-DCMAKE_Fortran_COMPILER={0}".format(fc_path),
                     "-DSEACASProj_ENABLE_SEACASExodus_for:BOOL=ON",
-                    "-DSEACASProj_ENABLE_SEACASExoIIv2for32:BOOL=ON"
+                    "-DSEACASProj_ENABLE_SEACASExoIIv2for32:BOOL=ON",
                 ]
             )
         # Python #


### PR DESCRIPTION
- Add `+fortran` variant, default to inactive
- Pass general cmake options to set the Fortran compiler
- Pass project-specific cmake options to activate Fortran language in the project and configure/build the Fortran interface libraries for exodusii
- Follows existing package implementation patterns 