### PR TITLE
Speed up relocation and fix bug

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1644,27 +1644,15 @@ def relocate_package(spec, allow_root):
                 old_prefix,
                 new_prefix,
             )
-            # Relocate links to the new install prefix
-            links = [link for link in buildinfo.get("relocate_links", [])]
-            relocate.relocate_links(links, old_layout_root, old_prefix, new_prefix)
+
+        # Relocate links to the new install prefix
+        links = [link for link in buildinfo.get("relocate_links", [])]
+        relocate.relocate_links(links, old_layout_root, old_prefix, new_prefix)
 
         # For all buildcaches
         # relocate the install prefixes in text files including dependencies
         relocate.unsafe_relocate_text(text_names, prefix_to_prefix_text)
 
-        paths_to_relocate = [old_prefix, old_layout_root]
-        paths_to_relocate.extend(prefix_to_hash.keys())
-        files_to_relocate = list(
-            filter(
-                lambda pathname: not relocate.file_is_relocatable(
-                    pathname, paths_to_relocate=paths_to_relocate
-                ),
-                map(
-                    lambda filename: os.path.join(workdir, filename),
-                    buildinfo["relocate_binaries"],
-                ),
-            )
-        )
         # relocate the install prefixes in binary files including dependencies
         relocate.unsafe_relocate_text_bin(files_to_relocate, prefix_to_prefix_bin)
 


### PR DESCRIPTION
- `relocate_links` was skipped for macOS
- Remove the sequential filter of binaries (very slow)

LLVM before:

```
elf      47.34s
text      0.01s
filter   84.72s
text bin  0.003s
```

LLVM after:

```
elf      13.37s # not sure why this is so flaky...
text      0.01s
text bin  4.81s
```

All in all llvm installs in < 1 min, the bottleneck is decompressing the tarball now.
