### PR TITLE
Python: fix bug detection, trying to access self

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -565,7 +565,7 @@ class Python(Package):
                 variants += "~tix"
 
         # Some modules are platform-dependent
-        if not self.spec.satisfies("platform=windows"):
+        if not is_windows:
             try:
                 python("-c", "import crypt", error=os.devnull)
                 variants += "+crypt"


### PR DESCRIPTION
Typo introduced in #33847

We cannot reference `self` in a classmethod.