### PR TITLE
Drop non-motivating example of package requirements from readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@
    packages:
      libfabric:
        require: "@1.13.2"
-     openmpi:
-       require:
-       - any_of: ["~cuda", "%gcc"]
      mpich:
        require:
        - one_of: ["+cuda", "+rocm"]


### PR DESCRIPTION
I don't see how this is helpful, it's only confusing?