### PR TITLE
netcdf-c: add variant optimize

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -77,6 +77,7 @@ class NetcdfC(AutotoolsPackage):
     variant("jna", default=False, description="Enable JNA support")
     variant("fsync", default=False, description="Enable fsync support")
     variant("zstd", default=True, description="Enable ZStandard compression", when="@4.9.0:")
+    variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
 
     # It's unclear if cdmremote can be enabled if '--enable-netcdf-4' is passed
     # to the configure script. Since netcdf-4 support is mandatory we comment
@@ -160,6 +161,9 @@ class NetcdfC(AutotoolsPackage):
             "--enable-largefile",
             "--enable-netcdf-4",
         ]
+
+        if "+optimize" in self.spec:
+            cflags.append("-O2")
 
         config_args.extend(self.enable_or_disable("fsync"))
 

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -169,9 +169,7 @@ class NetcdfC(AutotoolsPackage):
 
         config_args += self.enable_or_disable("shared")
 
-        if "~shared" in self.spec or "+pic" in self.spec:
-            # We don't have shared libraries but we still want it to be
-            # possible to use this library in shared builds
+        if "+pic" in self.spec:
             cflags.append(self.compiler.cc_pic_flag)
 
         config_args += self.enable_or_disable("dap")


### PR DESCRIPTION
I was wrong in https://github.com/spack/spack/pull/33514#issuecomment-1291605625 assuming that the configure script sets `CFLAGS` to `-g -O2` by default. It turns out that building with no optimization by default is intended (see [here](https://github.com/Unidata/netcdf-c/blob/0f29b454d282ea2f894648d533fa1ba045ef40c4/configure.ac#L15-L20)). This means that:

1. We actually should set `CFLAGS` on the command line to override the default `-O2 -g` for versions `@:4.4.0`, which don't have https://github.com/Unidata/netcdf-c/commit/9136afdcbe7f5db5eebb83bfb201604ddedfacf3.
2. We should append `-O2` to `CFLAGS` explicitly if we want the library to be built with optimizations enabled.

This PR adds a new variant `optimize`, which defaults to `True` and controls whether `-O2` is appended to `CFLAGS` (like in [`zlib`](https://github.com/spack/spack/blob/156dd5848eb257b3f37cdcc8e116d236cc75901f/var/spack/repos/builtin/packages/zlib/package.py#L69-L70)).

I also think that we should not build with the PIC flags when `~shared~pic`, so I have fixed that as well.