### PR TITLE
fix racy sbang

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1000,16 +1000,45 @@ def hash_directory(directory, ignore=[]):
     return md5_hash.hexdigest()
 
 
+def _try_unlink(path):
+    try:
+        os.unlink(path)
+    except (IOError, OSError):
+        # But if that fails, that's OK.
+        pass
+
+
 @contextmanager
 @system_path_filter
-def write_tmp_and_move(filename):
-    """Write to a temporary file, then move into place."""
-    dirname = os.path.dirname(filename)
-    basename = os.path.basename(filename)
-    tmp = os.path.join(dirname, ".%s.tmp" % basename)
-    with open(tmp, "w") as f:
-        yield f
-    shutil.move(tmp, filename)
+def write_tmp_and_move(path, mode="w"):
+    """Write to a temporary file in the same directory, then move into place."""
+    # Rely on NamedTemporaryFile to give a unique file without races
+    # in the directory of the target file.
+    file = tempfile.NamedTemporaryFile(
+        prefix="." + os.path.basename(path),
+        suffix=".tmp",
+        dir=os.path.dirname(path),
+        mode=mode,
+        delete=False,  # we delete it ourselves
+    )
+    tmp_path = file.name
+
+    try:
+        yield file
+    except:
+        # On any failure, try to remove the temporary file.
+        _try_unlink(tmp_path)
+        raise
+    finally:
+        # Always close the file decriptor
+        file.close()
+
+    # Atomically move into existence.
+    try:
+        os.rename(tmp_path, path)
+    except (IOError, OSError):
+        _try_unlink(tmp_path)
+        raise
 
 
 @contextmanager

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1025,7 +1025,7 @@ def write_tmp_and_move(path, mode="w"):
 
     try:
         yield file
-    except:
+    except BaseException:
         # On any failure, try to remove the temporary file.
         _try_unlink(tmp_path)
         raise

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -45,7 +45,7 @@ from six import iteritems
 
 import llnl.util.lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import mkdirp, rename
+from llnl.util.filesystem import mkdirp, rename, write_tmp_and_move
 
 import spack.compilers
 import spack.paths
@@ -287,10 +287,8 @@ class SingleFileScope(ConfigScope):
             parent = os.path.dirname(self.path)
             mkdirp(parent)
 
-            tmp = os.path.join(parent, ".%s.tmp" % os.path.basename(self.path))
-            with open(tmp, "w") as f:
+            with write_tmp_and_move(self.path) as f:
                 syaml.dump_config(data_to_write, stream=f, default_flow_style=False)
-            rename(tmp, self.path)
 
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError("Error writing to config file: '%s'" % str(e))

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -45,7 +45,7 @@ from six import iteritems
 
 import llnl.util.lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import mkdirp, rename, write_tmp_and_move
+from llnl.util.filesystem import mkdirp, write_tmp_and_move
 
 import spack.compilers
 import spack.paths

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -212,7 +212,8 @@ def install_sbang():
         already_installed = False
 
     if not already_installed:
-        shutil.copy(spack.paths.sbang_script, sbang_path)
+        with fs.write_tmp_and_move(sbang_path) as f:
+            shutil.copy(spack.paths.sbang_script, f.name)
 
     # Set permissions on `sbang` (including group if set in configuration)
     os.chmod(sbang_path, config_mode)

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -6,7 +6,6 @@ import stat
 
 from six import string_types
 
-import spack.config
 import spack.error
 import spack.repo
 from spack.config import ConfigError

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -6,9 +6,9 @@ import stat
 
 from six import string_types
 
+import spack.config
 import spack.error
 import spack.repo
-import spack.config
 from spack.config import ConfigError
 from spack.util.path import canonicalize_path
 from spack.version import VersionList

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -8,6 +8,7 @@ from six import string_types
 
 import spack.error
 import spack.repo
+import spack.config
 from spack.config import ConfigError
 from spack.util.path import canonicalize_path
 from spack.version import VersionList


### PR DESCRIPTION
refers #33547

Spack currently creates a temporary sbang that is moved "atomically" in place,
but this temporary causes races when multiple processes start installing sbang.

Let's just stick to an idempotent approach. Notice that we only re-install sbang
if Spack updates it (since we do file compare), and sbang was only touched
18 times in the past 6 years, whereas we hit the sbang tempfile issue
frequently with parallel install on a fresh spack instance in CI.

Also fixes a bug where permissions weren't updated if config changed but
the latest version of the sbang file was already installed.