### PR TITLE
vsearch: adding version 2.22.1

### DIFF
--- a/var/spack/repos/builtin/packages/vsearch/package.py
+++ b/var/spack/repos/builtin/packages/vsearch/package.py
@@ -11,7 +11,9 @@ class Vsearch(AutotoolsPackage):
 
     homepage = "https://github.com/torognes/vsearch"
     url = "https://github.com/torognes/vsearch/archive/v2.4.3.tar.gz"
+    maintainers = ["snehring"]
 
+    version("2.22.1", sha256="c62bf69e7cc3d011a12e3b522ba8c0c91fb90deea782359e9569677d0c991778")
     version("2.14.1", sha256="388529a39eb0618a09047bf91e0a8ae8c9fd851a05f8d975e299331748f97741")
     version("2.13.3", sha256="e5f34ece28b76403d3ba4a673eca41178fe399c35a1023dbc87d0c0da5efaa52")
     version("2.4.3", sha256="f7ffc2aec5d76bdaf1ffe7fb733102138214cec3e3846eb225455dcc3c088141")
@@ -19,4 +21,6 @@ class Vsearch(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
+    depends_on("bzip2")
     depends_on("libtool", type="build")
+    depends_on("zlib")


### PR DESCRIPTION
The new deps aren't strictly required, but the functionality they add is almost never going to be undesired. So I just opted to make them deps without corresponding variants. Most likely they were already being pulled in from the system installs automatically for many folks.