### PR TITLE
czmq %oneapi: add -Wno-error: gnu-null-pointer-arithmetic, strict-prototypes

### DIFF
--- a/var/spack/repos/builtin/packages/czmq/package.py
+++ b/var/spack/repos/builtin/packages/czmq/package.py
@@ -25,6 +25,14 @@ class Czmq(AutotoolsPackage):
     depends_on("uuid")
     depends_on("libzmq")
 
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2022.2.0:"):
+                iflags.append("-Wno-error=gnu-null-pointer-arithmetic")
+                iflags.append("-Wno-error=strict-prototypes")
+        return (iflags, None, None)
+
     def autoreconf(self, spec, prefix):
         autogen = Executable("./autogen.sh")
         autogen()


### PR DESCRIPTION
Needed to build `czmq %oneapi@2022.2.0:`

@wspear