### PR TITLE
depfile: improve tab completion

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -674,13 +674,14 @@ class MakeTargetVisitor(object):
         return ""
 
     def accept(self, node):
-        dag_hash = node.edge.spec.dag_hash()
+        fmt = "{name}-{version}-{hash}";
+        tgt = node.edge.spec.format(fmt)
         spec_str = node.edge.spec.format(
             "{name}{@version}{%compiler}{variants}{arch=architecture}"
         )
         buildcache_flag = self.build_cache_flag(node.depth)
-        prereqs = " ".join([self.target(dep.spec.dag_hash()) for dep in self.neighbors(node)])
-        self.adjacency_list.append((dag_hash, spec_str, buildcache_flag, prereqs))
+        prereqs = " ".join([self.target(dep.spec.format(fmt)) for dep in self.neighbors(node)])
+        self.adjacency_list.append((tgt, prereqs, node.edge.spec.dag_hash(), spec_str, buildcache_flag))
 
         # We already accepted this
         return True
@@ -707,10 +708,10 @@ def env_depfile(args):
             return os.path.join(target_prefix, name)
 
     def get_install_target(name):
-        return os.path.join(target_prefix, ".install", name)
+        return os.path.join(target_prefix, "install", name)
 
     def get_install_deps_target(name):
-        return os.path.join(target_prefix, ".install-deps", name)
+        return os.path.join(target_prefix, "install-deps", name)
 
     # What things do we build when running make? By default, we build the
     # root specs. If specific specs are provided as input, we build those.
@@ -729,12 +730,12 @@ def env_depfile(args):
     )
 
     # Root specs without deps are the prereqs for the environment target
-    root_install_targets = [get_install_target(h.dag_hash()) for h in roots]
+    root_install_targets = [get_install_target(h.format("{name}-{version}-{hash}")) for h in roots]
 
     # Cleanable targets...
-    cleanable_targets = [get_install_target(h) for h, _, _, _ in make_targets.adjacency_list]
+    cleanable_targets = [get_install_target(h) for h, _, _, _, _ in make_targets.adjacency_list]
     cleanable_targets.extend(
-        [get_install_deps_target(h) for h, _, _, _ in make_targets.adjacency_list]
+        [get_install_deps_target(h) for h, _, _, _, _ in make_targets.adjacency_list]
     )
 
     buf = six.StringIO()
@@ -750,8 +751,8 @@ def env_depfile(args):
             "root_install_targets": " ".join(root_install_targets),
             "dirs_target": get_target("dirs"),
             "environment": env.path,
-            "install_target": get_target(".install"),
-            "install_deps_target": get_target(".install-deps"),
+            "install_target": get_target("install"),
+            "install_deps_target": get_target("install-deps"),
             "any_hash_target": get_target("%"),
             "jobserver_support": "+" if args.jobserver else "",
             "adjacency_list": make_targets.adjacency_list,

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -674,14 +674,16 @@ class MakeTargetVisitor(object):
         return ""
 
     def accept(self, node):
-        fmt = "{name}-{version}-{hash}";
+        fmt = "{name}-{version}-{hash}"
         tgt = node.edge.spec.format(fmt)
         spec_str = node.edge.spec.format(
             "{name}{@version}{%compiler}{variants}{arch=architecture}"
         )
         buildcache_flag = self.build_cache_flag(node.depth)
         prereqs = " ".join([self.target(dep.spec.format(fmt)) for dep in self.neighbors(node)])
-        self.adjacency_list.append((tgt, prereqs, node.edge.spec.dag_hash(), spec_str, buildcache_flag))
+        self.adjacency_list.append(
+            (tgt, prereqs, node.edge.spec.dag_hash(), spec_str, buildcache_flag)
+        )
 
         # We already accepted this
         return True

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -1,4 +1,5 @@
 SPACK ?= spack
+SPACK_INSTALL_FLAGS ?=
 
 .PHONY: {{ all_target }} {{ clean_target }}
 

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -11,6 +11,10 @@ SPACK_INSTALL_FLAGS ?=
 {{ dirs_target }}:
 	@mkdir -p {{ install_target }} {{ install_deps_target }}
 
+{% if phony_convenience_targets %}
+.PHONY: {{ phony_convenience_targets }}
+{% endif %}
+
 # The spack install commands are of the form:
 # spack -e my_env --no-add --only=package --only=concrete /hash
 # This is an involved way of expressing that Spack should only install
@@ -33,7 +37,11 @@ SPACK_INSTALL_FLAGS ?=
 {% for (parent, prereqs, _, _, _) in adjacency_list -%}
 {{ install_target }}/{{ parent }}: {{ install_deps_target }}/{{ parent }}
 {{ install_deps_target }}/{{ parent }}: {{ prereqs }}
+{% if phony_convenience_targets %}
+install/{{ parent }}: {{ install_target }}/{{ parent }}
+install-deps/{{ parent }}: {{ install_deps_target }}/{{ parent }}
+{% endif %}
 {% endfor %}
 
 {{ clean_target }}:
-	rm -rf {{ env_target }} {{ cleanable_targets }}
+	rm -rf {{ env_target }} {{ all_install_related_targets }}

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -14,22 +14,24 @@ SPACK ?= spack
 # spack -e my_env --no-add --only=package --only=concrete /hash
 # This is an involved way of expressing that Spack should only install
 # an individual concrete spec from the environment without deps.
-{{ install_target }}/%: {{ install_deps_target }}/% | {{ dirs_target }}
-	{{ jobserver_support }}$(SPACK) -e '{{ environment }}' install $(SPACK_BUILDCACHE_FLAG) $(SPACK_INSTALL_FLAGS) --only-concrete --only=package --no-add /$(notdir $@) # $(SPEC)
+{{ install_target }}/%: | {{ dirs_target }}
+	{{ jobserver_support }}$(SPACK) -e '{{ environment }}' install $(SPACK_BUILDCACHE_FLAG) $(SPACK_INSTALL_FLAGS) --only-concrete --only=package --no-add /$(HASH) # $(SPEC)
 	@touch $@
 
 {{ install_deps_target }}/%: | {{ dirs_target }}
 	@touch $@
 
 # Set a human-readable SPEC variable for each target that has a hash
-{% for (parent, name, build_cache, _) in adjacency_list -%}
+{% for (parent, _, hash, name, build_cache) in adjacency_list -%}
+{{ any_hash_target }}/{{ parent }}: HASH = {{ hash }}
 {{ any_hash_target }}/{{ parent }}: SPEC = {{ name }}
 {{ any_hash_target }}/{{ parent }}: SPACK_BUILDCACHE_FLAG = {{ build_cache }}
 {% endfor %}
 
 # The Spack DAG expressed in targets:
-{% for (parent, _, _, prereqs) in adjacency_list -%}
-{{ install_deps_target }}/{{ parent }}: {{prereqs}}
+{% for (parent, prereqs, _, _, _) in adjacency_list -%}
+{{ install_target }}/{{ parent }}: {{ install_deps_target }}/{{ parent }}
+{{ install_deps_target }}/{{ parent }}: {{ prereqs }}
 {% endfor %}
 
 {{ clean_target }}:


### PR DESCRIPTION
This PR allows you to do:

```
spack env create -d .
spack -e . add python
spack -e . concretize
spack -e . env depfile -o Makefile

make in<tab>              # -> install
make install-<tab>        # -> install-deps/
make install-deps/py<tab> # -> install-deps/python-x.y.z-hash
make install/zl<tab>      # -> install/zlib-x.y.z-hash

make SP<tab>              # -> make SPACK
make SPACK_<tab>          # -> make SPACK_INSTALL_FLAGS=
```

This is thanks to a phony convenience targets (note that the actual targets are still put in `<env dir>/.spack-env/makedeps` independently of current working directory and location of the Makefile.

In the case of custom make target prefixes `--make-target-prefix hello` no such phony targets are created, since then tab completion already works from `make hello/<tab>` -- the point of custom targets is to avoid conflicts when the Makefile is included elsewhere, so we shouldn't those "shortcuts" to install and install-deps there.

Main changes of the PR:

- Drop the leading `.` in `.install` and `.install-deps` so they are tab-completed 
- Change `install` and `install-deps` targets format from `<hash>` into `<pkg name>-<version>-<hash>` so that targets, so targets are discoverable and easier to interpret
- Add phony convenience targets/shortcuts when there's no `--make-target-prefix <prefix>` given

[![asciicast](https://asciinema.org/a/ximkYdruPKh7IDHgMyVM9Yacx.svg)](https://asciinema.org/a/ximkYdruPKh7IDHgMyVM9Yacx)