### PR TITLE
hypre +rocm: needs explicit rocprim dep

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -97,6 +97,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("rocsparse", when="+rocm")
     depends_on("rocthrust", when="+rocm")
     depends_on("rocrand", when="+rocm")
+    depends_on("rocprim", when="+rocm")
     depends_on("umpire", when="+umpire")
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on(


### PR DESCRIPTION
`hypre +rocm` expects `rocprim` in the dependency tree
* https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/hypre/package.py#L241-L244

@balay @osborn9 @ulrikeyang @hypre