### PR TITLE
gitlab: when_possible -> false

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: when_possible
+    unify: false
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: when_possible
+    unify: false
 
   config:
     concretizer: clingo


### PR DESCRIPTION
`reuse` and `when_possible` concretization broke the invariant that
`spec[pkg_name]` has unique keys. This invariant is relied on in tons of
places, such as when setting up the build environment. Right now,
there is no guarantee that the intended spec is returned from the index
operator.

When using `when_possible` concretization, one may end up with two or
more `perl`s or `python`s among the transitive deps of a spec, because
reuse concretization prunes build-only deps that are later re-attached.

I think that a minimal reproducer could be created like this:

```
x
    ^ninja # reusable spec
        ^python # build type dep -- dropped during concretization
            ^openssl
    ^openssl # non-reusable for some reason
```

Then `x['openssl']` will likely traverse x -> ninja -> python -> openssl before
considering `x -> openssl` directly, due depth first traversal and edge ordering
by target package name.

Until the code base is fixed not to rely on this broken property of
`__getitem__`, we should disable reuse in CI.
