### PR TITLE
Fix for padding relocation (issue 28170)

### DIFF
--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -121,6 +121,7 @@ def parse_install_tree(config_dict):
             msg = "Cannot pad %s to %s characters." % (root, padded_length)
             msg += " It is already %s characters long" % len(root)
             tty.warn(msg)
+        root = root.rstrip(os.path.sep)
     else:
         root = unpadded_root
 


### PR DESCRIPTION
This is a proposed fix for #28170. The problem is that the trailing slash can be left at the end of the padded path, and when Spack subs that path during package relocation the slash is removed and an invalid path is produced in the resulting files/binaries. If we strip trailing slashes, as is done for non-padded paths, the problem goes away for any length padded prefix.