### PR TITLE
julia: don't look for the openlibm libraries when unneeded

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -209,8 +209,8 @@ class Julia(MakefilePackage):
             "utf8proc",
             "zlib",
         ]
-        if '+openlibm' in self.spec:
-            pkgs.append('openlibm') 
+        if "+openlibm" in self.spec:
+            pkgs.append("openlibm")
         if self.spec.satisfies("@1.7.0:"):
             pkgs.append("libblastrampoline")
         for pkg in pkgs:

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -204,12 +204,13 @@ class Julia(MakefilePackage):
             "mpfr",
             "nghttp2",
             "openblas",
-            "openlibm",
             "pcre2",
             "suite-sparse",
             "utf8proc",
             "zlib",
         ]
+        if '+openlibm' in self.spec:
+            pkgs.append('openlibm') 
         if self.spec.satisfies("@1.7.0:"):
             pkgs.append("libblastrampoline")
         for pkg in pkgs:


### PR DESCRIPTION
Cause spack to *not* check for the existence of the openlibm libraries (by adding it to the pkgs list) when ~openlibm is specified.