### PR TITLE
Make CI on Windows fail fast

### DIFF
--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -32,7 +32,7 @@ jobs:
         echo F|xcopy .\spack\share\spack\qa\configuration\windows_config.yaml $env:USERPROFILE\.spack\windows\config.yaml
         cd spack
         dir
-        spack unit-test --verbose --cov --cov-config=pyproject.toml --ignore=lib/spack/spack/test/cmd
+        spack unit-test -x --verbose --cov --cov-config=pyproject.toml --ignore=lib/spack/spack/test/cmd
         coverage combine -a
         coverage xml
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo F|xcopy .\spack\share\spack\qa\configuration\windows_config.yaml $env:USERPROFILE\.spack\windows\config.yaml
         cd spack
-        spack unit-test --verbose --cov --cov-config=pyproject.toml lib/spack/spack/test/cmd
+        spack unit-test -x --verbose --cov --cov-config=pyproject.toml lib/spack/spack/test/cmd
         coverage combine -a
         coverage xml
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70


### PR DESCRIPTION
Currently Windows uses a lot of time to fail 572 tests (see #33347). This PR make the CI stop when the first failure is encountered.