### PR TITLE
Add missing upperbound to docs/spack.yaml

### DIFF
--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -20,6 +20,8 @@ spack:
   - py-docutils@:0.16
   - py-sphinx-design
   - py-sphinx-rtd-theme
+  - py-pygments@:2.12
+
   # VCS
   - git
   - mercurial


### PR DESCRIPTION
Was added to requirement.txt but not to the environment file of this other amazing package manager called Spack.