### PR TITLE
spack env depfile in Gitlab CI should use `install-deps/pkg-version-hash` target

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -570,8 +570,6 @@ def ci_rebuild(args):
             "-o",
             "Makefile",
             "--use-buildcache=package:never,dependencies:only",
-            "--make-target-prefix",
-            "ci",
             slash_hash,  # limit to spec we're building
         ],
         [
@@ -588,7 +586,7 @@ def ci_rebuild(args):
             "SPACK_COLOR=always",
             "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
             "-j$(nproc)",
-            "ci/.install-deps/{}".format(job_spec.dag_hash()),
+            "install-deps/{}".format(job_spec.dag_hash()),
         ],
         spack_cmd + ["install"] + root_install_args,
     ]

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -586,7 +586,7 @@ def ci_rebuild(args):
             "SPACK_COLOR=always",
             "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
             "-j$(nproc)",
-            "install-deps/{}".format(job_spec.dag_hash()),
+            "install-deps/{}".format(job_spec.format("{name}-{version}-{hash}")),
         ],
         spack_cmd + ["install"] + root_install_args,
     ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -39,6 +39,7 @@ spack:
         - mpileaks
         - lmod
         - macsio@1.1+scr^scr@2.0.0~fortran^silo~fortran^hdf5~fortran
+        - libtree
       - ['%gcc@7.5.0']
   - gcc_old_packages:
     - zlib%gcc@6.5.0

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -39,7 +39,6 @@ spack:
         - mpileaks
         - lmod
         - macsio@1.1+scr^scr@2.0.0~fortran^silo~fortran^hdf5~fortran
-        - libtree
       - ['%gcc@7.5.0']
   - gcc_old_packages:
     - zlib%gcc@6.5.0


### PR DESCRIPTION
Gitlab CI did not trigger in #33773, so this was missed.