### PR TITLE
Speed-up bootstrap and architecture unit tests

### DIFF
--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -70,11 +70,11 @@ def test_user_input_combination(config, target_str, os_str):
     assert spec.architecture.target == TEST_PLATFORM.target(target_str)
 
 
-def test_default_os_and_target(config):
+def test_default_os_and_target(default_mock_concretization):
     """Test that is we don't specify `os=` or `target=` we get the default values
     after concretization.
     """
-    spec = spack.spec.Spec("libelf").concretized()
+    spec = default_mock_concretization("libelf")
     assert spec.architecture.os == str(TEST_PLATFORM.operating_system("default_os"))
     assert spec.architecture.target == TEST_PLATFORM.target("default_target")
 

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -182,6 +182,7 @@ def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmpdir
     """
     old_create = spack.mirror.create
     monkeypatch.setattr(spack.mirror, "create", lambda p, s: old_create(p, []))
+    monkeypatch.setattr(spack.spec.Spec, "concretized", lambda p: p)
 
     # Create the mirror in a temporary folder
     compilers = [


### PR DESCRIPTION
Trying to speed-up the slowest tests in CI:
- [x] The unit test in `cmd/bootstrap` doesn't need to concretize, since it checks only metadata for the mirror.
- [x] The unit test in `architecture.py` wasn't using the mock repository