### PR TITLE
WarpX 22.10 & PICMI-Standard

### DIFF
--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -16,6 +16,8 @@ class PyPicmistandard(PythonPackage):
     maintainers = ["ax3l", "dpgrote", "RemiLehe"]
 
     version("develop", branch="master")
+    version("0.0.21", sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b")
+    version("0.0.20", sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905")
     version("0.0.19", sha256="4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a")
     version("0.0.18", sha256="68c208c0c54b4786e133bb13eef0dd4824998da4906285987ddee84e6d195e71")
     # 0.15 - 0.17 have broken install logic: missing requirements.txt on pypi

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.05.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.10.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ["ax3l", "dpgrote", "RemiLehe"]
@@ -27,6 +27,8 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version("develop", branch="development")
+    version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
+    version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
     version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")
     version("22.07", sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b")
     version("22.06", sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9")
@@ -48,6 +50,8 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
+        "22.10",
+        "22.09",
         "22.08",
         "22.07",
         "22.06",
@@ -77,7 +81,8 @@ class PyWarpx(PythonPackage):
     depends_on("py-picmistandard@0.0.14", type=("build", "run"), when="@21.03:21.11")
     depends_on("py-picmistandard@0.0.16", type=("build", "run"), when="@21.12")
     depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
-    depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:")
+    depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
+    depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:")
     depends_on("py-setuptools@42:", type="build")
     # Since we use PYWARPX_LIB_DIR to pull binaries out of the
     # 'warpx' spack package, we don't need py-cmake as declared

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.05.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.10.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ["ax3l", "dpgrote", "MaxThevenet", "RemiLehe"]
@@ -25,6 +25,8 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
+    version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
+    version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
     version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")
     version("22.07", sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b")
     version("22.06", sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9")


### PR DESCRIPTION
Update `warpx` & `py-warpx` to the latest release, `22.10`. Update `py-picmistandard` accordingly.