### PR TITLE
Overhaul certain spack packages

### DIFF
--- a/etc/spack/defaults/windows/packages.yaml
+++ b/etc/spack/defaults/windows/packages.yaml
@@ -19,3 +19,4 @@ packages:
     - msvc
     providers:
       mpi: [msmpi]
+      gl: [wgl]

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -92,7 +92,7 @@ class NMakeBuilder(BaseBuilder):
         This path is relative to the root of the extracted tarball,
         not to the ``build_directory``. Defaults to the current directory.
         """
-        return self.stage.source_dir
+        return self.stage.source_path
 
     @property
     def nmakefile_name(self):

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -112,7 +112,8 @@ class Msvc(Compiler):
     def platform_toolset_ver(self):
         """
         This is the platform toolset version of current MSVC compiler
-        of form v<toolset-ver>, i.e. v142. This is different from the VC
+        of form <toolset-ver>, i.e. 142, and is typically consumed and prepended
+        with a 'v'. This is different from the VC
         toolset version as established by `short_msvc_version`
         """
         return self.msvc_version[:2].joined.string[:3]
@@ -120,7 +121,11 @@ class Msvc(Compiler):
     @property
     def cl_version(self):
         """Cl toolset version"""
-        return spack.compiler.get_compiler_version_output(self.cc)
+        return Version(re.search(Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")).group(1))
+
+    @property
+    def vs_root(self):
+        return os.path.abspath(os.path.join(self.cc, "../../../../../../../.."))
 
     def setup_custom_environment(self, pkg, env):
         """Set environment variables for MSVC using the

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -109,6 +109,15 @@ class Msvc(Compiler):
         return "MSVC" + ver
 
     @property
+    def platform_toolset_ver(self):
+        """
+        This is the platform toolset version of current MSVC compiler
+        of form v<toolset-ver>, i.e. v142. This is different from the VC
+        toolset version as established by `short_msvc_version`
+        """
+        return self.msvc_version[:2].joined.string[:3]
+
+    @property
     def cl_version(self):
         """Cl toolset version"""
         return spack.compiler.get_compiler_version_output(self.cc)

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -23,8 +23,10 @@ class AppleGl(Package):
     # Only supported on 'platform=darwin' and compiler=apple-clang
     conflicts("platform=linux")
     conflicts("platform=cray")
+    conflicts("platform=windows")
     conflicts("%gcc")
     conflicts("%clang")
+    conflicts("%msvc")
 
     phases = []
 

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -8,7 +8,7 @@ import sys
 from spack.package import *
 
 
-class Expat(AutotoolsPackage):
+class Expat(CMakePackage):
     """Expat is an XML parser library written in C."""
 
     homepage = "https://libexpat.github.io/"
@@ -102,7 +102,7 @@ class Expat(AutotoolsPackage):
     # `~libbsd`.
     variant(
         "libbsd",
-        default=sys.platform != "darwin",
+        default=sys.platform != "darwin" and sys.platform != "win32",
         description="Use libbsd (for high quality randomness)",
     )
 
@@ -112,12 +112,19 @@ class Expat(AutotoolsPackage):
         url = "https://github.com/libexpat/libexpat/releases/download/R_{0}/expat-{1}.tar.bz2"
         return url.format(version.underscored, version.dotted)
 
-    def configure_args(self):
-        spec = self.spec
+    # def configure_args(self):
+    #     spec = self.spec
+    #     args = [
+    #         "--without-docbook",
+    #         "--enable-static",
+    #     ]
+    #     if "+libbsd" in spec and "@2.2.1:" in spec:
+    #         args.append("--with-libbsd")
+    #     return args
+
+    def cmake_args(self):
         args = [
-            "--without-docbook",
-            "--enable-static",
+            self.define("EXPAT_BUILD_DOCS", False),
+            self.define_from_variant("EXPAT__WITH_LIBBSD", "libbsd"),
         ]
-        if "+libbsd" in spec and "@2.2.1:" in spec:
-            args.append("--with-libbsd")
         return args

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
-class Freetype(AutotoolsPackage):
+class Freetype(CMakePackage):
     """FreeType is a freely available software library to render fonts.
     It is written in C, designed to be small, efficient, highly customizable,
     and portable while capable of producing high-quality output (glyph images)
@@ -30,7 +32,6 @@ class Freetype(AutotoolsPackage):
 
     depends_on("bzip2")
     depends_on("libpng")
-    depends_on("pkgconfig", type="build")
 
     conflicts(
         "%intel",
@@ -47,6 +48,13 @@ class Freetype(AutotoolsPackage):
         headers.directories = [self.prefix.include.freetype2]
         return headers
 
+
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        return [self.define("FT_WITH_ZLIB", True), self.define("FT_WITH_BZIP2", True)]
+
+
+class AutoToolsBuilder(AutotoolsBuilder):
     def configure_args(self):
         args = [
             "--with-brotli=no",

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -195,7 +195,6 @@ class Hdf5(CMakePackage):
     depends_on("cmake@3.12:", type="build")
     depends_on("cmake@3.18:", type="build", when="@1.13:")
 
-    depends_on("msmpi", when="+mpi platform=windows")
     depends_on("mpi", when="+mpi")
     depends_on("java", type=("build", "run"), when="+java")
     depends_on("szip", when="+szip")

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -28,7 +28,8 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch("gets.patch", when="@1.14")
-    provides("iconv")
+
+    conflicts("platform=windows")
 
     conflicts("@1.14", when="%gcc@5:")
 

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -44,19 +44,19 @@ class GenericBuilder(GenericBuilder):
 
     def build(self, spec, prefix):
         if spec.satisfies("%msvc"):
-            plat_tools = self.compiler.msvc_version
+            plat_tools = self.pkg.compiler.msvc_version
         else:
             raise RuntimeError("Package does not support non MSVC compilers on Windows")
         ms_build_args = ["libogg_static.vcxproj", "/p:PlatformToolset=v%s" % plat_tools]
         msbuild(*ms_build_args)
 
     def install(self, spec, prefix):
-        mkdirp(self.prefix.include.ogg)
-        mkdirp(self.prefix.lib)
-        mkdirp(self.prefix.share)
+        mkdirp(prefix.include.ogg)
+        mkdirp(prefix.lib)
+        mkdirp(prefix.share)
         install(
-            os.path.join(self.stage.source_path, "include", "ogg", "*.h"), self.prefix.include.ogg
+            os.path.join(self.pkg.stage.source_path, "include", "ogg", "*.h"), prefix.include.ogg
         )
         plat_prefix = "x64" if self.is_64bit() else "x86"
-        install(os.path.join(plat_prefix, "Debug", "*.lib"), self.prefix.lib)
-        install_tree(os.path.join(self.stage.source_path, "doc"), self.prefix.share)
+        install(os.path.join(plat_prefix, "Debug", "*.lib"), prefix.lib)
+        install_tree(os.path.join(self.pkg.stage.source_path, "doc"), prefix.share)

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import platform
+
+from spack.build_systems.generic import GenericBuilder
 from spack.package import *
 
 
-class Libogg(AutotoolsPackage):
+class Libogg(CMakePackage, AutotoolsPackage, Package):
     """Ogg is a multimedia container format, and the native file and stream
     format for the Xiph.org multimedia codecs."""
 
@@ -24,3 +28,35 @@ class Libogg(AutotoolsPackage):
         sha256="0f4d289aecb3d5f7329d51f1a72ab10c04c336b25481a40d6d841120721be485",
         when="@1.3.4 platform=darwin",
     )
+    build_system(
+        conditional("cmake", when="@1.3.4:"),
+        conditional("generic", when="@1.3.2 platform=windows"),
+        "autotools",
+        default="autotools",
+    )
+
+
+class GenericBuilder(GenericBuilder):
+    phases = ["build", "install"]
+
+    def is_64bit(self):
+        return platform.machine().endswith("64")
+
+    def build(self, spec, prefix):
+        if spec.satisfies("%msvc"):
+            plat_tools = self.compiler.msvc_version
+        else:
+            raise RuntimeError("Package does not support non MSVC compilers on Windows")
+        ms_build_args = ["libogg_static.vcxproj", "/p:PlatformToolset=v%s" % plat_tools]
+        msbuild(*ms_build_args)
+
+    def install(self, spec, prefix):
+        mkdirp(self.prefix.include.ogg)
+        mkdirp(self.prefix.lib)
+        mkdirp(self.prefix.share)
+        install(
+            os.path.join(self.stage.source_path, "include", "ogg", "*.h"), self.prefix.include.ogg
+        )
+        plat_prefix = "x64" if self.is_64bit() else "x86"
+        install(os.path.join(plat_prefix, "Debug", "*.lib"), self.prefix.lib)
+        install_tree(os.path.join(self.stage.source_path, "doc"), self.prefix.share)

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.build_systems.cmake import CMakeBuilder
 
-
-class Libpng(AutotoolsPackage):
+class Libpng(CMakePackage):
     """libpng is the official PNG reference library."""
 
     homepage = "http://www.libpng.org/pub/png/libpng.html"
@@ -48,7 +48,9 @@ class Libpng(AutotoolsPackage):
         args += self.enable_or_disable("libs")
         return args
 
-    def check(self):
-        # Libpng has both 'check' and 'test' targets that are aliases.
-        # Only need to run the tests once.
-        make("check")
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        return [
+            self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
+            self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
+        ]

--- a/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
+++ b/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
@@ -1,0 +1,35 @@
+diff --git a/win32/VS2008/libogg.vsprops b/win32/VS2008/libogg.vsprops
+index 1355b50..8b3c5b8 100644
+--- a/win32/VS2008/libogg.vsprops
++++ b/win32/VS2008/libogg.vsprops
+@@ -6,11 +6,11 @@
+ 	>
+ 	<Tool
+ 		Name="VCCLCompilerTool"
+-		AdditionalIncludeDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
++		AdditionalIncludeDirectories="$(SPACK_OGG_PREFIX)\include;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
+ 	/>
+ 	<Tool
+ 		Name="VCLinkerTool"
+-		AdditionalLibraryDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
++		AdditionalLibraryDirectories="$(SPACK_OGG_PREFIX)\lib;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
+ 	/>
+ 	<UserMacro
+ 		Name="LIBOGG_VERSION"
+diff --git a/win32/VS2008/libtheora_static.sln b/win32/VS2008/libtheora_static.sln
+index 2b39635..fa40518 100644
+--- a/win32/VS2008/libtheora_static.sln
++++ b/win32/VS2008/libtheora_static.sln
+@@ -1,12 +1,8 @@
+
+ Microsoft Visual Studio Solution File, Format Version 10.00
+ # Visual Studio 2008
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dump_video_static", "dump_video\dump_video_static.vcproj", "{1A8CA99D-B6C7-48CB-B263-6CECDADF5FBF}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libtheora_static", "libtheora\libtheora_static.vcproj", "{653F3841-3F26-49B9-AFCF-091DB4B67031}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "encoder_example_static", "encoder_example\encoder_example_static.vcproj", "{AD710263-EBFA-4388-BAA9-AD73C32AFF26}"
+-EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Win32 = Debug|Win32

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -98,7 +98,8 @@ class MSBuildBuilder(MSBuildBuilder):
         super().build(pkg, spec, prefix)
 
     def install(self, pkg, spec, prefix):
+        plat_arch = "x64" if self.is_64bit() else "x86"
         with working_dir(self.build_directory):
-            install_tree(os.path.join("Win32", "Release"), prefix.lib)
+            install_tree(os.path.join(plat_arch, "Release"), prefix.lib)
         with working_dir(pkg.stage.source_path):
             install_tree("include", prefix.include)

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -113,12 +113,13 @@ class Libtiff(CMakePackage, AutotoolsPackage):
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        args = [self.define_from_variant(var) for var in VARIANTS]
+        return [
+            self.define_from_variant("jpeg"),
+            self.define_from_variant("zlib"),
+            self.define_from_variant("jbig"),
+            self.define_from_variant("pixarlog")
+        ]
 
-        # Remove empty strings
-        args = [arg for arg in args if arg]
-
-        return args
 
 
 class AutotoolsBuilder(AutotoolsBuilder):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -2,13 +2,17 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.nmake import NMakeBuilder
 from spack.package import *
 
 
-class Libxml2(AutotoolsPackage):
+class Libxml2(AutotoolsPackage, NMakePackage):
     """Libxml2 is the XML C parser and toolkit developed for the Gnome
     project (but usable outside of the Gnome platform), it is free
     software available under the MIT License."""
@@ -39,7 +43,7 @@ class Libxml2(AutotoolsPackage):
 
     variant("python", default=False, description="Enable Python support")
 
-    depends_on("pkgconfig@0.9.0:", type="build")
+    depends_on("pkgconfig@0.9.0:", type="build", when="build_system=autotools")
     depends_on("iconv")
     depends_on("zlib")
     depends_on("xz")
@@ -75,6 +79,7 @@ class Libxml2(AutotoolsPackage):
         sha256="3e06d42596b105839648070a5921157fe284b932289ffdbfa304ddc3457e5637",
         when="@2.9.11:2.9.14",
     )
+    build_system(conditional("nmake", when="platform=windows"), "autotools", default="autotools")
 
     @property
     def command(self):
@@ -86,26 +91,6 @@ class Libxml2(AutotoolsPackage):
         hl = find_all_headers(include_dir)
         hl.directories = [include_dir, self.spec.prefix.include]
         return hl
-
-    def configure_args(self):
-        spec = self.spec
-
-        args = [
-            "--with-lzma={0}".format(spec["xz"].prefix),
-            "--with-iconv={0}".format(spec["iconv"].prefix),
-        ]
-
-        if "+python" in spec:
-            args.extend(
-                [
-                    "--with-python={0}".format(spec["python"].home),
-                    "--with-python-install-dir={0}".format(python_platlib),
-                ]
-            )
-        else:
-            args.append("--without-python")
-
-        return args
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler
@@ -119,13 +104,6 @@ class Libxml2(AutotoolsPackage):
                 "configure",
             )
             filter_file("-Wno-long-long -Wno-format-extra-args", "", "configure")
-
-    @run_after("install")
-    @on_package_attributes(run_tests=True)
-    def import_module_test(self):
-        if "+python" in self.spec:
-            with working_dir("spack-test", create=True):
-                python("-c", "import libxml2")
 
     def test(self):
         """Perform smoke tests on the installed package"""
@@ -162,3 +140,60 @@ class Libxml2(AutotoolsPackage):
 
         # Perform some cleanup
         fs.force_remove(test_filename)
+
+
+class RunAfter(object):
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def import_module_test(self):
+        if "+python" in self.spec:
+            with working_dir("spack-test", create=True):
+                python("-c", "import libxml2")
+
+
+class AutotoolsBuilder(AutotoolsBuilder, RunAfter):
+    def configure_args(self):
+        spec = self.spec
+
+        args = [
+            "--with-lzma={0}".format(spec["xz"].prefix),
+            "--with-iconv={0}".format(spec["iconv"].prefix),
+        ]
+
+        if "+python" in spec:
+            args.extend(
+                [
+                    "--with-python={0}".format(spec["python"].home),
+                    "--with-python-install-dir={0}".format(python_platlib),
+                ]
+            )
+        else:
+            args.append("--without-python")
+
+        return args
+
+
+class NMakeBuilder(NMakeBuilder, RunAfter):
+    phases = ("configure", "build", "install")
+
+    @property
+    def makefile_name(self):
+        return "Makefile.msvc"
+
+    def build_directory(self):
+        return os.path.join(super().build_directory, "win32")
+
+    def configure(self, pkg, spec, prefix):
+        with working_dir(os.path.join(self.stage.source_path, "win32")):
+            opts = [
+                "prefix=%s" % prefix,
+                "compiler=msvc",
+                "iconv=yes",
+                "zlib=yes",
+                "lzma=yes",
+                "lib=%s" % spec["iconv"].prefix.lib,
+                "include=%s" % spec["iconv"].prefix.include,
+            ]
+            if "+python" in spec:
+                opts.append("python=yes")
+            cscript("configure.js", *opts)

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -19,7 +19,7 @@ class Msmpi(Package):
     url = "https://github.com/microsoft/Microsoft-MPI/archive/refs/tags/v10.1.1.tar.gz"
     git = "https://github.com/microsoft/Microsoft-MPI.git"
 
-    executable = ["mpiexec"]
+    executables = ["mpiexec"]
 
     version("10.1.1", sha256="63c7da941fc4ffb05a0f97bd54a67968c71f63389a0d162d3182eabba1beab3d")
     version("10.0.0", sha256="cfb53cf53c3cf0d4935ab58be13f013a0f7ccb1189109a5b8eea0fcfdcaef8c1")

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -43,7 +43,7 @@ class Msmpi(Package):
 
 class GenericBuilder(GenericBuilder):
     def setup_build_environment(self, env):
-        ifort_root = os.path.join(*self.compiler.fc.split(os.path.sep)[:-2])
+        ifort_root = os.path.join(*self.pkg.compiler.fc.split(os.path.sep)[:-2])
         env.set("SPACK_IFORT", ifort_root)
 
     def is_64bit(self):
@@ -51,18 +51,18 @@ class GenericBuilder(GenericBuilder):
 
     def build_command_line(self):
         args = ["-noLogo"]
-        ifort_bin = self.compiler.fc
+        ifort_bin = self.pkg.compiler.fc
         if not ifort_bin:
             raise InstallError(
                 "Cannot install MSMPI without fortran"
                 "please select a compiler with fortran support."
             )
         args.append("/p:IFORT_BIN=%s" % os.path.dirname(ifort_bin))
-        args.append("/p:VCToolsVersion=%s" % self.compiler.msvc_version)
-        args.append("/p:WindowsTargetPlatformVersion=%s" % str(self.spec["wdk"].version))
-        args.append("/p:PlatformToolset=%s" % self.compiler.cc_version)
+        args.append("/p:VCToolsVersion=%s" % self.pkg.compiler.msvc_version)
+        args.append("/p:WindowsTargetPlatformVersion=%s" % str(self.pkg.spec["wdk"].version))
+        args.append("/p:PlatformToolset=%s" % self.pkg.compiler.cc_version)
         return args
 
     def install(self, spec, prefix):
-        with working_dir(self.stage.build_directory, create=True):
+        with working_dir(self.pkg.stage.build_directory, create=True):
             msbuild(*self.build_command_line())

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -41,6 +41,15 @@ class Msmpi(Package):
         return Version(ver_str.group(1)) if ver_str else None
 
 
+    def setup_dependent_package(self, module, dependent_spec):
+        spec = self.spec
+
+        spec.mpicc = spack_cc
+        spec.mpicxx = spack_cxx
+        spec.mpifc = spack_fc
+        spec.mpif77 = spack_f77
+
+
 class GenericBuilder(GenericBuilder):
     def setup_build_environment(self, env):
         ifort_root = os.path.join(*self.pkg.compiler.fc.split(os.path.sep)[:-2])

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class Nasm(AutotoolsPackage):
+class Nasm(AutotoolsPackage, Package):
     """NASM (Netwide Assembler) is an 80x86 assembler designed for
     portability and modularity. It includes a disassembler as well."""
 
@@ -39,6 +39,8 @@ class Nasm(AutotoolsPackage):
 
     conflicts("%intel@:14", when="@2.14:", msg="Intel <= 14 lacks support for C11")
 
+    build_system("autotools", "generic", default="autotools")
+
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler
         if self.spec.satisfies("%nvhpc@:20.11"):
@@ -55,7 +57,7 @@ class Nasm(AutotoolsPackage):
 
 
 class GenericBuilder(spack.build_systems.generic.GenericBuilder):
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         with working_dir(self.stage.source_path, create=True):
             # build NASM with nmake
             touch("asm\\warnings.time")

--- a/var/spack/repos/builtin/packages/netcdf-c/4.8.1-win-hdf5-with-zlib.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/4.8.1-win-hdf5-with-zlib.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba66a6d4..217aa712 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -856,7 +856,7 @@ IF(USE_HDF5)
+   # This needs to be near the beginning since we
+   # need to know whether to add "-lz" to the symbol
+   # tests below.
+-  CHECK_C_SOURCE_COMPILES("#include <H5public.h>
++  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
+    #if !H5_HAVE_ZLIB_H
+    #error
+    #endif

--- a/var/spack/repos/builtin/packages/netcdf-c/netcdfc-hdf5-link-mpi.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/netcdfc-hdf5-link-mpi.patch
@@ -1,0 +1,12 @@
+diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
+index aa3a842d..691902c2 100644
+--- a/liblib/CMakeLists.txt
++++ b/liblib/CMakeLists.txt
+@@ -50,6 +50,7 @@ ADD_LIBRARY(netcdf nc_initialize.c ${LARGS} )
+ 
+ IF(MPI_C_INCLUDE_PATH)
+     target_include_directories(netcdf PUBLIC ${MPI_C_INCLUDE_PATH})
++    target_link_libraries(netcdf MPI::MPI_C)
+ ENDIF(MPI_C_INCLUDE_PATH)
+ 
+ IF(MOD_NETCDF_NAME)

--- a/var/spack/repos/builtin/packages/netcdf-c/netcdfc-win-inc-mpi.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/netcdfc-win-inc-mpi.patch
@@ -1,0 +1,14 @@
+diff --git a/plugins/CMakeLists.txt b/plugins/CMakeLists.txt
+index 65891d82..15567c8f 100644
+--- a/plugins/CMakeLists.txt
++++ b/plugins/CMakeLists.txt
+@@ -62,6 +62,9 @@ MACRO(buildplugin TARGET TARGETLIB)
+     set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF")
+     # Set file name & location
+     set_target_properties(${TARGET} PROPERTIES COMPILE_PDB_NAME ${TARGET} COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR})
++    IF(MPI_C_INCLUDE_PATH)
++      target_include_directories(${TARGET} PRIVATE ${MPI_C_INCLUDE_PATH})
++    ENDIF(MPI_C_INCLUDE_PATH)
+   ENDIF()
+ ENDMACRO()
+ 

--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class NetcdfCxx(AutotoolsPackage):
+class NetcdfCxx(CMakePackage):
     """Deprecated C++ compatibility bindings for NetCDF.
     These do NOT read or write NetCDF-4 files, and are no longer
     maintained by Unidata.  Developers should migrate to current
@@ -29,8 +29,8 @@ class NetcdfCxx(AutotoolsPackage):
         shared = True
         return find_libraries("libnetcdf_c++", root=self.prefix, shared=shared, recursive=True)
 
-    def configure_args(self):
-        args = []
+    def cmake_args(self):
+        args = [self.define_from_variant("USE_NETCDF4", "netcdf4")]
         if "+netcdf4" in self.spec:
             # There is no clear way to set this via configure, so set the flag
             # explicitly

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -98,7 +98,7 @@ class Opengl(BundlePackage):
     def gl_libs(self):
         spec = self.spec
         if "platform=windows" in spec:
-            lib_name = "opengl32"
+            lib_name = "OpenGL32"
         elif "platform=darwin" in spec:
             lib_name = "libOpenGL"
         else:  # linux and cray

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -204,11 +204,13 @@ class Paraview(CMakePackage, CudaPackage):
     depends_on("netcdf-c")
     depends_on("pegtl")
     depends_on("protobuf@3.4:")
-    depends_on("libxml2")
     depends_on("lz4")
     depends_on("xz")
     depends_on("zlib")
     depends_on("libcatalyst@2:", when="+libcatalyst")
+
+    for plat in ["linux", "darwin", "cray"]:
+        depends_on("libxml2", when="platform=%s" % plat)
 
     # Older builds of pugi export their symbols differently,
     # and pre-5.9 is unable to handle that.

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Proj(AutotoolsPackage):
+class Proj(CMakePackage):
     """PROJ is a generic coordinate transformation software, that transforms
     geospatial coordinates from one coordinate reference system (CRS) to
     another. This includes cartographic projections as well as geodetic
@@ -83,30 +83,16 @@ class Proj(AutotoolsPackage):
     )
 
     # https://proj.org/install.html#build-requirements
-    depends_on("pkgconfig@0.9.0:", type="build", when="@6:")
     depends_on("googletest", when="@6:")
     depends_on("sqlite@3.11:", when="@6:")
     depends_on("libtiff@4.0:", when="@7:+tiff")
     depends_on("curl@7.29.0:", when="@7:+curl")
 
-    def configure_args(self):
-        args = ["PROJ_LIB={0}".format(join_path(self.stage.source_path, "nad"))]
-
-        if self.spec.satisfies("@6:"):
-            args.append("--with-external-gtest")
-
-        if self.spec.satisfies("@7:"):
-            if "+tiff" in self.spec:
-                args.append("--enable-tiff")
-            else:
-                args.append("--disable-tiff")
-
-            if "+curl" in self.spec:
-                args.append("--with-curl=" + self.spec["curl"].prefix.bin.join("curl-config"))
-            else:
-                args.append("--without-curl")
-
-        return args
+    def cmake_args(self):
+        return [
+            self.define("PROJ_LIB", join_path(self.stage.source_path, "nad")),
+            self.define_from_variant("ENABLE_TIFF", "tiff"),
+        ]
 
     def setup_run_environment(self, env):
         # PROJ_LIB doesn't need to be set. However, it may be set by conda.

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -2,9 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import sys
 from spack.package import *
 
+
+is_windows = sys.platform == "win32"
 
 class Scons(PythonPackage):
     """SCons is a software construction tool"""
@@ -56,4 +58,7 @@ class Scons(PythonPackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib.scons)
 
     def setup_dependent_package(self, module, dspec):
-        module.scons = Executable(self.spec.prefix.bin.scons)
+        if is_windows:
+            module.scons = Executable(self.spec.prefix.Scripts.scons)
+        else:    
+            module.scons = Executable(self.spec.prefix.bin.scons)

--- a/var/spack/repos/builtin/packages/wgl/package.py
+++ b/var/spack/repos/builtin/packages/wgl/package.py
@@ -34,6 +34,7 @@ class Wgl(Package):
     version("10.0.14393")
     version("10.0.10586")
     version("10.0.26639")
+    version("10.0.20348")
 
     # As per https://github.com/spack/spack/pull/31748 this provisory version represents
     # an arbitrary openGL version designed for maximum compatibility with calling packages
@@ -48,13 +49,15 @@ class Wgl(Package):
     # needed to use OpenGL are found in the SDK (GL/gl.h)
     # Dep is needed to consolidate sdk version to locate header files for
     # version of SDK being used
-    depends_on("win-sdk@10.0.19041", when="@10.0.19041")
-    depends_on("win-sdk@10.0.18362", when="@10.0.18362")
-    depends_on("win-sdk@10.0.17763", when="@10.0.17763")
-    depends_on("win-sdk@10.0.17134", when="@10.0.17134")
-    depends_on("win-sdk@10.0.16299", when="@10.0.16299")
-    depends_on("win-sdk@10.0.15063", when="@10.0.15063")
-    depends_on("win-sdk@10.0.14393", when="@10.0.14393")
+    # Generic depends to capture handling for external versions
+    depends_on("win-sdk", type=("build", "run"))
+    depends_on("win-sdk@10.0.19041", when="@10.0.19041", type=("build", "run"))
+    depends_on("win-sdk@10.0.18362", when="@10.0.18362", type=("build", "run"))
+    depends_on("win-sdk@10.0.17763", when="@10.0.17763", type=("build", "run"))
+    depends_on("win-sdk@10.0.17134", when="@10.0.17134", type=("build", "run"))
+    depends_on("win-sdk@10.0.16299", when="@10.0.16299", type=("build", "run"))
+    depends_on("win-sdk@10.0.15063", when="@10.0.15063", type=("build", "run"))
+    depends_on("win-sdk@10.0.14393", when="@10.0.14393", type=("build", "run"))
 
     # WGL has no meaning on other platforms, should not be able to spec
     for plat in ["linux", "darwin", "cray"]:
@@ -80,11 +83,11 @@ class Wgl(Package):
     # As noted above, the headers neccesary to include
     @property
     def headers(self):
-        return find_headers("GL/gl.h", root=self.spec["win-sdk"].prefix.includes, recursive=True)
+        return find_headers("GL", root=os.path.join(self.prefix.Include, str(self.version)+".0"), recursive=True)
 
     @property
     def libs(self):
-        return find_libraries("opengl32", shared=False, root=self.prefix, recursive=True)
+        return find_libraries("opengl32", shared=False, root=os.path.join(self.prefix.Lib, str(self.version)+".0", "um", self.spec.variants["plat"].value), recursive=True)
 
     def install(self, spec, prefix):
         raise RuntimeError(

--- a/var/spack/repos/builtin/packages/winlibiconv/package.py
+++ b/var/spack/repos/builtin/packages/winlibiconv/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import glob
+import os
+
+from spack.build_systems.generic import GenericBuilder
+from spack.package import *
+
+
+class Winlibiconv(Package, SourceforgePackage):
+    """Windows GNUWIN32 project port of GNU libiconv provides an
+    implementation of the iconv() function
+    and the iconv program for character set conversion."""
+
+    homepage = "https://gnuwin32.sourceforge.net/packages/libiconv.htm"
+    sourceforge_mirror_path = "gnuwin32/files/libiconv-1.8-src.zip"
+
+    version("1.8", sha256="1da58752373f8234744f246e38d8fdc1ad70c7593da5a229305fbae63b36f334")
+    version("1.7", sha256="cb548cba97e2d1f667d2ccd7b9929094d5b50aba26864b970551552afbf5743d")
+    version("1.6.1", sha256="69c63e2208af97c8795d3ffe81a384712f1d5fe6f2d33e59d9bbb291c8902752")
+    version("1.6", sha256="c2023bdd9225f9b794085645de0f717634ed411962981e87c83444cb2491af2c")
+
+    provides("iconv")
+
+    for plat in ["linux", "darwin", "cray"]:
+        conflicts(plat)
+
+
+class NMakeBuilder(GenericBuilder):
+    def build(self, pkg, spec, prefix):
+        file_root = glob.glob(os.path.join(self.stage.source_path, "src", "libiconv-*"))[0]
+        with working_dir(file_root):
+            nmake("-f", "%s\\Makefile.msvc" % file_root)
+
+    def install(self, pkg, spec, prefix):
+        file_root = glob.glob(os.path.join(self.stage.source_path, "src", "libiconv-*"))[0]
+        with working_dir(file_root):
+            file_root = glob.glob(os.path.join("src", "libiconv-*"))[0]
+            nmake(
+                "-f",
+                "%s\\Makefile.msvc" % file_root,
+                "install",
+                "PREFIX=%s" % prefix,
+            )

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -100,9 +100,9 @@ class MSBuildBuilder(MSBuildBuilder):
         return "v" + self.pkg.compiler.platform_toolset_ver
 
     def msbuild_args(self):
-        if self.spec.satisfies("libs=shared,static"):
+        if self.pkg.spec.satisfies("libs=shared,static"):
             f =  "xz_win.sln"
-        elif self.spec.satisfies("libs=shared"):
+        elif self.pkg.spec.satisfies("libs=shared"):
             f =  "liblzma_dll.vcxproj"
         else:
             f = "liblzma.vcxproj"

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -3,12 +3,16 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
+import sys
 
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.msbuild import MSBuildBuilder
 from spack.package import *
 
 
-class Xz(AutotoolsPackage, SourceforgePackage):
+class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     """XZ Utils is free general-purpose data compression software with
     high compression ratio. XZ Utils were written for POSIX-like systems,
     but also work on some not-so-POSIX systems. XZ Utils are the successor
@@ -42,9 +46,11 @@ class Xz(AutotoolsPackage, SourceforgePackage):
     # xz-5.2.7/src/liblzma/common/common.h:56 uses attribute __symver__ instead of
     # __asm__(.symver) for newer GCC releases.
     conflicts("%intel", when="@5.2.7", msg="icc does not support attribute __symver__")
+    conflicts("platform=windows", when="+pic")  # no pic on Windows
+    # prior to 5.2.3, build system is for MinGW only, not currently supported by Spack
+    conflicts("platform=windows", when="@:5.2.3")
 
-    def configure_args(self):
-        return self.enable_or_disable("libs")
+    build_system(conditional("msbuild", when="platform=windows"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):
         if name == "cflags" and "+pic" in self.spec:
@@ -61,7 +67,47 @@ class Xz(AutotoolsPackage, SourceforgePackage):
         match = re.search(r"xz \(XZ Utils\) (\S+)", output)
         return match.group(1) if match else None
 
+
+class RunAfter(object):
     @run_after("install")
     def darwin_fix(self):
         if self.spec.satisfies("platform=darwin"):
             fix_darwin_install_name(self.prefix.lib)
+
+
+class AutotoolsBuilder(AutotoolsBuilder):
+    def configure_args(self):
+        return self.enable_or_disable("libs")
+
+
+class MSBuildBuilder(MSBuildBuilder):
+    @property
+    def build_directory(self):
+        def get_file_string_number(f):
+            s = re.findall(r"\d+$", f)
+            return (int(s[0]) if s else -1, f)
+        win_dir = os.path.join(super().build_directory, "windows")
+        compiler_dirs = []
+        with working_dir(win_dir):
+            for obj in os.scandir():
+                if obj.is_dir():
+                    compiler_dirs.append(obj.name)
+        newest_compiler = max(compiler_dirs, key=get_file_string_number)
+        return os.path.join(win_dir, newest_compiler)
+
+    @property
+    def toolchain_version(self):
+        return "v" + self.pkg.compiler.platform_toolset_ver
+
+    def msbuild_args(self):
+        if self.spec.satisfies("libs=shared,static"):
+            f =  "xz_win.sln"
+        elif self.spec.satisfies("libs=shared"):
+            f =  "liblzma_dll.vcxproj"
+        else:
+            f = "liblzma.vcxproj"
+        return [self.define("Configuration", "Release"), f]
+
+    def install(self, pkg, spec, prefix):
+        with working_dir(self.build_directory):
+            install_tree("Release", prefix)

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -116,9 +116,9 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder, SetupEnviron
 
 
 class GenericBuilder(spack.build_systems.generic.GenericBuilder, SetupEnvironment):
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         nmake("-f" "win32\\Makefile.msc")
-        build_dir = self.pkg.stage.source_path
+        build_dir = pkg.stage.source_path
         install_tree = {
             "bin": glob.glob(os.path.join(build_dir, "*.dll")),
             "lib": glob.glob(os.path.join(build_dir, "*.lib")),
@@ -138,4 +138,4 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder, SetupEnvironmen
                 for file in tree[inst_dir]:
                     install(file, install_dst)
 
-        installtree(self.prefix, install_tree)
+        installtree(prefix, install_tree)

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -3,10 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+from spack.build_systems.cmake import CMakeBuilder
+from spack.build_systems.makefile import MakefileBuilder
 from spack.package import *
 
 
-class Zstd(MakefilePackage):
+class Zstd(CMakePackage, MakefilePackage):
     """Zstandard, or zstd as short version, is a fast lossless compression
     algorithm, targeting real-time compression scenarios at zlib-level and
     better compression ratios."""
@@ -55,6 +58,28 @@ class Zstd(MakefilePackage):
     # (last tested: nvhpc@22.3)
     conflicts("+programs %nvhpc")
 
+    build_system("cmake", "makefile", default="cmake")
+
+
+class CMakeBuilder(CMakeBuilder):
+    @property
+    def root_cmakelists_dir(self):
+        return os.path.join(super().root_cmakelists_dir, "build", "cmake")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+        args.append(self.define_from_variant("ZSTD_BUILD_PROGRAMS", "programs"))
+        if "compression=zlib" in spec:
+            args.append(self.define("ZSTD_ZLIB_SUPPORT", True))
+        if "compression=lzma" in spec:
+            args.append(self.define("ZSTD_LZMA_SUPPORT", True))
+        if "compression=lz4" in spec:
+            args.append(self.define("ZSTD_LZ4_SUPPORT", True))
+        return args
+
+
+class MakefileBuilder(MakefileBuilder):
     def build(self, spec, prefix):
         pass
 
@@ -64,7 +89,6 @@ class Zstd(MakefilePackage):
         # Tested %nvhpc@22.3. No support for -MP
         if "%nvhpc" in self.spec:
             args.append("DEPFLAGS=-MT $@ -MMD -MF")
-
         # library targets
         lib_args = ["-C", "lib"] + args + ["install-pc", "install-includes"]
         if "libs=shared" in spec:
@@ -74,7 +98,6 @@ class Zstd(MakefilePackage):
 
         # install the library
         make(*lib_args)
-
         # install the programs
         if "+programs" in spec:
             programs_args = ["-C", "programs"] + args


### PR DESCRIPTION
This PR ports adds Windows support to a number of packages and ports a number of packages to use the recent builder system merged in by #30738 

This PR also adds two new builders `NMakefiles` and `MSBuild`

You may also note that all of these packages are dependencies of Paraview/VTK. This is not a coincidence as this PR is part of a larger effort to support those two packages on Windows.

This PR ports:
Python - to multibuild system
Perl - to multibuild system
adios2 -  to Windows and multibuild system
c-blosc -  to Windows and multibuild system
double-conversion -  to  multibuild system
eigen -  to  multibuild system
expat - to Windows and multibuild system
freetype - to multibuild system
jsoncpp - to multibuild system
libjpeg-turbo - to multibuild system
libogg -  to Windows and multibuild system
libpng -  to multibuild system
libtheora -  to Windows and multibuild system
libxml2 - to Windows and multibuild system
lz4 -  to Windows and multibuild system
netcdf-cxx - to multibuild system
netcdf-c -  to Windows and multibuild system
pegtl -  to Windows and multibuild system
proj -  to Windows and multibuild system
protobuf -  to Windows and multibuild system
snappy -  to Windows and multibuild system
winlibiconv - created a new package to provide libiconv on Windows
xz -  to Windows and multibuild system
zfp -  to Windows and multibuild system
zstd -  to Windows and multibuild system


This pr depends on #31141 and #33021 