### PR TITLE
GDAL: multi-build system support

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -228,7 +228,6 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     )
 
     with when("build_system=cmake"):
-        generator = "Ninja"
         depends_on("cmake@3.9:", type="build")
         depends_on("ninja", type="build")
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -86,7 +86,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         description="Speed up computations related to the Thin Plate Spline transformer",
     )
     variant(
-        "arrow", default=False, when="buildsystem=cmake", description="Required for Arrow driver"
+        "arrow", default=False, when="build_system=cmake", description="Required for Arrow driver"
     )
     variant("blosc", default=False, when="@3.4:", description="Required for Zarr driver")
     variant("brunsli", default=True, when="@3.4:", description="Required for MRF driver")
@@ -142,13 +142,13 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     variant(
         "mssql_ncli",
         default=False,
-        when="buildsystem=cmake",
+        when="build_system=cmake",
         description="Required for MSSQLSpatial driver",
     )
     variant(
         "mssql_odbc",
         default=False,
-        when="buildsystem=cmake",
+        when="build_system=cmake",
         description="Required for MSSQLSpatial driver",
     )
     variant("mysql", default=False, description="Required for MySQL driver")
@@ -157,12 +157,12 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     variant(
         "odbccpp",
         default=False,
-        when="buildsystem=cmake",
+        when="build_system=cmake",
         description="Required for SAP HANA driver",
     )
     variant("ogdi", default=False, description="Required for OGDI driver")
     variant(
-        "opencad", default=False, when="buildsystem=cmake", description="Required for CAD driver"
+        "opencad", default=False, when="build_system=cmake", description="Required for CAD driver"
     )
     variant("opencl", default=False, description="Required to accelerate warping computations")
     variant("openexr", default=False, when="@3.1:", description="Required for EXR driver")
@@ -172,7 +172,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     variant(
         "parquet",
         default=False,
-        when="buildsystem=cmake",
+        when="build_system=cmake",
         description="Required for Parquet driver",
     )
     variant("pcidsk", default=False, description="Required for PCIDSK driver")
@@ -216,23 +216,23 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     # Language bindings
     variant("python", default=False, description="Build Python bindings")
     variant("java", default=False, description="Build Java bindings")
-    variant("csharp", default=False, when="buildsystem=cmake", description="Build C# bindings")
+    variant("csharp", default=False, when="build_system=cmake", description="Build C# bindings")
     variant("perl", default=False, when="@:3.4", description="Build Perl bindings")
     variant("php", default=False, when="@:2.3", description="Build PHP bindings")
 
     # Build system
-    buildsystem(
+    build_system(
         conditional("cmake", when="@3.5:"),
         conditional("autotools", when="@:3.5"),
         default="cmake",
     )
 
-    with when("buildsystem=cmake"):
+    with when("build_system=cmake"):
         generator = "Ninja"
         depends_on("cmake@3.9:", type="build")
         depends_on("ninja", type="build")
 
-    with when("buildsystem=autotools"):
+    with when("build_system=autotools"):
         depends_on("gmake", type="build")
 
     # Required dependencies

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -6,10 +6,10 @@
 import os
 import sys
 
-from spack.package import *
-from spack.util.environment import filter_system_paths
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
+from spack.package import *
+from spack.util.environment import filter_system_paths
 
 
 class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -8,9 +8,11 @@ import sys
 
 from spack.package import *
 from spack.util.environment import filter_system_paths
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.cmake import CMakeBuilder
 
 
-class Gdal(CMakePackage):
+class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     """GDAL: Geospatial Data Abstraction Library.
 
     GDAL is a translator library for raster and vector geospatial data formats that
@@ -83,7 +85,9 @@ class Gdal(CMakePackage):
         default=False,
         description="Speed up computations related to the Thin Plate Spline transformer",
     )
-    variant("arrow", default=False, when="@3.5:", description="Required for Arrow driver")
+    variant(
+        "arrow", default=False, when="buildsystem=cmake", description="Required for Arrow driver"
+    )
     variant("blosc", default=False, when="@3.4:", description="Required for Zarr driver")
     variant("brunsli", default=True, when="@3.4:", description="Required for MRF driver")
     variant("bsb", default=False, when="@:2", description="Required for BSB driver")
@@ -136,23 +140,41 @@ class Gdal(CMakePackage):
         "mrsid_lidar", default=False, when="@:3.4", description="Required for MrSID/MG4 driver"
     )
     variant(
-        "mssql_ncli", default=False, when="@3.5:", description="Required for MSSQLSpatial driver"
+        "mssql_ncli",
+        default=False,
+        when="buildsystem=cmake",
+        description="Required for MSSQLSpatial driver",
     )
     variant(
-        "mssql_odbc", default=False, when="@3.5:", description="Required for MSSQLSpatial driver"
+        "mssql_odbc",
+        default=False,
+        when="buildsystem=cmake",
+        description="Required for MSSQLSpatial driver",
     )
     variant("mysql", default=False, description="Required for MySQL driver")
     variant("netcdf", default=False, description="Required for NetCDF driver")
     variant("odbc", default=False, description="Required for many OGR drivers")
-    variant("odbccpp", default=False, when="@3.5:", description="Required for SAP HANA driver")
+    variant(
+        "odbccpp",
+        default=False,
+        when="buildsystem=cmake",
+        description="Required for SAP HANA driver",
+    )
     variant("ogdi", default=False, description="Required for OGDI driver")
-    variant("opencad", default=False, when="@3.5:", description="Required for CAD driver")
+    variant(
+        "opencad", default=False, when="buildsystem=cmake", description="Required for CAD driver"
+    )
     variant("opencl", default=False, description="Required to accelerate warping computations")
     variant("openexr", default=False, when="@3.1:", description="Required for EXR driver")
     variant("openjpeg", default=False, description="Required for JP2OpenJPEG driver")
     variant("openssl", default=False, when="@2.3:", description="Required for EEDAI driver")
     variant("oracle", default=False, description="Required for OCI and GeoRaster drivers")
-    variant("parquet", default=False, when="@3.5:", description="Required for Parquet driver")
+    variant(
+        "parquet",
+        default=False,
+        when="buildsystem=cmake",
+        description="Required for Parquet driver",
+    )
     variant("pcidsk", default=False, description="Required for PCIDSK driver")
     variant(
         "pcre", default=False, description="Required for REGEXP operator in drivers using SQLite3"
@@ -194,14 +216,26 @@ class Gdal(CMakePackage):
     # Language bindings
     variant("python", default=False, description="Build Python bindings")
     variant("java", default=False, description="Build Java bindings")
-    variant("csharp", default=False, when="@3.5:", description="Build C# bindings")
+    variant("csharp", default=False, when="buildsystem=cmake", description="Build C# bindings")
     variant("perl", default=False, when="@:3.4", description="Build Perl bindings")
     variant("php", default=False, when="@:2.3", description="Build PHP bindings")
 
+    # Build system
+    buildsystem(
+        conditional("cmake", when="@3.5:"),
+        conditional("autotools", when="@:3.5"),
+        default="cmake",
+    )
+
+    with when("buildsystem=cmake"):
+        generator = "Ninja"
+        depends_on("cmake@3.9:", type="build")
+        depends_on("ninja", type="build")
+
+    with when("buildsystem=autotools"):
+        depends_on("gmake", type="build")
+
     # Required dependencies
-    depends_on("cmake@3.9:", when="@3.5:", type="build")
-    depends_on("ninja", when="@3.5:", type="build")
-    depends_on("gmake", when="@:3.4", type="build")
     depends_on("pkgconfig@0.25:", type="build")
     depends_on("proj@6:", when="@3:")
     depends_on("proj@:6", when="@2.5:2")
@@ -392,29 +426,11 @@ class Gdal(CMakePackage):
         sha256="9f9824296e75b34b3e78284ec772a5ac8f8ba92c17253ea9ca242caf766767ce",
     )
 
-    generator = "Ninja"
     executables = ["^gdal-config$"]
 
     @classmethod
     def determine_version(cls, exe):
         return Executable(exe)("--version", output=str, error=str).rstrip()
-
-    @property
-    def import_modules(self):
-        modules = ["osgeo"]
-        if self.spec.satisfies("@3.3:"):
-            modules.append("osgeo_utils")
-        else:
-            modules.append("osgeo.utils")
-        return modules
-
-    @when("@:3.4")
-    def setup_build_environment(self, env):
-        # Needed to install Python bindings to GDAL installation
-        # prefix instead of Python installation prefix.
-        # See swig/python/GNUmakefile for more details.
-        env.set("PREFIX", self.prefix)
-        env.set("DESTDIR", "/")
 
     def setup_run_environment(self, env):
         if "+java" in self.spec:
@@ -436,6 +452,10 @@ class Gdal(CMakePackage):
     def patch(self):
         if "+java platform=darwin" in self.spec:
             filter_file("linux", "darwin", "swig/java/java.opt", string=True)
+
+
+class CMakeBuilder(CMakeBuilder):
+    generator = "Ninja"
 
     def cmake_args(self):
         # https://gdal.org/build_hints.html
@@ -528,11 +548,20 @@ class Gdal(CMakePackage):
 
         return args
 
+
+class AutotoolsBuilder(AutotoolsBuilder):
+    def setup_build_environment(self, env):
+        # Needed to install Python bindings to GDAL installation
+        # prefix instead of Python installation prefix.
+        # See swig/python/GNUmakefile for more details.
+        env.set("PREFIX", self.prefix)
+        env.set("DESTDIR", "/")
+
     def with_or_without(self, name, variant=None, package=None, attribute=None):
         if not variant:
             variant = name
 
-        if variant not in self.variants:
+        if variant not in self.pkg.variants:
             msg = '"{}" is not a variant of "{}"'
             raise KeyError(msg.format(variant, self.name))
 
@@ -684,49 +713,26 @@ class Gdal(CMakePackage):
 
         return args
 
-    @when("@:3.4")
-    def cmake(self, spec, prefix):
-        configure(*self.configure_args())
-
-    @when("@:3.4")
-    def build(self, spec, prefix):
+    def build(self, pkg, spec, prefix):
         # https://trac.osgeo.org/gdal/wiki/GdalOgrInJavaBuildInstructionsUnix
         make()
         if "+java" in spec:
             with working_dir("swig/java"):
                 make()
 
-    @when("@:3.4")
     def check(self):
         # no top-level test target
         if "+java" in self.spec:
             with working_dir("swig/java"):
                 make("test")
 
-    @when("@:3.4")
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         make("install")
         if "+java" in spec:
             with working_dir("swig/java"):
                 make("install")
                 install("*.jar", prefix)
 
-    @run_after("install")
-    def darwin_fix(self):
         # The shared library is not installed correctly on Darwin; fix this
-        if self.spec.satisfies("@:3.4 platform=darwin"):
+        if self.spec.satisfies("platform=darwin"):
             fix_darwin_install_name(self.prefix.lib)
-
-    def test(self):
-        """Attempts to import modules of the installed package."""
-
-        if "+python" in self.spec:
-            # Make sure we are importing the installed modules,
-            # not the ones in the source directory
-            for module in self.import_modules:
-                self.run_test(
-                    self.spec["python"].command.path,
-                    ["-c", "import {0}".format(module)],
-                    purpose="checking import of {0}".format(module),
-                    work_dir="spack-test",
-                )


### PR DESCRIPTION
Tested the following configurations on macOS 12.6.1 (arm64) with Apple Clang 14.0.0:

* GDAL 3.5 (CMake)
* GDAL 3.5 (Autotools)
* GDAL 3.4 (Autotools)

All configurations build successfully and pass all build tests and post-install tests.