### PR TITLE
Don't fail over cpuinfo

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -243,8 +243,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -240,8 +240,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249 gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -150,8 +150,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -161,8 +161,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -34,8 +34,8 @@ spack:
 
   gitlab-ci:
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -47,8 +47,8 @@ spack:
   gitlab-ci:
     image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -214,8 +214,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.powerpc64le-linux-gnu.tar.gz | tar -xzf - -C /usr 2> /dev/null
       - . "./share/spack/setup-env.sh"
       - spack --version

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -266,8 +266,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -255,8 +255,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -87,8 +87,8 @@ spack:
 
   gitlab-ci:
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -90,8 +90,8 @@ spack:
 
   gitlab-ci:
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -93,8 +93,8 @@ spack:
 
   gitlab-ci:
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -56,8 +56,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'deb1dcae0eecdc7fce2902f294012ab5519629e6827204f1b9964dcfd3f74627 gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -61,8 +61,8 @@ spack:
   gitlab-ci:
 
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -64,8 +64,8 @@ spack:
   gitlab-ci:
     image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -65,8 +65,8 @@ spack:
 
   gitlab-ci:
     script:
-      - uname -a
-      - grep -E 'vendor|model name' /proc/cpuinfo | sort -u
+      - uname -a || true
+      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
       - curl -Lfs https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0%2B0/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz -o gmake.tar.gz
       - printf 'b019c4aa757503d442c906047f6b1c393bf8eeba71260d455537cfc708862249  gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null


### PR DESCRIPTION
`grep` is failing on aarch64 and Gitlab `set -o pipefail`