### PR TITLE
Python: do not set PYTHONHOME during build

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1424,12 +1424,7 @@ config.update(get_paths())
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
-        # If we set PYTHONHOME, we must also ensure that the corresponding
-        # python is found in the build environment. This to prevent cases
-        # where a system provided python is run against the standard libraries
-        # of a Spack built python. See issue #7128
-        env.set("PYTHONHOME", self.home)
-
+        # Ensure the current Python is first in the PATH
         path = os.path.dirname(self.command.path)
         if not is_system_path(path):
             env.prepend_path("PATH", path)


### PR DESCRIPTION
Setting `PYTHONHOME` is rarely needed (since each interpreter has various ways of setting it automatically) and very often it is difficult to get right manually. 

For instance, the change done to set `PYTHONHOME` to `sysconfig["base"]` broke bootstrapping Spack's dev dependencies for me when working inside a virtual environment in Linux. This PR is to just try removing it and check if anything breaks in pipelines.