### PR TITLE
Relocate Text Dependencies

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -698,7 +698,7 @@ def write_buildinfo_file(spec, workdir, rel=False):
     prefix_to_hash = dict()
     prefix_to_hash[str(spec.package.prefix)] = spec.dag_hash()
     deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in deps + spec.dependencies(type="run"):
+    for d in deps + spec.dependencies(deptype="run"):
         prefix_to_hash[str(d.prefix)] = d.dag_hash()
 
     # Create buildinfo data and write it to disk
@@ -1451,7 +1451,7 @@ def relocate_package(spec, allow_root):
     hash_to_prefix = dict()
     hash_to_prefix[spec.format("{hash}")] = str(spec.package.prefix)
     new_deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in new_deps + spec.dependencies(type="run"):
+    for d in new_deps + spec.dependencies(deptype="run"):
         hash_to_prefix[d.format("{hash}")] = str(d.prefix)
     # Spurious replacements (e.g. sbang) will cause issues with binaries
     # For example, the new sbang can be longer than the old one.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -698,7 +698,7 @@ def write_buildinfo_file(spec, workdir, rel=False):
     prefix_to_hash = dict()
     prefix_to_hash[str(spec.package.prefix)] = spec.dag_hash()
     deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in deps + spec.dependencies():
+    for d in deps + spec.dependencies(type="run"):
         prefix_to_hash[str(d.prefix)] = d.dag_hash()
 
     # Create buildinfo data and write it to disk
@@ -1451,7 +1451,7 @@ def relocate_package(spec, allow_root):
     hash_to_prefix = dict()
     hash_to_prefix[spec.format("{hash}")] = str(spec.package.prefix)
     new_deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in new_deps + spec.dependencies():
+    for d in new_deps + spec.dependencies(type="run"):
         hash_to_prefix[d.format("{hash}")] = str(d.prefix)
     # Spurious replacements (e.g. sbang) will cause issues with binaries
     # For example, the new sbang can be longer than the old one.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -698,7 +698,7 @@ def write_buildinfo_file(spec, workdir, rel=False):
     prefix_to_hash = dict()
     prefix_to_hash[str(spec.package.prefix)] = spec.dag_hash()
     deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in deps:
+    for d in deps + spec.dependencies():
         prefix_to_hash[str(d.prefix)] = d.dag_hash()
 
     # Create buildinfo data and write it to disk
@@ -1451,7 +1451,7 @@ def relocate_package(spec, allow_root):
     hash_to_prefix = dict()
     hash_to_prefix[spec.format("{hash}")] = str(spec.package.prefix)
     new_deps = spack.build_environment.get_rpath_deps(spec.package)
-    for d in new_deps:
+    for d in new_deps + spec.dependencies():
         hash_to_prefix[d.format("{hash}")] = str(d.prefix)
     # Spurious replacements (e.g. sbang) will cause issues with binaries
     # For example, the new sbang can be longer than the old one.


### PR DESCRIPTION
When downloading from binary cache not only replace RPATHs to dependencies, but also text references to dependencies.

Example:
`autoconf@2.69` contains a text reference to the executable of its dependency `perl`:

```
$ grep perl-5 /shared/spack/opt/spack/linux-amzn2-x86_64_v3/gcc-7.3.1/autoconf-2.69-q3lo/bin/autoreconf
eval 'case $# in 0) exec /shared/spack/opt/spack/linux-amzn2-x86_64_v3/gcc-7.3.1/perl-5.34.1-yphg/bin/perl -S "$0";; *) exec /shared/spack/opt/spack/linux-amzn2-x86_64_v3/gcc-7.3.1/perl-5.34.1-yphg/bin/perl -S "$0" "$@";; esac'
```

These references need to be replace or any package using `autoreconf` will fail as it cannot find the installed `perl`.