### PR TITLE
intel-tbb: add in versions 2021.7.0, 2021.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -29,12 +29,9 @@ class IntelTbb(CMakePackage):
     # patches, filters and url_for_version() below as needed.
 
     version("master", branch="master")
-    version("2021.6.0-rc1", tag="v2021.6.0-rc1")
-    version(
-        "2021.5.0",
-        sha256="e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a",
-        preferred=True,
-    )
+    version("2021.7.0", sha256="2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc")
+    version("2021.6.0", sha256="4897dd106d573e9dacda8509ca5af1a0e008755bf9c383ef6777ac490223031f")
+    version("2021.5.0", sha256="e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a")
     version("2021.4.0", sha256="021796c7845e155e616f5ecda16daa606ebb4c6f90b996e5c08aebab7a8d3de3")
     version("2021.3.0", sha256="8f616561603695bbb83871875d2c6051ea28f8187dbe59299961369904d1d49e")
     version("2021.2.0", sha256="cee20b0a71d977416f3e3b4ec643ee4f38cedeb2a9ff015303431dd9d8d79854")


### PR DESCRIPTION
2021.7.0 fixes build on linux-ubuntu20.04-skylake / oneapi@2022.2.0

Also this syncs with versions in intel-oneapi-tbb [and spack defaults to intel-tbb and not intel-oneapi-tb]