### PR TITLE
Fix spack install --only=dependencies ignoring install failure

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2486,11 +2486,17 @@ class PackageInstaller:
 
         # Ensure we properly report if one or more explicit specs failed
         # or were not installed when should have been.
-        missing = [
-            (request.pkg, request.pkg_id)
-            for request in self.build_requests
-            if request.install_args.get("install_package") and request.pkg_id not in self.installed
-        ]
+        missing = []
+        for request in self.build_requests:
+            miss_package = (
+                request.install_args.get("install_package")
+                and request.pkg_id not in self.installed
+            )
+            miss_deps = request.install_args.get(
+                "install_deps"
+            ) and not request.dependencies.issubset(self.installed)
+            if miss_package or miss_deps:
+                missing.append((request.pkg, request.pkg_id))
 
         if failed_build_requests or missing:
             for _, pkg_id, err in failed_build_requests:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2488,15 +2488,18 @@ class PackageInstaller:
         # or were not installed when should have been.
         missing = []
         for request in self.build_requests:
-            miss_package = (
+            if (
                 request.install_args.get("install_package")
                 and request.pkg_id not in self.installed
-            )
-            miss_deps = request.install_args.get(
-                "install_deps"
-            ) and not request.dependencies.issubset(self.installed)
-            if miss_package or miss_deps:
+            ):
                 missing.append((request.pkg, request.pkg_id))
+            if request.install_args.get("install_deps"):
+                # Associate requested package with its failed dependency
+                missing.extend(
+                    (request.pkg, dep_id)
+                    for dep_id in request.dependencies
+                    if dep_id not in self.installed
+                )
 
         if failed_build_requests or missing:
             for _, pkg_id, err in failed_build_requests:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -712,6 +712,30 @@ def test_install_only_dependencies(tmpdir, mock_fetch, install_mockery):
     assert not os.path.exists(root.prefix)
 
 
+def test_install_only_dependencies_already_installed(tmpdir, mock_fetch, install_mockery):
+    dep = spack.concretize.concretize_one("dependency-install")
+    root = spack.concretize.concretize_one("dependent-install")
+
+    install("dependency-install")
+    assert os.path.exists(dep.prefix)
+
+    install("--only", "dependencies", "dependent-install")
+    assert not os.path.exists(root.prefix)
+
+
+@pytest.mark.disable_clean_stage_check
+def test_install_only_dependencies_build_error(tmpdir, mock_fetch, install_mockery):
+    root = spack.concretize.concretize_one("build-error-in-dep")
+    dep = spack.concretize.concretize_one("build-error")
+
+    install("--only", "dependencies", "build-error-in-dep", fail_on_error=False)
+
+    assert install.error
+    assert isinstance(install.error, spack.error.InstallError)
+    assert not os.path.exists(dep.prefix)
+    assert not os.path.exists(root.prefix)
+
+
 def test_install_only_package(tmpdir, mock_fetch, install_mockery, capfd):
     msg = ""
     with capfd.disabled():

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error_in_dep/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error_in_dep/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class BuildErrorInDep(Package):
+    """This package has build-error as dependency."""
+
+    homepage = "http://www.example.com/trivial_install"
+    url = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version("1.0", "0123456789abcdef0123456789abcdef")
+
+    depends_on("build-error")


### PR DESCRIPTION
Fix #28335

Fix `spack install --only=dependencies` was not failing when a dependency failed to install.