### PR TITLE
updates and fixes for libpressio

### DIFF
--- a/var/spack/repos/builtin/packages/cusz/package.py
+++ b/var/spack/repos/builtin/packages/cusz/package.py
@@ -14,6 +14,7 @@ class Cusz(CMakePackage, CudaPackage):
     url = "https://github.com/szcompressor/cuSZ/archive/refs/tags/v0.3.tar.gz"
 
     maintainers = ["jtian0", "dingwentao"]
+    tags = ["e4s"]
 
     conflicts("~cuda")
     conflicts("cuda_arch=none", when="+cuda")

--- a/var/spack/repos/builtin/packages/cusz/package.py
+++ b/var/spack/repos/builtin/packages/cusz/package.py
@@ -21,6 +21,9 @@ class Cusz(CMakePackage, CudaPackage):
     version("develop", branch="develop")
     version("0.3", sha256="0feb4f7fd64879fe147624dd5ad164adf3983f79b2e0383d35724f8d185dcb11")
 
+    # these version of Cuda provide the CUB headers, but not CUB cmake configuration that we use.
+    conflicts("cuda@11.0.2:11.2.2")
+
     depends_on("cub", when="^ cuda@:10.2.89")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/libdistributed/package.py
+++ b/var/spack/repos/builtin/packages/libdistributed/package.py
@@ -17,6 +17,8 @@ class Libdistributed(CMakePackage):
     maintainers = ["robertu94"]
 
     version("master", branch="master")
+    version("0.4.2", sha256="ffb5e0aea2cd5ccbd7af2471059d6e70fa5ac2d6ce64fb71c6d434544c01be95")
+    version("0.4.1", sha256="62bbd4cbaf396cea7f33d62d5e79086a56ee1396d070ad3c4fd9720c50d242c0")
     version("0.4.0", sha256="7895d268c4f9b5444e4378f60b5a28198720bc48633d0e5d072c39e3366b096c")
     version("0.3.0", sha256="57443c72a5a9aa57d7f8760c878a77dcffca0b3b5ccf5124cdf5c1fad8a44ae8")
     version("0.2.0", sha256="4540136d39f98a21c59a7e127cb0568266747bfff886edf0f0007be4959a09a3")

--- a/var/spack/repos/builtin/packages/libpressio-tools/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tools/package.py
@@ -14,6 +14,7 @@ class LibpressioTools(CMakePackage):
     git = "https://github.com/robertu94/pressio-tools"
 
     maintainers = ["robertu94"]
+    tags = ["e4s"]
 
     version("master", branch="master")
     version("0.1.6", sha256="a67a364f46dea29ff1b3e5c52c0a5abf2d9d53412fb8d424f6bd71252bfa7792")

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -14,6 +14,7 @@ class Libpressio(CMakePackage, CudaPackage):
     url = "https://github.com/robertu94/libpressio/archive/0.31.1.tar.gz"
     git = "https://github.com/robertu94/libpressio"
 
+    tags = ["e4s"]
     maintainers = ["robertu94"]
 
     tests_require_compiler = True

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -14,8 +14,14 @@ class Libpressio(CMakePackage, CudaPackage):
     url = "https://github.com/robertu94/libpressio/archive/0.31.1.tar.gz"
     git = "https://github.com/robertu94/libpressio"
 
+    maintainers = ["robertu94"]
+
+    tests_require_compiler = True
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.88.3", sha256="b2df2ed11f77eb2e07206f7bdfa4754017559017235c3324820021ef451fd48b")
+    version("0.88.2", sha256="f5de6aff5ff906b164d6b2199ada10a8e32fb1e2a6295da3f0b79d9626661a46")
+    version("0.88.1", sha256="d7fe73a6b2d8de6d19c85e87888dcf1a62956f56b4e6dfd23e26901740031e00")
     version("0.88.0", sha256="4358441f0d10559d571327162a216617d16d09569a80e13ad286e3b7c41c5b9b")
     version("0.87.0", sha256="2bea685e5ed3a1528ea68ba4a281902ff77c0bebd38ff212b6e8edbfa263b572")
     version("0.86.7", sha256="2a6319640a018c39aa93aaf0f027fd496d7ea7dc5ac95509313cf1b4b6b1fb00")
@@ -178,9 +184,16 @@ class Libpressio(CMakePackage, CudaPackage):
     variant("mgardx", default=False, description="build support for the MGARDx compressor")
     variant("bzip2", default=False, description="build support for the bzip2 compressor")
     variant("qoz", default=False, description="build support for the qoz compressor")
+    variant("core", default=True, description="build core builtin libraries")
     variant(
         "cusz", default=False, description="build support for the cusz compressor", when="@0.86.0:"
     )
+
+    # cufile was only added to the .run file installer for cuda in 11.7.1
+    # dispite being in the APT/RPM packages for much longer
+    # a external install the cufile libraries could use an earlier version
+    # which provides these libraries
+    depends_on("cuda@11.7.1:", when="+cuda")
 
     depends_on("boost", when="@:0.51.0+boost")
 
@@ -197,6 +210,10 @@ class Libpressio(CMakePackage, CudaPackage):
     depends_on("c-blosc", when="+blosc")
     depends_on("fpzip", when="+fpzip")
     depends_on("hdf5", when="+hdf5")
+    # this might seem excessive, but if HDF5 is external and parallel
+    # we might not get the MPI compiler flags we need, so depend on this
+    # explicitly
+    depends_on("mpi@2:", when="+hdf5 ^hdf5+mpi")
     depends_on("imagemagick", when="+magick")
     depends_on("mgard", when="+mgard")
     depends_on("python@3:", when="+python", type=("build", "link", "run"))
@@ -313,11 +330,19 @@ class Libpressio(CMakePackage, CudaPackage):
             args.append("-DLIBPRESSIO_HAS_QoZ=ON")
         if "+cusz" in self.spec:
             args.append("-DLIBPRESSIO_HAS_CUSZ=ON")
+        if "+core" in self.spec:
+            args.append("-DLIBPRESSIO_BUILD_MODE=FULL")
+        else:
+            args.append("-DLIBPRESSIO_BUILD_MODE=CORE")
         if self.run_tests:
             args.append("-DBUILD_TESTING=ON")
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
+
+    def setup_run_environment(self, env):
+        if "+hdf5" in self.spec and "+json" in self.spec:
+            env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
@@ -329,3 +354,33 @@ class Libpressio(CMakePackage, CudaPackage):
         if "+docs" in self.spec:
             with working_dir(self.build_directory):
                 make("docs")
+
+    @run_after("install")
+    def copy_test_sources(self):
+        if self.version < Version("0.88.3"):
+            return
+        srcs = [
+            join_path("test", "smoke_test", "smoke_test.cc"),
+            join_path("test", "smoke_test", "CMakeLists.txt"),
+        ]
+        self.cache_extra_test_sources(srcs)
+
+    def test(self):
+        if self.version < Version("0.88.3"):
+            return
+
+        args = self.cmake_args()
+        args.append(
+            "-S{}".format(join_path(self.test_suite.current_test_cache_dir, "test", "smoke_test"))
+        )
+        args.append(
+            "-DCMAKE_PREFIX_PATH={};{}".format(self.spec["libstdcompat"].prefix, self.prefix)
+        )
+
+        self.run_test("cmake", args, purpose="cmake configuration works")
+
+        # this works for cmake@3.14: which is required for this package
+        args = ["--build", "."]
+        self.run_test("cmake", args, purpose="cmake builds works")
+
+        self.run_test("./pressio_smoke_tests", expected="all passed")

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -346,7 +346,7 @@ class Libpressio(CMakePackage, CudaPackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def build_test(self):
         make("test")
 
     @run_after("build")

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -78,6 +78,10 @@ class Sz(CMakePackage, AutotoolsPackage):
 
     patch("ctags-only-if-requested.patch", when="@2.1.8.1:2.1.8.3")
 
+    def setup_run_environment(self, env):
+        if "+hdf5" in self.spec:
+            env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
+
     def _test_2d_float(self):
         """This test performs simple 2D compression/decompression (float)"""
         test_data_dir = self.test_suite.current_test_data_dir

--- a/var/spack/repos/builtin/packages/sz3/package.py
+++ b/var/spack/repos/builtin/packages/sz3/package.py
@@ -15,17 +15,25 @@ class Sz3(CMakePackage):
     maintainers = ["disheng222"]
 
     version("master")
-    version("3.1.5.4", commit="08df24b566e6d2e419cb95553aebf4a4902a8015")
+    version("3.1.5.4", commit="4c6ddf628f27d36b28d1bbda02174359cd05573d")
     version("3.1.5.1", commit="5736a63b917e439dd62248b4ff6234e96726af5d")
     version("3.1.3.1", commit="323cb17b412d657c4be681b52c34beaf933fe7af")
     version("3.1.3", commit="695dff8dc326f3b165f6676d810f46add088a585")
 
+    variant("hdf5", default=False, description="enable hdf5 filter support")
+
     depends_on("zstd")
     depends_on("gsl")
     depends_on("pkgconfig")
+    depends_on("hdf5", when="+hdf5")
+
+    def setup_run_environment(self, env):
+        if "+hdf5" in self.spec:
+            env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
 
     def cmake_args(self):
         return [
             "-DSZ3_USE_BUNDLED_ZSTD=OFF",
             "-DSZ3_DEBUG_TIMINGS=OFF",
+            self.define_from_variant("BUILD_H5Z_FILTER", "hdf5"),
         ]


### PR DESCRIPTION
Various updates getting LibPressio and cuSZ ready for e4s inclusion, and other quality of life improvements:

+ `~core` for libpressio to avoid building various default plugins massively saving build times
+ smoke tests for LibPressio
+ expose the HDF5 filters for SZ, SZ3, and LibPressio when they are built
+ various version updates with bug fixes
+ fixes to cuda and hdf5 dependencies to behave more correctly.