### PR TITLE
warn about removal of deprecated format strings

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+      all: "${architecture}/${compiler.name}-${compiler.version}/${name}-${version}-${hash}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4384,7 +4384,8 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-
+        tty.warn("Using the old Spec.format method."
+                 " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20")
         color = kwargs.get("color", False)
 
         # Dictionary of transformations for named tokens

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4384,8 +4384,10 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        tty.warn("Using the old Spec.format method."
-                 " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20")
+        tty.warn(
+            "Using the old Spec.format method."
+            " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20"
+        )
         color = kwargs.get("color", False)
 
         # Dictionary of transformations for named tokens

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -60,7 +60,7 @@ def test_yaml_directory_layout_parameters(tmpdir, config):
     arch_scheme = (
         "{architecture.platform}/{architecture.target}/{architecture.os}/{name}/{version}/{hash:7}"
     )
-    ns_scheme = "${ARCHITECTURE}/${NAMESPACE}/${PACKAGE}-${VERSION}-${HASH:7}"
+    ns_scheme = "${architecture}/${namespace}/${name}-${version}-${hash:7}"
     arch_ns_scheme_projections = {"all": arch_scheme, "python": ns_scheme}
     layout_arch_ns = DirectoryLayout(str(tmpdir), projections=arch_ns_scheme_projections)
 

--- a/share/spack/qa/configuration/windows_config.yaml
+++ b/share/spack/qa/configuration/windows_config.yaml
@@ -3,6 +3,6 @@ config:
   install_tree:
     root: $spack\opt\spack
     projections:
-      all: '${ARCHITECTURE}\${COMPILERNAME}-${COMPILERVER}\${PACKAGE}-${VERSION}-${HASH}'
+      all: '${architecture}\${compiler.name}-${compiler.version}\${name}-${version}-${hash}'
   build_stage:
     - ~/.spack/stage


### PR DESCRIPTION
Removal scheduled for v0.20

Should have been scheduled long ago, but we kept configs in this format for too long.