### PR TITLE
axom@0.7.0: require cmake@3.21:

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -91,9 +91,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Dependencies
     # -----------------------------------------------------------------------
     # Basics
-    depends_on("cmake@3.8.2:", type="build")
-    depends_on("cmake@3.16.8:", type="build", when="+rocm")
-    depends_on("cmake@3.21:", type="build", when="@0.7.0")
+    depends_on("cmake@3.14:", type="build")
+    depends_on("cmake@3.21:", type="build", when="+rocm")
 
     depends_on("blt", type="build")
     depends_on("blt@0.5.1:", type="build", when="@0.6.2:")

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -93,6 +93,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Basics
     depends_on("cmake@3.8.2:", type="build")
     depends_on("cmake@3.16.8:", type="build", when="+rocm")
+    depends_on("cmake@3.21:", type="build", when="@0.7.0")
 
     depends_on("blt", type="build")
     depends_on("blt@0.5.1:", type="build", when="@0.6.2:")


### PR DESCRIPTION
I tried to build `axom@0.7.0 ^cmake@3.20.6` and it failed:
```
...
CMake Error at CMakeLists.txt:10 (cmake_minimum_required):
  CMake 3.21 or higher is required.  You are running version 3.20.6
```

This PR makes this constraint explicit.

Worth noting that both `RAJA` and `Umpire` constrain CMake to <3.21 when building `+rocm`
* RAJA: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/raja/package.py#L70-L71
* Umpire: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/umpire/package.py#L87

Perhaps those constraints can/should be relaxed? I was able to build both `raja+rocm` and `umpire+rocm` with `cmake@3.24.2` just now.

@white238 @davidbeckingsale @wspear 