### PR TITLE
e4s ci: vtk-m +rocm: try building with +openmp (default)

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -224,7 +224,7 @@ spack:
   - tasmanian ~openmp +rocm amdgpu_target=gfx90a
   - tau +mpi +rocm
   - upcxx +rocm amdgpu_target=gfx90a
-  - vtk-m ~openmp +rocm amdgpu_target=gfx90a
+  - vtk-m +rocm amdgpu_target=gfx90a
 
   # CPU failures
   #- geopm                                        # /usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error:'__builtin_strncpy' specified bound 512 equals destination size [-Werror=stringop-truncation]


### PR DESCRIPTION
E4S CI: try building `vtk-m +rocm` with `+openmp` enabled

We tried this before and it didn't work, see https://github.com/spack/spack/pull/32151#issuecomment-1234671175 for discussion

FYI @kwryankrattiger @wspear @kmorel @vicentebolea 