### PR TITLE
remove `deptype_query` remnants and fix incorrect `deptypes` kwarg 

### DIFF
--- a/lib/spack/spack/build_systems/lua.py
+++ b/lib/spack/spack/build_systems/lua.py
@@ -76,7 +76,7 @@ class LuaBuilder(spack.builder.Builder):
     def generate_luarocks_config(self, pkg, spec, prefix):
         spec = self.pkg.spec
         table_entries = []
-        for d in spec.traverse(deptypes=("build", "run")):
+        for d in spec.traverse(deptype=("build", "run")):
             if d.package.extends(self.pkg.extendee_spec):
                 table_entries.append(self._generate_tree_line(d.name, d.prefix))
 

--- a/lib/spack/spack/build_systems/lua.py
+++ b/lib/spack/spack/build_systems/lua.py
@@ -76,7 +76,7 @@ class LuaBuilder(spack.builder.Builder):
     def generate_luarocks_config(self, pkg, spec, prefix):
         spec = self.pkg.spec
         table_entries = []
-        for d in spec.traverse(deptypes=("build", "run"), deptype_query="run"):
+        for d in spec.traverse(deptypes=("build", "run")):
             if d.package.extends(self.pkg.extendee_spec):
                 table_entries.append(self._generate_tree_line(d.name, d.prefix))
 

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -115,7 +115,7 @@ class LuaImplPackage(MakefilePackage):
 
     def _setup_dependent_env_helper(self, env, dependent_spec):
         lua_paths = []
-        for d in dependent_spec.traverse(deptypes=("build", "run")):
+        for d in dependent_spec.traverse(deptype=("build", "run")):
             if d.package.extends(self.spec):
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib64_dir))

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -115,7 +115,7 @@ class LuaImplPackage(MakefilePackage):
 
     def _setup_dependent_env_helper(self, env, dependent_spec):
         lua_paths = []
-        for d in dependent_spec.traverse(deptypes=("build", "run"), deptype_query="run"):
+        for d in dependent_spec.traverse(deptypes=("build", "run")):
             if d.package.extends(self.spec):
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib64_dir))

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -355,12 +355,12 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 maker()
                 maker("install")
 
-    def _setup_dependent_env(self, env, dependent_spec, deptypes):
+    def _setup_dependent_env(self, env, dependent_spec, deptype):
         """Set PATH and PERL5LIB to include the extension and
         any other perl extensions it depends on,
         assuming they were installed with INSTALL_BASE defined."""
         perl_lib_dirs = []
-        for d in dependent_spec.traverse(deptype=deptypes):
+        for d in dependent_spec.traverse(deptype=deptype):
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
         if perl_lib_dirs:
@@ -370,10 +370,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             env.append_path("PATH", self.prefix.bin)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self._setup_dependent_env(env, dependent_spec, deptypes=("build", "run", "test"))
+        self._setup_dependent_env(env, dependent_spec, deptype=("build", "run", "test"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        self._setup_dependent_env(env, dependent_spec, deptypes=("run",))
+        self._setup_dependent_env(env, dependent_spec, deptype=("run",))
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before perl modules' install() methods.

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -198,7 +198,7 @@ class R(AutotoolsPackage):
         # Set R_LIBS to include the library dir for the
         # extension and any other R extensions it depends on.
         r_libs_path = []
-        for d in dependent_spec.traverse(deptype=("build", "run"), deptype_query="run"):
+        for d in dependent_spec.traverse(deptype=("build", "run")):
             if d.package.extends(self.spec):
                 r_libs_path.append(join_path(d.prefix, self.r_lib_dir))
 


### PR DESCRIPTION
This is not a thing since 2017, it's just that it errors now because
`traverse` doesn't ignore unused `**kwargs` since #33406.

(Also, probably `traverse` is wrong here, `dependencies` was intended?
Why look for build deps of build deps of ... maybe @glennpj  knows.)