### PR TITLE
netcdf-c: Update to latest version

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -17,9 +17,10 @@ class NetcdfC(AutotoolsPackage):
     git = "https://github.com/Unidata/netcdf-c.git"
     url = "https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz"
 
-    maintainers = ["skosukhin", "WardF"]
+    maintainers = ["skosukhin", "WardF", "gsjaardema"]
 
     version("main", branch="main")
+    version('4.9.0', sha256='9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6')
     version("4.8.1", sha256="bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0")
     version("4.8.0", sha256="aff58f02b1c3e91dc68f989746f652fe51ff39e6270764e484920cb8db5ad092")
     version("4.7.4", sha256="99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b")
@@ -65,7 +66,7 @@ class NetcdfC(AutotoolsPackage):
     patch("4.7.3-spectrum-mpi-pnetcdf-detect.patch", when="@4.7.3:4.7.4 +parallel-netcdf")
 
     # See https://github.com/Unidata/netcdf-c/pull/2293
-    patch("4.8.1-no-strict-aliasing-config.patch", when="@4.8.1:")
+    patch("4.8.1-no-strict-aliasing-config.patch", when="@4.8.1")
 
     variant("mpi", default=True, description="Enable parallel I/O for netcdf-4")
     variant("parallel-netcdf", default=False, description="Enable parallel I/O for classic files")


### PR DESCRIPTION
This does a minimal update to netcdf-c version 4.9.0.  There are some additional features of 4.9.0 such as filters and plugins and zarray support that will need a more extensive update, but this makes 4.9.0 available for use as a replacement to 4.8.1 or earlier versions.