### PR TITLE
opencascade: new version 7.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -21,7 +21,7 @@ class Opencascade(CMakePackage):
     version(
         "7.6.3",
         extension="tar.gz",
-        sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd",
+        sha256="baae5b3a7a38825396fc45ef9d170db406339f5eeec62e21b21036afeda31200",
     )
     version(
         "7.6.0",

--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -19,6 +19,11 @@ class Opencascade(CMakePackage):
     maintainers = ["wdconinc"]
 
     version(
+        "7.6.3",
+        extension="tar.gz",
+        sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd",
+    )
+    version(
         "7.6.0",
         extension="tar.gz",
         sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd",


### PR DESCRIPTION
New version of opencascade (well, a few new versions, but this is likely the last of the 7.6.x series before the 7.7.x series starts). Build tested on ubuntu 22.04 with gcc-12.