### PR TITLE
netlib-scalapack %cce: add -hnopattern to fflags

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -45,6 +45,13 @@ class ScalapackBase(CMakePackage):
         when="@2.2.0",
     )
 
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "fflags":
+            if self.spec.satisfies("%cce"):
+                iflags.append("-hnopattern")
+        return (iflags, None, None)
+
     @property
     def libs(self):
         # Note that the default will be to search


### PR DESCRIPTION
`netlib-scalapack %cce`: append `-hnopattern` to fflags

Fixes https://github.com/spack/spack/issues/33421

@lukebroskop @wspear @mgates3 