### PR TITLE
depfile: lost touch

### DIFF
--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -18,6 +18,9 @@ SPACK ?= spack
 	{{ jobserver_support }}$(SPACK) -e '{{ environment }}' install $(SPACK_BUILDCACHE_FLAG) $(SPACK_INSTALL_FLAGS) --only-concrete --only=package --no-add /$(notdir $@) # $(SPEC)
 	@touch $@
 
+{{ install_deps_target }}/%: | {{ dirs_target }}
+	@touch $@
+
 # Set a human-readable SPEC variable for each target that has a hash
 {% for (parent, name, build_cache, _) in adjacency_list -%}
 {{ any_hash_target }}/{{ parent }}: SPEC = {{ name }}


### PR DESCRIPTION
There's a missing `touch .install-deps/<hash>` causing repeated `make`
invocations to go over the full dag

