### PR TITLE
binary_distribution: compress level 9 -> 6

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1161,9 +1161,10 @@ def _build_tarball(
             tty.die(e)
 
     # create gzip compressed tarball of the install prefix
-    # compresslevel=6 corresponds to the default level of gzip, which is
-    # not reasonably fast and produces tarballs not much bigger than Python's
-    # default of level 9.
+    # On AMD Ryzen 3700X and an SSD disk, we have the following on compression speed:
+    # compresslevel=6 gzip default: llvm takes 4mins, roughly 2.1GB
+    # compresslevel=9 python default: llvm takes 12mins, roughly 2.1GB
+    # So we follow gzip.
     with closing(tarfile.open(tarfile_path, "w:gz", compresslevel=6)) as tar:
         tar.add(name="%s" % workdir, arcname="%s" % os.path.basename(spec.prefix))
     # remove copy of install directory

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1161,7 +1161,7 @@ def _build_tarball(
             tty.die(e)
 
     # create gzip compressed tarball of the install prefix
-    with closing(tarfile.open(tarfile_path, "w:gz")) as tar:
+    with closing(tarfile.open(tarfile_path, "w:gz", compresslevel=6)) as tar:
         tar.add(name="%s" % workdir, arcname="%s" % os.path.basename(spec.prefix))
     # remove copy of install directory
     shutil.rmtree(workdir)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1161,6 +1161,9 @@ def _build_tarball(
             tty.die(e)
 
     # create gzip compressed tarball of the install prefix
+    # compresslevel=6 corresponds to the default level of gzip, which is
+    # not reasonably fast and produces tarballs not much bigger than Python's
+    # default of level 9.
     with closing(tarfile.open(tarfile_path, "w:gz", compresslevel=6)) as tar:
         tar.add(name="%s" % workdir, arcname="%s" % os.path.basename(spec.prefix))
     # remove copy of install directory


### PR DESCRIPTION
Use the same compression level as `gzip` (6) instead of what Python uses
(9).

The LLVM tarball takes 4m instead of 12m to create, and goes from
2351091267 to 2365440599 bytes, so, less than 1%, not worth to
spend the majority of the time on...