### PR TITLE
provide scalapack, fix flag for icc

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -182,6 +182,13 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 # should not be patched
                 patchelf(file, fail_on_error=False)
 
+    def write_config_file(self, flags, path, compilers):
+        for compiler in compilers:
+            p = path.join(compiler + ".cfg")
+            with open(p, "w") as f:
+                f.write(" ".join(flags))
+            set_install_permissions(p)
+
     @run_after("install")
     def extend_config_flags(self):
         # Extends compiler config files to inject additional compiler flags.
@@ -196,7 +203,12 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         # TODO: it is unclear whether we should really use all elements of
         #  _ld_library_path because it looks like the only rpath that needs to be
         #  injected is self.component_prefix.linux.compiler.lib.intel64_lin.
-        flags_list = ["-Wl,-rpath,{}".format(d) for d in self._ld_library_path()]
+        common_flags = ["-Wl,-rpath,{}".format(d) for d in self._ld_library_path()]
+
+        # Make sure that underlying clang gets the right GCC toolchain by default
+        llvm_flags = ["--gcc-toolchain={}".format(self.compiler.prefix)]
+        classic_flags = ["-gcc-name={}".format(self.compiler.cc)]
+        classic_flags.append("-gxx-name={}".format(self.compiler.cxx))
 
         # Older versions trigger -Wunused-command-line-argument warnings whenever
         # linker flags are passed in preprocessor (-E) or compilation mode (-c).
@@ -204,33 +216,15 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         # do not trigger these warnings. In some build systems these warnings can
         # cause feature detection to fail, so we silence them with -Wno-unused-...
         if self.spec.version < Version("2022.1.0"):
-            flags_list.append("-Wno-unused-command-line-argument")
+            llvm_flags.append("-Wno-unused-command-line-argument")
 
-        def write_cfg(cmp_list, flags_list):
-            flags = " ".join(flags_list)
-            for cmp in cmp_list:
-                cfg_file = self.component_prefix.linux.bin.join(cmp + ".cfg")
-                with open(cfg_file, "w") as f:
-                    f.write(flags)
-                set_install_permissions(cfg_file)
-
-        # Make sure that icc gets the right GCC C+ support
-        write_cfg(
-            [
-                join_path("intel64", "icc"),
-            ],
-            flags_list + ["-gcc-name={}".format(self.compiler.cc)],
+        self.write_config_file(
+            common_flags + llvm_flags, self.component_prefix.linux.bin, ["icx", "icpx", "ifx"]
         )
-        write_cfg(
-            [
-                join_path("intel64", "icpc"),
-            ],
-            flags_list + ["-gxx-name={}".format(self.compiler.cxx)],
-        )
-        # Make sure that underlying clang gets the right GCC toolchain by default
-        write_cfg(
-            ["icx", "icpx", "ifx"],
-            flags_list + ["--gcc-toolchain={}".format(self.compiler.prefix)],
+        self.write_config_file(
+            common_flags + classic_flags,
+            self.component_prefix.linux.bin.intel64,
+            ["icc", "icpc", "ifort"],
         )
 
     def _ld_library_path(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -87,7 +87,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     depends_on("mpi", when="+cluster")
 
     provides("fftw-api@3")
-    provides("scalapack", when="+cluster")
+    provides("scalapack")
     provides("mkl")
     provides("lapack")
     provides("blas")


### PR DESCRIPTION
Provide scalapack unconditionally to match intel-mkl. Resolves #33371 

Do not provide -Wno-unused-command-line-argument when using classic compilers. It is not supported and not needed.

Restructure some code.