### PR TITLE
FIX CI after git update

### DIFF
--- a/.github/workflows/setup_git.ps1
+++ b/.github/workflows/setup_git.ps1
@@ -6,6 +6,10 @@ git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 git config --global core.longpaths true
 
+# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE--2022-39253)
+# This is needed to let some fixture in our unit-test suite run
+git config --global protocol.file.allow always
+
 if ($(git branch --show-current) -ne "develop")
 {
     git branch develop origin/develop

--- a/.github/workflows/setup_git.ps1
+++ b/.github/workflows/setup_git.ps1
@@ -6,7 +6,7 @@ git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 git config --global core.longpaths true
 
-# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE--2022-39253)
+# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE-2022-39253)
 # This is needed to let some fixture in our unit-test suite run
 git config --global protocol.file.allow always
 

--- a/.github/workflows/setup_git.sh
+++ b/.github/workflows/setup_git.sh
@@ -2,6 +2,10 @@
 git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 
+# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE--2022-39253)
+# This is needed to let some fixture in our unit-test suite run
+git config --global protocol.file.allow always
+
 # create a local pr base branch
 if [[ -n $GITHUB_BASE_REF ]]; then
     git fetch origin "${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"

--- a/.github/workflows/setup_git.sh
+++ b/.github/workflows/setup_git.sh
@@ -2,7 +2,7 @@
 git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 
-# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE--2022-39253)
+# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE-2022-39253)
 # This is needed to let some fixture in our unit-test suite run
 git config --global protocol.file.allow always
 


### PR DESCRIPTION
We use local repositories in unit-tests to stress some git related functionality. The default value of `protocol.file.allow` after CVE-2022-39253 conflicts with our fixtures. Here we restore the previous default value.

Modifications:
- [x] Add `protocol.file.allow always` to our git configuration in CI