### PR TITLE
gitlab ci install binary deps faster

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -25,7 +25,8 @@ description = "manage continuous integration pipelines"
 section = "build"
 level = "long"
 
-CI_REBUILD_INSTALL_BASE_ARGS = ["spack", "--color=always", "--backtrace", "--verbose"]
+SPACK_COMMAND = "spack"
+MAKE_COMMAND = "make"
 INSTALL_FAIL_CODE = 1
 
 
@@ -509,41 +510,88 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    install_args = [base_arg for base_arg in CI_REBUILD_INSTALL_BASE_ARGS]
+    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose"]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:
-        install_args.append("-k")
+        spack_cmd.append("-k")
 
-    install_args.extend(
-        [
-            "install",
-            "--keep-stage",
-            "--use-buildcache",
-            "dependencies:only,package:never",
-        ]
-    )
+    install_args = []
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
     if not verify_binaries:
         install_args.append("--no-check-signature")
 
+    cdash_args = []
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
-        install_args.extend(cdash_handler.args())
+        cdash_args.extend(cdash_handler.args())
 
-    # A compiler action of 'FIND_ANY' means we are building a bootstrap
-    # compiler or one of its deps.
-    # TODO: when compilers are dependencies, we should include --no-add
-    if compiler_action != "FIND_ANY":
-        install_args.append("--no-add")
+    slash_hash = "/{}".format(job_spec.dag_hash())
+    deps_install_args = install_args
+    root_install_args = install_args + [
+        "--no-add",
+        "--keep-stage",
+        "--only=package",
+        "--use-buildcache=package:never,dependencies:only",
+        slash_hash,
+    ]
 
-    # Identify spec to install by hash
-    install_args.append("/{0}".format(job_spec.dag_hash()))
+    # ["x", "y"] -> "'x' 'y'"
+    args_to_string = lambda args: " ".join("'{}'".format(arg) for arg in args)
+
+    commands = [
+        # apparently there's a race when spack bootstraps? do it up front once
+        [
+            SPACK_COMMAND,
+            "-e",
+            env.path,
+            "bootstrap",
+            "now",
+        ],
+        [
+            SPACK_COMMAND,
+            "-e",
+            env.path,
+            "config",
+            "add",
+            "config:db_lock_timeout:120",  # 2 minutes for processes to fight for a db lock
+        ],
+        [
+            SPACK_COMMAND,
+            "-e",
+            env.path,
+            "env",
+            "depfile",
+            "-o",
+            "Makefile",
+            "--use-buildcache=package:never,dependencies:only",
+            "--make-target-prefix",
+            "ci",
+            slash_hash,  # limit to spec we're building
+        ],
+        [
+            # --output-sync requires GNU make 4.x.
+            # Old make errors when you pass it a flag it doesn't recognize,
+            # but it doesn't error or warn when you set unrecognized flags in
+            # this variable.
+            "export",
+            "GNUMAKEFLAGS=--output-sync=recurse",
+        ],
+        [
+            MAKE_COMMAND,
+            "SPACK={}".format(args_to_string(spack_cmd)),
+            "SPACK_COLOR=always",
+            "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
+            "-j$(nproc)",
+            "ci/.install-deps/{}".format(job_spec.dag_hash()),
+        ],
+        spack_cmd + ["install"] + root_install_args,
+    ]
 
     tty.debug("Installing {0} from source".format(job_spec.name))
-    install_exit_code = spack_ci.process_command("install", install_args, repro_dir)
+    install_exit_code = spack_ci.process_command("install", commands, repro_dir)
 
     # Now do the post-install tasks
     tty.debug("spack install exited {0}".format(install_exit_code))

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -916,11 +916,8 @@ def test_ci_rebuild_mock_success(
     pkg_name = "archive-files"
     rebuild_env = create_rebuild_env(tmpdir, pkg_name, broken_tests)
 
-    monkeypatch.setattr(
-        spack.cmd.ci,
-        "CI_REBUILD_INSTALL_BASE_ARGS",
-        ["echo"],
-    )
+    monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "echo")
+    monkeypatch.setattr(spack.cmd.ci, "MAKE_COMMAND", "echo")
 
     with rebuild_env.env_dir.as_cwd():
         activate_rebuild_env(tmpdir, pkg_name, rebuild_env)
@@ -965,7 +962,8 @@ def test_ci_rebuild(
 
         ci_cmd("rebuild", "--tests", fail_on_error=False)
 
-    monkeypatch.setattr(spack.cmd.ci, "CI_REBUILD_INSTALL_BASE_ARGS", ["notcommand"])
+    monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "notcommand")
+    monkeypatch.setattr(spack.cmd.ci, "MAKE_COMMAND", "notcommand")
     monkeypatch.setattr(spack.cmd.ci, "INSTALL_FAIL_CODE", 127)
 
     with rebuild_env.env_dir.as_cwd():

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -241,6 +241,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -240,6 +240,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249 gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -148,6 +148,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -159,6 +159,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -32,6 +32,9 @@ spack:
 
   gitlab-ci:
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -47,6 +47,9 @@ spack:
   gitlab-ci:
     image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -214,6 +214,7 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.powerpc64le-linux-gnu.tar.gz | tar -xzf - -C /usr 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -266,6 +266,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -253,6 +253,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -87,6 +87,9 @@ spack:
 
   gitlab-ci:
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -90,6 +90,9 @@ spack:
 
   gitlab-ci:
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -93,6 +93,9 @@ spack:
 
   gitlab-ci:
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -56,6 +56,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -61,6 +61,9 @@ spack:
   gitlab-ci:
 
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -64,6 +64,9 @@ spack:
   gitlab-ci:
     image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -63,6 +63,9 @@ spack:
 
   gitlab-ci:
     script:
+      - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
+      - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
+      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version
       - spack compiler find


### PR DESCRIPTION
This PR does a few things:

- Parallel install of binary dependencies from buildcache (with redundant build edges pruned in the DAG)
- Improve legibility:
  1. Reduce verbosity installing buildcache deps, so that users get to see the build log for the source build
  2. Show timers for binary installation, so we get more insight into why a job is slow.
  3. Use GNU Make's output sync feature to get orderly output when installing deps in parallel
  4. Remove a few `spack -d` flags, so we get to see the build logs before hitting the max log size.

![Screenshot from 2022-10-20 11-42-10](https://user-images.githubusercontent.com/194764/196914643-3504cfa8-b7b0-41eb-aea5-acc4f4c6c4c5.png)
...
![Screenshot from 2022-10-20 11-44-14](https://user-images.githubusercontent.com/194764/196915157-cdf9b3e1-53fb-4424-a9e6-ebf59d77aab7.png)


This PR is built on top of these parts:

- #33305
- #33315 
- #33361 
- #33363
- #33367 