### PR TITLE
[WIP] Make sure external python extensions depend on python

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2961,6 +2961,21 @@ class Spec(object):
         else:
             self._old_concretize(tests)
 
+        self.link_externals_extensions_to_extendees()
+
+    def link_externals_extensions_to_extendees(self):
+        import spack.build_systems.python
+
+        python_spec = None
+        for spec in self.traverse():
+            if spec.name == "python":
+                python_spec = spec
+                break
+
+        for spec in self.traverse():
+            if isinstance(spec, spack.build_systems.python.PythonPackage):
+                spec.add_dependency_edge(python_spec, ("build", "link", "run"))
+
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
         if (not value) and self.concrete and self.installed:


### PR DESCRIPTION
Since https://github.com/spack/spack/pull/32970, external python extensions will often fail since some of their methods now refer to the `python` dependency, and externals are stripped of all dependencies.

This proposes adding a step which associates python extensions with the external python. It is assumed there is only one instance of `python` in this case. There are a number of scenarios where this may go wrong, but it is a simple solution that is expected to apply in most cases.