### PR TITLE
gettext %nvhpc: constrain patch to @:0.21.0

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -54,7 +54,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     # depends_on('cvs')
 
     patch("test-verify-parallel-make-check.patch", when="@:0.19.8.1")
-    patch("nvhpc-builtin.patch", when="%nvhpc")
+    patch("nvhpc-builtin.patch", when="@:0.21.0 %nvhpc")
     patch("nvhpc-export-symbols.patch", when="%nvhpc")
     patch("nvhpc-long-width.patch", when="%nvhpc")
 


### PR DESCRIPTION
`gettext %nvhpc`: restrict `nvhpc-builtin.patch` to `gettext@:0.21.0`
* patch is rejected for `gettext@0.21.1` and doesn't seem necessary for build to succeed w/ `%nvhpc`

Perhaps I should also add a lower bound too. I would have to find out what versions this patch doesn't apply to. 

@samcmill @michaelkuhn @wspear