### PR TITLE
Curl: Stop auto generating file named `str`

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -129,7 +129,7 @@ class Curl(AutotoolsPackage):
         for exe in exes:
             variants = ""
             curl = Executable(exe)
-            output = curl("--version", output=str, error="str")
+            output = curl("--version", output=str, error=str)
             if "nghttp2" in output:
                 variants += "+nghttp2"
             protocols_match = re.search(r"Protocols: (.*)\n", output)


### PR DESCRIPTION
Calling `determine_variants` from the `curl` package autogenerates an empty file every time it is called.

Pinging @nilsvu 

Closes #33318