### PR TITLE
demote warning for no source id to debug message

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1647,7 +1647,7 @@ class PackageBase(six.with_metaclass(PackageMeta, WindowsRPathMeta, PackageViewM
                 from_local_sources = env and env.is_develop(self.spec)
                 if self.has_code and not self.spec.external and not from_local_sources:
                     message = "Missing a source id for {s.name}@{s.version}"
-                    tty.warn(message.format(s=self))
+                    tty.debug(message.format(s=self))
                 hash_content.append("".encode("utf-8"))
             else:
                 hash_content.append(source_id.encode("utf-8"))

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -591,6 +591,16 @@ def linux_os():
     return LinuxOS(name=name, version=version)
 
 
+@pytest.fixture(scope="function")
+def debug_output():
+    saved = tty.debug_level()
+    tty.set_debug(2)
+
+    yield
+
+    tty.set_debug(saved)
+
+
 @pytest.fixture(autouse=is_windows, scope="session")
 def platform_config():
     spack.config.add_default_platform_scope(spack.platforms.real_host().name)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -591,14 +591,14 @@ def linux_os():
     return LinuxOS(name=name, version=version)
 
 
-@pytest.fixture(scope="function")
-def debug_output():
-    saved = tty.debug_level()
-    tty.set_debug(2)
+@pytest.fixture
+def ensure_debug(monkeypatch):
+    current_debug_level = tty.debug_level()
+    tty.set_debug(1)
 
     yield
 
-    tty.set_debug(saved)
+    tty.set_debug(current_debug_level)
 
 
 @pytest.fixture(autouse=is_windows, scope="session")

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -429,7 +429,7 @@ def test_uninstall_by_spec_errors(mutable_database):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd):
+def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, debug_output):
     """Test install phases with the nosource package."""
     spec = Spec("nosource").concretized()
     pkg = spec.package
@@ -444,7 +444,7 @@ def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd)
 
 
 @pytest.mark.disable_clean_stage_check
-def test_nosource_bundle_pkg_install(install_mockery, mock_fetch, mock_packages, capfd):
+def test_nosource_bundle_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, debug_output):
     """Test install phases with the nosource-bundle package."""
     spec = Spec("nosource-bundle").concretized()
     pkg = spec.package

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -444,7 +444,9 @@ def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd,
 
 
 @pytest.mark.disable_clean_stage_check
-def test_nosource_bundle_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, ensure_debug):
+def test_nosource_bundle_pkg_install(
+    install_mockery, mock_fetch, mock_packages, capfd, ensure_debug
+):
     """Test install phases with the nosource-bundle package."""
     spec = Spec("nosource-bundle").concretized()
     pkg = spec.package

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -429,7 +429,7 @@ def test_uninstall_by_spec_errors(mutable_database):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, debug_output):
+def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, ensure_debug):
     """Test install phases with the nosource package."""
     spec = Spec("nosource").concretized()
     pkg = spec.package
@@ -444,7 +444,7 @@ def test_nosource_pkg_install(install_mockery, mock_fetch, mock_packages, capfd,
 
 
 @pytest.mark.disable_clean_stage_check
-def test_nosource_bundle_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, debug_output):
+def test_nosource_bundle_pkg_install(install_mockery, mock_fetch, mock_packages, capfd, ensure_debug):
     """Test install phases with the nosource-bundle package."""
     spec = Spec("nosource-bundle").concretized()
     pkg = spec.package

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -7,8 +7,6 @@ import sys
 
 import pytest
 
-import llnl.util.tty as tty
-
 import spack.install_test
 import spack.spec
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -20,16 +20,6 @@ def _true(*args, **kwargs):
     return True
 
 
-@pytest.fixture
-def ensure_debug(monkeypatch):
-    current_debug_level = tty.debug_level()
-    tty.set_debug(1)
-
-    yield
-
-    tty.set_debug(current_debug_level)
-
-
 def ensure_results(filename, expected):
     assert os.path.exists(filename)
     with open(filename, "r") as fd:


### PR DESCRIPTION
We've talked for ages about making this change -- this warning doesn't mean much to users, and only signifies that we have slightly less reproducibility for the current build. It belongs as a debug message, not normal output.