### PR TITLE
pflotran: fix build errors with gfortran@10:

### DIFF
--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -36,3 +36,8 @@ class Pflotran(AutotoolsPackage):
     @property
     def parallel(self):
         return self.spec.satisfies("@xsdk-0.4.0:")
+
+    def flag_handler(self, name, flags):
+        if "%gcc@10:" in self.spec and name == "fflags":
+            flags.append("-fallow-argument-mismatch")
+        return flags, None, None


### PR DESCRIPTION
````
>> 38    Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
```