### PR TITLE
Clean unit-test workflow file

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -49,20 +49,11 @@ jobs:
           # Needed for unit tests
           sudo apt-get -y install \
               coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
-              patchelf cmake bison libbison-dev kcov
+              cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-xdist 
-          # Install pytest-cov only on recent Python, to avoid stalling on Python 2.7 due
-          # to bugs on an unmaintained version of the package when used with xdist.
-          if [[ ${{ matrix.python-version }} != "2.7" ]]; then
-            pip install --upgrade pytest-cov
-          fi
-          # ensure style checks are not skipped in unit tests for python >= 3.6
-          # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
-          if python -c 'import sys; sys.exit(not sys.version_info >= (3, 6))'; then
-              pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click==8.0.4" "black<=21.12b0"
-          fi
+          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-xdist pytest-cov
+          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -75,6 +66,7 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           spack bootstrap disable spack-install
+          spack bootstrap now
           spack -v solve zlib
     - name: Run unit tests
       env:
@@ -158,10 +150,7 @@ jobs:
     - name: Install System packages
       run: |
           sudo apt-get -y update
-          # Needed for unit tests
-          sudo apt-get -y install \
-              coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
-              patchelf kcov
+          sudo apt-get -y install coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build kcov
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools pytest codecov coverage[toml] pytest-cov clingo pytest-xdist


### PR DESCRIPTION
Delete statements related to Python 2.7, and avoid installing patchelf since now we can bootstrap it.