### PR TITLE
_replace_prefix_bin performance improvements

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -485,15 +485,17 @@ def _replace_prefix_bin(filename, byte_prefixes):
             raise BinaryTextReplaceError(old, new)
         return new + b"/" * pad
 
-    matches = []
-
     with open(filename, "rb+") as f:
-        for m in re.finditer(all_prefixes, f.read()):
-            matches.append((m.start(), padded_replacement(m.group(0))))
+        # Register what replacement string to put on what offsets in the file.
+        replacements_at_offset = [
+            (padded_replacement(m.group(0)), m.start())
+            for m in re.finditer(all_prefixes, f.read())
+        ]
 
-        for byte_offset, bytes_to_write in matches:
-            f.seek(byte_offset)
-            f.write(bytes_to_write)
+        # Apply the replacements
+        for replacement, offset in replacements_at_offset:
+            f.seek(offset)
+            f.write(replacement)
 
 
 def relocate_macho_binaries(

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -467,40 +467,33 @@ def _replace_prefix_bin(filename, byte_prefixes):
     """Replace all the occurrences of the old install prefix with a
     new install prefix in binary files.
 
-    The new install prefix is prefixed with ``os.sep`` until the
+    The new install prefix is prefixed with ``b'/'`` until the
     lengths of the prefixes are the same.
 
     Args:
         filename (str): target binary file
         byte_prefixes (OrderedDict): OrderedDictionary where the keys are
-        precompiled regex of the old prefixes and the values are the new
-        prefixes (uft-8 encoded)
+        binary strings of the old prefixes and the values are the new
+        binary prefixes
     """
+    all_prefixes = re.compile(b"|".join(re.escape(prefix) for prefix in byte_prefixes.keys()))
+
+    def padded_replacement(old):
+        new = byte_prefixes[old]
+        pad = len(old) - len(new)
+        if pad < 0:
+            raise BinaryTextReplaceError(old, new)
+        return new + b"/" * pad
+
+    matches = []
 
     with open(filename, "rb+") as f:
-        data = f.read()
-        f.seek(0)
-        for orig_bytes, new_bytes in byte_prefixes.items():
-            original_data_len = len(data)
-            # Skip this hassle if not found
-            if orig_bytes not in data:
-                continue
-            # We only care about this problem if we are about to replace
-            length_compatible = len(new_bytes) <= len(orig_bytes)
-            if not length_compatible:
-                tty.debug("Binary failing to relocate is %s" % filename)
-                raise BinaryTextReplaceError(orig_bytes, new_bytes)
-            pad_length = len(orig_bytes) - len(new_bytes)
-            padding = os.sep * pad_length
-            padding = padding.encode("utf-8")
-            data = data.replace(orig_bytes, new_bytes + padding)
-            # Really needs to be the same length
-            if not len(data) == original_data_len:
-                print("Length of pad:", pad_length, "should be", len(padding))
-                print(new_bytes, "was to replace", orig_bytes)
-                raise BinaryStringReplacementError(filename, original_data_len, len(data))
-        f.write(data)
-        f.truncate()
+        for m in re.finditer(all_prefixes, f.read()):
+            matches.append((m.start(), padded_replacement(m.group(0))))
+
+        for byte_offset, bytes_to_write in matches:
+            f.seek(byte_offset)
+            f.write(bytes_to_write)
 
 
 def relocate_macho_binaries(


### PR DESCRIPTION
- single pass over the binary data matching all prefixes
- collect offsets and replacement strings
- do in-place updates with `fseek` / `fwrite`, since typically our
  replacement touch O(few bytes) while the file is O(many megabytes)
- be nice: leave the file untouched if some string can't be
  replaced

Note: the order of ordered dict is preserved, since the regex will greedily match the left-hand side of `|` before backtracking and matching the rhs.