### PR TITLE
nsimd: Update Python requirements

### DIFF
--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -57,9 +57,13 @@ class Nsimd(CMakePackage):
     # The C++ interface requires a C++11 compiler to use.
     depends_on("cmake@2.8.7:", type="build")
     depends_on("cmake@3.0.2:", type="build", when="@2:")
-    depends_on("python@3:", type="build")
+    # We need `collections.MutableMapping`, which was removed in
+    # Python 3.10; see
+    # <https://docs.python.org/3.9/library/collections.html>
+    depends_on("python@3.0:3.9", type="build")
     depends_on("py-chardet", type="build", when="@3:")
     depends_on("py-requests", type="build", when="@3:")
+    depends_on("py-urllib3", type="build", when="@3:")
 
     @run_before("cmake")
     def generate_code(self):


### PR DESCRIPTION
We need Python 3.0:3.9