### PR TITLE
meson: update OneAPI compiler support patch

### DIFF
--- a/var/spack/repos/builtin/packages/meson/oneapi.patch
+++ b/var/spack/repos/builtin/packages/meson/oneapi.patch
@@ -1,20 +1,5 @@
-From 4e87a15b7abec2d1bc3922f3f6cf2a8dca91b2c0 Mon Sep 17 00:00:00 2001
-From: Robert Cohn <robert.s.cohn@intel.com>
-Date: Sun, 9 Oct 2022 09:14:52 -0400
-Subject: [PATCH] basic support for oneapi linux compilers
-
----
- docs/markdown/Reference-tables.md          |  1 +
- docs/markdown/snippets/oneapi_compilers.md |  8 ++++++++
- mesonbuild/compilers/c.py                  |  7 +++++++
- mesonbuild/compilers/cpp.py                |  7 +++++++
- mesonbuild/compilers/detect.py             | 16 ++++++++++++++++
- mesonbuild/compilers/fortran.py            |  6 ++++++
- 6 files changed, 45 insertions(+)
- create mode 100644 docs/markdown/snippets/oneapi_compilers.md
-
 diff --git a/docs/markdown/Reference-tables.md b/docs/markdown/Reference-tables.md
-index 60303dad633..421b33c079f 100644
+index 60303dad6..421b33c07 100644
 --- a/docs/markdown/Reference-tables.md
 +++ b/docs/markdown/Reference-tables.md
 @@ -20,6 +20,7 @@ These are return values of the `get_id` (Compiler family) and
@@ -27,7 +12,7 @@ index 60303dad633..421b33c079f 100644
  | mono      | Xamarin C# compiler              |                 |
 diff --git a/docs/markdown/snippets/oneapi_compilers.md b/docs/markdown/snippets/oneapi_compilers.md
 new file mode 100644
-index 00000000000..a982da22a99
+index 000000000..a982da22a
 --- /dev/null
 +++ b/docs/markdown/snippets/oneapi_compilers.md
 @@ -0,0 +1,8 @@
@@ -40,10 +25,10 @@ index 00000000000..a982da22a99
 +CC=icx CXX=icpx FC=ifx meson setup builddir
 +```
 diff --git a/mesonbuild/compilers/c.py b/mesonbuild/compilers/c.py
-index b1b4a7c9295..9490ee688a8 100644
+index b1b4a7c92..9490ee688 100644
 --- a/mesonbuild/compilers/c.py
 +++ b/mesonbuild/compilers/c.py
-@@ -406,6 +406,13 @@ def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]
+@@ -406,6 +406,13 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
          return args
  
  
@@ -58,10 +43,19 @@ index b1b4a7c9295..9490ee688a8 100644
  
      """Shared methods that apply to MSVC-like C compilers."""
 diff --git a/mesonbuild/compilers/cpp.py b/mesonbuild/compilers/cpp.py
-index ac65df9a101..80dc6bc5731 100644
+index ac65df9a1..3d728f169 100644
 --- a/mesonbuild/compilers/cpp.py
 +++ b/mesonbuild/compilers/cpp.py
-@@ -593,6 +593,13 @@ def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+@@ -153,7 +153,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
+         }
+ 
+         # Currently, remapping is only supported for Clang, Elbrus and GCC
+-        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang'])
++        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang', 'intel-llvm'])
+ 
+         if cpp_std not in CPP_FALLBACKS:
+             # 'c++03' and 'c++98' don't have fallback types
+@@ -593,6 +593,13 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
          return []
  
  
@@ -76,10 +70,10 @@ index ac65df9a101..80dc6bc5731 100644
  
      """Mixin for C++ specific method overrides in MSVC-like compilers."""
 diff --git a/mesonbuild/compilers/detect.py b/mesonbuild/compilers/detect.py
-index f4afa777d4d..5bd303df0bd 100644
+index f4afa777d..42a4b18a5 100644
 --- a/mesonbuild/compilers/detect.py
 +++ b/mesonbuild/compilers/detect.py
-@@ -62,6 +62,7 @@
+@@ -62,6 +62,7 @@ from .c import (
      EmscriptenCCompiler,
      IntelCCompiler,
      IntelClCCompiler,
@@ -87,7 +81,7 @@ index f4afa777d4d..5bd303df0bd 100644
      NvidiaHPC_CCompiler,
      PGICCompiler,
      CcrxCCompiler,
-@@ -83,6 +84,7 @@
+@@ -83,6 +84,7 @@ from .cpp import (
      EmscriptenCPPCompiler,
      IntelCPPCompiler,
      IntelClCPPCompiler,
@@ -95,7 +89,7 @@ index f4afa777d4d..5bd303df0bd 100644
      NvidiaHPC_CPPCompiler,
      PGICPPCompiler,
      CcrxCPPCompiler,
-@@ -106,6 +108,7 @@
+@@ -106,6 +108,7 @@ from .fortran import (
      FlangFortranCompiler,
      IntelFortranCompiler,
      IntelClFortranCompiler,
@@ -103,7 +97,22 @@ index f4afa777d4d..5bd303df0bd 100644
      NAGFortranCompiler,
      Open64FortranCompiler,
      PathScaleFortranCompiler,
-@@ -617,6 +620,12 @@ def sanitize(p: str) -> str:
+@@ -180,11 +183,11 @@ else:
+         defaults['objc'] = ['clang']
+         defaults['objcpp'] = ['clang++']
+     else:
+-        defaults['c'] = ['cc', 'gcc', 'clang', 'nvc', 'pgcc', 'icc']
+-        defaults['cpp'] = ['c++', 'g++', 'clang++', 'nvc++', 'pgc++', 'icpc']
++        defaults['c'] = ['cc', 'gcc', 'clang', 'nvc', 'pgcc', 'icc', 'icx']
++        defaults['cpp'] = ['c++', 'g++', 'clang++', 'nvc++', 'pgc++', 'icpc', 'icpx']
+         defaults['objc'] = ['cc', 'gcc', 'clang']
+         defaults['objcpp'] = ['c++', 'g++', 'clang++']
+-    defaults['fortran'] = ['gfortran', 'flang', 'nvfortran', 'pgfortran', 'ifort', 'g95']
++    defaults['fortran'] = ['gfortran', 'flang', 'nvfortran', 'pgfortran', 'ifort', 'ifx', 'g95']
+     defaults['cs'] = ['mcs', 'csc']
+ defaults['d'] = ['ldc2', 'ldc', 'gdc', 'dmd']
+ defaults['java'] = ['javac']
+@@ -617,6 +620,12 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
              return cls(
                  ccache + compiler, version, for_machine, is_cross, info,
                  exe_wrap, full_version=full_version, linker=l)
@@ -131,10 +140,10 @@ index f4afa777d4d..5bd303df0bd 100644
                  return PathScaleFortranCompiler(
                      compiler, version, for_machine, is_cross, info,
 diff --git a/mesonbuild/compilers/fortran.py b/mesonbuild/compilers/fortran.py
-index 0a0c3ec86d7..e7154fe876c 100644
+index 0a0c3ec86..e7154fe87 100644
 --- a/mesonbuild/compilers/fortran.py
 +++ b/mesonbuild/compilers/fortran.py
-@@ -352,6 +352,12 @@ def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+@@ -352,6 +352,12 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
          return ['-gen-dep=' + outtarget, '-gen-depformat=make']
  
  

--- a/var/spack/repos/builtin/packages/meson/oneapi.patch
+++ b/var/spack/repos/builtin/packages/meson/oneapi.patch
@@ -1,0 +1,149 @@
+From 4e87a15b7abec2d1bc3922f3f6cf2a8dca91b2c0 Mon Sep 17 00:00:00 2001
+From: Robert Cohn <robert.s.cohn@intel.com>
+Date: Sun, 9 Oct 2022 09:14:52 -0400
+Subject: [PATCH] basic support for oneapi linux compilers
+
+---
+ docs/markdown/Reference-tables.md          |  1 +
+ docs/markdown/snippets/oneapi_compilers.md |  8 ++++++++
+ mesonbuild/compilers/c.py                  |  7 +++++++
+ mesonbuild/compilers/cpp.py                |  7 +++++++
+ mesonbuild/compilers/detect.py             | 16 ++++++++++++++++
+ mesonbuild/compilers/fortran.py            |  6 ++++++
+ 6 files changed, 45 insertions(+)
+ create mode 100644 docs/markdown/snippets/oneapi_compilers.md
+
+diff --git a/docs/markdown/Reference-tables.md b/docs/markdown/Reference-tables.md
+index 60303dad633..421b33c079f 100644
+--- a/docs/markdown/Reference-tables.md
++++ b/docs/markdown/Reference-tables.md
+@@ -20,6 +20,7 @@ These are return values of the `get_id` (Compiler family) and
+ | gcc       | The GNU Compiler Collection      | gcc             |
+ | intel     | Intel compiler (Linux and Mac)   | gcc             |
+ | intel-cl  | Intel compiler (Windows)         | msvc            |
++| intel-llvm| Intel oneAPI LLVM-based compiler |                 |
+ | lcc       | Elbrus C/C++/Fortran Compiler    |                 |
+ | llvm      | LLVM-based compiler (Swift, D)   |                 |
+ | mono      | Xamarin C# compiler              |                 |
+diff --git a/docs/markdown/snippets/oneapi_compilers.md b/docs/markdown/snippets/oneapi_compilers.md
+new file mode 100644
+index 00000000000..a982da22a99
+--- /dev/null
++++ b/docs/markdown/snippets/oneapi_compilers.md
+@@ -0,0 +1,8 @@
++## Basic support for oneAPI compilers on Linux
++
++To use:
++
++```
++source /opt/intel/oneapi/setvars.sh
++CC=icx CXX=icpx FC=ifx meson setup builddir
++```
+diff --git a/mesonbuild/compilers/c.py b/mesonbuild/compilers/c.py
+index b1b4a7c9295..9490ee688a8 100644
+--- a/mesonbuild/compilers/c.py
++++ b/mesonbuild/compilers/c.py
+@@ -406,6 +406,13 @@ def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]
+         return args
+ 
+ 
++class IntelLLVMCCompiler(ClangCCompiler):
++
++
++    id = 'intel-llvm'
++
++
++
+ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
+ 
+     """Shared methods that apply to MSVC-like C compilers."""
+diff --git a/mesonbuild/compilers/cpp.py b/mesonbuild/compilers/cpp.py
+index ac65df9a101..80dc6bc5731 100644
+--- a/mesonbuild/compilers/cpp.py
++++ b/mesonbuild/compilers/cpp.py
+@@ -593,6 +593,13 @@ def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+         return []
+ 
+ 
++class IntelLLVMCPPCompiler(ClangCPPCompiler):
++
++
++    id = 'intel-llvm'
++
++
++
+ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
+ 
+     """Mixin for C++ specific method overrides in MSVC-like compilers."""
+diff --git a/mesonbuild/compilers/detect.py b/mesonbuild/compilers/detect.py
+index f4afa777d4d..5bd303df0bd 100644
+--- a/mesonbuild/compilers/detect.py
++++ b/mesonbuild/compilers/detect.py
+@@ -62,6 +62,7 @@
+     EmscriptenCCompiler,
+     IntelCCompiler,
+     IntelClCCompiler,
++    IntelLLVMCCompiler,
+     NvidiaHPC_CCompiler,
+     PGICCompiler,
+     CcrxCCompiler,
+@@ -83,6 +84,7 @@
+     EmscriptenCPPCompiler,
+     IntelCPPCompiler,
+     IntelClCPPCompiler,
++    IntelLLVMCPPCompiler,
+     NvidiaHPC_CPPCompiler,
+     PGICPPCompiler,
+     CcrxCPPCompiler,
+@@ -106,6 +108,7 @@
+     FlangFortranCompiler,
+     IntelFortranCompiler,
+     IntelClFortranCompiler,
++    IntelLLVMFortranCompiler,
+     NAGFortranCompiler,
+     Open64FortranCompiler,
+     PathScaleFortranCompiler,
+@@ -617,6 +620,12 @@ def sanitize(p: str) -> str:
+             return cls(
+                 ccache + compiler, version, for_machine, is_cross, info,
+                 exe_wrap, full_version=full_version, linker=l)
++        if 'Intel(R) oneAPI' in out:
++            cls = IntelLLVMCCompiler if lang == 'c' else IntelLLVMCPPCompiler
++            l = guess_nix_linker(env, compiler, cls, version, for_machine)
++            return cls(
++                ccache + compiler, version, for_machine, is_cross, info,
++                exe_wrap, full_version=full_version, linker=l)
+         if 'TMS320C2000 C/C++' in out or 'MSP430 C/C++' in out or 'TI ARM C/C++ Compiler' in out:
+             lnk: T.Union[T.Type[C2000DynamicLinker], T.Type[TIDynamicLinker]]
+             if 'TMS320C2000 C/C++' in out:
+@@ -789,6 +798,13 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
+                     compiler, version, for_machine, is_cross, info,
+                     exe_wrap, full_version=full_version, linker=linker)
+ 
++            if 'ifx (IFORT)' in out:
++                cls = IntelLLVMFortranCompiler
++                linker = guess_nix_linker(env, compiler, cls, version, for_machine)
++                return cls(
++                    compiler, version, for_machine, is_cross, info,
++                    exe_wrap, full_version=full_version, linker=linker)
++
+             if 'PathScale EKOPath(tm)' in err:
+                 return PathScaleFortranCompiler(
+                     compiler, version, for_machine, is_cross, info,
+diff --git a/mesonbuild/compilers/fortran.py b/mesonbuild/compilers/fortran.py
+index 0a0c3ec86d7..e7154fe876c 100644
+--- a/mesonbuild/compilers/fortran.py
++++ b/mesonbuild/compilers/fortran.py
+@@ -352,6 +352,12 @@ def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+         return ['-gen-dep=' + outtarget, '-gen-depformat=make']
+ 
+ 
++class IntelLLVMFortranCompiler(IntelFortranCompiler):
++
++
++    id = 'intel-llvm'
++
++
+ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
+ 
+     file_suffixes = ('f90', 'f', 'for', 'ftn', 'fpp', )

--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -67,12 +67,11 @@ class Meson(PythonPackage):
     patch("rpath-0.54.patch", when="@0.54:0.55")
     patch("rpath-0.56.patch", when="@0.56:0.57")
     patch("rpath-0.58.patch", when="@0.58:")
-    # Help meson recognize Intel OneAPI compilers
-    patch(
-        "https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/9850.patch?full_index=1",
-        sha256="9c874726ce0a06922580d3e3d6adbe74e5144b3a661ef1059f32c9c1bc478b65",
-        when="@0.60.0:",
-    )
+
+    # Intel OneAPI compiler support
+    # https://github.com/mesonbuild/meson/pull/10909
+    # https://github.com/mesonbuild/meson/pull/9850
+    patch("oneapi.patch", when="@0.62: %oneapi")
 
     executables = ["^meson$"]
 


### PR DESCRIPTION
Previous patch was a hack that only worked for C/C++. This patch is an actual feature that also works for Fortran.

@rscohn2 @eli-schwartz 