### PR TITLE
chai +rocm: use hipcc as CMAKE_CXX_COMPILER

### DIFF
--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -112,6 +112,13 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
             self.spec.compiler.version,
         )
 
+    def initconfig_compiler_entries(self):
+        spec = self.spec
+        entries = super(Chai, self).initconfig_compiler_entries()
+        if "+rocm" in spec:
+            entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
+        return entries
+
     def initconfig_hardware_entries(self):
         spec = self.spec
         entries = super(Chai, self).initconfig_hardware_entries()


### PR DESCRIPTION
`chai +rocm`: use `hipcc` as `CMAKE_CXX_COMPILER`

Fixes https://github.com/spack/spack/issues/33426

FYI @wspear @davidbeckingsale 