### PR TITLE
Add tracy 0.9

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -98,6 +98,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocblas", when="+rocm")
     depends_on("rocsolver", when="@0.5: +rocm")
     depends_on("tracy-client", when="+tracy")
+    conflicts("tracy-client@0.9:", when="@:0.9")
     depends_on("whip+rocm", when="@0.9: +rocm")
     depends_on("whip+cuda", when="@0.9: +cuda")
 

--- a/var/spack/repos/builtin/packages/tracy-client/package.py
+++ b/var/spack/repos/builtin/packages/tracy-client/package.py
@@ -15,6 +15,7 @@ class TracyClient(CMakePackage):
     maintainers = ["msimberg"]
 
     version("master", git="https://github.com/wolfpld/tracy.git", branch="master")
+    version("0.9", sha256="93a91544e3d88f3bc4c405bad3dbc916ba951cdaadd5fcec1139af6fa56e6bfc")
     version(
         "0.8.2",
         sha256="4784eddd89c17a5fa030d408392992b3da3c503c872800e9d3746d985cfcc92a",

--- a/var/spack/repos/builtin/packages/tracy/package.py
+++ b/var/spack/repos/builtin/packages/tracy/package.py
@@ -15,6 +15,7 @@ class Tracy(MakefilePackage):
     maintainers = ["msimberg"]
 
     version("master", git="https://github.com/wolfpld/tracy.git", branch="master")
+    version("0.9", sha256="93a91544e3d88f3bc4c405bad3dbc916ba951cdaadd5fcec1139af6fa56e6bfc")
     version(
         "0.8.2",
         sha256="4784eddd89c17a5fa030d408392992b3da3c503c872800e9d3746d985cfcc92a",


### PR DESCRIPTION
Also adds a conflict between pika 0.9 and older and tracy 0.9 and newer. The constraint is only until pika 0.9 because pika 0.10.0 will again compile with all versions of tracy.