### PR TITLE
Relocation regex single pass

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -42,7 +42,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.caches import misc_cache_location
-from spack.relocate import utf8_path_to_binary_regex, utf8_paths_to_single_binary_regex
+from spack.relocate import utf8_paths_to_single_binary_regex
 from spack.spec import Spec
 from spack.stage import Stage
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -42,7 +42,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.caches import misc_cache_location
-from spack.relocate import utf8_path_to_binary_regex
+from spack.relocate import utf8_path_to_binary_regex, utf8_paths_to_single_binary_regex
 from spack.spec import Spec
 from spack.stage import Stage
 
@@ -688,13 +688,10 @@ class BuildManifestVisitor(BaseDirectoryVisitor):
         return False
 
 
-def file_matches_any_binary_regex(path, regexes):
+def file_matches(path, regex):
     with open(path, "rb") as f:
         contents = f.read()
-    for regex in regexes:
-        if regex.search(contents):
-            return True
-    return False
+    return bool(regex.search(contents))
 
 
 def get_buildfile_manifest(spec):
@@ -728,8 +725,8 @@ def get_buildfile_manifest(spec):
     prefixes.append(spack.hooks.sbang.sbang_install_path())
     prefixes.append(str(spack.store.layout.root))
 
-    # Create a list regexes matching collected prefixes
-    compiled_prefixes = [utf8_path_to_binary_regex(prefix) for prefix in prefixes]
+    # Create a giant regex that matches all prefixes
+    regex = utf8_paths_to_single_binary_regex(prefixes)
 
     # Symlinks.
 
@@ -761,10 +758,9 @@ def get_buildfile_manifest(spec):
                 data["binary_to_relocate_fullpath"].append(abs_path)
                 continue
 
-        elif relocate.needs_text_relocation(m_type, m_subtype):
-            if file_matches_any_binary_regex(abs_path, compiled_prefixes):
-                data["text_to_relocate"].append(rel_path)
-                continue
+        elif relocate.needs_text_relocation(m_type, m_subtype) and file_matches(abs_path, regex):
+            data["text_to_relocate"].append(rel_path)
+            continue
 
         data["other"].append(abs_path)
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -747,9 +747,13 @@ def relocate_links(links, orig_layout_root, orig_install_prefix, new_install_pre
 def utf8_path_to_binary_regex(prefix):
     """Create a (binary) regex that matches the input path in utf8"""
     prefix_bytes = re.escape(prefix).encode("utf-8")
-    prefix_rexp = re.compile(b"(?<![\\w\\-_/])([\\w\\-_]*?)%s([\\w\\-_/]*)" % prefix_bytes)
+    return re.compile(b"(?<![\\w\\-_/])([\\w\\-_]*?)%s([\\w\\-_/]*)" % prefix_bytes)
 
-    return prefix_rexp
+
+def utf8_paths_to_single_binary_regex(prefixes):
+    """Create a (binary) regex that matches any input path in utf8"""
+    all_prefixes = b"|".join(re.escape(prefix).encode("utf-8") for prefix in prefixes)
+    return re.compile(b"(?<![\\w\\-_/])([\\w\\-_]*?)(%s)([\\w\\-_/]*)" % all_prefixes)
 
 
 def unsafe_relocate_text(files, prefixes, concurrency=32):


### PR DESCRIPTION
Instead of looping the entire file for each prefix, create a giant
regex with all literal prefixes and do a single pass. Not only is a
single pass faster in IO, it's also likely that the regex does fewer
ops per byte in the file, given that most prefixes share a common
... prefix.

Note: this just applies to the @iarspider logic of scanning text
files before creating the tarball for a buildcache. Something
similar could potentially be done during install from the buildcache.