### PR TITLE
build_systems, e4s-oneapi: Revert "gitlab: when_possible -> false"

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: false
+    unify: when_possible
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: false
+    unify: when_possible
 
   config:
     concretizer: clingo


### PR DESCRIPTION
Reverts spack/spack#33443

Now that we have a mitigation for the underlying issue, get back to `when_possible` and see if we have a smaller set of specs to build.