### PR TITLE
Nalu-Wind: Allow for standard versions of trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -51,7 +51,7 @@ class NaluWind(CMakePackage, CudaPackage):
     depends_on("mpi")
     depends_on("yaml-cpp@0.5.3:")
     depends_on(
-        "trilinos@stable:"
+        "trilinos@13.0.4:"
         "+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost"
         "~superlu-dist~superlu+hdf5+shards~hypre+gtest"
     )

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -51,7 +51,7 @@ class NaluWind(CMakePackage, CudaPackage):
     depends_on("mpi")
     depends_on("yaml-cpp@0.5.3:")
     depends_on(
-        "trilinos@13.0.4:"
+        "trilinos@13:"
         "+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost"
         "~superlu-dist~superlu+hdf5+shards~hypre+gtest"
     )


### PR DESCRIPTION
This will allow us to utilize custom numeric versions for trilinos in `spack-manager` while we continue to develop `nalu-wind`. Pinging @eugeneswalker @jrood-nrel @tasmith4