### PR TITLE
Fix pkgconfig dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -76,6 +76,7 @@ class Aml(AutotoolsPackage):
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
         # Required to have pkg config macros in configure.
+        # Note: This does NOT work with pkg-config but requires pkgconf!
         depends_on("pkgconf", type="build")
         # Required to generate AML version in configure.
         depends_on("git", type="build")

--- a/var/spack/repos/builtin/packages/bear/package.py
+++ b/var/spack/repos/builtin/packages/bear/package.py
@@ -22,7 +22,7 @@ class Bear(CMakePackage):
     version("2.2.0", sha256="6bd61a6d64a24a61eab17e7f2950e688820c72635e1cf7ea8ea7bf9482f3b612")
     version("2.0.4", sha256="33ea117b09068aa2cd59c0f0f7535ad82c5ee473133779f1cc20f6f99793a63e")
 
-    depends_on("pkgconf", when="@3:")
+    depends_on("pkgconfig", when="@3:")
     depends_on("fmt", when="@3.0.0:")
     depends_on("grpc", when="@3.0.0:")
     depends_on("nlohmann-json", when="@3.0.0:")

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -212,7 +212,7 @@ class Libpressio(CMakePackage, CudaPackage):
     depends_on("lua-sol2", when="+lua")
     depends_on("libdistributed@0.0.11:", when="+libdistributed")
     depends_on("libdistributed@0.4.0:", when="@0.85.0:+libdistributed")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("ftk@master", when="+ftk")
     depends_on("digitrounding", when="+digitrounding")
     depends_on("bitgroomingz", when="+bitgrooming")

--- a/var/spack/repos/builtin/packages/ophidia-analytics-framework/package.py
+++ b/var/spack/repos/builtin/packages/ophidia-analytics-framework/package.py
@@ -21,7 +21,7 @@ class OphidiaAnalyticsFramework(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("gsl")
     depends_on("mpich")

--- a/var/spack/repos/builtin/packages/ophidia-primitives/package.py
+++ b/var/spack/repos/builtin/packages/ophidia-primitives/package.py
@@ -21,7 +21,7 @@ class OphidiaPrimitives(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("boost@1.79.0")
     depends_on("mysql")

--- a/var/spack/repos/builtin/packages/riscv-gnu-toolchain/package.py
+++ b/var/spack/repos/builtin/packages/riscv-gnu-toolchain/package.py
@@ -21,7 +21,7 @@ class RiscvGnuToolchain(AutotoolsPackage):
     version("2022.08.08", tag="2022.08.08", submodules=True)
 
     # Dependencies:
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("autoconf", when="@main:", type="build")
     depends_on("python", type="build")
     depends_on("gawk", type="build")

--- a/var/spack/repos/builtin/packages/sperr/package.py
+++ b/var/spack/repos/builtin/packages/sperr/package.py
@@ -18,7 +18,7 @@ class Sperr(CMakePackage):
 
     depends_on("git", type="build")
     depends_on("zstd", type=("build", "link"), when="+zstd")
-    depends_on("pkgconf", type=("build"), when="+zstd")
+    depends_on("pkgconfig", type=("build"), when="+zstd")
 
     variant("shared", description="build shared libaries", default=True)
     variant("zstd", description="use Zstd for more compression", default=True)


### PR DESCRIPTION
Packages should depend on the virtual provider, pkgconfig, not on its implementations pkg-config or pkgconf.