### PR TITLE
e4s ci: use an appropriate name for cdash build group name

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -460,7 +460,7 @@ spack:
         - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
   cdash:
-    build-group: New PR testing workflow
+    build-group: E4S
     url: https://cdash.spack.io
     project: Spack Testing
     site: Cloud Gitlab Infrastructure


### PR DESCRIPTION
Finally updating the name of the CDash build group name for E4S stack!

CC @scottwittenburg