### PR TITLE
ParaView: Add openPMD Support

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -156,7 +156,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("py-cinemasci", when="+cinema")
 
     dav_sdk_depends_on(
-        "paraview@5.10:+mpi+python+kits+shared+catalyst+libcatalyst",
+        "paraview@5.10:+mpi+openpmd+python+kits+shared+catalyst+libcatalyst",
         when="+paraview",
         propagate=["hdf5", "adios2"],
     )

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -71,6 +71,12 @@ class Paraview(CMakePackage, CudaPackage):
     variant("eyedomelighting", default=False, description="Enable Eye Dome Lighting feature")
     variant("adios2", default=False, description="Enable ADIOS2 support", when="@5.8:")
     variant("visitbridge", default=False, description="Enable VisItBridge support")
+    variant(
+        "openpmd",
+        default=False,
+        description="Enable openPMD support (w/ ADIOS2/HDF5)",
+        when="@5.9: +python",
+    )
     variant("catalyst", default=False, description="Enable Catalyst 1", when="@5.7:")
     variant(
         "libcatalyst",
@@ -104,6 +110,7 @@ class Paraview(CMakePackage, CudaPackage):
 
     conflicts("~hdf5", when="+visitbridge")
     conflicts("+adios2", when="@:5.10 ~mpi")
+    conflicts("+openpmd", when="~adios2 ~hdf5", msg="openPMD needs ADIOS2 and/or HDF5")
     conflicts("~shared", when="+cuda")
     conflicts("+cuda", when="@5.8:5.10")
     # Legacy rendering dropped in 5.5
@@ -152,6 +159,11 @@ class Paraview(CMakePackage, CudaPackage):
 
     depends_on("py-matplotlib", when="+python", type="run")
     depends_on("py-pandas@0.21:", when="+python", type="run")
+
+    # openPMD is implemented as a Python module and provides ADIOS2 and HDF5 backends
+    depends_on("openpmd-api@0.14.5: +python", when="+python +openpmd", type=("build", "run"))
+    depends_on("openpmd-api +adios2", when="+openpmd +adios2", type=("build", "run"))
+    depends_on("openpmd-api +hdf5", when="+openpmd +hdf5", type=("build", "run"))
 
     depends_on("mpi", when="+mpi")
     depends_on("qt+opengl", when="@5.3.0:+qt+opengl2")


### PR DESCRIPTION
openPMD, a metadata standard on top of backends like ADIOS2 and HDF5, is implemented in ParaView 5.9+ via a Python3 module.