### PR TITLE
Respect the `buildable` attribute for packages in binary cache

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2335,7 +2335,8 @@ class Solver(object):
         return reusable
 
     def filter_buildable(self, index):
-        """Filter out buildcache entries of specs that match packages locally marked as buildable:false"""
+        """Filter out buildcache entries of specs that match packages locally marked as
+        buildable:false"""
         packages_yaml = spack.config.get("packages")
         filter = ()
         for pkg_name, data in packages_yaml.items():


### PR DESCRIPTION
When it comes to concretizing specs, packages in binary cache are treated in the same way as already installed packages. This leads to the fact that packages protected by `buildable:false` are still downloaded and installed from binary cache. In https://github.com/spack/spack/issues/33461 this even leads to preferring an older version of a package because it available in binary cache over a newer, locally installed one.

This patch filters out any packages that are locally protected by `buildable:false` before the list of packages available in binary cache gets sent as "reusable" to the concretizer.