### PR TITLE
conditional variant values: allow boolean

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1026,12 +1026,12 @@ class SpackSolverSetup(object):
                         trigger_id = self.condition(
                             condition_spec,
                             name=pkg.name,
-                            msg="invalid variant value {0}={1}".format(name, value)
+                            msg="invalid variant value {0}={1}".format(name, value),
                         )
                         constraint_id = self.condition(
                             spack.spec.Spec(),
                             name=pkg.name,
-                            msg="empty (total) conflict constraint"
+                            msg="empty (total) conflict constraint",
                         )
                         msg = "variant {0}={1} is conditionally disabled".format(name, value)
                         self.gen.fact(fn.conflict(pkg.name, trigger_id, constraint_id, msg))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1018,18 +1018,33 @@ class SpackSolverSetup(object):
 
             for value in sorted(values):
                 if getattr(value, "when", True) is not True:  # when=True means unconditional
+                    condition_spec = spack.spec.Spec("{0}={1}".format(name, value))
                     if value.when is False:
-                        continue
+                        # This value is a conflict
+                        # Cannot just prevent listing it as a possible value because it could
+                        # also come in as a possible value from the command line
+                        trigger_id = self.condition(
+                            condition_spec,
+                            name=pkg.name,
+                            msg="invalid variant value {0}={1}".format(name, value)
+                        )
+                        constraint_id = self.condition(
+                            spack.spec.Spec(),
+                            name=pkg.name,
+                            msg="empty (total) conflict constraint"
+                        )
+                        msg = "variant {0}={1} is conditionally disabled".format(name, value)
+                        self.gen.fact(fn.conflict(pkg.name, trigger_id, constraint_id, msg))
+                    else:
+                        imposed = spack.spec.Spec(value.when)
+                        imposed.name = pkg.name
 
-                    required = spack.spec.Spec("{0}={1}".format(name, value))
-                    imposed = spack.spec.Spec(value.when)
-                    imposed.name = pkg.name
-                    self.condition(
-                        required_spec=required,
-                        imposed_spec=imposed,
-                        name=pkg.name,
-                        msg="%s variant %s value %s when %s" % (pkg.name, name, value, when),
-                    )
+                        self.condition(
+                            required_spec=condition_spec,
+                            imposed_spec=imposed,
+                            name=pkg.name,
+                            msg="%s variant %s value %s when %s" % (pkg.name, name, value, when),
+                        )
                 self.gen.fact(fn.variant_possible_value(pkg.name, name, value))
 
             if variant.sticky:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1017,8 +1017,10 @@ class SpackSolverSetup(object):
                 values = [variant.default]
 
             for value in sorted(values):
-                self.gen.fact(fn.variant_possible_value(pkg.name, name, value))
-                if hasattr(value, "when"):
+                if getattr(value, "when", True) is not True:  # when=True means unconditional
+                    if value.when is False:
+                        continue
+
                     required = spack.spec.Spec("{0}={1}".format(name, value))
                     imposed = spack.spec.Spec(value.when)
                     imposed.name = pkg.name
@@ -1028,6 +1030,7 @@ class SpackSolverSetup(object):
                         name=pkg.name,
                         msg="%s variant %s value %s when %s" % (pkg.name, name, value, when),
                     )
+                self.gen.fact(fn.variant_possible_value(pkg.name, name, value))
 
             if variant.sticky:
                 self.gen.fact(fn.variant_sticky(pkg.name, name))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1481,21 +1481,25 @@ class TestConcretize(object):
         assert ver("2.7.21") == Spec("python@2.7.21").concretized().version
 
     @pytest.mark.parametrize(
-        "spec_str",
+        "spec_str,valid",
         [
-            "conditional-values-in-variant@1.62.0 cxxstd=17",
-            "conditional-values-in-variant@1.62.0 cxxstd=2a",
-            "conditional-values-in-variant@1.72.0 cxxstd=2a",
+            ("conditional-values-in-variant@1.62.0 cxxstd=17", False),
+            ("conditional-values-in-variant@1.62.0 cxxstd=2a", False),
+            ("conditional-values-in-variant@1.72.0 cxxstd=2a", False),
             # Ensure disjoint set of values work too
-            "conditional-values-in-variant@1.72.0 staging=flexpath",
+            ("conditional-values-in-variant@1.72.0 staging=flexpath", False),
+            # Ensure conditional values set False fail too
+            ("conditional-values-in-variant foo=bar", False),
+            ("conditional-values-in-variant foo=foo", True),
         ],
     )
-    def test_conditional_values_in_variants(self, spec_str):
+    def test_conditional_values_in_variants(self, spec_str, valid):
         if spack.config.get("config:concretizer") == "original":
             pytest.skip("Original concretizer doesn't resolve conditional values in variants")
 
         s = Spec(spec_str)
-        with pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError)):
+        raises = pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError))
+        with (llnl.util.lang.nullcontext() if valid else raises):
             s.concretize()
 
     def test_conditional_values_in_conditional_variant(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1499,7 +1499,7 @@ class TestConcretize(object):
 
         s = Spec(spec_str)
         raises = pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError))
-        with (llnl.util.lang.nullcontext() if valid else raises):
+        with llnl.util.lang.nullcontext() if valid else raises:
             s.concretize()
 
     def test_conditional_values_in_conditional_variant(self):

--- a/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
@@ -38,3 +38,9 @@ class ConditionalValuesInVariant(Package):
         values=any_combination_of(conditional("flexpath", "dataspaces", when="@1.73.0:")),
         description="Enable dataspaces and/or flexpath staging transports",
     )
+
+    variant(
+        "foo", default="foo",
+        values=(conditional("foo", when=True), conditional("bar", when=False)),
+        description="Variant with default condition false"
+    )

--- a/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
@@ -40,7 +40,8 @@ class ConditionalValuesInVariant(Package):
     )
 
     variant(
-        "foo", default="foo",
+        "foo",
+        default="foo",
         values=(conditional("foo", when=True), conditional("bar", when=False)),
-        description="Variant with default condition false"
+        description="Variant with default condition false",
     )


### PR DESCRIPTION
Most when specs in Spack allow either a spec or a boolean value that reflects system configuration.

@bvanessen pointed out on slack that this is not true for conditional variant values. This PR brings conditional variant values into line with the rest of Spack's `when`-clauses.