### PR TITLE
py-pytorch-lightning: add v1.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-lightning-lite/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning-lite/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLightningLite(PythonPackage):
+    """LightningLite enables pure PyTorch users to scale their existing code on any kind
+    of device while retaining full control over their own loops and optimization logic."""
+
+    homepage = "https://github.com/Lightning-AI/lightning"
+    pypi = "lightning-lite/lightning-lite-1.8.0.tar.gz"
+
+    maintainers = ["adamjstewart"]
+
+    version("1.8.0", sha256="a71940409d3d1a5bb20f63716c86a745157ce30100f1c16600dfe33d9b657955")
+
+    # src/lightning_lite/__setup__.py
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    # requirements/lite/base.txt
+    depends_on("py-numpy@1.17.2:", type=("build", "run"))
+    depends_on("py-torch@1.9:", type=("build", "run"))
+    depends_on("py-fsspec@2021.06.1:+http", type=("build", "run"))
+    depends_on("py-packaging@17:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-lightning-utilities/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning-utilities/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLightningUtilities(PythonPackage):
+    """Common Python utilities and GitHub Actions in Lightning Ecosystem"""
+
+    homepage = "https://github.com/Lightning-AI/utilities"
+    pypi = "lightning-utilities/lightning-utilities-0.4.1.tar.gz"
+
+    maintainers = ["adamjstewart"]
+
+    version("0.4.1", sha256="969697b0debffd808d4cf3b74af4952f82bf6726f4ce561119037871547690a5")
+    version("0.4.0", sha256="961c29774c2c8303e0a2f6e6512a2e21e1d8acaf6df182865667af4a51bc176c")
+    version("0.3.0", sha256="d769ab9b76ebdee3243d1051d509aafee57d7947734ddc22977deef8a6427f2f")
+
+    # setup.py
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    # requirements/base.txt
+    depends_on("py-importlib-metadata@4:", when="@0.4.1: ^python@:3.7", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-fire", when="@0.3.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -14,6 +14,7 @@ class PyPytorchLightning(PythonPackage):
 
     maintainers = ["adamjstewart"]
 
+    version("1.8.0", sha256="deff9bc7978ecebc8f45e881adef65dc8d9f4554e88c3b064f80587f32ab158d")
     version("1.7.7", sha256="27c2dd01a18db2415168e3fa3775ccb5a1fa1e2961a50439ad9365507fe9d4ae")
     version("1.7.6", sha256="93266c83f8340c100e41b3777bbab26dd2c20b4df3deccce3b8a15652326b9c8")
     version("1.7.5", sha256="a5838ae990f0eef9a894fa863be3bc1f5594d2abba7848fb21317ba3e885d7cd")
@@ -34,21 +35,26 @@ class PyPytorchLightning(PythonPackage):
     version("1.3.8", sha256="60b0a3e464d394864dae4c8d251afa7aa453644a19bb7672f5ee400343cdf7b0")
     version("1.2.10", sha256="2d8365e30ded0c20e73ce6e5b6028478ae460b8fd33727df2275666df005a301")
 
+    # src/pytorch_lightning/__setup__.py
     depends_on("python@3.7:", when="@1.6:", type=("build", "run"))
     depends_on("python@3.6:", when="@:1.5", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+
+    # requirements/pytorch/base.txt
     depends_on("py-numpy@1.17.2:", when="@1.3:", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", when="@:1.2", type=("build", "run"))
     depends_on("py-torch@1.9:", when="@1.7:", type=("build", "run"))
     depends_on("py-torch@1.8:", when="@1.6:", type=("build", "run"))
     depends_on("py-torch@1.6:", when="@1.4:1.5", type=("build", "run"))
     depends_on("py-torch@1.4:", when="@:1.3", type=("build", "run"))
+    depends_on("py-lightning-lite@1.8.0", when="@1.8.0", type=("build", "run"))
     depends_on("py-tqdm@4.57.0:", when="@1.6.3:", type=("build", "run"))
     depends_on("py-tqdm@4.41.0:", when="@:1.6.2", type=("build", "run"))
     depends_on("py-pyyaml@5.4:", when="@1.6:", type=("build", "run"))
     depends_on("py-pyyaml@5.1:", when="@1.4:1.5", type=("build", "run"))
     depends_on("py-pyyaml@5.1:5.4.1", when="@1.3", type=("build", "run"))
     depends_on("py-pyyaml@5.1:5.3,5.5:", when="@:1.2", type=("build", "run"))
+    depends_on("py-fsspec@2021.06.1:+http", when="@1.8:", type=("build", "run"))
     depends_on("py-fsspec@2021.05.0:2021.05,2021.06.1:+http", when="@1.3:", type=("build", "run"))
     depends_on("py-fsspec@0.8.1:+http", when="@:1.2", type=("build", "run"))
     depends_on("py-tensorboard@2.9.1:", when="@1.7:", type=("build", "run"))
@@ -59,14 +65,17 @@ class PyPytorchLightning(PythonPackage):
     depends_on("py-torchmetrics@0.4.0:", when="@1.4", type=("build", "run"))
     depends_on("py-torchmetrics@0.2.0:", when="@1.3", type=("build", "run"))
     depends_on("py-torchmetrics@0.2.0", when="@:1.2", type=("build", "run"))
-    depends_on("py-pydeprecate@0.3.1:", when="@1.6.4:", type=("build", "run"))
-    depends_on("py-pydeprecate@0.3.1:0.3", when="@1.6:1.6.3", type=("build", "run"))
-    depends_on("py-pydeprecate@0.3.1", when="@1.4:1.5", type=("build", "run"))
-    depends_on("py-pydeprecate@0.3.0", when="@1.3", type=("build", "run"))
     depends_on("py-packaging@17.0:", when="@1.3:", type=("build", "run"))
     depends_on("py-packaging", when="@:1.2", type=("build", "run"))
     depends_on("py-typing-extensions@4.0.0:", when="@1.6:", type=("build", "run"))
     depends_on("py-typing-extensions", when="@1.4:1.5", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.3", when="@1.8:", type=("build", "run"))
+
+    # Historical dependencies
     depends_on("py-future@0.17.1:", when="@:1.5", type=("build", "run"))
     depends_on("pil@:8.2,8.3.1:", when="@1.3", type=("build", "run"))
     depends_on("py-protobuf@:3.20.1", when="@1.6.4:1.6", type="build")
+    depends_on("py-pydeprecate@0.3.1:", when="@1.6.4:1.7", type=("build", "run"))
+    depends_on("py-pydeprecate@0.3.1:0.3", when="@1.6:1.6.3", type=("build", "run"))
+    depends_on("py-pydeprecate@0.3.1", when="@1.4:1.5", type=("build", "run"))
+    depends_on("py-pydeprecate@0.3.0", when="@1.3", type=("build", "run"))


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 (arm64) with Python 3.9.13 and Apple Clang 14.0.0.

https://github.com/Lightning-AI/lightning/releases