### PR TITLE
Update Spack Dockerfiles

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - '.github/workflows/build-containers.yml'
       - 'share/spack/docker/*'
-      - 'share/templates/container/*'
+      - 'share/spack/templates/container/*'
       - 'lib/spack/spack/container/*'
   # Let's also build & tag Spack containers on releases.
   release:

--- a/share/spack/templates/container/bootstrap-base.dockerfile
+++ b/share/spack/templates/container/bootstrap-base.dockerfile
@@ -39,7 +39,7 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # Creates the package cache
-RUN spack spec hdf5+mpi
+RUN spack bootstrap now && spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]

--- a/share/spack/templates/container/leap-15.dockerfile
+++ b/share/spack/templates/container/leap-15.dockerfile
@@ -12,7 +12,6 @@ RUN zypper ref && \
     git\
     gzip\
     patch\
-    patchelf\
     python3-base \
     python3-boto3\
     tar\


### PR DESCRIPTION
Modifications:
- [x] Use `spack bootstrap now` in Dockerfile
- [x] Don't install `patchelf` in OpenSUSE, but use the one we provide 