### PR TITLE
Add zstd support for elfutils

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -46,6 +46,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     # Libraries for reading compressed DWARF sections.
     variant("bzip2", default=False, description="Support bzip2 compressed sections.")
     variant("xz", default=False, description="Support xz (lzma) compressed sections.")
+    variant("zstd", default=False, description="Support zstd compressed sections.", when="@0.182:")
 
     # Native language support from libintl.
     variant("nls", default=True, description="Enable Native Language Support.")
@@ -69,6 +70,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     depends_on("bzip2", type="link", when="+bzip2")
     depends_on("xz", type="link", when="+xz")
+    depends_on("zstd", type="link", when="+zstd")
     depends_on("zlib", type="link")
     depends_on("gettext", when="+nls")
     depends_on("m4", type="build")
@@ -113,6 +115,11 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
             args.append("--with-lzma=%s" % spec["xz"].prefix)
         else:
             args.append("--without-lzma")
+
+        if "+zstd" in spec:
+            args.append("--with-zstd=%s" % spec["zstd"].prefix)
+        else:
+            args.append("--without-zstd")
 
         # zlib is required
         args.append("--with-zlib=%s" % spec["zlib"].prefix)

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -106,20 +106,11 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         spec = self.spec
         args = []
 
-        if "+bzip2" in spec:
-            args.append("--with-bzlib=%s" % spec["bzip2"].prefix)
-        else:
-            args.append("--without-bzlib")
+        args.extend(self.with_or_without("bzip2", activation_value="prefix"))
+        args.extend(self.with_or_without("xz", activation_value="prefix"))
 
-        if "+xz" in spec:
-            args.append("--with-lzma=%s" % spec["xz"].prefix)
-        else:
-            args.append("--without-lzma")
-
-        if "+zstd" in spec:
-            args.append("--with-zstd=%s" % spec["zstd"].prefix)
-        else:
-            args.append("--without-zstd")
+        with when("zstd"):  # zstd variant is available
+            args.extend(self.with_or_without("zstd", activation_value="prefix"))
 
         # zlib is required
         args.append("--with-zlib=%s" % spec["zlib"].prefix)

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -106,11 +106,17 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         spec = self.spec
         args = []
 
-        args.extend(self.with_or_without("bzip2", activation_value="prefix"))
-        args.extend(self.with_or_without("xz", activation_value="prefix"))
+        if "+bzip2" in spec:
+            args.append("--with-bzlib=%s" % spec["bzip2"].prefix)
+        else:
+            args.append("--without-bzlib")
 
-        with when("zstd"):  # zstd variant is available
-            args.extend(self.with_or_without("zstd", activation_value="prefix"))
+        if "+xz" in spec:
+            args.append("--with-lzma=%s" % spec["xz"].prefix)
+        else:
+            args.append("--without-lzma")
+
+        args.extend(self.with_or_without("zstd", activation_value="prefix"))
 
         # zlib is required
         args.append("--with-zlib=%s" % spec["zlib"].prefix)


### PR DESCRIPTION
Not defining `+zstd` implies `--without-zstd` flag to configure.

This avoids automatic library detection and thus make the build only depends on Spack installed dependencies. This was causing some problem on my Ubuntu 22.10 laptop with libzstd globally installed but not found later by `pkg_config`.

