### PR TITLE
Update command option for example

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1438,7 +1438,7 @@ built.
 You can see what virtual packages a particular package provides by
 getting info on it:
 
-.. command-output:: spack info mpich
+.. command-output:: spack info --virtuals mpich
 
 Spack is unique in that its virtual packages can be versioned, just
 like regular packages.  A particular version of a package may provide


### PR DESCRIPTION
The `spack info <package>` command does not show the `Virtual Packages:` output unless the `--virtuals` command option is passed.  Before this changes, the information that the command is supposed to be illustrating is not shown in the example and is confusing.