### PR TITLE
package_qgis_fix_pythonpath

### DIFF
--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -241,8 +241,9 @@ class Qgis(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        # python module isn't located at the standard path
-        env.prepend_path("PYTHONPATH", self.prefix.share.qgis.python)
+        if '+bindings' in self.spec:
+            # python module isn't located at the standard path
+            env.prepend_path("PYTHONPATH", self.prefix.share.qgis.python)
 
     def check(self):
         """The tests of fail without access to an X server, cant run on build servers"""

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -240,6 +240,10 @@ class Qgis(CMakePackage):
             args.append("-DWITH_GRASS7=OFF")
         return args
 
+    def setup_run_environment(self, env):
+        # python module isn't located at the standard path
+        env.prepend_path("PYTHONPATH", self.prefix.share.qgis.python)
+
     def check(self):
         """The tests of fail without access to an X server, cant run on build servers"""
         pass

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -241,7 +241,7 @@ class Qgis(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        if '+bindings' in self.spec:
+        if "+bindings" in self.spec:
             # python module isn't located at the standard path
             env.prepend_path("PYTHONPATH", self.prefix.share.qgis.python)
 


### PR DESCRIPTION
set pythonpath correctly so that `import qgis` also works in a regular python interpreter in addition to qgis's own python_console.
