### PR TITLE
bump release version for tutorial command

### DIFF
--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -11,6 +11,7 @@ import shutil
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
+import spack
 import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.paths
@@ -24,7 +25,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v%s" % ".".join(spack.spack_version_info[:2])
+tutorial_branch = "releases/v%s" % ".".join(str(v) for v in spack.spack_version_info[:2])
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -24,7 +24,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v0.18"
+tutorial_branch = "releases/v0.19"
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -24,7 +24,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v0.19"
+tutorial_branch = "releases/v%s" % ".".join(spack.spack_version_info[:2])
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 


### PR DESCRIPTION
Use v0.19

We should probably add updating this to the release instructions, since we generally won't run a tutorial on an old version