### PR TITLE
intel-mpi: add `cpio` as build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -127,6 +127,7 @@ class IntelMpi(IntelPackage):
         "external-libfabric", default=False, description="Enable external libfabric dependency"
     )
     depends_on("libfabric", when="+external-libfabric", type=("build", "link", "run"))
+    depends_on("cpio", type="build")
 
     def setup_dependent_build_environment(self, *args):
         # Handle in callback, conveying client's compilers in additional arg.


### PR DESCRIPTION
Trying to install `intel-mpi` locally I got
```
==> Installing intel-mpi-2019.10.317-iruy4wr4k245c2t3scfusfssddxzl3ul
==> No binary for intel-mpi-2019.10.317-iruy4wr4k245c2t3scfusfssddxzl3ul found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/28/28e1b615e63d2170a99feedc75e3b0c5a7e1a07dcdaf0a4181831b07817a5346.tgz
==> No patches needed for intel-mpi
==> intel-mpi: Executing phase: 'configure'
==> intel-mpi: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 4:
    './install.sh' '--silent' 'silent.cfg'

2 warnings found in build log:
  >> 4    egrep: warning: egrep is obsolescent; using grep -E
  >> 5    WARNING: Destination directory already exists.
     6    
     7    There are one or more critical unresolved issues which prevent setup from
     8    continuing.  Fix them and run the setup program again.
     9    --------------------------------------------------------------------------------
     10   Missing critical prerequisite
     11   -- 'cpio' tool could not be found
```
I have no clue how this ever worked before.