### PR TITLE
Let pytest-cov create the xml directly

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -89,8 +89,6 @@ jobs:
           UNIT_TEST_COVERAGE: ${{ (matrix.python-version == '3.10') }}
       run: |
           share/spack/qa/run-unit-tests
-          coverage combine -a
-          coverage xml
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         flags: unittests,linux,${{ matrix.concretizer }}
@@ -182,8 +180,6 @@ jobs:
           SPACK_TEST_SOLVER: clingo
       run: |
           share/spack/qa/run-unit-tests
-          coverage combine -a
-          coverage xml
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # @v2.1.0
       with:
         flags: unittests,linux,clingo

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -203,7 +203,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
-          pip install --upgrade pytest codecov coverage[toml] pytest-cov
+          pip install --upgrade pytest codecov coverage[toml] pytest-xdist pytest-cov
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov
@@ -217,9 +217,8 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        $(which spack) unit-test --cov --cov-config=pyproject.toml -x
-        coverage combine -a
-        coverage xml
+        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
+        $(which spack) unit-test --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}"
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         flags: unittests,macos

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -203,7 +203,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
-          pip install --upgrade pytest codecov coverage[toml] pytest-xdist pytest-cov
+          pip install --upgrade pytest codecov coverage[toml] pytest-cov
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov
@@ -217,8 +217,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable spack-install
         $(which spack) solve zlib
-        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        $(which spack) unit-test --cov --cov-config=pyproject.toml "${common_args[@]}"
+        $(which spack) unit-test --cov --cov-config=pyproject.toml -x
         coverage combine -a
         coverage xml
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -66,7 +66,7 @@ fi
 # where it seems that otherwise the configuration file might not be located by subprocesses
 # in some, not better specified, cases.
 if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
-  $(which spack) unit-test -x --verbose --cov --cov-config=pyproject.toml
+  $(which spack) unit-test -x --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml
 else
   $(which spack) unit-test -x --verbose
 fi


### PR DESCRIPTION
macOS unit-tests fail frequently due to `coverage combine -a` returning 1 and not finding existing data. Solve the issue by letting `pytest-cov` combine the coverage data into an XML.