### PR TITLE
installer.py: fix/test get_deptypes

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2357,7 +2357,13 @@ class BuildRequest(object):
         """
         deptypes = ["link", "run"]
         include_build_deps = self.install_args.get("include_build_deps")
-        if not self.install_args.get("cache_only") or include_build_deps:
+
+        if self.pkg_id == package_id(pkg):
+            cache_only = self.install_args.get("package_cache_only")
+        else:
+            cache_only = self.install_args.get("dependencies_cache_only")
+
+        if not cache_only or include_build_deps:
             deptypes.append("build")
         if self.run_tests(pkg):
             deptypes.append("test")

--- a/lib/spack/spack/test/buildrequest.py
+++ b/lib/spack/spack/test/buildrequest.py
@@ -62,3 +62,36 @@ def test_build_request_strings(install_mockery):
     istr = str(request)
     assert "package=dependent-install" in istr
     assert "install_args=" in istr
+
+
+@pytest.mark.parametrize(
+    "package_cache_only,dependencies_cache_only,package_deptypes,dependencies_deptypes",
+    [
+        (False, False, ["build", "link", "run"], ["build", "link", "run"]),
+        (True, False, ["link", "run"], ["build", "link", "run"]),
+        (False, True, ["build", "link", "run"], ["link", "run"]),
+        (True, True, ["link", "run"], ["link", "run"]),
+    ],
+)
+def test_build_request_deptypes(
+    install_mockery,
+    package_cache_only,
+    dependencies_cache_only,
+    package_deptypes,
+    dependencies_deptypes,
+):
+    s = spack.spec.Spec("dependent-install").concretized()
+
+    build_request = inst.BuildRequest(
+        s.package,
+        {
+            "package_cache_only": package_cache_only,
+            "dependencies_cache_only": dependencies_cache_only,
+        },
+    )
+
+    actual_package_deptypes = build_request.get_deptypes(s.package)
+    actual_dependency_deptypes = build_request.get_deptypes(s["dependency-install"].package)
+
+    assert sorted(actual_package_deptypes) == package_deptypes
+    assert sorted(actual_dependency_deptypes) == dependencies_deptypes


### PR DESCRIPTION
Fixing an oversight in https://github.com/spack/spack/pull/32537

`get_deptypes` should depend on new `package/dependencies_cache_only`
props.
