### PR TITLE
Bugfix for spec objects modified by flag handlers

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -346,7 +346,7 @@ def set_compiler_environment_variables(pkg, env):
                 handler = pkg.flag_handler.__func__
             else:
                 handler = pkg.flag_handler.im_func
-        injf, envf, bsf = handler(pkg, flag, spec.compiler_flags[flag])
+        injf, envf, bsf = handler(pkg, flag, spec.compiler_flags[flag][:])
         inject_flags[flag] = injf or []
         env_flags[flag] = envf or []
         build_system_flags[flag] = bsf or []

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -140,6 +140,7 @@ class TestFlagHandlers(object):
         def test_flag_handler(self, name, flags):
             flags.append("-foo")
             return (flags, None, None)
+
         s = spack.spec.Spec("cmake-client").concretized()
         s.package.flag_handler = test_flag_handler
         spack.build_environment.setup_package(s.package, False)

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -135,3 +135,14 @@ class TestFlagHandlers(object):
             "-DCMAKE_CXX_STANDARD_LIBRARIES=-lfoo",
             "-DCMAKE_Fortran_STANDARD_LIBRARIES=-lfoo",
         }
+
+    def test_flag_handler_no_modify_specs(self, temp_env):
+        def test_flag_handler(self, name, flags):
+            flags.append("-foo")
+            return (flags, None, None)
+        s = spack.spec.Spec("cmake-client").concretized()
+        s.package.flag_handler = test_flag_handler
+        spack.build_environment.setup_package(s.package, False)
+
+        assert not s.compiler_flags["cflags"]
+        assert os.environ["SPACK_CFLAGS"] == "-foo"


### PR DESCRIPTION
Fixes #33680

This issue was introduced in #29761:

```
==> Installing ncurses-6.3-22hz6q6cvo3ep2uhrs3erpp2kogxncbn
==> No binary for ncurses-6.3-22hz6q6cvo3ep2uhrs3erpp2kogxncbn found: installing from source
==> Using cached archive: /spack/var/spack/cache/_source-cache/archive/97/97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059.tar.gz
==> No patches needed for ncurses
==> ncurses: Executing phase: 'autoreconf'
==> ncurses: Executing phase: 'configure'
==> ncurses: Executing phase: 'build'
==> ncurses: Executing phase: 'install'
==> Error: AttributeError: 'str' object has no attribute 'propagate'

The 'ncurses' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure

/spack/lib/spack/spack/build_environment.py:1075, in _setup_pkg_and_run:
       1072        tb_string = traceback.format_exc()
       1073
       1074        # build up some context from the offending package so we can
  >>   1075        # show that, too.
       1076        package_context = get_package_context(tb)
       1077
       1078        logfile = None
```

It turns out this was caused by a bug that had been around much longer, in which the flags were passed by reference to the flag_handler, and the flag_handler was modifying the spec object, not just the flags given to the build system. The scope of this bug was limited by the forking model in Spack, which is how it went under the radar for so long.

PR includes regression test.

@tgamblin @lee218llnl 