### PR TITLE
py-ilmbase: add dependency to py-numpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-ilmbase/package.py
+++ b/var/spack/repos/builtin/packages/py-ilmbase/package.py
@@ -16,6 +16,7 @@ class PyIlmbase(AutotoolsPackage):
 
     depends_on("ilmbase")
     depends_on("boost+python")
+    depends_on('py-numpy')
 
     # https://github.com/AcademySoftwareFoundation/openexr/issues/336
     parallel = False

--- a/var/spack/repos/builtin/packages/py-ilmbase/package.py
+++ b/var/spack/repos/builtin/packages/py-ilmbase/package.py
@@ -16,7 +16,7 @@ class PyIlmbase(AutotoolsPackage):
 
     depends_on("ilmbase")
     depends_on("boost+python")
-    depends_on('py-numpy')
+    depends_on("py-numpy")
 
     # https://github.com/AcademySoftwareFoundation/openexr/issues/336
     parallel = False


### PR DESCRIPTION
Fix a bug by adding dependency to py-numpy.