### PR TITLE
Don't install xdist in CI on Python 2.7

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -52,7 +52,12 @@ jobs:
               patchelf cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-cov pytest-xdist
+          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-cov 
+          # Install xdist only on recent Python, to avoid stalling on Python 2.7 due
+          # to bugs on an unmaintained version of the package.
+          if [[ ${{ matrix.python-version }} != "2.7" ]]; then
+            pip install --upgrade pytest-xdist
+          fi
           # ensure style checks are not skipped in unit tests for python >= 3.6
           # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
           if python -c 'import sys; sys.exit(not sys.version_info >= (3, 6))'; then


### PR DESCRIPTION
xdist + cov on Python 2.7 is causing the CI jobs to hang more frequently than what we were used to. While we wait for #33063 to be mergeable (i.e. while we wait for v0.19 to be tagged), we can just disable parallelism for Python 2.7