### PR TITLE
Speed-up unit tests

### DIFF
--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on
 
 
 @pytest.fixture()
-def concretize_and_setup(mock_concretize):
+def concretize_and_setup(default_mock_concretization):
     def _func(spec_str):
-        s = mock_concretize(spec_str)
+        s = default_mock_concretization(spec_str)
         setup_package(s.package, False)
         return s
 
@@ -95,8 +95,8 @@ class TestTargets(object):
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestAutotoolsPackage(object):
-    def test_with_or_without(self, mock_concretize):
-        s = mock_concretize("a")
+    def test_with_or_without(self, default_mock_concretization):
+        s = default_mock_concretization("a")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature
@@ -127,8 +127,8 @@ class TestAutotoolsPackage(object):
         options = s.package.with_or_without("lorem-ipsum", variant="lorem_ipsum")
         assert "--without-lorem-ipsum" in options
 
-    def test_none_is_allowed(self, mock_concretize):
-        s = mock_concretize("a foo=none")
+    def test_none_is_allowed(self, default_mock_concretization):
+        s = default_mock_concretization("a foo=none")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature
@@ -138,9 +138,11 @@ class TestAutotoolsPackage(object):
         assert "--without-baz" in options
         assert "--no-fee" in options
 
-    def test_libtool_archive_files_are_deleted_by_default(self, mock_concretize, mutable_database):
+    def test_libtool_archive_files_are_deleted_by_default(
+        self, default_mock_concretization, mutable_database
+    ):
         # Install a package that creates a mock libtool archive
-        s = mock_concretize("libtool-deletion")
+        s = default_mock_concretization("libtool-deletion")
         s.package.do_install(explicit=True)
 
         # Assert the libtool archive is not there and we have
@@ -151,23 +153,25 @@ class TestAutotoolsPackage(object):
         assert libtool_deletion_log
 
     def test_libtool_archive_files_might_be_installed_on_demand(
-        self, mutable_database, monkeypatch, mock_concretize
+        self, mutable_database, monkeypatch, default_mock_concretization
     ):
         # Install a package that creates a mock libtool archive,
         # patch its package to preserve the installation
-        s = mock_concretize("libtool-deletion")
+        s = default_mock_concretization("libtool-deletion")
         monkeypatch.setattr(type(s.package.builder), "install_libtool_archives", True)
         s.package.do_install(explicit=True)
 
         # Assert libtool archives are installed
         assert os.path.exists(s.package.builder.libtool_archive_file)
 
-    def test_autotools_gnuconfig_replacement(self, mock_concretize, mutable_database):
+    def test_autotools_gnuconfig_replacement(self, default_mock_concretization, mutable_database):
         """
         Tests whether only broken config.sub and config.guess are replaced with
         files from working alternatives from the gnuconfig package.
         """
-        s = mock_concretize("autotools-config-replacement +patch_config_files +gnuconfig")
+        s = default_mock_concretization(
+            "autotools-config-replacement +patch_config_files +gnuconfig"
+        )
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:
@@ -182,11 +186,15 @@ class TestAutotoolsPackage(object):
         with open(os.path.join(s.prefix.working, "config.guess")) as f:
             assert "gnuconfig version of config.guess" not in f.read()
 
-    def test_autotools_gnuconfig_replacement_disabled(self, mock_concretize, mutable_database):
+    def test_autotools_gnuconfig_replacement_disabled(
+        self, default_mock_concretization, mutable_database
+    ):
         """
         Tests whether disabling patch_config_files
         """
-        s = mock_concretize("autotools-config-replacement ~patch_config_files +gnuconfig")
+        s = default_mock_concretization(
+            "autotools-config-replacement ~patch_config_files +gnuconfig"
+        )
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:
@@ -250,29 +258,29 @@ spack:
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestCMakePackage(object):
-    def test_cmake_std_args(self, mock_concretize):
+    def test_cmake_std_args(self, default_mock_concretization):
         # Call the function on a CMakePackage instance
-        s = mock_concretize("cmake-client")
+        s = default_mock_concretization("cmake-client")
         expected = spack.build_systems.cmake.CMakeBuilder.std_args(s.package)
         assert s.package.builder.std_cmake_args == expected
 
         # Call it on another kind of package
-        s = mock_concretize("mpich")
+        s = default_mock_concretization("mpich")
         assert spack.build_systems.cmake.CMakeBuilder.std_args(s.package)
 
-    def test_cmake_bad_generator(self, monkeypatch, mock_concretize):
-        s = mock_concretize("cmake-client")
+    def test_cmake_bad_generator(self, monkeypatch, default_mock_concretization):
+        s = default_mock_concretization("cmake-client")
         monkeypatch.setattr(type(s.package), "generator", "Yellow Sticky Notes", raising=False)
         with pytest.raises(spack.package_base.InstallError):
             s.package.builder.std_cmake_args
 
-    def test_cmake_secondary_generator(self, mock_concretize):
-        s = mock_concretize("cmake-client")
+    def test_cmake_secondary_generator(self, default_mock_concretization):
+        s = default_mock_concretization("cmake-client")
         s.package.generator = "CodeBlocks - Unix Makefiles"
         assert s.package.builder.std_cmake_args
 
-    def test_define(self, mock_concretize):
-        s = mock_concretize("cmake-client")
+    def test_define(self, default_mock_concretization):
+        s = default_mock_concretization("cmake-client")
 
         define = s.package.define
         for cls in (list, tuple):
@@ -322,8 +330,8 @@ class TestDownloadMixins(object):
             ),
         ],
     )
-    def test_attributes_defined(self, mock_concretize, spec_str, expected_url):
-        s = mock_concretize(spec_str)
+    def test_attributes_defined(self, default_mock_concretization, spec_str, expected_url):
+        s = default_mock_concretization(spec_str)
         assert s.package.urls[0] == expected_url
 
     @pytest.mark.parametrize(
@@ -342,33 +350,33 @@ class TestDownloadMixins(object):
             ("mirror-xorg-broken", r"{0} must define a `xorg_mirror_path` attribute"),
         ],
     )
-    def test_attributes_missing(self, mock_concretize, spec_str, error_fmt):
-        s = mock_concretize(spec_str)
+    def test_attributes_missing(self, default_mock_concretization, spec_str, error_fmt):
+        s = default_mock_concretization(spec_str)
         error_msg = error_fmt.format(type(s.package).__name__)
         with pytest.raises(AttributeError, match=error_msg):
             s.package.urls
 
 
-def test_cmake_define_from_variant_conditional(mock_concretize):
+def test_cmake_define_from_variant_conditional(default_mock_concretization):
     """Test that define_from_variant returns empty string when a condition on a variant
     is not met. When this is the case, the variant is not set in the spec."""
-    s = mock_concretize("cmake-conditional-variants-test")
+    s = default_mock_concretization("cmake-conditional-variants-test")
     assert "example" not in s.variants
     assert s.package.define_from_variant("EXAMPLE", "example") == ""
 
 
-def test_autotools_args_from_conditional_variant(mock_concretize):
+def test_autotools_args_from_conditional_variant(default_mock_concretization):
     """Test that _activate_or_not returns an empty string when a condition on a variant
     is not met. When this is the case, the variant is not set in the spec."""
-    s = mock_concretize("autotools-conditional-variants-test")
+    s = default_mock_concretization("autotools-conditional-variants-test")
     assert "example" not in s.variants
     assert len(s.package.builder._activate_or_not("example", "enable", "disable")) == 0
 
 
-def test_autoreconf_search_path_args_multiple(mock_concretize, tmpdir):
+def test_autoreconf_search_path_args_multiple(default_mock_concretization, tmpdir):
     """autoreconf should receive the right -I flags with search paths for m4 files
     for build deps."""
-    spec = mock_concretize("dttop")
+    spec = default_mock_concretization("dttop")
     aclocal_fst = str(tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal"))
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -382,11 +390,11 @@ def test_autoreconf_search_path_args_multiple(mock_concretize, tmpdir):
     ]
 
 
-def test_autoreconf_search_path_args_skip_automake(mock_concretize, tmpdir):
+def test_autoreconf_search_path_args_skip_automake(default_mock_concretization, tmpdir):
     """automake's aclocal dir should not be added as -I flag as it is a default
     3rd party dir search path, and if it's a system version it usually includes
     m4 files shadowing spack deps."""
-    spec = mock_concretize("dttop")
+    spec = default_mock_concretization("dttop")
     tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal")
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -396,9 +404,9 @@ def test_autoreconf_search_path_args_skip_automake(mock_concretize, tmpdir):
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == ["-I", aclocal_snd]
 
 
-def test_autoreconf_search_path_args_external_order(mock_concretize, tmpdir):
+def test_autoreconf_search_path_args_external_order(default_mock_concretization, tmpdir):
     """When a build dep is external, its -I flag should occur last"""
-    spec = mock_concretize("dttop")
+    spec = default_mock_concretization("dttop")
     aclocal_fst = str(tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal"))
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -412,18 +420,18 @@ def test_autoreconf_search_path_args_external_order(mock_concretize, tmpdir):
     ]
 
 
-def test_autoreconf_search_path_skip_nonexisting(mock_concretize, tmpdir):
+def test_autoreconf_search_path_skip_nonexisting(default_mock_concretization, tmpdir):
     """Skip -I flags for non-existing directories"""
-    spec = mock_concretize("dttop")
+    spec = default_mock_concretization("dttop")
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.prefix = str(tmpdir.join("fst"))
     build_dep_two.prefix = str(tmpdir.join("snd"))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == []
 
 
-def test_autoreconf_search_path_dont_repeat(mock_concretize, tmpdir):
+def test_autoreconf_search_path_dont_repeat(default_mock_concretization, tmpdir):
     """Do not add the same -I flag twice to keep things readable for humans"""
-    spec = mock_concretize("dttop")
+    spec = default_mock_concretization("dttop")
     aclocal = str(tmpdir.mkdir("prefix").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.external_path = str(tmpdir.join("prefix"))

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on
 
 
 @pytest.fixture()
-def concretize_and_setup():
+def concretize_and_setup(mock_concretize):
     def _func(spec_str):
-        s = Spec("mpich").concretized()
+        s = mock_concretize(spec_str)
         setup_package(s.package, False)
         return s
 
@@ -95,8 +95,8 @@ class TestTargets(object):
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestAutotoolsPackage(object):
-    def test_with_or_without(self):
-        s = Spec("a").concretized()
+    def test_with_or_without(self, mock_concretize):
+        s = mock_concretize("a")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature
@@ -127,8 +127,8 @@ class TestAutotoolsPackage(object):
         options = s.package.with_or_without("lorem-ipsum", variant="lorem_ipsum")
         assert "--without-lorem-ipsum" in options
 
-    def test_none_is_allowed(self):
-        s = Spec("a foo=none").concretized()
+    def test_none_is_allowed(self, mock_concretize):
+        s = mock_concretize("a foo=none")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature
@@ -138,9 +138,9 @@ class TestAutotoolsPackage(object):
         assert "--without-baz" in options
         assert "--no-fee" in options
 
-    def test_libtool_archive_files_are_deleted_by_default(self, mutable_database):
+    def test_libtool_archive_files_are_deleted_by_default(self, mock_concretize, mutable_database):
         # Install a package that creates a mock libtool archive
-        s = Spec("libtool-deletion").concretized()
+        s = mock_concretize("libtool-deletion")
         s.package.do_install(explicit=True)
 
         # Assert the libtool archive is not there and we have
@@ -151,24 +151,23 @@ class TestAutotoolsPackage(object):
         assert libtool_deletion_log
 
     def test_libtool_archive_files_might_be_installed_on_demand(
-        self, mutable_database, monkeypatch
+        self, mutable_database, monkeypatch, mock_concretize
     ):
         # Install a package that creates a mock libtool archive,
         # patch its package to preserve the installation
-        s = Spec("libtool-deletion").concretized()
+        s = mock_concretize("libtool-deletion")
         monkeypatch.setattr(type(s.package.builder), "install_libtool_archives", True)
         s.package.do_install(explicit=True)
 
         # Assert libtool archives are installed
         assert os.path.exists(s.package.builder.libtool_archive_file)
 
-    def test_autotools_gnuconfig_replacement(self, mutable_database):
+    def test_autotools_gnuconfig_replacement(self, mock_concretize, mutable_database):
         """
         Tests whether only broken config.sub and config.guess are replaced with
         files from working alternatives from the gnuconfig package.
         """
-        s = Spec("autotools-config-replacement +patch_config_files +gnuconfig")
-        s.concretize()
+        s = mock_concretize("autotools-config-replacement +patch_config_files +gnuconfig")
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:
@@ -183,12 +182,11 @@ class TestAutotoolsPackage(object):
         with open(os.path.join(s.prefix.working, "config.guess")) as f:
             assert "gnuconfig version of config.guess" not in f.read()
 
-    def test_autotools_gnuconfig_replacement_disabled(self, mutable_database):
+    def test_autotools_gnuconfig_replacement_disabled(self, mock_concretize, mutable_database):
         """
         Tests whether disabling patch_config_files
         """
-        s = Spec("autotools-config-replacement ~patch_config_files +gnuconfig")
-        s.concretize()
+        s = mock_concretize("autotools-config-replacement ~patch_config_files +gnuconfig")
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:
@@ -252,29 +250,29 @@ spack:
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestCMakePackage(object):
-    def test_cmake_std_args(self):
+    def test_cmake_std_args(self, mock_concretize):
         # Call the function on a CMakePackage instance
-        s = Spec("cmake-client").concretized()
+        s = mock_concretize("cmake-client")
         expected = spack.build_systems.cmake.CMakeBuilder.std_args(s.package)
         assert s.package.builder.std_cmake_args == expected
 
         # Call it on another kind of package
-        s = Spec("mpich").concretized()
+        s = mock_concretize("mpich")
         assert spack.build_systems.cmake.CMakeBuilder.std_args(s.package)
 
-    def test_cmake_bad_generator(self, monkeypatch):
-        s = Spec("cmake-client").concretized()
+    def test_cmake_bad_generator(self, monkeypatch, mock_concretize):
+        s = mock_concretize("cmake-client")
         monkeypatch.setattr(type(s.package), "generator", "Yellow Sticky Notes", raising=False)
         with pytest.raises(spack.package_base.InstallError):
             s.package.builder.std_cmake_args
 
-    def test_cmake_secondary_generator(config, mock_packages):
-        s = Spec("cmake-client").concretized()
+    def test_cmake_secondary_generator(self, mock_concretize):
+        s = mock_concretize("cmake-client")
         s.package.generator = "CodeBlocks - Unix Makefiles"
         assert s.package.builder.std_cmake_args
 
-    def test_define(self):
-        s = Spec("cmake-client").concretized()
+    def test_define(self, mock_concretize):
+        s = mock_concretize("cmake-client")
 
         define = s.package.define
         for cls in (list, tuple):
@@ -324,8 +322,8 @@ class TestDownloadMixins(object):
             ),
         ],
     )
-    def test_attributes_defined(self, spec_str, expected_url):
-        s = Spec(spec_str).concretized()
+    def test_attributes_defined(self, mock_concretize, spec_str, expected_url):
+        s = mock_concretize(spec_str)
         assert s.package.urls[0] == expected_url
 
     @pytest.mark.parametrize(
@@ -344,33 +342,33 @@ class TestDownloadMixins(object):
             ("mirror-xorg-broken", r"{0} must define a `xorg_mirror_path` attribute"),
         ],
     )
-    def test_attributes_missing(self, spec_str, error_fmt):
-        s = Spec(spec_str).concretized()
+    def test_attributes_missing(self, mock_concretize, spec_str, error_fmt):
+        s = mock_concretize(spec_str)
         error_msg = error_fmt.format(type(s.package).__name__)
         with pytest.raises(AttributeError, match=error_msg):
             s.package.urls
 
 
-def test_cmake_define_from_variant_conditional(config, mock_packages):
+def test_cmake_define_from_variant_conditional(mock_concretize):
     """Test that define_from_variant returns empty string when a condition on a variant
     is not met. When this is the case, the variant is not set in the spec."""
-    s = Spec("cmake-conditional-variants-test").concretized()
+    s = mock_concretize("cmake-conditional-variants-test")
     assert "example" not in s.variants
     assert s.package.define_from_variant("EXAMPLE", "example") == ""
 
 
-def test_autotools_args_from_conditional_variant(config, mock_packages):
+def test_autotools_args_from_conditional_variant(mock_concretize):
     """Test that _activate_or_not returns an empty string when a condition on a variant
     is not met. When this is the case, the variant is not set in the spec."""
-    s = Spec("autotools-conditional-variants-test").concretized()
+    s = mock_concretize("autotools-conditional-variants-test")
     assert "example" not in s.variants
     assert len(s.package.builder._activate_or_not("example", "enable", "disable")) == 0
 
 
-def test_autoreconf_search_path_args_multiple(config, mock_packages, tmpdir):
+def test_autoreconf_search_path_args_multiple(mock_concretize, tmpdir):
     """autoreconf should receive the right -I flags with search paths for m4 files
     for build deps."""
-    spec = Spec("dttop").concretized()
+    spec = mock_concretize("dttop")
     aclocal_fst = str(tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal"))
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -384,11 +382,11 @@ def test_autoreconf_search_path_args_multiple(config, mock_packages, tmpdir):
     ]
 
 
-def test_autoreconf_search_path_args_skip_automake(config, mock_packages, tmpdir):
+def test_autoreconf_search_path_args_skip_automake(mock_concretize, tmpdir):
     """automake's aclocal dir should not be added as -I flag as it is a default
     3rd party dir search path, and if it's a system version it usually includes
     m4 files shadowing spack deps."""
-    spec = Spec("dttop").concretized()
+    spec = mock_concretize("dttop")
     tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal")
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -398,9 +396,9 @@ def test_autoreconf_search_path_args_skip_automake(config, mock_packages, tmpdir
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == ["-I", aclocal_snd]
 
 
-def test_autoreconf_search_path_args_external_order(config, mock_packages, tmpdir):
+def test_autoreconf_search_path_args_external_order(mock_concretize, tmpdir):
     """When a build dep is external, its -I flag should occur last"""
-    spec = Spec("dttop").concretized()
+    spec = mock_concretize("dttop")
     aclocal_fst = str(tmpdir.mkdir("fst").mkdir("share").mkdir("aclocal"))
     aclocal_snd = str(tmpdir.mkdir("snd").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
@@ -414,18 +412,18 @@ def test_autoreconf_search_path_args_external_order(config, mock_packages, tmpdi
     ]
 
 
-def test_autoreconf_search_path_skip_nonexisting(config, mock_packages, tmpdir):
+def test_autoreconf_search_path_skip_nonexisting(mock_concretize, tmpdir):
     """Skip -I flags for non-existing directories"""
-    spec = Spec("dttop").concretized()
+    spec = mock_concretize("dttop")
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.prefix = str(tmpdir.join("fst"))
     build_dep_two.prefix = str(tmpdir.join("snd"))
     assert spack.build_systems.autotools._autoreconf_search_path_args(spec) == []
 
 
-def test_autoreconf_search_path_dont_repeat(config, mock_packages, tmpdir):
+def test_autoreconf_search_path_dont_repeat(mock_concretize, tmpdir):
     """Do not add the same -I flag twice to keep things readable for humans"""
-    spec = Spec("dttop").concretized()
+    spec = mock_concretize("dttop")
     aclocal = str(tmpdir.mkdir("prefix").mkdir("share").mkdir("aclocal"))
     build_dep_one, build_dep_two = spec.dependencies(deptype="build")
     build_dep_one.external_path = str(tmpdir.join("prefix"))

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -144,11 +144,11 @@ def test_download_and_extract_artifacts(tmpdir, monkeypatch, working_env):
         ci.download_and_extract_artifacts(url, working_dir)
 
 
-def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, mock_concretize, capfd):
+def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, default_mock_concretization, capfd):
     """The copy will fail because the spec is not concrete so does not have
     a package."""
     log_dir = tmpdir.join("log_dir")
-    concrete_spec = mock_concretize("printing-package")
+    concrete_spec = default_mock_concretization("printing-package")
     ci.copy_stage_logs_to_artifacts(concrete_spec, log_dir)
     _, err = capfd.readouterr()
     assert "Unable to copy files" in err
@@ -511,13 +511,15 @@ def test_ci_create_buildcache(tmpdir, working_env, config, mock_packages, monkey
     ci.create_buildcache(**args)
 
 
-def test_ci_run_standalone_tests_missing_requirements(tmpdir, working_env, mock_concretize, capfd):
+def test_ci_run_standalone_tests_missing_requirements(
+    tmpdir, working_env, default_mock_concretization, capfd
+):
     """This test case checks for failing prerequisite checks."""
     ci.run_standalone_tests()
     err = capfd.readouterr()[1]
     assert "Job spec is required" in err
 
-    args = {"job_spec": mock_concretize("printing-package")}
+    args = {"job_spec": default_mock_concretization("printing-package")}
     ci.run_standalone_tests(**args)
     err = capfd.readouterr()[1]
     assert "Reproduction directory is required" in err
@@ -527,12 +529,12 @@ def test_ci_run_standalone_tests_missing_requirements(tmpdir, working_env, mock_
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_junit(
-    tmpdir, working_env, mock_concretize, mock_test_stage, capfd
+    tmpdir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):
     log_file = tmpdir.join("junit.xml").strpath
     args = {
         "log_file": log_file,
-        "job_spec": mock_concretize("printing-package"),
+        "job_spec": default_mock_concretization("printing-package"),
         "repro_dir": tmpdir.join("repro_dir").strpath,
         "fail_fast": True,
     }
@@ -548,13 +550,13 @@ def test_ci_run_standalone_tests_not_installed_junit(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_cdash(
-    tmpdir, working_env, mock_concretize, mock_test_stage, capfd
+    tmpdir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):
     """Test run_standalone_tests with cdash and related options."""
     log_file = tmpdir.join("junit.xml").strpath
     args = {
         "log_file": log_file,
-        "job_spec": mock_concretize("printing-package"),
+        "job_spec": default_mock_concretization("printing-package"),
         "repro_dir": tmpdir.join("repro_dir").strpath,
     }
     os.makedirs(args["repro_dir"])

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -18,7 +18,6 @@ import spack.config as cfg
 import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
-import spack.spec as spec
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 
@@ -145,13 +144,12 @@ def test_download_and_extract_artifacts(tmpdir, monkeypatch, working_env):
         ci.download_and_extract_artifacts(url, working_dir)
 
 
-def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, config, mock_packages, monkeypatch, capfd):
+def test_ci_copy_stage_logs_to_artifacts_fail(tmpdir, mock_concretize, capfd):
     """The copy will fail because the spec is not concrete so does not have
     a package."""
     log_dir = tmpdir.join("log_dir")
-    s = spec.Spec("printing-package").concretized()
-
-    ci.copy_stage_logs_to_artifacts(s, log_dir)
+    concrete_spec = mock_concretize("printing-package")
+    ci.copy_stage_logs_to_artifacts(concrete_spec, log_dir)
     _, err = capfd.readouterr()
     assert "Unable to copy files" in err
     assert "No such file or directory" in err
@@ -456,17 +454,16 @@ def test_get_spec_filter_list(mutable_mock_env_path, config, mutable_mock_repo):
     assert affected_pkg_names == expected_affected_pkg_names
 
 
-@pytest.mark.maybeslow
 @pytest.mark.regression("29947")
-def test_affected_specs_on_first_concretization(mutable_mock_env_path, config):
+def test_affected_specs_on_first_concretization(mutable_mock_env_path, mock_packages, config):
     e = ev.create("first_concretization")
-    e.add("hdf5~mpi~szip")
-    e.add("hdf5~mpi+szip")
+    e.add("mpileaks~shared")
+    e.add("mpileaks+shared")
     e.concretize()
 
-    affected_specs = spack.ci.get_spec_filter_list(e, ["zlib"])
-    hdf5_specs = [s for s in affected_specs if s.name == "hdf5"]
-    assert len(hdf5_specs) == 2
+    affected_specs = spack.ci.get_spec_filter_list(e, ["callpath"])
+    mpileaks_specs = [s for s in affected_specs if s.name == "mpileaks"]
+    assert len(mpileaks_specs) == 2, e.all_specs()
 
 
 @pytest.mark.skipif(
@@ -514,15 +511,13 @@ def test_ci_create_buildcache(tmpdir, working_env, config, mock_packages, monkey
     ci.create_buildcache(**args)
 
 
-def test_ci_run_standalone_tests_missing_requirements(
-    tmpdir, working_env, config, mock_packages, capfd
-):
+def test_ci_run_standalone_tests_missing_requirements(tmpdir, working_env, mock_concretize, capfd):
     """This test case checks for failing prerequisite checks."""
     ci.run_standalone_tests()
     err = capfd.readouterr()[1]
     assert "Job spec is required" in err
 
-    args = {"job_spec": spec.Spec("printing-package").concretized()}
+    args = {"job_spec": mock_concretize("printing-package")}
     ci.run_standalone_tests(**args)
     err = capfd.readouterr()[1]
     assert "Reproduction directory is required" in err
@@ -532,12 +527,12 @@ def test_ci_run_standalone_tests_missing_requirements(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_junit(
-    tmpdir, working_env, config, mock_packages, mock_test_stage, capfd
+    tmpdir, working_env, mock_concretize, mock_test_stage, capfd
 ):
     log_file = tmpdir.join("junit.xml").strpath
     args = {
         "log_file": log_file,
-        "job_spec": spec.Spec("printing-package").concretized(),
+        "job_spec": mock_concretize("printing-package"),
         "repro_dir": tmpdir.join("repro_dir").strpath,
         "fail_fast": True,
     }
@@ -553,13 +548,13 @@ def test_ci_run_standalone_tests_not_installed_junit(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_cdash(
-    tmpdir, working_env, config, mock_packages, mock_test_stage, capfd
+    tmpdir, working_env, mock_concretize, mock_test_stage, capfd
 ):
     """Test run_standalone_tests with cdash and related options."""
     log_file = tmpdir.join("junit.xml").strpath
     args = {
         "log_file": log_file,
-        "job_spec": spec.Spec("printing-package").concretized(),
+        "job_spec": mock_concretize("printing-package"),
         "repro_dir": tmpdir.join("repro_dir").strpath,
     }
     os.makedirs(args["repro_dir"])

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1861,8 +1861,13 @@ def concretized_specs_cache():
 
 
 @pytest.fixture
-def mock_concretize(config, mock_packages, concretized_specs_cache):
-    """Return a concretized spec from immutable mock configuration."""
+def default_mock_concretization(config, mock_packages, concretized_specs_cache):
+    """Return the default mock concretization of a spec literal, obtained using the mock
+    repository and the mock configuration.
+
+    This fixture is unsafe to call in a test when either the default configuration or mock
+    repository are not used or have been modified.
+    """
 
     def _func(spec_str, tests=False):
         key = spec_str, tests

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1852,3 +1852,22 @@ def binary_with_rpaths(prefix_tmpdir):
         return executable
 
     return _factory
+
+
+@pytest.fixture(scope="session")
+def concretized_specs_cache():
+    """Cache for mock concrete specs"""
+    return {}
+
+
+@pytest.fixture
+def mock_concretize(config, mock_packages, concretized_specs_cache):
+    """Return a concretized spec from immutable mock configuration."""
+
+    def _func(spec_str, tests=False):
+        key = spec_str, tests
+        if key not in concretized_specs_cache:
+            concretized_specs_cache[key] = spack.spec.Spec(spec_str).concretized(tests=tests)
+        return concretized_specs_cache[key].copy()
+
+    return _func

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -835,7 +835,7 @@ def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_clear_failure_forced(mock_concretize, mutable_database, monkeypatch, capfd):
+def test_clear_failure_forced(default_mock_concretization, mutable_database, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when force."""
 
     def _is(db, spec):
@@ -846,7 +846,7 @@ def test_clear_failure_forced(mock_concretize, mutable_database, monkeypatch, ca
     # Ensure raise OSError when try to remove the non-existent marking
     monkeypatch.setattr(spack.database.Database, "prefix_failure_marked", _is)
 
-    s = mock_concretize("a")
+    s = default_mock_concretization("a")
     spack.store.db.clear_failure(s, force=True)
     out = capfd.readouterr()[1]
     assert "Removing failure marking despite lock" in out
@@ -854,7 +854,7 @@ def test_clear_failure_forced(mock_concretize, mutable_database, monkeypatch, ca
 
 
 @pytest.mark.db
-def test_mark_failed(mock_concretize, mutable_database, monkeypatch, tmpdir, capsys):
+def test_mark_failed(default_mock_concretization, mutable_database, monkeypatch, tmpdir, capsys):
     """Add coverage to mark_failed."""
 
     def _raise_exc(lock):
@@ -864,7 +864,7 @@ def test_mark_failed(mock_concretize, mutable_database, monkeypatch, tmpdir, cap
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise_exc)
 
     with tmpdir.as_cwd():
-        s = mock_concretize("a")
+        s = default_mock_concretization("a")
         spack.store.db.mark_failed(s)
 
         out = str(capsys.readouterr()[1])
@@ -876,13 +876,13 @@ def test_mark_failed(mock_concretize, mutable_database, monkeypatch, tmpdir, cap
 
 
 @pytest.mark.db
-def test_prefix_failed(mock_concretize, mutable_database, monkeypatch):
+def test_prefix_failed(default_mock_concretization, mutable_database, monkeypatch):
     """Add coverage to prefix_failed operation."""
 
     def _is(db, spec):
         return True
 
-    s = mock_concretize("a")
+    s = default_mock_concretization("a")
 
     # Confirm the spec is not already marked as failed
     assert not spack.store.db.prefix_failed(s)
@@ -900,13 +900,13 @@ def test_prefix_failed(mock_concretize, mutable_database, monkeypatch):
     assert spack.store.db.prefix_failed(s)
 
 
-def test_prefix_read_lock_error(mock_concretize, mutable_database, monkeypatch):
+def test_prefix_read_lock_error(default_mock_concretization, mutable_database, monkeypatch):
     """Cover the prefix read lock exception."""
 
     def _raise(db, spec):
         raise lk.LockError("Mock lock error")
 
-    s = mock_concretize("a")
+    s = default_mock_concretization("a")
 
     # Ensure subsequent lock operations fail
     monkeypatch.setattr(lk.Lock, "acquire_read", _raise)
@@ -916,13 +916,13 @@ def test_prefix_read_lock_error(mock_concretize, mutable_database, monkeypatch):
             assert False
 
 
-def test_prefix_write_lock_error(mock_concretize, mutable_database, monkeypatch):
+def test_prefix_write_lock_error(default_mock_concretization, mutable_database, monkeypatch):
     """Cover the prefix write lock exception."""
 
     def _raise(db, spec):
         raise lk.LockError("Mock lock error")
 
-    s = mock_concretize("a")
+    s = default_mock_concretization("a")
 
     # Ensure subsequent lock operations fail
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -835,7 +835,7 @@ def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
+def test_clear_failure_forced(mock_concretize, mutable_database, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when force."""
 
     def _is(db, spec):
@@ -846,7 +846,7 @@ def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
     # Ensure raise OSError when try to remove the non-existent marking
     monkeypatch.setattr(spack.database.Database, "prefix_failure_marked", _is)
 
-    s = spack.spec.Spec("a").concretized()
+    s = mock_concretize("a")
     spack.store.db.clear_failure(s, force=True)
     out = capfd.readouterr()[1]
     assert "Removing failure marking despite lock" in out
@@ -854,7 +854,7 @@ def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_mark_failed(mutable_database, monkeypatch, tmpdir, capsys):
+def test_mark_failed(mock_concretize, mutable_database, monkeypatch, tmpdir, capsys):
     """Add coverage to mark_failed."""
 
     def _raise_exc(lock):
@@ -864,7 +864,7 @@ def test_mark_failed(mutable_database, monkeypatch, tmpdir, capsys):
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise_exc)
 
     with tmpdir.as_cwd():
-        s = spack.spec.Spec("a").concretized()
+        s = mock_concretize("a")
         spack.store.db.mark_failed(s)
 
         out = str(capsys.readouterr()[1])
@@ -876,13 +876,13 @@ def test_mark_failed(mutable_database, monkeypatch, tmpdir, capsys):
 
 
 @pytest.mark.db
-def test_prefix_failed(mutable_database, monkeypatch):
+def test_prefix_failed(mock_concretize, mutable_database, monkeypatch):
     """Add coverage to prefix_failed operation."""
 
     def _is(db, spec):
         return True
 
-    s = spack.spec.Spec("a").concretized()
+    s = mock_concretize("a")
 
     # Confirm the spec is not already marked as failed
     assert not spack.store.db.prefix_failed(s)
@@ -900,13 +900,13 @@ def test_prefix_failed(mutable_database, monkeypatch):
     assert spack.store.db.prefix_failed(s)
 
 
-def test_prefix_read_lock_error(mutable_database, monkeypatch):
+def test_prefix_read_lock_error(mock_concretize, mutable_database, monkeypatch):
     """Cover the prefix read lock exception."""
 
     def _raise(db, spec):
         raise lk.LockError("Mock lock error")
 
-    s = spack.spec.Spec("a").concretized()
+    s = mock_concretize("a")
 
     # Ensure subsequent lock operations fail
     monkeypatch.setattr(lk.Lock, "acquire_read", _raise)
@@ -916,13 +916,13 @@ def test_prefix_read_lock_error(mutable_database, monkeypatch):
             assert False
 
 
-def test_prefix_write_lock_error(mutable_database, monkeypatch):
+def test_prefix_write_lock_error(mock_concretize, mutable_database, monkeypatch):
     """Cover the prefix write lock exception."""
 
     def _raise(db, spec):
         raise lk.LockError("Mock lock error")
 
-    s = spack.spec.Spec("a").concretized()
+    s = mock_concretize("a")
 
     # Ensure subsequent lock operations fail
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise)

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -24,11 +24,10 @@ from spack.util.path import path_to_os_path
 max_packages = 10
 
 
-def test_yaml_directory_layout_parameters(tmpdir, config):
+def test_yaml_directory_layout_parameters(tmpdir, mock_concretize):
     """This tests the various parameters that can be used to configure
     the install location"""
-    spec = Spec("python")
-    spec.concretize()
+    spec = mock_concretize("python")
 
     # Ensure default layout matches expected spec format
     layout_default = DirectoryLayout(str(tmpdir))
@@ -215,11 +214,9 @@ def test_find(temporary_store, config, mock_packages):
         assert found_specs[name].eq_dag(spec)
 
 
-def test_yaml_directory_layout_build_path(tmpdir, config):
+def test_yaml_directory_layout_build_path(tmpdir, mock_concretize):
     """This tests build path method."""
-    spec = Spec("python")
-    spec.concretize()
-
+    spec = mock_concretize("python")
     layout = DirectoryLayout(str(tmpdir))
     rel_path = os.path.join(layout.metadata_dir, layout.packages_dir)
     assert layout.build_packages_path(spec) == os.path.join(spec.prefix, rel_path)

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -24,10 +24,10 @@ from spack.util.path import path_to_os_path
 max_packages = 10
 
 
-def test_yaml_directory_layout_parameters(tmpdir, mock_concretize):
+def test_yaml_directory_layout_parameters(tmpdir, default_mock_concretization):
     """This tests the various parameters that can be used to configure
     the install location"""
-    spec = mock_concretize("python")
+    spec = default_mock_concretization("python")
 
     # Ensure default layout matches expected spec format
     layout_default = DirectoryLayout(str(tmpdir))
@@ -214,9 +214,9 @@ def test_find(temporary_store, config, mock_packages):
         assert found_specs[name].eq_dag(spec)
 
 
-def test_yaml_directory_layout_build_path(tmpdir, mock_concretize):
+def test_yaml_directory_layout_build_path(tmpdir, default_mock_concretization):
     """This tests build path method."""
-    spec = mock_concretize("python")
+    spec = default_mock_concretization("python")
     layout = DirectoryLayout(str(tmpdir))
     rel_path = os.path.join(layout.metadata_dir, layout.packages_dir)
     assert layout.build_packages_path(spec) == os.path.join(spec.prefix, rel_path)

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -83,7 +83,13 @@ def test_bad_git(tmpdir, mock_bad_git):
 @pytest.mark.parametrize("type_of_test", ["default", "branch", "tag", "commit"])
 @pytest.mark.parametrize("secure", [True, False])
 def test_fetch(
-    type_of_test, secure, mock_git_repository, config, mutable_mock_repo, git_version, monkeypatch
+    type_of_test,
+    secure,
+    mock_git_repository,
+    mock_concretize,
+    mutable_mock_repo,
+    git_version,
+    monkeypatch,
 ):
     """Tries to:
 
@@ -104,7 +110,7 @@ def test_fetch(
     monkeypatch.delattr(pkg_class, "git")
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     # Enter the stage directory and check some properties
@@ -136,7 +142,7 @@ def test_fetch(
 
 @pytest.mark.disable_clean_stage_check
 def test_fetch_pkg_attr_submodule_init(
-    mock_git_repository, config, mutable_mock_repo, monkeypatch, mock_stage
+    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch, mock_stage
 ):
     """In this case the version() args do not contain a 'git' URL, so
     the fetcher must be assembled using the Package-level 'git' attribute.
@@ -151,7 +157,7 @@ def test_fetch_pkg_attr_submodule_init(
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     s.package.do_stage()
@@ -193,13 +199,15 @@ def test_adhoc_version_submodules(
 
 
 @pytest.mark.parametrize("type_of_test", ["branch", "commit"])
-def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config, monkeypatch):
+def test_debug_fetch(
+    mock_packages, type_of_test, mock_git_repository, mock_concretize, monkeypatch
+):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     # Fetch then ensure source path exists
@@ -231,7 +239,12 @@ def test_needs_stage():
 
 @pytest.mark.parametrize("get_full_repo", [True, False])
 def test_get_full_repo(
-    get_full_repo, git_version, mock_git_repository, config, mutable_mock_repo, monkeypatch
+    get_full_repo,
+    git_version,
+    mock_git_repository,
+    mock_concretize,
+    mutable_mock_repo,
+    monkeypatch,
 ):
     """Ensure that we can clone a full repository."""
 
@@ -243,7 +256,7 @@ def test_get_full_repo(
 
     t = mock_git_repository.checks[type_of_test]
 
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     args = copy.copy(t.args)
     args["get_full_repo"] = get_full_repo
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -273,7 +286,9 @@ def test_get_full_repo(
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize("submodules", [True, False])
-def test_gitsubmodule(submodules, mock_git_repository, config, mutable_mock_repo, monkeypatch):
+def test_gitsubmodule(
+    submodules, mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+):
     """
     Test GitFetchStrategy behavior with submodules. This package
     has a `submodules` property which is always True: when a specific
@@ -286,7 +301,7 @@ def test_gitsubmodule(submodules, mock_git_repository, config, mutable_mock_repo
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -304,7 +319,9 @@ def test_gitsubmodule(submodules, mock_git_repository, config, mutable_mock_repo
 
 
 @pytest.mark.disable_clean_stage_check
-def test_gitsubmodules_callable(mock_git_repository, config, mutable_mock_repo, monkeypatch):
+def test_gitsubmodules_callable(
+    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+):
     """
     Test GitFetchStrategy behavior with submodules selected after concretization
     """
@@ -317,7 +334,7 @@ def test_gitsubmodules_callable(mock_git_repository, config, mutable_mock_repo, 
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules_callback
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -330,7 +347,9 @@ def test_gitsubmodules_callable(mock_git_repository, config, mutable_mock_repo, 
 
 
 @pytest.mark.disable_clean_stage_check
-def test_gitsubmodules_delete(mock_git_repository, config, mutable_mock_repo, monkeypatch):
+def test_gitsubmodules_delete(
+    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+):
     """
     Test GitFetchStrategy behavior with submodules_delete
     """
@@ -338,7 +357,7 @@ def test_gitsubmodules_delete(mock_git_repository, config, mutable_mock_repo, mo
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = Spec("git-test").concretized()
+    s = mock_concretize("git-test")
     args = copy.copy(t.args)
     args["submodules"] = True
     args["submodules_delete"] = ["third_party/submodule0", "third_party/submodule1"]

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -86,7 +86,7 @@ def test_fetch(
     type_of_test,
     secure,
     mock_git_repository,
-    mock_concretize,
+    default_mock_concretization,
     mutable_mock_repo,
     git_version,
     monkeypatch,
@@ -110,7 +110,7 @@ def test_fetch(
     monkeypatch.delattr(pkg_class, "git")
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     # Enter the stage directory and check some properties
@@ -142,7 +142,7 @@ def test_fetch(
 
 @pytest.mark.disable_clean_stage_check
 def test_fetch_pkg_attr_submodule_init(
-    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch, mock_stage
+    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch, mock_stage
 ):
     """In this case the version() args do not contain a 'git' URL, so
     the fetcher must be assembled using the Package-level 'git' attribute.
@@ -157,7 +157,7 @@ def test_fetch_pkg_attr_submodule_init(
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     s.package.do_stage()
@@ -200,14 +200,14 @@ def test_adhoc_version_submodules(
 
 @pytest.mark.parametrize("type_of_test", ["branch", "commit"])
 def test_debug_fetch(
-    mock_packages, type_of_test, mock_git_repository, mock_concretize, monkeypatch
+    mock_packages, type_of_test, mock_git_repository, default_mock_concretization, monkeypatch
 ):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     monkeypatch.setitem(s.package.versions, ver("git"), t.args)
 
     # Fetch then ensure source path exists
@@ -242,7 +242,7 @@ def test_get_full_repo(
     get_full_repo,
     git_version,
     mock_git_repository,
-    mock_concretize,
+    default_mock_concretization,
     mutable_mock_repo,
     monkeypatch,
 ):
@@ -256,7 +256,7 @@ def test_get_full_repo(
 
     t = mock_git_repository.checks[type_of_test]
 
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     args = copy.copy(t.args)
     args["get_full_repo"] = get_full_repo
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -287,7 +287,7 @@ def test_get_full_repo(
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize("submodules", [True, False])
 def test_gitsubmodule(
-    submodules, mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+    submodules, mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
 ):
     """
     Test GitFetchStrategy behavior with submodules. This package
@@ -301,7 +301,7 @@ def test_gitsubmodule(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -320,7 +320,7 @@ def test_gitsubmodule(
 
 @pytest.mark.disable_clean_stage_check
 def test_gitsubmodules_callable(
-    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
 ):
     """
     Test GitFetchStrategy behavior with submodules selected after concretization
@@ -334,7 +334,7 @@ def test_gitsubmodules_callable(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules_callback
     monkeypatch.setitem(s.package.versions, ver("git"), args)
@@ -348,7 +348,7 @@ def test_gitsubmodules_callable(
 
 @pytest.mark.disable_clean_stage_check
 def test_gitsubmodules_delete(
-    mock_git_repository, mock_concretize, mutable_mock_repo, monkeypatch
+    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
 ):
     """
     Test GitFetchStrategy behavior with submodules_delete
@@ -357,7 +357,7 @@ def test_gitsubmodules_delete(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = mock_concretize("git-test")
+    s = default_mock_concretization("git-test")
     args = copy.copy(t.args)
     args["submodules"] = True
     args["submodules_delete"] = ["third_party/submodule0", "third_party/submodule1"]

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -570,7 +570,9 @@ def mock_download():
     "manual,instr", [(False, False), (False, True), (True, False), (True, True)]
 )
 @pytest.mark.disable_clean_stage_check
-def test_manual_download(install_mockery, mock_download, monkeypatch, manual, instr):
+def test_manual_download(
+    install_mockery, mock_download, mock_concretize, monkeypatch, manual, instr
+):
     """
     Ensure expected fetcher fail message based on manual download and instr.
     """
@@ -579,7 +581,7 @@ def test_manual_download(install_mockery, mock_download, monkeypatch, manual, in
     def _instr(pkg):
         return "Download instructions for {0}".format(pkg.spec.name)
 
-    spec = Spec("a").concretized()
+    spec = mock_concretize("a")
     pkg = spec.package
 
     pkg.manual_download = manual
@@ -605,16 +607,16 @@ def fetching_not_allowed(monkeypatch):
     monkeypatch.setattr(spack.package_base.PackageBase, "fetcher", fetcher)
 
 
-def test_fetch_without_code_is_noop(install_mockery, fetching_not_allowed):
+def test_fetch_without_code_is_noop(mock_concretize, install_mockery, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
-    pkg = Spec("a").concretized().package
+    pkg = mock_concretize("a").package
     pkg.has_code = False
     pkg.do_fetch()
 
 
-def test_fetch_external_package_is_noop(install_mockery, fetching_not_allowed):
+def test_fetch_external_package_is_noop(mock_concretize, install_mockery, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
-    spec = Spec("a").concretized()
+    spec = mock_concretize("a")
     spec.external_path = "/some/where"
     assert spec.external
     spec.package.do_fetch()

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -571,7 +571,7 @@ def mock_download():
 )
 @pytest.mark.disable_clean_stage_check
 def test_manual_download(
-    install_mockery, mock_download, mock_concretize, monkeypatch, manual, instr
+    install_mockery, mock_download, default_mock_concretization, monkeypatch, manual, instr
 ):
     """
     Ensure expected fetcher fail message based on manual download and instr.
@@ -581,7 +581,7 @@ def test_manual_download(
     def _instr(pkg):
         return "Download instructions for {0}".format(pkg.spec.name)
 
-    spec = mock_concretize("a")
+    spec = default_mock_concretization("a")
     pkg = spec.package
 
     pkg.manual_download = manual
@@ -607,16 +607,20 @@ def fetching_not_allowed(monkeypatch):
     monkeypatch.setattr(spack.package_base.PackageBase, "fetcher", fetcher)
 
 
-def test_fetch_without_code_is_noop(mock_concretize, install_mockery, fetching_not_allowed):
+def test_fetch_without_code_is_noop(
+    default_mock_concretization, install_mockery, fetching_not_allowed
+):
     """do_fetch for packages without code should be a no-op"""
-    pkg = mock_concretize("a").package
+    pkg = default_mock_concretization("a").package
     pkg.has_code = False
     pkg.do_fetch()
 
 
-def test_fetch_external_package_is_noop(mock_concretize, install_mockery, fetching_not_allowed):
+def test_fetch_external_package_is_noop(
+    default_mock_concretization, install_mockery, fetching_not_allowed
+):
     """do_fetch for packages without code should be a no-op"""
-    spec = mock_concretize("a")
+    spec = default_mock_concretization("a")
     spec.external_path = "/some/where"
     assert spec.external
     spec.package.do_fetch()

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -719,8 +719,8 @@ class TestSpecSematics(object):
         with pytest.raises(ValueError):
             Spec("libelf foo")
 
-    def test_spec_formatting(self, mock_concretize):
-        spec = mock_concretize("multivalue-variant cflags=-O2")
+    def test_spec_formatting(self, default_mock_concretization):
+        spec = default_mock_concretization("multivalue-variant cflags=-O2")
 
         # Since the default is the full spec see if the string rep of
         # spec is the same as the output of spec.format()
@@ -796,8 +796,8 @@ class TestSpecSematics(object):
             actual = spec.format(named_str)
             assert expected == actual
 
-    def test_spec_formatting_escapes(self, mock_concretize):
-        spec = mock_concretize("multivalue-variant cflags=-O2")
+    def test_spec_formatting_escapes(self, default_mock_concretization):
+        spec = default_mock_concretization("multivalue-variant cflags=-O2")
 
         sigil_mismatches = [
             "{@name}",
@@ -952,11 +952,11 @@ class TestSpecSematics(object):
         assert spec.target < "broadwell"
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice(self, transitive, mock_concretize):
+    def test_splice(self, transitive, default_mock_concretization):
         # Tests the new splice function in Spec using a somewhat simple case
         # with a variant with a conditional dependency.
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
 
         # Sanity checking that these are not the same thing.
         assert dep.dag_hash() != spec["splice-h"].dag_hash()
@@ -989,9 +989,9 @@ class TestSpecSematics(object):
         assert out.spliced
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_with_cached_hashes(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+    def test_splice_with_cached_hashes(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
 
         # monkeypatch hashes so we can test that they are cached
         spec._hash = "aaaaaa"
@@ -1008,9 +1008,9 @@ class TestSpecSematics(object):
         assert out["splice-z"].dag_hash() == out_z_expected.dag_hash()
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_input_unchanged(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+    def test_splice_input_unchanged(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
         orig_spec_hash = spec.dag_hash()
         orig_dep_hash = dep.dag_hash()
         spec.splice(dep, transitive)
@@ -1020,13 +1020,13 @@ class TestSpecSematics(object):
         assert dep.dag_hash() == orig_dep_hash
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_subsequent(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+    def test_splice_subsequent(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Now we attempt a second splice.
-        dep = mock_concretize("splice-z+bar")
+        dep = default_mock_concretization("splice-z+bar")
 
         # Transitivity shouldn't matter since Splice Z has no dependencies.
         out2 = out.splice(dep, transitive)
@@ -1037,9 +1037,9 @@ class TestSpecSematics(object):
         assert out2.spliced
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_dict(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+    def test_splice_dict(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Sanity check all hashes are unique...
@@ -1054,9 +1054,9 @@ class TestSpecSematics(object):
         assert len(build_spec_nodes) == 1
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_dict_roundtrip(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-h+foo")
+    def test_splice_dict_roundtrip(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Sanity check all hashes are unique...
@@ -1119,17 +1119,17 @@ class TestSpecSematics(object):
         assert s.satisfies("mpileaks ^zmpi ^fake", strict=True)
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_swap_names(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-a+foo")
+    def test_splice_swap_names(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-a+foo")
         out = spec.splice(dep, transitive)
         assert dep.name in out
         assert transitive == ("+foo" in out["splice-z"])
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_swap_names_mismatch_virtuals(self, mock_concretize, transitive):
-        spec = mock_concretize("splice-t")
-        dep = mock_concretize("splice-vh+foo")
+    def test_splice_swap_names_mismatch_virtuals(self, default_mock_concretization, transitive):
+        spec = default_mock_concretization("splice-t")
+        dep = default_mock_concretization("splice-vh+foo")
         with pytest.raises(spack.spec.SpliceError, match="will not provide the same virtuals."):
             spec.splice(dep, transitive)
 
@@ -1213,7 +1213,7 @@ def test_merge_anonymous_spec_with_named_spec(anonymous, named, expected):
     assert s == Spec(expected)
 
 
-def test_spec_installed(mock_concretize, database):
+def test_spec_installed(default_mock_concretization, database):
     """Test whether Spec.installed works."""
     # a known installed spec should say that it's installed
     specs = database.query()
@@ -1226,14 +1226,14 @@ def test_spec_installed(mock_concretize, database):
     assert not spec.installed
 
     # 'a' is not in the mock DB and is not installed
-    spec = mock_concretize("a")
+    spec = default_mock_concretization("a")
     assert not spec.installed
 
 
 @pytest.mark.regression("30678")
-def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, mock_concretize):
+def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, default_mock_concretization):
     # create a concrete spec
-    a = mock_concretize("a")
+    a = default_mock_concretization("a")
     dag_hashes = {spec.name: spec.dag_hash() for spec in a.traverse()}
 
     # make it look like an old DAG hash spec with no package hash on the spec.
@@ -1280,9 +1280,9 @@ def test_unsupported_compiler():
         Spec("gcc%fake-compiler").validate_or_raise()
 
 
-def test_package_hash_affects_dunder_and_dag_hash(mock_packages, mock_concretize):
-    a1 = mock_concretize("a")
-    a2 = mock_concretize("a")
+def test_package_hash_affects_dunder_and_dag_hash(mock_packages, default_mock_concretization):
+    a1 = default_mock_concretization("a")
+    a2 = default_mock_concretization("a")
 
     assert hash(a1) == hash(a2)
     assert a1.dag_hash() == a2.dag_hash()

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -881,7 +881,7 @@ class TestSpecSematics(object):
         # different orderings for repeated concretizations of the same
         # spec and config
         spec_str = "libelf %gcc@11.1.0 os=redhat6"
-        for _ in range(25):
+        for _ in range(7):
             s = Spec(spec_str).concretized()
             assert all(
                 s.compiler_flags[x] == ["-O0", "-g"] for x in ("cflags", "cxxflags", "fflags")
@@ -1166,12 +1166,11 @@ class TestSpecSematics(object):
 
 
 @pytest.mark.regression("3887")
-@pytest.mark.parametrize("spec_str", ["git", "hdf5", "py-flake8"])
-def test_is_extension_after_round_trip_to_dict(config, spec_str):
+@pytest.mark.parametrize("spec_str", ["py-extension2", "extension1", "perl-extension"])
+def test_is_extension_after_round_trip_to_dict(config, mock_packages, spec_str):
     # x is constructed directly from string, y from a
     # round-trip to dict representation
-    x = Spec(spec_str)
-    x.concretize()
+    x = Spec(spec_str).concretized()
     y = Spec.from_dict(x.to_dict())
 
     # Using 'y' since the round-trip make us lose build dependencies
@@ -1231,7 +1230,7 @@ def test_merge_anonymous_spec_with_named_spec(anonymous, named, expected):
     assert s == Spec(expected)
 
 
-def test_spec_installed(install_mockery, database):
+def test_spec_installed(database):
     """Test whether Spec.installed works."""
     # a known installed spec should say that it's installed
     specs = database.query()

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -136,18 +136,17 @@ if sys.platform != "win32":
 @pytest.mark.parametrize("secure", [True, False])
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize("mock_archive", files, indirect=True)
-def test_fetch(mock_archive, secure, _fetch_method, checksum_type, config, mutable_mock_repo):
+def test_fetch(
+    mock_archive, secure, _fetch_method, checksum_type, mock_concretize, mutable_mock_repo
+):
     """Fetch an archive and make sure we can checksum it."""
-    mock_archive.url
-    mock_archive.path
-
     algo = crypto.hash_fun_for_algo(checksum_type)()
     with open(mock_archive.archive_file, "rb") as f:
         algo.update(f.read())
     checksum = algo.hexdigest()
 
-    # Get a spec and tweak the test package with new chcecksum params
-    s = Spec("url-test").concretized()
+    # Get a spec and tweak the test package with new checksum params
+    s = mock_concretize("url-test")
     s.package.url = mock_archive.url
     s.package.versions[ver("test")] = {checksum_type: checksum, "url": s.package.url}
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -137,7 +137,12 @@ if sys.platform != "win32":
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize("mock_archive", files, indirect=True)
 def test_fetch(
-    mock_archive, secure, _fetch_method, checksum_type, mock_concretize, mutable_mock_repo
+    mock_archive,
+    secure,
+    _fetch_method,
+    checksum_type,
+    default_mock_concretization,
+    mutable_mock_repo,
 ):
     """Fetch an archive and make sure we can checksum it."""
     algo = crypto.hash_fun_for_algo(checksum_type)()
@@ -146,7 +151,7 @@ def test_fetch(
     checksum = algo.hexdigest()
 
     # Get a spec and tweak the test package with new checksum params
-    s = mock_concretize("url-test")
+    s = default_mock_concretization("url-test")
     s.package.url = mock_archive.url
     s.package.versions[ver("test")] = {checksum_type: checksum, "url": s.package.url}
 


### PR DESCRIPTION
Results on my machine:

* **Spack:** 0.19.0.dev0 (fd5f8a666af292e2513ebe206bdb60f1387bf6bd)
* **Python:** 3.8.10
* **Platform:** linux-ubuntu20.04-icelake
* **Concretizer:** clingo


| Test file  | Time on develop | Time in this PR | Speedup |
| ----------- | ---------------------- | -------------------- | ------------ |
|  lib/spack/spack/test/architecture.py  | 18.18s  | 3.32s | **5.48x** |
| lib/spack/spack/test/spec_semantics.py  | 87.96s  | 11.18s | **7.87x** |
| lib/spack/spack/test/ci.py  | 24.79s  | 3.83s | **6.49x** |
| lib/spack/spack/test/url_fetch.py  | 53.32s  | 12.99s | **4.10x** |
| lib/spack/spack/test/git_fetch.py  | 26.56s  | 11.89s | **2.33x** |
| lib/spack/spack/test/directory_layout.py  | 17.66s  | 3.67s | **4.81x** |
| lib/spack/spack/test/build_systems.py  | 18.85s  | 12.86s | **1.47x** |
| lib/spack/spack/test/packaging.py  | 4.66s  | 2.65s | 1.76x |
| lib/spack/spack/test/database.py  | 9.34s  | 8.85s | 1.06x |



Modifications:
- [x] Avoid concretization in a few tests in `architecture.py`
- [x] Use mock packages everywhere in `spec_semantics`, reduce re-try in a test
- [x] Cache recurring concretizations in other places