### PR TITLE
axom: python only reliably available when +python, +devtools

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -449,7 +449,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append("# ClangFormat disabled due to disabled devtools\n")
             entries.append(cmake_cache_option("ENABLE_CLANGFORMAT", False))
 
-        if spec.satisfies("^python") or "+devtools" in spec:
+        if "+python" in spec or "+devtools" in spec:
             python_path = os.path.realpath(spec["python"].command.path)
             for key in path_replacements:
                 python_path = python_path.replace(key, path_replacements[key])


### PR DESCRIPTION
`axom` only explicitly depends_on `python` when `+python` or `+devtools`. 

Right now, if you try and install of `axom ~python ~devtools`'s dependencies from cache, `python` is not installed. However, `spec.satisfies("^python")` can return true if `python` comes in transitively as a build-only dep of some other package.

@scottwittenburg @white238 @wspear 