### PR TITLE
phist: add/update conflicts with cray-libsci and/or python@3.11: for …

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -131,7 +131,7 @@ class Phist(CMakePackage):
         description="generate Fortran 2003 bindings (requires Python3 and " "a Fortran compiler)",
     )
 
-    # Build error with cray-libsci because their headers define a macro 'I', workaround in phist-1.11.2
+    # Build error with cray-libsci because they define macro 'I', workaround in phist-1.11.2
     conflicts("^cray-libsci", when="@:1.11.1")
     # phist@1.11.2 got rid of some deprecated python code
     conflicts("^python@3.11:", when="@:1.11.1")

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -21,7 +21,7 @@ class Phist(CMakePackage):
     """
 
     homepage = "https://bitbucket.org/essex/phist/"
-    url = "https://bitbucket.org/essex/phist/get/phist-1.9.6.tar.gz"
+    url = "https://bitbucket.org/essex/phist/get/phist-1.11.2.tar.gz"
     git = "https://bitbucket.org/essex/phist.git"
 
     maintainers = ["jthies"]
@@ -34,7 +34,9 @@ class Phist(CMakePackage):
     version("develop", branch="devel")
     version("master", branch="master")
 
+    # compatible with python@3.11: and cray-libsci as BLAS/LAPACK provider
     version("1.11.2", sha256="e23f76307c26b930f7331a734b0a864ea6d7fb4a13c12f3c5d70c2c41481747b")
+
     # updated lapack interface to work with openblas and netlib-lapack
     version("1.11.0", sha256="36e6cc41a13884ba0a26f7be03e3f1882b1a2d14ca04353a609c0eec0cfb7a77")
 
@@ -129,6 +131,10 @@ class Phist(CMakePackage):
         description="generate Fortran 2003 bindings (requires Python3 and " "a Fortran compiler)",
     )
 
+    # Build error with cray-libsci because their headers define a macro 'I', workaround in phist-1.11.2
+    conflicts("^cray-libsci", when="@:1.11.1")
+    # phist@1.11.2 got rid of some deprecated python code
+    conflicts("^python@3.11:", when="@:1.11.1")
     # The builtin kernels switched from the 'mpi' to the 'mpi_f08' module in
     # phist 1.9.6, which causes compile-time errors with mpich and older
     # GCC versions.


### PR DESCRIPTION
…versions <1.11.2