### PR TITLE
Get rid of annoying & useless context for exceptions outside PackageBase

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1271,6 +1271,8 @@ def get_package_context(traceback, context=3):
             obj = frame.f_locals["self"]
             if isinstance(obj, spack.package_base.PackageBase):
                 break
+    else:
+        return None
 
     # We found obj, the Package implementation we care about.
     # Point out the location in the install method where we failed.


### PR DESCRIPTION
I don't wanna know how many times I've seen the exception handler highlight these lines:

```
/home/harmen/spack/lib/spack/spack/build_environment.py:1086, in _setup_pkg_and_run:
       1083        tb_string = traceback.format_exc()
       1084
       1085        # build up some context from the offending package so we can
  >>   1086        # show that, too.
       1087        package_context = get_package_context(tb)
       1088
       1089        logfile = None
```

completely wrong and useless :weary: https://github.com/spack/spack/issues?q=is%3Aissue++%22show+that%2C+too.%22

The problem is that the stack is unwinded and its looking for a frame inside PackageBase, assuming it is always there. But this is not true, since exceptions can happen during fetching or post install hooks that have nothing to do with the package.