### PR TITLE
Add a command to bootstrap Spack right now

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import os.path
+import platform
 import shutil
 import tempfile
 
@@ -72,6 +73,8 @@ def _add_scope_option(parser):
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(dest="subcommand")
+
+    sp.add_parser("now", help="Spack ready, right now!")
 
     status = sp.add_parser("status", help="get the status of Spack")
     status.add_argument(
@@ -404,6 +407,14 @@ def _mirror(args):
     print(instructions)
 
 
+def _now(args):
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.ensure_clingo_importable_or_raise()
+        spack.bootstrap.ensure_gpg_in_path_or_raise()
+        if platform.system().lower() == "linux":
+            spack.bootstrap.ensure_patchelf_in_path_or_raise()
+
+
 def bootstrap(parser, args):
     callbacks = {
         "status": _status,
@@ -417,5 +428,6 @@ def bootstrap(parser, args):
         "add": _add,
         "remove": _remove,
         "mirror": _mirror,
+        "now": _now,
     }
     callbacks[args.subcommand](args)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -412,8 +412,12 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="status enable disable reset root list trust untrust add remove mirror"
+        SPACK_COMPREPLY="now status enable disable reset root list trust untrust add remove mirror"
     fi
+}
+
+_spack_bootstrap_now() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_bootstrap_status() {


### PR DESCRIPTION
Add a command to bootstrap Spack explicitly, i.e. not lazily when a component is first needed. In a later PR this might get a `--dev` option too.

Example:
```console
$ spack bootstrap now
==> Bootstrapping clingo from pre-built binaries
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.3/build_cache/linux-centos7-x86_64-gcc-10.2.1-clingo-bootstrap-spack-shqedxgvjnhiwdcdrvjhbd73jaevv7wt.spec.json
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.3/build_cache/linux-centos7-x86_64/gcc-10.2.1/clingo-bootstrap-spack/linux-centos7-x86_64-gcc-10.2.1-clingo-bootstrap-spack-shqedxgvjnhiwdcdrvjhbd73jaevv7wt.spack
==> Installing "clingo-bootstrap@spack%gcc@10.2.1~docs~ipo+python+static_libstdcpp build_type=Release arch=linux-centos7-x86_64" from a buildcache
==> Bootstrapping patchelf from pre-built binaries
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.3/build_cache/linux-centos7-x86_64-gcc-10.2.1-patchelf-0.15.0-htk62k7efo2z22kh6kmhaselru7bfkuc.spec.json
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.3/build_cache/linux-centos7-x86_64/gcc-10.2.1/patchelf-0.15.0/linux-centos7-x86_64-gcc-10.2.1-patchelf-0.15.0-htk62k7efo2z22kh6kmhaselru7bfkuc.spack
==> Installing "patchelf@0.15.0%gcc@10.2.1 ldflags="-static-libstdc++ -static-libgcc"  arch=linux-centos7-x86_64" from a buildcache
```