### PR TITLE
starpu: add papi and blocking variants

### DIFF
--- a/var/spack/repos/builtin/packages/starpu/package.py
+++ b/var/spack/repos/builtin/packages/starpu/package.py
@@ -69,7 +69,7 @@ class Starpu(AutotoolsPackage):
     variant("simgrid", default=False, description="Enable SimGrid support")
     variant("simgridmc", default=False, description="Enable SimGrid model checker support")
     variant("examples", default=True, description="Enable Examples")
-    variant("papi", default=False, description="Enable PAPI support")
+    variant("papi", default=False, description="Enable PAPI support", when="@master:")
     variant("blocking", default=False, description="Enable blocking drivers support")
 
     depends_on("pkgconfig", type="build")
@@ -92,9 +92,6 @@ class Starpu(AutotoolsPackage):
         "+shared", when="+mpi+simgrid", msg="Simgrid MPI cannot be built with a shared library"
     )
 
-    conflicts(
-        "+papi", when="@:999", msg="PAPI support is only available at the development branch"
-    )
     conflicts("+papi", when="+simgrid")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/starpu/package.py
+++ b/var/spack/repos/builtin/packages/starpu/package.py
@@ -69,6 +69,8 @@ class Starpu(AutotoolsPackage):
     variant("simgrid", default=False, description="Enable SimGrid support")
     variant("simgridmc", default=False, description="Enable SimGrid model checker support")
     variant("examples", default=True, description="Enable Examples")
+    variant("papi", default=False, description="Enable PAPI support")
+    variant("blocking", default=False, description="Enable blocking drivers support")
 
     depends_on("pkgconfig", type="build")
     depends_on("autoconf", type="build")
@@ -84,10 +86,16 @@ class Starpu(AutotoolsPackage):
     depends_on("simgrid", when="+simgrid")
     depends_on("simgrid+smpi", when="+simgrid+mpi")
     depends_on("simgrid+mc", when="+simgridmc")
+    depends_on("papi", when="+papi")
 
     conflicts(
         "+shared", when="+mpi+simgrid", msg="Simgrid MPI cannot be built with a shared library"
     )
+
+    conflicts(
+        "+papi", when="@:999", msg="PAPI support is only available at the development branch"
+    )
+    conflicts("+papi", when="+simgrid")
 
     def autoreconf(self, spec, prefix):
         if not os.path.isfile("./configure"):
@@ -125,6 +133,8 @@ class Starpu(AutotoolsPackage):
                 "--%s-build-examples" % ("enable" if "+examples" in spec else "disable"),
                 "--%s-fortran" % ("enable" if "+fortran" in spec else "disable"),
                 "--%s-openmp" % ("enable" if "+openmp" in spec else "disable"),
+                "--%s-blocking-drivers" % ("enable" if "+blocking" in spec else "disable"),
+                "--%s-papi" % ("enable" if "+papi" in spec else "disable"),
                 "--%s-opencl"
                 % ("disable" if "~opencl" in spec or "+simgrid" in spec else "enable"),
                 "--%s-cuda" % ("disable" if "~cuda" in spec or "+simgrid" in spec else "enable"),


### PR DESCRIPTION
- Add papi variant to enable papi build support and respective conflicts
- Add a blocking variant to enable blocking drivers support