### PR TITLE
Rust: don't apply constraints to nightly/beta versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-tokenizers/package.py
+++ b/var/spack/repos/builtin/packages/py-tokenizers/package.py
@@ -21,7 +21,9 @@ class PyTokenizers(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-rust", type="build")
 
-    # TODO: This package currently requires internet access to install.
-    # Also, a nightly or dev version of rust is required to build older versions.
+    # A nightly or dev version of rust is required to build older versions.
     # https://github.com/huggingface/tokenizers/issues/176
     # https://github.com/PyO3/pyo3/issues/5
+    depends_on("rust@nightly", when="@:0.10", type="build")
+
+    # TODO: This package currently requires internet access to install.

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -54,7 +54,7 @@ class Rust(Package):
     )
 
     depends_on("python@2.7:", type="build")
-    depends_on("python@2.7:2.8", when="@:1.43", type="build")
+    depends_on("python@2.7:2.8", when="@0:1.43", type="build")
     depends_on("gmake@3.81:", type="build")
     depends_on("cmake@3.4.3:", type="build")
     depends_on("ninja", when="@1.48.0:", type="build")
@@ -63,7 +63,7 @@ class Rust(Package):
     depends_on("openssl@:1")
     depends_on("libssh2")
     # https://github.com/rust-lang/cargo/issues/10446
-    depends_on("libgit2@:1.3", when="@:1.60")
+    depends_on("libgit2@:1.3", when="@0:1.60")
     depends_on("libgit2")
 
     # Pre-release Versions


### PR DESCRIPTION
This is a follow-up to #33716. See https://github.com/spack/spack/issues/32444#issuecomment-1304278896 for a description of why this change is necessary.

TL;DR: `@nightly` doesn't behave like `@master` and is treated as older than all stable releases. By applying constraints like the Python 2 dependency only on older stable releases, it becomes possible to correctly concretize `@nightly`.