### PR TITLE
Fixed external HIP library detection

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -291,8 +291,13 @@ class Hip(CMakePackage):
             hip_libs_at_top = os.path.basename(self.spec.prefix) != "hip"
             # We assume self.spec.prefix is  /opt/rocm-x.y.z for rocm-5.2.0 and newer
             # and /opt/rocm-x.y.z/hip for older versions
+            # However, depending on how an external is found it can be at either level
+            # of the installation path
             if self.spec.satisfies("@5.2.0:"):
-                rocm_prefix = Prefix(self.spec.prefix)
+                if hip_libs_at_top:
+                    rocm_prefix = Prefix(self.spec.prefix)
+                else:
+                    rocm_prefix = Prefix(os.path.dirname(self.spec.prefix))
             else:
                 # We assume self.spec.prefix is /opt/rocm-x.y.z/hip and rocm has a
                 # default installation with everything installed under


### PR DESCRIPTION
Fixed a bug where the external HIP library is found in a nested direc…tory, even on newer releases of ROCm.

@tgamblin This is a revision to #33344 where even on new versions of HIP, the external library can be found at either level of the hierarchy.