### PR TITLE
Major version of pip 22 fails to bootstrap on Win

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -81,6 +81,8 @@ class PyPip(Package):
     depends_on("python@2.7:2.8,3.3:", when="@10:", type=("build", "run"))
     depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
 
+    conflicts("platform=windows", when="@22:")
+
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/p/pip/pip-{1}-{0}-none-any.whl"
         if version >= Version("21"):


### PR DESCRIPTION
Conflict with this version until a fix is determined or a patch is backported