### PR TITLE
Alquimia: tweak for building xsdk v0.8.0 with ROCm/HIP

### DIFF
--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -41,7 +41,8 @@ class Alquimia(CMakePackage):
     @when("@1.0.10")
     def patch(self):
         filter_file(
-            "use iso_[cC]_binding", "use, intrinsic :: iso_c_binding",
+            "use iso_[cC]_binding",
+            "use, intrinsic :: iso_c_binding",
             "alquimia/c_f_interface_module.F90",
             "alquimia/alquimia_fortran_interface_mod.F90",
         )

--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -38,6 +38,14 @@ class Alquimia(CMakePackage):
     depends_on("petsc@3.8.0:3.8", when="@xsdk-0.3.0")
     depends_on("petsc@3.10:", when="@develop")
 
+    @when("@1.0.10")
+    def patch(self):
+        filter_file(
+            "use iso_[cC]_binding", "use, intrinsic :: iso_c_binding",
+            "alquimia/c_f_interface_module.F90",
+            "alquimia/alquimia_fortran_interface_mod.F90",
+        )
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
This resolves a building issue similar to #27892 -- the Fortran statement `use iso_c_binding` results in gfortran trying to use `/opt/rocm-x.x.x/llvm/include/iso_c_binding.mod`.