### PR TITLE
CachedCMakePackage: Add back initconfig as a defined phase

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -228,7 +228,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         """This method is to be overwritten by the package"""
         return []
 
-    def initconfig(self):
+    def initconfig(self, pkg, spec, prefix):
         cache_entries = (
             self.std_initconfig_entries()
             + self.initconfig_compiler_entries()

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -32,6 +32,10 @@ def cmake_cache_option(name, boolean_value, comment=""):
 
 class CachedCMakeBuilder(CMakeBuilder):
 
+    #: Phases of a Cached CMake package
+    #: Note: the initconfig phase is used for developer builds as a final phase to stop on
+    phases = ("initconfig", "cmake", "build", "install")
+
     #: Names associated with package methods in the old build-system format
     legacy_methods = CMakeBuilder.legacy_methods + (
         "initconfig_compiler_entries",
@@ -224,7 +228,6 @@ class CachedCMakeBuilder(CMakeBuilder):
         """This method is to be overwritten by the package"""
         return []
 
-    @spack.builder.run_before("cmake")
     def initconfig(self):
         cache_entries = (
             self.std_initconfig_entries()

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -34,7 +34,7 @@ class CachedCMakeBuilder(CMakeBuilder):
 
     #: Phases of a Cached CMake package
     #: Note: the initconfig phase is used for developer builds as a final phase to stop on
-    phases = ("initconfig", "cmake", "build", "install")
+    phases = ("initconfig", "cmake", "build", "install") # type: Optional[Tuple[str, ...]]
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = CMakeBuilder.legacy_methods + (

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -34,7 +34,7 @@ class CachedCMakeBuilder(CMakeBuilder):
 
     #: Phases of a Cached CMake package
     #: Note: the initconfig phase is used for developer builds as a final phase to stop on
-    phases = ("initconfig", "cmake", "build", "install") # type: Optional[Tuple[str, ...]]
+    phases = ("initconfig", "cmake", "build", "install")  # type: Tuple[str, ...]
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = CMakeBuilder.legacy_methods + (

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-from typing import Optional, Tuple
+from typing import Tuple
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -155,7 +155,7 @@ class CMakeBuilder(BaseBuilder):
     """
 
     #: Phases of a CMake package
-    phases = ("cmake", "build", "install")
+    phases = ("cmake", "build", "install")  # type: Tuple[str, ...]
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("cmake_args", "check")  # type: Tuple[str, ...]

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -469,7 +469,7 @@ class Builder(six.with_metaclass(BuilderMeta, llnl.util.compat.Sequence)):
     """
 
     #: Sequence of phases. Must be defined in derived classes
-    phases = None  # type: Optional[Tuple[str, ...]]
+    phases = ()  # type: Tuple[str, ...]
     #: Build system name. Must also be defined in derived classes.
     build_system = None  # type: Optional[str]
 


### PR DESCRIPTION
I think this was mistakenly removed as a named build phase.  This is important to developers who use this as a final phase to stop after generating the initial cache file (we call it a host-config). The host-config is then used in developing the package outside of Spack.

Our workflow is basically this:

```
# This build the TPLs and generates a host-config
spack dev-build -u initconfig axom@develop
cd <axom repo>
mkdir build
cmake -C /path/to/generated/host/config ../src
```