### PR TITLE
sdl2: new versions 2.0.22 and 2.24.1

### DIFF
--- a/var/spack/repos/builtin/packages/sdl2/package.py
+++ b/var/spack/repos/builtin/packages/sdl2/package.py
@@ -23,7 +23,6 @@ class Sdl2(CMakePackage):
 
     depends_on("cmake@2.8.5:", type="build")
     depends_on("libxext", type="link")
-    depends_on("dbus", when="platform=linux")
 
     def cmake_args(self):
         return ["-DSSEMATH={0}".format("OFF" if self.spec.target.family == "aarch64" else "ON")]

--- a/var/spack/repos/builtin/packages/sdl2/package.py
+++ b/var/spack/repos/builtin/packages/sdl2/package.py
@@ -13,12 +13,17 @@ class Sdl2(CMakePackage):
 
     homepage = "https://wiki.libsdl.org/FrontPage"
     url = "https://libsdl.org/release/SDL2-2.0.5.tar.gz"
+    git = "https://github.com/libsdl-org/SDL.git"
+    list_url = "https://github.com/libsdl-org/SDL.git"
 
+    version("2.24.1", sha256="bc121588b1105065598ce38078026a414c28ea95e66ed2adab4c44d80b309e1b")
+    version("2.0.22", sha256="fe7cbf3127882e3fc7259a75a0cb585620272c51745d3852ab9dd87960697f2e")
     version("2.0.14", sha256="d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc")
     version("2.0.5", sha256="442038cf55965969f2ff06d976031813de643af9c9edc9e331bd761c242e8785")
 
     depends_on("cmake@2.8.5:", type="build")
     depends_on("libxext", type="link")
+    depends_on("dbus", when="platform=linux")
 
     def cmake_args(self):
         return ["-DSSEMATH={0}".format("OFF" if self.spec.target.family == "aarch64" else "ON")]


### PR DESCRIPTION
The SDL2 developers have [changed the version numbering scheme](https://github.com/libsdl-org/SDL/releases/tag/release-2.24.0) from 2.0.22 to 2.24.0. This adds the latest version in the old scheme and the latest bugfix release in the new scheme.