### PR TITLE
Patch `fmt` for hipcc/dpcpp

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -13,6 +13,7 @@ class Fmt(CMakePackage):
 
     homepage = "https://fmt.dev/"
     url = "https://github.com/fmtlib/fmt/releases/download/7.1.3/fmt-7.1.3.zip"
+    maintainers = ["msimberg"]
 
     version("9.1.0", sha256="cceb4cb9366e18a5742128cb3524ce5f50e88b476f1e54737a47ffdf4df4c996")
     version("9.0.0", sha256="fc96dd2d2fdf2bded630787adba892c23cb9e35c6fd3273c136b0c57d4651ad6")

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -70,6 +70,13 @@ class Fmt(CMakePackage):
     # Only allow [[attributes]] on C++11 and higher
     patch("fmt-attributes-cpp11_4.1.0.patch", when="@4.1.0")
 
+    # Fix compilation with hipcc/dpcpp: https://github.com/fmtlib/fmt/issues/3005
+    patch(
+        "https://github.com/fmtlib/fmt/commit/0b0f7cfbfcebd021c910078003d413354bd843e2.patch?full_index=1",
+        sha256="08fb707bf8b4fc890d6eed29217ead666558cbae38f9249e22ddb82212f0eb4a",
+        when="@9.0.0:9.1.0",
+    )
+
     def cmake_args(self):
         spec = self.spec
         args = []


### PR DESCRIPTION
Applies https://github.com/fmtlib/fmt/commit/0b0f7cfbfcebd021c910078003d413354bd843e2 to `fmt` to fix https://github.com/fmtlib/fmt/issues/3005.

The patch has already been merged to master so the patch is constrained to versions `9.0.0:9.1.0`. The patch isn't needed for older versions and hopefully won't be needed for newer versions.

The patch is not constrained by compiler because `fmt` can be built with e.g. `g++` and compiled in a dependency by `hipcc`.