### PR TITLE
ECP-SDK: enable hdf5 VOL adapters

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -125,6 +125,9 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
         )
     conflicts("~cuda", when="^hdf5-vfd-gds@1.0.2:")
     conflicts("~hdf5", when="^hdf5-vfd-gds@1.0.2:")
+    dav_sdk_depends_on("hdf5-vol-async", when="+hdf5")
+    dav_sdk_depends_on("hdf5-vol-cache", when="+hdf5")
+    dav_sdk_depends_on("hdf5-vol-log", when="+hdf5")
 
     dav_sdk_depends_on("parallel-netcdf+shared", when="+pnetcdf", propagate=["fortran"])
 

--- a/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
@@ -7,7 +7,9 @@ from spack.package import *
 
 
 class Hdf5VolAsync(CMakePackage):
-    """This package enables asynchronous IO in HDF5."""
+    """This package enables asynchronous IO in HDF5.  WARNING: Please refer to the
+    documentation.  This package will be available in HDF5_PLUGIN_PATH, but in order to
+    use it the consumer must set the HDF5_VOL_CONNECTOR environment variable."""
 
     homepage = "https://hdf5-vol-async.readthedocs.io"
     git = "https://github.com/hpc-io/vol-async.git"
@@ -23,13 +25,15 @@ class Hdf5VolAsync(CMakePackage):
     version("1.0", tag="v1.0")
 
     depends_on("mpi")
-    depends_on("argobots@main")
-    depends_on("hdf5@1.13: +mpi +threadsafe")
+    depends_on("argobots@1.1:")
+    depends_on("hdf5@1.13:1.13.2 +mpi +threadsafe", when="@:1.3")
+
+    # Enforce that MPI_THREAD_MULTIPLE is available.
+    depends_on("openmpi +thread_multiple", when="^openmpi")
+    depends_on("mvapich2 threads=multiple", when="^mvapich2")
 
     def setup_run_environment(self, env):
-        env.set("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
-        vol_connector = "async under_vol=0;under_info=[]"
-        env.set("HDF5_VOL_CONNECTOR", vol_connector)
+        env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
         env.set("MPICH_MAX_THREAD_SAFETY", "multiple")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
@@ -16,7 +16,11 @@ class Hdf5VolCache(CMakePackage):
     version("default", branch="develop")
     version("v1.0", tag="v1.0")
 
+    depends_on("hdf5@1.13:1.13.2 +mpi +threadsafe", when="@:v1.0")
     depends_on("hdf5-vol-async")
+
+    def setup_run_environment(self, env):
+        env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 
     def cmake_args(self):
         """Populate cmake arguments for HDF5 VOL."""

--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -21,11 +21,14 @@ class Hdf5VolLog(AutotoolsPackage):
     version("1.2.0", tag="logvol.1.2.0")
     version("1.1.0", tag="logvol.1.1.0")
 
-    depends_on("hdf5@1.13.2:")
+    depends_on("hdf5@1.13:1.13.2", when="@:1.3.0")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+
+    def setup_run_environment(self, env):
+        env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -46,6 +46,11 @@ class Hdf5(CMakePackage):
     version("develop-1.8", branch="hdf5_1_8")
 
     # Odd versions are considered experimental releases
+    # NOTE: retain version 1.13.2 until:
+    # 1. hdf5-vol-async, hdf5-vol-cache, and hdf5-vol-log are ready to build off
+    #    hdf5@1.13.3+ (VOL struct underwent breaking changes).
+    # 2. New versions for each package are ready to be tagged and updated in spack.
+    # 4. The ecp-data-vis-sdk maintainers are ready to abandon 1.13.2.
     version("1.13.2", sha256="01643fa5b37dba7be7c4db6bbf3c5d07adf5c1fa17dbfaaa632a279b1b2f06da")
 
     # Even versions are maintenance versions

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -299,7 +299,7 @@ class Paraview(CMakePackage, CudaPackage):
             elif self.spec.satisfies("@5.10: +hdf5"):
                 if self.spec["hdf5"].satisfies("@1.12:"):
                     flags.append("-DH5_USE_110_API")
-        return (flags, None, None)
+        return (None, None, flags)
 
     def setup_run_environment(self, env):
         # paraview 5.5 and later


### PR DESCRIPTION
- When +hdf5, enable VOL adapters suitable for the SDK.
- Each VOL package must prepend to the HDF5_PLUGIN_PATH.
- hdf5: 1.13.3 will break existing VOL packages, constrain
  VOLs related to SDK and add note to keep 1.13.2 available.
- hdf5-vol-async:
    - Do not set HDF5_VOL_CONNECTOR, consumers must opt-in.
    - Enforce DAG constraints on MPI to require threaded version.
    - Depend on an explicit version of argbots to relax
      concretization issues in other spack environments.
- paraview: fix compiler flag usage for the 110 ABI (followup to #33617).
- [ ] Confirm builds.
    - [X] e4s container build
    - [X] vanilla build bare metal
    - [ ] e4s site build incl. site yamls
    - [ ] gitlab dav-sdk pipeline keeps failing in paraview, cannot reproduce locally
- [X] Confirm with HDF5 group about vol-async environment variables.

```console
root@79bbd49cf2a8:/# spack load ecp-data-vis-sdk                                                                                                        
root@79bbd49cf2a8:/# echo $HDF5_PLUGIN_PATH | tr : $'\n' | xargs ls                                                                                     
/build/src/opt/spack/linux-ubuntu20.04-zen2/gcc-11.1.0/hdf5-vol-async-1.3-qdnz5mqjb2puxdcwoy7muk63udmw7uwz/lib:
libasynchdf5.a  libh5async.so

/build/src/opt/spack/linux-ubuntu20.04-zen2/gcc-11.1.0/hdf5-vol-cache-v1.0-oevenlhfpnlhbnykhwudmpovgg4rihtu/lib:
libhdf5_vol_cache.so

/build/src/opt/spack/linux-ubuntu20.04-zen2/gcc-11.1.0/hdf5-vol-log-1.3.0-2dl7s3whgwz6hs2ftzrolzfjd54me4hs/lib:
libH5VL_log.a  libH5VL_log.so  libH5VL_log.so.0  libH5VL_log.so.0.0.0
```