### PR TITLE
arpack-ng %cce: add -hnopattern to fflags

### DIFF
--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -87,6 +87,11 @@ class ArpackNg(Package):
         if name == "cflags":
             if spec.satisfies("%oneapi"):
                 iflags.append("-Wno-error=implicit-function-declaration")
+
+        if name == "fflags":
+            if self.spec.satisfies("%cce"):
+                iflags.append("-hnopattern")
+
         return (iflags, None, None)
 
     @property


### PR DESCRIPTION
`arpack-ng %cce`: add `-hnopattern` to fflags

Currently `arpack-ng %cce` fails to build with the same errors as seen here for netlib-scalapack:
* https://github.com/spack/spack/issues/33421

FYI @lukebroskop @wspear 