### PR TITLE
GDAL: add v3.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -94,11 +94,11 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         "basisu", default=False, when="@3.6:", description="Required for BASISU and KTX2 drivers"
     )
     variant("blosc", default=False, when="@3.4:", description="Required for Zarr driver")
-    variant("brunsli", default=True, when="@3.4:", description="Required for MRF driver")
+    variant("brunsli", default=False, when="@3.4:", description="Required for MRF driver")
     variant("bsb", default=False, when="@:2", description="Required for BSB driver")
     variant("cfitsio", default=False, description="Required for FITS driver")
     variant("crnlib", default=False, description="Required for DDS driver")
-    variant("curl", default=False, description="Required for network access")
+    variant("curl", default=True, description="Required for network access")
     variant("cryptopp", default=False, when="@2.1:", description="Required for EEDAI driver")
     variant("deflate", default=False, when="@3.2:", description="Required for Deflate compression")
     variant("dods", default=False, when="@:3.4", description="Required for DODS driver")
@@ -128,7 +128,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     variant("jxl", default=False, when="@3.4:", description="Required for JPEGXL driver")
     variant("kdu", default=False, description="Required for JP2KAK and JPIPKAK drivers")
     variant("kea", default=False, description="Required for KEA driver")
-    variant("lerc", default=True, when="@2.4:", description="Required for LERC compression")
+    variant("lerc", default=False, when="@2.4:", description="Required for LERC compression")
     variant("libcsf", default=False, description="Required for PCRaster driver")
     variant("libkml", default=False, description="Required for LIBKML driver")
     variant("liblzma", default=False, description="Required for Zarr driver")
@@ -193,10 +193,10 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         default=False,
         description="Required for PostgreSQL and PostGISRaster drivers",
     )
-    variant("qb3", default=True, when="@3.6:", description="Required for MRF driver")
+    variant("qb3", default=False, when="@3.6:", description="Required for MRF driver")
     variant(
         "qhull",
-        default=True,
+        default=False,
         when="@2.1:",
         description="Used for linear interpolation of gdal_grid",
     )

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -30,6 +30,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
     maintainers = ["adamjstewart"]
 
+    version("3.6.0", sha256="f7afa4aa8d32d0799e011a9f573c6a67e9471f78e70d3d0d0b45b45c8c0c1a94")
     version("3.5.3", sha256="d32223ddf145aafbbaec5ccfa5dbc164147fb3348a3413057f9b1600bb5b3890")
     version("3.5.2", sha256="0874dfdeb9ac42e53c37be4184b19350be76f0530e1f4fa8004361635b9030c2")
     version("3.5.1", sha256="d12c30a9eacdeaab493c0d1c9f88eb337c9cbb5bb40744c751bdd5a5af166ab6")
@@ -88,6 +89,9 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     )
     variant(
         "arrow", default=False, when="build_system=cmake", description="Required for Arrow driver"
+    )
+    variant(
+        "basisu", default=False, when="@3.6:", description="Required for BASISU and KTX2 drivers"
     )
     variant("blosc", default=False, when="@3.4:", description="Required for Zarr driver")
     variant("brunsli", default=True, when="@3.4:", description="Required for MRF driver")
@@ -189,6 +193,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         default=False,
         description="Required for PostgreSQL and PostGISRaster drivers",
     )
+    variant("qb3", default=True, when="@3.6:", description="Required for MRF driver")
     variant(
         "qhull",
         default=True,
@@ -255,6 +260,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     depends_on("blas", when="+armadillo")
     depends_on("lapack", when="+armadillo")
     depends_on("arrow", when="+arrow")
+    # depends_on("basis-universal", when="+basisu")
     depends_on("c-blosc", when="+blosc")
     depends_on("brunsli", when="+brunsli")
     # depends_on('bsb', when='+bsb')
@@ -328,6 +334,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     depends_on("poppler@:0.71", when="@:2.4 +poppler")
     depends_on("poppler@:21", when="@:3.4.1 +poppler")
     depends_on("postgresql", when="+postgresql")
+    depends_on("qb3", when="+qb3")
     depends_on("qhull", when="+qhull")
     depends_on("qhull@2015:", when="@3.5:+qhull")
     depends_on("qhull@:2020.1", when="@:3.3+qhull")
@@ -525,6 +532,7 @@ class CMakeBuilder(CMakeBuilder):
             self.define_from_variant("GDAL_USE_PODOFO", "podofo"),
             self.define_from_variant("GDAL_USE_POPPLER", "poppler"),
             self.define_from_variant("GDAL_USE_POSTGRESQL", "postgresql"),
+            self.define_from_variant("GDAL_USE_LIBQB3", "qb3"),
             self.define_from_variant("GDAL_USE_QHULL", "qhull"),
             self.define_from_variant("GDAL_USE_RASDAMAN", "rasdaman"),
             self.define_from_variant("GDAL_USE_RASTERLITE2", "rasterlite2"),

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -478,6 +478,7 @@ class CMakeBuilder(CMakeBuilder):
             # Optional dependencies
             self.define_from_variant("GDAL_USE_ARMADILLO", "armadillo"),
             self.define_from_variant("GDAL_USE_ARROW", "arrow"),
+            self.define_from_variant("GDAL_USE_BASISU", "basisu"),
             self.define_from_variant("GDAL_USE_BLOSC", "blosc"),
             self.define_from_variant("GDAL_USE_BRUNSLI", "brunsli"),
             self.define_from_variant("GDAL_USE_CFITSIO", "cfitsio"),

--- a/var/spack/repos/builtin/packages/libicd/package.py
+++ b/var/spack/repos/builtin/packages/libicd/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Libicd(CMakePackage):
+    """Image codec library."""
+
+    homepage = "https://github.com/lucianpls/libicd"
+    git = "https://github.com/lucianpls/libicd.git"
+
+    version("main", branch="main")
+
+    depends_on("cmake@3.5:", type="build")
+    depends_on("jpeg")
+    depends_on("libpng")
+    depends_on("lerc")
+
+    # https://github.com/lucianpls/libicd/issues/3
+    conflicts("platform=darwin")

--- a/var/spack/repos/builtin/packages/qb3/package.py
+++ b/var/spack/repos/builtin/packages/qb3/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Qb3(CMakePackage):
+    """QB3: Fast and Efficient Raster Compression."""
+
+    homepage = "https://github.com/lucianpls/QB3"
+    git = "https://github.com/lucianpls/QB3.git"
+
+    version("master", branch="master")
+
+    depends_on("cmake@3.5:", type="build")
+    depends_on("libicd")


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 (arm64) with Apple Clang 14.0.0.

https://github.com/OSGeo/gdal/releases/tag/v3.6.0

@rouault I noticed that the recommended dependencies listed [here](https://gdal.org/build_hints.html#build-requirements) don't match the dependencies listed as recommended by CMake. For example, CMake lists brand new dependencies like Brunsli and QB3 as recommended even though they are only needed for a single driver, while things like cURL are listed as optional instead of recommended. Which should I trust when choosing defaults here?