### PR TITLE
Lock, database and store don't need global configuration on construction

### DIFF
--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -27,8 +27,6 @@ jobs:
     - name: Create local develop
       run: |
         ./.github/workflows/setup_git.ps1
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
     - name: Unit Test
       run: |
         spack unit-test -x --verbose --cov --cov-config=pyproject.toml --ignore=lib/spack/spack/test/cmd

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Create local develop
       run: |
         ./.github/workflows/setup_git.ps1
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Unit Test
       run: |
         spack unit-test -x --verbose --cov --cov-config=pyproject.toml --ignore=lib/spack/spack/test/cmd

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -214,6 +214,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),
+    ("py:class", "spack.spec.SpecfileReaderBase"),
     ("py:class", "spack.install_test.Pb"),
 ]
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -821,7 +821,7 @@ class Singleton:
         # 'instance'/'_instance' to be defined or it will enter an infinite
         # loop, so protect against that here.
         if name in ["_instance", "instance"]:
-            raise AttributeError()
+            raise AttributeError(f"cannot create {name}")
         return getattr(self.instance, name)
 
     def __getitem__(self, name):

--- a/lib/spack/spack/bootstrap/__init__.py
+++ b/lib/spack/spack/bootstrap/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Function and classes needed to bootstrap Spack itself."""
 
-from .config import ensure_bootstrap_configuration, is_bootstrapping
+from .config import ensure_bootstrap_configuration, is_bootstrapping, store_path
 from .core import all_core_root_specs, ensure_core_dependencies, ensure_patchelf_in_path_or_raise
 from .environment import BootstrapEnvironment, ensure_environment_dependencies
 from .status import status_message
@@ -18,4 +18,5 @@ __all__ = [
     "ensure_environment_dependencies",
     "BootstrapEnvironment",
     "status_message",
+    "store_path",
 ]

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -368,7 +368,9 @@ callbacks = {"refresh": refresh, "rm": rm, "find": find, "loads": loads}
 
 def modules_cmd(parser, args, module_type, callbacks=callbacks):
     # Qualifiers to be used when querying the db for specs
-    constraint_qualifiers = {"refresh": {"installed": True, "known": True}}
+    constraint_qualifiers = {
+        "refresh": {"installed": True, "known": lambda x: not spack.repo.path.exists(x)}
+    }
     query_args = constraint_qualifiers.get(args.subparser_name, {})
 
     # Get the specs that match the query from the DB

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -767,7 +767,7 @@ def _add_command_line_scopes(cfg, command_line_scopes):
         _add_platform_scope(cfg, ImmutableConfigScope, name, path)
 
 
-def _config():
+def create():
     """Singleton Configuration instance.
 
     This constructs one instance associated with this module and returns
@@ -825,7 +825,7 @@ def _config():
 
 
 #: This is the singleton configuration instance for Spack.
-config: Union[Configuration, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(_config)
+config: Union[Configuration, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(create)
 
 
 def add_from_file(filename, scope=None):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -253,8 +253,11 @@ class ForbiddenLockError(SpackError):
 
 
 class ForbiddenLock:
-    def __getattribute__(self, name):
+    def __getattr__(self, name):
         raise ForbiddenLockError("Cannot access attribute '{0}' of lock".format(name))
+
+    def __reduce__(self):
+        return ForbiddenLock, tuple()
 
 
 _QUERY_DOCSTRING = """

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -342,7 +342,7 @@ DEFAULT_LOCK_CFG: LockConfiguration = LockConfiguration(
 def lock_configuration(configuration):
     """Return a LockConfiguration from a spack.config.Configuration object."""
     return LockConfiguration(
-        enable=configuration.get("config:locks", None),
+        enable=configuration.get("config:locks", True),
         database_timeout=configuration.get("config:db_lock_timeout"),
         package_timeout=configuration.get("config:db_lock_timeout"),
     )

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -18,14 +18,13 @@ as the authoritative database of packages in Spack.  This module
 provides a cache and a sanity checking mechanism for what is in the
 filesystem.
 """
-import collections
 import contextlib
 import datetime
 import os
 import socket
 import sys
 import time
-from typing import Dict
+from typing import Dict, NamedTuple
 
 try:
     import uuid
@@ -313,20 +312,27 @@ _QUERY_DOCSTRING = """
 #:    enable (bool): whether to enable locks or not.
 #:    database_timeout (int or None): timeout for the database lock
 #:    package_timeout (int or None): timeout for the package lock
-LockConfiguration = collections.namedtuple(
-    "LockConfiguration", ["enable", "database_timeout", "package_timeout"]
-)
+
+
+class LockConfiguration(NamedTuple):
+    enable: bool
+    database_timeout: Optional[int]
+    package_timeout: Optional[int]
 
 
 #: Configure a database to avoid using locks
-NO_LOCK = LockConfiguration(enable=False, database_timeout=None, package_timeout=None)
+NO_LOCK: LockConfiguration = LockConfiguration(
+    enable=False, database_timeout=None, package_timeout=None
+)
 
 
 #: Configure the database to use locks without a timeout
-NO_TIMEOUT = LockConfiguration(enable=True, database_timeout=None, package_timeout=None)
+NO_TIMEOUT: LockConfiguration = LockConfiguration(
+    enable=True, database_timeout=None, package_timeout=None
+)
 
 #: Default configuration for database locks
-DEFAULT_LOCK_CFG = LockConfiguration(
+DEFAULT_LOCK_CFG: LockConfiguration = LockConfiguration(
     enable=True,
     database_timeout=_DEFAULT_DB_LOCK_TIMEOUT,
     package_timeout=_DEFAULT_PKG_LOCK_TIMEOUT,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -38,7 +38,6 @@ except ImportError:
 from typing import Optional, Tuple
 
 import llnl.util.filesystem as fs
-import llnl.util.lang as lang
 import llnl.util.tty as tty
 
 import spack.hash_types as ht
@@ -353,7 +352,7 @@ class Database:
     _prefix_failures: Dict[str, lk.Lock] = {}
 
     #: Fields written for each install record
-    record_fields = DEFAULT_INSTALL_RECORD_FIELDS
+    record_fields: Tuple[str, ...] = DEFAULT_INSTALL_RECORD_FIELDS
 
     def __init__(self, root, upstream_dbs=None, is_upstream=False, lock_cfg=DEFAULT_LOCK_CFG):
         """Database for Spack installations.
@@ -367,10 +366,6 @@ class Database:
         The database will attempt to read an ``index.json`` file in the database directory.
         If that does not exist, it will create a database when needed by scanning the entire
         store root for ``spec.json`` files according to Spack's directory layout.
-
-        A database supports writing buildcache index files, in which case certain fields are not
-        needed in each install record, and no locking is required. To use this feature, provide
-        ``lock_cfg=NO_LOCK``, and override the list of ``record_fields``.
 
         Args:
             root (str): root directory where to create the database directory.
@@ -454,12 +449,8 @@ class Database:
         # message)
         self._fail_when_missing_deps = False
 
-        if lock_cfg.enable:
-            self._write_transaction_impl = lk.WriteTransaction
-            self._read_transaction_impl = lk.ReadTransaction
-        else:
-            self._write_transaction_impl = lang.nullcontext
-            self._read_transaction_impl = lang.nullcontext
+        self._write_transaction_impl = lk.WriteTransaction
+        self._read_transaction_impl = lk.ReadTransaction
 
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -157,19 +157,12 @@ class Store:
         projections=None,
         hash_length=None,
         upstreams=None,
-        enable_locks=None,
-        db_lock_timeout=None,
-        package_lock_timeout=None,
+        lock_cfg=spack.database.NO_LOCK,
     ):
         self.root = root
         self.unpadded_root = unpadded_root or root
         self.projections = projections
         self.hash_length = hash_length
-        lock_cfg = spack.database.LockConfiguration(
-            enable=enable_locks,
-            database_timeout=db_lock_timeout,
-            package_timeout=package_lock_timeout,
-        )
         self.db = spack.database.Database(root, upstream_dbs=upstreams, lock_cfg=lock_cfg)
         self.layout = spack.directory_layout.DirectoryLayout(
             root, projections=projections, hash_length=hash_length
@@ -216,18 +209,13 @@ def create(configuration):
     ]
     upstreams = _construct_upstream_dbs_from_install_roots(install_roots)
 
-    db_lock_timeout = configuration.get("config:db_lock_timeout")
-    package_lock_timeout = configuration.get("config:db_lock_timeout")
-    enable_locks = configuration.get("config:locks", None)
     return Store(
         root=root,
         unpadded_root=unpadded_root,
         projections=projections,
         hash_length=hash_length,
         upstreams=upstreams,
-        enable_locks=enable_locks,
-        db_lock_timeout=db_lock_timeout,
-        package_lock_timeout=package_lock_timeout,
+        lock_cfg=spack.database.lock_configuration(configuration),
     )
 
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -163,6 +163,8 @@ class Store:
         self.unpadded_root = unpadded_root or root
         self.projections = projections
         self.hash_length = hash_length
+        self.upstreams = upstreams
+        self.lock_cfg = lock_cfg
         self.db = spack.database.Database(root, upstream_dbs=upstreams, lock_cfg=lock_cfg)
         self.layout = spack.directory_layout.DirectoryLayout(
             root, projections=projections, hash_length=hash_length
@@ -172,24 +174,15 @@ class Store:
         """Convenience function to reindex the store DB with its own layout."""
         return self.db.reindex(self.layout)
 
-    def serialize(self):
-        """Return a pickle-able object that can be used to reconstruct
-        a store.
-        """
-        return (self.root, self.unpadded_root, self.projections, self.hash_length)
-
-    @staticmethod
-    def deserialize(token):
-        """Return a store reconstructed from a token created by
-        the serialize method.
-
-        Args:
-            token: return value of the serialize method
-
-        Returns:
-            Store object reconstructed from the token
-        """
-        return Store(*token)
+    def __reduce__(self):
+        return Store, (
+            self.root,
+            self.unpadded_root,
+            self.projections,
+            self.hash_length,
+            self.upstreams,
+            self.lock_cfg,
+        )
 
 
 def create(configuration):

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -67,10 +67,11 @@ class PackageInstallContext:
 
     def __init__(self, pkg):
         if _SERIALIZE:
+            self.serialized_pkg = serialize(pkg)
             self.serialized_env = serialize(spack.environment.active_environment())
         else:
+            self.pkg = pkg
             self.env = spack.environment.active_environment()
-        self.spec = pkg.spec
         self.spack_working_dir = spack.main.spack_working_dir
         self.test_state = TestState()
 
@@ -78,7 +79,7 @@ class PackageInstallContext:
         self.test_state.restore()
         spack.main.spack_working_dir = self.spack_working_dir
         env = pickle.load(self.serialized_env) if _SERIALIZE else self.env
-        pkg = self.spec.package
+        pkg = pickle.load(self.serialized_pkg) if _SERIALIZE else self.pkg
         if env:
             spack.environment.activate(env)
         return pkg

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -27,7 +27,7 @@ import spack.platforms
 import spack.repo
 import spack.store
 
-_serialize = sys.platform == "win32" or (sys.version_info >= (3, 8) and sys.platform == "darwin")
+_SERIALIZE = sys.platform == "win32" or (sys.version_info >= (3, 8) and sys.platform == "darwin")
 
 
 patches = None
@@ -66,20 +66,19 @@ class PackageInstallContext:
     """
 
     def __init__(self, pkg):
-        if _serialize:
-            self.serialized_pkg = serialize(pkg)
+        if _SERIALIZE:
             self.serialized_env = serialize(spack.environment.active_environment())
         else:
-            self.pkg = pkg
             self.env = spack.environment.active_environment()
+        self.spec = pkg.spec
         self.spack_working_dir = spack.main.spack_working_dir
         self.test_state = TestState()
 
     def restore(self):
         self.test_state.restore()
         spack.main.spack_working_dir = self.spack_working_dir
-        env = pickle.load(self.serialized_env) if _serialize else self.env
-        pkg = pickle.load(self.serialized_pkg) if _serialize else self.pkg
+        env = pickle.load(self.serialized_env) if _SERIALIZE else self.env
+        pkg = self.spec.package
         if env:
             spack.environment.activate(env)
         return pkg
@@ -93,25 +92,23 @@ class TestState:
     """
 
     def __init__(self):
-        if _serialize:
-            self.repo_dirs = list(r.root for r in spack.repo.path.repos)
+        if _SERIALIZE:
             self.config = spack.config.config
             self.platform = spack.platforms.host
             self.test_patches = store_patches()
-            self.store_token = spack.store.store.serialize()
+            self.store = spack.store.store
 
     def restore(self):
-        if _serialize:
+        if _SERIALIZE:
             spack.config.config = self.config
-            spack.repo.path = spack.repo._path(self.config)
+            spack.repo.path = spack.repo.create(self.config)
             spack.platforms.host = self.platform
 
-            new_store = spack.store.Store.deserialize(self.store_token)
-            spack.store.store = new_store
-            spack.store.root = new_store.root
-            spack.store.unpadded_root = new_store.unpadded_root
-            spack.store.db = new_store.db
-            spack.store.layout = new_store.layout
+            spack.store.store = self.store
+            spack.store.root = self.store.root
+            spack.store.unpadded_root = self.store.unpadded_root
+            spack.store.db = self.store.db
+            spack.store.layout = self.store.layout
 
             self.test_patches.restore()
 

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -479,9 +479,6 @@ def test_update_sbang(tmpdir, test_mirror):
     into the non-default directory layout scheme, triggering an update of the
     sbang.
     """
-    scheme = os.path.join(
-        "${name}", "${version}", "${architecture}-${compiler.name}-${compiler.version}-${hash}"
-    )
     spec_str = "old-sbang"
     # Concretize a package with some old-fashioned sbang lines.
     old_spec = Spec(spec_str).concretized()
@@ -504,12 +501,8 @@ def test_update_sbang(tmpdir, test_mirror):
 
     # Switch the store to the new install tree locations
     newtree_dir = tmpdir.join("newtree")
-    s = spack.store.Store(str(newtree_dir))
-    s.layout = DirectoryLayout(str(newtree_dir), path_scheme=scheme)
-
-    with spack.store.use_store(s):
-        new_spec = Spec("old-sbang")
-        new_spec.concretize()
+    with spack.store.use_store(str(newtree_dir)):
+        new_spec = Spec("old-sbang").concretized()
         assert new_spec.dag_hash() == old_spec.dag_hash()
 
         # Install package from buildcache

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -99,7 +99,7 @@ def test_reset_in_file_scopes_overwrites_backup_files(mutable_config):
     assert os.path.exists(backup_file)
 
 
-def test_list_sources(capsys):
+def test_list_sources(config, capsys):
     # Get the merged list and ensure we get our defaults
     with capsys.disabled():
         output = _bootstrap("list")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -150,7 +150,7 @@ def test_env_list(mutable_mock_env_path):
     assert "baz" in out
 
     # make sure `spack env list` skips invalid things in var/spack/env
-    mutable_mock_env_path.join(".DS_Store").ensure(file=True)
+    (mutable_mock_env_path / ".DS_Store").touch()
     out = env("list")
 
     assert "foo" in out
@@ -1118,12 +1118,12 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
 
 
 @pytest.mark.usefixtures("config")
-def test_indirect_build_dep(tmpdir):
+def test_indirect_build_dep(tmp_path):
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
     environment out and reading it back.
     """
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.repo.MockRepositoryBuilder(tmp_path / "repo")
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
     builder.add_package("x", dependencies=[("y", None, None)])
@@ -1146,7 +1146,7 @@ def test_indirect_build_dep(tmpdir):
 
 
 @pytest.mark.usefixtures("config")
-def test_store_different_build_deps(tmpdir):
+def test_store_different_build_deps(tmp_path):
     r"""Ensure that an environment can store two instances of a build-only
     dependency::
 
@@ -1157,7 +1157,7 @@ def test_store_different_build_deps(tmpdir):
               z1
 
     """
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    builder = spack.repo.MockRepositoryBuilder(tmp_path / "mirror")
     builder.add_package("z")
     builder.add_package("y", dependencies=[("z", "build", None)])
     builder.add_package("x", dependencies=[("y", None, None), ("z", "build", None)])
@@ -3350,12 +3350,11 @@ def test_relative_view_path_on_command_line_is_made_absolute(tmp_path, config):
         assert os.path.samefile("view", environment.default_view.root)
 
 
-def test_environment_created_in_users_location(mutable_config, tmpdir):
+def test_environment_created_in_users_location(mutable_mock_env_path, tmp_path):
     """Test that an environment is created in a location based on the config"""
-    spack.config.set("config:environments_root", str(tmpdir.join("envs")))
-    env_dir = spack.config.get("config:environments_root")
+    env_dir = str(mutable_mock_env_path)
 
-    assert tmpdir.strpath in env_dir
+    assert str(tmp_path) in env_dir
     assert not os.path.isdir(env_dir)
 
     dir_name = "user_env"

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -97,7 +97,7 @@ def test_location_with_active_env(mutable_mock_env_path):
         assert location("--env").strip() == e.path
 
 
-def test_location_env_flag_interference(mutable_mock_env_path, tmpdir):
+def test_location_env_flag_interference(mutable_mock_env_path):
     """
     Tests that specifying an active environment using `spack -e x location ...`
     does not interfere with the location command flags.

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -36,8 +36,8 @@ def test_regression_8083(tmpdir, capfd, mock_packages, mock_fetch, config):
 
 
 @pytest.mark.regression("12345")
-def test_mirror_from_env(tmpdir, mock_packages, mock_fetch, config, mutable_mock_env_path):
-    mirror_dir = str(tmpdir)
+def test_mirror_from_env(tmp_path, mock_packages, mock_fetch, config, mutable_mock_env_path):
+    mirror_dir = str(tmp_path / "mirror")
     env_name = "test"
 
     env("create", env_name)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -467,7 +467,7 @@ full_padded_string = os.path.join(os.sep + "path", os.sep.join(reps))[:MAX_PADDE
     ],
 )
 def test_parse_install_tree(config_settings, expected, mutable_config):
-    expected_root = expected[0] or spack.store.default_install_tree_root
+    expected_root = expected[0] or spack.store.DEFAULT_INSTALL_TREE_ROOT
     expected_unpadded_root = expected[1] or expected_root
     expected_proj = expected[2] or spack.directory_layout.default_projections
 
@@ -522,7 +522,7 @@ def test_parse_install_tree(config_settings, expected, mutable_config):
     ],
 )
 def test_parse_install_tree_padded(config_settings, expected, mutable_config):
-    expected_root = expected[0] or spack.store.default_install_tree_root
+    expected_root = expected[0] or spack.store.DEFAULT_INSTALL_TREE_ROOT
     expected_unpadded_root = expected[1] or expected_root
     expected_proj = expected[2] or spack.directory_layout.default_projections
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1230,21 +1230,21 @@ def test_default_install_tree(monkeypatch):
 
 def test_local_config_can_be_disabled(working_env):
     os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
-    cfg = spack.config._config()
+    cfg = spack.config.create()
     assert "defaults" in cfg.scopes
     assert "system" not in cfg.scopes
     assert "site" in cfg.scopes
     assert "user" not in cfg.scopes
 
     os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = ""
-    cfg = spack.config._config()
+    cfg = spack.config.create()
     assert "defaults" in cfg.scopes
     assert "system" not in cfg.scopes
     assert "site" in cfg.scopes
     assert "user" not in cfg.scopes
 
     del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
-    cfg = spack.config._config()
+    cfg = spack.config.create()
     assert "defaults" in cfg.scopes
     assert "system" in cfg.scopes
     assert "site" in cfg.scopes

--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -13,12 +13,7 @@ import spack.store
 @pytest.mark.usefixtures("mock_packages")
 def test_set_install_hash_length(hash_length, mutable_config, tmpdir):
     mutable_config.set("config:install_hash_length", hash_length)
-    mutable_config.set("config:install_tree", {"root": str(tmpdir)})
-    # The call below is to reinitialize the directory layout associated
-    # with the store according to the configuration changes above (i.e.
-    # with the shortened hash)
-    store = spack.store._store()
-    with spack.store.use_store(store):
+    with spack.store.use_store(str(tmpdir)):
         spec = spack.spec.Spec("libelf").concretized()
         prefix = spec.prefix
         hash_str = prefix.rsplit("-")[-1]
@@ -28,14 +23,7 @@ def test_set_install_hash_length(hash_length, mutable_config, tmpdir):
 @pytest.mark.usefixtures("mock_packages")
 def test_set_install_hash_length_upper_case(mutable_config, tmpdir):
     mutable_config.set("config:install_hash_length", 5)
-    mutable_config.set(
-        "config:install_tree", {"root": str(tmpdir), "projections": {"all": "{name}-{HASH}"}}
-    )
-    # The call below is to reinitialize the directory layout associated
-    # with the store according to the configuration changes above (i.e.
-    # with the shortened hash and projection)
-    store = spack.store._store()
-    with spack.store.use_store(store):
+    with spack.store.use_store(str(tmpdir), extra_data={"projections": {"all": "{name}-{HASH}"}}):
         spec = spack.spec.Spec("libelf").concretized()
         prefix = spec.prefix
         hash_str = prefix.rsplit("-")[-1]

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -968,8 +968,9 @@ def install_mockery(temporary_store, mutable_config, mock_packages):
 
 
 @pytest.fixture(scope="function")
-def temporary_store(tmpdir):
+def temporary_store(tmpdir, request):
     """Hooks a temporary empty store for the test function."""
+    ensure_configuration_fixture_run_before(request)
     temporary_store_path = tmpdir.join("opt")
     with spack.store.use_store(str(temporary_store_path)) as s:
         yield s
@@ -1536,13 +1537,12 @@ def mock_svn_repository(tmpdir_factory):
 
 
 @pytest.fixture(scope="function")
-def mutable_mock_env_path(tmpdir_factory, mutable_config):
+def mutable_mock_env_path(tmp_path, mutable_config, monkeypatch):
     """Fixture for mocking the internal spack environments directory."""
-    saved_path = ev.environment.default_env_path
-    mock_path = tmpdir_factory.mktemp("mock-env-path")
-    ev.environment.default_env_path = str(mock_path)
-    yield mock_path
-    ev.environment.default_env_path = saved_path
+    mock_path = tmp_path / "mock-env-path"
+    mutable_config.set("config:environments_root", str(mock_path))
+    monkeypatch.setattr(ev.environment, "default_env_path", str(mock_path))
+    return mock_path
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -950,7 +950,7 @@ def disable_compiler_execution(monkeypatch, request):
 
 
 @pytest.fixture(scope="function")
-def install_mockery(temporary_store, config, mock_packages):
+def install_mockery(temporary_store, mutable_config, mock_packages):
     """Hooks a fake install directory, DB, and stage directory into Spack."""
     # We use a fake package, so temporarily disable checksumming
     with spack.config.override("config:checksum", False):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1938,3 +1938,12 @@ def shell_as(shell):
         # restore old shell if one was set
         if _shell:
             os.environ["SPACK_SHELL"] = _shell
+
+
+@pytest.fixture()
+def nullify_globals(request, monkeypatch):
+    ensure_configuration_fixture_run_before(request)
+    monkeypatch.setattr(spack.config, "config", None)
+    monkeypatch.setattr(spack.caches, "misc_cache", None)
+    monkeypatch.setattr(spack.repo, "path", None)
+    monkeypatch.setattr(spack.store, "store", None)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1060,7 +1060,7 @@ def test_error_message_when_using_too_new_db(database, monkeypatch):
     back to an older version of Spack. This test ensures that the error message for a too
     new database version stays comprehensible across refactoring of the database code.
     """
-    monkeypatch.setattr(spack.database, "_db_version", vn.Version("0"))
+    monkeypatch.setattr(spack.database, "_DB_VERSION", vn.Version("0"))
     with pytest.raises(
         spack.database.InvalidDatabaseVersionError, match="you need a newer Spack version"
     ):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1065,3 +1065,13 @@ def test_error_message_when_using_too_new_db(database, monkeypatch):
         spack.database.InvalidDatabaseVersionError, match="you need a newer Spack version"
     ):
         spack.database.Database(database.root)._read()
+
+
+@pytest.mark.parametrize(
+    "lock_cfg",
+    [spack.database.NO_LOCK, spack.database.NO_TIMEOUT, spack.database.DEFAULT_LOCK_CFG, None],
+)
+def test_database_construction_doesnt_use_globals(tmpdir, config, nullify_globals, lock_cfg):
+    lock_cfg = lock_cfg or spack.database.lock_configuration(config)
+    db = spack.database.Database(str(tmpdir), lock_cfg=lock_cfg)
+    assert os.path.exists(db.database_directory)

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -288,17 +288,19 @@ def install_upstream(tmpdir_factory, gen_mock_layout, install_mockery):
     mock_db_root = str(tmpdir_factory.mktemp("mock_db_root"))
     prepared_db = spack.database.Database(mock_db_root)
     upstream_layout = gen_mock_layout("/a/")
+    spack.config.config.push_scope(
+        spack.config.InternalConfigScope(
+            name="install-upstream-fixture",
+            data={"upstreams": {"mock1": {"install_tree": prepared_db.root}}},
+        )
+    )
 
     def _install_upstream(*specs):
         for spec_str in specs:
             s = spack.spec.Spec(spec_str).concretized()
             prepared_db.add(s, upstream_layout)
-
         downstream_root = str(tmpdir_factory.mktemp("mock_downstream_db_root"))
-        db_for_test = spack.database.Database(downstream_root, upstream_dbs=[prepared_db])
-        store = spack.store.Store(downstream_root)
-        store.db = db_for_test
-        return store, upstream_layout
+        return downstream_root, upstream_layout
 
     return _install_upstream
 
@@ -307,8 +309,8 @@ def test_installed_upstream_external(install_upstream, mock_fetch):
     """Check that when a dependency package is recorded as installed in
     an upstream database that it is not reinstalled.
     """
-    s, _ = install_upstream("externaltool")
-    with spack.store.use_store(s):
+    store_root, _ = install_upstream("externaltool")
+    with spack.store.use_store(store_root):
         dependent = spack.spec.Spec("externaltest")
         dependent.concretize()
 
@@ -326,8 +328,8 @@ def test_installed_upstream(install_upstream, mock_fetch):
     """Check that when a dependency package is recorded as installed in
     an upstream database that it is not reinstalled.
     """
-    s, upstream_layout = install_upstream("dependency-install")
-    with spack.store.use_store(s):
+    store_root, upstream_layout = install_upstream("dependency-install")
+    with spack.store.use_store(store_root):
         dependency = spack.spec.Spec("dependency-install").concretized()
         dependent = spack.spec.Spec("dependent-install").concretized()
 
@@ -379,9 +381,8 @@ def test_install_prefix_collision_fails(config, mock_fetch, mock_packages, tmpdi
     Test that different specs with coinciding install prefixes will fail
     to install.
     """
-    projections = {"all": "all-specs-project-to-this-prefix"}
-    store = spack.store.Store(str(tmpdir), projections=projections)
-    with spack.store.use_store(store):
+    projections = {"projections": {"all": "all-specs-project-to-this-prefix"}}
+    with spack.store.use_store(str(tmpdir), extra_data=projections):
         with spack.config.override("config:checksum", False):
             pkg_a = Spec("libelf@0.8.13").concretized().package
             pkg_b = Spec("libelf@0.8.12").concretized().package

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -178,9 +178,7 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
         ([spack.paths.mock_packages_path, spack.paths.packages_path], ["builtin.mock", "builtin"]),
     ],
 )
-def test_repository_construction_doesnt_use_globals(
-    nullify_globals, repo_paths, namespaces
-):
+def test_repository_construction_doesnt_use_globals(nullify_globals, repo_paths, namespaces):
     repo_path = spack.repo.RepoPath(*repo_paths)
     assert len(repo_path.repos) == len(namespaces)
     assert [x.namespace for x in repo_path.repos] == namespaces

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -121,14 +121,13 @@ def test_relative_import_spack_packages_as_python_modules(mock_packages):
     assert issubclass(Mpileaks, spack.package_base.PackageBase)
 
 
-def test_all_virtual_packages_have_default_providers(default_config):
+def test_all_virtual_packages_have_default_providers():
     """All virtual packages must have a default provider explicitly set."""
-    defaults = spack.config.get("packages", scope="defaults")
+    configuration = spack.config.create()
+    defaults = configuration.get("packages", scope="defaults")
     default_providers = defaults["all"]["providers"]
     providers = spack.repo.path.provider_index.providers
-    default_providers_filename = spack.config.config.scopes["defaults"].get_section_filename(
-        "packages"
-    )
+    default_providers_filename = configuration.scopes["defaults"].get_section_filename("packages")
     for provider in providers:
         assert provider in default_providers, (
             "all providers must have a default in %s" % default_providers_filename

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -121,7 +121,7 @@ def test_relative_import_spack_packages_as_python_modules(mock_packages):
     assert issubclass(Mpileaks, spack.package_base.PackageBase)
 
 
-def test_all_virtual_packages_have_default_providers():
+def test_all_virtual_packages_have_default_providers(default_config):
     """All virtual packages must have a default provider explicitly set."""
     defaults = spack.config.get("packages", scope="defaults")
     default_providers = defaults["all"]["providers"]
@@ -167,3 +167,20 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
     captured = capsys.readouterr()[1]
     assert "Installing" in captured
     assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"
+
+
+@pytest.mark.parametrize(
+    "repo_paths,namespaces",
+    [
+        ([spack.paths.packages_path], ["builtin"]),
+        ([spack.paths.mock_packages_path], ["builtin.mock"]),
+        ([spack.paths.packages_path, spack.paths.mock_packages_path], ["builtin", "builtin.mock"]),
+        ([spack.paths.mock_packages_path, spack.paths.packages_path], ["builtin.mock", "builtin"]),
+    ],
+)
+def test_repository_construction_doesnt_use_globals(
+    nullify_globals, repo_paths, namespaces
+):
+    repo_path = spack.repo.RepoPath(*repo_paths)
+    assert len(repo_path.repos) == len(namespaces)
+    assert [x.namespace for x in repo_path.repos] == namespaces

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -368,7 +368,7 @@ def test_install_sbang_too_long(tmpdir):
         add = min(num_extend, 255)
         long_path = os.path.join(long_path, "e" * add)
         num_extend -= add
-    with spack.store.use_store(spack.store.Store(long_path)):
+    with spack.store.use_store(long_path):
         with pytest.raises(sbang.SbangPathError) as exc_info:
             sbang.sbang_install_path()
 

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -17,25 +17,19 @@ import spack.util.lock as lk
 def test_disable_locking(tmpdir):
     """Ensure that locks do no real locking when disabled."""
     lock_path = str(tmpdir.join("lockfile"))
+    lock = lk.Lock(lock_path, enable=False)
 
-    old_value = spack.config.get("config:locks")
+    lock.acquire_read()
+    assert not os.path.exists(lock_path)
 
-    with spack.config.override("config:locks", False):
-        lock = lk.Lock(lock_path)
+    lock.acquire_write()
+    assert not os.path.exists(lock_path)
 
-        lock.acquire_read()
-        assert not os.path.exists(lock_path)
+    lock.release_write()
+    assert not os.path.exists(lock_path)
 
-        lock.acquire_write()
-        assert not os.path.exists(lock_path)
-
-        lock.release_write()
-        assert not os.path.exists(lock_path)
-
-        lock.release_read()
-        assert not os.path.exists(lock_path)
-
-    assert old_value == spack.config.get("config:locks")
+    lock.release_read()
+    assert not os.path.exists(lock_path)
 
 
 # "Disable" mock_stage fixture to avoid subdir permissions issues on cleanup.

--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -86,11 +86,13 @@ def test_config_blame_defaults():
         if match:
             filename, line, key, val = match.groups()
             line = int(line)
-            val = val.strip("'\"")
+            lines = get_file_lines(filename)
+            assert key in lines[line]
 
+            val = val.strip("'\"")
+            printed_line = lines[line]
             if val.lower() in ("true", "false"):
                 val = val.lower()
+                printed_line = printed_line.lower()
 
-            lines = get_file_lines(filename)
-            assert key in lines[line], filename
-            assert val in lines[line]
+            assert val in printed_line, filename

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -17,7 +17,6 @@ from llnl.util.lock import LockUpgradeError  # noqa: F401
 from llnl.util.lock import ReadTransaction  # noqa: F401
 from llnl.util.lock import WriteTransaction  # noqa: F401
 
-import spack.config
 import spack.error
 import spack.paths
 
@@ -31,8 +30,11 @@ class Lock(llnl.util.lock.Lock):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._enable = spack.config.get("config:locks", sys.platform != "win32")
+        enable_lock = kwargs.pop("enable", None)
+        if enable_lock is None:
+            enable_lock = sys.platform != "win32"
+        self._enable = enable_lock
+        super(Lock, self).__init__(*args, **kwargs)
 
     def _lock(self, op, timeout=0):
         if self._enable:

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -31,8 +31,10 @@ class Lock(llnl.util.lock.Lock):
 
     def __init__(self, *args, **kwargs):
         enable_lock = kwargs.pop("enable", None)
-        if enable_lock is None:
-            enable_lock = sys.platform != "win32"
+        if sys.platform == "win32":
+            enable_lock = False
+        elif sys.platform != "win32" and enable_lock is None:
+            enable_lock = True
         self._enable = enable_lock
         super(Lock, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Modifications:
- [x] Lock objects can now be instantiated independently, without being tied to the global configuration. The same is true for database and store objects.
- [x] The database and store `__init__` methods have been simplified to take a single lock configuration object. Some common lock configurations[^1] have been named and are provided as globals.
- [x] The `use_store` context manager keeps the configuration consistent by pushing and popping an internal scope. It can also be tuned by passing extra data to set up e.g. upstreams or anything else that might be related to the store.
- [x] Unit tests have been added to ensure that database, locks and repos can be created without the need to access any  global variable.

[^1]: For instance `spack.database.NO_LOCK` or `spack.database.NO_TIMEOUT`
