### PR TITLE
Include concrete environments with `include_concrete`

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import copy
 import sys
 
 import llnl.util.lang
@@ -270,6 +271,27 @@ def display_env(env, args, decorator, results):
         )
 
     print()
+
+    if env.included_concrete_envs:
+        tty.msg("Included specs")
+
+        # Root specs cannot be displayed with prefixes, since those are not
+        # set for abstract specs. Same for hashes
+        root_args = copy.copy(args)
+        root_args.paths = False
+
+        # Roots are displayed with variants, etc. so that we can see
+        # specifically what the user asked for.
+        cmd.display_specs(
+            env.included_user_specs,
+            root_args,
+            decorator=lambda s, f: color.colorize("@*{%s}" % f),
+            namespace=True,
+            show_flags=True,
+            show_full_compiler=True,
+            variants=True,
+        )
+        print()
 
     if args.show_concretized:
         tty.msg("Concretized roots")

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -34,6 +34,9 @@ contents have.  Lockfiles are JSON-formatted and their top-level sections are:
       * ``spec``: a string representation of the abstract spec that was concretized
 
   4. ``concrete_specs``: a dictionary containing the specs in the environment.
+  5. ``include_concrete`` (dictionary): an optional dictionary that includes the roots
+     and concrete specs from the included environments, keyed by the path to that
+     environment
 
 Compatibility
 -------------
@@ -50,8 +53,10 @@ upgrade Spack to use them.
      - ``v2``
      - ``v3``
      - ``v4``
+     - ``v5``
    * - ``v0.12:0.14``
      - ✅
+     -
      -
      -
      -
@@ -60,12 +65,21 @@ upgrade Spack to use them.
      - ✅
      -
      -
+     -
    * - ``v0.17``
      - ✅
      - ✅
      - ✅
      -
+     -
    * - ``v0.18:``
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     -
+   * - ``v0.22:``
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -331,6 +345,118 @@ the commit or version.
                     }
                 ],
                 "hash": "<dag_hash 2>"
+            }
+        }
+    }
+
+
+Version 5
+---------
+
+Version 5 doesn't change the top-level lockfile format, but an optional dictionary is
+added. The dictionary has the ``root`` and ``concrete_specs`` of the included
+environments, which are keyed by the path to that environment. Since this is optional
+if the environment does not have any included environments ``include_concrete`` will
+not be a part of the lockfile.
+
+.. code-block:: json
+
+    {
+        "_meta": {
+            "file-type": "spack-lockfile",
+            "lockfile-version": 5,
+            "specfile-version": 3
+        },
+        "roots": [
+            {
+                "hash": "<dag_hash 1>",
+                "spec": "<abstract spec 1>"
+            },
+            {
+                "hash": "<dag_hash 2>",
+                "spec": "<abstract spec 2>"
+            }
+        ],
+        "concrete_specs": {
+            "<dag_hash 1>": {
+                "... <spec dict attributes> ...": { },
+                "dependencies": [
+                    {
+                        "name": "depname_1",
+                        "hash": "<dag_hash for depname_1>",
+                        "type": ["build", "link"]
+                    },
+                    {
+                        "name": "depname_2",
+                        "hash": "<dag_hash for depname_2>",
+                        "type": ["build", "link"]
+                    }
+                ],
+                "hash": "<dag_hash 1>",
+            },
+            "<daghash 2>": {
+                "... <spec dict attributes> ...": { },
+                "dependencies": [
+                    {
+                        "name": "depname_3",
+                        "hash": "<dag_hash for depname_3>",
+                        "type": ["build", "link"]
+                    },
+                    {
+                        "name": "depname_4",
+                        "hash": "<dag_hash for depname_4>",
+                        "type": ["build", "link"]
+                    }
+                ],
+                "hash": "<dag_hash 2>"
+            }
+        }
+        "include_concrete": {
+            "<path to environment>": {
+                "roots": [
+                    {
+                        "hash": "<dag_hash 1>",
+                        "spec": "<abstract spec 1>"
+                    },
+                    {
+                        "hash": "<dag_hash 2>",
+                        "spec": "<abstract spec 2>"
+                    }
+                ],
+                "concrete_specs": {
+                    "<dag_hash 1>": {
+                        "... <spec dict attributes> ...": { },
+                        "dependencies": [
+                            {
+                                "name": "depname_1",
+                                "hash": "<dag_hash for depname_1>",
+                                "type": ["build", "link"]
+                            },
+                            {
+                                "name": "depname_2",
+                                "hash": "<dag_hash for depname_2>",
+                                "type": ["build", "link"]
+                            }
+                        ],
+                        "hash": "<dag_hash 1>",
+                    },
+                    "<daghash 2>": {
+                        "... <spec dict attributes> ...": { },
+                        "dependencies": [
+                            {
+                                "name": "depname_3",
+                                "hash": "<dag_hash for depname_3>",
+                                "type": ["build", "link"]
+                            },
+                            {
+                                "name": "depname_4",
+                                "hash": "<dag_hash for depname_4>",
+                                "type": ["build", "link"]
+                            }
+                        ],
+                        "hash": "<dag_hash 2>"
+                    }
+                }
             }
         }
     }

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -35,6 +35,7 @@ properties: Dict[str, Any] = {
             {
                 "include": {"type": "array", "default": [], "items": {"type": "string"}},
                 "specs": spec_list_schema,
+                "include_concrete": {"type": "array", "default": [], "items": {"type": "string"}},
             },
         ),
     }

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -349,6 +349,87 @@ def test_find_prefix_in_env(
         # Would throw error on regression
 
 
+def test_find_specs_include_concrete_env(mutable_mock_env_path, config, mutable_mock_repo, tmpdir):
+    path = tmpdir.join("spack.yaml")
+
+    with tmpdir.as_cwd():
+        with open(str(path), "w") as f:
+            f.write(
+                """\
+spack:
+  specs:
+  - mpileaks
+"""
+            )
+        env("create", "test1", "spack.yaml")
+
+    test1 = ev.read("test1")
+    test1.concretize()
+    test1.write()
+
+    with tmpdir.as_cwd():
+        with open(str(path), "w") as f:
+            f.write(
+                """\
+spack:
+  specs:
+  - libelf
+"""
+            )
+        env("create", "test2", "spack.yaml")
+
+    test2 = ev.read("test2")
+    test2.concretize()
+    test2.write()
+
+    env("create", "--include-concrete", "test1", "--include-concrete", "test2", "combined_env")
+
+    with ev.read("combined_env"):
+        output = find()
+
+    assert "No root specs" in output
+    assert "Included specs" in output
+    assert "mpileaks" in output
+    assert "libelf" in output
+
+
+def test_find_specs_nested_include_concrete_env(
+    mutable_mock_env_path, config, mutable_mock_repo, tmpdir
+):
+    path = tmpdir.join("spack.yaml")
+
+    with tmpdir.as_cwd():
+        with open(str(path), "w") as f:
+            f.write(
+                """\
+spack:
+  specs:
+  - mpileaks
+"""
+            )
+        env("create", "test1", "spack.yaml")
+
+    test1 = ev.read("test1")
+    test1.concretize()
+    test1.write()
+
+    env("create", "--include-concrete", "test1", "test2")
+    test2 = ev.read("test2")
+    test2.add("libelf")
+    test2.concretize()
+    test2.write()
+
+    env("create", "--include-concrete", "test2", "test3")
+
+    with ev.read("test3"):
+        output = find()
+
+    assert "No root specs" in output
+    assert "Included specs" in output
+    assert "mpileaks" in output
+    assert "libelf" in output
+
+
 def test_find_loaded(database, working_env):
     output = find("--loaded", "--group")
     assert output == ""

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1052,7 +1052,7 @@ _spack_env_deactivate() {
 _spack_env_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --dir --keep-relative --without-view --with-view"
+        SPACK_COMPREPLY="-h --help -d --dir --keep-relative --without-view --with-view --include-concrete"
     else
         _environments
     fi
@@ -1061,7 +1061,7 @@ _spack_env_create() {
 _spack_env_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all -f --force"
     else
         _environments
     fi
@@ -1070,7 +1070,7 @@ _spack_env_remove() {
 _spack_env_rm() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all -f --force"
     else
         _environments
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1538,7 +1538,7 @@ complete -c spack -n '__fish_spack_using_command env deactivate' -l pwsh -f -a s
 complete -c spack -n '__fish_spack_using_command env deactivate' -l pwsh -d 'print pwsh commands to activate the environment'
 
 # spack env create
-set -g __fish_spack_optspecs_spack_env_create h/help d/dir keep-relative without-view with-view=
+set -g __fish_spack_optspecs_spack_env_create h/help d/dir keep-relative without-view with-view= include-concrete=
 complete -c spack -n '__fish_spack_using_command_pos 0 env create' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command env create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env create' -s h -l help -d 'show this help message and exit'
@@ -1550,22 +1550,28 @@ complete -c spack -n '__fish_spack_using_command env create' -l without-view -f 
 complete -c spack -n '__fish_spack_using_command env create' -l without-view -d 'do not maintain a view for this environment'
 complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -f -a with_view
 complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -d 'specify that this environment should maintain a view at the specified path (by default the view is maintained in the environment directory)'
+complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -f -a include_concrete
+complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -d 'name of old environment to copy specs from'
 
 # spack env remove
-set -g __fish_spack_optspecs_spack_env_remove h/help y/yes-to-all
+set -g __fish_spack_optspecs_spack_env_remove h/help y/yes-to-all f/force
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 env remove' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command env remove' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env remove' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command env remove' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command env remove' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
+complete -c spack -n '__fish_spack_using_command env remove' -s f -l force -f -a force
+complete -c spack -n '__fish_spack_using_command env remove' -s f -l force -d 'remove the environment even if it is included in another environment'
 
 # spack env rm
-set -g __fish_spack_optspecs_spack_env_rm h/help y/yes-to-all
+set -g __fish_spack_optspecs_spack_env_rm h/help y/yes-to-all f/force
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 env rm' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command env rm' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env rm' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command env rm' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command env rm' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
+complete -c spack -n '__fish_spack_using_command env rm' -s f -l force -f -a force
+complete -c spack -n '__fish_spack_using_command env rm' -s f -l force -d 'remove the environment even if it is included in another environment'
 
 # spack env rename
 set -g __fish_spack_optspecs_spack_env_rename h/help d/dir f/force


### PR DESCRIPTION
Resolves [#33313](https://github.com/spack/spack/issues/33313)

Add the ability to include any number of (potentially nested) concrete environments, e.g.:

```yaml
   spack:
     specs: []
     concretizer:
         unify: true
     include_concrete:
     - /path/to/environment1
     - /path/to/environment2
```

or, from the CLI:

```console
   $ spack env create myenv
   $ spack -e myenv add python
   $ spack -e myenv concretize
   $ spack env create --include-concrete myenv included_env
```

The contents of included concrete environments' spack.lock files are
included in the environment's lock file at creation time. Any changes
to included concrete environments are only reflected after the environment
is re-concretized from the re-concretized included environments.

- [x] Concretize included envs
- [x] Save concrete specs in memory by hash
- [x] Add included envs to combined env's lock file
- [x] Add test
- [x] Update documentation