### PR TITLE
Fix bootstrapping from sources in CI

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -42,7 +42,7 @@ jobs:
         shell: runuser -u spack-test -- bash {0}
         run: |
           source share/spack/setup-env.sh
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
@@ -79,7 +79,7 @@ jobs:
         shell: runuser -u spack-test -- bash {0}
         run: |
           source share/spack/setup-env.sh
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
@@ -143,7 +143,7 @@ jobs:
       - name: Bootstrap clingo
         run: |
           source share/spack/setup-env.sh
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
@@ -160,7 +160,7 @@ jobs:
         run: |
           source share/spack/setup-env.sh
           export PATH=/usr/local/opt/bison@2.7/bin:$PATH
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack external find --not-buildable cmake bison
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
@@ -298,7 +298,7 @@ jobs:
         run: |
           source share/spack/setup-env.sh
           spack solve zlib
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack -d gpg list
           tree ~/.spack/bootstrap/store/
 
@@ -333,7 +333,7 @@ jobs:
         run: |
           source share/spack/setup-env.sh
           spack solve zlib
-          spack bootstrap untrust github-actions-v0.2
+          spack bootstrap untrust github-actions-v0.3
           spack -d gpg list
           tree ~/.spack/bootstrap/store/
 


### PR DESCRIPTION
Since #32262 we are not testing bootstrapping from sources, since we didn't update the mirrors in tests