### PR TITLE
py-tensorflow: fix zlib

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
@@ -23,9 +23,11 @@ class PyTensorflowMetadata(PythonPackage):
     version("1.5.0", sha256="f0ec8aaf62fd772ef908efe4ee5ea3bc0d67dcbf10ae118415b7b206a1d61745")
 
     # Fix non-existing zlib URL
-    patch("https://github.com/tensorflow/metadata/commit/8df679e782f5bf2d163d63e550d8752c3812d566.patch?full_index=1",
-          sha256="a6b294d5e6099979192fcdb4d5b7b0388dc30b48671944d22e51a9e6bd5e1490",
-          when="@1.10.0")
+    patch(
+        "https://github.com/tensorflow/metadata/commit/8df679e782f5bf2d163d63e550d8752c3812d566.patch?full_index=1",
+        sha256="a6b294d5e6099979192fcdb4d5b7b0388dc30b48671944d22e51a9e6bd5e1490",
+        when="@1.10.0",
+    )
 
     depends_on("bazel@0.24.1:", type="build")
     depends_on("python@3.7:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
@@ -22,6 +22,11 @@ class PyTensorflowMetadata(PythonPackage):
     version("1.10.0", sha256="e7aa81aa01433e2a75c11425affd55125b64f384baf96b71eeb3a88dca8cf2ae")
     version("1.5.0", sha256="f0ec8aaf62fd772ef908efe4ee5ea3bc0d67dcbf10ae118415b7b206a1d61745")
 
+    # Fix non-existing zlib URL
+    patch("https://github.com/tensorflow/metadata/commit/8df679e782f5bf2d163d63e550d8752c3812d566.patch?full_index=1",
+          sha256="a6b294d5e6099979192fcdb4d5b7b0388dc30b48671944d22e51a9e6bd5e1490",
+          when="@1.10.0")
+
     depends_on("bazel@0.24.1:", type="build")
     depends_on("python@3.7:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -445,9 +445,11 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     # If the tf mirrors don't work, make sure the fallback is to something existing.
     patch("url-zlib.patch", when="@0.10.0")
     # bump to zlib 1.2.13
-    patch("https://github.com/tensorflow/tensorflow/commit/76b9fa22857148a562f3d9b5af6843402a93c15b.patch?full_index=1",
-          sha256="f9e26c544da729cfd376dbd3b096030e3777d3592459add1f3c78b1b9828d493",
-          when="@2.9:2.10.0")
+    patch(
+        "https://github.com/tensorflow/tensorflow/commit/76b9fa22857148a562f3d9b5af6843402a93c15b.patch?full_index=1",
+        sha256="f9e26c544da729cfd376dbd3b096030e3777d3592459add1f3c78b1b9828d493",
+        when="@2.9:2.10.0",
+    )
     # TODO: why is this needed?
     patch("crosstool.patch", when="@0.10.0+cuda")
     # Avoid build error: "no such package '@io_bazel_rules_docker..."

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -440,8 +440,14 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage):
     conflicts("~rocm", when="@2.7.4-rocm-enhanced")
     conflicts("+rocm", when="@:2.7.4-a,2.7.4.0:")
 
-    # TODO: why is this needed?
+    # zlib is vendored and downloaded directly from zlib.org (or mirrors), but
+    # old downloads are removed from that site immediately after a new release.
+    # If the tf mirrors don't work, make sure the fallback is to something existing.
     patch("url-zlib.patch", when="@0.10.0")
+    # bump to zlib 1.2.13
+    patch("https://github.com/tensorflow/tensorflow/commit/76b9fa22857148a562f3d9b5af6843402a93c15b.patch?full_index=1",
+          sha256="f9e26c544da729cfd376dbd3b096030e3777d3592459add1f3c78b1b9828d493",
+          when="@2.9:2.10.0")
     # TODO: why is this needed?
     patch("crosstool.patch", when="@0.10.0+cuda")
     # Avoid build error: "no such package '@io_bazel_rules_docker..."


### PR DESCRIPTION
tensorflow uses bazel, bazel vendors all deps and has urls pointing to a non-existing zlib url, since the new release of zlib of yesterday.