### PR TITLE
py-vermin: add latest version 1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -11,10 +11,11 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url = "https://github.com/netromdk/vermin/archive/v1.4.2.tar.gz"
+    url = "https://github.com/netromdk/vermin/archive/v1.5.0.tar.gz"
 
     maintainers = ["netromdk"]
 
+    version("1.5.0", sha256="77207385c9cea1f02053a8f2e7f2e8c945394cf37c44c70ce217cada077a2d17")
     version("1.4.2", sha256="c9a69420b610bfb25d5a2abd7da6edf0ae4329481a857ef6c5d71f602ed5c63d")
     version("1.4.1", sha256="ee69d5e84f0d446e0d6574ec60c428798de6e6c8d055589f65ac02f074a7da25")
     version("1.4.0", sha256="984773ed6af60329e700b39c58b7584032acbc908a00b5a76d1ce5468c825c70")


### PR DESCRIPTION
New version [1.5.0](https://github.com/netromdk/vermin/releases/tag/v1.5.0) with Python 3.11 support and general fixes.

@adamjstewart @alalazo 