### PR TITLE
Allow packages to detect presence of slingshot network

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -36,6 +36,10 @@ _ex_craype_dir = "/opt/cray/pe/cpe"
 _xc_craype_dir = "/opt/cray/pe/cdt"
 
 
+def slingshot_network():
+    return os.path.exists("/lib64/libcxi.so")
+
+
 def _target_name_from_craype_target_name(name):
     return _craype_name_to_target_name.get(name, name)
 

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.platforms.cray
 from spack.package import *
 
 
@@ -53,13 +54,13 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
     variant("rccl", default=False, description="Builds with support for RCCL communication lib")
     variant(
         "ofi_libfabric_plugin",
-        default=True,
+        default=spack.platforms.cray.slingshot_network(),
         when="+rccl",
         description="Builds with support for OFI libfabric enhanced RCCL/NCCL communication lib",
     )
     variant(
         "ofi_libfabric_plugin",
-        default=True,
+        default=spack.platforms.cray.slingshot_network(),
         when="+nccl",
         description="Builds with support for OFI libfabric enhanced RCCL/NCCL communication lib",
     )


### PR DESCRIPTION
This will replace the last use-case for `platform=cray` constraints that were not modeling the use of the module system. In a  very few cases, the platform was being used as a proxy for the network interconnect available.

@bvanessen 