### PR TITLE
raja@0.14.0 +rocm: add -std=c++14 to HIP_HIPCC_FLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -133,12 +133,14 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
             hip_repair_cache(entries, spec)
+            hipcc_flags = []
+            if self.spec.satisfies("@0.14.0"):
+                hipcc_flags.append("-std=c++14")
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ",".join(archs)
-                entries.append(
-                    cmake_cache_string("HIP_HIPCC_FLAGS", "--amdgpu-target={0}".format(arch_str))
-                )
+                hipcc_flags.append("--amdgpu-target={0}".format(arch_str))
+            entries.append(cmake_cache_string("HIP_HIPCC_FLAGS", " ".join(hipcc_flags)))
         else:
             entries.append(cmake_cache_option("ENABLE_HIP", False))
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/33455 by appending `-std=c++14` to `HIP_HIPCC_FLAGS` as suggested here:
* https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/349

FYI @wspear @davidbeckingsale @CameronRutherford 