### PR TITLE
patch for config update permission problem

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -258,7 +258,7 @@ def config_update(args):
     cannot_overwrite, skip_system_scope = [], False
     for scope in updates:
         cfg_file = spack.config.config.get_config_filename(scope.name, args.section)
-        scope_dir = scope.path
+        scope_dir = os.path.dirname(scope.path)
         can_be_updated = _can_update_config_file(scope_dir, cfg_file)
         if not can_be_updated:
             if scope.name == "system":


### PR DESCRIPTION
fixes #26169.

Using develop@b44c834 results in:

```
$ spack config update modules
==> Warning: Top-level properties "lmod" in module config are ignored as of Spack v0.18. They should be set on the "default" module set. Run

        $ spack config update modules

to update the file to the new format
==> Error: Detected permission issues with the following scopes:

        [scope=env:/opt/scorec/spack/spack0.18.1/v0181_0:/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml, cfg=/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml]

Either ensure that you have sufficient permissions to modify these files or do not include these scopes in the update.
```

Sanity check that I do have access (ignore the directory name... I was testing with the latest release prior to this PR):

```
$ ls -altr /opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml                                                                                                                                                                                                                                                                                                                                                   
-rw-r--r-- 1 cwsmith softadmin 2902 Oct 18 13:28 /opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml
```

The output from `spack -d config update modules`:

```
==> [2022-10-18-13:34:31.493321] Reading config from file /opt/scorec/spack/spack0.18.1/etc/spack/defaults/config.yaml                                                                                                                                                                                                                                                                                                                                                          
==> [2022-10-18-13:34:31.513115] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/defaults/linux/config.yaml                                                                                                                                                                                                                                                                                                                                            
==> [2022-10-18-13:34:31.513151] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/config.yaml                                                                                                                                                                                                                                                                                                                                                           
==> [2022-10-18-13:34:31.513176] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/linux/config.yaml                                                                                                                                                                                                                                                                                                                                                     
==> [2022-10-18-13:34:31.560105] Reading config from file /opt/scorec/spack/spack0.18.1/etc/spack/defaults/concretizer.yaml                                                                                                                                                                                                                                                                                                                                                     
==> [2022-10-18-13:34:31.564590] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/defaults/linux/concretizer.yaml                                                                                                                                                                                                                                                                                                                                       
==> [2022-10-18-13:34:31.564624] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/concretizer.yaml                                                                                                                                                                                                                                                                                                                                                      
==> [2022-10-18-13:34:31.564649] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/linux/concretizer.yaml                                                                                                                                                                                                                                                                                                                                                
==> [2022-10-18-13:34:31.565409] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/defaults/upstreams.yaml                                                                                                                                                                                                                                                                                                                                               
==> [2022-10-18-13:34:31.565437] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/defaults/linux/upstreams.yaml                                                                                                                                                                                                                                                                                                                                         
==> [2022-10-18-13:34:31.565460] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/upstreams.yaml                                                                                                                                                                                                                                                                                                                                                        
==> [2022-10-18-13:34:31.565482] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/linux/upstreams.yaml                                                                                                                                                                                                                                                                                                                                                  
==> [2022-10-18-13:34:31.566087] Creating SingleFileScope env:/opt/scorec/spack/spack0.18.1/v0181_0:/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml for '/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml'                                                                                                                                                                                                                                                                 
==> [2022-10-18-13:34:31.567714] Reading config from file /opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml                                                                                                                                                                                                                                                                                                                                                                    
==> [2022-10-18-13:34:31.599883] Warning: Top-level properties "lmod" in module config are ignored as of Spack v0.18. They should be set on the "default" module set. Run                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
        $ spack config update modules                                                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
to update the file to the new format                                                                                                                                                                                                                                                                                                                                                                                                                                            
==> [2022-10-18-13:34:31.600011] Reading config from file /opt/scorec/spack/spack0.18.1/v0181_0/spack.yaml                                                                                                                                                                                                                                                                                                                                                                      
==> [2022-10-18-13:34:31.635723] Using environment '/opt/scorec/spack/spack0.18.1/v0181_0'                                                                                                                                                                                                                                                                                                                                                                                      
==> [2022-10-18-13:34:31.644352] Imported config from built-in commands                                                                                                                                                                                                                                                                                                                                                                                                         
==> [2022-10-18-13:34:31.646269] Imported config from built-in commands                                                                                                                                                                                                                                                                                                                                                                                                         
==> [2022-10-18-13:34:31.646918] Reading config from file /opt/scorec/spack/spack0.18.1/etc/spack/defaults/modules.yaml                                                                                                                                                                                                                                                                                                                                                         
==> [2022-10-18-13:34:31.662984] Reading config from file /opt/scorec/spack/spack0.18.1/etc/spack/defaults/linux/modules.yaml                                                                                                                                                                                                                                                                                                                                                   
==> [2022-10-18-13:34:31.664570] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/modules.yaml                                                                                                                                                                                                                                                                                                                                                          
==> [2022-10-18-13:34:31.664603] Skipping nonexistent config path /opt/scorec/spack/spack0.18.1/etc/spack/linux/modules.yaml                                                                                                                                                                                                                                                                                                                                                    
==> [2022-10-18-13:34:31.671661] Error: Detected permission issues with the following scopes:                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
        [scope=env:/opt/scorec/spack/spack0.18.1/v0181_0:/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml, cfg=/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml]                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
Either ensure that you have sufficient permissions to modify these files or do not include these scopes in the update.                                                                                                                                                                                                                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                                                                                                              
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/main.py", line 990, in main                                                                                                                                                                                                                                                                                                                                                                                               
    return _main(argv)                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/main.py", line 945, in _main                                                                                                                                                                                                                                                                                                                                                                                              
    return finish_parse_and_run(parser, cmd_name, env_format_error)                                                                                                                                                                                                                                                                                                                                                                                                             
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/main.py", line 973, in finish_parse_and_run                                                                                                                                                                                                                                                                                                                                                                               
    return _invoke_command(command, parser, args, unknown)                                                                                                                                                                                                                                                                                                                                                                                                                      
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/main.py", line 622, in _invoke_command                                                                                                                                                                                                                                                                                                                                                                                    
    return_val = command(parser, args)                                                                                                                                                                                                                                                                                                                                                                                                                                          
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/cmd/config.py", line 484, in config                                                                                                                                                                                                                                                                                                                                                                                       
    action[args.config_command](args)                                                                                                                                                                                                                                                                                                                                                                                                                                           
  File "/opt/scorec/spack/spack0.18.1/lib/spack/spack/cmd/config.py", line 283, in config_update                                                                                                                                                                                                                                                                                                                                                                                
    tty.die(msg)                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  File "/opt/scorec/spack/spack0.18.1/lib/spack/llnl/util/tty/__init__.py", line 256, in die                                                                                                                                                                                                                                                                                                                                                                                    
    sys.exit(1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
SystemExit: 1   
```

With the fix applied from this PR the command executes successfully:

```
$ spack config update modules                                                                                                                                    
==> Warning: Top-level properties "lmod" in module config are ignored as of Spack v0.18. They should be set on the "default" module set. Run

        $ spack config update modules

to update the file to the new format
==> The following configuration files are going to be updated to the latest schema format:

        [scope=env:/opt/scorec/spack/spack0.18.1/v0181_0:/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml, file=/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml]

If the configuration files are updated, versions of Spack that are older than this version may not be able to read them. Spack stores backups of the updated files which can be retrieved with "spack config revert"
==> Do you want to proceed? [y/N] y
==> File "/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml" updated [backup=/opt/scorec/spack/spack0.18.1/v0181_0/modules.yaml.bkp]
```