### PR TITLE
Feature: alter BuildTask priority when no uninstalled dependencies

### DIFF
--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -39,14 +39,14 @@ def test_build_task_basics(install_mockery):
     task = inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_ADDED, [])
     assert task.explicit  # package was "explicitly" requested
     assert task.priority == len(task.uninstalled_deps)
-    assert task.key == (task.priority, task.randomizer, task.sequence)
+    assert task.key == (task.priority, task.attempts, task.random)
 
     # Ensure flagging installed works as expected
     assert len(task.uninstalled_deps) > 0
     assert task.dependencies == task.uninstalled_deps
     task.flag_installed(task.dependencies)
     assert len(task.uninstalled_deps) == 0
-    assert inst.install_priority(task.priority)
+    assert task.priority == 0
 
 
 def test_build_task_strings(install_mockery):

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -39,7 +39,7 @@ def test_build_task_basics(install_mockery):
     task = inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_ADDED, [])
     assert task.explicit  # package was "explicitly" requested
     assert task.priority == len(task.uninstalled_deps)
-    assert task.key == (task.priority, task.sequence)
+    assert task.key == (task.priority, task.randomizer, task.sequence)
 
     # Ensure flagging installed works as expected
     assert len(task.uninstalled_deps) > 0

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -46,7 +46,7 @@ def test_build_task_basics(install_mockery):
     assert task.dependencies == task.uninstalled_deps
     task.flag_installed(task.dependencies)
     assert len(task.uninstalled_deps) == 0
-    assert task.priority == 0
+    assert inst.install_priority(task.priority)
 
 
 def test_build_task_strings(install_mockery):


### PR DESCRIPTION
At @haampie 's suggestion, this PR adds some randomization to the build task priority for packages to help reduce bottlenecks when running parallel package builds.  This PR changes the priority for packages with no uninstalled dependencies to a random number in [0,1) to allow multiple `spack install`s a better chance of interleaving the builds.

Preliminary, small-scale timing on an LLNL/LC system indicates there could be a small average elapsed time speedup.

TODO:

- [x] Run/update unit tests