### PR TITLE
global: add `--with-ncurses` flag to configure

### DIFF
--- a/var/spack/repos/builtin/packages/global/global-ncurse.patch
+++ b/var/spack/repos/builtin/packages/global/global-ncurse.patch
@@ -1,0 +1,11 @@
+--- a/configure	2021-07-01 12:06:50.000000000 +0800
++++ b/configure	2022-10-10 14:30:01.348062669 +0800
+@@ -15771,7 +15771,7 @@
+   withval=$with_ncurses; if test x$withval = xno ; then
+ 		search_ncurses=false
+ 	  elif test x$withval != xyes ; then
+-		CURSES_LIBS="$LIBS -L$withval/lib -lncurses"
++		CURSES_LIBS="$LIBS -L$withval/lib -lncurses -ltinfo"
+ 		CURSES_INCLUDEDIR="-I$withval/include"
+ 		search_ncurses=false
+ 		screen_manager="ncurses"

--- a/var/spack/repos/builtin/packages/global/package.py
+++ b/var/spack/repos/builtin/packages/global/package.py
@@ -24,14 +24,16 @@ class Global(Package):
     depends_on("exuberant-ctags", type=("build", "run"))
     depends_on("ncurses")
 
-    def install(self, spec, prefix):
-        config_args = ["--prefix={0}".format(prefix)]
+    patch("global-ncurse.patch")
 
-        config_args.append(
+    def install(self, spec, prefix):
+        config_args = [
+            "--prefix={0}".format(prefix),
             "--with-exuberant-ctags={0}".format(
                 os.path.join(spec["exuberant-ctags"].prefix.bin, "ctags")
-            )
-        )
+            ),
+            "--with-ncurses={0}".format(spec["ncurses"].prefix),
+        ]
 
         configure(*config_args)
 


### PR DESCRIPTION
Add this option to make global turely depend on `ncurses`.