### PR TITLE
VTK-h: honor global spack flags

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -179,6 +179,23 @@ class VtkH(CMakePackage, CudaPackage):
         cfg.write("# cpp compiler used by spack\n")
         cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
 
+        # use global spack compiler flags
+        cppflags = " ".join(spec.compiler_flags["cppflags"])
+        if cppflags:
+            # avoid always ending up with ' ' with no flags defined
+            cppflags += " "
+        cflags = cppflags + " ".join(spec.compiler_flags["cflags"])
+        if cflags:
+            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+        cxxflags = cppflags + " ".join(spec.compiler_flags["cxxflags"])
+        if cxxflags:
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+        fflags = " ".join(spec.compiler_flags["fflags"])
+        if self.spec.satisfies("%cce"):
+            fflags += " -ef"
+        if fflags:
+            cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
+
         # shared vs static libs
         if "+shared" in spec:
             cfg.write(cmake_cache_entry("BUILD_SHARED_LIBS", "ON"))


### PR DESCRIPTION
Verified this by setting a noop flag and finding it both on the compile line and CMake's output.