### PR TITLE
Spack Bioconductor package updates

### DIFF
--- a/var/spack/repos/builtin/packages/r-a4/package.py
+++ b/var/spack/repos/builtin/packages/r-a4/package.py
@@ -14,6 +14,7 @@ class RA4(RPackage):
 
     bioc = "a4"
 
+    version("1.46.0", commit="1b8f1300025fb0940e7f24cff7ffec9fca02d0e4")
     version("1.44.0", commit="5b0fc5a9971d8f3688ad1f88a4f5ee1498e91633")
     version("1.42.0", commit="fc26809e2bce7cd50d99d6f6dd5f85c38342fdea")
     version("1.38.0", commit="5b7a9087bab10c55e24707e96e48046995236c94")

--- a/var/spack/repos/builtin/packages/r-a4base/package.py
+++ b/var/spack/repos/builtin/packages/r-a4base/package.py
@@ -14,6 +14,7 @@ class RA4base(RPackage):
 
     bioc = "a4Base"
 
+    version("1.46.0", commit="be70ae723bb6031cdf9540d62dc6113761074e88")
     version("1.44.0", commit="9ae69e03118c7b14df0e6c9e3b25362b09f25bbe")
     version("1.42.0", commit="d7296e2792020e9c5b1c19101104326ee8bebfe6")
     version("1.38.0", commit="4add242fa9c62795aca5b0dfca34a43484c5aa82")

--- a/var/spack/repos/builtin/packages/r-a4classif/package.py
+++ b/var/spack/repos/builtin/packages/r-a4classif/package.py
@@ -15,6 +15,7 @@ class RA4classif(RPackage):
 
     bioc = "a4Classif"
 
+    version("1.46.0", commit="96794183a76ab7da7a1863ccd421640254447af5")
     version("1.44.0", commit="df0fce781f9bc480a1159d958c9a63c314a9ed01")
     version("1.42.0", commit="820854a7ca9ed0c295479a25b7e3375c6d01d0b5")
     version("1.38.0", commit="c4d058813efb835774813b2d69c52912162f8e75")

--- a/var/spack/repos/builtin/packages/r-a4core/package.py
+++ b/var/spack/repos/builtin/packages/r-a4core/package.py
@@ -14,6 +14,7 @@ class RA4core(RPackage):
 
     bioc = "a4Core"
 
+    version("1.46.0", commit="8999fe146be6d04ae36c725d2b6324a6ce8ceb83")
     version("1.44.0", commit="61a7f3a51a41af615bfd4c22984e4c4a82874e8c")
     version("1.42.0", commit="6985950b72c2a0f20ec44fe2067d8864e004bfaa")
     version("1.38.0", commit="a027dcd3486c64950815ec7c7271f1f65ba3d8a1")

--- a/var/spack/repos/builtin/packages/r-a4preproc/package.py
+++ b/var/spack/repos/builtin/packages/r-a4preproc/package.py
@@ -14,6 +14,7 @@ class RA4preproc(RPackage):
 
     bioc = "a4Preproc"
 
+    version("1.46.0", commit="8463958692c73fd655a6dfec39ea99c915513719")
     version("1.44.0", commit="252381265b96b83803a93e0c2014dd6b0574e57f")
     version("1.42.0", commit="773a91e884d2ada16fe9cf57d5ed53c0155e3fa2")
     version("1.38.0", commit="c93c223bd531bff090531a109b51f8dcd710d0cb")

--- a/var/spack/repos/builtin/packages/r-a4reporting/package.py
+++ b/var/spack/repos/builtin/packages/r-a4reporting/package.py
@@ -14,6 +14,7 @@ class RA4reporting(RPackage):
 
     bioc = "a4Reporting"
 
+    version("1.46.0", commit="00b82d25bef4d518ae92f615d3a6f7931c0618dc")
     version("1.44.0", commit="bfe83507daf53e2e327474ea3012f0dc920efac1")
     version("1.42.0", commit="b0d715b9cdac80bc412f0a9a6b33941c4a7582bb")
     version("1.38.0", commit="cd3cf244e7a299b2485684ed15519cbbda1c590f")

--- a/var/spack/repos/builtin/packages/r-absseq/package.py
+++ b/var/spack/repos/builtin/packages/r-absseq/package.py
@@ -17,6 +17,7 @@ class RAbsseq(RPackage):
 
     bioc = "ABSSeq"
 
+    version("1.52.0", commit="07038c047775e17d5d29909927d2143efb63e9cb")
     version("1.50.0", commit="4f384d04ebaae6ea0b56e5cff9a9dcdcb6c8afb0")
     version("1.48.0", commit="b237c967d44d075ca306c35e92df8b66a60ce72d")
     version("1.44.0", commit="c202b4a059021ed1228ccee7303c69b0aa4ca1ee")

--- a/var/spack/repos/builtin/packages/r-acde/package.py
+++ b/var/spack/repos/builtin/packages/r-acde/package.py
@@ -22,6 +22,7 @@ class RAcde(RPackage):
 
     bioc = "acde"
 
+    version("1.28.0", commit="0edccca7be2475fa2ae3b3c36d0d64924c37b3c0")
     version("1.26.0", commit="dfef9a435062e948efd5eda22942a0d500baa992")
     version("1.24.0", commit="0c3c4d47af7eaff37420032ea5245743a65124cf")
     version("1.20.0", commit="cefb4f2e2b0ef3c5f51944c0ece7a71294020350")

--- a/var/spack/repos/builtin/packages/r-acgh/package.py
+++ b/var/spack/repos/builtin/packages/r-acgh/package.py
@@ -16,6 +16,7 @@ class RAcgh(RPackage):
 
     bioc = "aCGH"
 
+    version("1.76.0", commit="c6068522854ed0b1c3feb006619ef25590f70ad6")
     version("1.74.0", commit="e7ba380af0da138788eb6c86f5dbe453269c0810")
     version("1.72.0", commit="b5d4022ac487125194d3913f1b8c2948db6e2792")
     version("1.68.0", commit="91f41a3917ddce43eb05e11c90eb99c467ba2247")

--- a/var/spack/repos/builtin/packages/r-acme/package.py
+++ b/var/spack/repos/builtin/packages/r-acme/package.py
@@ -21,6 +21,7 @@ class RAcme(RPackage):
 
     bioc = "ACME"
 
+    version("2.54.0", commit="8d39d9d6623adf427f5eba308790e1de01213870")
     version("2.52.0", commit="14a97c722d0201654af9e583e7e462b458c28a77")
     version("2.50.0", commit="d55a19a8c091e8ea5fd35041520107a7f7603e14")
     version("2.46.0", commit="68f45c9f7d34c28adf6a0fc4245fdf63881109de")

--- a/var/spack/repos/builtin/packages/r-adsplit/package.py
+++ b/var/spack/repos/builtin/packages/r-adsplit/package.py
@@ -16,6 +16,7 @@ class RAdsplit(RPackage):
 
     bioc = "adSplit"
 
+    version("1.68.0", commit="705977b5e1cb7dd69793cc673fa215baaba42af5")
     version("1.66.0", commit="64580a6f7a9bc6b16334267c90df48fbb839cc16")
     version("1.64.0", commit="32f150eb51c66b867301dceeb527de5b97f9f490")
     version("1.60.0", commit="de5abccfe652cbc5b5f49fb6ed77cdd15cc760cd")

--- a/var/spack/repos/builtin/packages/r-affxparser/package.py
+++ b/var/spack/repos/builtin/packages/r-affxparser/package.py
@@ -20,6 +20,7 @@ class RAffxparser(RPackage):
 
     bioc = "affxparser"
 
+    version("1.70.0", commit="28f94cd3477e9500942be89cbcb5cad1bbb369fe")
     version("1.68.1", commit="821a01a2df18115a3b7864b3f45418255b7123eb")
     version("1.66.0", commit="2ea72d4c924ac14bdd807b23563c8501c226ce3a")
     version("1.62.0", commit="b3e988e5c136c3f1a064e1da13730b403c8704c0")

--- a/var/spack/repos/builtin/packages/r-affy/package.py
+++ b/var/spack/repos/builtin/packages/r-affy/package.py
@@ -15,6 +15,7 @@ class RAffy(RPackage):
 
     bioc = "affy"
 
+    version("1.76.0", commit="3bb309388d5d6402c356d4a5270ee83c5b88942f")
     version("1.74.0", commit="2266c4a46eda7e5b64f7f3e17e8b61e7b85579ff")
     version("1.72.0", commit="3750b4eb8e5224b19100f6c881b67e568d8968a2")
     version("1.68.0", commit="1664399610c9aa519399445a2ef8bb9ea2233eac")

--- a/var/spack/repos/builtin/packages/r-affycomp/package.py
+++ b/var/spack/repos/builtin/packages/r-affycomp/package.py
@@ -14,6 +14,7 @@ class RAffycomp(RPackage):
 
     bioc = "affycomp"
 
+    version("1.74.0", commit="1160d6395f23085456938ba2bd38fb45597fc92f")
     version("1.72.0", commit="c52baea98b80abd4a99380ac9d4b68ef91869d40")
     version("1.70.0", commit="487f6775975092475581a6c02ddb27590559cf07")
     version("1.66.0", commit="388d01af8b1e6ab11051407f77d0206512df8424")

--- a/var/spack/repos/builtin/packages/r-affycompatible/package.py
+++ b/var/spack/repos/builtin/packages/r-affycompatible/package.py
@@ -18,6 +18,7 @@ class RAffycompatible(RPackage):
 
     bioc = "AffyCompatible"
 
+    version("1.58.0", commit="6508e72736371d353ec5f02d30caf8ffe39b342a")
     version("1.56.0", commit="37ea4bb885c791fb989f40092f3d0d2c57d35641")
     version("1.54.0", commit="fde7d86ccdb03c13c4838c18ac25477ffe6e0fe5")
     version("1.50.0", commit="3b12d12bd6d1a9f0d45e012817231d137d47089e")

--- a/var/spack/repos/builtin/packages/r-affycontam/package.py
+++ b/var/spack/repos/builtin/packages/r-affycontam/package.py
@@ -14,6 +14,7 @@ class RAffycontam(RPackage):
 
     bioc = "affyContam"
 
+    version("1.56.0", commit="e2b8a4fba1648255eadce954a848f2dd8e22bcb3")
     version("1.54.0", commit="c5208b48b8881983ff53a4713244327e8ad13b78")
     version("1.52.0", commit="47c1d86da330f157d3ece0e26b0657d66a5ca0c9")
     version("1.48.0", commit="88387a2ad4be4234d36710c65f2ca3a5b06b67da")

--- a/var/spack/repos/builtin/packages/r-affycoretools/package.py
+++ b/var/spack/repos/builtin/packages/r-affycoretools/package.py
@@ -15,6 +15,7 @@ class RAffycoretools(RPackage):
 
     bioc = "affycoretools"
 
+    version("1.70.0", commit="f09a788aa83e1e052a7c5f148a451a99fe9c9c96")
     version("1.68.1", commit="69546b1fe5edd71eca130d53d33f0fb0fcf62c97")
     version("1.66.0", commit="6bf769d70e196634097f465ed2fa85cce5312a6d")
     version("1.62.0", commit="c9779e4da648fd174c9bd575c6020be1c03047c4")

--- a/var/spack/repos/builtin/packages/r-affydata/package.py
+++ b/var/spack/repos/builtin/packages/r-affydata/package.py
@@ -15,6 +15,7 @@ class RAffydata(RPackage):
 
     bioc = "affydata"
 
+    version("1.46.0", commit="870745b886df9f1fbbd6130d266c0ef96f3afa66")
     version("1.44.0", commit="f18304a356cee8cd7297bab362b13c40e50439df")
     version("1.42.0", commit="4b54c1206bedd27ff9be32affc999a279f4e96f0")
     version("1.38.0", commit="b5e843b2514789d0d87bea44d762c89a95314ee7")

--- a/var/spack/repos/builtin/packages/r-affyilm/package.py
+++ b/var/spack/repos/builtin/packages/r-affyilm/package.py
@@ -16,6 +16,7 @@ class RAffyilm(RPackage):
 
     bioc = "affyILM"
 
+    version("1.50.0", commit="185cd8e4712a3378ce7a156d4940224bbb2c4122")
     version("1.48.0", commit="4603a4c4d6c2330a8a56a7bb657dc56c51a9393a")
     version("1.46.0", commit="67ffbfa6c881ed83d15604bf4463fe5dba81036b")
     version("1.42.0", commit="b97b29786b866de38802ebbb995169be91e90942")

--- a/var/spack/repos/builtin/packages/r-affyio/package.py
+++ b/var/spack/repos/builtin/packages/r-affyio/package.py
@@ -15,6 +15,7 @@ class RAffyio(RPackage):
 
     bioc = "affyio"
 
+    version("1.68.0", commit="33080c5eeb14c0ca40f0d231706af4e0c2c1ef8b")
     version("1.66.0", commit="3a0b90704fc46cddd99a72b985a6bdb348f69b50")
     version("1.64.0", commit="aa7ce48f3f4110431f6f488d45961fde4019ffb0")
     version("1.60.0", commit="ee20528b32700e99768da48143d6d45c9a7bbe91")

--- a/var/spack/repos/builtin/packages/r-affyplm/package.py
+++ b/var/spack/repos/builtin/packages/r-affyplm/package.py
@@ -17,6 +17,7 @@ class RAffyplm(RPackage):
 
     bioc = "affyPLM"
 
+    version("1.74.0", commit="5f76ef92e69deabc19c5395eaec4adb85c66b63d")
     version("1.72.0", commit="394c0a8e213f188d0b1d01e20516df8bf1bc5c09")
     version("1.70.0", commit="64abfec92b347aa340b54a8c7b2fbd524fe9c312")
     version("1.66.0", commit="f0780c3d0e9dccaff83861b98beb5c1d324c4399")

--- a/var/spack/repos/builtin/packages/r-affyrnadegradation/package.py
+++ b/var/spack/repos/builtin/packages/r-affyrnadegradation/package.py
@@ -18,6 +18,7 @@ class RAffyrnadegradation(RPackage):
 
     bioc = "AffyRNADegradation"
 
+    version("1.44.0", commit="63881f41fc67cc7322b189446dcffb4e1060e303")
     version("1.42.0", commit="5775f41f538b3c8ee4d07d38cec1b49c548cebe6")
     version("1.40.0", commit="8539a91ee464d692a267bb17c91dc1ef9a231f41")
     version("1.36.0", commit="89662b93076659db2967a526899184c12c156bc5")

--- a/var/spack/repos/builtin/packages/r-agdex/package.py
+++ b/var/spack/repos/builtin/packages/r-agdex/package.py
@@ -14,6 +14,7 @@ class RAgdex(RPackage):
 
     bioc = "AGDEX"
 
+    version("1.46.0", commit="d7c38e8bdcaa7b0261117c605e7f61e2b07e8316")
     version("1.44.0", commit="9d3eb90eaf7bf093c7fa73facb3df89506a85185")
     version("1.42.0", commit="175cf1b384b0942103d841b1feb9e4f7d141ba06")
     version("1.38.0", commit="7e2c1f5f27ccbea6a7157f5122212e40408b74da")

--- a/var/spack/repos/builtin/packages/r-agilp/package.py
+++ b/var/spack/repos/builtin/packages/r-agilp/package.py
@@ -13,6 +13,7 @@ class RAgilp(RPackage):
 
     bioc = "agilp"
 
+    version("3.30.0", commit="a2c898dc901ccdda4b8582caff079ab20b1bfc28")
     version("3.28.0", commit="2c6dfccc76473b5bef13b75fa59adf46b3381f55")
     version("3.26.0", commit="3170fe2b1cc459d5e2ca7f61a127aac17cd66a96")
     version("3.22.0", commit="7d089d576752e0526f15a1007e94436089954313")

--- a/var/spack/repos/builtin/packages/r-agimicrorna/package.py
+++ b/var/spack/repos/builtin/packages/r-agimicrorna/package.py
@@ -14,6 +14,7 @@ class RAgimicrorna(RPackage):
 
     bioc = "AgiMicroRna"
 
+    version("2.48.0", commit="4c163b1b730150a3a60a3815bd8c08fa04d71fc1")
     version("2.46.0", commit="8c6d73e1c3f1f9cc019bdb219b19e6179bb1efe4")
     version("2.44.0", commit="8b308baa3b1b0afc0855ea263630a288689e3864")
     version("2.40.0", commit="cfa4acb2215da44767ab3a45845bcd587c309e74")

--- a/var/spack/repos/builtin/packages/r-aims/package.py
+++ b/var/spack/repos/builtin/packages/r-aims/package.py
@@ -17,6 +17,7 @@ class RAims(RPackage):
 
     bioc = "AIMS"
 
+    version("1.30.0", commit="2ab61159c5aa0902cc33fc1502f7853b66912cce")
     version("1.28.0", commit="84608df638b5694c08158ed77ad2c8a64c4e594b")
     version("1.26.0", commit="5dcf60eb4cdcf563ea848482c9c488f465c27bbd")
     version("1.22.0", commit="34a38978b24377abb864eff7683bb36344ff171d")

--- a/var/spack/repos/builtin/packages/r-aldex2/package.py
+++ b/var/spack/repos/builtin/packages/r-aldex2/package.py
@@ -23,6 +23,7 @@ class RAldex2(RPackage):
 
     bioc = "ALDEx2"
 
+    version("1.30.0", commit="cb6670515a8722f9cfedac12a8c2747a5298ee46")
     version("1.28.1", commit="f8d8ba6d2439bff75ab80f5466c9a047c31ed0a6")
     version("1.26.0", commit="0876a2eac08d3f1c01df7414d97d391c80182ada")
     version("1.22.0", commit="ac7f0ab3f094ec52713da7620a27058b14c7181d")

--- a/var/spack/repos/builtin/packages/r-allelicimbalance/package.py
+++ b/var/spack/repos/builtin/packages/r-allelicimbalance/package.py
@@ -14,6 +14,7 @@ class RAllelicimbalance(RPackage):
 
     bioc = "AllelicImbalance"
 
+    version("1.36.0", commit="cb4910c1fd58cc4272c21251a8f120990e1aa431")
     version("1.34.0", commit="290708ccc4ceae1fbb9e9257cb254916449d389b")
     version("1.32.0", commit="428ab8c96bb15fab45e4084da25f98b01b9d60b6")
     version("1.28.0", commit="ac5d13c9ee0935bf9500ee542792644e752a1fde")

--- a/var/spack/repos/builtin/packages/r-alpine/package.py
+++ b/var/spack/repos/builtin/packages/r-alpine/package.py
@@ -14,6 +14,7 @@ class RAlpine(RPackage):
 
     bioc = "alpine"
 
+    version("1.24.0", commit="7e734d49881761cafaacea096ce757531b6bd522")
     version("1.22.0", commit="6107a82962f07e0434e93f261cd375eaaa171d91")
     version("1.20.0", commit="9348ef14128aa6be10cca1987736ddbc385df7e9")
     version("1.16.0", commit="aee397774ac6cd17ad45dc05be14c526647f3c13")

--- a/var/spack/repos/builtin/packages/r-altcdfenvs/package.py
+++ b/var/spack/repos/builtin/packages/r-altcdfenvs/package.py
@@ -13,6 +13,7 @@ class RAltcdfenvs(RPackage):
 
     bioc = "altcdfenvs"
 
+    version("2.60.0", commit="0bc0b4493b8e9fe2eb47fb8e9377123ce8f472bb")
     version("2.58.0", commit="08255a777ffa1e1414d3dd3062d95bfdd3dfd47c")
     version("2.56.0", commit="941e00b97a33662a8230991e387070324b2e76bf")
     version("2.52.0", commit="21329abf82eae26f84b7c0270e81c8e089c548ce")

--- a/var/spack/repos/builtin/packages/r-anaquin/package.py
+++ b/var/spack/repos/builtin/packages/r-anaquin/package.py
@@ -17,6 +17,7 @@ class RAnaquin(RPackage):
 
     bioc = "Anaquin"
 
+    version("2.22.0", commit="d848a9bd7bf9d1d62202cc477300bf1a65b3e36c")
     version("2.20.0", commit="61598dd3430b09b57f31d7d550ea95126a2d73c8")
     version("2.18.0", commit="c8e3df3e299c32daac0dda23cea59a18673d886b")
     version("2.14.0", commit="d0a34c931a0e72080bff91dacb37dbbe26b45386")

--- a/var/spack/repos/builtin/packages/r-aneufinder/package.py
+++ b/var/spack/repos/builtin/packages/r-aneufinder/package.py
@@ -15,6 +15,7 @@ class RAneufinder(RPackage):
 
     bioc = "AneuFinder"
 
+    version("1.26.0", commit="7cd59a1e24c6512f2e4fcbe2c53a0d3cd2d06217")
     version("1.24.0", commit="4c6906eee514eba3e8ac159654a6953e37a99bba")
     version("1.22.0", commit="ea0beb3d827c2dd4bc56708a839a93c55304918b")
     version("1.18.0", commit="76ec9af947f97212084ca478e8e82f9e0eb79de9")

--- a/var/spack/repos/builtin/packages/r-aneufinderdata/package.py
+++ b/var/spack/repos/builtin/packages/r-aneufinderdata/package.py
@@ -14,6 +14,7 @@ class RAneufinderdata(RPackage):
 
     bioc = "AneuFinderData"
 
+    version("1.26.0", commit="4b810599b62a3fb39239bfd98ed960c93989e86b")
     version("1.24.0", commit="cf6f3852702aab28e3170fc56b695d00b7389666")
     version("1.22.0", commit="ae8eec3b0afdc351dc447aad2024df5b2c75e56b")
     version("1.18.0", commit="1bf1657b28fc8c1425e611980a692da952ce3d1e")

--- a/var/spack/repos/builtin/packages/r-annaffy/package.py
+++ b/var/spack/repos/builtin/packages/r-annaffy/package.py
@@ -16,6 +16,7 @@ class RAnnaffy(RPackage):
 
     bioc = "annaffy"
 
+    version("1.70.0", commit="c99e81259adb39b5d8e954fd7afe7f93675229bc")
     version("1.68.0", commit="fa930c0bbdca9828a130ab06d86c65d451380830")
     version("1.66.0", commit="aa1afa1509754128d27508228c1f39f51a8da043")
     version("1.62.0", commit="ad9c37e0e7e45e0f35c208ce528ba48000b37432")

--- a/var/spack/repos/builtin/packages/r-annotate/package.py
+++ b/var/spack/repos/builtin/packages/r-annotate/package.py
@@ -13,6 +13,7 @@ class RAnnotate(RPackage):
 
     bioc = "annotate"
 
+    version("1.76.0", commit="0181d5c41d594e36be06adb6a02302db0ad2c507")
     version("1.74.0", commit="200c71743417792880f8171d59b2ac0ddd3902a8")
     version("1.72.0", commit="67ac76a9ff6d60dc1620763d3aa98aef39443110")
     version("1.68.0", commit="98cdb12c612b3f3fc06329a89a1ffb0a92b555c0")

--- a/var/spack/repos/builtin/packages/r-annotationdbi/package.py
+++ b/var/spack/repos/builtin/packages/r-annotationdbi/package.py
@@ -14,6 +14,7 @@ class RAnnotationdbi(RPackage):
 
     bioc = "AnnotationDbi"
 
+    version("1.60.0", commit="cd61bd1b1538e2f1f411fd7087820749ecf39da8")
     version("1.58.0", commit="05fcf7a28a6b15b195da23474d7ba89bd0cfd891")
     version("1.56.2", commit="13fdc4a93852199ca6ec120a2fe1078f9f445f67")
     version("1.52.0", commit="c4e0ca9bd65362ae9cad6a98d90f54267b0ae838")

--- a/var/spack/repos/builtin/packages/r-annotationfilter/package.py
+++ b/var/spack/repos/builtin/packages/r-annotationfilter/package.py
@@ -15,6 +15,7 @@ class RAnnotationfilter(RPackage):
 
     bioc = "AnnotationFilter"
 
+    version("1.22.0", commit="c9fea4a829ce9419b6e0af987915b2d469358597")
     version("1.20.0", commit="2818aff6502fd6fe819521cd8d97695ef6f9198e")
     version("1.18.0", commit="60a9b666d7362d7ed5c357fd4a5d2744d8598c20")
     version("1.14.0", commit="6ee3a13ed93a535ed452cbc8c118151a2cbb732c")

--- a/var/spack/repos/builtin/packages/r-annotationforge/package.py
+++ b/var/spack/repos/builtin/packages/r-annotationforge/package.py
@@ -14,6 +14,7 @@ class RAnnotationforge(RPackage):
 
     bioc = "AnnotationForge"
 
+    version("1.40.0", commit="f77d3a942eb6b18c18888b7af3f0e652596cf19f")
     version("1.38.1", commit="2dcedf353bc57bf80818e6adb1f7129c21886f6b")
     version("1.38.0", commit="1f77750562ea3a01f0f1a46c299184fc31196ffd")
     version("1.36.0", commit="523b5f0c3ffb77e59e1568e5f36a5a470bfeeae5")

--- a/var/spack/repos/builtin/packages/r-annotationhub/package.py
+++ b/var/spack/repos/builtin/packages/r-annotationhub/package.py
@@ -20,6 +20,7 @@ class RAnnotationhub(RPackage):
 
     bioc = "AnnotationHub"
 
+    version("3.6.0", commit="3315a73b7803a92412ed18209dd37b378195b86f")
     version("3.4.0", commit="e74e54ca44f50c2c15c60f8620e3d1721f8f5b6d")
     version("3.2.1", commit="ad1dfe86f0b0ea4711cc9cdb89e073e8794ec9aa")
     version("2.22.0", commit="3ab7dceebbc31ac14ca931f66c662cf9538b7d0a")

--- a/var/spack/repos/builtin/packages/r-aroma-light/package.py
+++ b/var/spack/repos/builtin/packages/r-aroma-light/package.py
@@ -16,6 +16,7 @@ class RAromaLight(RPackage):
 
     bioc = "aroma.light"
 
+    version("3.28.0", commit="7749dd7033e9885ec2546a5cac0562bac2fea04d")
     version("3.26.0", commit="7ead7517a77bc8b4b4b42aace69957a17e8fe016")
     version("3.24.0", commit="3ff48b8f546acc9803b3c652363cac78d3b81ae5")
     version("3.20.0", commit="02cde7fa166259bce73c396a87dca2ecc8249c39")

--- a/var/spack/repos/builtin/packages/r-bamsignals/package.py
+++ b/var/spack/repos/builtin/packages/r-bamsignals/package.py
@@ -16,6 +16,7 @@ class RBamsignals(RPackage):
 
     bioc = "bamsignals"
 
+    version("1.30.0", commit="aac37dffd6f6876b4626866e3d40bb7af75620fe")
     version("1.28.0", commit="27b70be6f73747d9d32054da043f4a37ea55b917")
     version("1.26.0", commit="d57643441d04f77db0907637dc9e7cd5bed5842f")
     version("1.22.0", commit="5f533969c84212406bcb3ebf725ebb6d77e9947a")

--- a/var/spack/repos/builtin/packages/r-beachmat/package.py
+++ b/var/spack/repos/builtin/packages/r-beachmat/package.py
@@ -17,6 +17,7 @@ class RBeachmat(RPackage):
 
     bioc = "beachmat"
 
+    version("2.14.0", commit="5a4b85f4a22f3447f12d03157ab95de73f6137c6")
     version("2.12.0", commit="3e6af145bdcdf0a0b722d8256ba1a38b8a36b2f5")
     version("2.10.0", commit="b7cc532d4a5b26d9073135cc9945258ea08e5079")
     version("2.6.4", commit="7d9dc6379017d723dda3e8dc9fd1f6de7fd33cdb")

--- a/var/spack/repos/builtin/packages/r-biobase/package.py
+++ b/var/spack/repos/builtin/packages/r-biobase/package.py
@@ -14,6 +14,7 @@ class RBiobase(RPackage):
 
     bioc = "Biobase"
 
+    version("2.58.0", commit="767f2f33f158f233616178e12ce08cdb03d2a5a2")
     version("2.56.0", commit="3b2dd91b333677c2f27257c7624014a55e73c52b")
     version("2.54.0", commit="8215d76ce44899e6d10fe8a2f503821a94ef6b40")
     version("2.50.0", commit="9927f90d0676382f2f99e099d8d2c8e2e6f1b4de")

--- a/var/spack/repos/builtin/packages/r-biocfilecache/package.py
+++ b/var/spack/repos/builtin/packages/r-biocfilecache/package.py
@@ -16,6 +16,7 @@ class RBiocfilecache(RPackage):
 
     bioc = "BiocFileCache"
 
+    version("2.6.0", commit="f5b8368c1402b15e8db8eab59217f1176e902e6f")
     version("2.4.0", commit="2c00eee40d95fddad223f115f959b09e1a14f75d")
     version("2.2.1", commit="cc912123408803193bf37395f4d18baa8dcd6f47")
     version("1.14.0", commit="cdcde4b59ae73dda12aa225948dbd0a058d9be6d")

--- a/var/spack/repos/builtin/packages/r-biocgenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-biocgenerics/package.py
@@ -13,6 +13,7 @@ class RBiocgenerics(RPackage):
 
     bioc = "BiocGenerics"
 
+    version("0.44.0", commit="d7cd9c19958bd8d4573d980494188fa15ab16e45")
     version("0.42.0", commit="3582d47b836387afc08157f3d6a5013fd64334ed")
     version("0.40.0", commit="0bc1e0ed4d20c7101cd782a14f6373e27478acfc")
     version("0.36.0", commit="0d5d169d7d64d648a22f9043837c93bc784e71ed")

--- a/var/spack/repos/builtin/packages/r-biocio/package.py
+++ b/var/spack/repos/builtin/packages/r-biocio/package.py
@@ -22,9 +22,11 @@ class RBiocio(RPackage):
 
     bioc = "BiocIO"
 
+    version("1.8.0", commit="4a719fa41e014b7b948f7b245e581ede6a04eda1")
     version("1.6.0", commit="60c8aa1a961e43bf0ee5d563a6d9fcec84f7f8f8")
     version("1.4.0", commit="c335932526a38c75dbfa4970c1d90b8a21466d37")
 
     depends_on("r@4.0.0:", type=("build", "run"))
+    depends_on("r@4.0:", type=("build", "run"), when="@1.8.0:")
     depends_on("r-biocgenerics", type=("build", "run"))
     depends_on("r-s4vectors", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-biocneighbors/package.py
+++ b/var/spack/repos/builtin/packages/r-biocneighbors/package.py
@@ -21,6 +21,7 @@ class RBiocneighbors(RPackage):
 
     bioc = "BiocNeighbors"
 
+    version("1.16.0", commit="3b227beead424314aab5ef847222f8f4243c684f")
     version("1.14.0", commit="670a1bd4d82636d28fbff50cea2157e16bb1a858")
     version("1.12.0", commit="3c8a290f75adc944b408e6e77a36f3a0c1509c4c")
     version("1.8.2", commit="889bc91f8cb45d210b47ae5c0b9cfb86fb071ca2")

--- a/var/spack/repos/builtin/packages/r-biocparallel/package.py
+++ b/var/spack/repos/builtin/packages/r-biocparallel/package.py
@@ -15,6 +15,7 @@ class RBiocparallel(RPackage):
 
     bioc = "BiocParallel"
 
+    version("1.32.1", commit="6c85dbad596a74a6d3022173a4a11c6b81a4a2c2")
     version("1.30.4", commit="1229ebe9f6d8305f9f61e562464f83f9ba86e699")
     version("1.30.2", commit="e7e109f7a94dbfbc50f926be030c7ad8c1a053db")
     version("1.28.3", commit="2f9d88ad83659939e7911d49c2d24d2cd599c7cc")
@@ -30,3 +31,4 @@ class RBiocparallel(RPackage):
     depends_on("r-snow", type=("build", "run"))
     depends_on("r-codetools", type=("build", "run"), when="@1.30.4:")
     depends_on("r-bh", type=("build", "run"), when="@1.12.0:")
+    depends_on("r-cpp11", type=("build", "run"), when="@1.32.1:")

--- a/var/spack/repos/builtin/packages/r-biocsingular/package.py
+++ b/var/spack/repos/builtin/packages/r-biocsingular/package.py
@@ -17,6 +17,7 @@ class RBiocsingular(RPackage):
 
     bioc = "BiocSingular"
 
+    version("1.14.0", commit="6dc42b30110e498f6694f18037f991c1006c71b7")
     version("1.12.0", commit="7d1b8f4954e9e6f2c30a5111cdab9aabc8bcc3a6")
     version("1.10.0", commit="6615ae8cb124aba6507447c1081bd2eba655e57d")
     version("1.6.0", commit="11baf1080d6f791439cd5d97357589d6451643d9")

--- a/var/spack/repos/builtin/packages/r-biocstyle/package.py
+++ b/var/spack/repos/builtin/packages/r-biocstyle/package.py
@@ -14,6 +14,7 @@ class RBiocstyle(RPackage):
 
     bioc = "BiocStyle"
 
+    version("2.26.0", commit="add035498bdce76d71a0afa22a063c2d8e5588bc")
     version("2.24.0", commit="53095b534b7e6c80a33a67b5f2db0db8f00db902")
     version("2.22.0", commit="86250b637afa3a3463fac939b99c0402b47876ea")
     version("2.18.1", commit="956f0654e8e18882ba09305742401128c9c7d47d")

--- a/var/spack/repos/builtin/packages/r-biocversion/package.py
+++ b/var/spack/repos/builtin/packages/r-biocversion/package.py
@@ -14,6 +14,7 @@ class RBiocversion(RPackage):
 
     bioc = "BiocVersion"
 
+    version("3.16.0", commit="c681e06fe30ea6815f958c1a3c74c090863680ba")
     version("3.15.2", commit="818ab03b6a3551993b712e3702126040f9fb7600")
     version("3.14.0", commit="aa56d93d0ea5dcdbf301f120502981740fd91e1e")
     version("3.12.0", commit="23b971963c6b73550a7e330dab5a046d58ce0223")

--- a/var/spack/repos/builtin/packages/r-biomart/package.py
+++ b/var/spack/repos/builtin/packages/r-biomart/package.py
@@ -24,6 +24,7 @@ class RBiomart(RPackage):
 
     bioc = "biomaRt"
 
+    version("2.54.0", commit="4fb88fb56c684d5678f8288ba05db193e4881758")
     version("2.52.0", commit="cf4932ac02686da45ea36ff5137fa63cead8860b")
     version("2.50.3", commit="83a519ac13d73dc545cb6aafde5f4b5001e9e08f")
     version("2.46.2", commit="90d6abfdfa04259006f7b47efb10271ada76aec1")

--- a/var/spack/repos/builtin/packages/r-biomformat/package.py
+++ b/var/spack/repos/builtin/packages/r-biomformat/package.py
@@ -21,6 +21,7 @@ class RBiomformat(RPackage):
 
     bioc = "biomformat"
 
+    version("1.26.0", commit="f851ba2428b57769f6fbb287874bad0dc84dd69c")
     version("1.24.0", commit="4e14692dbcc34c3bd51defd74c728df5de9d0829")
     version("1.22.0", commit="ab7c6411a038fec010baa72e663f362fd972cb34")
     version("1.18.0", commit="dc18859c139f4d76805adb6f01e199573cdd5a8b")

--- a/var/spack/repos/builtin/packages/r-biostrings/package.py
+++ b/var/spack/repos/builtin/packages/r-biostrings/package.py
@@ -15,6 +15,7 @@ class RBiostrings(RPackage):
 
     bioc = "Biostrings"
 
+    version("2.66.0", commit="3470ca7da798971e2c3a595d8dc8d0d86f14dc53")
     version("2.64.1", commit="ffe263e958463bd1edb5d5d9316cfd89905be53c")
     version("2.64.0", commit="c7ad3c7af607bc8fe4a5e1c37f09e6c9bf70b4f6")
     version("2.62.0", commit="53ed287e03d16fa523789af3131c60375ccf587f")
@@ -41,10 +42,12 @@ class RBiostrings(RPackage):
     depends_on("r-iranges@2.13.24:", type=("build", "run"), when="@2.48.0:")
     depends_on("r-iranges@2.23.9:", type=("build", "run"), when="@2.58.0:")
     depends_on("r-iranges@2.30.1:", type=("build", "run"), when="@2.64.1:")
+    depends_on("r-iranges@2.31.2:", type=("build", "run"), when="@2.66.0:")
     depends_on("r-xvector@0.11.6:", type=("build", "run"))
     depends_on("r-xvector@0.19.8:", type=("build", "run"), when="@2.48.0:")
     depends_on("r-xvector@0.21.4:", type=("build", "run"), when="@2.50.2:")
     depends_on("r-xvector@0.23.2:", type=("build", "run"), when="@2.52.0:")
     depends_on("r-xvector@0.29.2:", type=("build", "run"), when="@2.58.0:")
+    depends_on("r-xvector@0.37.1:", type=("build", "run"), when="@2.66.0:")
     depends_on("r-genomeinfodb", type=("build", "run"), when="@2.62.0:")
     depends_on("r-crayon", type=("build", "run"), when="@2.58.0:")

--- a/var/spack/repos/builtin/packages/r-biovizbase/package.py
+++ b/var/spack/repos/builtin/packages/r-biovizbase/package.py
@@ -16,6 +16,7 @@ class RBiovizbase(RPackage):
 
     bioc = "biovizBase"
 
+    version("1.46.0", commit="a47060cfb68e3f3b4876114af932823aed5d2d57")
     version("1.44.0", commit="a8f05c56c27b278524033cb896a6c97f3ee0081c")
     version("1.42.0", commit="f1627b2b567471837daca6e763acfc3e13937461")
     version("1.38.0", commit="d0f3362e0ad0e90b4b1d3e47b13ed57907d03403")

--- a/var/spack/repos/builtin/packages/r-bluster/package.py
+++ b/var/spack/repos/builtin/packages/r-bluster/package.py
@@ -16,6 +16,7 @@ class RBluster(RPackage):
 
     bioc = "bluster"
 
+    version("1.8.0", commit="156115c8960c0b66b2c588d9fd8bbdfe56e5f0be")
     version("1.6.0", commit="ff86c7d8d36233e838d4f00e6a4e173e7bf16816")
 
     depends_on("r-cluster", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-bsgenome-hsapiens-ucsc-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-bsgenome-hsapiens-ucsc-hg19/package.py
@@ -19,13 +19,13 @@ class RBsgenomeHsapiensUcscHg19(RPackage):
 
     version(
         "1.4.3",
-        sha256="5bfa65d7836449d9b30c356968497cdfaa98be48c4e329e71e8f8a120f3e9d1a",
         url="https://bioconductor.org/packages/3.12/data/annotation/src/contrib/BSgenome.Hsapiens.UCSC.hg19_1.4.3.tar.gz",
+        sha256="5bfa65d7836449d9b30c356968497cdfaa98be48c4e329e71e8f8a120f3e9d1a",
     )
     version(
         "1.4.0",
-        sha256="88f515e5c27dd11d10654250e3a0a9389e4dfeb0b1c2d43419aa7086e6c516f8",
         url="https://bioconductor.org/packages/3.10/data/annotation/src/contrib/BSgenome.Hsapiens.UCSC.hg19_1.4.0.tar.gz",
+        sha256="88f515e5c27dd11d10654250e3a0a9389e4dfeb0b1c2d43419aa7086e6c516f8",
     )
 
     depends_on("r-bsgenome@1.33.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-bsgenome/package.py
+++ b/var/spack/repos/builtin/packages/r-bsgenome/package.py
@@ -14,6 +14,7 @@ class RBsgenome(RPackage):
 
     bioc = "BSgenome"
 
+    version("1.66.1", commit="d1efdfa8e7242bc0f54cc1c3a9583ea555c924f6")
     version("1.64.0", commit="59cdebde613e9702985c003f699f4aea2b0f0e7b")
     version("1.62.0", commit="9b1859e11ffa082833f035a45274af6e4e83e863")
     version("1.58.0", commit="3a4926e03a7a1d7140a10c1b2bf6090808470145")

--- a/var/spack/repos/builtin/packages/r-bsseq/package.py
+++ b/var/spack/repos/builtin/packages/r-bsseq/package.py
@@ -14,6 +14,7 @@ class RBsseq(RPackage):
 
     bioc = "bsseq"
 
+    version("1.34.0", commit="98239c07d74e1362c7ba2a3bf4f6119830fc95dc")
     version("1.32.0", commit="a0c1eacbc479c57bd836e885e162c28bbe08e115")
     version("1.30.0", commit="7eb5223e9ee02fd08a52be56eaa9316a67c0d66b")
     version("1.26.0", commit="fae32292687625012a2938a48c93df55ad4257b5")

--- a/var/spack/repos/builtin/packages/r-bumphunter/package.py
+++ b/var/spack/repos/builtin/packages/r-bumphunter/package.py
@@ -13,6 +13,7 @@ class RBumphunter(RPackage):
 
     bioc = "bumphunter"
 
+    version("1.40.0", commit="3de207a3659859737d4c748fc8023694943da43b")
     version("1.38.0", commit="06e2fa87b342d48793d0d2f1f7d94a95a6613995")
     version("1.36.0", commit="db50fcf7798c2eddfe48fd510d081dda82f2ee4e")
     version("1.32.0", commit="b7d39c2a6385ca217dceefc918b3ccd5c31bbaa0")

--- a/var/spack/repos/builtin/packages/r-category/package.py
+++ b/var/spack/repos/builtin/packages/r-category/package.py
@@ -14,6 +14,7 @@ class RCategory(RPackage):
 
     bioc = "Category"
 
+    version("2.64.0", commit="b512cbeb22fc50a2f6d767a2eef356fb143a974e")
     version("2.62.0", commit="0fe801c0c443aebd5d4cefa8c30e4e7d0931b673")
     version("2.60.0", commit="55210d8c539474954d18cf913a219dce883eac2e")
     version("2.56.0", commit="ad478caa9d693dbc2770608e79dd852375b9a223")

--- a/var/spack/repos/builtin/packages/r-champ/package.py
+++ b/var/spack/repos/builtin/packages/r-champ/package.py
@@ -16,6 +16,7 @@ class RChamp(RPackage):
 
     bioc = "ChAMP"
 
+    version("2.28.0", commit="3d27ac67a738afea8cc9ece6ea1301120e4b48f7")
     version("2.26.0", commit="1548910bf53e1e5f7a8d80c83b742a94297d8a34")
     version("2.24.0", commit="7ba19da74b61e1c40ced162ba753f0f9b9c7647a")
     version("2.20.1", commit="99ea0463bce59f5b06bcc91f479dcd4065074896")

--- a/var/spack/repos/builtin/packages/r-champdata/package.py
+++ b/var/spack/repos/builtin/packages/r-champdata/package.py
@@ -14,6 +14,7 @@ class RChampdata(RPackage):
 
     bioc = "ChAMPdata"
 
+    version("2.30.0", commit="6e05b8f7b004b1a5185ec4b387c32725e8bd95cb")
     version("2.28.0", commit="601555bf599828b6cfa125beffa51aebccdc8503")
     version("2.26.0", commit="ea7882707921af33eefab5133a1ccd4a409f045d")
     version("2.22.0", commit="eeedd4c477fac79f00743da8ff7da064221c5f3d")

--- a/var/spack/repos/builtin/packages/r-chipseq/package.py
+++ b/var/spack/repos/builtin/packages/r-chipseq/package.py
@@ -15,6 +15,7 @@ class RChipseq(RPackage):
 
     maintainers = ["dorton21"]
 
+    version("1.48.0", commit="9c78296001b6dd4102318879c8504dac70015822")
     version("1.46.0", commit="76b00397cd117d5432158f50fc1032d50485bd24")
     version("1.44.0", commit="b64d0d28e9fcf0fdab9a7f9c521baf729426a594")
     version("1.40.0", commit="84bcbc0b7ad732730b5989a308f1624a6a358df1")

--- a/var/spack/repos/builtin/packages/r-clusterprofiler/package.py
+++ b/var/spack/repos/builtin/packages/r-clusterprofiler/package.py
@@ -15,6 +15,7 @@ class RClusterprofiler(RPackage):
 
     bioc = "clusterProfiler"
 
+    version("4.6.0", commit="2644118c36a3aa14408bc0c97ac20a545e40344d")
     version("4.4.4", commit="9fca9a45ca1793884d8dcfd0f077353dbf75df29")
     version("4.4.1", commit="daad11fb80be2dd9b825e0b484815a0a2b1592a4")
     version("4.2.2", commit="4ebb9de8e03eedc971f54a57cf5bf1b250ed43d5")
@@ -34,12 +35,14 @@ class RClusterprofiler(RPackage):
     depends_on("r-dose@3.3.2:", type=("build", "run"), when="@3.6.0:")
     depends_on("r-dose@3.5.1:", type=("build", "run"), when="@3.8.1:")
     depends_on("r-dose@3.13.1:", type=("build", "run"), when="@3.18.0:")
+    depends_on("r-dose@3.23.2:", type=("build", "run"), when="@4.6.0:")
     depends_on("r-dplyr", type=("build", "run"), when="@3.18.0:")
     depends_on("r-enrichplot@0.99.7:", type=("build", "run"), when="@3.8.1:")
     depends_on("r-enrichplot@1.9.3:", type=("build", "run"), when="@3.18.0:")
     depends_on("r-go-db", type=("build", "run"))
     depends_on("r-gosemsim", type=("build", "run"))
     depends_on("r-gosemsim@2.0.0:", type=("build", "run"), when="@3.4.4:3.6.0")
+    depends_on("r-gson@0.0.7:", type=("build", "run"), when="@4.6.0:")
     depends_on("r-magrittr", type=("build", "run"))
     depends_on("r-plyr", type=("build", "run"))
     depends_on("r-qvalue", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-cner/package.py
+++ b/var/spack/repos/builtin/packages/r-cner/package.py
@@ -14,6 +14,7 @@ class RCner(RPackage):
 
     bioc = "CNEr"
 
+    version("1.34.0", commit="878de98d18f6f959ad5e014ecd8165d3105d8b48")
     version("1.32.0", commit="1c92f3d7f3dccf76ab7d54f286117b09bc470b8f")
     version("1.30.0", commit="e682f2a7c8ebb561c872cf51a58ba36eed341187")
     version("1.26.0", commit="e5e582da6feeae0618c4460f16ece724215e3b20")

--- a/var/spack/repos/builtin/packages/r-codex/package.py
+++ b/var/spack/repos/builtin/packages/r-codex/package.py
@@ -22,6 +22,7 @@ class RCodex(RPackage):
 
     bioc = "CODEX"
 
+    version("1.30.0", commit="0694f11be9e0b02ab15047d01db2afce943f92d8")
     version("1.28.0", commit="c707497bd93aa4a0516fcf3671a64997c28c9f67")
     version("1.26.0", commit="729fd10bd42d12edcedd65b5a8fb1579e5949718")
     version("1.22.0", commit="aa0ee4278111a46e0c790312b0526ba07aab22eb")

--- a/var/spack/repos/builtin/packages/r-complexheatmap/package.py
+++ b/var/spack/repos/builtin/packages/r-complexheatmap/package.py
@@ -16,6 +16,7 @@ class RComplexheatmap(RPackage):
 
     bioc = "ComplexHeatmap"
 
+    version("2.14.0", commit="57fcaa040b08917c97fb66b963eb240d5fd5a8c7")
     version("2.12.1", commit="2c5fe70724219008174d4e6f83189cddbd895ec6")
     version("2.12.0", commit="8a5f060b06646f9d6a5032832ea72e3f183ca5d7")
     version("2.10.0", commit="170df82a1568e879e4019e0ff6feb0047851684f")

--- a/var/spack/repos/builtin/packages/r-ctc/package.py
+++ b/var/spack/repos/builtin/packages/r-ctc/package.py
@@ -14,6 +14,7 @@ class RCtc(RPackage):
 
     bioc = "ctc"
 
+    version("1.72.0", commit="0a4b464e1768e6407c1c2ce64ec4ae5a4577be65")
     version("1.70.0", commit="05dc046ecfddbc1eeadf77e8f3ec0ce054794437")
     version("1.68.0", commit="c2733534ef9d948e07ea654d1998a67ed8f7a98a")
     version("1.64.0", commit="35dbe620a21056b8f69890e6f9a7c320528d8621")

--- a/var/spack/repos/builtin/packages/r-decipher/package.py
+++ b/var/spack/repos/builtin/packages/r-decipher/package.py
@@ -13,6 +13,7 @@ class RDecipher(RPackage):
 
     bioc = "DECIPHER"
 
+    version("2.26.0", commit="7de99ec5e79f1f645f29dfbe24d2a106c2b0e69a")
     version("2.24.0", commit="437e60005ab281bd836f47756a367795bc16755d")
     version("2.22.0", commit="45da5cab5869d83af797aa82b08ebcd24f5bdab3")
     version("2.18.1", commit="6a708421550e6705d05e2fb50a0f5ab4f9041cb0")

--- a/var/spack/repos/builtin/packages/r-delayedarray/package.py
+++ b/var/spack/repos/builtin/packages/r-delayedarray/package.py
@@ -20,6 +20,7 @@ class RDelayedarray(RPackage):
 
     bioc = "DelayedArray"
 
+    version("0.24.0", commit="68ee3d0626c234ee1e9248a6cb95b901e4b3ad90")
     version("0.22.0", commit="4a5afd117b189b40bd409c7aff60e09d41797472")
     version("0.20.0", commit="829b52916ec54bb4f1a3c6f06c9955f3e28b3592")
     version("0.16.1", commit="c95eba771ad3fee1b49ec38c51cd8fd1486feadc")
@@ -37,6 +38,7 @@ class RDelayedarray(RPackage):
     depends_on("r-biocgenerics@0.27.1:", type=("build", "run"), when="@0.8.0:")
     depends_on("r-biocgenerics@0.31.5:", type=("build", "run"), when="@0.16.1:")
     depends_on("r-biocgenerics@0.37.0:", type=("build", "run"), when="@0.20.1:")
+    depends_on("r-biocgenerics@0.43.4:", type=("build", "run"), when="@0.24.0:")
     depends_on("r-matrixgenerics@1.1.3:", type=("build", "run"), when="@0.16.1:")
     depends_on("r-s4vectors@0.14.3:", type=("build", "run"))
     depends_on("r-s4vectors@0.15.3:", type=("build", "run"), when="@0.4.1:")

--- a/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
+++ b/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
@@ -18,6 +18,7 @@ class RDelayedmatrixstats(RPackage):
 
     bioc = "DelayedMatrixStats"
 
+    version("1.20.0", commit="1ed14250e8731e60bccb44946cafad4c2b3ac5b0")
     version("1.18.1", commit="9c4658d11fc20b7d88e05b9c52140c2ca8a65768")
     version("1.18.0", commit="50c9aab259b6e8f68abf44b78122662a41c8bf47")
     version("1.16.0", commit="d44a3d765769cb022193428a77af25bf19916be7")
@@ -42,6 +43,7 @@ class RDelayedmatrixstats(RPackage):
     depends_on("r-sparsematrixstats", type=("build", "run"), when="@1.12.2:")
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-matrix@1.5.0:", type=("build", "run"), when="@1.18.1:")
+    depends_on("r-matrix@1.5-0:", type=("build", "run"), when="@1.20.0:")
     depends_on("r-s4vectors", type=("build", "run"))
     depends_on("r-s4vectors@0.17.5:", type=("build", "run"), when="@1.2.0:")
     depends_on("r-iranges", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
+++ b/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
@@ -43,7 +43,6 @@ class RDelayedmatrixstats(RPackage):
     depends_on("r-sparsematrixstats", type=("build", "run"), when="@1.12.2:")
     depends_on("r-matrix", type=("build", "run"))
     depends_on("r-matrix@1.5-0:", type=("build", "run"), when="@1.18.1:")
-    depends_on("r-matrix@1.5-0:", type=("build", "run"), when="@1.20.0:")
     depends_on("r-s4vectors", type=("build", "run"))
     depends_on("r-s4vectors@0.17.5:", type=("build", "run"), when="@1.2.0:")
     depends_on("r-iranges", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
+++ b/var/spack/repos/builtin/packages/r-delayedmatrixstats/package.py
@@ -42,7 +42,7 @@ class RDelayedmatrixstats(RPackage):
     depends_on("r-matrixstats@0.60.0:", type=("build", "run"), when="@1.16.0:")
     depends_on("r-sparsematrixstats", type=("build", "run"), when="@1.12.2:")
     depends_on("r-matrix", type=("build", "run"))
-    depends_on("r-matrix@1.5.0:", type=("build", "run"), when="@1.18.1:")
+    depends_on("r-matrix@1.5-0:", type=("build", "run"), when="@1.18.1:")
     depends_on("r-matrix@1.5-0:", type=("build", "run"), when="@1.20.0:")
     depends_on("r-s4vectors", type=("build", "run"))
     depends_on("r-s4vectors@0.17.5:", type=("build", "run"), when="@1.2.0:")

--- a/var/spack/repos/builtin/packages/r-deseq2/package.py
+++ b/var/spack/repos/builtin/packages/r-deseq2/package.py
@@ -17,6 +17,7 @@ class RDeseq2(RPackage):
     homepage = "https://bioconductor.org/packages/DESeq2"
     git = "https://git.bioconductor.org/packages/DESeq2.git"
 
+    version("1.38.0", commit="0e059f425d4ce6a5203685a4ad434f15bbd6e211")
     version("1.36.0", commit="2800b78ae52c0600f7e603c54af59beed3a2ed17")
     version("1.34.0", commit="25d4f74be59548122ccfbe8687d30c0bae5cf49a")
     version("1.30.0", commit="f4b47b208ee26ab23fe65c345f907fcfe70b3f77")

--- a/var/spack/repos/builtin/packages/r-dexseq/package.py
+++ b/var/spack/repos/builtin/packages/r-dexseq/package.py
@@ -21,6 +21,7 @@ class RDexseq(RPackage):
 
     maintainers = ["dorton21"]
 
+    version("1.44.0", commit="9660d7372d5ced1a7e324ed9a61b935023b7d135")
     version("1.42.0", commit="d91de62a27d0cab2ef12ef1a5f23dc2f7a0cfadd")
     version("1.40.0", commit="7d2d639b3a157e443058fc557132cd2629bb36f3")
     version("1.36.0", commit="f0a361af6954fcc2abb2db801c26e303570669b2")

--- a/var/spack/repos/builtin/packages/r-dirichletmultinomial/package.py
+++ b/var/spack/repos/builtin/packages/r-dirichletmultinomial/package.py
@@ -18,6 +18,7 @@ class RDirichletmultinomial(RPackage):
 
     bioc = "DirichletMultinomial"
 
+    version("1.40.0", commit="200176f8c72ff127788c500629b71872bc6b1f83")
     version("1.38.0", commit="b4de83d354e974fdb7cb3526d029487f24aab670")
     version("1.36.0", commit="926baff6c75cb498945c5895f25cc143c907a357")
     version("1.32.0", commit="6949abab2462b2c09f7a0ca5b5cbf0c95a40ad16")

--- a/var/spack/repos/builtin/packages/r-dmrcate/package.py
+++ b/var/spack/repos/builtin/packages/r-dmrcate/package.py
@@ -17,6 +17,7 @@ class RDmrcate(RPackage):
 
     bioc = "DMRcate"
 
+    version("2.12.0", commit="560dd5067b05715631739d0fb58ef9cebdbf7078")
     version("2.10.0", commit="81e83701da5c55ac83d0e0b5e640a9d431f09551")
     version("2.8.5", commit="c65dc79a33a047c10932a98b3383709a6bcb8903")
     version("2.4.1", commit="bc6242a0291a9b997872f575a4417d38550c9550")

--- a/var/spack/repos/builtin/packages/r-dnacopy/package.py
+++ b/var/spack/repos/builtin/packages/r-dnacopy/package.py
@@ -15,6 +15,7 @@ class RDnacopy(RPackage):
 
     bioc = "DNAcopy"
 
+    version("1.72.0", commit="1a1ae854c3425aee68b060e3e7ab788db5bed08c")
     version("1.70.0", commit="9595d0ad7c78af4ed568cbd210b894d3350eae0a")
     version("1.68.0", commit="08f039f58bc2f5ed2cc3117ae817dbac333002a6")
     version("1.64.0", commit="01650266ea7a4e5c600de545fe70a1103e79b2d8")

--- a/var/spack/repos/builtin/packages/r-dose/package.py
+++ b/var/spack/repos/builtin/packages/r-dose/package.py
@@ -18,6 +18,7 @@ class RDose(RPackage):
 
     bioc = "DOSE"
 
+    version("3.24.1", commit="a78995d3b12bd4baabb69c497102687814cd4c68")
     version("3.22.1", commit="6b711a0f076a9fefcb00ddef66e8f198039e6dfa")
     version("3.22.0", commit="242ac1b746c44fbbf281fbe6e5e4424a8dc74375")
     version("3.20.1", commit="bf434f24d035217822cb1b0ab08a486b9a53edb4")
@@ -32,11 +33,12 @@ class RDose(RPackage):
     depends_on("r@3.4.0:", type=("build", "run"), when="@3.6.1:")
     depends_on("r@3.5.0:", type=("build", "run"), when="@3.16.0:")
     depends_on("r-annotationdbi", type=("build", "run"))
+    depends_on("r-hdo-db", type=("build", "run"), when="@3.24.1:")
     depends_on("r-biocparallel", type=("build", "run"))
-    depends_on("r-do-db", type=("build", "run"))
     depends_on("r-fgsea", type=("build", "run"))
     depends_on("r-ggplot2", type=("build", "run"))
     depends_on("r-gosemsim@2.0.0:", type=("build", "run"))
+    depends_on("r-gosemsim@2.23.1:", type=("build", "run"), when="@3.24.1:")
     depends_on("r-qvalue", type=("build", "run"))
     depends_on("r-reshape2", type=("build", "run"))
 
@@ -44,3 +46,5 @@ class RDose(RPackage):
     depends_on("r-scales", type=("build", "run"), when="@3.2.0:3.4.0")
     depends_on("r-rvcheck", type=("build", "run"), when="@3.4.0")
     depends_on("r-igraph", type=("build", "run"), when="@3.2.0:3.4.0")
+    depends_on("r-do-db", type=("build", "run"))
+    depends_on("r-do-db", when="@:3.22.1")

--- a/var/spack/repos/builtin/packages/r-dss/package.py
+++ b/var/spack/repos/builtin/packages/r-dss/package.py
@@ -18,6 +18,7 @@ class RDss(RPackage):
 
     bioc = "DSS"
 
+    version("2.46.0", commit="debfbac4bc741961ba57915d4f2d98534f02cc21")
     version("2.44.0", commit="b9f44106f139c93564dfb4afab50555d24a657ba")
     version("2.42.0", commit="33e87450fbb64bb3e321688ff613e83cd40efe48")
     version("2.38.0", commit="82e65b92e6e227f1f99620362db8b03059e07e98")
@@ -30,6 +31,7 @@ class RDss(RPackage):
     depends_on("r-biobase", type=("build", "run"))
     depends_on("r-biocparallel", type=("build", "run"), when="@2.36.0:")
     depends_on("r-bsseq", type=("build", "run"))
-    depends_on("r-matrixstats", type=("build", "run"), when="@2.44.0:")
 
     depends_on("r-delayedarray", type=("build", "run"), when="@2.36.0:2.42.0")
+    depends_on("r-matrixstats", type=("build", "run"), when="@2.44.0:")
+    depends_on("r-matrixstats", when="@:2.44.0")

--- a/var/spack/repos/builtin/packages/r-edger/package.py
+++ b/var/spack/repos/builtin/packages/r-edger/package.py
@@ -19,6 +19,7 @@ class REdger(RPackage):
 
     bioc = "edgeR"
 
+    version("3.40.0", commit="0b25adcc6b3cb0a8c641964d1274536ee07ee162")
     version("3.38.4", commit="f5a3bb568a23b34146ac66329a95ee4785093536")
     version("3.38.1", commit="e58bf52f34ec451096f593126922ad7e5d517f7e")
     version("3.36.0", commit="c7db03addfc42138a1901834409c02da9d873026")

--- a/var/spack/repos/builtin/packages/r-enrichplot/package.py
+++ b/var/spack/repos/builtin/packages/r-enrichplot/package.py
@@ -16,6 +16,7 @@ class REnrichplot(RPackage):
 
     bioc = "enrichplot"
 
+    version("1.18.0", commit="61ea941784a1ed6cc604af1c1cc4532b8b5fcea7")
     version("1.16.2", commit="eeb21345288d96c116ac308649fa772d03760259")
     version("1.16.1", commit="cff77b622b2312be546714ec437aa4bc585bac87")
     version("1.14.1", commit="ccf3a6d9b7cd9cffd8de6d6263efdffe59d2ec36")
@@ -27,9 +28,11 @@ class REnrichplot(RPackage):
     depends_on("r@3.4.0:", type=("build", "run"))
     depends_on("r@3.5.0:", type=("build", "run"), when="@1.10.2:")
     depends_on("r-aplot", type=("build", "run"), when="@1.14.1:")
+    depends_on("r-aplot@0.1.4:", type=("build", "run"), when="@1.18.0:")
     depends_on("r-dose@3.5.1:", type=("build", "run"))
     depends_on("r-dose@3.13.1:", type=("build", "run"), when="@1.8.1:")
     depends_on("r-dose@3.16.0:", type=("build", "run"), when="@1.12.3:")
+    depends_on("r-ggnewscale", type=("build", "run"), when="@1.18.0:")
     depends_on("r-ggplot2", type=("build", "run"))
     depends_on("r-ggraph", type=("build", "run"))
     depends_on("r-igraph", type=("build", "run"))
@@ -37,6 +40,7 @@ class REnrichplot(RPackage):
     depends_on("r-purrr", type=("build", "run"), when="@1.2.0:")
     depends_on("r-rcolorbrewer", type=("build", "run"), when="@1.2.0:")
     depends_on("r-reshape2", type=("build", "run"))
+    depends_on("r-rlang", type=("build", "run"), when="@1.18.0:")
     depends_on("r-scatterpie", type=("build", "run"), when="@1.10.2:")
     depends_on("r-shadowtext", type=("build", "run"), when="@1.10.2:")
     depends_on("r-gosemsim", type=("build", "run"))
@@ -52,3 +56,4 @@ class REnrichplot(RPackage):
     depends_on("r-gridextra", type=("build", "run"), when="@1.2.0:1.4.0")
     depends_on("r-cowplot", type=("build", "run"))
     depends_on("r-cowplot", when="@:1.16.1")
+    depends_on("r-cowplot", when="@:1.16.2")

--- a/var/spack/repos/builtin/packages/r-ensembldb/package.py
+++ b/var/spack/repos/builtin/packages/r-ensembldb/package.py
@@ -24,6 +24,7 @@ class REnsembldb(RPackage):
 
     bioc = "ensembldb"
 
+    version("2.22.0", commit="4dda178a14e080c643bbd8c4dd6378bfe4e6ee9f")
     version("2.20.2", commit="ac1fb8389efd88099600af298d6bb3384206f9ed")
     version("2.20.1", commit="e547d184730cfe5e65f59e4f3512395fb1cdba1a")
     version("2.18.3", commit="e2fcfc0c7700110df070a171d2d542b37ec098f3")
@@ -40,6 +41,7 @@ class REnsembldb(RPackage):
     depends_on("r-genomicranges@1.31.18:", type=("build", "run"), when="@2.4.1:")
     depends_on("r-genomicfeatures@1.23.18:", type=("build", "run"))
     depends_on("r-genomicfeatures@1.29.10:", type=("build", "run"), when="@2.2.2:")
+    depends_on("r-genomicfeatures@1.49.6:", type=("build", "run"), when="@2.22.0:")
     depends_on("r-annotationfilter@0.99.7:", type=("build", "run"))
     depends_on("r-annotationfilter@1.1.9:", type=("build", "run"), when="@2.2.2:")
     depends_on("r-annotationfilter@1.5.2:", type=("build", "run"), when="@2.6.8:")

--- a/var/spack/repos/builtin/packages/r-exomecopy/package.py
+++ b/var/spack/repos/builtin/packages/r-exomecopy/package.py
@@ -17,6 +17,7 @@ class RExomecopy(RPackage):
 
     bioc = "exomeCopy"
 
+    version("1.44.0", commit="2dd6598d5fb14d49f7a42e597284c7a929c0cd62")
     version("1.42.0", commit="ba0979cf5fbdefed841022f2dc0604941315c1b8")
     version("1.40.0", commit="ebde39be67baace2c326359421fd17f4a02fd4fe")
     version("1.36.0", commit="cbe3134acbbc9b7d5426ae2f142dc64cadb3fc26")

--- a/var/spack/repos/builtin/packages/r-experimenthub/package.py
+++ b/var/spack/repos/builtin/packages/r-experimenthub/package.py
@@ -18,6 +18,7 @@ class RExperimenthub(RPackage):
 
     bioc = "ExperimentHub"
 
+    version("2.6.0", commit="557ba29720bce85902a85445dd0435b7356cdd7f")
     version("2.4.0", commit="bdce35d3a89e8633cc395f28991e6b5d1eccbe8e")
     version("2.2.1", commit="4e10686fa72baefef5d2990f41a7c44c527a7a7d")
     version("1.16.1", commit="61d51b7ca968d6cc1befe299e0784d9a19ca51f6")

--- a/var/spack/repos/builtin/packages/r-fgsea/package.py
+++ b/var/spack/repos/builtin/packages/r-fgsea/package.py
@@ -16,6 +16,7 @@ class RFgsea(RPackage):
 
     bioc = "fgsea"
 
+    version("1.24.0", commit="ac74ccd935c15623b8584caa791835aec514144b")
     version("1.22.0", commit="e4e203aa64faa984e0406fed5d87a422d9df92f2")
     version("1.20.0", commit="b704f81687dc16afdaafc6d30108c62a067856b2")
     version("1.16.0", commit="9d9df596c7e160afa18e067b7637cfc465494318")
@@ -30,7 +31,9 @@ class RFgsea(RPackage):
     depends_on("r-data-table", type=("build", "run"))
     depends_on("r-biocparallel", type=("build", "run"))
     depends_on("r-ggplot2@2.2.0:", type=("build", "run"))
-    depends_on("r-gridextra", type=("build", "run"))
+    depends_on("r-cowplot", type=("build", "run"), when="@1.24.0:")
     depends_on("r-fastmatch", type=("build", "run"))
     depends_on("r-matrix", type=("build", "run"), when="@1.6.0:")
     depends_on("r-bh", type=("build", "run"), when="@1.10.1:")
+    depends_on("r-gridextra", type=("build", "run"))
+    depends_on("r-gridextra", when="@:1.22.0")

--- a/var/spack/repos/builtin/packages/r-gcrma/package.py
+++ b/var/spack/repos/builtin/packages/r-gcrma/package.py
@@ -13,6 +13,7 @@ class RGcrma(RPackage):
 
     bioc = "gcrma"
 
+    version("2.70.0", commit="095f38914525d8812524a3cb38db8075382f8121")
     version("2.68.0", commit="c14063ff5490fac8d60530826613d728e68b3d66")
     version("2.66.0", commit="ba134b392def89d36b5639a187e0c25a4353457b")
     version("2.62.0", commit="b91bdf5bf4e875defedb4d4e3e1e75867773287a")

--- a/var/spack/repos/builtin/packages/r-gdsfmt/package.py
+++ b/var/spack/repos/builtin/packages/r-gdsfmt/package.py
@@ -24,6 +24,7 @@ class RGdsfmt(RPackage):
 
     bioc = "gdsfmt"
 
+    version("1.34.0", commit="ab912c393d8eb6dc26f844a13422a29b9ce7265b")
     version("1.32.0", commit="06f2097cc10b1888739f86e635383a0f2ee7e208")
     version("1.30.0", commit="d27dde6a70bb2295f5bbc8961152b45ccee7a652")
     version("1.26.1", commit="bd180b21b1ace120035f0da255cbf6f13088f069")

--- a/var/spack/repos/builtin/packages/r-genefilter/package.py
+++ b/var/spack/repos/builtin/packages/r-genefilter/package.py
@@ -13,6 +13,7 @@ class RGenefilter(RPackage):
 
     bioc = "genefilter"
 
+    version("1.80.0", commit="14fbc2d776916e572583e3c268ea9ba60ed60a9a")
     version("1.78.0", commit="2f574388971641d3a71858f5c34606c04fcd2ba2")
     version("1.76.0", commit="8d630fd25f0d2a4101e05e123c3959591203a7ea")
     version("1.72.1", commit="b01b00a766982ef7d80b90a252085c8c4f085e1b")

--- a/var/spack/repos/builtin/packages/r-genelendatabase/package.py
+++ b/var/spack/repos/builtin/packages/r-genelendatabase/package.py
@@ -14,6 +14,7 @@ class RGenelendatabase(RPackage):
 
     bioc = "geneLenDataBase"
 
+    version("1.34.0", commit="e26cf8e3fc20b5d183cbd39b7b28a8cc866f6ead")
     version("1.32.0", commit="eaa193a2c6d502c6d59113fd42f66761b8730594")
     version("1.30.0", commit="b3cc755f1ffcbb2eacd9ea45e11f39f1639782b1")
     version("1.26.0", commit="2724715ae23a6647d1c0c6e934720aad9377d65e")

--- a/var/spack/repos/builtin/packages/r-genemeta/package.py
+++ b/var/spack/repos/builtin/packages/r-genemeta/package.py
@@ -14,6 +14,7 @@ class RGenemeta(RPackage):
 
     bioc = "GeneMeta"
 
+    version("1.70.0", commit="e5db82e04efc4572358abce7e0c09273f94c9d72")
     version("1.68.0", commit="4213c0205d477660195300a0aa9751972f86bf91")
     version("1.66.0", commit="c16eb09492f08f6cc0f253fafa3fa5dce35dcdba")
     version("1.62.0", commit="eb4273ff5867e39592f50b97b454fa5e32b4a9bf")

--- a/var/spack/repos/builtin/packages/r-geneplotter/package.py
+++ b/var/spack/repos/builtin/packages/r-geneplotter/package.py
@@ -13,6 +13,7 @@ class RGeneplotter(RPackage):
 
     bioc = "geneplotter"
 
+    version("1.76.0", commit="4eb6a787d0c66110ec9a7d34fc76b64030fbde5d")
     version("1.74.0", commit="ca819565829eac7a9a98e3cafafd6c06a466fddf")
     version("1.72.0", commit="57a1d830ba7844fda5236af0153d5b5587634f96")
     version("1.68.0", commit="f1fea7e468fb24fdfa93ef4493600a4d8d183f69")

--- a/var/spack/repos/builtin/packages/r-genie3/package.py
+++ b/var/spack/repos/builtin/packages/r-genie3/package.py
@@ -14,6 +14,7 @@ class RGenie3(RPackage):
 
     bioc = "GENIE3"
 
+    version("1.20.0", commit="aea2e686a262f30b16c068241938d04f21251a0d")
     version("1.18.0", commit="f16b25ef50978a4a497eb2f911e21f2e839fa33c")
     version("1.16.0", commit="5543b1b883d3a1c92e955de6668444278edc2bdf")
     version("1.12.0", commit="14289cee9bed113ab35ba03bcaac4a30e5784497")

--- a/var/spack/repos/builtin/packages/r-genomeinfodb/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodb/package.py
@@ -17,6 +17,7 @@ class RGenomeinfodb(RPackage):
 
     bioc = "GenomeInfoDb"
 
+    version("1.34.3", commit="ea6f131f1d1ee61535d6733ce76fabf3c62185fc")
     version("1.32.4", commit="69df6a5a10027fecf6a6d1c8298f3f686b990d8f")
     version("1.32.2", commit="2e40af38f00ee86d2c83d140e234c1349baa27de")
     version("1.30.1", commit="bf8b385a2ffcecf9b41e581794056f267895863d")

--- a/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
@@ -14,6 +14,11 @@ class RGenomeinfodbdata(RPackage):
     url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/GenomeInfoDbData_0.99.0.tar.gz"
 
     version(
+        "1.2.9",
+        url="https://bioconductor.org/packages/3.16/data/annotation/src/contrib/GenomeInfoDbData_1.2.9.tar.gz",
+        sha256="e63a719a8eceefeda39fc95de83e7aa41caad39705efc712a44ab4021adc45fa",
+    )
+    version(
         "1.2.8",
         url="https://bioconductor.org/packages/3.15/data/annotation/src/contrib/GenomeInfoDbData_1.2.8.tar.gz",
         sha256="576750330a011c1eccb47c7154ca1b40ae4cd473fd7973f6c2955237a0729eb4",

--- a/var/spack/repos/builtin/packages/r-genomicalignments/package.py
+++ b/var/spack/repos/builtin/packages/r-genomicalignments/package.py
@@ -16,6 +16,7 @@ class RGenomicalignments(RPackage):
 
     bioc = "GenomicAlignments"
 
+    version("1.34.0", commit="c6eb78079c8aa21d47c95b3d16a606e8c2c5d799")
     version("1.32.1", commit="2553580d0b8a8a5fd7835c1446616b39f707b8a9")
     version("1.32.0", commit="7a660a914a04e2eb0758082b6f64c4124a887ef3")
     version("1.30.0", commit="2d2c5fce3529c2962fdcefd736d8b7f7c0ec2d54")

--- a/var/spack/repos/builtin/packages/r-genomicfeatures/package.py
+++ b/var/spack/repos/builtin/packages/r-genomicfeatures/package.py
@@ -20,6 +20,7 @@ class RGenomicfeatures(RPackage):
 
     bioc = "GenomicFeatures"
 
+    version("1.50.2", commit="4fc9120ceed9ff59f390c8bbdbd79b212ee35b84")
     version("1.48.4", commit="06e37dc1847d49d91391264caec877ed33abf359")
     version("1.48.3", commit="b0ddea0e101e3861928f3ad353348df047d90382")
     version("1.46.4", commit="d3ab6fd069624904ce7fcdf75dad884473f97975")
@@ -41,6 +42,7 @@ class RGenomicfeatures(RPackage):
     depends_on("r-genomeinfodb@1.13.1:", type=("build", "run"), when="@1.30.3:")
     depends_on("r-genomeinfodb@1.15.4:", type=("build", "run"), when="@1.32.3:")
     depends_on("r-genomeinfodb@1.25.7:", type=("build", "run"), when="@1.42.1:")
+    depends_on("r-genomeinfodb@1.34.1:", type=("build", "run"), when="@1.50.2:")
     depends_on("r-genomicranges@1.27.6:", type=("build", "run"))
     depends_on("r-genomicranges@1.29.14:", type=("build", "run"), when="@1.30.3:")
     depends_on("r-genomicranges@1.31.17:", type=("build", "run"), when="@1.32.3:")

--- a/var/spack/repos/builtin/packages/r-genomicranges/package.py
+++ b/var/spack/repos/builtin/packages/r-genomicranges/package.py
@@ -22,6 +22,7 @@ class RGenomicranges(RPackage):
 
     bioc = "GenomicRanges"
 
+    version("1.50.1", commit="6b3fb388ec038fb43f3cd26684ce778ee0e80e81")
     version("1.48.0", commit="2bce60814db7c20949892587740fb484aa435978")
     version("1.46.1", commit="e422642f64815cdfee8fc340681ad87a7eafc3bb")
     version("1.42.0", commit="32baca734b599d60fa13bdbe31c5712e648f538d")
@@ -46,6 +47,7 @@ class RGenomicranges(RPackage):
     depends_on("r-iranges@2.15.12:", type=("build", "run"), when="@1.34.0:")
     depends_on("r-iranges@2.17.1:", type=("build", "run"), when="@1.36.1:")
     depends_on("r-iranges@2.23.9:", type=("build", "run"), when="@1.42.0:")
+    depends_on("r-iranges@2.31.2:", type=("build", "run"), when="@1.50.1:")
     depends_on("r-genomeinfodb@1.11.5:", type=("build", "run"))
     depends_on("r-genomeinfodb@1.13.1:", type=("build", "run"), when="@1.30.3:")
     depends_on("r-genomeinfodb@1.15.2:", type=("build", "run"), when="@1.32.7:")

--- a/var/spack/repos/builtin/packages/r-geoquery/package.py
+++ b/var/spack/repos/builtin/packages/r-geoquery/package.py
@@ -16,6 +16,7 @@ class RGeoquery(RPackage):
 
     bioc = "GEOquery"
 
+    version("2.66.0", commit="00a954e9f8223607b43cf112943ab575d03a0eb6")
     version("2.64.2", commit="e9b7f075a4a6a952660443ca93ed392d7a4fd6d7")
     version("2.62.2", commit="1966c108fe8a58ac39ef53c3c452fd160efa526e")
     version("2.58.0", commit="6332ca3791ddcfb233b9ad75b5904b3d60f49b93")

--- a/var/spack/repos/builtin/packages/r-ggbio/package.py
+++ b/var/spack/repos/builtin/packages/r-ggbio/package.py
@@ -21,6 +21,7 @@ class RGgbio(RPackage):
 
     bioc = "ggbio"
 
+    version("1.46.0", commit="d9c6cb495c7268bcaaab141231a9038aec8498bc")
     version("1.44.1", commit="0301d9464e304a8113ea4479185cd358855ca365")
     version("1.44.0", commit="cb21284a9803917fa76e116adfc456525c95f660")
     version("1.42.0", commit="3540047ef018957d59fba8af7d3c58e4659f8e26")

--- a/var/spack/repos/builtin/packages/r-ggnewscale/package.py
+++ b/var/spack/repos/builtin/packages/r-ggnewscale/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RGgnewscale(RPackage):
+    """Multiple Fill and Colour Scales in 'ggplot2'.
+
+    Use multiple fill and colour scales in 'ggplot2'."""
+
+    cran = "ggnewscale"
+
+    version("0.4.8", sha256="c7fefa6941ecbc789507e59be13fa96327fe2549681a938c43beb06ca22a9700")
+
+    depends_on("r-ggplot2@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-ggrastr/package.py
+++ b/var/spack/repos/builtin/packages/r-ggrastr/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RGgrastr(RPackage):
+    """Rasterize Layers for 'ggplot2'.
+
+    Rasterize only specific layers of a 'ggplot2' plot while simultaneously
+    keeping all labels and text in vector format. This allows users to keep
+    plots within the reasonable size limit without loosing vector properties of
+    the scale-sensitive information."""
+
+    cran = "ggrastr"
+
+    version("1.0.1", sha256="82d6e90fa38dec85e829f71018532ed5b709a50a585455fc07cb3bae282f5d1f")
+
+    depends_on("r@3.2.2:", type=("build", "run"))
+    depends_on("r-ggplot2@2.1.0:", type=("build", "run"))
+    depends_on("r-cairo@1.5.9:", type=("build", "run"))
+    depends_on("r-ggbeeswarm", type=("build", "run"))
+    depends_on("r-png", type=("build", "run"))
+    depends_on("r-ragg", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-ggtree/package.py
+++ b/var/spack/repos/builtin/packages/r-ggtree/package.py
@@ -27,7 +27,7 @@ class RGgtree(RPackage):
     depends_on("r-aplot", type=("build", "run"), when="@3.4.0:")
     depends_on("r-dplyr", type=("build", "run"))
     depends_on("r-ggplot2@3.0.0:", type=("build", "run"))
-    depends_on("r-ggplot2@3.3.6:", type=("build", "run"), when="@3.6.2:")
+    depends_on("r-ggplot2@3.4.0:", type=("build", "run"), when="@3.6.2:")
     depends_on("r-magrittr", type=("build", "run"))
     depends_on("r-purrr", type=("build", "run"))
     depends_on("r-rlang", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-ggtree/package.py
+++ b/var/spack/repos/builtin/packages/r-ggtree/package.py
@@ -16,6 +16,7 @@ class RGgtree(RPackage):
 
     bioc = "ggtree"
 
+    version("3.6.2", commit="431ec37bc0f0159b08a7990ce1d9374e160b9f44")
     version("3.4.4", commit="8e48d3e2ea445b6c2213f0471462108a7a72b333")
     version("3.4.0", commit="23f08a3da1829d1bbb6827ed1c4cf878daa4b539")
     version("3.2.1", commit="d3747e636fe1a6a9e09b56a3a3899208ebd05547")
@@ -26,6 +27,7 @@ class RGgtree(RPackage):
     depends_on("r-aplot", type=("build", "run"), when="@3.4.0:")
     depends_on("r-dplyr", type=("build", "run"))
     depends_on("r-ggplot2@3.0.0:", type=("build", "run"))
+    depends_on("r-ggplot2@3.3.6:", type=("build", "run"), when="@3.6.2:")
     depends_on("r-magrittr", type=("build", "run"))
     depends_on("r-purrr", type=("build", "run"))
     depends_on("r-rlang", type=("build", "run"))
@@ -37,3 +39,4 @@ class RGgtree(RPackage):
     depends_on("r-tidytree@0.3.9:", type=("build", "run"), when="@3.4.0:")
     depends_on("r-treeio@1.8.0:", type=("build", "run"))
     depends_on("r-scales", type=("build", "run"))
+    depends_on("r-cli", type=("build", "run"), when="@3.6.2:")

--- a/var/spack/repos/builtin/packages/r-glimma/package.py
+++ b/var/spack/repos/builtin/packages/r-glimma/package.py
@@ -17,6 +17,7 @@ class RGlimma(RPackage):
 
     bioc = "Glimma"
 
+    version("2.8.0", commit="09cec82e9af9c6775192570f8c28f050c0df08ac")
     version("2.6.0", commit="23220d9b90476059aab035b5de11b7ce04b331c8")
     version("2.4.0", commit="caa270e44ec6994035d2e915c0f68a14ccbb58db")
     version("2.0.0", commit="40bebaa79e8c87c5686cff7285def4461c11bca9")

--- a/var/spack/repos/builtin/packages/r-glmgampoi/package.py
+++ b/var/spack/repos/builtin/packages/r-glmgampoi/package.py
@@ -16,14 +16,18 @@ class RGlmgampoi(RPackage):
 
     bioc = "glmGamPoi"
 
+    version("1.10.0", commit="048e17384209fc07031e09875ec6eea35e90ef46")
     version("1.8.0", commit="b723d61e05c1ad50a3cf6a6393ec3d97adc7edb4")
 
     depends_on("r-rcpp", type=("build", "run"))
     depends_on("r-delayedmatrixstats", type=("build", "run"))
     depends_on("r-matrixstats", type=("build", "run"))
+    depends_on("r-matrixgenerics", type=("build", "run"), when="@1.10.0:")
     depends_on("r-delayedarray", type=("build", "run"))
     depends_on("r-hdf5array", type=("build", "run"))
     depends_on("r-summarizedexperiment", type=("build", "run"))
+    depends_on("r-singlecellexperiment", type=("build", "run"), when="@1.10.0:")
     depends_on("r-biocgenerics", type=("build", "run"))
+    depends_on("r-rlang", type=("build", "run"), when="@1.10.0:")
     depends_on("r-rcpparmadillo", type=("build", "run"))
     depends_on("r-beachmat", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-globaltest/package.py
+++ b/var/spack/repos/builtin/packages/r-globaltest/package.py
@@ -18,6 +18,7 @@ class RGlobaltest(RPackage):
 
     bioc = "globaltest"
 
+    version("5.52.0", commit="a1fc3ad206454d1151bcc940644fd8a5c4164d63")
     version("5.50.0", commit="08612a06eb1cc7381f9bf70f6fe198bb401a21df")
     version("5.48.0", commit="86c2c8f35734dcbc8c8ca791d8a190dc525beac9")
     version("5.44.0", commit="571933d5c779a241740be913ff49ecdd59bcbc45")

--- a/var/spack/repos/builtin/packages/r-go-db/package.py
+++ b/var/spack/repos/builtin/packages/r-go-db/package.py
@@ -17,28 +17,28 @@ class RGoDb(RPackage):
 
     version(
         "3.16.0",
-        sha256="4652812d8ba380aeeb9b136efbc9365156397eec99c5ca36cfb8294139493b8e",
         url="https://bioconductor.org/packages/3.16/data/annotation/src/contrib/GO.db_3.16.0.tar.gz",
+        sha256="4652812d8ba380aeeb9b136efbc9365156397eec99c5ca36cfb8294139493b8e",
     )
     version(
         "3.15.0",
-        sha256="bac91d73c57f206fa5bc4a501a2aaf61b365cf411181ce44353370cdbc132d99",
         url="https://bioconductor.org/packages/3.15/data/annotation/src/contrib/GO.db_3.15.0.tar.gz",
+        sha256="bac91d73c57f206fa5bc4a501a2aaf61b365cf411181ce44353370cdbc132d99",
     )
     version(
         "3.14.0",
-        sha256="45d0a681a662667d45b2472d160b72f7058ad0a28dd0ca24742e11ddfd87d8e7",
         url="https://bioconductor.org/packages/3.14/data/annotation/src/contrib/GO.db_3.14.0.tar.gz",
+        sha256="45d0a681a662667d45b2472d160b72f7058ad0a28dd0ca24742e11ddfd87d8e7",
     )
     version(
         "3.12.1",
-        sha256="e0316959d3d32096f9432c897413dff74fce53e15ead7917a7724467d971dab9",
         url="https://bioconductor.org/packages/3.12/data/annotation/src/contrib/GO.db_3.12.1.tar.gz",
+        sha256="e0316959d3d32096f9432c897413dff74fce53e15ead7917a7724467d971dab9",
     )
     version(
         "3.4.1",
-        sha256="2fc2048e9d26edb98e35e4adc4d18c6df54f44836b5cc4a482d36ed99e058cc1",
         url="https://bioconductor.org/packages/3.5/data/annotation/src/contrib/GO.db_3.4.1.tar.gz",
+        sha256="2fc2048e9d26edb98e35e4adc4d18c6df54f44836b5cc4a482d36ed99e058cc1",
     )
 
     depends_on("r@2.7.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-go-db/package.py
+++ b/var/spack/repos/builtin/packages/r-go-db/package.py
@@ -16,6 +16,11 @@ class RGoDb(RPackage):
     url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/GO.db_3.4.1.tar.gz"
 
     version(
+        "3.16.0",
+        sha256="4652812d8ba380aeeb9b136efbc9365156397eec99c5ca36cfb8294139493b8e",
+        url="https://bioconductor.org/packages/3.16/data/annotation/src/contrib/GO.db_3.16.0.tar.gz",
+    )
+    version(
         "3.15.0",
         sha256="bac91d73c57f206fa5bc4a501a2aaf61b365cf411181ce44353370cdbc132d99",
         url="https://bioconductor.org/packages/3.15/data/annotation/src/contrib/GO.db_3.15.0.tar.gz",

--- a/var/spack/repos/builtin/packages/r-gofuncr/package.py
+++ b/var/spack/repos/builtin/packages/r-gofuncr/package.py
@@ -28,6 +28,7 @@ class RGofuncr(RPackage):
 
     bioc = "GOfuncR"
 
+    version("1.18.0", commit="49182411e40a5d72abf99a5cca9287f34f870b19")
     version("1.16.0", commit="603fc79e13b58ec4612b6092f37d2450078dbfe1")
     version("1.14.0", commit="b3d445acf95851241d1fdb673d108ee115bdc17b")
     version("1.10.0", commit="51b01a2b9afa03fde2e1628036096cbeafaa2ef4")

--- a/var/spack/repos/builtin/packages/r-gosemsim/package.py
+++ b/var/spack/repos/builtin/packages/r-gosemsim/package.py
@@ -19,6 +19,7 @@ class RGosemsim(RPackage):
 
     bioc = "GOSemSim"
 
+    version("2.24.0", commit="ed7334f3cf3ac7ce5be76003934c29b598089f4d")
     version("2.22.0", commit="fd74aeba2371ebf9db0595cf18674441bdac9618")
     version("2.20.0", commit="fa82442aaa4ad1a8dacc05ee2c54f5e5e770a794")
     version("2.16.1", commit="92f1d567f3584fe488f434abce87c2e1950081c0")

--- a/var/spack/repos/builtin/packages/r-goseq/package.py
+++ b/var/spack/repos/builtin/packages/r-goseq/package.py
@@ -14,6 +14,7 @@ class RGoseq(RPackage):
 
     bioc = "goseq"
 
+    version("1.50.0", commit="f9fad238e2d08a87b14c3c8c228ad332efa60f14")
     version("1.48.0", commit="d077fda56986cc7218a88f7db37a42412b227025")
     version("1.46.0", commit="1fb5626cc80f595499af511a830322ed12bbe144")
     version("1.42.0", commit="8164b90e7505bbc1035105fdc15219c764ef8b8d")

--- a/var/spack/repos/builtin/packages/r-gostats/package.py
+++ b/var/spack/repos/builtin/packages/r-gostats/package.py
@@ -15,6 +15,7 @@ class RGostats(RPackage):
 
     bioc = "GOstats"
 
+    version("2.64.0", commit="62813253249dc02d2ddaafa7f0249e69d6f2c6b0")
     version("2.62.0", commit="217db032272010ebb8fe3af4647153428f42cd47")
     version("2.60.0", commit="a20055cc1c04a91b0291a918dadd9ea912c187ce")
     version("2.56.0", commit="8f988c3b4b1ce7e05626aae8956004c7bbdd6f3a")

--- a/var/spack/repos/builtin/packages/r-graph/package.py
+++ b/var/spack/repos/builtin/packages/r-graph/package.py
@@ -13,6 +13,7 @@ class RGraph(RPackage):
 
     bioc = "graph"
 
+    version("1.76.0", commit="e3efc108716e98bd3363621d17a6f9c3ef975d19")
     version("1.74.0", commit="4af608a5d9e1de33fda6ae28fb73bff9272ee296")
     version("1.72.0", commit="7afbd26ecd76e55e6bbd74915a561d7a9b15f907")
     version("1.68.0", commit="03ad9ed088095605e317510b8234501318994e94")

--- a/var/spack/repos/builtin/packages/r-gseabase/package.py
+++ b/var/spack/repos/builtin/packages/r-gseabase/package.py
@@ -14,6 +14,7 @@ class RGseabase(RPackage):
 
     bioc = "GSEABase"
 
+    version("1.60.0", commit="aae4e52b50b076550967601f98031e952fb97765")
     version("1.58.0", commit="7de04442fb1ab63ffde29f4e3daf13ad32e90bdb")
     version("1.56.0", commit="ee7c3ca4ad0f1f3e9b9162db1515413802860ecc")
     version("1.52.1", commit="257dfccbc5b507d82099fac6b06bb03825e995e8")

--- a/var/spack/repos/builtin/packages/r-gson/package.py
+++ b/var/spack/repos/builtin/packages/r-gson/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RGson(RPackage):
+    """Base Class and Methods for 'gson' Format.
+
+    Proposes a new file format ('gson') for storing gene set and related
+    information, and provides read, write and other utilities to process this
+    file format."""
+
+    cran = "gson"
+
+    version("0.0.9", sha256="f694765cd2872efb73dd7be66ef8e31395915f9b277f59e0891cff138777b118")
+
+    depends_on("r-jsonlite", type=("build", "run"))
+    depends_on("r-rlang", type=("build", "run"))
+    depends_on("r-tidyr", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-gtrellis/package.py
+++ b/var/spack/repos/builtin/packages/r-gtrellis/package.py
@@ -18,6 +18,7 @@ class RGtrellis(RPackage):
 
     bioc = "gtrellis"
 
+    version("1.30.0", commit="da93b30ef812e231c47aa83da5c521f1801b3d14")
     version("1.28.0", commit="d770a7b3441e4003869c88cfd8e21fd6508b86c4")
     version("1.26.0", commit="f2c3121b31ad1b422e2cf503435d0590e903ff3f")
     version("1.22.0", commit="c071c5631f3dedda212aed87d9c02954b5ed6611")

--- a/var/spack/repos/builtin/packages/r-gviz/package.py
+++ b/var/spack/repos/builtin/packages/r-gviz/package.py
@@ -18,6 +18,7 @@ class RGviz(RPackage):
 
     bioc = "Gviz"
 
+    version("1.42.0", commit="4eddb688bca3fdeb65fd536d653d7ba7f7976121")
     version("1.40.1", commit="d21843710cd05135353de5cd4ce4d35cdd333b7c")
     version("1.38.3", commit="c4b352a16455a5744533c511e59354977814cb9e")
     version("1.34.0", commit="445fadff2aedd8734580fa908aa47ff1216a8182")

--- a/var/spack/repos/builtin/packages/r-hdf5array/package.py
+++ b/var/spack/repos/builtin/packages/r-hdf5array/package.py
@@ -20,6 +20,7 @@ class RHdf5array(RPackage):
 
     bioc = "HDF5Array"
 
+    version("1.26.0", commit="38b7bd603f7281245605048d8d57237e00b74d79")
     version("1.24.2", commit="fb213ba36631b04dfe754705f701f3a015c4fc82")
     version("1.24.1", commit="d002fe70c84baaadb62058ce467d6c1ea032d8f5")
     version("1.22.1", commit="b3f091fbc159609e8e0792d2bf9fbef52c6ceede")

--- a/var/spack/repos/builtin/packages/r-hdo-db/package.py
+++ b/var/spack/repos/builtin/packages/r-hdo-db/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RHdoDb(RPackage):
+    """ A set of annotation maps describing the entire Human Disease Ontology.
+
+    A set of annotation maps describing the entire Human Disease Ontology
+    assembled using data from DO.  Its annotation data comes from
+    https://github.com/DiseaseOntology/HumanDiseaseOntology/tree/main/src/ontology."""
+
+    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/HDO.db_0.99.1.tar.gz"
+    bioc = "HDO.db"
+
+    version("0.99.1", sha256="c17cf28d06621d91148a64d47fdeaa906d8621aba7a688715fb9571a55f7cf92")
+
+    depends_on("r@4.2.0:", type=("build", "run"))
+    depends_on("r-annotationdbi", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-hdo-db/package.py
+++ b/var/spack/repos/builtin/packages/r-hdo-db/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class RHdoDb(RPackage):
-    """ A set of annotation maps describing the entire Human Disease Ontology.
+    """A set of annotation maps describing the entire Human Disease Ontology.
 
     A set of annotation maps describing the entire Human Disease Ontology
     assembled using data from DO.  Its annotation data comes from

--- a/var/spack/repos/builtin/packages/r-hypergraph/package.py
+++ b/var/spack/repos/builtin/packages/r-hypergraph/package.py
@@ -14,6 +14,7 @@ class RHypergraph(RPackage):
 
     bioc = "hypergraph"
 
+    version("1.70.0", commit="a5ffeafa8b999b5e7e77f93f4e6284abafc81621")
     version("1.68.0", commit="7d53b5050f4ebe0a7007c02b76e93498195da3a4")
     version("1.66.0", commit="e9c47336df6409006622818f541f258103163a39")
     version("1.62.0", commit="a286bbb70289e9f3cdf41407d52e5976bd6ed11e")

--- a/var/spack/repos/builtin/packages/r-illumina450probevariants-db/package.py
+++ b/var/spack/repos/builtin/packages/r-illumina450probevariants-db/package.py
@@ -15,6 +15,7 @@ class RIllumina450probevariantsDb(RPackage):
 
     bioc = "Illumina450ProbeVariants.db"
 
+    version("1.34.0", commit="6c0f0b4d2bcf13da852b2f132a8ce1229fa5269e")
     version("1.32.0", commit="a15602253e675a104303627957653a08876d8d7c")
     version("1.30.0", commit="ba1296b4aafc287dea61f5f37c6c99fd553e52a2")
     version("1.26.0", commit="fffe6033cc8d87354078c14de1e29976eaedd611")

--- a/var/spack/repos/builtin/packages/r-illuminaio/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminaio/package.py
@@ -13,6 +13,7 @@ class RIlluminaio(RPackage):
 
     bioc = "illuminaio"
 
+    version("0.40.0", commit="1d7045697eaf09e5c61447a6f61e2eeaaf7a5095")
     version("0.38.0", commit="b16231b7417b4d6e9cff1e2724ed3529871dff92")
     version("0.36.0", commit="c5b6e9164b73c650c0a9f055f4fd0580ac64fae7")
     version("0.32.0", commit="e1322c781dd475a5e8ff6c0422bebb3deb47fa80")

--- a/var/spack/repos/builtin/packages/r-impute/package.py
+++ b/var/spack/repos/builtin/packages/r-impute/package.py
@@ -13,6 +13,7 @@ class RImpute(RPackage):
 
     bioc = "impute"
 
+    version("1.72.0", commit="638ac916464f5a392b947ef5bb426b8445d27325")
     version("1.70.0", commit="970b2c28d908e26369b01dddf36dab2f8916d4af")
     version("1.68.0", commit="fa4e4d883e609633c49d865a44acd6a79954eaac")
     version("1.64.0", commit="31a5636f4dfbb1fd61386738786a0de048a620c2")

--- a/var/spack/repos/builtin/packages/r-interactivedisplaybase/package.py
+++ b/var/spack/repos/builtin/packages/r-interactivedisplaybase/package.py
@@ -16,6 +16,7 @@ class RInteractivedisplaybase(RPackage):
 
     bioc = "interactiveDisplayBase"
 
+    version("1.36.0", commit="79a0552bd467367866ceda2efc2b60a04a81f5fb")
     version("1.34.0", commit="fafbb13a42bb7549f17aa08cdb0e51728c5e825e")
     version("1.32.0", commit="0f88b2ac3689d51abb6ac0045b3207ca77963a5a")
     version("1.28.0", commit="a74c02c971c4f9c7086e14abd23f1a4190da4599")

--- a/var/spack/repos/builtin/packages/r-iranges/package.py
+++ b/var/spack/repos/builtin/packages/r-iranges/package.py
@@ -18,6 +18,7 @@ class RIranges(RPackage):
 
     bioc = "IRanges"
 
+    version("2.32.0", commit="2b5c9fc706c8cdc96f0c46508087863df1502f81")
     version("2.30.1", commit="ead506a14d6cc89ac2f14b55a4b04496755e4e50")
     version("2.30.0", commit="9b5f3ca12812fb76c23b1550aa3a794384384d9b")
     version("2.28.0", commit="d85ee908a379e12d1e32599e999c71ab37c25e57")

--- a/var/spack/repos/builtin/packages/r-kegg-db/package.py
+++ b/var/spack/repos/builtin/packages/r-kegg-db/package.py
@@ -18,14 +18,14 @@ class RKeggDb(RPackage):
 
     version(
         "3.2.4",
-        sha256="2e60d1b664cbd1491cc00ed13a22904706c5a4651150f70daca04bf3ba9ead88",
         url="https://bioconductor.org/packages/3.12/data/annotation/src/contrib/KEGG.db_3.2.4.tar.gz",
+        sha256="2e60d1b664cbd1491cc00ed13a22904706c5a4651150f70daca04bf3ba9ead88",
         deprecated=True,
     )
     version(
         "3.2.3",
-        sha256="02ea4630a3ec06a8d9a6151627c96d3f71dfc7e8857800bb5c0cdb6a838d6963",
         url="https://bioconductor.org/packages/3.10/data/annotation/src/contrib/KEGG.db_3.2.3.tar.gz",
+        sha256="02ea4630a3ec06a8d9a6151627c96d3f71dfc7e8857800bb5c0cdb6a838d6963",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/r-kegggraph/package.py
+++ b/var/spack/repos/builtin/packages/r-kegggraph/package.py
@@ -18,6 +18,7 @@ class RKegggraph(RPackage):
 
     bioc = "KEGGgraph"
 
+    version("1.58.0", commit="7c3f148b57903b8df517f94824f07f38bbd3b591")
     version("1.56.0", commit="e95cbf9f8a095d59b78a053463191b89c00d5ded")
     version("1.54.0", commit="135ee3dad30ca208e21acd0a2d81120b74b64079")
     version("1.50.0", commit="3335e85cdba264c04e6e36378578cf6c83a30eb8")

--- a/var/spack/repos/builtin/packages/r-keggrest/package.py
+++ b/var/spack/repos/builtin/packages/r-keggrest/package.py
@@ -15,6 +15,7 @@ class RKeggrest(RPackage):
 
     bioc = "KEGGREST"
 
+    version("1.38.0", commit="4dfbff9f6662227bd49d64d18a342f469dd88ad3")
     version("1.36.3", commit="1827cde76863aa80c83264a0dd95514654358df3")
     version("1.36.0", commit="591818bbc9195bfd0657cf4f5c7c771ea7f86830")
     version("1.34.0", commit="2056750dc202fa04a34b84c6c712e884c7cad2bd")

--- a/var/spack/repos/builtin/packages/r-limma/package.py
+++ b/var/spack/repos/builtin/packages/r-limma/package.py
@@ -14,6 +14,7 @@ class RLimma(RPackage):
 
     bioc = "limma"
 
+    version("3.54.0", commit="1d1fa843d4fe2f8c94fd843bb1e80b8384d8306e")
     version("3.52.4", commit="3226c29ad8c18aa7e6722f4a2c95ff8ac900437e")
     version("3.52.1", commit="c81c539a217ac1cf46e850f8a20266cecfafed50")
     version("3.50.0", commit="657b19bbc33c5c941af79aeb68967bf42ea40e23")

--- a/var/spack/repos/builtin/packages/r-lumi/package.py
+++ b/var/spack/repos/builtin/packages/r-lumi/package.py
@@ -19,6 +19,7 @@ class RLumi(RPackage):
 
     bioc = "lumi"
 
+    version("2.50.0", commit="8711b77a1b5b0a58770d25d3d079ad02208704f5")
     version("2.48.0", commit="1f988ffe04d2c0707b2202d2074d02b679a3204b")
     version("2.46.0", commit="a68932c17a61c99e58ebbd8008d078bec6adb4e7")
     version("2.42.0", commit="a643b3ba46fee951b8566ddd8216af7e6c92f6f6")

--- a/var/spack/repos/builtin/packages/r-makecdfenv/package.py
+++ b/var/spack/repos/builtin/packages/r-makecdfenv/package.py
@@ -16,6 +16,7 @@ class RMakecdfenv(RPackage):
 
     bioc = "makecdfenv"
 
+    version("1.74.0", commit="412affc333ba51cad0ff3c7919e2eadaaf426359")
     version("1.72.0", commit="85c89688e6b6e8bff46b92cbeba49e38c510492e")
     version("1.70.0", commit="82ecd0fa8ac401e4ac8f1e9139556d2be4a3c4f3")
     version("1.66.0", commit="02aa975d543089f5495cb3b4e8edbcf0ff05148a")

--- a/var/spack/repos/builtin/packages/r-marray/package.py
+++ b/var/spack/repos/builtin/packages/r-marray/package.py
@@ -14,6 +14,7 @@ class RMarray(RPackage):
 
     bioc = "marray"
 
+    version("1.76.0", commit="88cb0fd21cc60ac65410ca4314eca2e351933ec5")
     version("1.74.0", commit="9130a936fffb7d2d445ff21d04520e78b62625ac")
     version("1.72.0", commit="da35e8b8d2c9ef17e779013a5d252f38a1c66633")
     version("1.68.0", commit="67b3080486abdba7dd19fccd7fb731b0e8b5b3f9")

--- a/var/spack/repos/builtin/packages/r-matrixgenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-matrixgenerics/package.py
@@ -19,6 +19,7 @@ class RMatrixgenerics(RPackage):
 
     bioc = "MatrixGenerics"
 
+    version("1.10.0", commit="6d9d907e8c4d1fc96a32160fb9f3ab805d6eb356")
     version("1.8.1", commit="a4a21089e9f78275dd4a6f0df0c4b6b45c4650c7")
     version("1.8.0", commit="e4cc34d53bcfb9a5914afd79fda31ecd5037a47a")
     version("1.6.0", commit="4588a60e5cc691424c17faa281bdd7d99d83ec34")

--- a/var/spack/repos/builtin/packages/r-metapod/package.py
+++ b/var/spack/repos/builtin/packages/r-metapod/package.py
@@ -19,6 +19,7 @@ class RMetapod(RPackage):
 
     bioc = "metapod"
 
+    version("1.6.0", commit="cfeaa959f5c6b2119df270f40af9c3ea718c4b00")
     version("1.4.0", commit="e71c2072e5b39f74599e279b28f4da7923b515fb")
 
     depends_on("r-rcpp", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-methylumi/package.py
+++ b/var/spack/repos/builtin/packages/r-methylumi/package.py
@@ -20,6 +20,7 @@ class RMethylumi(RPackage):
 
     bioc = "methylumi"
 
+    version("2.44.0", commit="8f1f1f944993800da2776cb3240b4482c09429ad")
     version("2.42.0", commit="73e9c7fe1252c4ca20dc7b4e58decf04bf22d5e0")
     version("2.40.1", commit="211039225ca6fca9af75b8266f656161912ce10f")
     version("2.36.0", commit="5fb0b609f9c9181ac99f902745958774e5489606")

--- a/var/spack/repos/builtin/packages/r-minfi/package.py
+++ b/var/spack/repos/builtin/packages/r-minfi/package.py
@@ -13,6 +13,7 @@ class RMinfi(RPackage):
 
     bioc = "minfi"
 
+    version("1.44.0", commit="7c89fefc2e174d43ed9891b3f30b51ee19e916a6")
     version("1.42.0", commit="30fc7059460a9ec0be734fc26e608426ca9f5614")
     version("1.40.0", commit="17fa2b5d6cdbef6cbfb690242bd3f660731431f1")
     version("1.36.0", commit="94301da343226be7cd878c2a6c1bb529564785d6")

--- a/var/spack/repos/builtin/packages/r-missmethyl/package.py
+++ b/var/spack/repos/builtin/packages/r-missmethyl/package.py
@@ -23,6 +23,7 @@ class RMissmethyl(RPackage):
 
     bioc = "missMethyl"
 
+    version("1.32.0", commit="969b892e400b9821398099bcea46f2d0431daedf")
     version("1.30.0", commit="734846653f332f10e557b87aca4cb5d100b62469")
     version("1.28.0", commit="6a36aee28837736291ac630c1da3909f0e9c8d6a")
     version("1.24.0", commit="f6c86048911dc0e302fb593b7d0623f6e77ac332")

--- a/var/spack/repos/builtin/packages/r-mlinterfaces/package.py
+++ b/var/spack/repos/builtin/packages/r-mlinterfaces/package.py
@@ -15,6 +15,7 @@ class RMlinterfaces(RPackage):
 
     bioc = "MLInterfaces"
 
+    version("1.78.0", commit="0988b95d282a6bffe56b7df4da2e23485e96d12c")
     version("1.76.0", commit="935323d8ce1e4bbf41844a1f9b6c946c5a30c673")
     version("1.74.0", commit="5ee73b6491b1d68d7b49ddce6483df98ad880946")
     version("1.70.0", commit="7b076c3e85314dd5fd5bd8a98e8123d08d9acd3b")
@@ -46,5 +47,6 @@ class RMlinterfaces(RPackage):
     depends_on("r-threejs@0.2.2:", type=("build", "run"))
     depends_on("r-mlbench", type=("build", "run"))
     depends_on("r-magrittr", type=("build", "run"), when="@1.74.0:")
+    depends_on("r-summarizedexperiment", type=("build", "run"), when="@1.78.0:")
 
     depends_on("r-rda", type=("build", "run"), when="@:1.64.1")

--- a/var/spack/repos/builtin/packages/r-mscoreutils/package.py
+++ b/var/spack/repos/builtin/packages/r-mscoreutils/package.py
@@ -19,6 +19,7 @@ class RMscoreutils(RPackage):
 
     bioc = "MsCoreUtils"
 
+    version("1.10.0", commit="742c0c7143b1c32f75cc96b555e9f8cd265096c9")
     version("1.8.0", commit="8b7e2c31009276aad0b418ba5cdfc94d03e1973e")
     version("1.6.0", commit="9ed95b2d20dacaa83567fadd04349c81db9127ef")
 

--- a/var/spack/repos/builtin/packages/r-msnbase/package.py
+++ b/var/spack/repos/builtin/packages/r-msnbase/package.py
@@ -15,6 +15,7 @@ class RMsnbase(RPackage):
 
     bioc = "MSnbase"
 
+    version("2.24.0", commit="b96e0142c663c2cb01e92479816a503c46caa1a8")
     version("2.22.0", commit="4f6e5767eee91b2105781b494fcabcfed16eba2d")
     version("2.20.4", commit="c86ac8b341832f2b577f2153258c1abf064e6448")
     version("2.16.1", commit="4d88b4edd1af59474462b1b06ad0ec5831f3a878")
@@ -40,6 +41,7 @@ class RMsnbase(RPackage):
     depends_on("r-protgenerics@1.19.3:", type=("build", "run"), when="@2.16.1:")
     depends_on("r-protgenerics@1.25.1:", type=("build", "run"), when="@2.20.4:")
     depends_on("r-protgenerics@1.27.2:", type=("build", "run"), when="@2.22.0:")
+    depends_on("r-protgenerics@1.29.1:", type=("build", "run"), when="@2.24.0:")
     depends_on("r-mscoreutils", type=("build", "run"), when="@2.20.4:")
     depends_on("r-biocparallel", type=("build", "run"))
     depends_on("r-iranges", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-multtest/package.py
+++ b/var/spack/repos/builtin/packages/r-multtest/package.py
@@ -29,6 +29,7 @@ class RMulttest(RPackage):
 
     bioc = "multtest"
 
+    version("2.54.0", commit="4e2c9e939dfd9984d8ff4bab0a95e1bd0457ec72")
     version("2.52.0", commit="00cfc9beb6d063c2b04fc83495a76824f8a33a64")
     version("2.50.0", commit="1de96649a942b115d3d554394514745e86eb3fd3")
     version("2.46.0", commit="c4dd27b333c80313a88668b59d0299988c6478a2")

--- a/var/spack/repos/builtin/packages/r-mzid/package.py
+++ b/var/spack/repos/builtin/packages/r-mzid/package.py
@@ -17,6 +17,7 @@ class RMzid(RPackage):
 
     bioc = "mzID"
 
+    version("1.36.0", commit="d6525edce3389fd4a05ff5fd42e9d611f00a545d")
     version("1.34.0", commit="bef64db159a0a4d241ba2ba271f70266c1522b2b")
     version("1.32.0", commit="d4146385b54f4d8361e23fc2c2aef79e952f4730")
     version("1.28.0", commit="cd006631c8222ce5b4af0577a7401b39cc58fd9c")

--- a/var/spack/repos/builtin/packages/r-mzr/package.py
+++ b/var/spack/repos/builtin/packages/r-mzr/package.py
@@ -19,6 +19,7 @@ class RMzr(RPackage):
 
     bioc = "mzR"
 
+    version("2.32.0", commit="ef57d59205398558898a748ba9c8de66b0bddb81")
     version("2.30.0", commit="563ae755cfc7de1ac8862247779182b7b3aebdcc")
     version("2.28.0", commit="bee7d6fb5f99e1fab5444ae1ad27b0bc6e83be9e")
     version("2.24.1", commit="e1d4de8761e6729fd45320d842691c8fe9116b7b")

--- a/var/spack/repos/builtin/packages/r-oligoclasses/package.py
+++ b/var/spack/repos/builtin/packages/r-oligoclasses/package.py
@@ -15,6 +15,7 @@ class ROligoclasses(RPackage):
 
     bioc = "oligoClasses"
 
+    version("1.60.0", commit="cf9d76c2551ad061d8b882ff1dc0a5cadc64a8a7")
     version("1.58.0", commit="5544e937913bb0df54c66d738d279c38efeb30cd")
     version("1.56.0", commit="6e6c7b4ba54095d1d3c44c081839f57af9261cbf")
     version("1.52.0", commit="7995efbd2d26b8fa950830d62db92bdaf5cbeeea")

--- a/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
+++ b/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
@@ -17,33 +17,33 @@ class ROrgHsEgDb(RPackage):
 
     version(
         "3.16.0",
-        sha256="2d2e6fdefa0dbb61c86d4736e5a0d430745ae733e310f240b97b2cb3703a2c0a",
         url="https://www.bioconductor.org/packages/3.16/data/annotation/src/contrib/org.Hs.eg.db_3.16.0.tar.gz",
+        sha256="2d2e6fdefa0dbb61c86d4736e5a0d430745ae733e310f240b97b2cb3703a2c0a",
     )
     version(
         "3.15.0",
-        sha256="1dc9bb6019e0f0a222b9ec84a1c5870cdbca480f45d9ad08e35f77278baa3c5f",
         url="https://www.bioconductor.org/packages/3.15/data/annotation/src/contrib/org.Hs.eg.db_3.15.0.tar.gz",
+        sha256="1dc9bb6019e0f0a222b9ec84a1c5870cdbca480f45d9ad08e35f77278baa3c5f",
     )
     version(
         "3.14.0",
-        sha256="0f87b3f1925a1d7007e5ad9200bdf511788bd1d7cb76f1121feeb109889c2b00",
         url="https://www.bioconductor.org/packages/3.14/data/annotation/src/contrib/org.Hs.eg.db_3.14.0.tar.gz",
+        sha256="0f87b3f1925a1d7007e5ad9200bdf511788bd1d7cb76f1121feeb109889c2b00",
     )
     version(
         "3.12.0",
-        sha256="48a1ab5347ec7a8602c555d9aba233102b61ffa2765826e5c8890ff0003249bb",
         url="https://www.bioconductor.org/packages/3.12/data/annotation/src/contrib/org.Hs.eg.db_3.12.0.tar.gz",
+        sha256="48a1ab5347ec7a8602c555d9aba233102b61ffa2765826e5c8890ff0003249bb",
     )
     version(
         "3.8.2",
-        sha256="a0a16b7428f9e3d6ba54ebf4e05cd97a7bd298510ec4cf46ed2bed3e8f80db02",
         url="https://www.bioconductor.org/packages/3.9/data/annotation/src/contrib/org.Hs.eg.db_3.8.2.tar.gz",
+        sha256="a0a16b7428f9e3d6ba54ebf4e05cd97a7bd298510ec4cf46ed2bed3e8f80db02",
     )
     version(
         "3.4.1",
-        sha256="0f87b3f1925a1d7007e5ad9200bdf511788bd1d7cb76f1121feeb109889c2b00",
         url="https://www.bioconductor.org/packages/3.5/data/annotation/src/contrib/org.Hs.eg.db_3.4.1.tar.gz",
+        sha256="0f87b3f1925a1d7007e5ad9200bdf511788bd1d7cb76f1121feeb109889c2b00",
     )
 
     depends_on("r@2.7.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
+++ b/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
@@ -13,8 +13,13 @@ class ROrgHsEgDb(RPackage):
     Gene identifiers."""
 
     bioc = "org.Hs.eg.db"
-    url = "https://www.bioconductor.org/packages/3.5/data/annotation/src/contrib/org.Hs.eg.db_3.4.1.tar.gz"
+    url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/org.Hs.eg.db_3.4.1.tar.gz"
 
+    version(
+        "3.16.0",
+        sha256="2d2e6fdefa0dbb61c86d4736e5a0d430745ae733e310f240b97b2cb3703a2c0a",
+        url="https://www.bioconductor.org/packages/3.16/data/annotation/src/contrib/org.Hs.eg.db_3.16.0.tar.gz",
+    )
     version(
         "3.15.0",
         sha256="1dc9bb6019e0f0a222b9ec84a1c5870cdbca480f45d9ad08e35f77278baa3c5f",

--- a/var/spack/repos/builtin/packages/r-organismdbi/package.py
+++ b/var/spack/repos/builtin/packages/r-organismdbi/package.py
@@ -16,6 +16,7 @@ class ROrganismdbi(RPackage):
 
     bioc = "OrganismDbi"
 
+    version("1.40.0", commit="fac971dabef3b6d2473d2061bc1723e3de59c9d7")
     version("1.38.1", commit="fa8da4dd42ab15e1d21fd9f8286440596d50b1ec")
     version("1.38.0", commit="2ca01830a6ffcd0c0018d2bdbd3de8b4df716771")
     version("1.36.0", commit="3e7a90d248ff09f05ccd381ff921e12373a4b330")

--- a/var/spack/repos/builtin/packages/r-pathview/package.py
+++ b/var/spack/repos/builtin/packages/r-pathview/package.py
@@ -20,6 +20,7 @@ class RPathview(RPackage):
 
     bioc = "pathview"
 
+    version("1.38.0", commit="8229376ffd45278b74a6e4ccfb3abea8992667f7")
     version("1.36.1", commit="f2e86b106c1cd91aac703337f968b7593a61c68d")
     version("1.36.0", commit="4f6be090a4089b5259d8e796d62f9830e2d63943")
     version("1.34.0", commit="a8788902a3bb047f8ee785966e57f84596076bbd")

--- a/var/spack/repos/builtin/packages/r-pcamethods/package.py
+++ b/var/spack/repos/builtin/packages/r-pcamethods/package.py
@@ -21,6 +21,7 @@ class RPcamethods(RPackage):
 
     bioc = "pcaMethods"
 
+    version("1.90.0", commit="52474bc6d125122e89834328a1a780988349756f")
     version("1.88.0", commit="02fb58d6fe35579b86fb2ebd2eaf92e6b53444d2")
     version("1.86.0", commit="9419cfa18c18dfbd1e1194127fd120ab456c3657")
     version("1.82.0", commit="d500b3363308f1f8ca70625c5cd10cce59b27641")

--- a/var/spack/repos/builtin/packages/r-pfam-db/package.py
+++ b/var/spack/repos/builtin/packages/r-pfam-db/package.py
@@ -16,6 +16,11 @@ class RPfamDb(RPackage):
     url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/PFAM.db_3.4.1.tar.gz"
 
     version(
+        "3.16.0",
+        sha256="8082aaa94eb962b2cf42cfaead8ff9e1bdbd12fdeae82a49d0f3b37bd50eb30c",
+        url="https://bioconductor.org/packages/3.16/data/annotation/src/contrib/PFAM.db_3.16.0.tar.gz",
+    )
+    version(
         "3.15.0",
         sha256="e7036a5f76779ab6e8a32eb659c54f52426c4824dee02903cffd85bed372720f",
         url="https://bioconductor.org/packages/3.15/data/annotation/src/contrib/PFAM.db_3.15.0.tar.gz",

--- a/var/spack/repos/builtin/packages/r-pfam-db/package.py
+++ b/var/spack/repos/builtin/packages/r-pfam-db/package.py
@@ -17,33 +17,33 @@ class RPfamDb(RPackage):
 
     version(
         "3.16.0",
-        sha256="8082aaa94eb962b2cf42cfaead8ff9e1bdbd12fdeae82a49d0f3b37bd50eb30c",
         url="https://bioconductor.org/packages/3.16/data/annotation/src/contrib/PFAM.db_3.16.0.tar.gz",
+        sha256="8082aaa94eb962b2cf42cfaead8ff9e1bdbd12fdeae82a49d0f3b37bd50eb30c",
     )
     version(
         "3.15.0",
-        sha256="e7036a5f76779ab6e8a32eb659c54f52426c4824dee02903cffd85bed372720f",
         url="https://bioconductor.org/packages/3.15/data/annotation/src/contrib/PFAM.db_3.15.0.tar.gz",
+        sha256="e7036a5f76779ab6e8a32eb659c54f52426c4824dee02903cffd85bed372720f",
     )
     version(
         "3.14.0",
-        sha256="25c1915079e8f93d04e2cc1ab791f7f47813aaab5ac394feaf57520bb292d616",
         url="https://bioconductor.org/packages/3.14/data/annotation/src/contrib/PFAM.db_3.14.0.tar.gz",
+        sha256="25c1915079e8f93d04e2cc1ab791f7f47813aaab5ac394feaf57520bb292d616",
     )
     version(
         "3.12.0",
-        sha256="ec42d067522baf2d7d3ca78d4f8cc0dac08a4b98f1d890f52424e5d5b16f2fe9",
         url="https://bioconductor.org/packages/3.12/data/annotation/src/contrib/PFAM.db_3.12.0.tar.gz",
+        sha256="ec42d067522baf2d7d3ca78d4f8cc0dac08a4b98f1d890f52424e5d5b16f2fe9",
     )
     version(
         "3.10.0",
-        sha256="038888f95ce69230ac0e0b08aa3bcb09965682415520d437a7fb0a031eefe158",
         url="https://bioconductor.org/packages/3.10/data/annotation/src/contrib/PFAM.db_3.10.0.tar.gz",
+        sha256="038888f95ce69230ac0e0b08aa3bcb09965682415520d437a7fb0a031eefe158",
     )
     version(
         "3.4.1",
-        sha256="fc45a0d53139daf85873f67bd3f1b68f2d883617f4447caddbd2d7dcc58a393f",
         url="https://bioconductor.org/packages/3.5/data/annotation/src/contrib/PFAM.db_3.4.1.tar.gz",
+        sha256="fc45a0d53139daf85873f67bd3f1b68f2d883617f4447caddbd2d7dcc58a393f",
     )
 
     depends_on("r@2.7.0:", when="@3.4.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-phyloseq/package.py
+++ b/var/spack/repos/builtin/packages/r-phyloseq/package.py
@@ -14,6 +14,7 @@ class RPhyloseq(RPackage):
 
     bioc = "phyloseq"
 
+    version("1.42.0", commit="de6be71fe9902bdfe7791163acb7b67d238424dc")
     version("1.40.0", commit="20bb27d5e6e0d4368978a15671b829990b1f4568")
     version("1.38.0", commit="1e2409a6ed3c23e308275098c2dc9fdba9d5e5f6")
     version("1.34.0", commit="cbed93ead5528fe9024d646c597dab9fc95952d3")
@@ -26,6 +27,7 @@ class RPhyloseq(RPackage):
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.22.3")
     depends_on("r-ade4@1.7.4:", type=("build", "run"))
+    depends_on("r-ade4@1.7-4:", type=("build", "run"), when="@1.42.0:")
     depends_on("r-ape@3.4:", type=("build", "run"))
     depends_on("r-ape@5.0:", type=("build", "run"), when="@1.22.3:")
     depends_on("r-biobase", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-phyloseq/package.py
+++ b/var/spack/repos/builtin/packages/r-phyloseq/package.py
@@ -27,7 +27,6 @@ class RPhyloseq(RPackage):
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.22.3")
     depends_on("r-ade4@1.7-4:", type=("build", "run"))
-    depends_on("r-ade4@1.7-4:", type=("build", "run"), when="@1.42.0:")
     depends_on("r-ape@3.4:", type=("build", "run"))
     depends_on("r-ape@5.0:", type=("build", "run"), when="@1.22.3:")
     depends_on("r-biobase", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-phyloseq/package.py
+++ b/var/spack/repos/builtin/packages/r-phyloseq/package.py
@@ -26,7 +26,7 @@ class RPhyloseq(RPackage):
 
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r@3.4.0:", type=("build", "run"), when="@1.22.3")
-    depends_on("r-ade4@1.7.4:", type=("build", "run"))
+    depends_on("r-ade4@1.7-4:", type=("build", "run"))
     depends_on("r-ade4@1.7-4:", type=("build", "run"), when="@1.42.0:")
     depends_on("r-ape@3.4:", type=("build", "run"))
     depends_on("r-ape@5.0:", type=("build", "run"), when="@1.22.3:")

--- a/var/spack/repos/builtin/packages/r-preprocesscore/package.py
+++ b/var/spack/repos/builtin/packages/r-preprocesscore/package.py
@@ -13,6 +13,7 @@ class RPreprocesscore(RPackage):
 
     bioc = "preprocessCore"
 
+    version("1.60.0", commit="7f62a7d54776a21ab6c2d3df4668382d531d1ee8")
     version("1.58.0", commit="2995e3e1a8f428a80aee200db42ee44743d893f6")
     version("1.56.0", commit="8f3272219507aa85e0c876fb434dc3b926c22c5d")
     version("1.52.1", commit="91de4ab67315dc2af68554ae3c48823f4b1ea8ac")

--- a/var/spack/repos/builtin/packages/r-protgenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-protgenerics/package.py
@@ -13,6 +13,7 @@ class RProtgenerics(RPackage):
 
     bioc = "ProtGenerics"
 
+    version("1.30.0", commit="fcd566bf04034cf52db3338b5d6de7447443cf77")
     version("1.28.0", commit="cfcd0a9ebd642515764ba70c5c4e9c2a0f2f07ac")
     version("1.26.0", commit="2033289ab928034b86c321e56c37e502e557c7a1")
     version("1.22.0", commit="2bb3011fb0d79536e1c50251084a7057004449c6")

--- a/var/spack/repos/builtin/packages/r-quantro/package.py
+++ b/var/spack/repos/builtin/packages/r-quantro/package.py
@@ -18,6 +18,7 @@ class RQuantro(RPackage):
 
     bioc = "quantro"
 
+    version("1.32.0", commit="0c70b787866d915abb720f2ab326a83eb1e775b7")
     version("1.30.0", commit="e756c439cdc5a6fb4d7879aff56a8368475513b5")
     version("1.28.0", commit="109e7452a349f273e10d2ffb79d5624260b67dd5")
     version("1.24.0", commit="c7c0180292156a01722d91b353da44324e72d68f")

--- a/var/spack/repos/builtin/packages/r-qvalue/package.py
+++ b/var/spack/repos/builtin/packages/r-qvalue/package.py
@@ -23,6 +23,7 @@ class RQvalue(RPackage):
 
     bioc = "qvalue"
 
+    version("2.30.0", commit="e8a4c22d035f860ee730aa7c5a4dbc7460afcedc")
     version("2.28.0", commit="aaa62d5ab5a960e0a626928abaf5b3a5c5f73374")
     version("2.26.0", commit="6d7410d4b8673bcf9065e054670c1fbcb917a27e")
     version("2.22.0", commit="b4bde8198252737b287fd7f9a4ed697f57fad92c")

--- a/var/spack/repos/builtin/packages/r-rbgl/package.py
+++ b/var/spack/repos/builtin/packages/r-rbgl/package.py
@@ -14,6 +14,7 @@ class RRbgl(RPackage):
 
     bioc = "RBGL"
 
+    version("1.74.0", commit="e698db897b719992a8c0747138735c0e7d9dfb21")
     version("1.72.0", commit="a86f3102f2795e1ffb530bb061247e3a42ca22f7")
     version("1.70.0", commit="9cfd5fdad4f1f438ff748317f32e822aede8921b")
     version("1.66.0", commit="bf0c111dbc231de6d3423c28e115b54fb010e1ea")

--- a/var/spack/repos/builtin/packages/r-reportingtools/package.py
+++ b/var/spack/repos/builtin/packages/r-reportingtools/package.py
@@ -23,6 +23,7 @@ class RReportingtools(RPackage):
 
     bioc = "ReportingTools"
 
+    version("2.38.0", commit="5c4971eebbaf3577ef20b74bf36c2db4e91561cc")
     version("2.36.0", commit="34122d4bde5ce43415f63f2e39e3a088c55282cc")
     version("2.34.0", commit="fb5aef0b6e1c6166d0f025d9e6ca60e54c68dbaf")
     version("2.30.0", commit="fb9aee416f38cfd308d6d7264ccbcda0467642a7")

--- a/var/spack/repos/builtin/packages/r-rgraphviz/package.py
+++ b/var/spack/repos/builtin/packages/r-rgraphviz/package.py
@@ -14,6 +14,7 @@ class RRgraphviz(RPackage):
 
     bioc = "Rgraphviz"
 
+    version("2.42.0", commit="f6877441ab256876ef6a62c2e6faf980c2190b20")
     version("2.40.0", commit="d864c9741c9177bc627cca1198673be2b1bfbc3e")
     version("2.38.0", commit="004de09a5b171211aff6cbaa1969ab8e3a5d6c61")
     version("2.34.0", commit="9746623211be794226258631992dfcccccfd7487")

--- a/var/spack/repos/builtin/packages/r-rhdf5/package.py
+++ b/var/spack/repos/builtin/packages/r-rhdf5/package.py
@@ -19,6 +19,7 @@ class RRhdf5(RPackage):
 
     bioc = "rhdf5"
 
+    version("2.42.0", commit="fa26027d57b5b6d1c297446d9bbed74d5710c5d2")
     version("2.40.0", commit="fb6c15a3199f3ffd746fb9a381d574d17fef45a2")
     version("2.38.0", commit="f6fdfa807f5cd5a4d11d4aa6ebfaa81c118b4c3f")
     version("2.34.0", commit="ec861b81fc6962e844bf56b7549ba565a7e4c69c")

--- a/var/spack/repos/builtin/packages/r-rhdf5filters/package.py
+++ b/var/spack/repos/builtin/packages/r-rhdf5filters/package.py
@@ -13,6 +13,7 @@ class RRhdf5filters(RPackage):
 
     bioc = "rhdf5filters"
 
+    version("1.10.0", commit="6131538e2c5896dca0af33882bc2da961d79e49a")
     version("1.8.0", commit="b0b588b71a5595b30f4e698a50b84310dc19745d")
     version("1.6.0", commit="5f7f3a5b7dabd6e7d0c50cda70290e2472ff4f53")
     version("1.2.0", commit="25af0180f926b4b3ea11b30ec9277d26ad3d56b3")

--- a/var/spack/repos/builtin/packages/r-rhdf5lib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhdf5lib/package.py
@@ -13,6 +13,7 @@ class RRhdf5lib(RPackage):
 
     bioc = "Rhdf5lib"
 
+    version("1.20.0", commit="760679995f17996a9de328cf7a8bcaa6c87286d4")
     version("1.18.2", commit="d104bbfdb91ac5ec7db3c453f23e4d1d6feb671f")
     version("1.16.0", commit="534c49705dbdb27ae0c564acff2c72df2b27b3f1")
     version("1.12.1", commit="cf464f40fd95274d0d351cf28b586c49307c4f0b")

--- a/var/spack/repos/builtin/packages/r-rhtslib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhtslib/package.py
@@ -49,9 +49,9 @@ class RRhtslib(RPackage):
     # available
     depends_on("patchelf", type="build", when="@1.12:1.14")
 
-    patch("use_spack_Makeconf.patch", when="@1.12:")
+    patch("use_spack_Makeconf.patch", when="@1.12:1.28.0")
     patch("find_deps-1.12.patch", when="@1.12:1.14")
-    patch("find_deps-1.16.patch", when="@1.16:")
+    patch("find_deps-1.16.patch", when="@1.16:1.28.0")
 
     @when("@1.12:")
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/r-rhtslib/package.py
+++ b/var/spack/repos/builtin/packages/r-rhtslib/package.py
@@ -27,6 +27,7 @@ class RRhtslib(RPackage):
     #             branches.
     #             Aborting
     # version("1.28.0", commit='214fde2218bdbca89f1e12a30d2e081e76915aef')
+    version("2.0.0", commit="1757333eb88625158505e5fa47840081110cf8a4")
     version("1.28.0", branch="RELEASE_3_15")
     version("1.26.0", commit="f5b20e97b283942877529f750b28398782552655")
     version("1.22.0", commit="899b79faa54d42c7c9b9a2bc49972109637d367f")

--- a/var/spack/repos/builtin/packages/r-roc/package.py
+++ b/var/spack/repos/builtin/packages/r-roc/package.py
@@ -13,6 +13,7 @@ class RRoc(RPackage):
 
     bioc = "ROC"
 
+    version("1.74.0", commit="982ad4d3606b19b8460e8a8af7cfe7c30b83f9b9")
     version("1.72.0", commit="c5d083b01314280dd43eb4cddd8a7fde8b5dce18")
     version("1.70.0", commit="44fd639958b9b1be4f8f731dc2be9dd91b2fa632")
     version("1.66.0", commit="62701ee41f48f99d15344127384fa032db69486f")

--- a/var/spack/repos/builtin/packages/r-rots/package.py
+++ b/var/spack/repos/builtin/packages/r-rots/package.py
@@ -14,6 +14,7 @@ class RRots(RPackage):
 
     bioc = "ROTS"
 
+    version("1.26.0", commit="8bb45fe78779583ae4d30cf0dc3af0d8de405fdf")
     version("1.24.0", commit="372e4623b39f585d4196d21164436c1ba013173f")
     version("1.22.0", commit="a53ec77c40ed3b3c84e91d794c1602dd509cad83")
     version("1.18.0", commit="1d4e206a8ce68d5a1417ff51c26174ed9d0ba7d2")

--- a/var/spack/repos/builtin/packages/r-rsamtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rsamtools/package.py
@@ -17,6 +17,7 @@ class RRsamtools(RPackage):
 
     bioc = "Rsamtools"
 
+    version("2.14.0", commit="8302eb7fa1c40384f1af5855222d94f2efbdcad1")
     version("2.12.0", commit="d6a65dd57c5a17e4c441a27492e92072f69b175e")
     version("2.10.0", commit="b19738e85a467f9032fc7903be3ba10e655e7061")
     version("2.6.0", commit="f2aea061517c5a55e314c039251ece9831c7fad2")
@@ -46,6 +47,7 @@ class RRsamtools(RPackage):
     depends_on("r-biocparallel", type=("build", "run"))
     depends_on("r-rhtslib@1.16.3", type=("build", "run"), when="@2.0.3")
     depends_on("r-rhtslib@1.17.7:", type=("build", "run"), when="@2.2.1:")
+    depends_on("r-rhtslib@1.99.3:", type=("build", "run"), when="@2.14.0:")
     depends_on("gmake", type="build")
 
     # this is not a listed dependency but is needed

--- a/var/spack/repos/builtin/packages/r-rtracklayer/package.py
+++ b/var/spack/repos/builtin/packages/r-rtracklayer/package.py
@@ -18,6 +18,7 @@ class RRtracklayer(RPackage):
 
     bioc = "rtracklayer"
 
+    version("1.58.0", commit="54a74972c08775fdf1e83e6e22cd0b8fad677fc1")
     version("1.56.1", commit="4c6d2201fcb102d471bd88f4f51cc34317669955")
     version("1.56.0", commit="1d70f7dc464ad87a1fde61588cd9ae0cb86b6e86")
     version("1.54.0", commit="04cdd75521a8364e67a49d7352500dd4a3e83c55")

--- a/var/spack/repos/builtin/packages/r-s4vectors/package.py
+++ b/var/spack/repos/builtin/packages/r-s4vectors/package.py
@@ -20,6 +20,7 @@ class RS4vectors(RPackage):
 
     bioc = "S4Vectors"
 
+    version("0.36.0", commit="af58701957ffdd9209031dd6a8dee3acdc58e999")
     version("0.34.0", commit="f590de3ec4d896a63351d0c1925d3856c0bd5292")
     version("0.32.3", commit="ad90e78fd3a4059cfcf2846498fb0748b4394e1a")
     version("0.28.1", commit="994cb7ef830e76f8b43169cc72b553869fafb2ed")

--- a/var/spack/repos/builtin/packages/r-scaledmatrix/package.py
+++ b/var/spack/repos/builtin/packages/r-scaledmatrix/package.py
@@ -16,6 +16,7 @@ class RScaledmatrix(RPackage):
 
     bioc = "ScaledMatrix"
 
+    version("1.6.0", commit="45a29d3662e2766f973b281ed86ce2654be84b70")
     version("1.4.1", commit="15e2efcb6b11e26c31ef2d44968355f71cc1f4fc")
     version("1.4.0", commit="32e6e918bc7bb64bbf75613d353ca268c7d04292")
     version("1.2.0", commit="d0573e14ca537b40ade7dd1c9cf0cadae60d4349")

--- a/var/spack/repos/builtin/packages/r-scater/package.py
+++ b/var/spack/repos/builtin/packages/r-scater/package.py
@@ -15,6 +15,7 @@ class RScater(RPackage):
 
     bioc = "scater"
 
+    version("1.26.0", commit="a548ddc8424e185bfb06f48bfc174071e69fc687")
     version("1.24.0", commit="013f0935a1a225139986ca5a3f0e9d08a1558153")
     version("1.22.0", commit="ea2c95c53adb8c6fab558c1cb869e2eab36aa9f8")
     version("1.18.3", commit="a94e7f413bf0f5f527b41b0b34e7a8e5c947ae37")
@@ -48,6 +49,9 @@ class RScater(RPackage):
     depends_on("r-rtsne", type=("build", "run"), when="@1.22.0:")
     depends_on("r-rcolorbrewer", type=("build", "run"), when="@1.22.0:")
     depends_on("r-rcppml", type=("build", "run"), when="@1.24.0:")
+    depends_on("r-ggrastr", type=("build", "run"), when="@1.26.0:")
+    depends_on("r-pheatmap", type=("build", "run"), when="@1.26.0:")
+    depends_on("r-uwot", type=("build", "run"), when="@1.26.0:")
     depends_on("r-ggrepel", type=("build", "run"), when="@1.22.0:")
 
     depends_on("r-biobase", type=("build", "run"), when="@1.4.0:1.8.4")

--- a/var/spack/repos/builtin/packages/r-scdblfinder/package.py
+++ b/var/spack/repos/builtin/packages/r-scdblfinder/package.py
@@ -16,6 +16,7 @@ class RScdblfinder(RPackage):
 
     bioc = "scDblFinder"
 
+    version("1.12.0", commit="65a88be3a4ca98ccad0a1829a19652df1a3c94fd")
     version("1.10.0", commit="03512cad0cdfe3cddbef66ec5e330b53661eccfc")
 
     depends_on("r@4.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-scran/package.py
+++ b/var/spack/repos/builtin/packages/r-scran/package.py
@@ -17,6 +17,7 @@ class RScran(RPackage):
 
     bioc = "scran"
 
+    version("1.26.0", commit="df66576d6958a088c38bd45e1cad9c16cbb52991")
     version("1.24.1", commit="1a83eb7c948b1dc49253080c23b26cefb3a0f3b9")
     version("1.24.0", commit="c3f9e169c4538ce827d4f14a4141571c2366cd31")
 

--- a/var/spack/repos/builtin/packages/r-scuttle/package.py
+++ b/var/spack/repos/builtin/packages/r-scuttle/package.py
@@ -16,6 +16,7 @@ class RScuttle(RPackage):
 
     bioc = "scuttle"
 
+    version("1.8.0", commit="dabf6b95e478d599557ebbed03edd44031fd6b78")
     version("1.6.3", commit="df23680da9fa4d685df77e4561467f491c850b50")
     version("1.6.2", commit="afdfc555151d84cc332757b4ec0b97cb7f39d2d5")
     version("1.4.0", commit="b335263dd56bb859b5dd3ea27ee00dffa0215313")

--- a/var/spack/repos/builtin/packages/r-seqlogo/package.py
+++ b/var/spack/repos/builtin/packages/r-seqlogo/package.py
@@ -15,6 +15,7 @@ class RSeqlogo(RPackage):
 
     bioc = "seqLogo"
 
+    version("1.64.0", commit="75ff6c0689fce541f054d33750acb6224d14ed4e")
     version("1.62.0", commit="f2d0b53b1411ea98299201a8125a85f4cbf7c9cd")
     version("1.60.0", commit="4115c8e1d01accb8c8cc1cf96f23359466827e16")
     version("1.56.0", commit="169260c43fc58dc75becb3b7842cac3d0038a8d5")

--- a/var/spack/repos/builtin/packages/r-shortread/package.py
+++ b/var/spack/repos/builtin/packages/r-shortread/package.py
@@ -18,6 +18,7 @@ class RShortread(RPackage):
 
     bioc = "ShortRead"
 
+    version("1.56.0", commit="df25d0872d52aac3610998abda0d7bfd37298726")
     version("1.54.0", commit="a1082a335120860d019aa0065a975d41890351f7")
     version("1.52.0", commit="4d7304d7b5a0ca5c904c0b919d6c95599db72a39")
     version("1.48.0", commit="ba44cd2517bc0e6f46d2cfcfce393f86eec814d0")

--- a/var/spack/repos/builtin/packages/r-siggenes/package.py
+++ b/var/spack/repos/builtin/packages/r-siggenes/package.py
@@ -16,6 +16,7 @@ class RSiggenes(RPackage):
 
     bioc = "siggenes"
 
+    version("1.72.0", commit="4f93d1a28087c941b275e6c6bae9e42d721cf422")
     version("1.70.0", commit="c263daa14cf87c61b41e3a9e88573ba339c66179")
     version("1.68.0", commit="a29bf02b19cc9003c8401608831232b7c2af26e7")
     version("1.64.0", commit="3b528d37c16fc41bbc5c98165f606394313aa050")

--- a/var/spack/repos/builtin/packages/r-singlecellexperiment/package.py
+++ b/var/spack/repos/builtin/packages/r-singlecellexperiment/package.py
@@ -16,6 +16,7 @@ class RSinglecellexperiment(RPackage):
 
     bioc = "SingleCellExperiment"
 
+    version("1.20.0", commit="467f02c0346e3ca5ec8825a6faa80a90d20fcd29")
     version("1.18.1", commit="db7768a7cb5eca724bcf7e4cea3234992ac714a1")
     version("1.18.0", commit="3a72dcd97e628055b2d02294eaecca9a41aba604")
     version("1.16.0", commit="bb27609ba08052607fc08529ffbbbcf1eab265cb")

--- a/var/spack/repos/builtin/packages/r-snprelate/package.py
+++ b/var/spack/repos/builtin/packages/r-snprelate/package.py
@@ -29,6 +29,7 @@ class RSnprelate(RPackage):
 
     bioc = "SNPRelate"
 
+    version("1.32.0", commit="2e8cc807baa74fca5137148b672f3945c36689b2")
     version("1.30.1", commit="baef8a71d3908287a2307768348c02db0720d125")
     version("1.28.0", commit="8fcd837f4627a3bb77cb8d992b2baedd0589d123")
     version("1.24.0", commit="419b13b761ea39a8b1b9bc73097fb0359c59f1c2")

--- a/var/spack/repos/builtin/packages/r-snpstats/package.py
+++ b/var/spack/repos/builtin/packages/r-snpstats/package.py
@@ -15,6 +15,7 @@ class RSnpstats(RPackage):
 
     bioc = "snpStats"
 
+    version("1.48.0", commit="7d4cec7275b9360d98cb59d15c4140bed3e6a74c")
     version("1.46.0", commit="1e70784b113eaca231bc5f91fc8ae5aadb151ddb")
     version("1.44.0", commit="72392dab4e75de2da459b1e95f1d48947811597b")
     version("1.40.0", commit="5fcac6f3b4bb6f45c19dff8f3089b693b74a56ce")

--- a/var/spack/repos/builtin/packages/r-somaticsignatures/package.py
+++ b/var/spack/repos/builtin/packages/r-somaticsignatures/package.py
@@ -16,6 +16,7 @@ class RSomaticsignatures(RPackage):
 
     bioc = "SomaticSignatures"
 
+    version("2.34.0", commit="249b1ef7cef3c94cfb96cc8aa2a16e00c2bd5d1f")
     version("2.32.0", commit="444d37661d147618f6830fd5de01a83ddf2a694d")
     version("2.30.0", commit="03f7ad707f6530fa7f62093f808884b6e83b0526")
     version("2.26.0", commit="9d4bed6e118ac76755ffb7abd058b09bac58a9d7")

--- a/var/spack/repos/builtin/packages/r-sparsematrixstats/package.py
+++ b/var/spack/repos/builtin/packages/r-sparsematrixstats/package.py
@@ -17,6 +17,7 @@ class RSparsematrixstats(RPackage):
 
     bioc = "sparseMatrixStats"
 
+    version("1.10.0", commit="75d85ba2c9c4c36887fef1a007883167aa85bd94")
     version("1.8.0", commit="4f1e2213e5b0d6b3d817c2c9129b7566288916f6")
     version("1.6.0", commit="78627a842790af42b6634893087b2bb1f4ac0392")
     version("1.2.1", commit="9726f3d5e0f03b50c332d85d5e4c339c18b0494c")

--- a/var/spack/repos/builtin/packages/r-spem/package.py
+++ b/var/spack/repos/builtin/packages/r-spem/package.py
@@ -14,6 +14,7 @@ class RSpem(RPackage):
 
     bioc = "SPEM"
 
+    version("1.38.0", commit="43ff6b0a84e7aef947d1a793583d2e9a0119c99d")
     version("1.36.0", commit="75832966ba3e2bae6b56aa138764f7a98c7ba9b1")
     version("1.34.0", commit="53fd404638a04ec8e2e826e55c3f2d91d8b28e3d")
     version("1.30.0", commit="6b2eb64bfe6287846b1408297dd46dc772431031")

--- a/var/spack/repos/builtin/packages/r-sseq/package.py
+++ b/var/spack/repos/builtin/packages/r-sseq/package.py
@@ -23,6 +23,7 @@ class RSseq(RPackage):
 
     bioc = "sSeq"
 
+    version("1.36.0", commit="0345ac579c4bdcc9c42c24831ad86fc6225c5cb9")
     version("1.34.0", commit="882bea1664f55d85550a7185cbd4a0108c35df36")
     version("1.32.0", commit="c0d3c305755d888f64d334a4ab5fa54c623054cf")
     version("1.28.0", commit="401f6805628bdf6579cc0e643b7ed54319f024be")

--- a/var/spack/repos/builtin/packages/r-summarizedexperiment/package.py
+++ b/var/spack/repos/builtin/packages/r-summarizedexperiment/package.py
@@ -16,6 +16,7 @@ class RSummarizedexperiment(RPackage):
 
     bioc = "SummarizedExperiment"
 
+    version("1.28.0", commit="ba55dac12224f0aafe8f52f1397611b5efb41626")
     version("1.26.1", commit="c8cbd3b4f0fa1d686c4d7ce5b8614a24c74b2074")
     version("1.24.0", commit="d37f19383d03c107a8a41c0df2326e28efe46b28")
     version("1.20.0", commit="874aa87a481e4076a0ec3369f55c9c0a1ab8025e")

--- a/var/spack/repos/builtin/packages/r-sva/package.py
+++ b/var/spack/repos/builtin/packages/r-sva/package.py
@@ -30,6 +30,7 @@ class RSva(RPackage):
 
     bioc = "sva"
 
+    version("3.46.0", commit="4aac49cf806f05bb98e08a6be539adebbecbfdb2")
     version("3.44.0", commit="45ab2c1d6643bcda4de2d95a81b9b28d33a1a8a1")
     version("3.42.0", commit="54c843cc46437be233ecb43b6aa868e968d71138")
     version("3.38.0", commit="5ded8ba649200ec4829051f86a59e1a2548a7ab8")

--- a/var/spack/repos/builtin/packages/r-tfbstools/package.py
+++ b/var/spack/repos/builtin/packages/r-tfbstools/package.py
@@ -18,6 +18,7 @@ class RTfbstools(RPackage):
 
     bioc = "TFBSTools"
 
+    version("1.36.0", commit="3358c89227a4d2e237ee5f8c532f468460a16ee2")
     version("1.34.0", commit="7f8d0cb58a527a5d7ba94a773279f13aedca6ec7")
     version("1.32.0", commit="235505626b910de29156a07e1f990daa3b5d57d9")
     version("1.28.0", commit="15e7cf76f39ee3280a27284d58f7adef1c33f193")

--- a/var/spack/repos/builtin/packages/r-tmixclust/package.py
+++ b/var/spack/repos/builtin/packages/r-tmixclust/package.py
@@ -18,6 +18,7 @@ class RTmixclust(RPackage):
 
     bioc = "TMixClust"
 
+    version("1.20.0", commit="df27f53d088b02cf596504b44909f2762900ab49")
     version("1.18.0", commit="71f80a7ace481f46471f36c91223effb85e17186")
     version("1.16.0", commit="e525cfd9c729a73a1964c243e5c34c37343f7bfa")
     version("1.12.0", commit="982b31bd7e22a3dc638bbda0336546220444f0c2")

--- a/var/spack/repos/builtin/packages/r-topgo/package.py
+++ b/var/spack/repos/builtin/packages/r-topgo/package.py
@@ -16,6 +16,7 @@ class RTopgo(RPackage):
 
     bioc = "topGO"
 
+    version("2.50.0", commit="befbff4e67c1b01e23f111d147274641a8b7b0f5")
     version("2.48.0", commit="a47f0079319c7d74db4aeda6399e06f12a34b585")
     version("2.46.0", commit="2bfa9dff41fff261aa6188f8368aebd6e8250b18")
     version("2.42.0", commit="3a33cf53883de45bda506953303e1809ab982adc")

--- a/var/spack/repos/builtin/packages/r-treeio/package.py
+++ b/var/spack/repos/builtin/packages/r-treeio/package.py
@@ -18,6 +18,7 @@ class RTreeio(RPackage):
 
     bioc = "treeio"
 
+    version("1.22.0", commit="eb24a854806a671e7b37ef36dafc60b4eb9ddaa1")
     version("1.20.2", commit="ed457d6fd85a50e0993c8c9acbd9b701be01a348")
     version("1.20.0", commit="5f7c3704fc8202c52451d092148fdcfe683f026a")
     version("1.18.1", commit="a06b6b3d2a64f1b22c6c8c5f97c08f5863349c83")

--- a/var/spack/repos/builtin/packages/r-tximport/package.py
+++ b/var/spack/repos/builtin/packages/r-tximport/package.py
@@ -19,6 +19,7 @@ class RTximport(RPackage):
 
     bioc = "tximport"
 
+    version("1.26.0", commit="5ae7139edf9d3445210ea014026813fd030212a8")
     version("1.24.0", commit="58524f39bdd55299cfe80a726f99b714b724be20")
     version("1.22.0", commit="335213baee3492fbf6baaa8b4e067ac0ef384684")
     version("1.18.0", commit="58b20cbc566648586b6990b30ebc70bef308cb05")

--- a/var/spack/repos/builtin/packages/r-tximportdata/package.py
+++ b/var/spack/repos/builtin/packages/r-tximportdata/package.py
@@ -18,6 +18,7 @@ class RTximportdata(RPackage):
 
     bioc = "tximportData"
 
+    version("1.26.0", commit="8f6ef3e3ae54e6eb99fe915364f5174c4f50a986")
     version("1.24.0", commit="646f366fb25be359c95dc97c9369961c8d5ed942")
     version("1.22.0", commit="c576b18e43985baf8beab327cbc54afe8324659c")
     version("1.18.0", commit="24945f8dd1e4e441ad5145fb7a37a1630912f929")

--- a/var/spack/repos/builtin/packages/r-variantannotation/package.py
+++ b/var/spack/repos/builtin/packages/r-variantannotation/package.py
@@ -14,6 +14,7 @@ class RVariantannotation(RPackage):
 
     bioc = "VariantAnnotation"
 
+    version("1.44.0", commit="2e7e0a3b7c1918c0d64170dc7c173a636d3764f4")
     version("1.42.1", commit="d1121696c76c189d6b4df9914806bf585a495845")
     version("1.40.0", commit="50ead7cb60cedf3c053853fab92d9f104f9f85bd")
     version("1.36.0", commit="9918bd19a2e6f89e5edc5fe03c8812f500bb3e19")
@@ -62,6 +63,7 @@ class RVariantannotation(RPackage):
     depends_on("r-genomicfeatures@1.27.4:", type=("build", "run"))
     depends_on("r-genomicfeatures@1.31.3:", type=("build", "run"), when="@1.26.1:")
     depends_on("r-rhtslib", type=("build", "run"), when="@1.30.1:")
+    depends_on("r-rhtslib@1.99.3:", type=("build", "run"), when="@1.44.0:")
     depends_on("gmake", type="build")
 
     # Not listed but needed

--- a/var/spack/repos/builtin/packages/r-vsn/package.py
+++ b/var/spack/repos/builtin/packages/r-vsn/package.py
@@ -24,6 +24,7 @@ class RVsn(RPackage):
 
     bioc = "vsn"
 
+    version("3.66.0", commit="ddccd6c74ebea426056794c2bfad2dfd02631092")
     version("3.64.0", commit="1f09f20ee7f81100fb0bf66288c4caf0049b5508")
     version("3.62.0", commit="6ae7f4e07ec1a5a9482cab892d98175983bfcd50")
     version("3.58.0", commit="a451e6ae989623750feacf26d99683a7955adf85")

--- a/var/spack/repos/builtin/packages/r-watermelon/package.py
+++ b/var/spack/repos/builtin/packages/r-watermelon/package.py
@@ -14,6 +14,7 @@ class RWatermelon(RPackage):
 
     bioc = "wateRmelon"
 
+    version("2.4.0", commit="31c15255511940b8b83d039c42ec89e43ceb0885")
     version("2.2.0", commit="6ec49efe98aef31d0789b31ab048eb46edec762c")
     version("2.0.0", commit="f6a331bdf50e0e5c94009fb67be873d996348ade")
     version("1.34.0", commit="3fa2745535c22068a438747b41b9d793196098d4")

--- a/var/spack/repos/builtin/packages/r-xde/package.py
+++ b/var/spack/repos/builtin/packages/r-xde/package.py
@@ -15,6 +15,7 @@ class RXde(RPackage):
 
     bioc = "XDE"
 
+    version("2.44.0", commit="a6ddedb91afe381f223e52ae49c6704f8f046916")
     version("2.42.0", commit="298e83eff7fc5f72a2bb76b559c5115c6cd3ee84")
     version("2.40.0", commit="bfc3c54787aec97b70bef7b99a6adc75d2cf5ed2")
     version("2.36.0", commit="0277f9dffbd7d1880be77cb8581fc614501b3293")

--- a/var/spack/repos/builtin/packages/r-xmapbridge/package.py
+++ b/var/spack/repos/builtin/packages/r-xmapbridge/package.py
@@ -14,6 +14,7 @@ class RXmapbridge(RPackage):
 
     bioc = "xmapbridge"
 
+    version("1.56.0", commit="fdf2cafca8ad348813d3381fee57623fab53f0ab")
     version("1.54.0", commit="a316e2399894191646c229378fa138b7461c75ab")
     version("1.52.0", commit="fe32fcd2a83432c721eb948cb3af73dd187065f6")
     version("1.48.0", commit="1cefe6b56c6dcb1f18028b3b7d6a67d490bc9730")

--- a/var/spack/repos/builtin/packages/r-xvector/package.py
+++ b/var/spack/repos/builtin/packages/r-xvector/package.py
@@ -15,6 +15,7 @@ class RXvector(RPackage):
 
     bioc = "XVector"
 
+    version("0.38.0", commit="8cad08446091dcc7cd759e880c0f3e47228278dd")
     version("0.36.0", commit="ff6f818ff4357eb9bf00654de9e0f508a5285408")
     version("0.34.0", commit="06adb25ac51c707b90fb8e0637fa06df237a863c")
     version("0.30.0", commit="985e963e0b1c3ff004dd0b07ad7c9ff7ed853ec0")

--- a/var/spack/repos/builtin/packages/r-yapsa/package.py
+++ b/var/spack/repos/builtin/packages/r-yapsa/package.py
@@ -18,6 +18,7 @@ class RYapsa(RPackage):
 
     bioc = "YAPSA"
 
+    version("1.24.0", commit="68d1c9c71af3ade4a44237ec2d3003688378f898")
     version("1.22.0", commit="55c2886874f154c737264ce6843089bf3565fa57")
     version("1.20.1", commit="6c3f437911859df6f6e4a9af5571c3a5aafbffb2")
     version("1.16.0", commit="f344cdb81bb886c633f9325f811912fb59d58eb1")

--- a/var/spack/repos/builtin/packages/r-yarn/package.py
+++ b/var/spack/repos/builtin/packages/r-yarn/package.py
@@ -18,6 +18,7 @@ class RYarn(RPackage):
 
     bioc = "yarn"
 
+    version("1.24.0", commit="d3a9c5cc1f97bff111dc9332f32ded676e3709d3")
     version("1.22.0", commit="0d94152eee4224bf1ca467fad7f2b35c2e1df6b2")
     version("1.20.0", commit="b41e4ef14f980518af2fc59f202ad8ec148e8b47")
     version("1.16.0", commit="ff5a18cb946ffec3cb773fe32af401c8a72d674a")

--- a/var/spack/repos/builtin/packages/r-zlibbioc/package.py
+++ b/var/spack/repos/builtin/packages/r-zlibbioc/package.py
@@ -16,6 +16,7 @@ class RZlibbioc(RPackage):
 
     bioc = "zlibbioc"
 
+    version("1.44.0", commit="d39f0b02fa108ab907b4042c00a114569430a333")
     version("1.42.0", commit="aa074d72515df745ad65133ca21d3cad778ccc0e")
     version("1.40.0", commit="3f116b39d104c1ea8288f6b8f0ef94bb95f41f69")
     version("1.36.0", commit="62e888cd7fb482d512c6c31961b657e0b924e357")


### PR DESCRIPTION
This PR updates the Spack BioConductor R packages to BioConductor Release 3.16.

[Bioconductor - Bioconductor 3.16 Released](https://bioconductor.org/news/bioc_3_16_release/)