### PR TITLE
Be strict on the markers used in unit tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -144,6 +144,9 @@ jobs:
     - name: Run unit tests
       shell: runuser -u spack-test -- bash {0}
       run: |
+          /usr/libexec/platform-python -m venv platform-python
+          source platform-python/bin/activate
+          pip install -U pip setuptools six pytest 
           source share/spack/setup-env.sh
           spack -d bootstrap now --dev
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -144,9 +144,6 @@ jobs:
     - name: Run unit tests
       shell: runuser -u spack-test -- bash {0}
       run: |
-          /usr/libexec/platform-python -m venv platform-python
-          source platform-python/bin/activate
-          pip install -U pip setuptools six pytest 
           source share/spack/setup-env.sh
           spack -d bootstrap now --dev
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 # content of pytest.ini
 [pytest]
-addopts = --durations=30 -ra
+addopts = --durations=30 -ra --strict-markers
 testpaths = lib/spack/spack/test
 python_files = *.py
 filterwarnings =


### PR DESCRIPTION
This needs a recent `pytest` version and doesn't work with our vendored dependency

Modifications:
- [x] Add `--strict-markers` to options used to run unit tests