### PR TITLE
Add rocblas, cublas, and gpu-aware-mpi variants to hypre

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -100,6 +100,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("rocsparse", when="+rocm")
     depends_on("rocthrust", when="+rocm")
     depends_on("rocrand", when="+rocm")
+    depends_on("rocprim", when="+rocm")
     depends_on("umpire", when="+umpire")
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on(

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -209,7 +209,9 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
                 configure_args.append("--with-umpire-host")
             else:
                 configure_args.append("--with-umpire")
-            if (("+cuda" in spec or "+rocm" in spec) and "--enable-device-memory-pool" in configure_args):
+            if (
+                "+cuda" in spec or "+rocm" in spec
+            ) and "--enable-device-memory-pool" in configure_args:
                 configure_args.remove("--enable-device-memory-pool")
 
         configure_args.extend(self.enable_or_disable("debug"))

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -118,6 +118,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     conflicts("+cublas", when="~cuda", msg="cuBLAS requires CUDA to be enabled")
     conflicts("+rocblas", when="~rocm", msg="rocBLAS requires ROCm to be enabled")
     conflicts("+unified-memory", when="~cuda~rocm")
+    conflicts("+gpu-aware-mpi", when="~cuda~rocm~mpi")
     conflicts("+gptune", when="~mpi")
     # Umpire device allocator exports device code, which requires static libs
     conflicts("+umpire", when="+shared+cuda")


### PR DESCRIPTION
Also update some things with Umpire in hypre.

@psakievich @eugeneswalker 

@PaulMullowney maybe you could comment on needing to remove `--enable-device-memory-pool` when using Umpire?