### PR TITLE
Pull RHEL8 package when OS is Rocky8

### DIFF
--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -13,6 +13,7 @@ _os_map = {
     "sles15": "SLES-15",
     "centos7": "RHEL-7",
     "centos8": "RHEL-8",
+    "rocky8" : "RHEL-8",
     "amzn2": "RHEL-7",
 }
 

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -13,7 +13,7 @@ _os_map = {
     "sles15": "SLES-15",
     "centos7": "RHEL-7",
     "centos8": "RHEL-8",
-    "rocky8" : "RHEL-8",
+    "rocky8": "RHEL-8",
     "amzn2": "RHEL-7",
 }
 


### PR DESCRIPTION
Added specific entry to identify 'rocky8', otherwise RHEL7 package is used (default).