### PR TITLE
 add ANL mpi-serial package (used by parallelio)

### DIFF
--- a/var/spack/repos/builtin/packages/mpi-serial/install.patch
+++ b/var/spack/repos/builtin/packages/mpi-serial/install.patch
@@ -1,0 +1,34 @@
+--- old/Makefile
++++ new/Makefile
+@@ -76,6 +76,9 @@
+
+ .PHONY: clean tests install
+
++includedir = $(PREFIX)/include
++libdir = $(PREFIX)/lib
++
+ clean:
+ 	/bin/rm -f *.o ctest ftest $(LIB) mpi.mod config.log config.status
+ 	cd tests ; $(MAKE) clean
+@@ -83,7 +86,7 @@
+ tests:
+ 	cd tests; make
+
+-install: lib
++install: $(LIB)
+ 	$(MKINSTALLDIRS) $(libdir) $(includedir)
+ 	$(INSTALL) lib$(MODULE).a -m 644 $(libdir)
+ 	$(INSTALL) mpi.h -m 644 $(includedir)
+--- old/Makefile.conf.in
++++ new/Makefile.conf.in
+@@ -10,7 +10,8 @@
+ LIBS            = @LIBS@
+ CRULE           = .c.o
+ F90RULE         = .F90.o
+-
++MKINSTALLDIRS   = mkdir
+ SHELL		= /bin/sh
+-
++INSTALL         = install
+ MODULE		= mpi-serial
++PREFIX          = @prefix@

--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MpiSerial(AutotoolsPackage):
+    """A single processor implementation of the mpi library."""
+
+    homepage = "https://github.com/MCSclimate/mpi-serial"
+    url = "https://github.com/MCSclimate/mpi-serial/archive/refs/tags/MPIserial_2.3.0.tar.gz"
+
+    # notify when the package is updated.
+    maintainers = ["jedwards4b"]
+
+    version("2.3.0", sha256="cc55e6bf0ae5e1d93aafa31ba91bfc13e896642a511c3101695ea05eccf97988")
+
+    variant(
+        "fort-real-size",
+        values=int,
+        default=4,
+        description="Specify the size of Fortran real variables",
+    )
+
+    variant(
+        "fort-double-size",
+        values=int,
+        default=8,
+        description="Specify the size of Fortran double precision variables",
+    )
+
+    patch("install.patch")
+
+    provides("mpi")
+
+    def configure_args(self):
+        args = []
+        realsize = int(self.spec.variants["fort-real-size"].value)
+        if realsize != 4:
+            args.extend(
+                [
+                    "--enable-fort-real={0}".format(realsize),
+                ]
+            )
+        doublesize = int(self.spec.variants["fort-double-size"].value)
+        if doublesize != 8:
+            args.extend(
+                [
+                    "--enable-fort-double={0}".format(doublesize),
+                ]
+            )
+        return args


### PR DESCRIPTION
The mpi-serial package is needed to build a single processor version of the parallelio library.
This single processor version is useful for testing and is used in some single processor applications.  
