### PR TITLE
Scotch: add 'link_error_lib' variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -57,7 +57,7 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     # Optional dependencies
     depends_on("py-scipy", when="+scipy", type=("build", "run"))
     depends_on("metis@5.0:", when="+metis", type=("run"))
-    depends_on("scotch@6.0:", when="+scotch", type=("run"))
+    depends_on("scotch@7.0.1: +link_error_lib", when="+scotch", type=("run"))
     depends_on("cuda@8.0: +allow-unsupported-compilers", when="@:1.14.0 +cuda", type=("run"))
     depends_on("cuda@11.4.0: +allow-unsupported-compilers", when="@1.15.0: +cuda", type=("run"))
     depends_on("rocblas@5.2.0:", when="+hip", type=("run"))

--- a/var/spack/repos/builtin/packages/scotch/libscotch-scotcherr-link-7.0.1.patch
+++ b/var/spack/repos/builtin/packages/scotch/libscotch-scotcherr-link-7.0.1.patch
@@ -1,0 +1,20 @@
+--- a/src/libscotch/CMakeLists.txt
++++ b/src/libscotch/CMakeLists.txt
+@@ -508,7 +508,7 @@ add_library(scotch
+ set_target_properties(scotch PROPERTIES VERSION
+   ${SCOTCH_VERSION}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL})
+ add_dependencies(scotch parser_yy_c parser_ll_c)
+-target_link_libraries(scotch PUBLIC m)
++target_link_libraries(scotch PUBLIC m scotcherr)
+ target_include_directories(scotch PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+@@ -748,7 +748,7 @@ if(BUILD_PTSCOTCH)
+   set_target_properties(ptscotch PROPERTIES
+     VERSION ${SCOTCH_VERSION}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL}
+     COMPILE_FLAGS -DSCOTCH_PTSCOTCH)
+-  target_link_libraries(ptscotch PUBLIC scotch MPI::MPI_C)
++  target_link_libraries(ptscotch PUBLIC ptscotcherr scotch MPI::MPI_C)
+   target_include_directories(ptscotch PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -44,6 +44,12 @@ class Scotch(CMakePackage):
         "metis", default=False, description="Expose vendored METIS/ParMETIS libraries and wrappers"
     )
     variant("int64", default=False, description="Use int64_t for SCOTCH_Num typedef")
+    variant(
+        "link_error_lib",
+        default=False,
+        when="@7.0.1",
+        description="Link error handling library to libscotch/libptscotch",
+    )
 
     # Does not build with flex 2.6.[23]
     depends_on("flex@:2.6.1,2.6.4:", type="build")
@@ -57,6 +63,7 @@ class Scotch(CMakePackage):
     patch("metis-headers-6.0.4.patch", when="@6.0.4")
 
     patch("libscotchmetis-return-6.0.5a.patch", when="@6.0.5a")
+    patch("libscotch-scotcherr-link-7.0.1.patch", when="@7.0.1 +link_error_lib")
 
     # Vendored dependency of METIS/ParMETIS conflicts with standard
     # installations


### PR DESCRIPTION
Adds variant for v7.0.1 that links error handling library with the main `libscotch` and `libptscotch` libraries.

This allows for Spack to package Scotch in a way that is consistent with other package management systems who link the error library by default ([Debian](https://salsa.debian.org/science-team/scotch/-/blob/master/debian/patches/build-shared-library-soname.patch), [Macports](https://github.com/macports/macports-ports/blob/master/science/scotch/files/patch-libscotch-shared.diff), [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/sci-libs/scotch/scotch-7.0.1-r1.ebuild))

This is required by PyFR, which assumes this type of packaging.

@pghysels @FreddieWitherden