### PR TITLE
hpctoolkit: adjust rocm dependency types

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -137,10 +137,12 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on("hpcviewer@2022.10:", type="run", when="@2022.10: +viewer")
     depends_on("hpcviewer", type="run", when="+viewer")
 
-    depends_on("hip@4.5:", when="+rocm")
-    depends_on("hsa-rocr-dev@4.5:", when="+rocm")
-    depends_on("roctracer-dev@4.5:", when="+rocm")
-    depends_on("rocprofiler-dev@4.5:", when="+rocm")
+    # Avoid 'link' dep, we don't actually link, and that adds rpath
+    # that conflicts with app.
+    depends_on("hip@4.5:", type=("build", "run"), when="+rocm")
+    depends_on("hsa-rocr-dev@4.5:", type=("build", "run"), when="+rocm")
+    depends_on("roctracer-dev@4.5:", type=("build", "run"), when="+rocm")
+    depends_on("rocprofiler-dev@4.5:", type=("build", "run"), when="+rocm")
 
     conflicts("%gcc@:7", when="@2022.10:", msg="hpctoolkit requires gnu gcc 8.x or later")
     conflicts("%gcc@:6", when="@2021.00:2022.06", msg="hpctoolkit requires gnu gcc 7.x or later")


### PR DESCRIPTION
Drop the link dependency type for the rocm packages.  We don't actually link, and that adds rpaths that conflict with the app.