### PR TITLE
Fixup clingo dll lookup on Windows

### DIFF
--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip six pywin32 setuptools codecov pytest-cov
+          python -m pip install --upgrade pip six pywin32 setuptools codecov pytest-cov clingo
     - name: Create local develop
       run: |
         .\spack\.github\workflows\setup_git.ps1
@@ -49,7 +49,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip six pywin32 setuptools codecov coverage pytest-cov
+          python -m pip install --upgrade pip six pywin32 setuptools codecov coverage pytest-cov clingo
     - name: Create local develop
       run: |
         .\spack\.github\workflows\setup_git.ps1
@@ -82,7 +82,6 @@ jobs:
         spack external find cmake
         spack external find ninja
         spack -d install abseil-cpp
-        spack unit-test lib/spack/spack/test/cmd
   make-installer:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -81,7 +81,7 @@ jobs:
         echo F|xcopy .\spack\share\spack\qa\configuration\windows_config.yaml $env:USERPROFILE\.spack\windows\config.yaml
         spack external find cmake
         spack external find ninja
-        spack install abseil-cpp
+        spack -d install abseil-cpp
   make-installer:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -82,6 +82,7 @@ jobs:
         spack external find cmake
         spack external find ninja
         spack -d install abseil-cpp
+        spack unit-test lib/spack/spack/test/cmd
   make-installer:
     runs-on: windows-latest
     steps:

--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -1,5 +1,5 @@
 config:
   locks: false
-  concretizer: original
+  concretizer: clingo
   build_stage::
     - '$spack/.staging'

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2095,7 +2095,7 @@ def find_system_libraries(libraries, shared=True):
     return libraries_found
 
 
-def find_libraries(libraries, root, shared=True, recursive=False):
+def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
     """Returns an iterable of full paths to libraries found in a root dir.
 
     Accepts any glob characters accepted by fnmatch:
@@ -2116,6 +2116,10 @@ def find_libraries(libraries, root, shared=True, recursive=False):
             otherwise for static. Defaults to True.
         recursive (bool): if False search only root folder,
             if True descends top-down from the root. Defaults to False.
+        runtime (bool): Windows only option, no-op elsewhere. If true,
+            search for runtime shared libs (.DLL), otherwise, search
+            for .Lib files. If shared is false, this has no meaning.
+            Defaults to True.
 
     Returns:
         LibraryList: The libraries that have been found
@@ -2130,7 +2134,7 @@ def find_libraries(libraries, root, shared=True, recursive=False):
 
     if is_windows:
         static_ext = "lib"
-        shared_ext = "dll"
+        shared_ext = "dll" if runtime else "lib"
     else:
         # Used on both Linux and macOS
         static_ext = "a"
@@ -2174,13 +2178,13 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     return LibraryList(found_libs)
 
 
-def find_all_shared_libraries(root, recursive=False):
+def find_all_shared_libraries(root, recursive=False, runtime=True):
     """Convenience function that returns the list of all shared libraries found
     in the directory passed as argument.
 
     See documentation for `llnl.util.filesystem.find_libraries` for more information
     """
-    return find_libraries("*", root=root, shared=True, recursive=recursive)
+    return find_libraries("*", root=root, shared=True, recursive=recursive, runtime=runtime)
 
 
 def find_all_static_libraries(root, recursive=False):
@@ -2189,7 +2193,7 @@ def find_all_static_libraries(root, recursive=False):
 
     See documentation for `llnl.util.filesystem.find_libraries` for more information
     """
-    return find_libraries("*", root=root, shared=False, recursive=recursive)
+    return find_libraries("*", root=root, shared=False, recursive=recursive, runtime=False)
 
 
 def find_all_libraries(root, recursive=False):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1083,7 +1083,11 @@ def temp_cwd():
         with working_dir(tmp_dir):
             yield tmp_dir
     finally:
-        shutil.rmtree(tmp_dir)
+        kwargs = {}
+        if is_windows:
+            kwargs["ignore_errors"] = False
+            kwargs["onerror"] = readonly_file_handler(ignore_errors=True)
+        shutil.rmtree(tmp_dir, **kwargs)
 
 
 @contextmanager

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2233,12 +2233,7 @@ class WindowsSimulatedRPath(object):
         """
         Set of directories where package binaries/libraries are located.
         """
-        if hasattr(self.pkg, "libs") and self.pkg.libs:
-            pkg_libs = set(self.pkg.libs.directories)
-        else:
-            pkg_libs = set((self.pkg.prefix.lib, self.pkg.prefix.lib64, self.pkg.prefix.bin))
-
-        return pkg_libs | self._additional_library_dependents
+        return set(self.pkg.prefix.bin) | self._additional_library_dependents
 
     def add_library_dependent(self, *dest):
         """
@@ -2246,7 +2241,7 @@ class WindowsSimulatedRPath(object):
         common paths that need to link against other libraries
 
         Specified paths should fall outside of a package's common
-        link paths, i.e. the lib, lib64, and bin
+        link paths, i.e. the bin
         directories.
         """
         for pth in dest:
@@ -2261,7 +2256,6 @@ class WindowsSimulatedRPath(object):
         Set of libraries this package needs to link against during runtime
         These packages will each be symlinked into the packages lib and binary dir
         """
-
         dependent_libs = []
         for path in self.pkg.rpath:
             dependent_libs.extend(list(find_all_shared_libraries(path, recursive=True)))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2134,6 +2134,8 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
 
     if is_windows:
         static_ext = "lib"
+        # For linking (runtime=False) you need the .lib files regardless of
+        # whether you are doing a shared or static link
         shared_ext = "dll" if runtime else "lib"
     else:
         # Used on both Linux and macOS
@@ -2193,7 +2195,7 @@ def find_all_static_libraries(root, recursive=False):
 
     See documentation for `llnl.util.filesystem.find_libraries` for more information
     """
-    return find_libraries("*", root=root, shared=False, recursive=recursive, runtime=False)
+    return find_libraries("*", root=root, shared=False, recursive=recursive)
 
 
 def find_all_libraries(root, recursive=False):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2303,7 +2303,8 @@ class WindowsSimulatedRPath(object):
                     tty.debug(
                         "Linking library %s to %s failed, " % (path, dest_file) + "already linked."
                         if already_linked
-                        else "library with name %s already exists at location %s." % (file_name, dest)
+                        else "library with name %s already exists at location %s."
+                        % (file_name, dest)
                     )
                     pass
                 else:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2243,7 +2243,7 @@ class WindowsSimulatedRPath(object):
         """
         Set of directories where package binaries/libraries are located.
         """
-        return set(self.pkg.prefix.bin) | self._additional_library_dependents
+        return set([self.pkg.prefix.bin]) | self._additional_library_dependents
 
     def add_library_dependent(self, *dest):
         """
@@ -2303,7 +2303,7 @@ class WindowsSimulatedRPath(object):
                     tty.debug(
                         "Linking library %s to %s failed, " % (path, dest_file) + "already linked."
                         if already_linked
-                        else "library with name %s already exists." % file_name
+                        else "library with name %s already exists at location %s." % (file_name, dest)
                     )
                     pass
                 else:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -866,7 +866,11 @@ class GitFetchStrategy(VCSFetchStrategy):
                 if self.stage:
                     self.stage.srcdir = repo_name
                 shutil.copytree(repo_name, dest, symlinks=True)
-                shutil.rmtree(repo_name, ignore_errors=False, onerror=fs.readonly_file_handler(ignore_errors=True))
+                shutil.rmtree(
+                    repo_name,
+                    ignore_errors=False,
+                    onerror=fs.readonly_file_handler(ignore_errors=True),
+                )
 
             with working_dir(dest):
                 checkout_args = ["checkout", commit]

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -865,7 +865,8 @@ class GitFetchStrategy(VCSFetchStrategy):
                 repo_name = get_single_file(".")
                 if self.stage:
                     self.stage.srcdir = repo_name
-                shutil.move(repo_name, dest)
+                shutil.copytree(repo_name, dest, symlinks=True)
+                shutil.rmtree(repo_name, ignore_errors=False, onerror=fs.readonly_file_handler(ignore_errors=True))
 
             with working_dir(dest):
                 checkout_args = ["checkout", commit]

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2817,16 +2817,17 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     @property
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
-        rpaths = [self.prefix.lib, self.prefix.lib64]
+        deps = self.spec.dependencies(deptype="link")
+
         # on Windows, libraries of runtime interest are typically
         # stored in the bin directory
         if is_windows:
             rpaths = [self.prefix.bin]
-        deps = self.spec.dependencies(deptype="link")
-        rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
-        rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
-        if is_windows:
             rpaths.extend(d.prefix.bin for d in deps if os.path.isdir(d.prefix.bin))
+        else:
+            rpaths = [self.prefix.lib, self.prefix.lib64]
+            rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
+            rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))
         return rpaths
 
     @property

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2818,8 +2818,10 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
         rpaths = [self.prefix.lib, self.prefix.lib64]
+        # on Windows, libraries of runtime interest are typically
+        # stored in the bin directory
         if is_windows:
-            rpaths.append(self.prefix.bin)
+            rpaths = [self.prefix.bin]
         deps = self.spec.dependencies(deptype="link")
         rpaths.extend(d.prefix.lib for d in deps if os.path.isdir(d.prefix.lib))
         rpaths.extend(d.prefix.lib64 for d in deps if os.path.isdir(d.prefix.lib64))

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -211,11 +211,21 @@ class WindowsRPathMeta(object):
     they would a genuine RPATH, i.e. adding directories that contain
     runtime library dependencies"""
 
-    def add_search_paths(self, *path):
+    def add_search_paths(self, *paths):
         """Add additional rpaths that are not implicitly included in the search
         scheme
         """
-        self.win_rpath.include_additional_link_paths(*path)
+        self.win_rpath.include_additional_link_paths(*paths)
+
+    def add_internal_links(self, *paths):
+        """Add additional rpaths internal to a package, i.e.
+        linking pkg.prefix.bin to pkg.prefix.lib.site-packages"""
+        self.win_rpath.add_internal_links(*paths)
+
+    def win_setup_rpath(self):
+        """This method should be overridden by packages needing bespoke RPATH
+        support. No-op otherwise"""
+        pass
 
     def windows_establish_runtime_linkage(self):
         """Establish RPATH on Windows
@@ -223,6 +233,7 @@ class WindowsRPathMeta(object):
         Performs symlinking to incorporate rpath dependencies to Windows runtime search paths
         """
         if is_windows:
+            self.win_setup_rpath()
             self.win_rpath.establish_link()
 
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -211,7 +211,7 @@ class WindowsRPathMeta(object):
     they would a genuine RPATH, i.e. adding directories that contain
     runtime library dependencies"""
 
-    def win_add_linked_library(self):
+    def win_add_library_dependent(self):
         """Return extra set of directories that require linking for package
 
         This method should be overridden by packages that produce

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -242,7 +242,7 @@ class WindowsRPathMeta(object):
         Performs symlinking to incorporate rpath dependencies to Windows runtime search paths
         """
         if is_windows:
-            self.win_rpath.add_library_dependent(*self.win_add_linked_library())
+            self.win_rpath.add_library_dependent(*self.win_add_library_dependent())
             self.win_rpath.add_rpath(*self.win_add_rpath())
             self.win_rpath.establish_link()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1030,7 +1030,9 @@ def _libs_default_handler(descriptor, spec, cls):
     )
 
     for shared in search_shared:
-        libs = fs.find_libraries(name, home, shared=shared, recursive=True)
+        # Since we are searching for link libraries, on Windows search only for
+        # ".Lib" extensions by default as those represent import libraries for implict links.
+        libs = fs.find_libraries(name, home, shared=shared, recursive=True, runtime=False)
         if libs:
             return libs
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 import posixpath
 import sys
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import posixpath
 import sys
 
 import jinja2
@@ -459,7 +460,7 @@ class TestConcretize(object):
     def test_external_package(self):
         spec = Spec("externaltool%gcc")
         spec.concretize()
-        assert spec["externaltool"].external_path == os.path.sep + os.path.join(
+        assert spec["externaltool"].external_path == posixpath.sep + posixpath.join(
             "path", "to", "external_tool"
         )
         assert "externalprereq" not in spec
@@ -490,10 +491,10 @@ class TestConcretize(object):
     def test_external_and_virtual(self):
         spec = Spec("externaltest")
         spec.concretize()
-        assert spec["externaltool"].external_path == os.path.sep + os.path.join(
+        assert spec["externaltool"].external_path == posixpath.sep + posixpath.join(
             "path", "to", "external_tool"
         )
-        assert spec["stuff"].external_path == os.path.sep + os.path.join(
+        assert spec["stuff"].external_path == posixpath.sep + posixpath.join(
             "path", "to", "external_virtual_gcc"
         )
         assert spec["externaltool"].compiler.satisfies("gcc")

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
-import os
-
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
@@ -121,7 +118,7 @@ class Clingo(CMakePackage):
 
         return args
 
-    def win_add_linked_library(self):
+    def win_add_library_dependent(self):
         if "+python" in self.spec:
             return [self.spec["python"].platlib]
         else:

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -121,5 +121,8 @@ class Clingo(CMakePackage):
 
         return args
 
-    def win_setup_rpath(self):
-        self.add_internal_links(os.path.join(self.prefix.Lib, "site-packages"))
+    def win_add_linked_library(self):
+        if "+python" in self.spec:
+            return [self.spec["python"].platlib]
+        else:
+            return []

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
@@ -120,6 +121,6 @@ class Clingo(CMakePackage):
 
     def win_add_library_dependent(self):
         if "+python" in self.spec:
-            return [self.spec["python"].platlib]
+            return [os.path.join(self.prefix, self.spec["python"].package.platlib)]
         else:
             return []

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import os
+
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
@@ -118,3 +120,6 @@ class Clingo(CMakePackage):
             args += ["-DCLINGO_BUILD_WITH_PYTHON=OFF"]
 
         return args
+
+    def win_setup_rpath(self):
+        self.add_internal_links(os.path.join(self.prefix.Lib, "site-packages"))

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 


### PR DESCRIPTION
Current RPath on Windows support was lacking a proper package side interface to establish appropriate linkage to support Clingo (and other python extension libraries). This PR adds that support, provides an example and use case for RPath on Windows, and applies some much needed updates to RPath support.

Establishes Clingo as default concertizer on Windows

Partial fix to: #33347 