### PR TITLE
rempi %oneapi: add -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/rempi/package.py
+++ b/var/spack/repos/builtin/packages/rempi/package.py
@@ -23,6 +23,13 @@ class Rempi(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("libpciaccess", type="link")
 
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2022.2.0:"):
+                iflags.append("-Wno-error=implicit-function-declaration")
+        return (iflags, None, None)
+
     def setup_build_environment(self, env):
         if self.spec.satisfies("%cce"):
             env.set("MPICC", "mpicc")


### PR DESCRIPTION
Needed to avert this error w/ `%oneapi@2022.2.0`
```
...
  >> 1091    example1.c:55:7: error: call to undeclared function 'usleep'; ISO 
             C99 and later do not support implicit function declarations [-Wimp
             licit-function-declaration]
     1092          usleep(rand() % 10 * 10000);
     1093          ^
     1094    1 error generated.
  >> 1095    make[2]: *** [Makefile:414: example1.o] Error 1
     1096    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-remp
             i-1.1.0-vqbrstze3sho62zvsguglkfoy5tt3x4t/spack-src/example'
  >> 1097    make[1]: *** [Makefile:415: all-recursive] Error 1
     1098    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-remp
             i-1.1.0-vqbrstze3sho62zvsguglkfoy5tt3x4t/spack-src'
  >> 1099    make: *** [Makefile:346: all] Error 2
```

FYI @wspear 
CC @lee218llnl @lukebroskop 