### PR TITLE
Environments: Add support for including definitions files

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -69,6 +69,7 @@ from spack.util.cpus import cpus_available
 SECTION_SCHEMAS = {
     "compilers": spack.schema.compilers.schema,
     "concretizer": spack.schema.concretizer.schema,
+    "definitions": spack.schema.definitions.schema,
     "mirrors": spack.schema.mirrors.schema,
     "repos": spack.schema.repos.schema,
     "packages": spack.schema.packages.schema,
@@ -994,6 +995,7 @@ def read_config_file(filename, schema=None):
                 key = next(iter(data))
                 schema = _ALL_SCHEMAS[key]
             validate(data, schema)
+
         return data
 
     except StopIteration:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1024,7 +1024,8 @@ class Environment:
 
             elif include_url.scheme:
                 raise ValueError(
-                    f"Unsupported URL scheme ({include_url.scheme}) for environment include: {config_path}"
+                    f"Unsupported URL scheme ({include_url.scheme}) for "
+                    f"environment include: {config_path}"
                 )
 
             # treat relative paths as relative to the environment

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -784,9 +784,14 @@ class Environment:
         self._read()
 
     def _read(self):
-        # TODO: This must be done before constructing the state BUT is this
-        #    the right place?
-        prepare_config_scope(self)
+        # If the manifest has included files, then some of the information
+        # (e.g., definitions) MAY be in those files. So we need to ensure
+        # the config is populated with any associated spec lists in order
+        # to fully construct the manifest state.
+        includes = self.manifest[TOP_LEVEL_KEY].get("include", [])
+        if includes:
+            prepare_config_scope(self)
+
         self._construct_state_from_manifest()
 
         if os.path.exists(self.lock_path):
@@ -1019,9 +1024,7 @@ class Environment:
 
             elif include_url.scheme:
                 raise ValueError(
-                    "Unsupported URL scheme ({}) for environment include: {}".format(
-                        include_url.scheme, config_path
-                    )
+                    f"Unsupported URL scheme ({include_url.scheme}) for environment include: {config_path}"
                 )
 
             # treat relative paths as relative to the environment

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -819,9 +819,13 @@ class Environment:
             else:
                 self.spec_lists[name] = user_specs
 
+    def _clear_speclists(self):
+        """Wipe the spec lists clean and initialize 'specs'."""
+        self.spec_lists = {user_speclist_name: SpecList()}
+
     def _construct_state_from_manifest(self):
         """Read manifest file and set up user specs."""
-        self.spec_lists = collections.OrderedDict()
+        self._clear_speclists()
 
         definitions = spack.config.get("definitions", [])
         for item in definitions:
@@ -875,7 +879,7 @@ class Environment:
                 yaml, and need to be maintained when re-reading an existing
                 environment.
         """
-        self.spec_lists = {user_speclist_name: SpecList()}  # specs from yaml
+        self._clear_speclists()
         self.dev_specs = {}  # dev-build specs from yaml
         self.concretized_user_specs = []  # user specs from last concretize
         self.concretized_order = []  # roots of last concretize, in order

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -62,3 +62,25 @@ def _make_validator():
 
 
 Validator = llnl.util.lang.Singleton(_make_validator)
+
+spec_list_schema = {
+    "type": "array",
+    "default": [],
+    "items": {
+        "anyOf": [
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "matrix": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "exclude": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            {"type": "string"},
+            {"type": "null"},
+        ]
+    },
+}

--- a/lib/spack/spack/schema/definitions.py
+++ b/lib/spack/spack/schema/definitions.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for definitions
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/definitions.py
+   :lines: 13-
+"""
+
+import spack.schema
+
+#: Properties for inclusion in other schemas
+properties = {
+    "definitions": {
+        "type": "array",
+        "default": [],
+        "items": {
+            "type": "object",
+            "properties": {"when": {"type": "string"}},
+            "patternProperties": {r"^(?!when$)\w*": spack.schema.spec_list_schema},
+        },
+    }
+}
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Spack definitions configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": properties,
+}

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -12,33 +12,10 @@ from llnl.util.lang import union_dicts
 
 import spack.schema.gitlab_ci  # DEPRECATED
 import spack.schema.merged
-import spack.schema.packages
 import spack.schema.projections
 
 #: Top level key in a manifest file
 TOP_LEVEL_KEY = "spack"
-
-spec_list_schema = {
-    "type": "array",
-    "default": [],
-    "items": {
-        "anyOf": [
-            {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    "matrix": {
-                        "type": "array",
-                        "items": {"type": "array", "items": {"type": "string"}},
-                    },
-                    "exclude": {"type": "array", "items": {"type": "string"}},
-                },
-            },
-            {"type": "string"},
-            {"type": "null"},
-        ]
-    },
-}
 
 projections_scheme = spack.schema.projections.properties["projections"]
 
@@ -75,16 +52,7 @@ schema = {
                             }
                         },
                     },
-                    "definitions": {
-                        "type": "array",
-                        "default": [],
-                        "items": {
-                            "type": "object",
-                            "properties": {"when": {"type": "string"}},
-                            "patternProperties": {r"^(?!when$)\w*": spec_list_schema},
-                        },
-                    },
-                    "specs": spec_list_schema,
+                    "specs": spack.schema.spec_list_schema,
                     "view": {
                         "anyOf": [
                             {"type": "boolean"},

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -17,6 +17,7 @@ import spack.schema.compilers
 import spack.schema.concretizer
 import spack.schema.config
 import spack.schema.container
+import spack.schema.definitions
 import spack.schema.mirrors
 import spack.schema.modules
 import spack.schema.packages
@@ -32,6 +33,7 @@ properties = union_dicts(
     spack.schema.config.properties,
     spack.schema.container.properties,
     spack.schema.ci.properties,
+    spack.schema.definitions.properties,
     spack.schema.mirrors.properties,
     spack.schema.modules.properties,
     spack.schema.packages.properties,

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -93,8 +93,8 @@ class SpecList:
             if (isinstance(s, str) and not s.startswith("$")) and Spec(s) == Spec(spec)
         ]
         if not remove:
-            msg = "Cannot remove %s from SpecList %s\n" % (spec, self.name)
-            msg += "Either %s is not in %s or %s is " % (spec, self.name, spec)
+            msg = f"Cannot remove {spec} from SpecList {self.name}.\n"
+            msg += f"Either {spec} is not in {self.name} or {spec} is "
             msg += "expanded from a matrix and cannot be removed directly."
             raise SpecListError(msg)
 
@@ -133,9 +133,8 @@ class SpecList:
 
         # Make sure the reference is valid
         if name not in self._reference:
-            msg = "SpecList %s refers to " % self.name
-            msg += "named list %s " % name
-            msg += "which does not appear in its reference dict"
+            msg = f"SpecList '{self.name}' refers to named list '{name}'"
+            msg += " which does not appear in its reference dict."
             raise UndefinedReferenceError(msg)
 
         return (name, sigil)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -805,15 +805,18 @@ spack:
     )
 
 
-def test_env_with_included_config_file(tmp_path, environment_from_manifest, packages_file):
+def test_env_with_included_config_file(mutable_mock_env_path, packages_file):
     """Test inclusion of a relative packages configuration file added to an
     existing environment.
     """
+    env_root = mutable_mock_env_path
+    fs.mkdirp(env_root)
     include_filename = "included-config.yaml"
-    included_path = os.path.join(tmp_path, include_filename)
+    included_path = env_root / include_filename
     shutil.move(packages_file.strpath, included_path)
 
-    e = environment_from_manifest(
+    spack_yaml = env_root / ev.manifest_name
+    spack_yaml.write_text(
         f"""\
 spack:
   include:
@@ -823,6 +826,7 @@ spack:
 """
     )
 
+    e = ev.Environment(env_root)
     with e:
         e.concretize()
 
@@ -859,63 +863,63 @@ def test_env_with_included_config_missing_file(tmpdir, mutable_empty_config):
         e = ev.Environment(tmpdir.strpath)
 
 
-def test_env_with_included_config_scope(environment_from_manifest, packages_file):
+def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):
     """Test inclusion of a package file from the environment's configuration
     stage directory. This test is intended to represent a case where a remote
     file has already been staged."""
-    config_scope_path = os.path.join(ev.root("test"), "config")
+    env_root = mutable_mock_env_path
+    config_scope_path = env_root / "config"
 
     # Copy the packages.yaml file to the environment configuration
     # directory, so it is picked up during concretization. (Using
     # copy instead of rename in case the fixture scope changes.)
     fs.mkdirp(config_scope_path)
     include_filename = os.path.basename(packages_file.strpath)
-    included_path = os.path.join(config_scope_path, include_filename)
+    included_path = config_scope_path / include_filename
     fs.copy(packages_file.strpath, included_path)
 
     # Configure the environment to include file(s) from the environment's
     # remote configuration stage directory.
-    e = environment_from_manifest(mpileaks_env_config(config_scope_path))
+    spack_yaml = env_root / ev.manifest_name
+    spack_yaml.write_text(mpileaks_env_config(config_scope_path))
 
     # Ensure the concretized environment reflects contents of the
     # packages.yaml file.
+    e = ev.Environment(env_root)
     with e:
         e.concretize()
 
     assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
 
 
-def test_env_with_included_config_var_path(environment_from_manifest, packages_file):
+def test_env_with_included_config_var_path(tmpdir, packages_file, clean_test_environment):
     """Test inclusion of a package configuration file with path variables
     "staged" in the environment's configuration stage directory."""
-    config_var_path = os.path.join("$tempdir", "included-config.yaml")
-    e = environment_from_manifest(mpileaks_env_config(config_var_path))
+    included_file = packages_file.strpath
+    env_path = pathlib.PosixPath(tmpdir)
+    config_var_path = os.path.join("$tempdir", "included-packages.yaml")
+
+    spack_yaml = env_path / ev.manifest_name
+    spack_yaml.write_text(mpileaks_env_config(config_var_path))
 
     config_real_path = substitute_path_variables(config_var_path)
-    fs.mkdirp(os.path.dirname(config_real_path))
-    shutil.move(packages_file.strpath, config_real_path)
+    shutil.move(included_file, config_real_path)
     assert os.path.exists(config_real_path)
 
+    e = ev.Environment(env_path)
     with e:
-        e.concretize()
+        concretize()
 
     assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
 
 
-def test_env_config_precedence(environment_from_manifest):
-    e = environment_from_manifest(
-        """
-spack:
-  packages:
-    libelf:
-      version: ["0.8.12"]
-  include:
-  - ./included-config.yaml
-  specs:
-  - mpileaks
-"""
-    )
-    with open(os.path.join(e.path, "included-config.yaml"), "w") as f:
+def test_env_with_included_config_precedence(tmp_path):
+    """Test included scope and manifest precedence when including a package
+    configuration file."""
+
+    included_file = "included-packages.yaml"
+    included_path = tmp_path / included_file
+    with open(included_path, "w") as f:
         f.write(
             """\
 packages:
@@ -926,29 +930,50 @@ packages:
 """
         )
 
-    with e:
-        e.concretize()
-
-    # ensure included scope took effect
-    assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
-
-    # ensure env file takes precedence
-    assert any(x.satisfies("libelf@0.8.12") for x in e._get_environment_specs())
-
-
-def test_included_config_precedence(environment_from_manifest):
-    e = environment_from_manifest(
-        """
+    spack_yaml = tmp_path / ev.manifest_name
+    spack_yaml.write_text(
+        f"""\
 spack:
+  packages:
+    libelf:
+      version: ["0.8.12"]
   include:
-  - ./high-config.yaml  # this one should take precedence
-  - ./low-config.yaml
+  - {os.path.join(".", included_file)}
   specs:
   - mpileaks
 """
     )
 
-    with open(os.path.join(e.path, "high-config.yaml"), "w") as f:
+    e = ev.Environment(tmp_path)
+    with e:
+        e.concretize()
+    specs = e._get_environment_specs()
+
+    # ensure included scope took effect
+    assert any(x.satisfies("mpileaks@2.2") for x in specs)
+
+    # ensure env file takes precedence
+    assert any(x.satisfies("libelf@0.8.12") for x in specs)
+
+
+def test_env_with_included_configs_precedence(tmp_path):
+    """Test precendence of multiple included configuration files."""
+    file1 = "high-config.yaml"
+    file2 = "low-config.yaml"
+
+    spack_yaml = tmp_path / ev.manifest_name
+    spack_yaml.write_text(
+        f"""\
+spack:
+  include:
+  - {os.path.join(".", file1)} # this one should take precedence
+  - {os.path.join(".", file2)}
+  specs:
+  - mpileaks
+"""
+    )
+
+    with open(tmp_path / file1, "w") as f:
         f.write(
             """\
 packages:
@@ -957,7 +982,7 @@ packages:
 """
         )
 
-    with open(os.path.join(e.path, "low-config.yaml"), "w") as f:
+    with open(tmp_path / file2, "w") as f:
         f.write(
             """\
 packages:
@@ -968,12 +993,16 @@ packages:
 """
         )
 
+    e = ev.Environment(tmp_path)
     with e:
         e.concretize()
+    specs = e._get_environment_specs()
 
-    assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
+    # ensure included package spec took precedence over manifest spec
+    assert any(x.satisfies("mpileaks@2.2") for x in specs)
 
-    assert any([x.satisfies("libelf@0.8.10") for x in e._get_environment_specs()])
+    # ensure first included package spec took precedence over one from second
+    assert any(x.satisfies("libelf@0.8.10") for x in specs)
 
 
 def test_bad_env_yaml_format(environment_from_manifest):
@@ -1576,11 +1605,10 @@ spack:
         assert Spec("callpath") in test.user_specs
 
 
-def test_stack_yaml_remove_from_list_force(tmpdir):
-    filename = str(tmpdir.join("spack.yaml"))
-    with open(filename, "w") as f:
-        f.write(
-            """\
+def test_stack_yaml_remove_from_list_force(tmp_path):
+    spack_yaml = tmp_path / ev.manifest_name
+    spack_yaml.write_text(
+        """\
 spack:
   definitions:
     - packages: [mpileaks, callpath]
@@ -1589,20 +1617,20 @@ spack:
         - [$packages]
         - [^mpich, ^zmpi]
 """
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            concretize()
-            remove("-f", "-l", "packages", "mpileaks")
-            find_output = find("-c")
+    )
 
-        assert "mpileaks" not in find_output
+    env("create", "test", str(spack_yaml))
+    with ev.read("test"):
+        concretize()
+        remove("-f", "-l", "packages", "mpileaks")
+        find_output = find("-c")
 
-        test = ev.read("test")
-        assert len(test.user_specs) == 2
-        assert Spec("callpath ^zmpi") in test.user_specs
-        assert Spec("callpath ^mpich") in test.user_specs
+    assert "mpileaks" not in find_output
+
+    test = ev.read("test")
+    assert len(test.user_specs) == 2
+    assert Spec("callpath ^zmpi") in test.user_specs
+    assert Spec("callpath ^mpich") in test.user_specs
 
 
 def test_stack_yaml_remove_from_matrix_no_effect(tmpdir):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -729,6 +729,8 @@ spack:
   - no/such/file.yaml
 """
         )
+        with e:
+            e.concretize()
 
     assert ev.active_environment() is None
 
@@ -768,7 +770,6 @@ spack:
 """
     )
 
-    e = ev.read("test")
     with e:
         e.concretize()
 
@@ -892,7 +893,7 @@ def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):
     assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
 
 
-def test_env_with_included_config_var_path(tmpdir, packages_file, clean_test_environment):
+def test_env_with_included_config_var_path(tmpdir, packages_file):
     """Test inclusion of a package configuration file with path variables
     "staged" in the environment's configuration stage directory."""
     included_file = packages_file.strpath

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -31,7 +31,6 @@ import spack.util.spack_json as sjson
 from spack.cmd.env import _env_create
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
-from spack.spec_list import UndefinedReferenceError
 from spack.stage import stage_prefix
 from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
@@ -3475,58 +3474,3 @@ def test_environment_created_from_lockfile_has_view(mock_packages, tmpdir):
     # Make sure the view was created
     with ev.Environment(env_b) as e:
         assert os.path.isdir(e.view_path_default)
-
-
-_test_included_defs = """\
-definitions:
-- core_specs: [libdwarf, libelf]
-- compilers: ['%gcc']
-"""
-
-_test_include_manifest = """\
-spack:
-  include:
-  - ./{0}
-
-  definitions:
-  - my_packages: [zlib]
-
-  specs:
-  - matrix:
-    - [$core_specs]
-    - [$compilers]
-  - $my_packages
-"""
-
-
-def test_env_with_include_defs(tmp_path, mock_packages, config, mutable_mock_env_path):
-    filename = "definitions.yaml"
-    defs_file = tmp_path / filename
-    defs_file.write_text(_test_included_defs)
-
-    manifest_file = tmp_path / ev.manifest_name
-    manifest_file.write_text(_test_include_manifest.format(filename))
-
-    env = ev.Environment(tmp_path)
-    ev.activate(env)
-    env.concretize()
-
-
-_test_included_defs = """\
-definitions:
-- core_specs: [libdwarf, libelf]
-"""
-
-
-def test_env_with_include_defs_missing(tmp_path, mock_packages, config, mutable_mock_env_path):
-    filename = "definitions.yaml"
-    defs_file = tmp_path / filename
-    defs_file.write_text(_test_included_defs)
-
-    manifest_file = tmp_path / ev.manifest_name
-    manifest_file.write_text(_test_include_manifest.format(filename))
-
-    env = ev.Environment(tmp_path)
-    ev.activate(env)
-    with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):
-        env.concretize()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -861,7 +861,7 @@ def test_env_with_included_config_missing_file(tmpdir, mutable_empty_config):
         f.write("spack:\n  include:\n    - {0}\n".format(missing_file.strpath))
 
     with pytest.raises(spack.config.ConfigError, match="missing include path"):
-        e = ev.Environment(tmpdir.strpath)
+        ev.Environment(tmpdir.strpath)
 
 
 def test_env_with_included_config_scope(mutable_mock_env_path, packages_file):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -632,7 +632,7 @@ def test_env_view_external_prefix(tmp_path, mutable_database, mock_packages):
     manifest_dir.mkdir(parents=True, exist_ok=False)
     manifest_file = manifest_dir / ev.manifest_name
     manifest_file.write_text(
-        """
+        """\
 spack:
   specs:
   - a

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -909,7 +909,7 @@ def test_env_with_included_config_var_path(tmpdir, packages_file):
 
     e = ev.Environment(env_path)
     with e:
-        concretize()
+        e.concretize()
 
     assert any(x.satisfies("mpileaks@2.2") for x in e._get_environment_specs())
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1677,7 +1677,7 @@ spack:
     with tmpdir.as_cwd():
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
-            concretize()
+            e.concretize()
 
             before_user = e.user_specs.specs
             before_conc = e.concretized_user_specs

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -18,6 +18,7 @@ from spack.environment.environment import (
     SpackEnvironmentViewError,
     _error_on_nonempty_view_dir,
 )
+from spack.spec_list import UndefinedReferenceError
 
 pytestmark = pytest.mark.not_on_windows("Envs are not supported on windows")
 
@@ -716,3 +717,66 @@ def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
     root = env.matching_spec("parent-foo")
     for node in root.traverse():
         assert node.satisfies("+foo")
+
+
+def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mock_packages):
+    env_path = mutable_mock_env_path
+    env_path.mkdir()
+    defs_file = env_path / "definitions.yaml"
+    defs_file.write_text(
+        """definitions:
+- core_specs: [libdwarf, libelf]
+- compilers: ['%gcc']
+"""
+    )
+
+    spack_yaml = env_path / ev.manifest_name
+    spack_yaml.write_text(
+        """spack:
+  include:
+  - file://{0}
+
+  definitions:
+  - my_packages: [zlib]
+
+  specs:
+  - matrix:
+    - [$core_specs]
+    - [$compilers]
+  - $my_packages
+""".format(
+            defs_file
+        )
+    )
+    e = ev.Environment(env_path)
+    ev.activate(e)
+    e.concretize()
+
+
+def test_env_with_include_def_missing(
+    clean_test_environment, mutable_mock_env_path, mock_packages
+):
+    env_path = mutable_mock_env_path
+    env_path.mkdir()
+    filename = "missing-def.yaml"
+    defs_file = env_path / filename
+    defs_file.write_text("definitions:\n- my_compilers: ['%gcc']\n")
+
+    spack_yaml = env_path / ev.manifest_name
+    spack_yaml.write_text(
+        """spack:
+  include:
+  - file://{0}
+
+  specs:
+  - matrix:
+    - [$core_specs]
+    - [$my_compilers]
+""".format(
+            defs_file
+        )
+    )
+    e = ev.Environment(env_path)
+    ev.activate(e)
+    with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):
+        e.concretize()

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -720,6 +720,7 @@ def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
 
 
 def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mock_packages):
+    """Test environment with included definitions file."""
     env_path = mutable_mock_env_path
     env_path.mkdir()
     defs_file = env_path / "definitions.yaml"
@@ -732,9 +733,9 @@ def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mo
 
     spack_yaml = env_path / ev.manifest_name
     spack_yaml.write_text(
-        """spack:
+        f"""spack:
   include:
-  - file://{0}
+  - file://{defs_file}
 
   definitions:
   - my_packages: [zlib]
@@ -744,10 +745,9 @@ def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mo
     - [$core_specs]
     - [$compilers]
   - $my_packages
-""".format(
-            defs_file
-        )
+"""
     )
+
     e = ev.Environment(env_path)
     ev.activate(e)
     e.concretize()
@@ -756,6 +756,7 @@ def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mo
 def test_env_with_include_def_missing(
     clean_test_environment, mutable_mock_env_path, mock_packages
 ):
+    """Test environment with included definitions file that is missing a definition."""
     env_path = mutable_mock_env_path
     env_path.mkdir()
     filename = "missing-def.yaml"
@@ -764,18 +765,17 @@ def test_env_with_include_def_missing(
 
     spack_yaml = env_path / ev.manifest_name
     spack_yaml.write_text(
-        """spack:
+        f"""spack:
   include:
-  - file://{0}
+  - file://{defs_file}
 
   specs:
   - matrix:
     - [$core_specs]
     - [$my_compilers]
-""".format(
-            defs_file
-        )
+"""
     )
+
     e = ev.Environment(env_path)
     ev.activate(e)
     with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -719,7 +719,7 @@ def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
         assert node.satisfies("+foo")
 
 
-def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mock_packages):
+def test_env_with_include_defs(mutable_mock_env_path, mock_packages):
     """Test environment with included definitions file."""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -749,8 +749,8 @@ def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mo
     )
 
     e = ev.Environment(env_path)
-    ev.activate(e)
-    e.concretize()
+    with e:
+        e.concretize()
 
 
 def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
@@ -775,6 +775,6 @@ def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
     )
 
     e = ev.Environment(env_path)
-    ev.activate(e)
-    with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):
-        e.concretize()
+    with e:
+        with pytest.raises(UndefinedReferenceError, match=r"which does not appear"):
+            e.concretize()

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -753,9 +753,7 @@ def test_env_with_include_defs(clean_test_environment, mutable_mock_env_path, mo
     e.concretize()
 
 
-def test_env_with_include_def_missing(
-    clean_test_environment, mutable_mock_env_path, mock_packages
-):
+def test_env_with_include_def_missing(mutable_mock_env_path, mock_packages):
     """Test environment with included definitions file that is missing a definition."""
     env_path = mutable_mock_env_path
     env_path.mkdir()

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -80,7 +80,17 @@ def test_module_suffixes(module_suffixes_schema):
 @pytest.mark.regression("10246")
 @pytest.mark.parametrize(
     "config_name",
-    ["compilers", "config", "env", "merged", "mirrors", "modules", "packages", "repos"],
+    [
+        "compilers",
+        "config",
+        "definitions",
+        "env",
+        "merged",
+        "mirrors",
+        "modules",
+        "packages",
+        "repos",
+    ],
 )
 def test_schema_validation(meta_schema, config_name):
     import importlib

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -53,14 +53,12 @@ NOMATCH = object()
 
 
 # Substitutions to perform
-def replacements(env_default=None):
+def replacements():
     # break circular imports
     import spack.environment as ev
     import spack.paths
 
     arch = architecture()
-    active_env = ev.active_environment()
-    env_path = active_env.path if active_env else env_default or NOMATCH
 
     return {
         "spack": lambda: spack.paths.prefix,
@@ -75,7 +73,7 @@ def replacements(env_default=None):
         "target": lambda: arch.target,
         "target_family": lambda: arch.target.microarchitecture.family,
         "date": lambda: date.today().strftime("%Y-%m-%d"),
-        "env": lambda: env_path,
+        "env": lambda: ev.active_environment().path if ev.active_environment() else NOMATCH,
     }
 
 
@@ -151,7 +149,7 @@ def substitute_config_variables(path):
 
     Spack allows paths in configs to have some placeholders, as follows:
 
-    - $env               The active Spack environment or env_root.
+    - $env               The active Spack environment.
     - $spack             The Spack instance's prefix
     - $tempdir           Default temporary directory returned by tempfile.gettempdir()
     - $user              The current user's username
@@ -170,7 +168,7 @@ def substitute_config_variables(path):
     replaced if there is an active environment, and should only be used in
     environment yaml files.
     """
-    _replacements = replacements(env_root)
+    _replacements = replacements()
 
     # Look up replacements
     def repl(match):
@@ -185,8 +183,7 @@ def substitute_config_variables(path):
 
 def substitute_path_variables(path):
     """Substitute config vars, expand environment vars, expand user home."""
-    env_root = path if "$env" in path or "${env}" in path else None
-    path = substitute_config_variables(path, env_root=env_root)
+    path = substitute_config_variables(path)
     path = os.path.expandvars(path)
     path = os.path.expanduser(path)
     return path

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1159,19 +1159,19 @@ complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configu
 
 # spack config get
 set -g __fish_spack_optspecs_spack_config_get h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -d 'show this help message and exit'
 
 # spack config blame
 set -g __fish_spack_optspecs_spack_config_blame h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -d 'show this help message and exit'
 
 # spack config edit
 set -g __fish_spack_optspecs_spack_config_edit h/help print-file
-complete -c spack -n '__fish_spack_using_command_pos 0 config edit' -f -a 'bootstrap cdash ci compilers concretizer config mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config edit' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
 complete -c spack -n '__fish_spack_using_command config edit' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config edit' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config edit' -l print-file -f -a print_file


### PR DESCRIPTION
This PR adds support for including separate definitions from `spack.yaml`.

Supporting the inclusion of files with definitions enables user to make curated/standardized collections of packages that can re-used by others.