### PR TITLE
env depfile: allow deps only install

### DIFF
--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -11,6 +11,7 @@ import six
 import llnl.util.lang
 
 import spack.config
+import spack.extensions
 from spack.util.path import canonicalize_path
 
 

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -1,0 +1,37 @@
+SPACK ?= spack
+
+.PHONY: {{ all_target }} {{ clean_target }}
+
+{{ all_target }}: {{ env_target }}
+
+{{ env_target }}: {{ root_install_targets }}
+	@touch $@
+
+{{ dirs_target }}:
+	@mkdir -p {{ install_target }} {{ install_deps_target }}
+
+# The spack install commands are of the form:
+# spack -e my_env --no-add --only=package --only=concrete /hash
+# This is an involved way of expressing that Spack should only install
+# an individual concrete spec from the environment without deps.
+{{ install_target }}/%: {{ install_deps_target }}/% | {{ dirs_target }}
+	$(info Installing $(SPEC))
+	{{ jobserver_support }}$(SPACK) -e '{{ environment }}' install $(SPACK_INSTALL_FLAGS) --only-concrete --only=package --no-add /$(notdir $@)
+	@touch $@
+
+# Targets of the form {{ install_deps_target }}/<hash> install dependencies only
+{{ install_deps_target }}/%: | {{ dirs_target }}
+	touch $@
+
+# Set a human-readable SPEC variable for each target that has a hash
+{% for (hash, name) in hash_with_name -%} 
+{{ any_hash_target }}/{{ hash }}: SPEC = {{ name }}
+{% endfor %}
+
+# The Spack DAG expressed in targets:
+{% for (target, prereqs) in targets_to_prereqs -%}
+{{ target }}: {{prereqs}}
+{% endfor %}
+
+{{ clean_target }}:
+	rm -rf {{ env_target }} {{ all_install_targets }} {{ all_install_deps_targets }}

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -21,7 +21,7 @@ SPACK ?= spack
 
 # Targets of the form {{ install_deps_target }}/<hash> install dependencies only
 {{ install_deps_target }}/%: | {{ dirs_target }}
-	touch $@
+	@touch $@
 
 # Set a human-readable SPEC variable for each target that has a hash
 {% for (hash, name) in hash_with_name -%} 


### PR DESCRIPTION
- Refactor `spack env depfile` to use a Jinja template, making it a bit
  easier to follow as a human being.
- Add a layer of indirection in the generated Makefile through an
  `<prefix>/.install-deps/<hash>` target, which allows one to specify
  different options when installing dependencies. For example, only
  verbose/debug mode on when installing some particular spec:
  ```console
  $ spack -e my_env env depfile -o Makefile --make-target-prefix example
  $ make -j16 example/.install-deps/{hash} SPACK_INSTALL_FLAGS=--please-never-build-from-sources
  $ make -j16 example/.install/{hash} SPACK="spack -d" SPACK_INSTALL_FLAGS=--verbose
  ```

This could be used to speed up `spack ci rebuild`:
- Parallel install of dependencies from buildcache
- Better readability of logs, e.g. reducing verbosity when installing
  dependencies, and splitting logs into deps.log and current_spec.log

Given that `spack ci rebuild` is already unix only and make is a required spack dep... I think it's worth doing this.