### PR TITLE
GCC: update Xcode 14 conflict

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -332,7 +332,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     conflicts("%gcc@:4.7", when="@11:")
 
     # https://github.com/iains/gcc-12-branch/issues/6
-    conflicts("%apple-clang@14:")
+    conflicts("%apple-clang@14.0")
 
     if sys.platform == "darwin":
         # Fix parallel build on APFS filesystem


### PR DESCRIPTION
According to https://github.com/iains/gcc-12-branch/issues/6#issuecomment-1260282797, this issue will be fixed in the 14.1 release.