### PR TITLE
deprecate: traverse doesn't have type kwarg

### DIFF
--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -117,7 +117,7 @@ def deprecate(parser, args):
     all_deprecators = []
 
     generator = (
-        deprecate.traverse(order="post", type="link", root=True)
+        deprecate.traverse(order="post", deptype="link", root=True)
         if args.dependencies
         else [deprecate]
     )


### PR DESCRIPTION
This is a typo.
