### PR TITLE
traverse: add topo

### DIFF
--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -284,3 +284,32 @@ chain-a
     ^chain-d
 """
     assert s.tree(depth_first=False, cover="edges", **args) == bfs_tree_edges
+
+
+def test_traverse_topo_order():
+    # Good old Wiki example
+    s = [Spec("s{}".format(i)) for i in range(12)]
+
+    for parent, child in (
+        (5, 11),
+        (7, 11),
+        (7, 8),
+        (3, 8),
+        (3, 10),
+        (11, 2),
+        (11, 9),
+        (11, 10),
+        (8, 9),
+    ):
+        s[parent].add_dependency_edge(s[child], "all")
+
+    # These are *actual* roots (all nodes with no incoming edges)
+    roots = [s[5], s[7], s[3]]
+    nodes = [x.spec for x in traverse.traverse_edges(roots, order="topo")]
+
+    # Ensure the invariant that all parents of node[i] are in node[0:i]
+    # Since we have actual roots, we can just traverse in reverse with a different
+    # traversal method from the one we're testing.
+    for i in range(len(nodes)):
+        parents = list(nodes[i].traverse(order="pre", direction="parents", root=False))
+        assert set(parents).issubset(set(nodes[:i]))

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -289,7 +289,7 @@ chain-a
 @pytest.fixture()
 def abstract_specs_toposort():
     # Create a graph that both BFS and DFS would not traverse in topo order, assuming
-    # edges are traversed by target node name. Roots are {A, E} in forward order and
+    # edges are ordered by target node name. Roots are {A, E} in forward order and
     # {F, G} in backward order.
     # forward: DFS([A, E]) traverses [A, B, F, G, C, D, E] (not topo since C < B)
     # forward: BFS([A, E]) traverses [A, E, B, C, D, F, G] (not topo since C < B)

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -369,15 +369,13 @@ def test_traverse_topo_nodes(abstract_specs_toposort):
 
     def test_topo(roots, direction="children"):
         # Ensure the invariant that all parents of specs[i] are in specs[0:i]
-        ordered = list(
+        specs = list(
             traverse.traverse_nodes(roots, order="topo", cover="nodes", direction=direction)
         )
         reverse = "parents" if direction == "children" else "children"
-        for i in range(len(ordered)):
-            parents = ordered[i].traverse(
-                order="pre", cover="nodes", direction=reverse, root=False
-            )
-            assert set(list(parents)).issubset(set(ordered[:i]))
+        for i in range(len(specs)):
+            parents = specs[i].traverse(cover="nodes", direction=reverse, root=False)
+            assert set(list(parents)).issubset(set(specs[:i]))
 
     # Traverse forward from roots A and E and a non-root D
     test_topo([nodes["D"], nodes["E"], nodes["A"]], direction="children")

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -303,13 +303,15 @@ def test_traverse_topo_order():
     ):
         s[parent].add_dependency_edge(s[child], "all")
 
-    # These are *actual* roots (all nodes with no incoming edges)
-    roots = [s[5], s[7], s[3]]
-    nodes = [x.spec for x in traverse.traverse_edges(roots, order="topo")]
+    def is_topo(ordered_specs):
+        # Ensure the invariant that all parents of specs[i] are in specs[0:i]
+        specs = [s for s in ordered_specs]
+        for i in range(len(specs)):
+            parents = specs[i].traverse(order="pre", direction="parents", root=False)
+            assert set(list(parents)).issubset(set(specs[:i]))
 
-    # Ensure the invariant that all parents of node[i] are in node[0:i]
-    # Since we have actual roots, we can just traverse in reverse with a different
-    # traversal method from the one we're testing.
-    for i in range(len(nodes)):
-        parents = list(nodes[i].traverse(order="pre", direction="parents", root=False))
-        assert set(parents).issubset(set(nodes[:i]))
+    # Using all *actual* root (no in-coming edge) of the DAG
+    is_topo(traverse.traverse_nodes([s[5], s[7], s[3]], order="topo"))
+
+    # The same, but now also include some spec that *has* parents
+    is_topo(traverse.traverse_nodes([s[11], s[7], s[5], s[3]], order="topo"))

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -214,18 +214,18 @@ def test_breadth_first_traversal_reverse(abstract_specs_dt_diamond):
     ]
 
 
-def test_breadth_first_traversal_multiple_roots(abstract_specs_dt_diamond):
+def test_breadth_first_traversal_multiple_input_specs(abstract_specs_dt_diamond):
     # With DFS, the branch dt-diamond -> dt-diamond-left -> dt-diamond-bottom
     # is followed, with BFS, dt-diamond-bottom should be traced through the second
-    # root dt-diamond-right at depth 1 instead.
-    roots = [
+    # input spec dt-diamond-right at depth 1 instead.
+    input_specs = [
         abstract_specs_dt_diamond["dt-diamond"],
         abstract_specs_dt_diamond["dt-diamond-right"],
     ]
-    gen = traverse.traverse_edges(roots, order="breadth", key=id, depth=True, root=False)
+    gen = traverse.traverse_edges(input_specs, order="breadth", key=id, depth=True, root=False)
     assert [(depth, edge.parent.name, edge.spec.name) for (depth, edge) in gen] == [
-        (1, "dt-diamond", "dt-diamond-left"),  # edge from first root "to" depth 1
-        (1, "dt-diamond-right", "dt-diamond-bottom"),  # edge from second root "to" depth 1
+        (1, "dt-diamond", "dt-diamond-left"),  # edge from first input spec "to" depth 1
+        (1, "dt-diamond-right", "dt-diamond-bottom"),  # edge from second input spec "to" depth 1
     ]
 
 
@@ -369,10 +369,10 @@ def test_traverse_nodes_topo(abstract_specs_toposort):
     # order=topo and cover=nodes.
     nodes = abstract_specs_toposort
 
-    def test_topo(roots, direction="children"):
+    def test_topo(input_specs, direction="children"):
         # Ensure the invariant that all parents of specs[i] are in specs[0:i]
         specs = list(
-            traverse.traverse_nodes(roots, order="topo", cover="nodes", direction=direction)
+            traverse.traverse_nodes(input_specs, order="topo", cover="nodes", direction=direction)
         )
         reverse = "parents" if direction == "children" else "children"
         for i in range(len(specs)):
@@ -392,12 +392,12 @@ def test_traverse_edges_topo(abstract_specs_toposort):
     # Test the invariant that for each node in-edges precede out-edges when
     # using traverse_edges with order=topo.
     nodes = abstract_specs_toposort
-    roots = [nodes["E"], nodes["A"]]
+    input_specs = [nodes["E"], nodes["A"]]
 
     # Collect pairs of (parent spec name, child spec name)
     edges = [
         (e.parent.name, e.spec.name)
-        for e in traverse.traverse_edges(roots, order="topo", cover="edges", root=False)
+        for e in traverse.traverse_edges(input_specs, order="topo", cover="edges", root=False)
     ]
 
     # See figure above, we have 7 edges (excluding artifical ones to the root)

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -282,7 +282,7 @@ def traverse_depth_first_with_visitor(edges, visitor):
         visitor: class instance implementing accept(), pre() and neigbors()
     """
     for edge in edges:
-        if not visitor.accept(edges):
+        if not visitor.accept(edge):
             continue
 
         visitor.pre(edge)
@@ -415,8 +415,8 @@ def traverse_edges(
         # For cover=edges we could ensure the order (s -> t) < (u -> v)
         # iff (t, s) < (v, u) lexicographically where element-wise < is topo order,
         # but right now we only generates vertices in topo order.
-        if cover != "edges":
-            raise ValueError("cover=edges is not implemented for order=topo")
+        if cover != "nodes":
+            raise ValueError("cover=nodes is only supported for order=topo")
         # For topo order it's somewhat unclear how to handle a pre-existing visited
         # set. Exclude them? But what if excludes vertices have edges to non-excluded
         # ones? Not following would violate topo order.

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -287,9 +287,7 @@ def traverse_depth_first_with_visitor(edges, visitor):
 
         visitor.pre(edge)
 
-        neighbors = [
-            EdgeAndDepth(edge=e, depth=edge.depth + 1) for e in visitor.neighbors(edge)
-        ]
+        neighbors = [EdgeAndDepth(edge=e, depth=edge.depth + 1) for e in visitor.neighbors(edge)]
 
         traverse_depth_first_with_visitor(neighbors, visitor)
 

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -375,10 +375,10 @@ def traverse_edges_topo(
     specs, direction="children", deptype="all", key=id, root=True, all_edges=False
 ):
     """
-    Returns a list of edges where ordered in topo order, in the sense that all
-    in-edges of a vertex appear before all out-edges. By default with direction=children
-    edges are directed from dependent to dependency. With directions=parents, the edges
-    are directed from dependency to dependent.
+    Returns a list of edges in topological order, in the sense that all in-edges of a
+    vertex appear before all out-edges. By default with direction=children edges are
+    directed from dependent to dependency. With directions=parents, the edges are
+    directed from dependency to dependent.
 
     Arguments:
         specs (list): List of root specs (considered to be depth 0)
@@ -448,9 +448,8 @@ def traverse_edges(
     if order == "topo":
         if cover == "paths":
             raise ValueError("cover=paths not supported for order=topo")
-        # For topo order it's somewhat unclear how to handle a pre-existing visited
-        # set. Exclude them? But what if excludes vertices have edges to non-excluded
-        # ones? Not following would violate topo order.
+        # TODO: There is no known need for topological ordering of traversals (edge or node)
+        # with an initialized "visited" set. Revisit if needed.
         if visited is not None:
             raise ValueError("visited set not implemented for order=topo")
         return traverse_edges_topo(

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -428,9 +428,6 @@ def traverse_edges(
     """
 
     if order == "topo":
-        # For cover=edges we could ensure the order (s -> t) < (u -> v)
-        # iff (t, s) < (v, u) lexicographically where element-wise < is topo order,
-        # but right now we only generates vertices in topo order.
         if cover == "paths":
             raise ValueError("cover=paths not supported for order=topo")
         # For topo order it's somewhat unclear how to handle a pre-existing visited

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -111,7 +111,8 @@ class CoverEdgesVisitor(object):
 
 
 class TopoVisitor(object):
-    """Visitor that can be used in depth-first traversal to generate
+    """Visitor that can be used in :py:func:`depth-first traversal
+    <spack.traverse.traverse_depth_first_with_visitor>` to generate
     a topologically ordered list of edges (in-edges before out-edges).
 
     Algorithm based on "Section 22.4: Topological sort", Introduction to Algorithms

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -120,7 +120,7 @@ class TopoVisitor(object):
 
     The algorithm in plain English: realize that (1) we only append a vertex A before
     traversing all possible paths to any descendant B (that means A is always appended
-    to reverse_order after all its descendents) and (2) while following paths from
+    to reverse_order after all its descendants) and (2) while following paths from
     A -> B, we push B to reverse_order the first time it is reached, and guarantee its
     ancestors are always appended and its descendants are not (on the first path
     this is thanks to backtracking, on any other path we do not follow B as its

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -247,8 +247,8 @@ def traverse_breadth_first_edges_generator(queue, visitor, root=True, depth=Fals
         if root or edge.depth > 0:
             yield (edge.depth, edge.edge) if depth else edge.edge
 
-        for edge in visitor.neighbors(edge):
-            queue.append(EdgeAndDepth(edge, edge.depth + 1))
+        for e in visitor.neighbors(edge):
+            queue.append(EdgeAndDepth(e, edge.depth + 1))
 
 
 def traverse_breadth_first_with_visitor(specs, visitor):
@@ -267,8 +267,8 @@ def traverse_breadth_first_with_visitor(specs, visitor):
         if not visitor.accept(edge):
             continue
 
-        for edge in visitor.neighbors(edge):
-            queue.append(EdgeAndDepth(edge, edge.depth + 1))
+        for e in visitor.neighbors(edge):
+            queue.append(EdgeAndDepth(e, edge.depth + 1))
 
 
 def traverse_depth_first_with_visitor(edges, visitor):
@@ -288,7 +288,7 @@ def traverse_depth_first_with_visitor(edges, visitor):
         visitor.pre(edge)
 
         neighbors = [
-            EdgeAndDepth(edge=edge, depth=edge.depth + 1) for edge in visitor.neighbors(edge)
+            EdgeAndDepth(edge=e, depth=edge.depth + 1) for e in visitor.neighbors(edge)
         ]
 
         traverse_depth_first_with_visitor(neighbors, visitor)


### PR DESCRIPTION
@scheibelp since we talked about this. It's useful in the installer, as well as for removal (currently it screams about the db being in an inconsistent state), and as you suggested: environment modifications (although I'm still not convinced).

Basically gives you 

```python
spack.traverse.traverse_edges([s1, s2], order="topo", direction="parents/children", key=...)
```

and `spack.traverse.traverse_nodes`.