### PR TITLE
xsdk: deprecate 0.6.0, and remove older deprecated releases

### DIFF
--- a/var/spack/repos/builtin/packages/xsdk-examples/package.py
+++ b/var/spack/repos/builtin/packages/xsdk-examples/package.py
@@ -18,8 +18,11 @@ class XsdkExamples(CMakePackage, CudaPackage):
 
     version("develop", branch="master")
     version("0.3.0", sha256="e7444a403c0a69eeeb34a4068be4d6f4e5b54cbfd275629019b9236a538a739e")
-    version("0.2.0", sha256="cf26e3a16a83eba6fb297fb106b0934046f17cf978f96243b44d9d17ad186db6")
-    version("0.1.0", sha256="d24cab1db7c0872b6474d69e598df9c8e25d254d09c425fb0a6a8d6469b8018f")
+    version(
+        "0.2.0",
+        sha256="cf26e3a16a83eba6fb297fb106b0934046f17cf978f96243b44d9d17ad186db6",
+        deprecated=True,
+    )
 
     depends_on("xsdk+cuda", when="+cuda")
     for sm_ in CudaPackage.cuda_arch_values:
@@ -30,7 +33,6 @@ class XsdkExamples(CMakePackage, CudaPackage):
     depends_on("xsdk@0.7.0 ^mfem+strumpack", when="@0.3.0 ^xsdk+strumpack")
     depends_on("xsdk@0.7.0 ^sundials+magma", when="@0.3.0 +cuda")
     depends_on("xsdk@0.6.0", when="@0.2.0")
-    depends_on("xsdk@0.5.0", when="@0.1.0")
     depends_on("mpi")
     depends_on("cmake@3.21:", type="build", when="@0.3.0:")
 

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -86,10 +86,7 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
 
     version("develop")
     version("0.7.0")
-    version("0.6.0")
-    version("0.5.0", deprecated=True)
-    version("0.4.0", deprecated=True)
-    version("0.3.0", deprecated=True)
+    version("0.6.0", deprecated=True)
 
     variant("trilinos", default=True, description="Enable trilinos package build")
     variant("datatransferkit", default=True, description="Enable datatransferkit package build")
@@ -111,9 +108,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on("hypre@develop+superlu-dist+shared", when="@develop", cuda_var="cuda")
     xsdk_depends_on("hypre@2.23.0+superlu-dist+shared", when="@0.7.0", cuda_var="cuda")
     xsdk_depends_on("hypre@2.20.0+superlu-dist+shared", when="@0.6.0")
-    xsdk_depends_on("hypre@2.18.2+superlu-dist+shared", when="@0.5.0")
-    xsdk_depends_on("hypre@2.15.1~internal-superlu", when="@0.4.0")
-    xsdk_depends_on("hypre@2.12.1~internal-superlu", when="@0.3.0")
 
     xsdk_depends_on(
         "mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps",
@@ -132,18 +126,10 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         when="@0.6.0",
         cuda_var="cuda",
     )
-    xsdk_depends_on(
-        "mfem@4.0.1-xsdk+mpi~superlu-dist+petsc+sundials+examples+miniapps", when="@0.5.0"
-    )
-    xsdk_depends_on("mfem@3.4.0+mpi+superlu-dist+petsc+sundials+examples+miniapps", when="@0.4.0")
-    xsdk_depends_on("mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps", when="@0.3.0")
 
     xsdk_depends_on("superlu-dist@develop", when="@develop")
     xsdk_depends_on("superlu-dist@7.1.1", when="@0.7.0")
     xsdk_depends_on("superlu-dist@6.4.0", when="@0.6.0")
-    xsdk_depends_on("superlu-dist@6.1.1", when="@0.5.0")
-    xsdk_depends_on("superlu-dist@6.1.0", when="@0.4.0")
-    xsdk_depends_on("superlu-dist@5.2.2", when="@0.3.0")
     xsdk_depends_on(
         "trilinos@develop+hypre+superlu-dist+hdf5~mumps+boost"
         + "~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2"
@@ -165,24 +151,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         + " cxxstd=11",
         when="@0.6.0 +trilinos",
     )
-    xsdk_depends_on(
-        "trilinos@12.18.1+hypre+superlu-dist+hdf5~mumps+boost"
-        + "~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2"
-        + "~exodus+dtk+intrepid2+shards",
-        when="@0.5.0 +trilinos",
-    )
-    xsdk_depends_on(
-        "trilinos@12.14.1+hypre+superlu-dist+hdf5~mumps+boost"
-        + "~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2"
-        + "~exodus+dtk+intrepid2+shards",
-        when="@0.4.0 +trilinos",
-    )
-    xsdk_depends_on(
-        "trilinos@12.12.1+hypre+superlu-dist+hdf5~mumps+boost"
-        + "~suite-sparse~tpetra~ifpack2~zoltan~zoltan2~amesos2"
-        "~exodus",
-        when="@0.3.0 +trilinos",
-    )
 
     xsdk_depends_on("datatransferkit@master", when="@develop +trilinos +datatransferkit")
     dtk7ver = "3.1-rc2" if sys.platform == "darwin" else "3.1-rc3"
@@ -190,7 +158,7 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on("datatransferkit@3.1-rc2", when="@0.6.0 +trilinos +datatransferkit")
 
     xsdk_depends_on("petsc +trilinos", when="+trilinos @:0.6.0")
-    xsdk_depends_on("petsc +batch", when="@0.5.0: ^cray-mpich")
+    xsdk_depends_on("petsc +batch", when="@0.6.0: ^cray-mpich")
     xsdk_depends_on(
         "petsc@main+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64",
         when="@develop",
@@ -205,15 +173,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         "petsc@3.14.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64",
         when="@0.6.0",
         cuda_var="cuda",
-    )
-    xsdk_depends_on(
-        "petsc@3.12.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64", when="@0.5.0"
-    )
-    xsdk_depends_on(
-        "petsc@3.10.3+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64", when="@0.4.0"
-    )
-    xsdk_depends_on(
-        "petsc@3.8.2+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64", when="@0.3.0"
     )
 
     xsdk_depends_on("dealii +trilinos~adol-c", when="+trilinos +dealii")
@@ -233,30 +192,14 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         + "~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx",
         when="@0.6.0 +dealii",
     )
-    xsdk_depends_on(
-        "dealii@9.1.1~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5"
-        + "~netcdf+metis~sundials~ginkgo~symengine",
-        when="@0.5.0 +dealii",
-    )
-    xsdk_depends_on(
-        "dealii@9.0.1~assimp~python~doc~gmsh+petsc~slepc+mpi~int64+hdf5"
-        + "~netcdf+metis~ginkgo~symengine",
-        when="@0.4.0 +dealii",
-    )
 
     xsdk_depends_on("pflotran@develop", when="@develop")
     xsdk_depends_on("pflotran@3.0.2", when="@0.7.0")
     xsdk_depends_on("pflotran@xsdk-0.6.0", when="@0.6.0")
-    xsdk_depends_on("pflotran@xsdk-0.5.0", when="@0.5.0")
-    xsdk_depends_on("pflotran@xsdk-0.4.0", when="@0.4.0")
-    xsdk_depends_on("pflotran@xsdk-0.3.0", when="@0.3.0")
 
     xsdk_depends_on("alquimia@develop", when="@develop +alquimia")
     xsdk_depends_on("alquimia@1.0.9", when="@0.7.0 +alquimia")
     xsdk_depends_on("alquimia@xsdk-0.6.0", when="@0.6.0 +alquimia")
-    xsdk_depends_on("alquimia@xsdk-0.5.0", when="@0.5.0 +alquimia ")
-    xsdk_depends_on("alquimia@xsdk-0.4.0", when="@0.4.0 +alquimia")
-    xsdk_depends_on("alquimia@xsdk-0.3.0", when="@0.3.0 +alquimia")
 
     xsdk_depends_on("sundials +trilinos", when="+trilinos @0.6.0:")
     xsdk_depends_on(
@@ -274,22 +217,14 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on(
         "sundials@5.5.0~int64+hypre+petsc+superlu-dist", when="@0.6.0", cuda_var="cuda"
     )
-    xsdk_depends_on("sundials@5.0.0~int64+hypre+petsc+superlu-dist", when="@0.5.0")
-    xsdk_depends_on("sundials@3.2.1~int64+hypre", when="@0.4.0")
-    xsdk_depends_on("sundials@3.1.0~int64+hypre", when="@0.3.0")
 
     xsdk_depends_on("plasma@develop:", when="@develop %gcc@6.0:")
     xsdk_depends_on("plasma@21.8.29:", when="@0.7.0 %gcc@6.0:")
     xsdk_depends_on("plasma@20.9.20:", when="@0.6.0 %gcc@6.0:")
-    xsdk_depends_on("plasma@19.8.1:", when="@0.5.0 %gcc@6.0:")
-    xsdk_depends_on("plasma@18.11.1:", when="@0.4.0 %gcc@6.0:")
 
     xsdk_depends_on("magma@master", when="@develop", cuda_var="?cuda", rocm_var="?rocm")
     xsdk_depends_on("magma@2.6.1", when="@0.7.0", cuda_var="?cuda", rocm_var="?rocm")
     xsdk_depends_on("magma@2.5.4", when="@0.6.0", cuda_var="?cuda")
-    xsdk_depends_on("magma@2.5.1", when="@0.5.0", cuda_var="?cuda")
-    xsdk_depends_on("magma@2.4.0", when="@0.4.0", cuda_var="?cuda")
-    xsdk_depends_on("magma@2.2.0", when="@0.3.0", cuda_var="?cuda")
 
     xsdk_depends_on(
         "amrex@develop+sundials", when="@develop %intel", cuda_var="cuda", rocm_var="rocm"
@@ -305,37 +240,25 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on("amrex@21.10+sundials", when="@0.7.0 %cce", cuda_var="cuda", rocm_var="rocm")
     xsdk_depends_on("amrex@20.10", when="@0.6.0 %intel")
     xsdk_depends_on("amrex@20.10", when="@0.6.0 %gcc")
-    xsdk_depends_on("amrex@19.08", when="@0.5.0 %intel")
-    xsdk_depends_on("amrex@19.08", when="@0.5.0 %gcc")
-    xsdk_depends_on("amrex@18.10.1", when="@0.4.0 %intel")
-    xsdk_depends_on("amrex@18.10.1", when="@0.4.0 %gcc")
 
     xsdk_depends_on("slepc@main", when="@develop")
     xsdk_depends_on("slepc@3.16.0", when="@0.7.0")
     xsdk_depends_on("slepc@3.14.0", when="@0.6.0")
-    xsdk_depends_on("slepc@3.12.0", when="@0.5.0")
-    xsdk_depends_on("slepc@3.10.1", when="@0.4.0")
 
     xsdk_depends_on("omega-h +trilinos", when="+trilinos +omega-h")
     xsdk_depends_on("omega-h ~trilinos", when="~trilinos +omega-h")
     xsdk_depends_on("omega-h@main", when="@develop +omega-h")
     xsdk_depends_on("omega-h@9.34.1", when="@0.7.0 +omega-h")
     xsdk_depends_on("omega-h@9.32.5", when="@0.6.0 +omega-h")
-    xsdk_depends_on("omega-h@9.29.0", when="@0.5.0 +omega-h")
-    xsdk_depends_on("omega-h@9.19.1", when="@0.4.0 +omega-h")
 
     xsdk_depends_on("strumpack ~cuda", when="~cuda @0.6.0: +strumpack")
     xsdk_depends_on("strumpack@master~slate~openmp", when="@develop +strumpack")
     xsdk_depends_on("strumpack@6.1.0~slate~openmp", when="@0.7.0 +strumpack")
     xsdk_depends_on("strumpack@5.0.0~slate~openmp", when="@0.6.0 +strumpack")
-    xsdk_depends_on("strumpack@3.3.0~slate~openmp", when="@0.5.0 +strumpack")
-    xsdk_depends_on("strumpack@3.1.1~slate~openmp", when="@0.4.0 +strumpack")
 
     xsdk_depends_on("pumi@master", when="@develop")
     xsdk_depends_on("pumi@2.2.6", when="@0.7.0")
     xsdk_depends_on("pumi@2.2.5", when="@0.6.0")
-    xsdk_depends_on("pumi@2.2.1", when="@0.5.0")
-    xsdk_depends_on("pumi@2.2.0", when="@0.4.0")
 
     tasmanian_openmp = "~openmp" if sys.platform == "darwin" else "+openmp"
     xsdk_depends_on(
@@ -354,14 +277,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         when="@0.6.0",
         cuda_var=["cuda", "?magma"],
     )
-    xsdk_depends_on(
-        "tasmanian@7.0+xsdkflags+mpi+blas" + tasmanian_openmp,
-        when="@0.5.0",
-        cuda_var=["cuda", "?magma"],
-    )
-    xsdk_depends_on(
-        "tasmanian@6.0+xsdkflags+blas~openmp", when="@0.4.0", cuda_var=["cuda", "?magma"]
-    )
 
     xsdk_depends_on("arborx@master", when="@develop +arborx")
     xsdk_depends_on("arborx@1.1", when="@0.7.0 +arborx")
@@ -377,8 +292,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on("phist@develop ~fortran ~scamac ~openmp ~host ~int64", when="@develop +phist")
     xsdk_depends_on("phist@1.9.5 ~fortran ~scamac ~openmp ~host ~int64", when="@0.7.0 +phist")
     xsdk_depends_on("phist@1.9.3 ~fortran ~scamac ~openmp ~host ~int64", when="@0.6.0 +phist")
-    xsdk_depends_on("phist@1.8.0 ~fortran ~scamac ~openmp ~host ~int64", when="@0.5.0 +phist")
-    xsdk_depends_on("phist@1.7.5 ~fortran ~scamac ~openmp ~host ~int64", when="@0.4.0 +phist")
 
     xsdk_depends_on(
         "ginkgo@develop ~openmp", when="@develop +ginkgo", cuda_var="cuda", rocm_var="rocm"
@@ -387,7 +300,6 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
         "ginkgo@1.4.0 ~openmp", when="@0.7.0 +ginkgo", cuda_var="cuda", rocm_var="rocm"
     )
     xsdk_depends_on("ginkgo@1.3.0 ~openmp", when="@0.6.0 +ginkgo", cuda_var="cuda")
-    xsdk_depends_on("ginkgo@1.1.0 ~openmp", when="@0.5.0 +ginkgo")
 
     xsdk_depends_on("py-libensemble@develop+petsc4py", when="@develop +libensemble")
     xsdk_depends_on("py-petsc4py@main", when="@develop +libensemble")
@@ -395,19 +307,15 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     xsdk_depends_on("py-petsc4py@3.16.1", when="@0.7.0 +libensemble")
     xsdk_depends_on("py-libensemble@0.7.1+petsc4py", when="@0.6.0 +libensemble")
     xsdk_depends_on("py-petsc4py@3.14.0", when="@0.6.0 +libensemble")
-    xsdk_depends_on("py-libensemble@0.5.2+petsc4py", when="@0.5.0 +libensemble")
-    xsdk_depends_on("py-petsc4py@3.12.0", when="@0.5.0 +libensemble")
 
     xsdk_depends_on("precice ~petsc", when="+precice ^cray-mpich")
     xsdk_depends_on("precice@develop", when="@develop +precice")
     xsdk_depends_on("precice@2.3.0", when="@0.7.0 +precice")
     xsdk_depends_on("precice@2.1.1", when="@0.6.0 +precice")
-    xsdk_depends_on("precice@1.6.1", when="@0.5.0 +precice")
 
     xsdk_depends_on("butterflypack@master", when="@develop +butterflypack")
     xsdk_depends_on("butterflypack@2.0.0", when="@0.7.0 +butterflypack")
     xsdk_depends_on("butterflypack@1.2.1", when="@0.6.0 +butterflypack")
-    xsdk_depends_on("butterflypack@1.1.0", when="@0.5.0 +butterflypack")
 
     xsdk_depends_on(
         "heffte@develop+fftw",


### PR DESCRIPTION
xsdk-examples: deprecate @0.2.0, remove @0.1.0 in sync with older xsdk releases

@adamjstewart, xsdk-examples should be deprecated in sync with xsdk. But I previously missed deprecating `xsdk-examples@0.1.0` - when `xsdk@0.5.0` was deprecated.