### PR TITLE
gitlab ci: Do not force protected build jobs to run on aws runners

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -866,7 +866,7 @@ def generate_gitlab_ci_yaml(
                     # For spack pipelines "public" and "protected" are reserved tags
                     tags = _remove_reserved_tags(tags)
                     if spack_pipeline_type == "spack_protected_branch":
-                        tags.extend(["aws", "protected"])
+                        tags.extend(["protected"])
                     elif spack_pipeline_type == "spack_pull_request":
                         tags.extend(["public"])
 


### PR DESCRIPTION
To allow UO runners to build protected binaries for public deployment, we need to remove the constraint that all protected rebuild jobs run on aws runners.