### PR TITLE
ECP-SDK: enable hdf5-vfd-gds when +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -15,17 +15,22 @@ def dav_sdk_depends_on(spec, when=None, propagate=None):
     # ie. A +c ~b -> A
     spec = Spec(spec).name
 
-    if "+" in when and len(when.split()) == 1:
-        when_not = when.replace("+", "~")
-        # If the package is in the spec tree then it must
-        # be enabled in the SDK.
-        conflicts(when_not, "^" + spec)
+    # If the package is in the spec tree then it must be enabled in the SDK.
+    if "+" in when:
+        _when_variants = when.strip("+").split("+")
+        if any(tok in when for tok in ["~", "="]):
+            tty.error("Bad token in when clause, only positive boolean tokens allowed")
+
+        for variant in _when_variants:
+            conflicts("~" + variant, when="^" + spec)
 
     # Skip if there is nothing to propagate
     if not propagate:
         return
 
-    # Map the propagated variants to the dependency variant
+    # Map the propagated variants to the dependency variant.  Some packages may need
+    # overrides to propagate a dependency as something else, e.g., {"visit": "libsim"}.
+    # Most call-sites will just use a list.
     if not type(propagate) is dict:
         propagate = dict([(v, v) for v in propagate])
 
@@ -108,6 +113,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on("faodel+shared+mpi network=libfabric", when="+faodel", propagate=["hdf5"])
 
     dav_sdk_depends_on("hdf5@1.12: +shared+mpi", when="+hdf5", propagate=["fortran"])
+    dav_sdk_depends_on("hdf5-vfd-gds@1.0.2:", when="+cuda+hdf5", propagate=cuda_arch_variants)
 
     dav_sdk_depends_on("parallel-netcdf+shared", when="+pnetcdf", propagate=["fortran"])
 

--- a/var/spack/repos/builtin/packages/hdf5-vfd-gds/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vfd-gds/package.py
@@ -17,19 +17,22 @@ class Hdf5VfdGds(CMakePackage, CudaPackage):
 
     # Versions
     version("master", branch="master")
+    version("1.0.2", sha256="f7df64ff62e057b525bc30ed6534f9c0752e52bd58b65f7c147878d6c68105ae")
     version("1.0.1", sha256="00e125fd149561be991f41e883824de826d8add604aebccf103a4fb82d5faac2")
     version("1.0.0", sha256="6b16105c7c49f13fc05784ee69b78d45fb159270c78d760689f9cd21e230ddd2")
 
     # Dependencies
     conflicts("~cuda")
-    depends_on("cmake@3.12:")
+    depends_on("cmake@3.12:", type="build")
     depends_on("hdf5@1.13.0:")
 
     def cmake_args(self):
-
         # CMake options
         args = [
             self.define("BUILD_TESTING", self.run_tests),
         ]
 
         return args
+
+    def setup_run_environment(self, env):
+        env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)


### PR DESCRIPTION
- hdf5-vfd-gds:
    - Add new version 1.0.2 compatible with hdf5@1.13.
    - CMake is a build dependency.
    - Set `HDF5_PLUGIN_PATH` in the runtime environment, this plugin
      is loaded dynamically.
- SDK:
    - The VFD GDS driver only has utility when CUDA is enabled.
    - Require hdf5-vfd-gds@1.0.2+ (1.0.1 and earlier do not compile).

--------

TODO:

- [X] Finish local testing:
    - [x] https://github.com/hpc-io/vfd-gds/issues/8 (new release 1.0.2!)
- [X] Test onsite.