### PR TITLE
Stop building binaries for the 1%

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -16,7 +16,7 @@ spack:
   packages:
     all:
       compiler: [gcc@11.2.0]
-      target: [x86_64_v4]
+      target: [x86_64_v3]
       variants: ~cuda~rocm
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -16,7 +16,7 @@ spack:
   packages:
     all:
       compiler: [gcc@11.2.0]
-      target: [x86_64_v4]
+      target: [x86_64_v3]
       variants: ~rocm+cuda cuda_arch=80
     llvm:
       # https://github.com/spack/spack/issues/27999

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -16,7 +16,7 @@ spack:
   packages:
     all:
       compiler: [gcc@11.2.0]
-      target: [x86_64_v4]
+      target: [x86_64_v3]
       variants: ~cuda+rocm amdgpu_target=gfx90a
     gl:
       require: "osmesa"


### PR DESCRIPTION
x86-64-v3 is pretty much everywhere, but x86-64-v4 ... not quite.

Let's stick to AVX2 so we can actually debug pipelines without involved setups
with QEMU

Let's see if it also hits the same issue from https://gitlab.spack.io/spack/spack/-/jobs/3796363