### PR TITLE
blast-plus: update to 2.13.0 and add cpio as build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -10,10 +10,11 @@ class BlastPlus(AutotoolsPackage):
     """Basic Local Alignment Search Tool."""
 
     homepage = "https://blast.ncbi.nlm.nih.gov/"
-    url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.12.0/ncbi-blast-2.12.0+-src.tar.gz"
+    url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.13.0/ncbi-blast-2.13.0+-src.tar.gz"
 
     maintainers = ["weijianwen"]
 
+    version("2.13.0", sha256="89553714d133daf28c477f83d333794b3c62e4148408c072a1b4620e5ec4feb2")
     version("2.12.0", sha256="fda3c9c9d488cad6c1880a98a236d842bcf3610e3e702af61f7a48cf0a714b88")
     version("2.11.0", sha256="d88e1858ae7ce553545a795a2120e657a799a6d334f2a07ef0330cc3e74e1954")
     version("2.9.0", sha256="a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257")

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -46,7 +46,7 @@ class BlastPlus(AutotoolsPackage):
     # No...
     # depends_on :mysql => :optional
 
-    depends_on('cpio', type='build')
+    depends_on("cpio", type="build")
 
     variant("static", default=False, description="Build with static linkage")
     variant("jpeg", default=True, description="Build with jpeg support")

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -48,7 +48,6 @@ class BlastPlus(AutotoolsPackage):
 
     depends_on('cpio', type='build')
 
-
     variant("static", default=False, description="Build with static linkage")
     variant("jpeg", default=True, description="Build with jpeg support")
     variant("png", default=True, description="Build with png support")

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -46,6 +46,9 @@ class BlastPlus(AutotoolsPackage):
     # No...
     # depends_on :mysql => :optional
 
+    depends_on('cpio', type='build')
+
+
     variant("static", default=False, description="Build with static linkage")
     variant("jpeg", default=True, description="Build with jpeg support")
     variant("png", default=True, description="Build with png support")


### PR DESCRIPTION
To fix #33148 I changed the package and add a build dependency. While at it I updated the version to the latest. 
@weijianwen (Maintainer)