### PR TITLE
Add new custom markers to unit tests

### DIFF
--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -199,14 +199,10 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     ],
 )
 @pytest.mark.usefixtures("mock_packages", "config")
+@pytest.mark.only_clingo("Fixing the parser broke this test for the original concretizer.")
 def test_concretize_target_ranges(root_target_range, dep_target_range, result, monkeypatch):
     # Monkeypatch so that all concretization is done as if the machine is core2
     monkeypatch.setattr(spack.platforms.test.Test, "default", "core2")
-
-    # use foobar=bar to make the problem simpler for the old concretizer
-    # the new concretizer should not need that help
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Fixing the parser broke this test for the original concretizer.")
 
     spec_str = "a %%gcc@10 foobar=bar target=%s ^b target=%s" % (
         root_target_range,

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -37,7 +37,7 @@ from spack.directory_layout import DirectoryLayout
 from spack.paths import test_path
 from spack.spec import Spec
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 mirror_cmd = spack.main.SpackCommand("mirror")
 install_cmd = spack.main.SpackCommand("install")

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -5,7 +5,6 @@
 
 import os
 import os.path
-import sys
 
 import pytest
 
@@ -16,7 +15,7 @@ import spack.util.url
 
 install = spack.main.SpackCommand("install")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmpdir):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -6,7 +6,6 @@ import inspect
 import os
 import platform
 import posixpath
-import sys
 
 import pytest
 
@@ -119,7 +118,7 @@ def mock_module_cmd(monkeypatch):
     return mock_module_cmd
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Static to Shared not supported on Win (yet)")
+@pytest.mark.not_on_windows("Static to Shared not supported on Win (yet)")
 def test_static_to_shared_library(build_environment):
     os.environ["SPACK_TEST_COMMAND"] = "dump-args"
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -5,7 +5,6 @@
 
 import glob
 import os
-import sys
 
 import py.path
 import pytest
@@ -43,7 +42,7 @@ def test_dir(tmpdir):
     return _func
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="make not available on Windows")
+@pytest.mark.not_on_windows("make not available on Windows")
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
 class TestTargets:
     @pytest.mark.parametrize(
@@ -92,7 +91,7 @@ class TestTargets:
             s.package._if_ninja_target_execute("check")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="autotools not available on windows")
+@pytest.mark.not_on_windows("autotools not available on windows")
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestAutotoolsPackage:
     def test_with_or_without(self, default_mock_concretization):

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
-import sys
 
 import pytest
 
@@ -106,10 +105,7 @@ def test_old_style_compatibility_with_super(spec_str, method_name, expected):
     assert value == expected
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="log_ouput cannot currently be used outside of subprocess on Windows",
-)
+@pytest.mark.not_on_windows("log_ouput cannot currently be used outside of subprocess on Windows")
 @pytest.mark.regression("33928")
 @pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
 @pytest.mark.disable_clean_stage_check
@@ -153,7 +149,7 @@ def test_monkey_patching_test_log_file():
 
 # Windows context manager's __exit__ fails with ValueError ("I/O operation
 # on closed file").
-@pytest.mark.skipif(sys.platform == "win32", reason="Does not run on windows")
+@pytest.mark.not_on_windows("Does not run on windows")
 def test_install_time_test_callback(tmpdir, config, mock_packages, mock_stage):
     """Confirm able to run stand-alone test as a post-install callback."""
     s = spack.spec.Spec("py-test-callback").concretized()

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -8,7 +8,6 @@ This test checks that the Spack cc compiler wrapper is parsing
 arguments correctly.
 """
 import os
-import sys
 
 import pytest
 
@@ -145,7 +144,7 @@ common_compile_args = (
     + test_args_without_paths
 )
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -5,7 +5,6 @@
 import itertools
 import os
 import subprocess
-import sys
 
 import pytest
 
@@ -35,7 +34,7 @@ def test_urlencode_string():
     assert ci._url_encode_string("Spack Test Project") == "Spack+Test+Project"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, "package-signing-key")
@@ -427,18 +426,14 @@ def test_affected_specs_on_first_concretization(mutable_mock_env_path, mock_pack
     assert len(mpileaks_specs) == 2, e.all_specs()
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
-)
+@pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_process_command(repro_dir):
     result = ci.process_command("help", commands=[], repro_dir=str(repro_dir))
     help_sh = repro_dir / "help.sh"
     assert help_sh.exists() and not result
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
-)
+@pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_process_command_fail(repro_dir, monkeypatch):
     msg = "subprocess wait exception"
 
@@ -489,9 +484,7 @@ def test_ci_run_standalone_tests_missing_requirements(
     assert "Reproduction directory is required" in err
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
-)
+@pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_run_standalone_tests_not_installed_junit(
     tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):
@@ -509,9 +502,7 @@ def test_ci_run_standalone_tests_not_installed_junit(
     assert os.path.getsize(log_file) > 0
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
-)
+@pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_run_standalone_tests_not_installed_cdash(
     tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 from llnl.util.filesystem import working_dir
@@ -35,7 +33,7 @@ def test_blame_by_percent(mock_packages):
     assert "EMAIL" in out
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_blame_file(mock_packages):
     """Sanity check the blame command to make sure it works."""
     with working_dir(spack.paths.prefix):
@@ -68,7 +66,7 @@ def test_blame_json(mock_packages):
         assert key in loaded["authors"][0]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="git hangs")
+@pytest.mark.not_on_windows("git hangs")
 def test_blame_by_git(mock_packages, capfd):
     """Sanity check the blame command to make sure it works."""
     with capfd.disabled():

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -174,7 +174,7 @@ def test_remove_and_add_a_source(mutable_config):
 
 
 @pytest.mark.maybeslow
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmpdir):
     """Test that `spack bootstrap mirror` creates a folder that can be ingested by
     `spack bootstrap add`. Here we don't download data, since that would be an

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -6,7 +6,6 @@
 import errno
 import os
 import shutil
-import sys
 
 import pytest
 
@@ -26,7 +25,7 @@ gpg = spack.main.SpackCommand("gpg")
 mirror = spack.main.SpackCommand("mirror")
 uninstall = spack.main.SpackCommand("uninstall")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import sys
 
 import pytest
 
@@ -36,7 +35,7 @@ def test_checksum_args(arguments, expected):
     assert check == expected
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "arguments,expected",
     [
@@ -57,7 +56,7 @@ def test_checksum(arguments, expected, mock_packages, mock_clone_repo, mock_stag
         assert "version(" in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_checksum_interactive(mock_packages, mock_fetch, mock_stage, monkeypatch):
     # TODO: mock_fetch doesn't actually work with stage, working around with ignoring
     # fail_on_error for now

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -7,7 +7,6 @@ import filecmp
 import json
 import os
 import shutil
-import sys
 
 import jsonschema
 import pytest
@@ -41,10 +40,7 @@ install_cmd = spack.main.SpackCommand("install")
 uninstall_cmd = spack.main.SpackCommand("uninstall")
 buildcache_cmd = spack.main.SpackCommand("buildcache")
 
-pytestmark = [
-    pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),
-    pytest.mark.maybeslow,
-]
+pytestmark = [pytest.mark.not_on_windows("does not run on windows"), pytest.mark.maybeslow]
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -7,7 +7,6 @@ import filecmp
 import os
 import shutil
 import subprocess
-import sys
 
 import pytest
 
@@ -254,9 +253,7 @@ def test_update_completion_arg(shell, tmpdir, monkeypatch):
 
 
 # Note: this test is never expected to be supported on Windows
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="shell completion script generator fails on windows"
-)
+@pytest.mark.not_on_windows("Shell completion script generator fails on windows")
 @pytest.mark.parametrize("shell", ["bash", "fish"])
 def test_updated_completion_scripts(shell, tmpdir):
     """Make sure our shell tab completion scripts remain up-to-date."""

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -64,7 +64,7 @@ fi
     return clang_path.parent
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute bash script on Windows")
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("11678,13138")
 def test_compiler_find_without_paths(no_compilers_yaml, working_env, mock_executable):
     """Tests that 'spack compiler find' looks into PATH by default, if no specific path
@@ -127,7 +127,7 @@ def test_removing_compilers_from_multiple_scopes(mutable_config, mock_packages):
     assert spack.spec.CompilerSpec("gcc@=4.5.0") not in spack.compilers.all_compiler_specs()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute bash script on Windows")
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 def test_compiler_add(mutable_config, mock_packages, mock_executable):
     """Tests that we can add a compiler to configuration."""
     expected_version = "4.5.3"
@@ -157,7 +157,7 @@ done
     assert new_compiler.version == spack.version.Version(expected_version)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute bash script on Windows")
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("17590")
 def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, compilers_dir):
     """Ensure that we'll mix compilers with different suffixes when necessary."""
@@ -189,7 +189,7 @@ def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, compilers_
     }
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute bash script on Windows")
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 @pytest.mark.regression("17590")
 def test_compiler_find_prefer_no_suffix(no_compilers_yaml, working_env, compilers_dir):
     """Ensure that we'll pick 'clang' over 'clang-gpu' when there is a choice."""
@@ -210,7 +210,7 @@ def test_compiler_find_prefer_no_suffix(no_compilers_yaml, working_env, compiler
     assert clang["paths"]["cxx"] == str(compilers_dir / "clang++")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute bash script on Windows")
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
 def test_compiler_find_path_order(no_compilers_yaml, working_env, compilers_dir):
     """Ensure that we look for compilers in the same order as PATH, when there are duplicates"""
     new_dir = compilers_dir / "first_in_path"

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -6,7 +6,6 @@
 import os
 import os.path
 import platform
-import sys
 
 import pytest
 
@@ -17,7 +16,7 @@ from spack.util.executable import which
 
 debug = SpackCommand("debug")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 import spack.store
@@ -16,7 +14,7 @@ uninstall = SpackCommand("uninstall")
 deprecate = SpackCommand("deprecate")
 find = SpackCommand("find")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -18,7 +17,7 @@ dev_build = SpackCommand("dev-build")
 install = SpackCommand("install")
 env = SpackCommand("env")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_dev_build_basics(tmpdir, mock_packages, install_mockery):

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import shutil
-import sys
 
 import pytest
 
@@ -17,7 +16,7 @@ from spack.main import SpackCommand
 develop = SpackCommand("develop")
 env = SpackCommand("env")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.usefixtures("mutable_mock_env_path", "mock_packages", "mock_fetch", "config")

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 import spack.cmd.diff
@@ -45,7 +43,7 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     assert ["hash", "mpileaks %s" % specB.dag_hash()] in c["b_not_a"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
     install_cmd("mpileaks")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -8,7 +8,6 @@ import io
 import os
 import pathlib
 import shutil
-import sys
 from argparse import Namespace
 
 import pytest
@@ -41,7 +40,7 @@ from spack.version import Version
 pytestmark = [
     pytest.mark.usefixtures("mutable_mock_env_path", "config", "mutable_mock_repo"),
     pytest.mark.maybeslow,
-    pytest.mark.skipif(sys.platform == "win32", reason="Envs unsupported on Window"),
+    pytest.mark.not_on_windows("Envs unsupported on Window"),
 ]
 
 env = SpackCommand("env")

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -23,7 +22,7 @@ def python_database(mock_packages, mutable_database):
     yield
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="All Fetchers Failed")
+@pytest.mark.not_on_windows("All Fetchers Failed")
 @pytest.mark.db
 def test_extensions(mock_packages, python_database, config, capsys):
     ext2 = Spec("py-extension2").concretized()

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -212,7 +212,7 @@ def test_find_external_empty_default_manifest_dir(
     external("find")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Can't chmod on Windows")
+@pytest.mark.not_on_windows("Can't chmod on Windows")
 @pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_find_external_manifest_with_bad_permissions(
     mutable_config,
@@ -399,7 +399,7 @@ def test_use_tags_for_detection(command_args, mock_executable, mutable_config, m
 
 
 @pytest.mark.regression("38733")
-@pytest.mark.skipif(sys.platform == "win32", reason="the test uses bash scripts")
+@pytest.mark.not_on_windows("the test uses bash scripts")
 def test_failures_in_scanning_do_not_result_in_an_error(
     mock_executable, monkeypatch, mutable_config
 ):

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -332,7 +332,7 @@ def test_find_command_basic_usage(database):
     assert "mpileaks" in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="envirnment is not yet supported on windows")
+@pytest.mark.not_on_windows("envirnment is not yet supported on windows")
 @pytest.mark.regression("9875")
 def test_find_prefix_in_env(
     mutable_mock_env_path, install_mockery, mock_fetch, mock_packages, mock_archive, config

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -13,7 +12,7 @@ import spack.spec
 
 gc = spack.main.SpackCommand("gc")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -22,7 +21,7 @@ gpg = SpackCommand("gpg")
 bootstrap = SpackCommand("bootstrap")
 mirror = SpackCommand("mirror")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 # test gpg command detection

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -9,7 +9,6 @@ import itertools
 import os
 import pathlib
 import re
-import sys
 import time
 
 import pytest
@@ -547,9 +546,7 @@ def test_cdash_report_concretization_error(
             assert any(x in content for x in expected_messages)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Windows log_output logs phase header out of order"
-)
+@pytest.mark.not_on_windows("Windows log_output logs phase header out of order")
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_build_error(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capturing
@@ -749,10 +746,7 @@ def test_install_deps_then_package(tmpdir, mock_fetch, install_mockery):
     assert os.path.exists(root.prefix)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Environment views not supported on windows. Revisit after #34701",
-)
+@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 @pytest.mark.regression("12002")
 def test_install_only_dependencies_in_env(
     tmpdir, mock_fetch, install_mockery, mutable_mock_env_path
@@ -919,9 +913,7 @@ def test_cdash_auth_token(tmpdir, mock_fetch, install_mockery, capfd):
             assert "Using CDash auth token from environment" in out
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Windows log_output logs phase header out of order"
-)
+@pytest.mark.not_on_windows("Windows log_output logs phase header out of order")
 @pytest.mark.disable_clean_stage_check
 def test_cdash_configure_warning(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capturing of e.g., Build.xml output
@@ -947,9 +939,7 @@ def test_cdash_configure_warning(tmpdir, mock_fetch, install_mockery, capfd):
             assert "foo: No such file or directory" in content
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="ArchSpec gives test platform debian rather than windows"
-)
+@pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
 def test_compiler_bootstrap(
     install_mockery_mutable_config,
     mock_packages,
@@ -966,7 +956,7 @@ def test_compiler_bootstrap(
     install("a%gcc@=12.0")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Binary mirrors not supported on windows")
+@pytest.mark.not_on_windows("Binary mirrors not supported on windows")
 def test_compiler_bootstrap_from_binary_mirror(
     install_mockery_mutable_config,
     mock_packages,
@@ -1007,9 +997,7 @@ def test_compiler_bootstrap_from_binary_mirror(
     install("--no-cache", "--only", "package", "b%gcc@10.2.0")
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="ArchSpec gives test platform debian rather than windows"
-)
+@pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
 @pytest.mark.regression("16221")
 def test_compiler_bootstrap_already_installed(
     install_mockery_mutable_config,
@@ -1053,10 +1041,7 @@ def test_install_fails_no_args_suggests_env_activation(tmpdir):
     assert "using the `spack.yaml` in this directory" in output
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Environment views not supported on windows. Revisit after #34701",
-)
+@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_env_with_tests_all(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):
@@ -1068,10 +1053,7 @@ def test_install_env_with_tests_all(
         assert os.path.exists(test_dep.prefix)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Environment views not supported on windows. Revisit after #34701",
-)
+@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_env_with_tests_root(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):
@@ -1083,10 +1065,7 @@ def test_install_env_with_tests_root(
         assert not os.path.exists(test_dep.prefix)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Environment views not supported on windows. Revisit after #34701",
-)
+@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_empty_env(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):
@@ -1100,10 +1079,7 @@ def test_install_empty_env(
     assert "no specs to install" in out
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows logger I/O operation on closed file when install fails",
-)
+@pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize(
     "name,method",
@@ -1127,7 +1103,7 @@ def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
     assert "See test log for details" in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Buildcache not supported on windows")
+@pytest.mark.not_on_windows("Buildcache not supported on windows")
 def test_install_use_buildcache(
     capsys,
     mock_packages,
@@ -1205,10 +1181,7 @@ def test_install_use_buildcache(
             install_use_buildcache(opt)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows logger I/O operation on closed file when install fails",
-)
+@pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
 @pytest.mark.regression("34006")
 @pytest.mark.disable_clean_stage_check
 def test_padded_install_runtests_root(install_mockery_mutable_config, mock_fetch):

--- a/lib/spack/spack/test/cmd/license.py
+++ b/lib/spack/spack/test/cmd/license.py
@@ -5,7 +5,6 @@
 
 import os.path
 import re
-import sys
 
 import pytest
 
@@ -17,7 +16,7 @@ from spack.main import SpackCommand
 
 license = SpackCommand("license")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_list_files():

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import re
-import sys
 
 import pytest
 
@@ -17,7 +16,7 @@ unload = SpackCommand("unload")
 install = SpackCommand("install")
 location = SpackCommand("location")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_manpath_trailing_colon(

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-import sys
 
 import pytest
 
@@ -19,7 +18,7 @@ from spack.main import SpackCommand, SpackCommandError
 # Everything here uses (or can use) the mock config and database.
 pytestmark = [
     pytest.mark.usefixtures("config", "database"),
-    pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),
+    pytest.mark.not_on_windows("does not run on windows"),
 ]
 # location prints out "locations of packages and spack directories"
 location = SpackCommand("location")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -23,7 +22,7 @@ install = SpackCommand("install")
 buildcache = SpackCommand("buildcache")
 uninstall = SpackCommand("uninstall")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -5,7 +5,6 @@
 
 import os.path
 import re
-import sys
 
 import pytest
 
@@ -16,7 +15,7 @@ import spack.store
 
 module = spack.main.SpackCommand("module")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 #: make sure module files are generated for all the tests here

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -5,7 +5,6 @@
 
 import re
 import shutil
-import sys
 
 import pytest
 
@@ -133,7 +132,7 @@ def test_pkg_add(git, mock_pkg_git_repo):
         pkg("add", "does-not-exist")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="stdout format conflict")
+@pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_list(mock_pkg_git_repo, mock_pkg_names):
     out = split(pkg("list", "HEAD^^"))
     assert sorted(mock_pkg_names) == sorted(out)
@@ -149,7 +148,7 @@ def test_pkg_list(mock_pkg_git_repo, mock_pkg_names):
     assert sorted(mock_pkg_names) == sorted(out)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="stdout format conflict")
+@pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_diff(mock_pkg_git_repo, mock_pkg_names):
     out = split(pkg("diff", "HEAD^^", "HEAD^"))
     assert out == ["HEAD^:", "pkg-a", "pkg-b", "pkg-c"]
@@ -161,7 +160,7 @@ def test_pkg_diff(mock_pkg_git_repo, mock_pkg_names):
     assert out == ["HEAD^:", "pkg-c", "HEAD:", "pkg-d"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="stdout format conflict")
+@pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_added(mock_pkg_git_repo):
     out = split(pkg("added", "HEAD^^", "HEAD^"))
     assert ["pkg-a", "pkg-b", "pkg-c"] == out
@@ -176,7 +175,7 @@ def test_pkg_added(mock_pkg_git_repo):
     assert out == []
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="stdout format conflict")
+@pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_removed(mock_pkg_git_repo):
     out = split(pkg("removed", "HEAD^^", "HEAD^"))
     assert out == []
@@ -188,7 +187,7 @@ def test_pkg_removed(mock_pkg_git_repo):
     assert out == ["pkg-c"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="stdout format conflict")
+@pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_changed(mock_pkg_git_repo):
     out = split(pkg("changed", "HEAD^^", "HEAD^"))
     assert out == []

--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -4,17 +4,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import sys
-
 import pytest
 
 from spack.main import SpackCommand
 
 providers = SpackCommand("providers")
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="Providers not currently supported on Windows"
-)
+pytestmark = pytest.mark.not_on_windows("Providers not currently supported on Windows")
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import sys
 
 import pytest
 
@@ -14,7 +13,7 @@ install = SpackCommand("install")
 deprecate = SpackCommand("deprecate")
 reindex = SpackCommand("reindex")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_reindex_basic(mock_packages, mock_archive, mock_fetch, install_mockery):

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -32,6 +32,7 @@ def test_spec():
     assert "mpich@3.0.4" in output
 
 
+@pytest.mark.only_clingo("Known failure of the original concretizer")
 def test_spec_concretizer_args(mutable_config, mutable_database):
     """End-to-end test of CLI concretizer prefs.
 
@@ -39,9 +40,6 @@ def test_spec_concretizer_args(mutable_config, mutable_database):
     options to `solver.py`, and that config options are not
     lost along the way.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.xfail("Known failure of the original concretizer")
-
     # remove two non-preferred mpileaks installations
     # so that reuse will pick up the zmpi one
     uninstall = SpackCommand("uninstall")

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -23,7 +22,7 @@ env = SpackCommand("env")
 pytestmark = pytest.mark.usefixtures("install_mockery", "mock_packages")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="not implemented on windows")
+@pytest.mark.not_on_windows("not implemented on windows")
 @pytest.mark.disable_clean_stage_check
 def test_stage_spec(monkeypatch):
     """Verify that staging specs works."""
@@ -52,7 +51,7 @@ def check_stage_path(monkeypatch, tmpdir):
     return expected_path
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="PermissionError")
+@pytest.mark.not_on_windows("PermissionError")
 def test_stage_path(check_stage_path):
     """Verify that --path only works with single specs."""
     stage("--path={0}".format(check_stage_path), "trivial-install-test-package")
@@ -64,7 +63,7 @@ def test_stage_path_errors_multiple_specs(check_stage_path):
         stage(f"--path={check_stage_path}", "trivial-install-test-package", "mpileaks")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="not implemented on windows")
+@pytest.mark.not_on_windows("not implemented on windows")
 @pytest.mark.disable_clean_stage_check
 def test_stage_with_env_outside_env(mutable_mock_env_path, monkeypatch):
     """Verify that stage concretizes specs not in environment instead of erroring."""
@@ -83,7 +82,7 @@ def test_stage_with_env_outside_env(mutable_mock_env_path, monkeypatch):
         stage("trivial-install-test-package")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="not implemented on windows")
+@pytest.mark.not_on_windows("not implemented on windows")
 @pytest.mark.disable_clean_stage_check
 def test_stage_with_env_inside_env(mutable_mock_env_path, monkeypatch):
     """Verify that stage filters specs in environment instead of reconcretizing."""
@@ -102,7 +101,7 @@ def test_stage_with_env_inside_env(mutable_mock_env_path, monkeypatch):
         stage("mpileaks")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="not implemented on windows")
+@pytest.mark.not_on_windows("not implemented on windows")
 @pytest.mark.disable_clean_stage_check
 def test_stage_full_env(mutable_mock_env_path, monkeypatch):
     """Verify that stage filters specs in environment."""

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -5,7 +5,6 @@
 
 import argparse
 import os
-import sys
 
 import pytest
 
@@ -22,7 +21,7 @@ from spack.main import SpackCommand
 install = SpackCommand("install")
 spack_test = SpackCommand("test")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_test_package_not_installed(

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -15,7 +14,7 @@ undevelop = SpackCommand("undevelop")
 env = SpackCommand("env")
 concretize = SpackCommand("concretize")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_undevelop(tmpdir, config, mock_packages, mutable_mock_env_path):

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -206,7 +205,7 @@ def test_in_memory_consistency_when_uninstalling(mutable_database, monkeypatch):
 
 # Note: I want to use https://docs.pytest.org/en/7.1.x/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 # the style formatter insists on separating these two lines.
-@pytest.mark.skipif(sys.platform == "win32", reason="Envs unsupported on Windows")
+@pytest.mark.not_on_windows("Envs unsupported on Windows")
 class TestUninstallFromEnv:
     """Tests an installation with two environments e1 and e2, which each have
     shared package installations:

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os.path
-import sys
 
 import pytest
 
@@ -16,7 +15,7 @@ extensions = SpackCommand("extensions")
 install = SpackCommand("install")
 view = SpackCommand("view")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def create_projection_file(tmpdir, projection):

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test basic behavior of compilers in Spack"""
 import os
-import sys
 from copy import copy
 
 import pytest
@@ -192,7 +191,7 @@ def call_compiler(exe, *args, **kwargs):
     return no_flag_output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "exe,flagname",
     [
@@ -248,7 +247,7 @@ def test_get_compiler_link_paths_no_verbose_flag():
     assert dirs == []
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.enable_compiler_link_paths
 def test_get_compiler_link_paths_load_env(working_env, monkeypatch, tmpdir):
     gcc = str(tmpdir.join("gcc"))
@@ -693,7 +692,7 @@ def test_raising_if_compiler_target_is_over_specific(config):
             spack.compilers.get_compilers(cfg, spack.spec.CompilerSpec("gcc@9.0.1"), arch_spec)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_compiler_get_real_version(working_env, monkeypatch, tmpdir):
     # Test variables
     test_version = "2.2.2"
@@ -796,9 +795,7 @@ fi
         assert "SPACK_TEST_CMP_ON" not in os.environ
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Bash scripting unsupported on Windows (for now)"
-)
+@pytest.mark.not_on_windows("Bash scripting unsupported on Windows (for now)")
 def test_compiler_flags_use_real_version(working_env, monkeypatch, tmpdir):
     # Create compiler
     gcc = str(tmpdir.join("gcc"))

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test detection of compiler version"""
 import os
-import sys
 
 import pytest
 
@@ -414,7 +413,7 @@ def test_xl_version_detection(version_str, expected_version):
     assert version == expected_version
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "compiler,version",
     [

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -353,9 +353,8 @@ class TestConcretize:
 
         assert spec.satisfies("^openblas cflags='-g'")
 
-    @pytest.mark.skipif(
-        os.environ.get("SPACK_TEST_SOLVER") == "original",
-        reason="Optional compiler propagation isn't deprecated for original concretizer",
+    @pytest.mark.only_clingo(
+        "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_compiler_flag_does_not_propagate(self):
         spec = Spec("hypre cflags='-g' ^openblas")
@@ -363,9 +362,8 @@ class TestConcretize:
 
         assert not spec.satisfies("^openblas cflags='-g'")
 
-    @pytest.mark.skipif(
-        os.environ.get("SPACK_TEST_SOLVER") == "original",
-        reason="Optional compiler propagation isn't deprecated for original concretizer",
+    @pytest.mark.only_clingo(
+        "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_propagate_compiler_flag_not_passed_to_dependent(self):
         spec = Spec("hypre cflags=='-g' ^openblas cflags='-O3'")
@@ -394,14 +392,12 @@ class TestConcretize:
         spec.concretize()
         assert spec["cmake"].architecture == spec.architecture
 
+    @pytest.mark.only_clingo("Fixing the parser broke this test for the original concretizer")
     def test_architecture_deep_inheritance(self, mock_targets):
         """Make sure that indirect dependencies receive architecture
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Fixing the parser broke this test for the original concretizer.")
-
         spec_str = "mpileaks %gcc@4.5.0 os=CNL target=nocona" " ^dyninst os=CNL ^callpath os=CNL"
         spec = Spec(spec_str).concretized()
         for s in spec.traverse(root=False):
@@ -457,9 +453,8 @@ class TestConcretize:
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
-    @pytest.mark.skipif(
-        os.environ.get("SPACK_TEST_SOLVER") == "original",
-        reason="Optional compiler propagation isn't deprecated for original concretizer",
+    @pytest.mark.only_clingo(
+        "Optional compiler propagation isn't deprecated for original concretizer"
     )
     def test_concretize_propagate_disabled_variant(self):
         """Test a package variant value was passed from its parent."""
@@ -619,10 +614,8 @@ class TestConcretize:
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
+    @pytest.mark.only_clingo("Testing debug statements specific to new concretizer")
     def test_conflicts_show_cores(self, conflict_spec, monkeypatch):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Testing debug statements specific to new concretizer")
-
         s = Spec(conflict_spec)
         with pytest.raises(spack.error.SpackError) as e:
             s.concretize()
@@ -795,10 +788,8 @@ class TestConcretize:
             ("bowtie@1.2.2 os=redhat6", "%gcc@11.1.0"),
         ],
     )
+    @pytest.mark.only_clingo("Original concretizer cannot work around conflicts")
     def test_compiler_conflicts_in_package_py(self, spec_str, expected_str):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Original concretizer cannot work around conflicts")
-
         s = Spec(spec_str).concretized()
         assert s.satisfies(expected_str)
 
@@ -902,10 +893,8 @@ class TestConcretize:
             ("quantum-espresso~veritas", ["^libelf@0.8.13"]),
         ],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_working_around_conflicting_defaults(self, spec_str, expected):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         s = Spec(spec_str).concretized()
 
         assert s.concrete
@@ -917,10 +906,8 @@ class TestConcretize:
         "spec_str,expected",
         [("cmake", ["%clang"]), ("cmake %gcc", ["%gcc"]), ("cmake %clang", ["%clang"])],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_external_package_and_compiler_preferences(self, spec_str, expected):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         packages_yaml = {
             "all": {"compiler": ["clang", "gcc"]},
             "cmake": {
@@ -936,14 +923,12 @@ class TestConcretize:
             assert s.satisfies(condition)
 
     @pytest.mark.regression("5651")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_package_with_constraint_not_met_by_external(self):
         """Check that if we have an external package A at version X.Y in
         packages.yaml, but our spec doesn't allow X.Y as a version, then
         a new version of A is built that meets the requirements.
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         packages_yaml = {"libelf": {"externals": [{"spec": "libelf@0.8.13", "prefix": "/usr"}]}}
         spack.config.set("packages", packages_yaml)
 
@@ -953,10 +938,8 @@ class TestConcretize:
         assert not s["libelf"].external
 
     @pytest.mark.regression("9744")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_cumulative_version_ranges_with_different_length(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         s = Spec("cumulative-vrange-root").concretized()
         assert s.concrete
         assert s.satisfies("^cumulative-vrange-bottom@2.2")
@@ -983,10 +966,8 @@ class TestConcretize:
     @pytest.mark.parametrize(
         "spec_str,expected", [("cmake %gcc", "%gcc"), ("cmake %clang", "%clang")]
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_compiler_constraint_with_external_package(self, spec_str, expected):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         packages_yaml = {
             "cmake": {"externals": [{"spec": "cmake@3.4.3", "prefix": "/usr"}], "buildable": False}
         }
@@ -1035,10 +1016,8 @@ class TestConcretize:
         assert s.satisfies(expected)
         assert "external-common-perl" not in [d.name for d in s.dependencies()]
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_external_packages_have_consistent_hash(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("This tests needs the ASP-based concretizer")
-
         s, t = Spec("externaltool"), Spec("externaltool")
         s._old_concretize(), t._new_concretize()
 
@@ -1062,10 +1041,8 @@ class TestConcretize:
         assert "externalvirtual" in s
 
     @pytest.mark.regression("20040")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_conditional_provides_or_depends_on(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         # Check that we can concretize correctly a spec that can either
         # provide a virtual or depend on it based on the value of a variant
         s = Spec("conditional-provider +disable-v1").concretized()
@@ -1103,10 +1080,8 @@ class TestConcretize:
             assert not node.dependencies(deptype="test"), msg.format(pkg_name)
 
     @pytest.mark.regression("20019")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_compiler_match_is_preferred_to_newer_version(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         # This spec depends on openblas. Openblas has a conflict
         # that doesn't allow newer versions with gcc@4.4.0. Check
         # that an old version of openblas is selected, rather than
@@ -1122,9 +1097,8 @@ class TestConcretize:
         with pytest.raises(spack.error.SpackError):
             Spec("impossible-concretization").concretized()
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_target_compatibility(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
         with pytest.raises(spack.error.SpackError):
             Spec("libdwarf target=x86_64 ^libelf target=x86_64_v2").concretized()
 
@@ -1140,10 +1114,8 @@ class TestConcretize:
         assert "+foo+bar+baz" in d
 
     @pytest.mark.regression("20055")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_custom_compiler_version(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         s = Spec("a %gcc@10foo os=redhat6").concretized()
         assert "%gcc@10foo" in s
 
@@ -1240,12 +1212,10 @@ class TestConcretize:
             {"add_variant": True, "delete_variant": True},
         ],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_reuse_installed_packages_when_package_def_changes(
         self, context, mutable_database, repo_with_changing_recipe
     ):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         # Install a spec
         root = Spec("root").concretized()
         dependency = root["changing"].copy()
@@ -1269,10 +1239,8 @@ class TestConcretize:
         # Structure and package hash will be different without reuse
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_reuse_with_flags(self, mutable_database, mutable_config):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Original concretizer does not reuse")
-
         spack.config.set("concretizer:reuse", True)
         spec = Spec("a cflags=-g cxxflags=-g").concretized()
         spack.store.STORE.db.add(spec, None)
@@ -1292,10 +1260,8 @@ class TestConcretize:
     @pytest.mark.parametrize(
         "spec_str", ["wrong-variant-in-conflicts", "wrong-variant-in-depends-on"]
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_error_message_for_inconsistent_variants(self, spec_str):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         s = Spec(spec_str)
         with pytest.raises(RuntimeError, match="not found in package"):
             s.concretize()
@@ -1392,12 +1358,9 @@ class TestConcretize:
             ("deprecated-versions@1.1.0", ["deprecated-versions@1.1.0"]),
         ],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_deprecated_versions_not_selected(self, spec_str, expected):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         s = Spec(spec_str).concretized()
-
         for abstract_spec in expected:
             assert abstract_spec in s
 
@@ -1456,12 +1419,10 @@ class TestConcretize:
         "spec_str,expect_installed",
         [("mpich", True), ("mpich+debug", False), ("mpich~debug", True)],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_concrete_specs_are_not_modified_on_reuse(
         self, mutable_database, spec_str, expect_installed, config
     ):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Original concretizer cannot reuse specs")
-
         # Test the internal consistency of solve + DAG reconstruction
         # when reused specs are added to the mix. This prevents things
         # like additional constraints being added to concrete specs in
@@ -1472,10 +1433,8 @@ class TestConcretize:
         assert s.satisfies(spec_str)
 
     @pytest.mark.regression("26721,19736")
+    @pytest.mark.only_clingo("Original concretizer cannot use sticky variants")
     def test_sticky_variant_in_package(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Original concretizer cannot use sticky variants")
-
         # Here we test that a sticky variant cannot be changed from its default value
         # by the ASP solver if not set explicitly. The package used in the test needs
         # to have +allow-gcc set to be concretized with %gcc and clingo is not allowed
@@ -1489,10 +1448,8 @@ class TestConcretize:
         s = Spec("sticky-variant %clang").concretized()
         assert s.satisfies("%clang") and s.satisfies("~allow-gcc")
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_do_not_invent_new_concrete_versions_unless_necessary(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Original concretizer doesn't resolve concrete versions to known ones")
-
         # ensure we select a known satisfying version rather than creating
         # a new '2.7' version.
         assert ver("=2.7.11") == Spec("python@2.7").concretized().version
@@ -1513,30 +1470,24 @@ class TestConcretize:
             ("conditional-values-in-variant foo=foo", True),
         ],
     )
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_conditional_values_in_variants(self, spec_str, valid):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer doesn't resolve conditional values in variants")
-
         s = Spec(spec_str)
         raises = pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError))
         with llnl.util.lang.nullcontext() if valid else raises:
             s.concretize()
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_conditional_values_in_conditional_variant(self):
         """Test that conditional variants play well with conditional possible values"""
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer doesn't resolve conditional values in variants")
-
         s = Spec("conditional-values-in-variant@1.50.0").concretized()
         assert "cxxstd" not in s.variants
 
         s = Spec("conditional-values-in-variant@1.60.0").concretized()
         assert "cxxstd" in s.variants
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_target_granularity(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot account for target granularity")
-
         # The test architecture uses core2 as the default target. Check that when
         # we configure Spack for "generic" granularity we concretize for x86_64
         default_target = spack.platforms.test.Test.default
@@ -1546,10 +1497,8 @@ class TestConcretize:
         with spack.config.override("concretizer:targets", {"granularity": "generic"}):
             assert s.concretized().satisfies("target=%s" % generic_target)
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_host_compatible_concretization(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot account for host compatibility")
-
         # Check that after setting "host_compatible" to false we cannot concretize.
         # Here we use "k10" to set a target non-compatible with the current host
         # to avoid a lot of boilerplate when mocking the test platform. The issue
@@ -1561,10 +1510,8 @@ class TestConcretize:
             with pytest.raises(spack.error.SpackError):
                 s.concretized()
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_add_microarchitectures_on_explicit_request(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot account for host compatibility")
-
         # Check that if we consider only "generic" targets, we can still solve for
         # specific microarchitectures on explicit requests
         with spack.config.override("concretizer:targets", {"granularity": "generic"}):
@@ -1572,13 +1519,11 @@ class TestConcretize:
         assert s.satisfies("target=k10")
 
     @pytest.mark.regression("29201")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_delete_version_and_reuse(self, mutable_database, repo_with_changing_recipe):
         """Test that we can reuse installed specs with versions not
         declared in package.py
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         root = Spec("root").concretized()
         root.package.do_install(fake=True, explicit=True)
         repo_with_changing_recipe.change({"delete_version": True})
@@ -1589,15 +1534,13 @@ class TestConcretize:
         assert root.dag_hash() == new_root.dag_hash()
 
     @pytest.mark.regression("29201")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_installed_version_is_selected_only_for_reuse(
         self, mutable_database, repo_with_changing_recipe
     ):
         """Test that a version coming from an installed spec is a possible
         version only for reuse
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known failure of the original concretizer")
-
         # Install a dependency that cannot be reused with "root"
         # because of a conflict a variant, then delete its version
         dependency = Spec("changing@1.0~foo").concretized()
@@ -1653,11 +1596,9 @@ class TestConcretize:
             (["mpi", "mpich"], 1),
         ],
     )
+    @pytest.mark.only_clingo("Original concretizer cannot concretize in rounds")
     def test_best_effort_coconcretize(self, specs, expected):
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot concretize in rounds")
 
         specs = [Spec(s) for s in specs]
         solver = spack.solver.asp.Solver()
@@ -1699,12 +1640,10 @@ class TestConcretize:
             (["hdf5+mpi", "zmpi", "mpich"], "mpich", 2),
         ],
     )
+    @pytest.mark.only_clingo("Original concretizer cannot concretize in rounds")
     def test_best_effort_coconcretize_preferences(self, specs, expected_spec, occurances):
         """Test package preferences during coconcretization."""
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot concretize in rounds")
 
         specs = [Spec(s) for s in specs]
         solver = spack.solver.asp.Solver()
@@ -1719,19 +1658,15 @@ class TestConcretize:
                 counter += 1
         assert counter == occurances, concrete_specs
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_coconcretize_reuse_and_virtuals(self):
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot reuse")
 
         reusable_specs = []
         for s in ["mpileaks ^mpich", "zmpi"]:
             reusable_specs.extend(Spec(s).concretized().traverse(root=True))
 
         root_specs = [Spec("mpileaks"), Spec("zmpi")]
-
-        import spack.solver.asp
 
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
@@ -1742,14 +1677,12 @@ class TestConcretize:
             assert "zmpi" in spec
 
     @pytest.mark.regression("30864")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_misleading_error_message_on_version(self, mutable_database):
         # For this bug to be triggered we need a reusable dependency
         # that is not optimal in terms of optimization scores.
         # We pick an old version of "b"
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot reuse")
 
         reusable_specs = [Spec("non-existing-conditional-dep@1.0").concretized()]
         root_spec = Spec("non-existing-conditional-dep@2.0")
@@ -1763,12 +1696,10 @@ class TestConcretize:
                 solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
 
     @pytest.mark.regression("31148")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_version_weight_and_provenance(self):
         """Test package preferences during coconcretization."""
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot reuse")
 
         reusable_specs = [Spec(spec_str).concretized() for spec_str in ("b@0.9", "b@1.0")]
         root_spec = Spec("a foobar=bar")
@@ -1799,11 +1730,9 @@ class TestConcretize:
             assert result_spec.satisfies("^b@1.0")
 
     @pytest.mark.regression("31169")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_not_reusing_incompatible_os_or_compiler(self):
         import spack.solver.asp
-
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot reuse")
 
         root_spec = Spec("b")
         s = root_spec.concretized()
@@ -1826,9 +1755,8 @@ class TestConcretize:
         assert hash in str(c)
 
     @pytest.mark.parametrize("git_ref", ("a" * 40, "0.2.15", "main"))
+    @pytest.mark.only_clingo("Original concretizer cannot account for git hashes")
     def test_git_ref_version_is_equivalent_to_specified_version(self, git_ref):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot account for git hashes")
         s = Spec("develop-branch-version@git.%s=develop" % git_ref)
         c = s.concretized()
         assert git_ref in str(c)
@@ -1837,21 +1765,17 @@ class TestConcretize:
         assert s.satisfies("@0.1:")
 
     @pytest.mark.parametrize("git_ref", ("a" * 40, "0.2.15", "fbranch"))
+    @pytest.mark.only_clingo("Original concretizer cannot account for git hashes")
     def test_git_ref_version_succeeds_with_unknown_version(self, git_ref):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("Original concretizer cannot account for git hashes")
         # main is not defined in the package.py for this file
         s = Spec("develop-branch-version@git.%s=main" % git_ref)
         s.concretize()
         assert s.satisfies("develop-branch-version@main")
 
     @pytest.mark.regression("31484")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_installed_externals_are_reused(self, mutable_database, repo_with_changing_recipe):
         """Test that external specs that are in the DB can be reused."""
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Use case not supported by the original concretizer")
-
-        # Configuration to be added to packages.yaml
         external_conf = {
             "changing": {
                 "buildable": False,
@@ -1879,12 +1803,9 @@ class TestConcretize:
         assert external3.dag_hash() == external1.dag_hash()
 
     @pytest.mark.regression("31484")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_user_can_select_externals_with_require(self, mutable_database):
         """Test that users have means to select an external even in presence of reusable specs."""
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Use case not supported by the original concretizer")
-
-        # Configuration to be added to packages.yaml
         external_conf = {
             "mpi": {"buildable": False},
             "multi-provider-mpi": {
@@ -1911,13 +1832,11 @@ class TestConcretize:
             assert mpi_spec.name == "multi-provider-mpi"
 
     @pytest.mark.regression("31484")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_installed_specs_disregard_conflicts(self, mutable_database, monkeypatch):
         """Test that installed specs do not trigger conflicts. This covers for the rare case
         where a conflict is added on a package after a spec matching the conflict was installed.
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Use case not supported by the original concretizer")
-
         # Add a conflict to "mpich" that match an already installed "mpich~debug"
         pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
         monkeypatch.setitem(pkg_cls.conflicts, "~debug", [(Spec(), None)])
@@ -1933,11 +1852,9 @@ class TestConcretize:
             assert s.satisfies("~debug")
 
     @pytest.mark.regression("32471")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_require_targets_are_allowed(self, mutable_database):
         """Test that users can set target constraints under the require attribute."""
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Use case not supported by the original concretizer")
-
         # Configuration to be added to packages.yaml
         external_conf = {"all": {"require": "target=%s" % spack.platforms.test.Test.front_end}}
         spack.config.set("packages", external_conf)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -742,7 +742,7 @@ class TestConcretize:
         with pytest.raises(spack.error.SpackError):
             Spec(spec).concretized()
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+    @pytest.mark.not_on_windows("Not supported on Windows (yet)")
     # Include targets to prevent regression on 20537
     @pytest.mark.parametrize(
         "spec, best_achievable",
@@ -2125,7 +2125,7 @@ class TestConcretize:
         assert s.compiler.version == ver("=11.1.0"), s
 
     @pytest.mark.regression("36339")
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows")
+    @pytest.mark.not_on_windows("Not supported on Windows")
     def test_compiler_with_custom_non_numeric_version(self, mock_executable):
         """Test that, when a compiler has a completely made up version, we can use its
         'real version' to detect targets and don't raise during concretization.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -117,13 +117,9 @@ class TestConcretizePreferences:
         # etc.
         assert spec.compiler.satisfies(CompilerSpec(compiler_str))
 
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_preferred_target(self, mutable_mock_repo):
         """Test preferred targets are applied correctly"""
-        # FIXME: This test was a false negative, since the default and
-        # FIXME: the preferred target were the same
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("Known bug in the original concretizer")
-
         spec = concretize("mpich")
         default = str(spec.target)
         preferred = str(spec.target.family)
@@ -151,9 +147,8 @@ class TestConcretizePreferences:
         spec = concretize("mpileaks")
         assert spec.version == Version("2.2")
 
+    @pytest.mark.only_clingo("This behavior is not enforced for the old concretizer")
     def test_preferred_versions_mixed_version_types(self):
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("This behavior is not enforced for the old concretizer")
         update_packages("mixedversions", "version", ["=2.0"])
         spec = concretize("mixedversions")
         assert spec.version == Version("2.0")
@@ -230,24 +225,20 @@ mpileaks:
         spec.concretize()
         assert spec.version == Version("3.5.0")
 
+    @pytest.mark.only_clingo("This behavior is not enforced for the old concretizer")
     def test_preferred_undefined_raises(self):
         """Preference should not specify an undefined version"""
-        if spack.config.get("config:concretizer") == "original":
-            pytest.xfail("This behavior is not enforced for the old concretizer")
-
         update_packages("python", "version", ["3.5.0.1"])
         spec = Spec("python")
         with pytest.raises(spack.config.ConfigError):
             spec.concretize()
 
+    @pytest.mark.only_clingo("This behavior is not enforced for the old concretizer")
     def test_preferred_truncated(self):
         """Versions without "=" are treated as version ranges: if there is
         a satisfying version defined in the package.py, we should use that
         (don't define a new version).
         """
-        if spack.config.get("config:concretizer") == "original":
-            pytest.skip("This behavior is not enforced for the old concretizer")
-
         update_packages("python", "version", ["3.5"])
         spec = Spec("python")
         spec.concretize()

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pathlib
-import sys
 
 import pytest
 
@@ -18,7 +17,7 @@ from spack.solver.asp import UnsatisfiableSpecError
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Windows uses old concretizer")
+pytestmark = pytest.mark.not_on_windows("Windows uses old concretizer")
 
 
 def update_packages_config(conf_str):

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -17,7 +17,10 @@ from spack.solver.asp import UnsatisfiableSpecError
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
 
-pytestmark = pytest.mark.not_on_windows("Windows uses old concretizer")
+pytestmark = [
+    pytest.mark.not_on_windows("Windows uses old concretizer"),
+    pytest.mark.only_clingo("Original concretizer does not support configuration requirements"),
+]
 
 
 def update_packages_config(conf_str):
@@ -133,9 +136,6 @@ def fake_installs(monkeypatch, tmpdir):
 
 
 def test_one_package_multiple_reqs(concretize_scope, test_repo):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   y:
@@ -152,9 +152,6 @@ def test_requirement_isnt_optional(concretize_scope, test_repo):
     """If a user spec requests something that directly conflicts
     with a requirement, make sure we get an error.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   x:
@@ -172,9 +169,6 @@ def test_require_undefined_version(concretize_scope, test_repo):
     (it is assumed this is a typo, and raising the error here
     avoids a likely error when Spack attempts to fetch the version).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   x:
@@ -191,9 +185,6 @@ def test_require_truncated(concretize_scope, test_repo):
     of the defined versions (vs. allowing the requirement to
     define a new version).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   x:
@@ -255,9 +246,6 @@ def test_git_user_supplied_reference_satisfaction(
 def test_requirement_adds_new_version(
     concretize_scope, test_repo, mock_git_version_info, monkeypatch
 ):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
@@ -288,9 +276,6 @@ def test_requirement_adds_version_satisfies(
     depends_on condition and make sure it is triggered (i.e. the
     dependency is added).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration" " requirements")
-
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
@@ -317,9 +302,6 @@ packages:
 def test_requirement_adds_git_hash_version(
     concretize_scope, test_repo, mock_git_version_info, monkeypatch
 ):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
@@ -341,9 +323,6 @@ packages:
 def test_requirement_adds_multiple_new_versions(
     concretize_scope, test_repo, mock_git_version_info, monkeypatch
 ):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
@@ -369,9 +348,6 @@ def test_preference_adds_new_version(
     """Normally a preference cannot define a new version, but that constraint
     is ignored if the version is a Git hash-based version.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not enforce this constraint for preferences")
-
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
@@ -397,9 +373,6 @@ def test_external_adds_new_version_that_is_preferred(concretize_scope, test_repo
     """Test that we can use a version, not declared in package recipe, as the
     preferred version if that version appears in an external spec.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not enforce this constraint for preferences")
-
     conf_str = """\
 packages:
   y:
@@ -420,9 +393,6 @@ def test_requirement_is_successfully_applied(concretize_scope, test_repo):
     """If a simple requirement can be satisfied, make sure the
     concretization succeeds and the requirement spec is applied.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     s1 = Spec("x").concretized()
     # Without any requirements/preferences, the later version is preferred
     assert s1.satisfies("@1.1")
@@ -442,9 +412,6 @@ def test_multiple_packages_requirements_are_respected(concretize_scope, test_rep
     """Apply requirements to two packages; make sure the concretization
     succeeds and both requirements are respected.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   x:
@@ -462,9 +429,6 @@ def test_oneof(concretize_scope, test_repo):
     """'one_of' allows forcing the concretizer to satisfy one of
     the specs in the group (but not all have to be satisfied).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   y:
@@ -482,9 +446,6 @@ def test_one_package_multiple_oneof_groups(concretize_scope, test_repo):
     """One package has two 'one_of' groups; check that both are
     applied.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   y:
@@ -504,9 +465,6 @@ packages:
 @pytest.mark.regression("34241")
 def test_require_cflags(concretize_scope, test_repo):
     """Ensures that flags can be required from configuration."""
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration" " requirements")
-
     conf_str = """\
 packages:
   y:
@@ -522,9 +480,6 @@ def test_requirements_for_package_that_is_not_needed(concretize_scope, test_repo
     a dependency of a concretized spec (in other words, none of
     the requirements are used for the requested spec).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     # Note that the exact contents aren't important since this isn't
     # intended to be used, but the important thing is that a number of
     # packages have requirements applied
@@ -548,9 +503,6 @@ def test_oneof_ordering(concretize_scope, test_repo):
     This priority should override default priority (e.g. choosing
     later versions).
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   y:
@@ -567,9 +519,6 @@ packages:
 
 
 def test_reuse_oneof(concretize_scope, create_test_repo, mutable_database, fake_installs):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   y:
@@ -590,9 +539,6 @@ packages:
 
 def test_requirements_are_higher_priority_than_deprecation(concretize_scope, test_repo):
     """Test that users can override a deprecated version with a requirement."""
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     # @2.3 is a deprecated versions. Ensure that any_of picks both constraints,
     # since they are possible
     conf_str = """\
@@ -611,9 +557,6 @@ packages:
 @pytest.mark.parametrize("spec_str,requirement_str", [("x", "%gcc"), ("x", "%clang")])
 def test_default_requirements_with_all(spec_str, requirement_str, concretize_scope, test_repo):
     """Test that default requirements are applied to all packages."""
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     conf_str = """\
 packages:
   all:
@@ -639,8 +582,6 @@ def test_default_and_package_specific_requirements(
     concretize_scope, requirements, expectations, test_repo
 ):
     """Test that specific package requirements override default package requirements."""
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     generic_req, specific_req = requirements
     generic_exp, specific_exp = expectations
     conf_str = """\
@@ -662,8 +603,6 @@ packages:
 
 @pytest.mark.parametrize("mpi_requirement", ["mpich", "mpich2", "zmpi"])
 def test_requirements_on_virtual(mpi_requirement, concretize_scope, mock_packages):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     conf_str = """\
 packages:
   mpi:
@@ -685,8 +624,6 @@ packages:
 def test_requirements_on_virtual_and_on_package(
     mpi_requirement, specific_requirement, concretize_scope, mock_packages
 ):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     conf_str = """\
 packages:
   mpi:
@@ -705,8 +642,6 @@ packages:
 
 
 def test_incompatible_virtual_requirements_raise(concretize_scope, mock_packages):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     conf_str = """\
     packages:
       mpi:
@@ -720,8 +655,6 @@ def test_incompatible_virtual_requirements_raise(concretize_scope, mock_packages
 
 
 def test_non_existing_variants_under_all(concretize_scope, mock_packages):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     conf_str = """\
     packages:
       all:
@@ -804,9 +737,6 @@ def test_conditional_requirements_from_packages_yaml(
     """Test that conditional requirements are required when the condition is met,
     and optional when the condition is not met.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     update_packages_config(packages_yaml)
     spec = Spec(spec_str).concretized()
     for match_str, expected in expected_satisfies:
@@ -882,9 +812,6 @@ def test_requirements_fail_with_custom_message(
     """Test that specs failing due to requirements not being satisfiable fail with a
     custom error message.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     update_packages_config(packages_yaml)
     with pytest.raises(spack.error.SpackError, match=expected_message):
         Spec(spec_str).concretized()
@@ -898,9 +825,6 @@ def test_skip_requirement_when_default_requirement_condition_cannot_be_met(
     package. For those packages the requirement rule is not emitted, since it can be
     determined to be always false.
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
-
     packages_yaml = """
         packages:
           all:
@@ -918,8 +842,6 @@ def test_skip_requirement_when_default_requirement_condition_cannot_be_met(
 
 
 def test_requires_directive(concretize_scope, mock_packages):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration requirements")
     compilers_yaml = pathlib.Path(concretize_scope) / "compilers.yaml"
     compilers_yaml.write_text(
         """

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -7,7 +7,6 @@ import collections
 import getpass
 import io
 import os
-import sys
 import tempfile
 from datetime import date
 
@@ -484,7 +483,7 @@ def test_parse_install_tree(config_settings, expected, mutable_config):
     assert projections == expected_proj
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Padding unsupported on Windows")
+@pytest.mark.not_on_windows("Padding unsupported on Windows")
 @pytest.mark.parametrize(
     "config_settings,expected",
     [
@@ -816,7 +815,7 @@ def test_bad_config_section(mock_low_high_config):
         spack.config.get("foobar")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="chmod not supported on Windows")
+@pytest.mark.not_on_windows("chmod not supported on Windows")
 @pytest.mark.skipif(getuid() == 0, reason="user is root")
 def test_bad_command_line_scopes(tmpdir, config):
     cfg = spack.config.Configuration()
@@ -1395,7 +1394,7 @@ def test_config_file_dir_failure(tmpdir, mutable_empty_config):
         spack.config.read_config_file(tmpdir.strpath)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="chmod not supported on Windows")
+@pytest.mark.not_on_windows("chmod not supported on Windows")
 def test_config_file_read_perms_failure(tmpdir, mutable_empty_config):
     """Test reading a configuration file without permissions to ensure
     ConfigFileError is raised."""

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1940,3 +1940,20 @@ def nullify_globals(request, monkeypatch):
     monkeypatch.setattr(spack.caches, "FETCH_CACHE", None)
     monkeypatch.setattr(spack.repo, "PATH", None)
     monkeypatch.setattr(spack.store, "STORE", None)
+
+
+def pytest_runtest_setup(item):
+    # Skip tests if they are marked only clingo and are run with the original concretizer
+    only_clingo_marker = item.get_closest_marker(name="only_clingo")
+    if only_clingo_marker and os.environ.get("SPACK_TEST_SOLVER") == "original":
+        pytest.skip(*only_clingo_marker.args)
+
+    # Skip tests if they are marked only original and are run with clingo
+    only_original_marker = item.get_closest_marker(name="only_original")
+    if only_original_marker and os.environ.get("SPACK_TEST_SOLVER", "clingo") == "clingo":
+        pytest.skip(*only_original_marker.args)
+
+    # Skip test marked "not_on_windows" if they're run on Windows
+    not_on_windows_marker = item.get_closest_marker(name="not_on_windows")
+    if not_on_windows_marker and sys.platform == "win32":
+        pytest.skip(*not_on_windows_marker.args)

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -324,15 +324,13 @@ def create_manifest_content():
     }
 
 
+@pytest.mark.only_original(
+    "The ASP-based concretizer is currently picky about OS matching and will fail."
+)
 def test_read_cray_manifest(tmpdir, mutable_config, mock_packages, mutable_database):
     """Check that (a) we can read the cray manifest and add it to the Spack
     Database and (b) we can concretize specs based on that.
     """
-    if spack.config.get("config:concretizer") == "clingo":
-        pytest.skip(
-            "The ASP-based concretizer is currently picky about " " OS matching and will fail."
-        )
-
     with tmpdir.as_cwd():
         test_db_fname = "external-db.json"
         with open(test_db_fname, "w") as db_file:
@@ -348,14 +346,12 @@ def test_read_cray_manifest(tmpdir, mutable_config, mock_packages, mutable_datab
         assert concretized_specs[0]["hwloc"].dag_hash() == "hwlocfakehashaaa"
 
 
+@pytest.mark.only_original(
+    "The ASP-based concretizer is currently picky about OS matching and will fail."
+)
 def test_read_cray_manifest_twice_no_compiler_duplicates(
     tmpdir, mutable_config, mock_packages, mutable_database
 ):
-    if spack.config.get("config:concretizer") == "clingo":
-        pytest.skip(
-            "The ASP-based concretizer is currently picky about OS matching and will fail."
-        )
-
     with tmpdir.as_cwd():
         test_db_fname = "external-db.json"
         with open(test_db_fname, "w") as db_file:

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -18,7 +18,6 @@ try:
     _use_uuid = True
 except ImportError:
     _use_uuid = False
-    pass
 
 import jsonschema
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -6,7 +6,6 @@
 import filecmp
 import os
 import pickle
-import sys
 
 import pytest
 
@@ -16,9 +15,7 @@ import spack.environment as ev
 import spack.spec
 from spack.environment.environment import SpackEnvironmentViewError, _error_on_nonempty_view_dir
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="Envs are not supported on windows"
-)
+pytestmark = pytest.mark.not_on_windows("Envs are not supported on windows")
 
 
 class TestDirectoryInitialization:

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -159,7 +158,7 @@ def test_unset(env):
         os.environ["UNSET_ME"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_filter_system_paths(miscellaneous_paths):
     """Tests that the filtering of system paths works as expected."""
     filtered = filter_system_paths(miscellaneous_paths)
@@ -174,7 +173,7 @@ def test_filter_system_paths(miscellaneous_paths):
 
 
 # TODO 27021
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_set_path(env):
     """Tests setting paths in an environment variable."""
 
@@ -190,7 +189,7 @@ def test_set_path(env):
     assert "foo;bar;baz" == os.environ["B"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_path_manipulation(env):
     """Tests manipulating list of paths in the environment."""
 
@@ -244,7 +243,7 @@ def test_extend(env):
         assert x is y
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.usefixtures("prepare_environment_for_tests")
 def test_source_files(files_to_be_sourced):
     """Tests the construction of a list of environment modifications that are
@@ -311,7 +310,7 @@ def test_preserve_environment(prepare_environment_for_tests):
     assert os.environ["PATH_LIST"] == "/path/second:/path/third"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "files,expected,deleted",
     [
@@ -486,7 +485,7 @@ def test_from_environment_diff(before, after, search_list):
         assert item in mod
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Lmod not supported on Windows")
+@pytest.mark.not_on_windows("Lmod not supported on Windows")
 @pytest.mark.regression("15775")
 def test_exclude_lmod_variables():
     # Construct the list of environment modifications
@@ -498,7 +497,7 @@ def test_exclude_lmod_variables():
     assert not any(x.startswith("LMOD_") for x in modifications)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.regression("13504")
 def test_exclude_modules_variables():
     # Construct the list of environment modifications

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -22,7 +21,7 @@ from spack.version import Version
 # and expected to be fixed
 pytestmark = [
     pytest.mark.skipif(not which("hg"), reason="requires mercurial to be installed"),
-    pytest.mark.skipif(sys.platform == "win32", reason="Failing on Win"),
+    pytest.mark.not_on_windows("Failing on Win"),
 ]
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -52,7 +52,6 @@ repo:
 
 def _noop(*args, **kwargs):
     """Generic monkeypatch no-op routine."""
-    pass
 
 
 def _none(*args, **kwargs):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -150,7 +150,7 @@ class TestInstall:
                 fs.install("source/a/*/*", "dest/1")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Skip test on Windows")
+@pytest.mark.not_on_windows("Skip test on Windows")
 class TestCopyTree:
     """Tests for ``filesystem.copy_tree``"""
 
@@ -231,7 +231,7 @@ class TestCopyTree:
                 fs.copy_tree("source", "source/sub/directory")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Skip test on Windows")
+@pytest.mark.not_on_windows("Skip test on Windows")
 class TestInstallTree:
     """Tests for ``filesystem.install_tree``"""
 
@@ -502,7 +502,7 @@ def test_filter_files_with_different_encodings(regex, replacement, filename, tmp
         assert replacement in f.read()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="chgrp isn't used on Windows")
+@pytest.mark.not_on_windows("chgrp isn't used on Windows")
 def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
     with fs.working_dir(tmpdir):
         os.mkdir("test-dir_chgrp_dont_set_group_if_already_set")
@@ -722,7 +722,7 @@ def test_temporary_dir_context_manager():
         assert os.path.realpath(str(tmp_dir)) == os.path.realpath(os.getcwd())
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="No shebang on Windows")
+@pytest.mark.not_on_windows("No shebang on Windows")
 def test_is_nonsymlink_exe_with_shebang(tmpdir):
     with tmpdir.as_cwd():
         # Create an executable with shebang.
@@ -825,7 +825,7 @@ class RegisterVisitor(fs.BaseDirectoryVisitor):
         self.symlinked_dirs_after.append(rel_path)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Requires symlinks")
+@pytest.mark.not_on_windows("Requires symlinks")
 def test_visit_directory_tree_follow_all(noncyclical_dir_structure):
     root = str(noncyclical_dir_structure)
     visitor = RegisterVisitor(root, follow_dirs=True, follow_symlink_dirs=True)
@@ -850,7 +850,7 @@ def test_visit_directory_tree_follow_all(noncyclical_dir_structure):
     assert visitor.symlinked_dirs_after == [j("a", "to_c"), j("b", "to_c"), j("b")]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Requires symlinks")
+@pytest.mark.not_on_windows("Requires symlinks")
 def test_visit_directory_tree_follow_dirs(noncyclical_dir_structure):
     root = str(noncyclical_dir_structure)
     visitor = RegisterVisitor(root, follow_dirs=True, follow_symlink_dirs=False)
@@ -869,7 +869,7 @@ def test_visit_directory_tree_follow_dirs(noncyclical_dir_structure):
     assert not visitor.symlinked_dirs_after
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Requires symlinks")
+@pytest.mark.not_on_windows("Requires symlinks")
 def test_visit_directory_tree_follow_none(noncyclical_dir_structure):
     root = str(noncyclical_dir_structure)
     visitor = RegisterVisitor(root, follow_dirs=False, follow_symlink_dirs=False)
@@ -884,7 +884,7 @@ def test_visit_directory_tree_follow_none(noncyclical_dir_structure):
 
 @pytest.mark.regression("29687")
 @pytest.mark.parametrize("initial_mode", [stat.S_IRUSR | stat.S_IXUSR, stat.S_IWGRP])
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows might change permissions")
+@pytest.mark.not_on_windows("Windows might change permissions")
 def test_remove_linked_tree_doesnt_change_file_permission(tmpdir, initial_mode):
     # Here we test that a failed call to remove_linked_tree, due to passing a file
     # as an argument instead of a directory, doesn't leave the file with different

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -65,7 +65,7 @@ from llnl.util.filesystem import getuid, touch
 if sys.platform != "win32":
     import fcntl
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 #

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -29,7 +29,7 @@ except ImportError:
     pass
 
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -14,8 +13,8 @@ import spack.util.executable as exe
 import spack.util.git
 from spack.main import get_version, main
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="Test functionality supported but tests are failing on Win"
+pytestmark = pytest.mark.not_on_windows(
+    "Test functionality supported but tests are failing on Win"
 )
 
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -5,7 +5,6 @@
 
 import filecmp
 import os
-import sys
 
 import pytest
 
@@ -22,7 +21,7 @@ from spack.util.executable import which
 from spack.util.spack_yaml import SpackYAMLError
 
 pytestmark = [
-    pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),
+    pytest.mark.not_on_windows("does not run on windows"),
     pytest.mark.usefixtures("mutable_config", "mutable_mock_repo"),
 ]
 

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -17,7 +16,7 @@ from spack.util.module_cmd import (
     path_from_modules,
 )
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Tests fail on Windows")
+pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")
 
 test_module_lines = [
     "prepend-path LD_LIBRARY_PATH /path/to/lib",

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import stat
-import sys
 
 import pytest
 
@@ -18,7 +17,7 @@ import spack.spec
 from spack.modules.common import UpstreamModuleIndex
 from spack.spec import Spec
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_update_dictionary_extending_list():

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -21,7 +20,7 @@ install = spack.main.SpackCommand("install")
 #: Class of the writer tested in this module
 writer_cls = spack.modules.lmod.LmodModulefileWriter
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.fixture(params=["clang@=12.0.0", "gcc@=10.2.1"])

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 import pytest
 
@@ -18,7 +17,7 @@ libdwarf_spec_string = "libdwarf target=x86_64"
 #: Class of the writer tested in this module
 writer_cls = spack.modules.tcl.TclModulefileWriter
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "mock_module_filename")

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test for multi_method dispatch."""
-import os
-import sys
 
 import pytest
 
@@ -16,10 +14,8 @@ from spack.multimethod import NoSuchMethodError
 
 pytestmark = [
     pytest.mark.usefixtures("mock_packages", "config"),
-    pytest.mark.skipif(
-        os.environ.get("SPACK_TEST_SOLVER") == "original" or sys.platform == "win32",
-        reason="The original concretizer cannot concretize most of the specs",
-    ),
+    pytest.mark.only_clingo("The original concretizer cannot concretize most of the specs"),
+    pytest.mark.not_on_windows("Not running on windows"),
 ]
 
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -11,7 +11,6 @@ import os
 import pathlib
 import platform
 import shutil
-import sys
 from collections import OrderedDict
 
 import pytest
@@ -39,7 +38,7 @@ from spack.relocate import (
 )
 from spack.spec import Spec
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_gnupghome")

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -71,7 +71,7 @@ def mock_patch_stage(tmpdir_factory, monkeypatch):
 data_path = os.path.join(spack.paths.test_path, "data", "patch")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Line ending conflict on Windows")
+@pytest.mark.not_on_windows("Line ending conflict on Windows")
 @pytest.mark.parametrize(
     "filename, sha256, archive_sha256",
     [
@@ -210,7 +210,7 @@ def test_nested_directives(mock_packages):
     assert len(fake_dep.patches[Spec()]) == 2
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Test requires Autotools")
+@pytest.mark.not_on_windows("Test requires Autotools")
 def test_patched_dependency(mock_packages, config, install_mockery, mock_fetch):
     """Test whether patched dependencies work."""
     spec = Spec("patch-a-dependency")

--- a/lib/spack/spack/test/permissions.py
+++ b/lib/spack/spack/test/permissions.py
@@ -5,7 +5,6 @@
 
 import os
 import stat
-import sys
 
 import pytest
 
@@ -13,7 +12,7 @@ import llnl.util.filesystem as fs
 
 from spack.util.file_permissions import InvalidPermissionsError, set_permissions
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="chmod unsupported on Windows")
+pytestmark = pytest.mark.not_on_windows("chmod unsupported on Windows")
 
 
 def ensure_known_group(path):

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -6,7 +6,6 @@ import os
 import os.path
 import re
 import shutil
-import sys
 
 import pytest
 
@@ -20,7 +19,7 @@ import spack.store
 import spack.tengine
 import spack.util.executable
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Tests fail on Windows")
+pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")
 
 
 def skip_unless_linux(f):

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -27,7 +27,7 @@ if sys.platform != "win32":
     import grp
 
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 too_long = sbang.system_shebang_limit + 1

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -81,6 +81,7 @@ def test_test_deptype(tmpdir):
 
 
 @pytest.mark.usefixtures("config")
+@pytest.mark.only_clingo("fails with the original concretizer and full hashes")
 def test_installed_deps(monkeypatch, mock_packages):
     """Ensure that concrete specs and their build deps don't constrain solves.
 
@@ -93,9 +94,6 @@ def test_installed_deps(monkeypatch, mock_packages):
     constrain ``a``'s dependency on ``d``.
 
     """
-    if spack.config.get("config:concretizer") == "original":
-        pytest.xfail("fails with the original concretizer and full hashes")
-
     # see installed-deps-[abcde] test packages.
     #     a
     #    / \

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -659,9 +659,7 @@ class TestStage:
         assert source_path.endswith(spack.stage._source_path_subdir)
         assert not os.path.exists(source_path)
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="Windows file permission erroring is not yet supported"
-    )
+    @pytest.mark.not_on_windows("Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_first_accessible_path(self, tmpdir):
         """Test _first_accessible_path names."""
@@ -756,9 +754,7 @@ class TestStage:
 
         assert spack.stage._resolve_paths(paths) == res_paths
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="Windows file permission erroring is not yet supported"
-    )
+    @pytest.mark.not_on_windows("Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_get_stage_root_bad_path(self, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -22,7 +21,7 @@ pytestmark = [
     pytest.mark.skipif(
         not which("svn") or not which("svnadmin"), reason="requires subversion to be installed"
     ),
-    pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),
+    pytest.mark.not_on_windows("does not run on windows"),
 ]
 
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import os
-import sys
 
 import pytest
 
@@ -148,7 +147,7 @@ def test_test_spec_run_once(mock_packages, install_mockery, mock_test_stage):
         test_suite()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Cannot find echo executable")
+@pytest.mark.not_on_windows("Cannot find echo executable")
 def test_test_spec_passes(mock_packages, install_mockery, mock_test_stage, monkeypatch):
     spec = spack.spec.Spec("simple-standalone-test").concretized()
     monkeypatch.setattr(spack.spec.Spec, "installed", _true)

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -221,12 +221,10 @@ def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
         ("2.0.0", "foo-2.0.0b2.tar.gz", "000000000000000000000000000200b2"),
     ],
 )
+@pytest.mark.only_clingo("Original concretizer doesn't resolve concrete versions to known ones")
 def test_new_version_from_list_url(
     mock_packages, config, _fetch_method, requested_version, tarball, digest
 ):
-    if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer doesn't resolve concrete versions to known ones")
-
     """Test non-specific URLs from the url-list-test package."""
     with spack.config.override("config:url_fetch_method", _fetch_method):
         s = Spec("url-list-test @%s" % requested_version).concretized()

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -173,7 +173,7 @@ def test_fetch(
 
 
 # TODO-27021
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "spec,url,digest",
     [
@@ -204,7 +204,7 @@ def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
         assert fetch_strategy.extra_options == {"timeout": 60}
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize(
     "requested_version,tarball,digest",

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -6,7 +6,6 @@
 
 import os
 import shutil
-import sys
 from itertools import product
 
 import pytest
@@ -71,7 +70,7 @@ def test_native_unpacking(tmpdir_factory, archive_file_and_extension):
         assert "TEST" in contents
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Only Python unpacking available on Windows")
+@pytest.mark.not_on_windows("Only Python unpacking available on Windows")
 @pytest.mark.parametrize(
     "archive_file_and_extension", [(ext, True) for ext in ext_archive.keys()], indirect=True
 )

--- a/lib/spack/spack/test/util/editor.py
+++ b/lib/spack/spack/test/util/editor.py
@@ -14,7 +14,7 @@ import spack.util.editor as ed
 
 pytestmark = [
     pytest.mark.usefixtures("working_env"),
-    pytest.mark.skipif(sys.platform == "win32", reason="editor not implemented on windows"),
+    pytest.mark.not_on_windows("editor not implemented on windows"),
 ]
 
 
@@ -33,7 +33,6 @@ def clean_env_vars():
 @pytest.fixture(autouse=True)
 def working_editor_test_env(working_env):
     """Don't leak environent variables between functions here."""
-    pass
 
 
 # parameterized fixture for editor var names

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -5,7 +5,6 @@
 
 """Test Spack's FileCache."""
 import os
-import sys
 
 import pytest
 
@@ -32,7 +31,7 @@ def test_write_and_read_cache_file(file_cache):
         assert text == "foobar\n"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Locks not supported on Windows")
+@pytest.mark.not_on_windows("Locks not supported on Windows")
 def test_failed_write_and_read_cache_file(file_cache):
     """Test failing to write then attempting to read a cached file."""
     with pytest.raises(RuntimeError, match=r"^foobar$"):
@@ -84,7 +83,7 @@ def test_write_and_remove_cache_file(file_cache):
     # assert os.path.exists(file_cache._lock_path('test.yaml'))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_cache_init_entry_fails(file_cache):
     """Test init_entry failures."""
     relpath = fs.join_path("test-dir", "read-only-file.txt")

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -41,7 +41,7 @@ def test_sanitize_filename():
 # This class pertains to path string padding manipulation specifically
 # which is used for binary caching. This functionality is not supported
 # on Windows as of yet.
-@pytest.mark.skipif(sys.platform == "win32", reason="Padding funtionality unsupported on Windows")
+@pytest.mark.not_on_windows("Padding funtionality unsupported on Windows")
 class TestPathPadding:
     @pytest.mark.parametrize("padded,fixed", zip(padded_lines, fixed_lines))
     def test_padding_substitution(self, padded, fixed):

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -12,9 +12,7 @@ import pytest
 
 import spack.util.unparse
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="Test module unsupported on Windows"
-)
+pytestmark = pytest.mark.not_on_windows("Test module unsupported on Windows")
 
 
 def read_pyfile(filename):

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -7,7 +7,6 @@
 import os
 import shutil
 import stat
-import sys
 
 import pytest
 
@@ -19,7 +18,7 @@ import spack.store
 import spack.util.spack_json as sjson
 import spack.verify
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Tests fail on Win")
+pytestmark = pytest.mark.not_on_windows("Tests fail on Win")
 
 
 def test_link_manifest_entry(tmpdir):

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -9,7 +9,6 @@ where it makes sense.
 """
 import os
 import pathlib
-import sys
 
 import pytest
 
@@ -931,7 +930,7 @@ def test_inclusion_upperbound():
     assert is_specific.intersects(upperbound) and is_range.intersects(upperbound)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_git_version_repo_attached_after_serialization(
     mock_git_version_info, mock_packages, config, monkeypatch
 ):
@@ -951,7 +950,7 @@ def test_git_version_repo_attached_after_serialization(
     assert spack.spec.Spec.from_dict(spec.to_dict()).satisfies("@1.0")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_resolved_git_version_is_shown_in_str(
     mock_git_version_info, mock_packages, config, monkeypatch
 ):

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -13,7 +12,7 @@ from spack.filesystem_view import SimpleFilesystemView, YamlFilesystemView
 from spack.spec import Spec
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_remove_extensions_ordered(install_mockery, mock_fetch, tmpdir):
     view_dir = str(tmpdir.join("view"))
     layout = DirectoryLayout(view_dir)

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,6 @@ markers =
   enable_compiler_verification: enable compiler verification within unit tests
   enable_compiler_link_paths: verifies compiler link paths within unit tests
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
+  only_clingo: mark unit tests that run only with clingo
+  only_original: mark unit tests that are specific to the original concretizer
+  not_on_windows: mark tests that are skipped on Windows


### PR DESCRIPTION
This PR consolidate in one place common logic to skip tests. It also changes all the tests employing that logic accordingly. By using markers we can also list or run tests that e.g. don't run yet on Windows, or need clingo to pass:
```console
$ spack unit-test -m only_clingo 
```

The main modification is here: f0aafd7cf5f81a33fea9197530928055fc63d6a6 All the other changes are just substituting duplicated logic with the markers.

Modifications:
- [x] Add a `only_clingo` marker, to mark tests that run only with clingo
- [x] Add a `only_original` marker, to mark tests that are specific to the original concretizer
- [x] Add a `not_on_windows` marker, to mark tests that are not supported on windows
- [x] Modified test files to use the new markers
