### PR TITLE
[py-pmw-patched] needs setuptools to build

### DIFF
--- a/var/spack/repos/builtin/packages/py-pmw-patched/package.py
+++ b/var/spack/repos/builtin/packages/py-pmw-patched/package.py
@@ -16,3 +16,6 @@ class PyPmwPatched(PythonPackage):
     git = "https://github.com/schrodinger/pmw-patched"
 
     version("02-10-2020", commit="8bedfc8747e7757c1048bc5e11899d1163717a43")
+
+    # pip silently replaces distutils with setuptools
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Error message:
```
ModuleNotFoundError: No module named 'setuptools'
```