### PR TITLE
gcc: drop target bootstrap flags for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -682,6 +682,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # result in compilation errors, when gcc@7 is built with gcc@11, and znver3
         # is taken as a the target, which gcc@7 doesn't support.
         # Note we're not adding this for aarch64 because of
+        # https://github.com/spack/spack/issues/31184
         if "+bootstrap %gcc" in self.spec and self.spec.target.family != "aarch64":
             flags += " " + self.get_common_target_flags(self.spec)
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -681,7 +681,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # concretization, so we'll stick to that. The other way around however can
         # result in compilation errors, when gcc@7 is built with gcc@11, and znver3
         # is taken as a the target, which gcc@7 doesn't support.
-        if "+bootstrap %gcc" in self.spec:
+        # Note we're not adding this for aarch64 because of
+        if "+bootstrap %gcc" in self.spec and self.spec.target.family != "aarch64":
             flags += " " + self.get_common_target_flags(self.spec)
 
         if "+bootstrap" in self.spec:


### PR DESCRIPTION
See https://github.com/spack/spack/issues/31184

GCC bootstrap logic adds `-mpcu` for libatomic (iirc), which conflicts
with the `-march` flag we provide.

