### PR TITLE
postgresql: fix weird spack message

### DIFF
--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -100,7 +100,7 @@ class Postgresql(AutotoolsPackage):
                 with working_dir(os.path.join("src", subdir)):
                     make("install")
         else:
-            AutotoolsPackage.install(self, spec, prefix)
+            super(Postgresql, self).install(spec, prefix)
 
     def setup_run_environment(self, env):
         spec = self.spec


### PR DESCRIPTION
Started seeing the following error when building my huge environment within the past week or so:
```
==> Installing postgresql-14.0-7msc7a237byvjffcdxnswdfcnicxzxqr                                                                                                                                                                                                                                                               
==> No binary for postgresql-14.0-7msc7a237byvjffcdxnswdfcnicxzxqr found: installing from source                                                               
==> Fetching https://mirror.spack.io/_source-cache/archive/ee/ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122.tar.bz2                                                                                                                                                                                        
==> No patches needed for postgresql                                                                                                                           
==> postgresql: Executing phase: 'autoreconf'                                                                                                                  
==> postgresql: Executing phase: 'configure'                                                                                                                                                                                                                                                                                  
==> postgresql: Executing phase: 'build'                                                                                                                                                                                                                                                                                      
==> postgresql: Executing phase: 'install'                                                                                                                                                                                                                                                                                    
==> Error: AttributeError: type object 'AutotoolsPackage' has no attribute 'install'                                                                           
                                                                                                                                                                                                                                                                                                                              
The 'postgresql' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://s
pack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure                                                                                      
                                                                                                                                                               
/home/snehring/projects/spack/var/spack/repos/builtin/packages/postgresql/package.py:103, in install:                                                                                                                                                                                                                         
        100                with working_dir(os.path.join("src", subdir)):                                                                                      
        101                    make("install")                                                                                                                 
        102        else:                                                                                                                                       
  >>    103            AutotoolsPackage.install(self, spec, prefix)                                                                                            
                                                                                                                                                               
See build log for details:                                                                                                                                                                                                                                                                                                    
  /home/snehring/projects/spack/var/spack/stage/spack-stage-postgresql-14.0-7msc7a237byvjffcdxnswdfcnicxzxqr/spack-build-out.txt
```

Which made me think I was crazy, and maybe I am, because no one else seems to have noticed it.

This fixes it for me, and I believe preserves the original intention.