### PR TITLE
fixes for ndzip and sperr

### DIFF
--- a/var/spack/repos/builtin/packages/ndzip/package.py
+++ b/var/spack/repos/builtin/packages/ndzip/package.py
@@ -26,6 +26,8 @@ class Ndzip(CMakePackage, CudaPackage):
     variant("cuda", description="build with cuda support", default=False)
     variant("openmp", description="build with cuda support", default=False)
 
+    depends_on("boost+thread+program_options")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("NDZIP_WITH_CUDA", "cuda"),

--- a/var/spack/repos/builtin/packages/sperr/package.py
+++ b/var/spack/repos/builtin/packages/sperr/package.py
@@ -11,9 +11,10 @@ class Sperr(CMakePackage):
     perform either error-bounded or size-bounded data compression"""
 
     homepage = "https://github.com/NCAR/SPERR"
+    url = "https://github.com/NCAR/SPERR/archive/refs/tags/v0.5.tar.gz"
     git = homepage
 
-    version("2022.07.18", commit="0819c98e143e003fd9a12bce6df054827bfa8136")
+    version("0.5", sha256="20ad48c0e7599d3e5866e024d0c49648eb817f72ad5459f5468122cf14a97171")
 
     depends_on("git", type="build")
     depends_on("zstd", type=("build", "link"), when="+zstd")

--- a/var/spack/repos/builtin/packages/sperr/package.py
+++ b/var/spack/repos/builtin/packages/sperr/package.py
@@ -13,8 +13,7 @@ class Sperr(CMakePackage):
     homepage = "https://github.com/NCAR/SPERR"
     git = homepage
 
-    version("2022.07.18", commit="640305d049db9e9651ebdd773e6936e2c028ff3a")
-    version("2022.05.26", commit="7894a5fe1b5ca5a4aaa952d1779dfc31fd741243")
+    version("2022.07.18", commit="0819c98e143e003fd9a12bce6df054827bfa8136")
 
     depends_on("git", type="build")
     depends_on("zstd", type=("build", "link"), when="+zstd")


### PR DESCRIPTION
Adds a missing dependency for ndzip.  

When we merged sperr we changed from my personal fork to the upstream, and we didn't update the commits.  Unfortunately these commits sha's I used weren't in what was merged from my fork to SPERR's upstream (because squash commits; the shas changed), and we missed this testing after we updated the git url.  Since you couldn't clone either successfully before, I am confident that no one is using this and we can remove the broken one and use the right commit from upstream for the other.