### PR TITLE
Add option to disable reordering of -I/-L/-isystem paths in spack compiler wrapper

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -445,17 +445,25 @@ while [ $# -ne 0 ]; do
             arg="${1#-isystem}"
             isystem_was_used=true
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if system_dir "$arg"; then
-                append isystem_system_include_dirs_list "$arg"
+            if empty "SPACK_REORDER_PATHS"; then
+                if system_dir "$arg"; then
+                    append isystem_system_include_dirs_list "$arg"
+                else
+                    append isystem_include_dirs_list "$arg"
+                fi
             else
-                append isystem_include_dirs_list "$arg"
+                append include_dirs_list "$arg"
             fi
             ;;
         -I*)
             arg="${1#-I}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if system_dir "$arg"; then
-                append system_include_dirs_list "$arg"
+            if empty "SPACK_REORDER_PATHS"; then
+                if system_dir "$arg"; then
+                    append system_include_dirs_list "$arg"
+                else
+                    append include_dirs_list "$arg"
+                fi
             else
                 append include_dirs_list "$arg"
             fi
@@ -463,8 +471,12 @@ while [ $# -ne 0 ]; do
         -L*)
             arg="${1#-L}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if system_dir "$arg"; then
-                append system_lib_dirs_list "$arg"
+            if empty "SPACK_REORDER_PATHS"; then
+                if system_dir "$arg"; then
+                    append system_lib_dirs_list "$arg"
+                else
+                    append lib_dirs_list "$arg"
+                fi
             else
                 append lib_dirs_list "$arg"
             fi

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -494,6 +494,8 @@ def set_wrapper_variables(pkg, env):
     env.set(SPACK_INCLUDE_DIRS, ":".join(include_dirs))
     env.set(SPACK_RPATH_DIRS, ":".join(rpath_dirs))
 
+    env.set("SPACK_REORDER_PATHS", pkg.reorder_paths)
+
 
 def determine_number_of_jobs(
     parallel=False, command_line=None, config_default=None, max_cpus=None

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -494,7 +494,8 @@ def set_wrapper_variables(pkg, env):
     env.set(SPACK_INCLUDE_DIRS, ":".join(include_dirs))
     env.set(SPACK_RPATH_DIRS, ":".join(rpath_dirs))
 
-    env.set("SPACK_REORDER_PATHS", pkg.reorder_paths)
+    if pkg.reorder_paths:
+        env.set("SPACK_REORDER_PATHS", "TRUE")
 
 
 def determine_number_of_jobs(

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -494,8 +494,8 @@ def set_wrapper_variables(pkg, env):
     env.set(SPACK_INCLUDE_DIRS, ":".join(include_dirs))
     env.set(SPACK_RPATH_DIRS, ":".join(rpath_dirs))
 
-    if pkg.reorder_paths:
-        env.set("SPACK_REORDER_PATHS", "TRUE")
+    if not pkg.reorder_paths:
+        env.set("SPACK_REORDER_PATHS", "FALSE")
 
 
 def determine_number_of_jobs(

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -911,6 +911,11 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
         return "%s.%s" % (cls.namespace, cls.name)
 
     @classproperty
+    def reorder_paths(cls):
+        """Reorder -I and -L paths when using Spack compiler wrapper"""
+        return True
+
+    @classproperty
     def fullnames(cls):
         """Fullnames for this package and any packages from which it inherits."""
         fullnames = []


### PR DESCRIPTION
Short description: add class property to prevent Spack from reordering -I/-L paths in compiler wrapper, treating all `-I/-L/-isystem`. Default behavior is to 

Reasoning: CMS offline software [cmssw](https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_6_X/master/cmssw-tool-conf.spec) is an example of a large package with lots of dependencies. It is built using `scram` tool (makefile generator similar to `cmake`) using custom ordering of `-I` and `-L` paths to speed up compilation process (e.g. pushing ROOT's paths to the front of the command line, so that `gcc` does not need to check 100+ other paths for ROOT headers). 

@smuzaffar can provide more information on how CMS builds it's offline software.