### PR TITLE
py-black: add v22.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -17,6 +17,7 @@ class PyBlack(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("22.10.0", sha256="f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1")
     version("22.8.0", sha256="792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e")
     version("22.6.0", sha256="6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9")
     version("22.3.0", sha256="35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79")
@@ -25,29 +26,30 @@ class PyBlack(PythonPackage):
     # This is the last v21 release, and it's needed to format for Python 2.7
     version("21.12b0", sha256="77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3")
 
-    variant("d", default=False, description="enable blackd HTTP server")
     variant("colorama", default=False, description="enable colorama support")
     variant("uvloop", default=False, description="enable uvloop support")
+    variant("d", default=False, description="enable blackd HTTP server")
     variant("jupyter", default=False, description="enable Jupyter support")
 
-    # pyproject.toml
-    depends_on("py-setuptools@45:", type=("build", "run"))
-    depends_on("py-setuptools-scm@6.3.1:+toml", type="build")
-
-    # setup.py
+    depends_on("py-hatchling@1.8:", when="@22.10:", type="build")
+    depends_on("py-hatch-vcs", when="@22.10:", type="build")
+    depends_on("py-hatch-fancy-pypi-readme", when="@22.10:", type="build")
+    depends_on("py-setuptools@45:", when="@:22.8", type=("build", "run"))
+    depends_on("py-setuptools-scm@6.3.1:+toml", when="@:22.8", type="build")
+    depends_on("python@3.7:", when="@22.10:", type=("build", "run"))
     depends_on("python@3.6.2:", type=("build", "run"))
     depends_on("py-click@8:", type=("build", "run"))
+    depends_on("py-mypy-extensions@0.4.3:", type=("build", "run"))
+    depends_on("py-pathspec@0.9:", type=("build", "run"))
     depends_on("py-platformdirs@2:", type=("build", "run"))
     depends_on("py-tomli@1.1:", when="@22.8: ^python@:3.10", type=("build", "run"))
     depends_on("py-tomli@1.1:", when="@21.7:22.6", type=("build", "run"))
     depends_on("py-typed-ast@1.4.2:", when="^python@:3.7", type=("build", "run"))
-    depends_on("py-pathspec@0.9:", type=("build", "run"))
-    depends_on("py-dataclasses@0.6:", when="^python@:3.6", type=("build", "run"))
     depends_on("py-typing-extensions@3.10:", when="^python@:3.9", type=("build", "run"))
-    depends_on("py-mypy-extensions@0.4.3:", type=("build", "run"))
-    depends_on("py-aiohttp@3.7.4:", when="+d", type=("build", "run"))
+    depends_on("py-dataclasses@0.6:", when="^python@:3.6", type=("build", "run"))
     depends_on("py-colorama@0.4.3:", when="+colorama", type=("build", "run"))
     depends_on("py-uvloop@0.15.2:", when="+uvloop", type=("build", "run"))
+    depends_on("py-aiohttp@3.7.4:", when="+d", type=("build", "run"))
     depends_on("py-ipython@7.8:", when="+jupyter", type=("build", "run"))
     depends_on("py-tokenize-rt@3.2:", when="+jupyter", type=("build", "run"))
 


### PR DESCRIPTION
Successfully builds on macOS 12.6 (arm64) with Python 3.9.13 and Apple Clang 14.0.0.

https://github.com/psf/black/releases/tag/22.10.0