### PR TITLE
More jobs in Gitlab CI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -246,6 +246,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -243,6 +243,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -153,6 +153,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -164,6 +164,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -37,6 +37,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: when_possible
 
   config:
+    build_jobs: 256
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: when_possible
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -50,6 +50,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -216,6 +216,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.powerpc64le-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf '8096d202fe0a0c400b8c0573c4b9e009f2f10d2fa850a3f495340f16e9c42454 gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: when_possible
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: when_possible
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -269,6 +269,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -259,6 +259,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -90,6 +90,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -93,6 +93,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -96,6 +96,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -59,6 +59,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/spack

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -64,6 +64,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     concretizer: clingo
     install_tree:
       root: /home/software/radiuss

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     concretizer: clingo
     install_tree:
       root: /home/software/radiuss

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -67,6 +67,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -68,6 +68,7 @@ spack:
     script:
       - uname -a || true
       - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+      - nproc
       - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
       - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
       - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -6,7 +6,7 @@ spack:
     unify: false
 
   config:
-    build_jobs: 256
+    build_jobs: 32
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -6,6 +6,7 @@ spack:
     unify: false
 
   config:
+    build_jobs: 256
     install_tree:
       root: /home/software/spack
       padded_length: 512


### PR DESCRIPTION
Updated description:

The PR applies only to Gitlab pipelines (restricted now to x86 / aarch64), where we do CPU claims such as "at least 11000 milli-cpus" (whatever that is) but often get a node with 64 / 128 / 192 cores; in that case Spack caps to -j16, which is... not particularly getting the most out of it. @zackgalbreath showed an example where the LLVM Gitlab job took 3.5 hours (the actual build took 2h), with the above using -j128 it took only 20 minutes (the actual build 10 minutes).

Notice that setting `config:build_jobs` really only sets an _upperbound_, the effective value is determined by the number of _available jobs_ (whatever is allowed to the process; not physical # cores / threads)