### PR TITLE
Fix minor issues with Waf build system MultiBuild

### DIFF
--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -73,8 +73,8 @@ class WafBuilder(BaseBuilder):
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = (
         "build_time_test_callbacks",
-        "build_time_test_callbacks",
         "build_directory",
+        "install_time_test_callbacks",
     )
 
     # Callback names for build-time test

--- a/var/spack/repos/builtin/packages/py-py2cairo/package.py
+++ b/var/spack/repos/builtin/packages/py-py2cairo/package.py
@@ -23,8 +23,6 @@ class PyPy2cairo(WafPackage):
 
     depends_on("py-pytest", type="test")
 
-    @run_after("install")
-    @on_package_attributes(run_tests=True)
     def install_test(self):
         with working_dir("test"):
             pytest = which("py.test")


### PR DESCRIPTION
[ Spotted while investigating #33928 ]

* Remove unnecessary duplication in `legacy_methods`

* Fix erroneous duplication of `build_time_test_callbacks` in
  `legacy_attributes`: one of the duplicates should be
  `install_time_test_callbacks`

* Remove now-unnecessary directives around `install_test()` in
  `py-py2cairo` (requires fix to #33928)
