### PR TITLE
update fms package for v2022.04

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -13,7 +13,7 @@ class Fms(CMakePackage):
     system models."""
 
     homepage = "https://github.com/NOAA-GFDL/FMS"
-    url = "https://github.com/NOAA-GFDL/FMS/archive/refs/tags/2022.02.tar.gz"
+    url = "https://github.com/NOAA-GFDL/FMS/archive/refs/tags/2022.04.tar.gz"
     git = "https://github.com/NOAA-GFDL/FMS.git"
 
     maintainers = [
@@ -23,6 +23,7 @@ class Fms(CMakePackage):
         "rem1776",
     ]
 
+    version("2022.04", sha256="f741479128afc2b93ca8291a4c5bcdb024a8cbeda1a26bf77a236c0f629e1b03")
     version("2022.03", sha256="42d2ac53d3c889a8177a6d7a132583364c0f6e5d5cbde0d980443b6797ad4838")
     version("2022.02", sha256="ad4978302b219e11b883b2f52519e1ee455137ad947474abb316c8654f72c874")
     version("2022.01", sha256="a1cba1f536923f5953c28729a28e5431e127b45d6bc2c15d230939f0c02daa9b")


### PR DESCRIPTION
Just adds the most recent FMS version and changes the url to point to that release.