### PR TITLE
neovim: add version 0.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -13,6 +13,8 @@ class Libvterm(Package):
     homepage = "http://www.leonerd.org.uk/code/libvterm/"
     url = "http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.3.tar.gz"
 
+    version("0.3", sha256="61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358")
+    version("0.2", sha256="4c5150655438cfb8c57e7bd133041140857eb04defd0e544521c0e469258e105")
     version("0.1.4", sha256="bc70349e95559c667672fc8c55b9527d9db9ada0fb80a3beda533418d782d3dd")
     version("0.1.3", sha256="e41724466a4658e0f095e8fc5aeae26026c0726dce98ee71d6920d06f7d78e2b")
     version(

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -17,6 +17,7 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable")
+    version("0.8.0", sha256="505e3dfb71e2f73495c737c034a416911c260c0ba9fd2092c6be296655be4d18")
     version("0.7.2", sha256="ccab8ca02a0c292de9ea14b39f84f90b635a69282de38a6b4ccc8565bc65d096")
     version("0.7.0", sha256="792a9c55d5d5f4a5148d475847267df309d65fb20f05523f21c1319ea8a6c7df")
     version(
@@ -132,6 +133,8 @@ class Neovim(CMakePackage):
         depends_on("libluv@1.43.0:")
         depends_on("libuv@1.44.1:")
         depends_on("tree-sitter@0.20.6:")
+    with when("@0.8:"):
+        depends_on("libvterm@0.3:")
 
     @when("^lua")
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -118,7 +118,7 @@ class Neovim(CMakePackage):
         depends_on("libvterm@0.1:")
         depends_on("unibilium@2.0:")
         depends_on("msgpack-c@1.0.0:")
-    with when("@0.5:,stable,master"):
+    with when("@0.5:"):
         depends_on("libuv@1.42:")
         depends_on("tree-sitter")
     with when("@0.6:"):
@@ -128,7 +128,7 @@ class Neovim(CMakePackage):
         depends_on("libtermkey@0.22:")
         depends_on("libvterm@0.1.4:")
         depends_on("msgpack-c@3.0.0:")
-    with when("@0.6:,master"):
+    with when("@0.7:"):
         depends_on("gettext@0.20.1:")
         depends_on("libluv@1.43.0:")
         depends_on("libuv@1.44.1:")


### PR DESCRIPTION
Fix #33219

- add new versions for dependency `libvterm`
- add `neovim@0.8.0` and related constraint

Reference:
- Release note https://github.com/neovim/neovim/commit/d367ed9b23d481998d297d812f54b950e5511c24
- https://github.com/neovim/neovim/pull/20222

In addition to this, non-numeric versions management has been removed from older version constraints.
I don't know why they were there. By quickly looking at the git logs, it seems they were there from very long time, probably they did not took into account about https://spack.readthedocs.io/en/latest/packaging_guide.html#version-comparison or it was not fully working.

I don't know, just speculating. Let me know if you prefer to revert 35fe0ad847c7f7aab6196b165f2ec5cc1fafc579