### PR TITLE
swig: needs zlib

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -56,6 +56,7 @@ class Swig(AutotoolsPackage, SourceforgePackage):
     )
 
     depends_on("pcre")
+    depends_on("zlib")
 
     AUTOCONF_VERSIONS = ["@master", "@fortran", "@4.0.2-fortran", "@4.1.dev1-fortran"]
 


### PR DESCRIPTION
Detected using #28109

```
bin/ccache-swig
        libz.so.1 => not found
```
