### PR TITLE
depfile: use --output-sync=recurse by default

### DIFF
--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -1,5 +1,10 @@
 SPACK ?= spack
 
+# Enable --output-sync=recurse by default
+ifeq (output-sync,$(findstring output-sync,$(.FEATURES)))
+MAKEFLAGS += --output-sync=recurse
+endif
+
 .PHONY: {{ all_target }} {{ clean_target }}
 
 {{ all_target }}: {{ env_target }}


### PR DESCRIPTION
Support is tested for using `.FEATURES`.

I haven't checked yet how to improve this s.t. we don't override
`--output-sync` on the command line; I'd like to just set the default.
