### PR TITLE
remove patchelf relocation weirdness

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -356,13 +356,7 @@ def _set_elf_rpaths(target, rpaths):
     # Join the paths using ':' as a separator
     rpaths_str = ":".join(rpaths)
 
-    # If we're relocating patchelf itself, make a copy and use it
-    bak_path = None
-    if target.endswith("/bin/patchelf"):
-        bak_path = target + ".bak"
-        shutil.copy(target, bak_path)
-
-    patchelf, output = executable.Executable(bak_path or _patchelf()), None
+    patchelf, output = executable.Executable(_patchelf()), None
     try:
         # TODO: revisit the use of --force-rpath as it might be conditional
         # TODO: if we want to support setting RUNPATH from binary packages
@@ -371,9 +365,6 @@ def _set_elf_rpaths(target, rpaths):
     except executable.ProcessError as e:
         msg = "patchelf --force-rpath --set-rpath {0} failed with error {1}"
         tty.warn(msg.format(target, e))
-    finally:
-        if bak_path and os.path.exists(bak_path):
-            os.remove(bak_path)
     return output
 
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -6,7 +6,6 @@ import collections
 import itertools
 import os
 import re
-import shutil
 from collections import OrderedDict
 
 import macholib.mach_o

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -233,30 +233,6 @@ def test_normalize_relative_paths(start_path, relative_paths, expected):
     assert normalized == expected
 
 
-def test_set_elf_rpaths(mock_patchelf):
-    # Try to relocate a mock version of patchelf and check
-    # the call made to patchelf itself
-    patchelf = mock_patchelf("echo $@")
-    rpaths = ["/usr/lib", "/usr/lib64", "/opt/local/lib"]
-    output = spack.relocate._set_elf_rpaths(patchelf, rpaths)
-
-    # Assert that the arguments of the call to patchelf are as expected
-    assert "--force-rpath" in output
-    assert "--set-rpath " + ":".join(rpaths) in output
-    assert patchelf in output
-
-
-@skip_unless_linux
-def test_set_elf_rpaths_warning(mock_patchelf):
-    # Mock a failing patchelf command and ensure it warns users
-    patchelf = mock_patchelf("exit 1")
-    rpaths = ["/usr/lib", "/usr/lib64", "/opt/local/lib"]
-    # To avoid using capfd in order to check if the warning was triggered
-    # here we just check that output is not set
-    output = spack.relocate._set_elf_rpaths(patchelf, rpaths)
-    assert output is None
-
-
 @pytest.mark.requires_executables("patchelf", "strings", "file", "gcc")
 @skip_unless_linux
 def test_relocate_text_bin(binary_with_rpaths, prefix_like):

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -173,14 +173,6 @@ def test_ensure_binary_is_relocatable(source_file, is_relocatable):
     assert relocatable == is_relocatable
 
 
-@pytest.mark.requires_executables("patchelf", "strings", "file")
-@skip_unless_linux
-def test_patchelf_is_relocatable():
-    patchelf = os.path.realpath(spack.relocate._patchelf())
-    assert llnl.util.filesystem.is_exe(patchelf)
-    spack.relocate.ensure_binary_is_relocatable(patchelf)
-
-
 @skip_unless_linux
 def test_ensure_binary_is_relocatable_errors(tmpdir):
     # The file passed in as argument must exist...


### PR DESCRIPTION
There is a test that tests whether system patchelf is relocatable (fails for me
with patchelf in PATH)

There is code that "relocates" patchelf by using itself
