### PR TITLE
Adding NVIDIA HPC SDK 22.11

### DIFF
--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -21,6 +21,20 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    "22.11": {
+        "Linux-aarch64": (
+            "e60e798657c33b06754d33dfd5ab3bea2882d4a9b9476102303edf2bbe3b7a95",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "ef800203cf6040b3a5df24f19944b272f62caee8362875bcb394e86dc1de2353",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "cb91b3a04368457d5cfe3c0e9c0611591fdc8076b01ea977343fe7db7fdcfa3c",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
     "22.9": {
         "Linux-aarch64": (
             "bc4473f04b49bc9a26f08c17a72360650ddf48a3b6eefacdc525d79c8d730f30",

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -24,15 +24,15 @@ _versions = {
     "22.11": {
         "Linux-aarch64": (
             "e60e798657c33b06754d33dfd5ab3bea2882d4a9b9476102303edf2bbe3b7a95",
-            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_aarch64_cuda_multi.tar.gz",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-ppc64le": (
             "ef800203cf6040b3a5df24f19944b272f62caee8362875bcb394e86dc1de2353",
-            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_ppc64le_cuda_multi.tar.gz",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_ppc64le_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
             "cb91b3a04368457d5cfe3c0e9c0611591fdc8076b01ea977343fe7db7fdcfa3c",
-            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_2211_Linux_x86_64_cuda_multi.tar.gz",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "22.9": {


### PR DESCRIPTION
Adding NVIDIA HPC SDK 22.11 (latest release for 2022)

Release Notes: https://docs.nvidia.com/hpc-sdk/hpc-sdk-release-notes/index.html