### PR TITLE
remove deprecated `concretization` environment key

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -786,17 +786,12 @@ class Environment(object):
             )
         else:
             self.views = {}
+
         # Retrieve the current concretization strategy
         configuration = config_dict(self.yaml)
 
-        # Let `concretization` overrule `concretize:unify` config for now,
-        # but use a translation table to have internally a representation
-        # as if we were using the new configuration
-        translation = {"separately": False, "together": True}
-        try:
-            self.unify = translation[configuration["concretization"]]
-        except KeyError:
-            self.unify = spack.config.get("concretizer:unify", False)
+        # Retrieve unification scheme for the concretizer
+        self.unify = spack.config.get("concretizer:unify", False)
 
         # Retrieve dev-build packages:
         self.dev_specs = configuration.get("develop", {})

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -8,8 +8,6 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/env.py
    :lines: 36-
 """
-import warnings
-
 from llnl.util.lang import union_dicts
 
 import spack.schema.merged

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -16,24 +16,6 @@ import spack.schema.merged
 import spack.schema.packages
 import spack.schema.projections
 
-warned_about_concretization = False
-
-
-def deprecate_concretization(instance, props):
-    global warned_about_concretization
-    if warned_about_concretization:
-        return None
-    # Deprecate `spack:concretization` in favor of `spack:concretizer:unify`.
-    concretization_to_unify = {"together": "true", "separately": "false"}
-    concretization = instance["concretization"]
-    unify = concretization_to_unify[concretization]
-
-    return (
-        "concretization:{} is deprecated and will be removed in Spack 0.19 in favor of "
-        "the new concretizer:unify:{} config option.".format(concretization, unify)
-    )
-
-
 #: legal first keys in the schema
 keys = ("spack", "env")
 
@@ -76,11 +58,6 @@ schema = {
             "type": "object",
             "default": {},
             "additionalProperties": False,
-            "deprecatedProperties": {
-                "properties": ["concretization"],
-                "message": deprecate_concretization,
-                "error": False,
-            },
             "properties": union_dicts(
                 # merged configuration scope schemas
                 spack.schema.merged.properties,
@@ -148,11 +125,6 @@ schema = {
                             },
                         ]
                     },
-                    "concretization": {
-                        "type": "string",
-                        "enum": ["together", "separately"],
-                        "default": "separately",
-                    },
                 },
             ),
         }
@@ -169,31 +141,6 @@ def update(data):
     Returns:
         True if data was changed, False otherwise
     """
-    updated = False
-    if "include" in data:
-        msg = "included configuration files should be updated manually" " [files={0}]"
-        warnings.warn(msg.format(", ".join(data["include"])))
-
-    # Spack 0.19 drops support for `spack:concretization` in favor of
-    # `spack:concretizer:unify`. Here we provide an upgrade path that changes the former
-    # into the latter, or warns when there's an ambiguity. Note that Spack 0.17 is not
-    # forward compatible with `spack:concretizer:unify`.
-    if "concretization" in data:
-        has_unify = "unify" in data.get("concretizer", {})
-        to_unify = {"together": True, "separately": False}
-        unify = to_unify[data["concretization"]]
-
-        if has_unify and data["concretizer"]["unify"] != unify:
-            warnings.warn(
-                "The following configuration conflicts: "
-                "`spack:concretization:{}` and `spack:concretizer:unify:{}`"
-                ". Please update manually.".format(
-                    data["concretization"], data["concretizer"]["unify"]
-                )
-            )
-        else:
-            data.update({"concretizer": {"unify": unify}})
-            data.pop("concretization")
-            updated = True
-
-    return updated
+    # There are not currently any deprecated attributes in this section
+    # that have not been removed
+    return False

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2476,30 +2476,6 @@ env:
     assert manifest == contents
 
 
-@pytest.mark.parametrize("concretization,unify", [("together", "true"), ("separately", "false")])
-def test_update_concretization_to_concretizer_unify(concretization, unify, tmpdir):
-    spack_yaml = """\
-spack:
-  concretization: {}
-""".format(
-        concretization
-    )
-    tmpdir.join("spack.yaml").write(spack_yaml)
-    # Update the environment
-    env("update", "-y", str(tmpdir))
-    with open(str(tmpdir.join("spack.yaml"))) as f:
-        assert (
-            f.read()
-            == """\
-spack:
-  concretizer:
-    unify: {}
-""".format(
-                unify
-            )
-        )
-
-
 @pytest.mark.regression("18147")
 def test_can_update_attributes_with_override(tmpdir):
     spack_yaml = """


### PR DESCRIPTION
Deprecation message added in v0.18.0, listed v0.19.0 as the version it would be removed fully.