### PR TITLE
adding sha for 7.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
@@ -16,10 +16,11 @@ class OsuMicroBenchmarks(AutotoolsPackage, CudaPackage, ROCmPackage):
     and can be used for both traditional and GPU-enhanced nodes."""
 
     homepage = "https://mvapich.cse.ohio-state.edu/benchmarks/"
-    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-6.2.tar.gz"
+    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.0.tar.gz"
 
     maintainers = ["natshineman", "harisubramoni", "MatthewLieber"]
 
+    version("7.0", sha256="958e2faf9f3a4a244d7baac3469acee0375447decff6026c442552f0f6f08306")
     version("6.2", sha256="bb9dbc87dcf8ec6785977a61f6fceee8febf1a682488eaab4c58cf50e4fa985f")
     version("6.1", sha256="ecccedc868264f75db4d9529af79005419a2775113c7fae8f4e4a8434362e4a7")
     version("6.0", sha256="309fb7583ff54562343b0e0df1eebde3fc245191e183be362f031ac74f4ab542")


### PR DESCRIPTION
Updating the url and adding sha for the 7.0 release of osu-micro-benchmarks.