### PR TITLE
e4s ci: add quantum-espresso

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -132,6 +132,7 @@ spack:
   - py-warpx ^warpx dims=3
   - py-warpx ^warpx dims=rz
   - qthreads scheduler=distrib
+  - quantum-espresso
   - raja
   - scr
   - slate ~cuda


### PR DESCRIPTION
Adding `quantum-espresso` to E4S stack

@bellenlau @danielecesarini @ye-luo @wspear 

Are there specific variants you would like to see turned on here?