### PR TITLE
mpich: avoid '-fallow-argument-mismatch' in the compiler wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -380,21 +380,23 @@ with '-Wl,-commons,use_dylibs' and without
             results.append(" ".join(variants))
         return results
 
+    def flag_handler(self, name, flags):
+        if name == "fflags":
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
+            # https://github.com/spack/spack/issues/17934
+            # TODO: we should add the flag depending on the real Fortran compiler spec and not the
+            #  toolchain spec, which might be mixed.
+            if any(self.spec.satisfies(s) for s in ["%gcc@10:", "%apple-clang@11:", "%clang@11:"]):
+                # Note that the flag is not needed to build the package starting version 4.1
+                # (see https://github.com/pmodels/mpich/pull/5840) but we keep adding the flag here
+                # to avoid its presence in the MPI compiler wrappers.
+                flags.append("-fallow-argument-mismatch")
+
+        return flags, None, None
+
     def setup_build_environment(self, env):
         env.unset("F90")
         env.unset("F90FLAGS")
-
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
-        if self.spec.satisfies("%gcc@10:"):
-            env.set("FFLAGS", "-fallow-argument-mismatch")
-            env.set("FCFLAGS", "-fallow-argument-mismatch")
-        # Same fix but for macOS - avoids issue #17934
-        if self.spec.satisfies("%apple-clang@11:"):
-            env.set("FFLAGS", "-fallow-argument-mismatch")
-            env.set("FCFLAGS", "-fallow-argument-mismatch")
-        if self.spec.satisfies("%clang@11:"):
-            env.set("FFLAGS", "-fallow-argument-mismatch")
-            env.set("FCFLAGS", "-fallow-argument-mismatch")
 
         if "pmi=cray" in self.spec:
             env.set("CRAY_PMI_INCLUDE_OPTS", "-I" + self.spec["cray-pmi"].headers.directories[0])


### PR DESCRIPTION
The presence of the `-fallow-argument-mismatch` flag in the MPI compiler wrappers is rather confusing. In my opinion, it's for the library users to decide whether they want to compile their code with the flag.

This PR implements the flag injection in a more idiomatic way and hides the flags from the build system of the package.

@alalazo @haampie it would be nice to have something like [this](https://github.com/spack/spack/blob/89b3e6c6d01d674977c3a6d6827e180fb04e419c/var/spack/repos/builtin/packages/claw/package.py#L86-L106) in the core functionality of Spack. I decided not to duplicate the code here but we need it for two things:
1. Currently, we inject flags that are required for Gfortran version 10 or later also when building with `%clang@11:` and `%apple-clang@11:`, which, however, can be mixed with older versions of Gfortran that do not need/understand `-fallow-argument-mismatch`.
2. [Most of the modern C compilers](https://github.com/spack/spack/blob/89b3e6c6d01d674977c3a6d6827e180fb04e419c/var/spack/repos/builtin/packages/claw/package.py#L72) can build older versions of `mpich` only if they are provided with the `-fcommon` flag. The problem is that we don't know what version of `gcc` is used when building with `%nag`. So, the aforementioned method would help here as well.