### PR TITLE
updated python version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/py-biopython/package.py
+++ b/var/spack/repos/builtin/packages/py-biopython/package.py
@@ -10,11 +10,10 @@ class PyBiopython(PythonPackage):
     """A distributed collaborative effort to develop Python libraries and
     applications which address the needs of current and future work in
     bioinformatics.
-
     """
 
     homepage = "https://biopython.org/wiki/Main_Page"
-    url = "https://biopython.org/DIST/biopython-1.65.tar.gz"
+    pypi = "biopython/biopython-1.79.tar.gz"
 
     version("1.79", sha256="edb07eac99d3b8abd7ba56ff4bedec9263f76dfc3c3f450e7d2e2bcdecf8559b")
     version("1.78", sha256="1ee0a0b6c2376680fea6642d5080baa419fd73df104a62d58a8baf7a8bbe4564")
@@ -22,6 +21,10 @@ class PyBiopython(PythonPackage):
     version("1.70", sha256="4a7c5298f03d1a45523f32bae1fffcff323ea9dce007fb1241af092f5ab2e45b")
     version("1.65", sha256="463cc81db84e9bfcdfb15629511c81ed556a6c0287e670dbfe80f03c65d2a88e")
 
+    depends_on("python@2.6:2.7,3.3:", type=("build", "run"), when="@1.63:1.68")
+    depends_on("python@2.7,3.3:", type=("build", "run"), when="@1.69")
+    depends_on("python@2.7,3.4:", type=("build", "run"), when="@1.70:1.74")
+    depends_on("python@2.7,3.5:", type=("build", "run"), when="@1.75:1.76")
+    depends_on("python@3.6:", type=("build", "run"), when="@1.77:")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("python@3.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-biopython/package.py
+++ b/var/spack/repos/builtin/packages/py-biopython/package.py
@@ -19,7 +19,7 @@ class PyBiopython(PythonPackage):
     version("1.78", sha256="1ee0a0b6c2376680fea6642d5080baa419fd73df104a62d58a8baf7a8bbe4564")
     version("1.73", sha256="70c5cc27dc61c23d18bb33b6d38d70edc4b926033aea3b7434737c731c94a5e0")
     version("1.70", sha256="4a7c5298f03d1a45523f32bae1fffcff323ea9dce007fb1241af092f5ab2e45b")
-    version("1.65", sha256="463cc81db84e9bfcdfb15629511c81ed556a6c0287e670dbfe80f03c65d2a88e")
+    version("1.65", sha256="6d591523ba4d07a505978f6e1d7fac57e335d6d62fb5b0bcb8c40bdde5c8998e")
 
     depends_on("python@2.6:2.7,3.3:", type=("build", "run"), when="@1.63:1.68")
     depends_on("python@2.7,3.3:", type=("build", "run"), when="@1.69")


### PR DESCRIPTION
the py-biopython package was previously limited to python 3, which was preventing certain packages from building (see PR #33404). Added support for python 2 and updated python requirements for the different versions (according to the setup.py)