### PR TITLE
gitlab ci: Add "script_failure" as a reason for retrying service jobs

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1167,7 +1167,14 @@ def generate_gitlab_ci_yaml(
         "after_script",
     ]
 
-    service_job_retries = {"max": 2, "when": ["runner_system_failure", "stuck_or_timeout_failure"]}
+    service_job_retries = {
+        "max": 2,
+        "when": [
+            "runner_system_failure",
+            "stuck_or_timeout_failure",
+            "script_failure",
+        ],
+    }
 
     if job_id > 0:
         if temp_storage_url_prefix:


### PR DESCRIPTION
Apparently when the runner encounters a network error when trying to clone the repo for testing, before any "script" or "before_script" gets a chance to run, gitlab categorizes that as a script failure. So to make sure we retry jobs that failed for that reason or a similar one, include "script_failure" as one of the reasons for retrying service jobs (which include "no specs to rebuild" jobs, signing/notary jobs, update buildcache index jobs, and temp storage cleanup jobs.