### PR TITLE
ECP-SDK: fixup +hdf5 +cuda contraints

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -113,7 +113,18 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on("faodel+shared+mpi network=libfabric", when="+faodel", propagate=["hdf5"])
 
     dav_sdk_depends_on("hdf5@1.12: +shared+mpi", when="+hdf5", propagate=["fortran"])
-    dav_sdk_depends_on("hdf5-vfd-gds@1.0.2:", when="+cuda+hdf5", propagate=cuda_arch_variants)
+    # hdf5-vfd-gds needs cuda@11.7.1 or later, only enable when 11.7.1+ available.
+    depends_on(
+        "hdf5-vfd-gds@1.0.2:",
+        when="+cuda+hdf5^cuda@11.7.1:",
+    )
+    for cuda_arch in cuda_arch_variants:
+        depends_on(
+            "hdf5-vfd-gds@1.0.2: {0}".format(cuda_arch),
+            when="+cuda+hdf5 {0} ^cuda@11.7.1:".format(cuda_arch),
+        )
+    conflicts("~cuda", when="^hdf5-vfd-gds@1.0.2:")
+    conflicts("~hdf5", when="^hdf5-vfd-gds@1.0.2:")
 
     dav_sdk_depends_on("parallel-netcdf+shared", when="+pnetcdf", propagate=["fortran"])
 

--- a/var/spack/repos/builtin/packages/hdf5-vfd-gds/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vfd-gds/package.py
@@ -23,6 +23,9 @@ class Hdf5VfdGds(CMakePackage, CudaPackage):
 
     # Dependencies
     conflicts("~cuda")
+    # Although cuFILE predates 11.7.0, it is not installed in a location the build
+    # system can obtaion via `find_library`.  Packaging issues fixed in 11.7.1.
+    conflicts("^cuda@:11.7.0")
     depends_on("cmake@3.12:", type="build")
     depends_on("hdf5@1.13.0:")
 


### PR DESCRIPTION
Only enable the hdf5-vfd-gds package if it can compile.

- hdf5-vfd-gds needs cuda@11.7.1+ to be able to `find_library` for cuFile.
- Only enable hdf5-vfd-gds in the sdk if cuda@11.7.1+ is available. If an earlier version of cuda is being used, do not depend on the hdf5-vfd-gds package at all.

Identified by: #33621, follow-up to: #33300

FYI @hyoklee @brtnfld we confirmed that `hdf5-vfd-gds@1.0.2` can build with `cuda@11.7.1` but not with `cuda@11.7.0` so we're just stamping that into the package.