### PR TITLE
tests: fix group membership check in sbang tests.

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -505,8 +505,15 @@ def group_ids(uid=None):
 
     if uid is None:
         uid = getuid()
-    user = pwd.getpwuid(uid).pw_name
-    return [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
+
+    pwd_entry = pwd.getpwuid(uid)
+    user = pwd_entry.pw_name
+
+    # user's primary group id may not be listed in grp (i.e. /etc/group)
+    # you have to check pwd for that, so start the list with that
+    gids = [pwd_entry.pw_gid]
+
+    return sorted(set(gids + [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]))
 
 
 @system_path_filter(arg_slice=slice(1))

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -7,7 +7,6 @@
 Test that Spack's shebang filtering works correctly.
 """
 import filecmp
-import getpass
 import os
 import shutil
 import stat
@@ -273,6 +272,9 @@ def configure_group_perms():
     # and grp does not act on remote groups.
     # To ensure we find a group we can operate on, we get take the first group
     # listed which has the current user as a member.
+    gid = fs.group_ids(os.getuid())[0]
+    group_name = grp.getgrgid(gid).gr_name
+
     conf = syaml.load_config(
         """\
 all:
@@ -281,7 +283,7 @@ all:
     write: group
     group: {0}
 """.format(
-            [g.gr_name for g in grp.getgrall() if getpass.getuser() in g.gr_mem][0]
+            group_name
         )
     )
     spack.config.set("packages", conf, scope="user")


### PR DESCRIPTION
Fixes `develop`, which is broken by this test.

Fixes an issue on the RHEL8 UBI container where this test would fail because `gr_mem` was empty for every entry in the `grp` DB.

You have to check *both* the `pwd` database (which has primary groups) and `grp` (which has other groups) to do this correctly.

- [x] update `llnl.util.filesystem.group_ids()` to do this
- [x] use it in the `sbang` test