### PR TITLE
Fix incorrect timer

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2035,6 +2035,7 @@ class BuildProcessInstaller(object):
                     )
 
                     with log_contextmanager as logger:
+                        # Redirect stdout and stderr to daemon pipe
                         with logger.force_echo():
                             inner_debug_level = tty.debug_level()
                             tty.set_debug(debug_level)
@@ -2042,12 +2043,10 @@ class BuildProcessInstaller(object):
                             tty.msg(msg.format(self.pre, phase_fn.name))
                             tty.set_debug(inner_debug_level)
 
-                        # Redirect stdout and stderr to daemon pipe
-                        self.timer.phase(phase_fn.name)
-
                         # Catch any errors to report to logging
                         phase_fn.execute()
                         spack.hooks.on_phase_success(pkg, phase_fn.name, log_file)
+                        self.timer.phase(phase_fn.name)
 
                 except BaseException:
                     combine_phase_logs(pkg.phase_log_files, pkg.log_path)

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -252,12 +252,8 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
 
     # The order should be maintained
     phases = [x["name"] for x in times["phases"]]
-    total = sum([x["seconds"] for x in times["phases"]])
-    for name in ["one", "two", "three", "install"]:
-        assert name in phases
-
-    # Give a generous difference threshold
-    assert abs(total - times["total"]["seconds"]) < 5
+    assert phases == ["one", "two", "three", "install"]
+    assert all(isinstance(x["seconds"], float) for x in times["phases"])
 
 
 def test_flatten_deps(install_mockery, mock_fetch, mutable_mock_repo):

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -129,3 +129,21 @@ def test_timer_write():
         "phases": [{"name": "timer", "seconds": 1.0}],
         "total": {"seconds": 3.0},
     }
+
+
+def test_null_timer():
+    # Just ensure that the interface of the noop-timer doesn't break at some point
+    buffer = StringIO()
+    t = timer.NullTimer()
+    t.start()
+    t.start("first")
+    t.stop("first")
+    with t.measure("second"):
+        pass
+    t.stop()
+    assert t.duration("first") == 0.0
+    assert t.duration() == 0.0
+    assert not t.phases
+    t.write_json(buffer)
+    t.write_tty(buffer)
+    assert not buffer.getvalue()

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.util.timer as timer
+
+
+class Tick:
+    def __init__(self):
+        self.time = 0.0
+
+    def tick(self):
+        self.time += 1
+        return self.time
+
+
+def test_timer():
+    # Every call to now is +1 second.
+    t = timer.Timer(now=Tick().tick)
+
+    # tick 1
+    t.start()
+    t.start("wrapped")
+
+    # tick 3-4
+    t.start("first")
+    t.stop("first")
+    assert t.duration("first") == 1.0
+
+    # tick 5-6
+    t.start("second")
+    t.stop("second")
+    assert t.duration("second") == 1.0
+
+    # tick 2-7
+    t.stop("wrapped")
+    assert t.duration("wrapped") == 5.0
+
+    # tick 8-11
+    t.start("not-stopped")
+    assert t.duration("not-stopped") == 1.0
+    assert t.duration("not-stopped") == 2.0
+    assert t.duration("not-stopped") == 3.0
+
+    # tick 1-12
+    assert t.duration() == 11.0
+    t.stop()

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -33,16 +33,21 @@ def test_timer():
     t.stop("second")
     assert t.duration("second") == 1.0
 
-    # tick 2-7
-    t.stop("wrapped")
-    assert t.duration("wrapped") == 5.0
+    # tick 7-8
+    with t.measure("third"):
+        pass
+    assert t.duration("third") == 1.0
 
-    # tick 8-11
+    # tick 2-9
+    t.stop("wrapped")
+    assert t.duration("wrapped") == 7.0
+
+    # tick 10-13
     t.start("not-stopped")
     assert t.duration("not-stopped") == 1.0
     assert t.duration("not-stopped") == 2.0
     assert t.duration("not-stopped") == 3.0
 
-    # tick 1-12
-    assert t.duration() == 11.0
+    # tick 1-14
+    assert t.duration() == 13.0
     t.stop()

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.util.timer as timer
-from io import StringIO
 import json
+from io import StringIO
+
+import spack.util.timer as timer
 
 
 class Tick:

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -9,7 +9,7 @@ from io import StringIO
 import spack.util.timer as timer
 
 
-class Tick:
+class Tick(object):
     """Timer that increments the seconds passed by 1
     everytime tick is called."""
 

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -25,46 +25,89 @@ class Timer(object):
     """Simple interval timer"""
 
     def __init__(self, now=time.time):
+        """
+        Arguments:
+            now: function that gives the seconds since e.g. epoch
+        """
         self._now = now
         self._timers = OrderedDict()  # type: OrderedDict[str,Interval]
+
+        # _global is the overal timer since the instance was created
         self._timers["_global"] = Interval(self._now(), end=None)
 
     def start(self, name="_global"):
+        """
+        Start/Restart a named timer, or the global timer when no name is given.
+        Arguments:
+            name (str): Optional name of the timer. When no name is passed, the
+                global timer is started.
+        """
         self._timers[name] = Interval(self._now(), None)
 
     def stop(self, name="_global"):
+        """
+        Stop a named timer, or all timers when no name is given. Stopping a
+        timer that has not started has no effect.
+        Arguments:
+            name (str): Optional name of the timer. When no name is passed, all
+                timers are stopped.
+        """
         interval = self._timers.get(name, None)
         if not interval:
             return
         self._timers[name] = Interval(interval.begin, self._now())
 
     def duration(self, name="_global"):
+        """
+        Get the time in seconds of a named timer, or the total time if no
+        name is passed. The duration is always 0 for timers that have not been
+        started, no error is raised.
+
+        Arguments:
+            name (str): (Optional) name of the timer
+
+        Returns:
+            float: duration of timer.
+        """
         try:
             interval = self._timers[name]
         except KeyError:
             return 0.0
-        end = self._now() if interval.end is None else interval.end
+        # Take either the interval end, the global timer, or now.
+        end = interval.end or self._timers["_global"].end or self._now()
         return end - interval.begin
 
     @contextmanager
     def measure(self, name):
+        """
+        Context manager that allows you to time a block of code.
+
+        Arguments:
+            name (str): Name of the timer
+        """
         begin = self._now()
         yield
         self._timers[name] = Interval(begin, self._now())
 
     @property
     def phases(self):
+        """Get all named timers (excluding the global/total timer)"""
         return [k for k in self._timers.keys() if k != "_global"]
 
     def write_json(self, out=sys.stdout):
-        """
-        Write a json object with times to file
-        """
+        """Write a json object with times to file"""
         phases = [{"name": p, "seconds": self.duration(p)} for p in self.phases]
         times = {"phases": phases, "total": {"seconds": self.duration()}}
         out.write(sjson.dump(times))
 
     def write_tty(self, out=sys.stdout):
-        for p in self.phases:
-            out.write("    {:10s} {:>10s}\n".format(p, pretty_seconds(self.duration(p))))
-        out.write("    {:10s} {:>10s}\n".format("total", pretty_seconds(self.duration())))
+        """Write a human-readable summary of timings"""
+        # Individual timers ordered by registration
+        formatted = [(p, pretty_seconds(self.duration(p))) for p in self.phases]
+
+        # Total time
+        formatted.append(("total", pretty_seconds(self.duration())))
+
+        # Write to out
+        for name, duration in formatted:
+            out.write("    {:10s} {:>10s}\n".format(name, duration))

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -72,7 +72,8 @@ class Timer(object):
 
     def start(self, name=global_timer_name):
         """
-        Start/Restart a named timer, or the global timer when no name is given.
+        Start or restart a named timer, or the global timer when no name is given.
+
         Arguments:
             name (str): Optional name of the timer. When no name is passed, the
                 global timer is started.
@@ -83,6 +84,7 @@ class Timer(object):
         """
         Stop a named timer, or all timers when no name is given. Stopping a
         timer that has not started has no effect.
+
         Arguments:
             name (str): Optional name of the timer. When no name is passed, all
                 timers are stopped.

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from time import sleep
-
 from spack.package import *
 
 
@@ -17,15 +15,12 @@ class DevBuildTestInstallPhases(Package):
     phases = ["one", "two", "three", "install"]
 
     def one(self, spec, prefix):
-        sleep(1)
         print("One locomoco")
 
     def two(self, spec, prefix):
-        sleep(2)
         print("Two locomoco")
 
     def three(self, spec, prefix):
-        sleep(3)
         print("Three locomoco")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Before this PR, the timer for a phase would effectively stop *before* it started.
Effectively all entries in `timers.json` were off by one.

Just moving the `timer.phase(...)` bit after the phase ends is not enough, since
there is no way to start the time as the phase starts; without that we would
include the time spent on fetching etc too. To solve this, we now simply have
a `timer.start("name")` and `timer.stop("name")` API, which is much easier
to follow than the current odd implementation where a `timer.phase("name")`
should be called _after_ completion.

I've also added a context manager so you can do:

```python
with timer.measure("phase"):
  # block
```

But I don't wanna use it cause it's only cluttering the stacktrace and nesting
code unnecessarily.

It would be nice if this was backported, but at the same time it has changed the
timer API.