### PR TITLE
libxcrypt: 4.4.30

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -36,6 +36,10 @@ class Libxcrypt(AutotoolsPackage):
         args += self.enable_or_disable("obsolete-api", variant="obsolete_api")
         return args
 
+    @property
+    def libs(self):
+        return find_libraries("libcrypt", root=self.prefix, recursive=True)
+
     with when("@:4.4.17"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -24,11 +24,17 @@ class Libxcrypt(AutotoolsPackage):
     version("4.4.16", sha256="a98f65b8baffa2b5ba68ee53c10c0a328166ef4116bce3baece190c8ce01f375")
     version("4.4.15", sha256="8bcdef03bc65f9dbda742e56820435b6f13eea59fb903765141c6467f4655e5a")
 
+    variant("obsolete_api", default=False, when="@4.4.30:")
+
     patch("truncating-conversion.patch", when="@4.4.30")
 
     def configure_args(self):
         # Disable test dependency on Python (Python itself depends on libxcrypt).
-        return ["ac_cv_path_python3_passlib=not found"]
+        args = [
+            "ac_cv_path_python3_passlib=not found",
+        ]
+        args += self.enable_or_disable("obsolete-api", variant="obsolete_api")
+        return args
 
     with when("@:4.4.17"):
         depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -10,13 +10,28 @@ class Libxcrypt(AutotoolsPackage):
     """libxcrypt is a modern library for one-way hashing of passwords."""
 
     homepage = "https://github.com/besser82/libxcrypt"
-    url = "https://github.com/besser82/libxcrypt/archive/v4.4.17.tar.gz"
+    url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.30/libxcrypt-4.4.30.tar.xz"
 
+    def url_for_version(self, version):
+        if version <= Version("4.4.17"):
+            return "https://github.com/besser82/libxcrypt/archive/v{}.tar.gz".format(version)
+        return "https://github.com/besser82/libxcrypt/releases/download/v{}/libxcrypt-{}.tar.xz".format(
+            version, version
+        )
+
+    version("4.4.30", sha256="b3667f0ba85daad6af246ba4090fbe53163ad93c8b6a2a1257d22a78bb7ceeba")
     version("4.4.17", sha256="7665168d0409574a03f7b484682e68334764c29c21ca5df438955a381384ca07")
     version("4.4.16", sha256="a98f65b8baffa2b5ba68ee53c10c0a328166ef4116bce3baece190c8ce01f375")
     version("4.4.15", sha256="8bcdef03bc65f9dbda742e56820435b6f13eea59fb903765141c6467f4655e5a")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    patch("truncating-conversion.patch", when="@4.4.30")
+
+    def configure_args(self):
+        # Disable test dependency on Python (Python itself depends on libxcrypt).
+        return ["ac_cv_path_python3_passlib=not found"]
+
+    with when("@:4.4.17"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")

--- a/var/spack/repos/builtin/packages/libxcrypt/truncating-conversion.patch
+++ b/var/spack/repos/builtin/packages/libxcrypt/truncating-conversion.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/alg-yescrypt-opt.c b/lib/alg-yescrypt-opt.c
+index 60a6ccd..a33c6e4 100644
+--- a/lib/alg-yescrypt-opt.c
++++ b/lib/alg-yescrypt-opt.c
+@@ -514,7 +514,7 @@ static volatile uint64_t Smask2var = Smask2;
+ #define PWXFORM_SIMD(X) { \
+ 	uint64_t x; \
+ 	FORCE_REGALLOC_1 \
+-	uint32_t lo = x = EXTRACT64(X) & Smask2reg; \
++	uint32_t lo = (uint32_t)(x = ((uint64_t)EXTRACT64(X)) & Smask2reg); \
+ 	FORCE_REGALLOC_2 \
+ 	uint32_t hi = x >> 32; \
+ 	X = _mm_mul_epu32(HI32(X), X); \


### PR DESCRIPTION
This is a (missing) dependency of Python and Perl.

It used to be in `glibc` until it wasn't. `libxcrypt` provides a drop-in replacement `libcrypt.so.1`, but also an ABI-incompatible version `libcrypt.so.2` which is the default everywhere except Linux. I think it's alright to default to this anywhere, since we don't really have issues with ABI-incompatibility by design :upside_down_face: except maybe when mixing externals, but then people can work around it by toggling the variant value.