### PR TITLE
Proper terminal width with prompt decorator

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -158,7 +158,7 @@ class match_to_ansi(object):
         """Returns a TTY escape sequence for a color"""
         if self.color:
             if self.enclose:
-                return "\[\033[%sm\]" % s
+                return r"\[\033[%sm\]" % s
             else:
                 return "\033[%sm" % s
         else:

--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -150,13 +150,17 @@ def color_when(value):
 
 
 class match_to_ansi(object):
-    def __init__(self, color=True):
+    def __init__(self, color=True, enclose=False):
         self.color = _color_when_value(color)
+        self.enclose = enclose
 
     def escape(self, s):
         """Returns a TTY escape sequence for a color"""
         if self.color:
-            return "\033[%sm" % s
+            if self.enclose:
+                return "\[\033[%sm\]" % s
+            else:
+                return "\033[%sm" % s
         else:
             return ""
 
@@ -201,9 +205,11 @@ def colorize(string, **kwargs):
     Keyword Arguments:
         color (bool): If False, output will be plain text without control
             codes, for output to non-console devices.
+        enclose (bool): If True, enclose ansi color sequences with
+            square brackets to prevent misestimation of terminal width.
     """
     color = _color_when_value(kwargs.get("color", get_color_when()))
-    string = re.sub(color_re, match_to_ansi(color), string)
+    string = re.sub(color_re, match_to_ansi(color, kwargs.get("enclose")), string)
     string = string.replace("}}", "}")
     return string
 

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -44,7 +44,7 @@ def activate_header(env, shell, prompt=None):
         # TODO: prompt
     else:
         if "color" in os.getenv("TERM", "") and prompt:
-            prompt = colorize("@G{%s}" % prompt, color=True)
+            prompt = colorize("@G{%s}" % prompt, color=True, enclose=True)
 
         cmds += "export SPACK_ENV=%s;\n" % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"


### PR DESCRIPTION
The Spack environment prompt decorator for Bourne shells (set by `spack env activate -p`) does not properly encapsulate color codes with square brackets. Thus, when a line of text spills to the next line in the terminal, the display is broken as the shell is confused about the width of the $PS1 value. This StackExchange post describes the problem more generally:

https://unix.stackexchange.com/questions/105958/terminal-prompt-not-wrapping-correctly

The proposed modification in this PR adds a keyword argument to the colorize method to add these square brackets around color sequences if the argument is true. The argument is only set when colorize is called by the shell decoration code in shell.py, and so other uses of colorize should be unaffected by the change.