### PR TITLE
py-poetry-core: jail git to stage directory

### DIFF
--- a/var/spack/repos/builtin/packages/py-poetry-core/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-core/package.py
@@ -27,3 +27,10 @@ class PyPoetryCore(PythonPackage):
     depends_on("py-typing@3.7.4.1:3", when="^python@2.7", type=("build", "run"))
     depends_on("py-enum34@1.1.10:1", when="^python@2.7", type=("build", "run"))
     depends_on("py-functools32@3.2.3-2:3", when="^python@2.7", type=("build", "run"))
+
+    # https://github.com/python-poetry/poetry/issues/5547
+    def setup_build_environment(self, env):
+        env.set("GIT_DIR", self.stage.source_path)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("GIT_DIR", dependent_spec.package.stage.source_path)


### PR DESCRIPTION
See https://github.com/python-poetry/poetry/issues/5547 for discussion of the bug that this PR works around.

Fixes #32375 @skosukhin 
Fixes #29308 @climbfuji
Fixes https://github.com/spack/spack/pull/32936#discussion_r985116969 @luke-dt 

Can everyone test this to ensure that it works?

Should this be done for all packages in Spack? I can imagine other packages whose build behavior changes depending on how far git recurses up the build tree. But I'm not sure where in `build_environment.py` to put this.

Are there any possible issues with this approach? What if someone is behind a firewall and requires proxy stuff that is in their global git configuration file?