### PR TITLE
builtin packages: added latest versions for tower-agent and tower-cli

### DIFF
--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -15,6 +15,7 @@ class TowerAgent(Package):
     """
 
     homepage = "https://github.com/seqeralabs/tower-agent"
+    maintainers = ["marcodelapierre"]
 
     if platform.machine() == "x86_64":
         if platform.system() == "Linux":

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -19,6 +19,12 @@ class TowerAgent(Package):
     if platform.machine() == "x86_64":
         if platform.system() == "Linux":
             version(
+                "0.4.5",
+                sha256="d3f38931ff769299b9f9f7e78d9f6a55f93914878c09117b8eaf5decd0c734ec",
+                url="https://github.com/seqeralabs/tower-agent/releases/download/v0.4.5/tw-agent-linux-x86_64",
+                expand=False,
+            )
+            version(
                 "0.4.3",
                 sha256="1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0",
                 url="https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64",

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -15,6 +15,7 @@ class TowerCli(Package):
     """
 
     homepage = "https://github.com/seqeralabs/tower-cli"
+    maintainers = ["marcodelapierre"]
 
     if platform.machine() == "x86_64":
         if platform.system() == "Darwin":

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -19,12 +19,36 @@ class TowerCli(Package):
     if platform.machine() == "x86_64":
         if platform.system() == "Darwin":
             version(
+                "0.7.0",
+                sha256="b1b3ade4231de2c7303832bac406510c9de171d07d6384a54945903f5123f772",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.7.0/tw-0.7.0-osx-x86_64",
+                expand=False,
+            )
+            version(
+                "0.6.5",
+                sha256="8e7369611f3617bad3e76264d93fe467c6039c86af9f18e26142dee5df1e7346",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.6.5/tw-0.6.5-osx-x86_64",
+                expand=False,
+            )
+            version(
                 "0.6.2",
                 sha256="2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91",
                 url="https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64",
                 expand=False,
             )
         elif platform.system() == "Linux":
+            version(
+                "0.7.0",
+                sha256="651f564b80585c9060639f1a8fc82966f81becb0ab3e3ba34e53baf3baabff39",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.7.0/tw-0.7.0-linux-x86_64",
+                expand=False,
+            )
+            version(
+                "0.6.5",
+                sha256="0d1f3a6f53694000c1764bd3b40ce141f4b8923d477e2bdfdce75c66de95be00",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.6.5/tw-0.6.5-linux-x86_64",
+                expand=False,
+            )
             version(
                 "0.6.2",
                 sha256="02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50",


### PR DESCRIPTION
Packages `tower-agent` and `tower-cli`:
* adding shasums for latest versions
* proposing myself as recipe maintainer

FYI @pditommaso @evanfloden
