### PR TITLE
Build_systems tests on windows

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -248,7 +248,8 @@ class CMakeBuilder(BaseBuilder):
     @staticmethod
     def std_args(pkg, generator=None):
         """Computes the standard cmake arguments for a generic package"""
-        generator = generator or "Unix Makefiles"
+        default_generator = "Ninja" if sys.platform == "win32" else "Unix Makefiles"
+        generator = generator or default_generator
         valid_primary_generators = ["Unix Makefiles", "Ninja"]
         primary_generator = _extract_primary_generator(generator)
         if primary_generator not in valid_primary_generators:

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -24,7 +24,6 @@ from spack.util.executable import which
 DATA_PATH = os.path.join(spack.paths.test_path, "data")
 
 
-
 @pytest.fixture()
 def concretize_and_setup(default_mock_concretization):
     def _func(spec_str):
@@ -42,6 +41,7 @@ def test_dir(tmpdir):
         return str(tmpdir)
 
     return _func
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="autotools not available on Windows")
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -23,7 +23,6 @@ from spack.util.executable import which
 
 DATA_PATH = os.path.join(spack.paths.test_path, "data")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
 @pytest.fixture()
@@ -44,7 +43,7 @@ def test_dir(tmpdir):
 
     return _func
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="autotools not available on Windows")
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
 class TestTargets:
     @pytest.mark.parametrize(
@@ -93,6 +92,7 @@ class TestTargets:
             s.package._if_ninja_target_execute("check")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="autotools not available on windows")
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestAutotoolsPackage:
     def test_with_or_without(self, default_mock_concretization):

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -43,7 +43,7 @@ def test_dir(tmpdir):
     return _func
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="autotools not available on Windows")
+@pytest.mark.skipif(sys.platform == "win32", reason="make not available on Windows")
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
 class TestTargets:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Removes windows skips for non-autotools dependent tests. Autotools tests are skipped because they will not be supported on windows.