### PR TITLE
ESMF package update

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/longtoint.patch
+++ b/var/spack/repos/builtin/packages/esmf/longtoint.patch
@@ -3,10 +3,10 @@
 @@ -122,7 +122,7 @@ void LoadNCDualMeshPar(Mesh &mesh, const std::string fname) {
        local_grid_start = my_start*grid_dims[0];
      }
-     
+
 -    int local_grid_dims[2] = {grid_dims[0], my_num > 0 ? my_num+1 : 0};
 +    int local_grid_dims[2] = {grid_dims[0], (int) my_num > 0 ? (int) my_num+1 : 0};
- 
+
      Par::Out() << "min_row=" << min_row << ", max_row=" << max_row << std::endl;
      Par::Out() << "local_grid_start=" << local_grid_start << ", local_grid_size:" << local_grid_size << std::endl;
 --- old/src/Infrastructure/Mesh/src/Legacy/ESMCI_WriteWeightsPar.C
@@ -14,9 +14,9 @@
 @@ -229,7 +229,7 @@ static void get_nc_grid_file1(nc_grid_file1 &ncf, const std::string &ncfile, boo
    ncf.local_grid_size = local_grid_size;
    ncf.local_grid_start = local_grid_start;
-   
+
 -  int local_grid_dims[2] = {grid_dims[0], my_num > 0 ? my_num+1 : 0};
 +  int local_grid_dims[2] = {grid_dims[0], (int) my_num > 0 ? (int) my_num+1 : 0};
- 
+
    Par::Out() << "min_row=" << min_row << ", max_row=" << max_row << std::endl;
    Par::Out() << "local_grid_start=" << local_grid_start << ", local_grid_size:" << local_grid_size << std::endl;

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -116,7 +116,8 @@ class Esmf(MakefilePackage):
     patch("mvapich2.patch", when="@:7.0")
 
     # explicit type cast of variables from long to int
-    patch("cce.patch", when="@:8.3.2 %cce@14:")
+    patch("longtoint.patch", when="@:8.3.2 %cce@14:")
+    patch("longtoint.patch", when="@:8.3.2 %oneapi@2022:")
 
     # Allow different directories for creation and
     # installation of dynamic libraries on OSX:

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -23,6 +23,11 @@ class Esmf(MakefilePackage):
 
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
+    # generate chksum with spack checksum esmf@x.y.z
+    version(
+        "8.3.1",
+        sha256="6c39261e55dcdf9781cdfa344417b9606f7f961889d5ec626150f992f04f146d",
+    )
     version(
         "8.3.0",
         sha256="0ff43ede83d1ac6beabd3d5e2a646f7574174b28a48d1b9f2c318a054ba268fd",
@@ -56,7 +61,7 @@ class Esmf(MakefilePackage):
         description="Build with external LAPACK support",
     )
     variant("netcdf", default=True, description="Build with NetCDF support")
-    variant("pnetcdf", default=True, description="Build with pNetCDF support")
+    variant("pnetcdf", default=True, description="Build with pNetCDF support", when="+mpi")
     variant("xerces", default=True, description="Build with Xerces support")
     variant(
         "parallelio",
@@ -111,7 +116,7 @@ class Esmf(MakefilePackage):
     patch("mvapich2.patch", when="@:7.0")
 
     # explicit type cast of variables from long to int
-    patch("cce.patch", when="@:8.4.0 %cce@13.99:")
+    patch("cce.patch", when="@:8.3.2 %cce@14:")
 
     # Allow different directories for creation and
     # installation of dynamic libraries on OSX:
@@ -194,7 +199,7 @@ class Esmf(MakefilePackage):
                     "."
                 )[0]
             )
-        elif self.compiler.name == "intel":
+        elif self.compiler.name == "intel" or self.compiler.name == "oneapi":
             os.environ["ESMF_COMPILER"] = "intel"
         elif self.compiler.name in ["clang", "apple-clang"]:
             os.environ["ESMF_COMPILER"] = "gfortranclang"
@@ -207,6 +212,8 @@ class Esmf(MakefilePackage):
             os.environ["ESMF_COMPILER"] = "nag"
         elif self.compiler.name == "pgi":
             os.environ["ESMF_COMPILER"] = "pgi"
+        elif self.compiler.name == "nvhpc":
+            os.environ["ESMF_COMPILER"] = "nvhpc"
         elif self.compiler.name == "cce":
             os.environ["ESMF_COMPILER"] = "cce"
         else:


### PR DESCRIPTION
1. Updates the default version to latest release 8.3.1.   
2. Make pnetcdf variant dependent on mpi
3. Improve when parameters for cce patch
4. Add support for nvhpc and intel oneapi compilers
