### PR TITLE
packages.yaml: set url/git

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -548,7 +548,8 @@ You can assign class-level attributes in the configuration:
       x: 1
 
 Attributes set this way will be accessible to any method executed
-in the package.py file (e.g. the ``install()`` method).
+in the package.py file (e.g. the ``install()`` method). Values for these
+attributes may be any value parseable by yaml.
 
 These can only be applied to specific packages, not "all" or
 virtual packages.

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -531,3 +531,24 @@ directories inside the install prefix. This will ensure that even
 manually placed files within the install prefix are owned by the
 assigned group. If no group is assigned, Spack will allow the OS
 default behavior to go as expected.
+
+----------------------------
+Assigning Package Attributes
+----------------------------
+
+You can assign class-level attributes in the configuration:
+
+.. code-block:: yaml
+
+  packages:
+    mpileaks:
+      # Override existing attributes
+      url: http://www.somewhereelse.com/mpileaks-1.0.tar.gz
+      # ... or add new ones
+      x: 1
+
+Attributes set this way will be accessible to any method executed
+in the package.py file (e.g. the ``install()`` method).
+
+These can only be applied to specific packages, not "all" or
+virtual packages.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -700,6 +700,8 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
         settings = spack.config.get("packages").get(spec.name, {}).get("package_attributes", {})
         for key, val in settings.items():
             setattr(self, key, val)
+        # Note: the potential issue with setting these attributes here vs.
+        # in Repo.get is that subclasses could override these properties
 
     @classmethod
     def possible_dependencies(

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -694,15 +694,6 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
 
         super(PackageBase, self).__init__()
 
-        # packages.yaml config can override package attributes. This is set
-        # on the instance rather than the class since the configuration can
-        # change between calls to repo.get for the same package.
-        settings = spack.config.get("packages").get(spec.name, {}).get("package_attributes", {})
-        for key, val in settings.items():
-            setattr(self, key, val)
-        # Note: the potential issue with setting these attributes here vs.
-        # in Repo.get is that subclasses could override these properties
-
     @classmethod
     def possible_dependencies(
         cls,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -697,7 +697,7 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
         # packages.yaml config can override package attributes. This is set
         # on the instance rather than the class since the configuration can
         # change between calls to repo.get for the same package.
-        settings = spack.config.get("packages").get(spec.name, {}).get("set", {})
+        settings = spack.config.get("packages").get(spec.name, {}).get("package_attributes", {})
         for key, val in settings.items():
             setattr(self, key, val)
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -694,6 +694,13 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
 
         super(PackageBase, self).__init__()
 
+        # packages.yaml config can override package attributes. This is set
+        # on the instance rather than the class since the configuration can
+        # change between calls to repo.get for the same package.
+        settings = spack.config.get("packages").get(spec.name, {}).get("set", {})
+        for key, val in settings.items():
+            setattr(self, key, val)
+
     @classmethod
     def possible_dependencies(
         cls,

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1366,6 +1366,10 @@ class Repo(object):
         overidden_attrs = getattr(cls, 'overidden_attrs', {})
         for key, val in overidden_attrs.items():
             setattr(cls, key, val)
+        # Keep track of every class attribute that is overidden by the config:
+        # if the config changes between calls to this method, we make sure to
+        # restore the original config values (in case the new config no longer
+        # sets attributes that it used to)
         new_overidden_attrs = {}
         for key, val in new_cfg_settings.items():
             new_overidden_attrs[key] = getattr(cls, key)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1378,6 +1378,8 @@ class Repo(object):
             setattr(cls, key, val)
         if new_overidden_attrs:
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
+        else:
+            delattr(cls, "overidden_attrs")
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1366,16 +1366,26 @@ class Repo(object):
             spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
         )
         overidden_attrs = getattr(cls, "overidden_attrs", {})
+        attrs_exclusively_from_config = getattr(cls, "attrs_exclusively_from_config", [])
+        # Clear any prior changes to class attributes in case the config has
+        # since changed
         for key, val in overidden_attrs.items():
             setattr(cls, key, val)
+        for key in attrs_exclusively_from_config:
+            delattr(cls, key)
+
         # Keep track of every class attribute that is overidden by the config:
         # if the config changes between calls to this method, we make sure to
         # restore the original config values (in case the new config no longer
         # sets attributes that it used to)
         new_overidden_attrs = {}
+        new_attrs_exclusively_from_config = set()
         for key, val in new_cfg_settings.items():
             if hasattr(cls, key):
                 new_overidden_attrs[key] = getattr(cls, key)
+            else:
+                new_attrs_exclusively_from_config.add(key)
+
             if isinstance(val, list):
                 raise spack.config.ConfigError("Unsupported attribute value: list")
             elif isinstance(val, dict):
@@ -1388,6 +1398,10 @@ class Repo(object):
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
         elif hasattr(cls, "overidden_attrs"):
             delattr(cls, "overidden_attrs")
+        if new_attrs_exclusively_from_config:
+            setattr(cls, "attrs_exclusively_from_config", new_attrs_exclusively_from_config)
+        elif hasattr(cls, "attrs_exclusively_from_config"):
+            delattr(cls, "attrs_exclusively_from_config")
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1362,6 +1362,16 @@ class Repo(object):
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
 
+        new_cfg_settings = spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
+        overidden_attrs = getattr(cls, 'overidden_attrs', {})
+        for key, val in overidden_attrs.items():
+            setattr(cls, key, val)
+        new_overidden_attrs = {}
+        for key, val in new_cfg_settings.items():
+            new_overidden_attrs[key] = getattr(cls, key)
+            setattr(cls, key, val)
+        setattr(cls, 'overidden_attrs', dict(new_overidden_attrs))
+
         return cls
 
     def __str__(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1378,7 +1378,7 @@ class Repo(object):
             setattr(cls, key, val)
         if new_overidden_attrs:
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
-        else:
+        elif hasattr(cls, "overidden_attrs"):
             delattr(cls, "overidden_attrs")
 
         return cls

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1366,32 +1366,32 @@ class Repo(object):
             spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
         )
 
-        overidden_attrs = getattr(cls, "overidden_attrs", {})
+        overridden_attrs = getattr(cls, "overridden_attrs", {})
         attrs_exclusively_from_config = getattr(cls, "attrs_exclusively_from_config", [])
         # Clear any prior changes to class attributes in case the config has
         # since changed
-        for key, val in overidden_attrs.items():
+        for key, val in overridden_attrs.items():
             setattr(cls, key, val)
         for key in attrs_exclusively_from_config:
             delattr(cls, key)
 
-        # Keep track of every class attribute that is overidden by the config:
+        # Keep track of every class attribute that is overridden by the config:
         # if the config changes between calls to this method, we make sure to
         # restore the original config values (in case the new config no longer
         # sets attributes that it used to)
-        new_overidden_attrs = {}
+        new_overridden_attrs = {}
         new_attrs_exclusively_from_config = set()
         for key, val in new_cfg_settings.items():
             if hasattr(cls, key):
-                new_overidden_attrs[key] = getattr(cls, key)
+                new_overridden_attrs[key] = getattr(cls, key)
             else:
                 new_attrs_exclusively_from_config.add(key)
 
             setattr(cls, key, val)
-        if new_overidden_attrs:
-            setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
-        elif hasattr(cls, "overidden_attrs"):
-            delattr(cls, "overidden_attrs")
+        if new_overridden_attrs:
+            setattr(cls, "overridden_attrs", dict(new_overridden_attrs))
+        elif hasattr(cls, "overridden_attrs"):
+            delattr(cls, "overridden_attrs")
         if new_attrs_exclusively_from_config:
             setattr(cls, "attrs_exclusively_from_config", new_attrs_exclusively_from_config)
         elif hasattr(cls, "attrs_exclusively_from_config"):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1387,11 +1387,6 @@ class Repo(object):
             else:
                 new_attrs_exclusively_from_config.add(key)
 
-            if isinstance(val, list):
-                raise spack.config.ConfigError("Unsupported attribute value: list")
-            elif isinstance(val, dict):
-                raise spack.config.ConfigError("Unsupported attribute value: dict")
-
             setattr(cls, key, val)
         if new_overidden_attrs:
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1374,20 +1374,10 @@ class Repo(object):
         # sets attributes that it used to)
         new_overidden_attrs = {}
         for key, val in new_cfg_settings.items():
-            if hasattr(cls, key):
-                new_overidden_attrs[key] = getattr(cls, key)
-            if isinstance(val, dict):
-                t = val.get("type", "string")
-                v = val["value"]
-                if t == "int":
-                    v = int(v)
-                elif t == "float":
-                    v = float(v)
-                elif t == "boolean":
-                    v = yaml.load(v)
-                setattr(cls, key, v)
-            else:
-                setattr(cls, key, val)
+            if key not in ["git", "url", "submodules"]:
+                # Infer type
+                val = yaml.load(val)
+            setattr(cls, key, val)
         if new_overidden_attrs:
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
         elif hasattr(cls, "overidden_attrs"):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1376,7 +1376,8 @@ class Repo(object):
         for key, val in new_cfg_settings.items():
             new_overidden_attrs[key] = getattr(cls, key)
             setattr(cls, key, val)
-        setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
+        if new_overidden_attrs:
+            setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1374,6 +1374,12 @@ class Repo(object):
         # sets attributes that it used to)
         new_overidden_attrs = {}
         for key, val in new_cfg_settings.items():
+            if hasattr(cls, key):
+                new_overidden_attrs[key] = getattr(cls, key)
+            if isinstance(val, list):
+                raise spack.config.ConfigError("Unsupported attribute value: list")
+            elif isinstance(val, dict):
+                raise spack.config.ConfigError("Unsupported attribute value: dict")
             if key not in ["git", "url", "submodules"]:
                 # Infer type
                 val = yaml.load(val)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1362,6 +1362,11 @@ class Repo(object):
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
 
+        # packages.yaml config can override package attributes
+        settings = spack.config.get("packages").get(pkg_name, {}).get("set", {})
+        for key, val in settings.items():
+            setattr(cls, key, val)
+
         return cls
 
     def __str__(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1362,21 +1362,7 @@ class Repo(object):
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
 
-        new_cfg_settings = (
-            spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
-        )
-        overidden_attrs = getattr(cls, "overidden_attrs", {})
-        for key, val in overidden_attrs.items():
-            setattr(cls, key, val)
-        # Keep track of every class attribute that is overidden by the config:
-        # if the config changes between calls to this method, we make sure to
-        # restore the original config values (in case the new config no longer
-        # sets attributes that it used to)
-        new_overidden_attrs = {}
-        for key, val in new_cfg_settings.items():
-            new_overidden_attrs[key] = getattr(cls, key)
-            setattr(cls, key, val)
-        setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
+        # TODO: restore logic here
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1362,7 +1362,21 @@ class Repo(object):
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
 
-        # TODO: restore logic here
+        new_cfg_settings = (
+            spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
+        )
+        overidden_attrs = getattr(cls, "overidden_attrs", {})
+        for key, val in overidden_attrs.items():
+            setattr(cls, key, val)
+        # Keep track of every class attribute that is overidden by the config:
+        # if the config changes between calls to this method, we make sure to
+        # restore the original config values (in case the new config no longer
+        # sets attributes that it used to)
+        new_overidden_attrs = {}
+        for key, val in new_cfg_settings.items():
+            new_overidden_attrs[key] = getattr(cls, key)
+            setattr(cls, key, val)
+        setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1169,7 +1169,7 @@ class Repo(object):
 
         package_class = self.get_pkg_class(spec.name)
         try:
-            package_instance = package_class(spec)
+            return package_class(spec)
         except spack.error.SpackError:
             # pass these through as their error messages will be fine.
             raise
@@ -1181,15 +1181,6 @@ class Repo(object):
             if spack.config.get("config:debug"):
                 sys.excepthook(*sys.exc_info())
             raise FailedConstructorError(spec.fullname, *sys.exc_info())
-
-        # packages.yaml config can override package attributes. This is set
-        # on the instance rather than the class since the configuration can
-        # change between calls to repo.get for the same package.
-        settings = spack.config.get("packages").get(spec.name, {}).get("set", {})
-        for key, val in settings.items():
-            setattr(package_instance, key, val)
-
-        return package_instance
 
     @autospec
     def dump_provenance(self, spec, path):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1365,6 +1365,7 @@ class Repo(object):
         new_cfg_settings = (
             spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
         )
+
         overidden_attrs = getattr(cls, "overidden_attrs", {})
         attrs_exclusively_from_config = getattr(cls, "attrs_exclusively_from_config", [])
         # Clear any prior changes to class attributes in case the config has
@@ -1390,9 +1391,7 @@ class Repo(object):
                 raise spack.config.ConfigError("Unsupported attribute value: list")
             elif isinstance(val, dict):
                 raise spack.config.ConfigError("Unsupported attribute value: dict")
-            if key not in ["git", "url", "submodules"]:
-                # Infer type
-                val = yaml.load(val)
+
             setattr(cls, key, val)
         if new_overidden_attrs:
             setattr(cls, "overidden_attrs", dict(new_overidden_attrs))

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1169,7 +1169,7 @@ class Repo(object):
 
         package_class = self.get_pkg_class(spec.name)
         try:
-            return package_class(spec)
+            package_instance = package_class(spec)
         except spack.error.SpackError:
             # pass these through as their error messages will be fine.
             raise
@@ -1181,6 +1181,15 @@ class Repo(object):
             if spack.config.get("config:debug"):
                 sys.excepthook(*sys.exc_info())
             raise FailedConstructorError(spec.fullname, *sys.exc_info())
+
+        # packages.yaml config can override package attributes. This is set
+        # on the instance rather than the class since the configuration can
+        # change between calls to repo.get for the same package.
+        settings = spack.config.get("packages").get(spec.name, {}).get("set", {})
+        for key, val in settings.items():
+            setattr(package_instance, key, val)
+
+        return package_instance
 
     @autospec
     def dump_provenance(self, spec, path):
@@ -1361,11 +1370,6 @@ class Repo(object):
         cls = getattr(module, class_name)
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
-
-        # packages.yaml config can override package attributes
-        settings = spack.config.get("packages").get(pkg_name, {}).get("set", {})
-        for key, val in settings.items():
-            setattr(cls, key, val)
 
         return cls
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -33,8 +33,6 @@ import llnl.util.tty as tty
 from llnl.util.compat import Mapping
 from llnl.util.filesystem import working_dir
 
-import spack.util.spack_yaml as syaml
-import ruamel.yaml as ryaml
 import spack.caches
 import spack.config
 import spack.error
@@ -1386,7 +1384,7 @@ class Repo(object):
                 elif t == "float":
                     v = float(v)
                 elif t == "boolean":
-                    v = ryaml.load(v)
+                    v = yaml.load(v)
                 setattr(cls, key, v)
             else:
                 setattr(cls, key, val)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1362,8 +1362,10 @@ class Repo(object):
         if not inspect.isclass(cls):
             tty.die("%s.%s is not a class" % (pkg_name, class_name))
 
-        new_cfg_settings = spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
-        overidden_attrs = getattr(cls, 'overidden_attrs', {})
+        new_cfg_settings = (
+            spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
+        )
+        overidden_attrs = getattr(cls, "overidden_attrs", {})
         for key, val in overidden_attrs.items():
             setattr(cls, key, val)
         # Keep track of every class attribute that is overidden by the config:
@@ -1374,7 +1376,7 @@ class Repo(object):
         for key, val in new_cfg_settings.items():
             new_overidden_attrs[key] = getattr(cls, key)
             setattr(cls, key, val)
-        setattr(cls, 'overidden_attrs', dict(new_overidden_attrs))
+        setattr(cls, "overidden_attrs", dict(new_overidden_attrs))
 
         return cls
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -100,17 +100,7 @@ properties = {
                         },
                         "patternProperties": {
                             r"\w[\w-]*": {
-                                "type": "object",
-                                "additionalProperties": False,
-                                "properties": {
-                                    "value": {
-                                        "type": "string",
-                                    },
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["int", "float", "boolean"],
-                                    },
-                                },
+                                "type": "string",
                             },
                         },
                     },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -84,7 +84,7 @@ properties = {
                     },
                     # If 'get_full_repo' is promoted to a Package-level
                     # attribute, it could be useful to set it here
-                    "set": {
+                    "package_attributes": {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -82,6 +82,23 @@ properties = {
                             },
                         },
                     },
+                    # If 'get_full_repo' is promoted to a Package-level
+                    # attribute, it could be useful to set it here
+                    "set": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "git": {
+                                "type": "string",
+                            },
+                            "url": {
+                                "type": "string",
+                            },
+                            "submodules": {
+                                "type": "boolean",
+                            },
+                        },
+                    },
                     "providers": {
                         "type": "object",
                         "default": {},

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -99,8 +99,15 @@ properties = {
                             },
                         },
                         "patternProperties": {
-                            r"\w[\w-]*": {
-                                "type": "string",
+                            r"\w+": {
+                                "oneOf": [
+                                    {"type": "string"},
+                                    {"type": "array", "items": {"type": "string"}},
+                                    {
+                                        "type": "object",
+                                        "patternProperties": {r"\w+": {"type": "string"}},
+                                    },
+                                ]
                             },
                         },
                     },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -98,6 +98,21 @@ properties = {
                                 "type": "boolean",
                             },
                         },
+                        "patternProperties": {
+                            r"\w[\w-]*": {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["int", "float", "boolean"],
+                                    },
+                                },
+                            },
+                        },
                     },
                     "providers": {
                         "type": "object",

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -87,28 +87,8 @@ properties = {
                     "package_attributes": {
                         "type": "object",
                         "additionalProperties": False,
-                        "properties": {
-                            "git": {
-                                "type": "string",
-                            },
-                            "url": {
-                                "type": "string",
-                            },
-                            "submodules": {
-                                "type": "boolean",
-                            },
-                        },
                         "patternProperties": {
-                            r"\w+": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {"type": "array", "items": {"type": "string"}},
-                                    {
-                                        "type": "object",
-                                        "patternProperties": {r"\w+": {"type": "string"}},
-                                    },
-                                ]
-                            },
+                            r"\w+": {},
                         },
                     },
                     "providers": {

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -195,20 +195,36 @@ class TestConcretizePreferences(object):
 
     def test_config_set_pkg_property_new(self, mutable_mock_repo):
         """Test that you can set arbitrary attributes on the Package class"""
-        update_packages(
-            "mpileaks",
-            "package_attributes",
-            {"x": 1, "y": True, "z": "yesterday"},
+        conf = syaml.load_config(
+            """\
+mpileaks:
+  package_attributes:
+    v1: 1
+    v2: true
+    v4: yesterday
+    v5: "true"
+    v6:
+      x: 1
+      y: 2
+    v7:
+    - 1
+    - 2
+"""
         )
+        spack.config.set("packages", conf, scope="concretize")
+
         spec = concretize("mpileaks")
-        assert spec.package.x == 1
-        assert spec.package.y is True
-        assert spec.package.z == "yesterday"
+        assert spec.package.v1 == 1
+        assert spec.package.v2 is True
+        assert spec.package.v4 == "yesterday"
+        assert spec.package.v5 == "true"
+        assert dict(spec.package.v6) == {"x": 1, "y": 2}
+        assert list(spec.package.v7) == [1, 2]
 
         update_packages("mpileaks", "package_attributes", {})
         spec = concretize("mpileaks")
         with pytest.raises(AttributeError):
-            spec.package.x
+            spec.package.v1
 
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -179,6 +179,22 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert "zmpi" in spec
 
+    def test_config_set_url_for_package(self, mutable_mock_repo):
+        """Test preferred providers of virtual packages are
+        applied correctly
+        """
+        update_packages(
+            "mpileaks",
+            "package_attributes",
+            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
+        )
+        spec = concretize("mpileaks")
+        assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"
+
+        update_packages("mpileaks", "package_attributes", {})
+        spec = concretize("mpileaks")
+        assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
+
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""
         spec = Spec("python")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -204,15 +204,15 @@ class TestConcretizePreferences(object):
         )
         spec = concretize("mpileaks")
         assert spec.package.x == 1
-        assert spec.package.y == True
-        assert spec.package.w == True
+        assert spec.package.y is True
+        assert spec.package.w is True
         assert spec.package.z == "yesterday"
 
     def test_config_set_pkg_property_collecton_unsupported(self, mutable_mock_repo):
         """Test that an error is raised if you attempt to assign a list value"""
         update_packages("mpileaks", "package_attributes", {"x": ["a", "b"]})
         with pytest.raises(ConfigError):
-            spec = concretize("mpileaks")
+            concretize("mpileaks")
 
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -180,8 +180,7 @@ class TestConcretizePreferences(object):
         assert "zmpi" in spec
 
     def test_config_set_pkg_property_url(self, mutable_mock_repo):
-        """Test setting an attribute that is explicitly-handled in the schema
-        """
+        """Test setting an attribute that is explicitly-handled in the schema"""
         update_packages(
             "mpileaks",
             "package_attributes",

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -202,16 +202,7 @@ class TestConcretizePreferences(object):
         update_packages(
             "mpileaks",
             "package_attributes",
-            {
-                "x": {
-                    "value": "1",
-                    "type": "int",
-                },
-                "y": {
-                    "value": "true",
-                    "type": "boolean",
-                },
-            },
+            {"x": "1", "y": "true"},
         )
         spec = concretize("mpileaks")
         assert spec.package.x == 1

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -184,12 +184,12 @@ class TestConcretizePreferences(object):
         applied correctly
         """
         update_packages(
-            "mpileaks", "set", {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
+            "mpileaks", "package_attributes", {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
         )
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"
 
-        update_packages("mpileaks", "set", {})
+        update_packages("mpileaks", "package_attributes", {})
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -179,6 +179,22 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert "zmpi" in spec
 
+    def test_config_set_url_for_package(self, mutable_mock_repo):
+        """Test preferred providers of virtual packages are
+        applied correctly
+        """
+        update_packages(
+            "mpileaks",
+            "set",
+            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
+        )
+        spec = concretize("mpileaks")
+        assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"
+
+        update_packages("mpileaks", "set", {})
+        spec = concretize("mpileaks")
+        assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
+
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""
         spec = Spec("python")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -180,8 +180,7 @@ class TestConcretizePreferences(object):
         assert "zmpi" in spec
 
     def test_config_set_pkg_property_url(self, mutable_mock_repo):
-        """Test preferred providers of virtual packages are
-        applied correctly
+        """Test setting an attribute that is explicitly-handled in the schema
         """
         update_packages(
             "mpileaks",
@@ -208,7 +207,12 @@ class TestConcretizePreferences(object):
         assert spec.package.w is True
         assert spec.package.z == "yesterday"
 
-    def test_config_set_pkg_property_collecton_unsupported(self, mutable_mock_repo):
+        update_packages("mpileaks", "package_attributes", {})
+        spec = concretize("mpileaks")
+        with pytest.raises(AttributeError):
+            spec.package.x
+
+    def test_config_set_pkg_property_collection_unsupported(self, mutable_mock_repo):
         """Test that an error is raised if you attempt to assign a list value"""
         update_packages("mpileaks", "package_attributes", {"x": ["a", "b"]})
         with pytest.raises(ConfigError):

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -180,7 +180,7 @@ class TestConcretizePreferences(object):
         assert "zmpi" in spec
 
     def test_config_set_pkg_property_url(self, mutable_mock_repo):
-        """Test setting an attribute that is explicitly-handled in the schema"""
+        """Test setting an existing attribute in the package class"""
         update_packages(
             "mpileaks",
             "package_attributes",
@@ -209,12 +209,6 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         with pytest.raises(AttributeError):
             spec.package.x
-
-    def test_config_set_pkg_property_collection_unsupported(self, mutable_mock_repo):
-        """Test that an error is raised if you attempt to assign a list value"""
-        update_packages("mpileaks", "package_attributes", {"x": ["a", "b"]})
-        with pytest.raises(ConfigError):
-            concretize("mpileaks")
 
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -201,12 +201,12 @@ mpileaks:
   package_attributes:
     v1: 1
     v2: true
-    v4: yesterday
-    v5: "true"
-    v6:
+    v3: yesterday
+    v4: "true"
+    v5:
       x: 1
       y: 2
-    v7:
+    v6:
     - 1
     - 2
 """
@@ -216,10 +216,10 @@ mpileaks:
         spec = concretize("mpileaks")
         assert spec.package.v1 == 1
         assert spec.package.v2 is True
-        assert spec.package.v4 == "yesterday"
-        assert spec.package.v5 == "true"
-        assert dict(spec.package.v6) == {"x": 1, "y": 2}
-        assert list(spec.package.v7) == [1, 2]
+        assert spec.package.v3 == "yesterday"
+        assert spec.package.v4 == "true"
+        assert dict(spec.package.v5) == {"x": 1, "y": 2}
+        assert list(spec.package.v6) == [1, 2]
 
         update_packages("mpileaks", "package_attributes", {})
         spec = concretize("mpileaks")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -179,7 +179,7 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert "zmpi" in spec
 
-    def test_config_set_url_for_package(self, mutable_mock_repo):
+    def test_config_set_pkg_property_url(self, mutable_mock_repo):
         """Test preferred providers of virtual packages are
         applied correctly
         """
@@ -195,10 +195,8 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
 
-    def test_config_set_package_property(self, mutable_mock_repo):
-        """Test preferred providers of virtual packages are
-        applied correctly
-        """
+    def test_config_set_pkg_property_new(self, mutable_mock_repo):
+        """Test that you can set arbitrary attributes on the Package class"""
         update_packages(
             "mpileaks",
             "package_attributes",
@@ -207,6 +205,12 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert spec.package.x == 1
         assert spec.package.y == True
+
+    def test_config_set_pkg_property_collecton_unsupported(self, mutable_mock_repo):
+        """Test that an error is raised if you attempt to assign a list value"""
+        update_packages("mpileaks", "package_attributes", {"x": ["a", "b"]})
+        with pytest.raises(ConfigError):
+            spec = concretize("mpileaks")
 
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -202,14 +202,15 @@ class TestConcretizePreferences(object):
         update_packages(
             "mpileaks",
             "package_attributes",
-            {"x": {
-                "value": "1",
-                "type": "int",
-             },
-             "y": {
-                "value": "true",
-                "type": "boolean",
-             }
+            {
+                "x": {
+                    "value": "1",
+                    "type": "int",
+                },
+                "y": {
+                    "value": "true",
+                    "type": "boolean",
+                },
             },
         )
         spec = concretize("mpileaks")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -184,7 +184,9 @@ class TestConcretizePreferences(object):
         applied correctly
         """
         update_packages(
-            "mpileaks", "package_attributes", {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
+            "mpileaks",
+            "package_attributes",
+            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
         )
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -179,22 +179,6 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert "zmpi" in spec
 
-    def test_config_set_url_for_package(self, mutable_mock_repo):
-        """Test preferred providers of virtual packages are
-        applied correctly
-        """
-        update_packages(
-            "mpileaks",
-            "package_attributes",
-            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
-        )
-        spec = concretize("mpileaks")
-        assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"
-
-        update_packages("mpileaks", "package_attributes", {})
-        spec = concretize("mpileaks")
-        assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
-
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""
         spec = Spec("python")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -195,6 +195,27 @@ class TestConcretizePreferences(object):
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
 
+    def test_config_set_package_property(self, mutable_mock_repo):
+        """Test preferred providers of virtual packages are
+        applied correctly
+        """
+        update_packages(
+            "mpileaks",
+            "package_attributes",
+            {"x": {
+                "value": "1",
+                "type": "int",
+             },
+             "y": {
+                "value": "true",
+                "type": "boolean",
+             }
+            },
+        )
+        spec = concretize("mpileaks")
+        assert spec.package.x == 1
+        assert spec.package.y == True
+
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""
         spec = Spec("python")

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -200,11 +200,13 @@ class TestConcretizePreferences(object):
         update_packages(
             "mpileaks",
             "package_attributes",
-            {"x": "1", "y": "true"},
+            {"x": "1", "y": "true", "w": "yes", "z": "yesterday"},
         )
         spec = concretize("mpileaks")
         assert spec.package.x == 1
         assert spec.package.y == True
+        assert spec.package.w == True
+        assert spec.package.z == "yesterday"
 
     def test_config_set_pkg_property_collecton_unsupported(self, mutable_mock_repo):
         """Test that an error is raised if you attempt to assign a list value"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -184,9 +184,7 @@ class TestConcretizePreferences(object):
         applied correctly
         """
         update_packages(
-            "mpileaks",
-            "set",
-            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
+            "mpileaks", "set", {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"}
         )
         spec = concretize("mpileaks")
         assert spec.package.fetcher[0].url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -198,12 +198,11 @@ class TestConcretizePreferences(object):
         update_packages(
             "mpileaks",
             "package_attributes",
-            {"x": "1", "y": "true", "w": "yes", "z": "yesterday"},
+            {"x": 1, "y": True, "z": "yesterday"},
         )
         spec = concretize("mpileaks")
         assert spec.package.x == 1
         assert spec.package.y is True
-        assert spec.package.w is True
         assert spec.package.z == "yesterday"
 
         update_packages("mpileaks", "package_attributes", {})


### PR DESCRIPTION
A user may want to set some attributes on a package without actually modifying the package (e.g. if they want to `git pull` updates to the package without conflicts). This PR adds a per-package configuration section called "set", which is a dictionary of attribute names to desired values. For example:

```
packages:
  openblas:
    set:
      submodules: true
```

in this case, the package will always retrieve git submodules. Right now the PR maintains a limited list of acceptable attributes that can be set.