### PR TITLE
Remove "spack buildcache copy" in v0.19.0

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import sys
 import tempfile
-import warnings
 
 import llnl.util.tty as tty
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -258,19 +258,6 @@ def setup_parser(subparser):
     )
     savespecfile.set_defaults(func=save_specfile_fn)
 
-    # Copy buildcache from some directory to another mirror url
-    copy = subparsers.add_parser("copy", help=copy_fn.__doc__)
-    copy.add_argument(
-        "--base-dir", default=None, help="Path to mirror directory (root of existing buildcache)"
-    )
-    copy.add_argument(
-        "--spec-file",
-        default=None,
-        help=("Path to spec json or yaml file representing buildcache entry to" + " copy"),
-    )
-    copy.add_argument("--destination-url", default=None, help="Destination mirror url")
-    copy.set_defaults(func=copy_fn)
-
     # Sync buildcache entries from one mirror to another
     sync = subparsers.add_parser("sync", help=sync_fn.__doc__)
     sync.add_argument(
@@ -547,78 +534,6 @@ def save_specfile_fn(args):
     )
 
     sys.exit(0)
-
-
-def copy_fn(args):
-    """Copy a buildcache entry and all its files from one mirror, given as
-    '--base-dir', to some other mirror, specified as '--destination-url'.
-    The specific buildcache entry to be copied from one location to the
-    other is identified using the '--spec-file' argument."""
-    # TODO: Remove after v0.18.0 release
-    msg = (
-        '"spack buildcache copy" is deprecated and will be removed from '
-        "Spack starting in v0.19.0"
-    )
-    warnings.warn(msg)
-
-    if not args.spec_file:
-        tty.msg("No spec yaml provided, exiting.")
-        sys.exit(1)
-
-    if not args.base_dir:
-        tty.msg("No base directory provided, exiting.")
-        sys.exit(1)
-
-    if not args.destination_url:
-        tty.msg("No destination mirror url provided, exiting.")
-        sys.exit(1)
-
-    dest_url = args.destination_url
-
-    if dest_url[0:7] != "file://" and dest_url[0] != "/":
-        tty.msg('Only urls beginning with "file://" or "/" are supported ' + "by buildcache copy.")
-        sys.exit(1)
-
-    try:
-        with open(args.spec_file, "r") as fd:
-            spec = Spec.from_yaml(fd.read())
-    except Exception as e:
-        tty.debug(e)
-        tty.error("Unable to concrectize spec from yaml {0}".format(args.spec_file))
-        sys.exit(1)
-
-    dest_root_path = dest_url
-    if dest_url[0:7] == "file://":
-        dest_root_path = dest_url[7:]
-
-    build_cache_dir = bindist.build_cache_relative_path()
-
-    tarball_rel_path = os.path.join(build_cache_dir, bindist.tarball_path_name(spec, ".spack"))
-    tarball_src_path = os.path.join(args.base_dir, tarball_rel_path)
-    tarball_dest_path = os.path.join(dest_root_path, tarball_rel_path)
-
-    specfile_rel_path = os.path.join(build_cache_dir, bindist.tarball_name(spec, ".spec.json"))
-    specfile_src_path = os.path.join(args.base_dir, specfile_rel_path)
-    specfile_dest_path = os.path.join(dest_root_path, specfile_rel_path)
-
-    specfile_rel_path_yaml = os.path.join(
-        build_cache_dir, bindist.tarball_name(spec, ".spec.yaml")
-    )
-    specfile_src_path_yaml = os.path.join(args.base_dir, specfile_rel_path)
-    specfile_dest_path_yaml = os.path.join(dest_root_path, specfile_rel_path)
-
-    # Make sure directory structure exists before attempting to copy
-    os.makedirs(os.path.dirname(tarball_dest_path))
-
-    # Now copy the specfile and tarball files to the destination mirror
-    tty.msg("Copying {0}".format(tarball_rel_path))
-    shutil.copyfile(tarball_src_path, tarball_dest_path)
-
-    tty.msg("Copying {0}".format(specfile_rel_path))
-    shutil.copyfile(specfile_src_path, specfile_dest_path)
-
-    tty.msg("Copying {0}".format(specfile_rel_path_yaml))
-    shutil.copyfile(specfile_src_path_yaml, specfile_dest_path_yaml)
 
 
 def copy_buildcache_file(src_url, dest_url, local_path=None):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -508,7 +508,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create install list keys preview check download get-buildcache-name save-specfile copy sync update-index"
+        SPACK_COMPREPLY="create install list keys preview check download get-buildcache-name save-specfile sync update-index"
     fi
 }
 
@@ -566,10 +566,6 @@ _spack_buildcache_get_buildcache_name() {
 
 _spack_buildcache_save_specfile() {
     SPACK_COMPREPLY="-h --help --root-spec --root-specfile -s --specs --specfile-dir"
-}
-
-_spack_buildcache_copy() {
-    SPACK_COMPREPLY="-h --help --base-dir --spec-file --destination-url"
 }
 
 _spack_buildcache_sync() {


### PR DESCRIPTION
The function was already marked as deprecated.