### PR TITLE
SEACAS: further refactor

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -234,23 +234,23 @@ class Seacas(CMakePackage):
 
             if "+applications" in spec:
                 # C / C++ applications
-                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu", 
-                            "Exo2mat", "Exo_format", "Exodiff", "Mat2exo", "Nas2exo", 
+                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu",
+                            "Exo2mat", "Exo_format", "Exodiff", "Mat2exo", "Nas2exo",
                             "Nemslice", "Nemspread", "Slice", "Zellij"):
                     options.append(define(project_name_base + "_ENABLE_SEACAS" + app, True))
                 # Fortran-based applications
                 for app in ("Explore", "Grepos"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, 
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app,
                                                 "fortran"))
 
             if "+legacy" in spec:
                 # Legacy applications -- all are fortran-based except Nemesis
                 options.append(define(project_name_base + "_ENABLE_SEACASNemesis", True))
 
-                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab", 
-                            "Exotec2", "Exotxt", "Fastq", "Gen3D", "Genshell", "Gjoin", 
+                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab",
+                            "Exotec2", "Exotxt", "Fastq", "Gen3D", "Genshell", "Gjoin",
                             "Mapvar", "Mapvar-kd", "Numbers", "Txtexo"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, 
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app,
                                                 "fortran"))
 
         # ##################### Dependencies ##########################
@@ -270,10 +270,10 @@ class Seacas(CMakePackage):
                     define("METIS_LIBRARY_NAMES", "metis"),
                     define("TPL_METIS_INCLUDE_DIRS", spec["metis"].prefix.include),
                     define("TPL_ENABLE_ParMETIS", True),
-                    define("ParMETIS_LIBRARY_DIRS", 
+                    define("ParMETIS_LIBRARY_DIRS",
                            [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib]),
                     define("ParMETIS_LIBRARY_NAMES", ["parmetis", "metis"]),
-                    define("TPL_ParMETIS_INCLUDE_DIRS", 
+                    define("TPL_ParMETIS_INCLUDE_DIRS",
                            [spec["parmetis"].prefix.include, spec["metis"].prefix.include]),
                 ]
             )

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -207,7 +207,6 @@ class Seacas(CMakePackage):
                 ]
             )
 
-
         # ########## What applications should be built #############
         # Check whether they want everything; if so, do the easy way...
         if "+applications" in spec and "+legacy" in spec:
@@ -235,20 +234,24 @@ class Seacas(CMakePackage):
 
             if "+applications" in spec:
                 # C / C++ applications
-                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu", "Exo2mat", "Exo_format",
-                            "Exodiff", "Mat2exo", "Nas2exo", "Nemslice", "Nemspread", "Slice", "Zellij"):
+                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu", 
+                            "Exo2mat", "Exo_format", "Exodiff", "Mat2exo", "Nas2exo", 
+                            "Nemslice", "Nemspread", "Slice", "Zellij"):
                     options.append(define(project_name_base + "_ENABLE_SEACAS" + app, True))
                 # Fortran-based applications
                 for app in ("Explore", "Grepos"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran"))
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, 
+                                                "fortran"))
 
             if "+legacy" in spec:
                 # Legacy applications -- all are fortran-based except Nemesis
                 options.append(define(project_name_base + "_ENABLE_SEACASNemesis", True))
 
-                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab", "Exotec2", "Exotxt",
-                            "Fastq", "Gen3D", "Genshell", "Gjoin", "Mapvar", "Mapvar-kd", "Numbers", "Txtexo"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran"))
+                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab", 
+                            "Exotec2", "Exotxt", "Fastq", "Gen3D", "Genshell", "Gjoin", 
+                            "Mapvar", "Mapvar-kd", "Numbers", "Txtexo"):
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, 
+                                                "fortran"))
 
         # ##################### Dependencies ##########################
         # Always need NetCDF-C
@@ -267,9 +270,11 @@ class Seacas(CMakePackage):
                     define("METIS_LIBRARY_NAMES", "metis"),
                     define("TPL_METIS_INCLUDE_DIRS", spec["metis"].prefix.include),
                     define("TPL_ENABLE_ParMETIS", True),
-                    define("ParMETIS_LIBRARY_DIRS", [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib]),
+                    define("ParMETIS_LIBRARY_DIRS", 
+                           [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib]),
                     define("ParMETIS_LIBRARY_NAMES", ["parmetis", "metis"]),
-                    define("TPL_ParMETIS_INCLUDE_DIRS", [spec["parmetis"].prefix.include, spec["metis"].prefix.include]),
+                    define("TPL_ParMETIS_INCLUDE_DIRS", 
+                           [spec["parmetis"].prefix.include, spec["metis"].prefix.include]),
                 ]
             )
         elif "+metis" in spec:

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -234,24 +234,54 @@ class Seacas(CMakePackage):
 
             if "+applications" in spec:
                 # C / C++ applications
-                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu",
-                            "Exo2mat", "Exo_format", "Exodiff", "Mat2exo", "Nas2exo",
-                            "Nemslice", "Nemspread", "Slice", "Zellij"):
+                for app in (
+                    "Aprepro",
+                    "Aprepro_lib",
+                    "Conjoin",
+                    "Cpup",
+                    "Ejoin",
+                    "Epu",
+                    "Exo2mat",
+                    "Exo_format",
+                    "Exodiff",
+                    "Mat2exo",
+                    "Nas2exo",
+                    "Nemslice",
+                    "Nemspread",
+                    "Slice",
+                    "Zellij",
+                ):
                     options.append(define(project_name_base + "_ENABLE_SEACAS" + app, True))
                 # Fortran-based applications
                 for app in ("Explore", "Grepos"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app,
-                                                "fortran"))
+                    options.append(
+                        from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran")
+                    )
 
             if "+legacy" in spec:
                 # Legacy applications -- all are fortran-based except Nemesis
                 options.append(define(project_name_base + "_ENABLE_SEACASNemesis", True))
 
-                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab",
-                            "Exotec2", "Exotxt", "Fastq", "Gen3D", "Genshell", "Gjoin",
-                            "Mapvar", "Mapvar-kd", "Numbers", "Txtexo"):
-                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app,
-                                                "fortran"))
+                for app in (
+                    "Algebra",
+                    "Blot",
+                    "Ex1ex2v2",
+                    "Ex2ex1v2",
+                    "Exomatlab",
+                    "Exotec2",
+                    "Exotxt",
+                    "Fastq",
+                    "Gen3D",
+                    "Genshell",
+                    "Gjoin",
+                    "Mapvar",
+                    "Mapvar-kd",
+                    "Numbers",
+                    "Txtexo",
+                ):
+                    options.append(
+                        from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran")
+                    )
 
         # ##################### Dependencies ##########################
         # Always need NetCDF-C
@@ -270,11 +300,15 @@ class Seacas(CMakePackage):
                     define("METIS_LIBRARY_NAMES", "metis"),
                     define("TPL_METIS_INCLUDE_DIRS", spec["metis"].prefix.include),
                     define("TPL_ENABLE_ParMETIS", True),
-                    define("ParMETIS_LIBRARY_DIRS",
-                           [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib]),
+                    define(
+                        "ParMETIS_LIBRARY_DIRS",
+                        [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib],
+                    ),
                     define("ParMETIS_LIBRARY_NAMES", ["parmetis", "metis"]),
-                    define("TPL_ParMETIS_INCLUDE_DIRS",
-                           [spec["parmetis"].prefix.include, spec["metis"].prefix.include]),
+                    define(
+                        "TPL_ParMETIS_INCLUDE_DIRS",
+                        [spec["parmetis"].prefix.include, spec["metis"].prefix.include],
+                    ),
                 ]
             )
         elif "+metis" in spec:

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -129,24 +129,31 @@ class Seacas(CMakePackage):
     variant("x11", default=True, description="Compile with X11")
 
     # ###################### Dependencies ##########################
+    depends_on("cmake@3.17:", type="build")
+    depends_on("mpi", when="+mpi")
+
+    # Always depends on netcdf-c
     depends_on("netcdf-c@4.8.0:+mpi+parallel-netcdf", when="+mpi")
     depends_on("netcdf-c@4.8.0:~mpi", when="~mpi")
     depends_on("hdf5+hl~mpi", when="~mpi")
-    depends_on("cgns@4.2.0:+mpi+scoping", when="+cgns +mpi")
-    depends_on("cgns@4.2.0:~mpi+scoping", when="+cgns ~mpi")
+
     depends_on("fmt@8.1.0:", when="@2022-03-04:2022-05-16")
     depends_on("fmt@9.1.0:", when="@2022-10-14")
+    depends_on("matio", when="+matio")
+    depends_on("libx11", when="+x11")
+
+    with when("+cgns"):
+        depends_on("cgns@4.2.0:+mpi+scoping", when="+mpi")
+        depends_on("cgns@4.2.0:~mpi+scoping", when="~mpi")
 
     with when("+adios2"):
         depends_on("adios2@master")
         depends_on("adios2~mpi", when="~mpi")
         depends_on("adios2+mpi", when="+mpi")
 
-    depends_on("matio", when="+matio")
     with when("+metis"):
         depends_on("metis+int64+real64")
         depends_on("parmetis+int64", when="+mpi")
-    depends_on("libx11", when="+x11")
 
     # The Faodel TPL is only supported in seacas@2021-04-05:
     depends_on("faodel@1.2108.1:+mpi", when="+faodel +mpi")
@@ -156,11 +163,6 @@ class Seacas(CMakePackage):
         when="@:2021-01-20",
         msg="The Faodel TPL is only compatible with @2021-04-05 and later.",
     )
-
-    # MPI related dependencies
-    depends_on("mpi", when="+mpi")
-
-    depends_on("cmake@3.1:", type="build")
 
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.lib)
@@ -181,40 +183,30 @@ class Seacas(CMakePackage):
 
         options.extend(
             [
+                define(project_name_base + "_ENABLE_TESTS", True),
+                define(project_name_base + "_ENABLE_CXX11", True),
+                define(project_name_base + "_ENABLE_Kokkos", False),
+                define(project_name_base + "_HIDE_DEPRECATED_CODE", False),
                 from_variant("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "shared"),
                 from_variant("BUILD_SHARED_LIBS", "shared"),
                 from_variant("SEACASExodus_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("SEACASIoss_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("TPL_ENABLE_X11", "x11"),
-            ]
-        )
-
-        if "+mpi" in spec:
-            options.extend(
-                [
-                    "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,
-                    "-DCMAKE_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
-                    "-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
-                    define("TPL_ENABLE_MPI", True),
-                    "-DMPI_BASE_DIR:PATH=%s" % spec["mpi"].prefix,
-                ]
-            )
-        else:
-            options.extend(
-                [
-                    define("TPL_ENABLE_MPI", False),
-                ]
-            )
-
-        options.extend(
-            [
-                define(project_name_base + "_ENABLE_TESTS", True),
-                define(project_name_base + "_ENABLE_CXX11", True),
-                define(project_name_base + "_ENABLE_Kokkos", False),
-                define(project_name_base + "_HIDE_DEPRECATED_CODE", False),
                 from_variant(project_name_base + "_ENABLE_Fortran", "fortran"),
             ]
         )
+
+        options.append(from_variant("TPL_ENABLE_MPI", "mpi"))
+        if "+mpi" in spec:
+            options.extend(
+                [
+                    define("CMAKE_C_COMPILER", spec["mpi"].mpicc),
+                    define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx),
+                    define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc),
+                    define("MPI_BASE_DIR", spec["mpi"].prefix),
+                ]
+            )
+
 
         # ########## What applications should be built #############
         # Check whether they want everything; if so, do the easy way...
@@ -242,56 +234,28 @@ class Seacas(CMakePackage):
             )
 
             if "+applications" in spec:
-                options.extend(
-                    [
-                        define(project_name_base + "_ENABLE_SEACASAprepro", True),
-                        define(project_name_base + "_ENABLE_SEACASAprepro_lib", True),
-                        define(project_name_base + "_ENABLE_SEACASConjoin", True),
-                        define(project_name_base + "_ENABLE_SEACASCpup", True),
-                        define(project_name_base + "_ENABLE_SEACASEjoin", True),
-                        define(project_name_base + "_ENABLE_SEACASEpu", True),
-                        define(project_name_base + "_ENABLE_SEACASExo2mat", True),
-                        define(project_name_base + "_ENABLE_SEACASExo_format", True),
-                        define(project_name_base + "_ENABLE_SEACASExodiff", True),
-                        from_variant(project_name_base + "_ENABLE_SEACASExplore", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASGrepos", "fortran"),
-                        define(project_name_base + "_ENABLE_SEACASMat2exo", True),
-                        define(project_name_base + "_ENABLE_SEACASNas2exo", True),
-                        define(project_name_base + "_ENABLE_SEACASNemslice", True),
-                        define(project_name_base + "_ENABLE_SEACASNemspread", True),
-                        define(project_name_base + "_ENABLE_SEACASSlice", True),
-                        define(project_name_base + "_ENABLE_SEACASZellij", True),
-                    ]
-                )
+                # C / C++ applications
+                for app in ("Aprepro", "Aprepro_lib", "Conjoin", "Cpup", "Ejoin", "Epu", "Exo2mat", "Exo_format",
+                            "Exodiff", "Mat2exo", "Nas2exo", "Nemslice", "Nemspread", "Slice", "Zellij"):
+                    options.append(define(project_name_base + "_ENABLE_SEACAS" + app, True))
+                # Fortran-based applications
+                for app in ("Explore", "Grepos"):
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran"))
 
             if "+legacy" in spec:
-                options.extend(
-                    [
-                        define(project_name_base + "_ENABLE_SEACASNemesis", True),
-                        from_variant(project_name_base + "_ENABLE_SEACASAlgebra", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASBlot", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASEx1ex2v2", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASEx2ex1v2", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASExomatlab", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASExotec2", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASExotxt", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASFastq", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASGen3D", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASGenshell", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASGjoin", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASMapvar", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASMapvar-kd", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASNumbers", "fortran"),
-                        from_variant(project_name_base + "_ENABLE_SEACASTxtexo", "fortran"),
-                    ]
-                )
+                # Legacy applications -- all are fortran-based except Nemesis
+                options.append(define(project_name_base + "_ENABLE_SEACASNemesis", True))
+
+                for app in ("Algebra", "Blot", "Ex1ex2v2", "Ex2ex1v2", "Exomatlab", "Exotec2", "Exotxt",
+                            "Fastq", "Gen3D", "Genshell", "Gjoin", "Mapvar", "Mapvar-kd", "Numbers", "Txtexo"):
+                    options.append(from_variant(project_name_base + "_ENABLE_SEACAS" + app, "fortran"))
 
         # ##################### Dependencies ##########################
         # Always need NetCDF-C
         options.extend(
             [
                 define("TPL_ENABLE_Netcdf", True),
-                "-DNetCDF_ROOT:PATH=%s" % spec["netcdf-c"].prefix,
+                define("NetCDF_ROOT", spec["netcdf-c"].prefix),
             ]
         )
 
@@ -299,24 +263,22 @@ class Seacas(CMakePackage):
             options.extend(
                 [
                     define("TPL_ENABLE_METIS", True),
-                    "-DMETIS_LIBRARY_DIRS=%s" % spec["metis"].prefix.lib,
-                    "-DMETIS_LIBRARY_NAMES=metis",
-                    "-DTPL_METIS_INCLUDE_DIRS=%s" % spec["metis"].prefix.include,
+                    define("METIS_LIBRARY_DIRS", spec["metis"].prefix.lib),
+                    define("METIS_LIBRARY_NAMES", "metis"),
+                    define("TPL_METIS_INCLUDE_DIRS", spec["metis"].prefix.include),
                     define("TPL_ENABLE_ParMETIS", True),
-                    "-DParMETIS_LIBRARY_DIRS=%s;%s"
-                    % (spec["parmetis"].prefix.lib, spec["metis"].prefix.lib),
-                    "-DParMETIS_LIBRARY_NAMES=parmetis;metis",
-                    "-DTPL_ParMETIS_INCLUDE_DIRS=%s;%s"
-                    % (spec["parmetis"].prefix.include, spec["metis"].prefix.include),
+                    define("ParMETIS_LIBRARY_DIRS", [spec["parmetis"].prefix.lib, spec["metis"].prefix.lib]),
+                    define("ParMETIS_LIBRARY_NAMES", ["parmetis", "metis"]),
+                    define("TPL_ParMETIS_INCLUDE_DIRS", [spec["parmetis"].prefix.include, spec["metis"].prefix.include]),
                 ]
             )
         elif "+metis" in spec:
             options.extend(
                 [
                     define("TPL_ENABLE_METIS", True),
-                    "-DMETIS_LIBRARY_DIRS=%s" % spec["metis"].prefix.lib,
-                    "-DMETIS_LIBRARY_NAMES=metis",
-                    "-DTPL_METIS_INCLUDE_DIRS=%s" % spec["metis"].prefix.include,
+                    define("METIS_LIBRARY_DIRS", spec["metis"].prefix.lib),
+                    define("METIS_LIBRARY_NAMES", "metis"),
+                    define("TPL_METIS_INCLUDE_DIRS", spec["metis"].prefix.include),
                     define("TPL_ENABLE_ParMETIS", False),
                 ]
             )
@@ -328,59 +290,28 @@ class Seacas(CMakePackage):
                 ]
             )
 
+        options.append(from_variant("TPL_ENABLE_Matio", "matio"))
         if "+matio" in spec:
-            options.extend(
-                [
-                    define("TPL_ENABLE_Matio", True),
-                    "-DMatio_ROOT:PATH=%s" % spec["matio"].prefix,
-                ]
-            )
-        else:
-            options.extend(
-                [
-                    define("TPL_ENABLE_Matio", False),
-                ]
-            )
+            options.append(define("Matio_ROOT", spec["matio"].prefix))
 
+        options.append(from_variant("TPL_ENABLE_CGNS", "cgns"))
         if "+cgns" in spec:
-            options.extend(
-                [
-                    define("TPL_ENABLE_CGNS", True),
-                    "-DCGNS_ROOT:PATH=%s" % spec["cgns"].prefix,
-                ]
-            )
-        else:
-            options.extend(
-                [
-                    define("TPL_ENABLE_CGNS", False),
-                ]
-            )
+            options.append(define("CGNS_ROOT", spec["cgns"].prefix))
 
         options.append(from_variant("TPL_ENABLE_Faodel", "faodel"))
-
         for pkg in ("Faodel", "BOOST"):
             if pkg.lower() in spec:
                 options.append(define(pkg + "_ROOT", spec[pkg.lower()].prefix))
 
+        options.append(from_variant("TPL_ENABLE_ADIOS2", "adios2"))
         if "+adios2" in spec:
-            options.extend(
-                [
-                    define("TPL_ENABLE_ADIOS2", True),
-                    "-DADIOS2_ROOT:PATH=%s" % spec["adios2"].prefix,
-                ]
-            )
-        else:
-            options.extend(
-                [
-                    define("TPL_ENABLE_ADIOS2", False),
-                ]
-            )
+            options.append(define("ADIOS2_ROOT", spec["adios2"].prefix))
 
         # ################# RPath Handling ######################
         if sys.platform == "darwin" and macos_version() >= Version("10.12"):
             # use @rpath on Sierra due to limit of dynamic loader
-            options.append("-DCMAKE_MACOSX_RPATH:BOOL=ON")
+            options.append(define("CMAKE_MACOSX_RPATH", True))
         else:
-            options.append("-DCMAKE_INSTALL_NAME_DIR:PATH=%s" % self.prefix.lib)
+            options.append(define("CMAKE_INSTALL_NAME_DIR", self.prefix.lib))
 
         return options


### PR DESCRIPTION
* Replaced all cmake `"-Dsomething=other"` lines with either `define`
or `define_from_variant` functions.

* Consolidated the application (fortran, legacy, all) enabling lines
into loops over the code names.  Easier to see categorization of
applications and also to add/move/remove an application

* Reordered some lines; general cleanup and restructuring.