### PR TITLE
CI: speed-up tests by dropping coverage on Python 2.7

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Pin pathlib for Python 2.7
       if: ${{ matrix.python-version == 2.7 }}
       run: |
-          pip install -U pathlib2==2.3.6
+          pip install -U pathlib2==2.3.6 toml
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -52,11 +52,11 @@ jobs:
               patchelf cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-cov 
-          # Install xdist only on recent Python, to avoid stalling on Python 2.7 due
-          # to bugs on an unmaintained version of the package.
+          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-xdist 
+          # Install pytest-cov only on recent Python, to avoid stalling on Python 2.7 due
+          # to bugs on an unmaintained version of the package when used with xdist.
           if [[ ${{ matrix.python-version }} != "2.7" ]]; then
-            pip install --upgrade pytest-xdist
+            pip install --upgrade pytest-cov
           fi
           # ensure style checks are not skipped in unit tests for python >= 3.6
           # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
@@ -86,7 +86,7 @@ jobs:
           SPACK_TEST_SOLVER: ${{ matrix.concretizer }}
           SPACK_TEST_PARALLEL: 2
           COVERAGE: true
-          UNIT_TEST_COVERAGE: ${{ (matrix.concretizer == 'original' && matrix.python-version == '2.7') || (matrix.python-version == '3.10') }}
+          UNIT_TEST_COVERAGE: ${{ (matrix.python-version == '3.10') }}
       run: |
           share/spack/qa/run-unit-tests
           coverage combine -a


### PR DESCRIPTION
Modifications:
- [x] Use `xdist` but drop coverage for Python 2.7 unit tests