### PR TITLE
E4S: Conservatively add ecp-data-vis-sdk

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -163,7 +163,9 @@ spack:
   - chai ~benchmarks ~tests +cuda cuda_arch=80 ^umpire@6.0.0 ~shared
   - dealii +cuda cuda_arch=80
   - ecp-data-vis-sdk +cuda cuda_arch=80
-    +adios2 +ascent +hdf5 +vtkm +zfp
+    +adios2 +hdf5 +vtkm +zfp
+    # Removing ascent because Dray is hung in CI.
+    # +ascent
   - flecsi +cuda cuda_arch=80
   - flux-core +cuda
   - ginkgo +cuda cuda_arch=80

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -57,14 +57,12 @@ spack:
   specs:
   # CPU
   - adios
-  - adios2
   - alquimia
   - aml
   - amrex
   - arborx
   - archer
   - argobots
-  - ascent
   - axom
   - bolt
   - bricks
@@ -74,12 +72,11 @@ spack:
   - chai ~benchmarks ~tests
   - charliecloud
   - conduit
-  - darshan-runtime
-  - darshan-util
   - datatransferkit
   - dyninst
+  - ecp-data-vis-sdk ~cuda ~rocm
+    +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp
   - exaworks
-  - faodel
   - flecsi
   - flit
   - flux-core
@@ -91,8 +88,6 @@ spack:
   - gotcha
   - gptune
   - h5bench
-  - hdf5 +fortran +hl +shared
-  - hdf5-vol-async
   - heffte +fftw
   - hpctoolkit
   - hpx networking=mpi
@@ -119,7 +114,6 @@ spack:
   - openpmd-api
   - papi
   - papyrus
-  - parallel-netcdf
   - parsec ~cuda
   - pdt
   - petsc
@@ -128,7 +122,6 @@ spack:
   - plumed
   - precice
   - pumi
-  - py-cinemasci
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
@@ -148,7 +141,6 @@ spack:
   - superlu-dist
   - swig
   - swig@4.0.2-fortran
-  - sz
   - tasmanian
   - tau +mpi +python
   - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack
@@ -158,24 +150,20 @@ spack:
   - turbine
   - umap
   - umpire
-  - unifyfs
   - upcxx
   - variorum
-  - veloc
-  - vtk-m
   - wannier90
-  - zfp
 
   # CUDA
-  - adios2 +cuda cuda_arch=80
   - amrex +cuda cuda_arch=80
   - arborx +cuda cuda_arch=80 ^kokkos@3.6.00 +wrapper
-  - ascent +cuda cuda_arch=80
   - bricks +cuda
   - cabana +cuda ^kokkos@3.6.00 +wrapper +cuda_lambda +cuda cuda_arch=80
   - caliper +cuda cuda_arch=80
   - chai ~benchmarks ~tests +cuda cuda_arch=80 ^umpire@6.0.0 ~shared
   - dealii +cuda cuda_arch=80
+  - ecp-data-vis-sdk +cuda cuda_arch=80
+    +adios2 +ascent +hdf5 +vtkm +zfp
   - flecsi +cuda cuda_arch=80
   - flux-core +cuda
   - ginkgo +cuda cuda_arch=80
@@ -201,8 +189,6 @@ spack:
   - tau +mpi +cuda
   - trilinos@13.4.0 +cuda cuda_arch=80
   - umpire ~shared +cuda cuda_arch=80
-  - vtk-m +cuda cuda_arch=80
-  - zfp +cuda cuda_arch=80
 
   # ROCm
   - amrex +rocm amdgpu_target=gfx90a
@@ -210,6 +196,8 @@ spack:
   - cabana +rocm
   - caliper +rocm amdgpu_target=gfx90a
   - chai ~benchmarks +rocm amdgpu_target=gfx90a
+  - ecp-data-vis-sdk +rocm amdgpu_target=gfx90a
+    +vtkm
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
@@ -236,7 +224,6 @@ spack:
     +rocm amdgpu_target=gfx90a
   - umpire +rocm amdgpu_target=gfx90a
   - upcxx +rocm amdgpu_target=gfx90a
-  - vtk-m ~openmp +rocm amdgpu_target=gfx90a
 
   # CPU failures
   #- geopm                                        # /usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error:'__builtin_strncpy' specified bound 512 equals destination size [-Werror=stringop-truncation]
@@ -297,6 +284,7 @@ spack:
 
       - match:
           - cuda
+          - dray
           - dyninst
           - ginkgo
           - hpx

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -208,6 +208,7 @@ class Adios2(CMakePackage, CudaPackage):
 
         if "+python" in spec or self.run_tests:
             args.append("-DPYTHON_EXECUTABLE:FILEPATH=%s" % spec["python"].command.path)
+            args.append("-DPython_EXECUTABLE:FILEPATH=%s" % spec["python"].command.path)
 
         return args
 


### PR DESCRIPTION
More conservative effort than #32764 but enough to get the SDK building in the e4s environment.