### PR TITLE
Show time per phase

### DIFF
--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -252,7 +252,7 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
 
     # The order should be maintained
     phases = [x["name"] for x in times["phases"]]
-    assert phases == ["one", "two", "three", "install"]
+    assert phases == ["stage", "one", "two", "three", "install"]
     assert all(isinstance(x["seconds"], float) for x in times["phases"])
 
 


### PR DESCRIPTION
Instead of

```
Fetch: 1m23s.  Build: 1m23s.  Total: 1m23s
```

Show

```
Stage: 1m23s.  Cmake: 1m23s.  Make: 1m23s.  Install: 1m23s.  Total: 1m23s.
```

I'd like to show something along those lines for install from binary cache, where it's unclear how much time is spent on fetching and relocation.