### PR TITLE
MFEM: fix some issues with building with ROCm

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/mfem-4.5.patch
+++ b/var/spack/repos/builtin/packages/mfem/mfem-4.5.patch
@@ -1,0 +1,36 @@
+diff --git a/miniapps/common/makefile b/miniapps/common/makefile
+index 12506bf8b..681d9e83c 100644
+--- a/miniapps/common/makefile
++++ b/miniapps/common/makefile
+@@ -31,10 +31,12 @@ MFEM_LIB_FILE = mfem_is_not_built
+ ifneq (clean,$(MAKECMDGOALS))
+    -include $(CONFIG_MK)
+ 
+-   ifeq ($(MFEM_USE_CUDA)$(MFEM_USE_HIP),NONO)
+-      XLINKER = $(CXX_XLINKER)
+-   else ifeq ($(MFEM_USE_CUDA),YES)
++   ifeq ($(MFEM_USE_CUDA),YES)
+       XLINKER = $(CUDA_XLINKER)
++   else ifeq ($(MFEM_USE_HIP),YES)
++      XLINKER = $(HIP_XLINKER)
++   else
++      XLINKER = $(CXX_XLINKER)
+    endif
+ 
+    BUILD_REAL_DIR = $(realpath .)
+diff --git a/miniapps/hooke/makefile b/miniapps/hooke/makefile
+index 7687a7eb3..6c5c2b24d 100644
+--- a/miniapps/hooke/makefile
++++ b/miniapps/hooke/makefile
+@@ -29,6 +29,11 @@ HOOKE_OBJ = $(HOOKE_SRC:.cpp=.o)
+ 
+ SEQ_MINIAPPS =
+ PAR_MINIAPPS = hooke
++# The hooke miniapp crashes the AMD HIP compiler, so for now we disable it
++# when HIP is enabled:
++ifeq ($(MFEM_USE_HIP),YES)
++   PAR_MINIAPPS =
++endif
+ ifeq ($(MFEM_USE_MPI),NO)
+    MINIAPPS = $(SEQ_MINIAPPS)
+ else

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -429,12 +429,13 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     patch("mfem-4.2-petsc-3.15.0.patch", when="@4.2.0+petsc ^petsc@3.15.0:")
     patch("mfem-4.3-hypre-2.23.0.patch", when="@4.3.0")
     patch("mfem-4.3-cusparse-11.4.patch", when="@4.3.0+cuda")
-
     # Patch to fix MFEM makefile syntax error. See
     # https://github.com/mfem/mfem/issues/1042 for the bug report and
     # https://github.com/mfem/mfem/pull/1043 for the bugfix contributed
     # upstream.
     patch("mfem-4.0.0-makefile-syntax-fix.patch", when="@4.0.0")
+    patch("mfem-4.5.patch", when="@4.5.0")
+
     phases = ["configure", "build", "install"]
 
     def setup_build_environment(self, env):
@@ -1029,9 +1030,6 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             make("-C", "examples", "ex1p" if ("+mpi" in self.spec) else "ex1", parallel=False)
             # make('check', parallel=False)
         else:
-            # As of v4.5.0 and ROCm up to 5.2.3, the following miniapp crashes
-            # the HIP compiler, so it has to be disabled for testing with HIP:
-            # filter_file("PAR_MINIAPPS = hooke", "PAR_MINIAPPS =", "miniapps/hooke/makefile")
             make("all")
             make("test", parallel=False)
 

--- a/var/spack/repos/builtin/packages/mfem/test_builds.sh
+++ b/var/spack/repos/builtin/packages/mfem/test_builds.sh
@@ -186,11 +186,6 @@ builds_cuda=(
 
 
 builds_rocm=(
-    # NOTE: the miniapp 'hooke' crashes the HIP compiler, so it needs to be
-    #       disabled in Spack, e.g. with
-    #          filter_file("PAR_MINIAPPS = hooke", "PAR_MINIAPPS =",
-    #                      "miniapps/hooke/makefile")
-
     # hypre without rocm:
     ${mfem}'+rocm amdgpu_target='"${rocm_arch}"
 


### PR DESCRIPTION
This is a patch for mfem v4.5 that includes the fixes from https://github.com/mfem/mfem/pull/3317.