### PR TITLE
Omega-H: Current constraint doesn't allow any cuda

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -53,16 +53,16 @@ class OmegaH(CMakePackage, CudaPackage):
     # Note: '+cuda' and 'cuda_arch' variants are added by the CudaPackage
     depends_on("cuda", when="+cuda")
     conflicts(
-        "cuda@11.2:",
+        "cuda@11.2",
         when="@scorec.10.1.0:",
-        msg="Thrust is broken in CUDA >= 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
+        msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
     )
     # the sandia repo has a fix for cuda > 11.2 support
     #  see github.com/sandialabs/omega_h/pull/373
     conflicts(
-        "cuda@11.2:",
+        "cuda@11.2",
         when="@:9.34.4",
-        msg="Thrust is broken in CUDA >= 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
+        msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
     )
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86610


### PR DESCRIPTION
From the issue referenced, it seems later and earlier versions of cuda work.