### PR TITLE
paraview: static cuda is not supported

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -109,7 +109,7 @@ class Paraview(CMakePackage, CudaPackage):
     # Python 2 support dropped with 5.9.0
     conflicts("+python", when="@5.9:")
     conflicts("+python3", when="@:5.5")
-    conflicts("+shared", when="+cuda")
+    conflicts("~shared", when="+cuda")
     conflicts("+cuda", when="@5.8:5.10")
     # Legacy rendering dropped in 5.5
     # See commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c


### PR DESCRIPTION
At this moment we do not support static CUDA builds. This change reflects this.

fixes https://github.com/spack/spack/issues/33233