### PR TITLE
UPC++/GASNet-EX 2022.9.0 update

### DIFF
--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -31,7 +31,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
 
     maintainers = ["PHHargrove", "bonachea"]
 
-    tags = ["e4s"]
+    tags = ["e4s", "ecp"]
 
     version("develop", branch="develop")
     version("main", branch="stable")
@@ -54,9 +54,9 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
         description="The hardware-dependent network backends to enable.\n"
         + "(smp) = SMP conduit for single-node operation ;\n"
         + "(ibv) = Native InfiniBand verbs conduit ;\n"
+        + "(ofi) = OFI conduit over libfabric, for HPE Cray Slingshot and Intel Omni-Path ;\n"
         + "(udp) = Portable UDP conduit, for Ethernet networks ;\n"
         + "(mpi) = Low-performance/portable MPI conduit ;\n"
-        + "(ofi) = EXPERIMENTAL Portable OFI conduit over libfabric ;\n"
         + "(ucx) = EXPERIMENTAL UCX conduit for Mellanox IB/RoCE ConnectX-5+ ;\n"
         + "For detailed recommendations, consult https://gasnet.lbl.gov",
     )
@@ -165,6 +165,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
         }
 
         os.environ["GASNET_VERBOSEENV"] = "1"  # include diagnostic info
+        os.environ["GASNET_SPAWN_VERBOSE"] = "1"  # include spawning diagnostics
         if "GASNET_SSH_SERVERS" not in os.environ:
             os.environ["GASNET_SSH_SERVERS"] = "localhost " * 4
 

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -37,6 +37,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
     version("main", branch="stable")
     version("master", branch="master")
 
+    version("2022.9.0", sha256="6873ff4ad8ebee49da4378f2d78095a6ccc31333d6ae4cd739b9f772af11f936")
     version("2022.3.0", sha256="91b59aa84c0680c807e00d3d1d8fa7c33c1aed50b86d1616f93e499620a9ba09")
     version("2021.9.0", sha256="1b6ff6cdad5ecf76b92032ef9507e8a0876c9fc3ee0ab008de847c1fad0359ee")
     version("2021.3.0", sha256="8a40fb3fa8bacc3922cd4d45217816fcb60100357ab97fb622a245567ea31747")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -42,7 +42,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     url = "https://bitbucket.org/berkeleylab/upcxx/downloads/upcxx-2021.3.0.tar.gz"
     git = "https://bitbucket.org/berkeleylab/upcxx.git"
 
-    tags = ["e4s"]
+    tags = ["e4s", "ecp"]
 
     version("develop", branch="develop")
     version("master", branch="master")
@@ -90,7 +90,8 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
     # UPC++ always relies on GASNet-EX.
     # The default (and recommendation) is to use the implicit, embedded version.
-    # This variant allows overriding with a particular version of GASNet-EX sources.
+    # This variant allows overriding with a particular version of GASNet-EX sources,
+    # although this is not officially supported and some combinations might be rejected.
     variant("gasnet", default=False, description="Override embedded GASNet-EX version")
     depends_on("gasnet conduits=none", when="+gasnet")
 
@@ -149,6 +150,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             real_cc = join_path(env["CRAYPE_DIR"], "bin", "cc")
             real_cxx = join_path(env["CRAYPE_DIR"], "bin", "CC")
             # workaround a bug in the UPC++ installer: (issue #346)
+            # this can be removed once the floor version reaches 2020.10.0
             env["GASNET_CONFIGURE_ARGS"] += " --with-cc=" + real_cc + " --with-cxx=" + real_cxx
             if "+mpi" in spec:
                 env["GASNET_CONFIGURE_ARGS"] += " --with-mpicc=" + real_cc
@@ -170,6 +172,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
                 provider = "verbs;ofi_rxm"
 
             # Append the recommended options for Cray Shasta
+            # This list can be pruned once the floor version reaches 2022.9.0
             options.append("--with-pmi-version=cray")
             options.append("--with-pmi-runcmd='srun -n %N -- %C'")
             options.append("--disable-ibv")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -47,6 +47,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("master", branch="master")
 
+    version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")
     version("2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496")
     version("2021.9.0", sha256="9299e17602bcc8c05542cdc339897a9c2dba5b5c3838d6ef2df7a02250f42177")
     version("2021.3.0", sha256="3433714cd4162ffd8aad9a727c12dbf1c207b7d6664879fc41259a4b351595b7")


### PR DESCRIPTION
Updates the UPC++ and GASNet-EX packages to their 2022.9.0 release.