### PR TITLE
openblas %oneapi: extend application of flag to newer oneapi

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -196,7 +196,7 @@ class Openblas(MakefilePackage):
         spec = self.spec
         iflags = []
         if name == "cflags":
-            if spec.satisfies("@0.3.20 %oneapi"):
+            if spec.satisfies("@0.3.20: %oneapi"):
                 iflags.append("-Wno-error=implicit-function-declaration")
         return (iflags, None, None)
 


### PR DESCRIPTION
Need `-Wno-error=implicit-function-declaration` also for newer versions of OpenBLAS built with `%oneapi`

@wspear 