### PR TITLE
[build_system] Fix: python not defined in builder

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -13,7 +13,6 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
-from spack.util.executable import Executable
 
 from ._checks import BaseBuilder, execute_install_time_tests
 
@@ -158,8 +157,7 @@ class SIPBuilder(BaseBuilder):
             ]
         )
 
-        python = Executable(spec["python"].prefix.bin.python)
-        python(configure, *args)
+        self.pkg.python(configure, *args)
 
     def configure_args(self):
         """Arguments to pass to configure."""

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -13,7 +13,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
-from spack.util.executable import *
+from spack.util.executable import Executable
 
 from ._checks import BaseBuilder, execute_install_time_tests
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -13,6 +13,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
+from spack.util.executable import *
 
 from ._checks import BaseBuilder, execute_install_time_tests
 
@@ -157,7 +158,8 @@ class SIPBuilder(BaseBuilder):
             ]
         )
 
-        self.python(configure, *args)
+        python = Executable(spec["python"].prefix.bin.python)
+        python(configure, *args)
 
     def configure_args(self):
         """Arguments to pass to configure."""


### PR DESCRIPTION
`self.python` is never defined in class SIPBuilder. This fixes the issue. I don't believe this is the most elegant solution, so adding @alalazo for review.

This fixes https://github.com/spack/spack/issues/33806