### PR TITLE
Remove deprecated subcommands from "spack bootstrap"

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -8,7 +8,6 @@ import os.path
 import platform
 import shutil
 import tempfile
-import warnings
 
 import llnl.util.filesystem
 import llnl.util.tty
@@ -112,18 +111,10 @@ def setup_parser(subparser):
     list = sp.add_parser("list", help="list all the sources of software to bootstrap Spack")
     _add_scope_option(list)
 
-    trust = sp.add_parser("trust", help="(DEPRECATED) trust a bootstrapping source")
-    _add_scope_option(trust)
-    trust.add_argument("name", help="name of the source to be trusted")
-
-    untrust = sp.add_parser("untrust", help="(DEPRECATED) untrust a bootstrapping source")
-    _add_scope_option(untrust)
-    untrust.add_argument("name", help="name of the source to be untrusted")
-
     add = sp.add_parser("add", help="add a new source for bootstrapping")
     _add_scope_option(add)
     add.add_argument(
-        "--trust", action="store_true", help="trust the source immediately upon addition"
+        "--trust", action="store_true", help="enable the source immediately upon addition"
     )
     add.add_argument("name", help="name of the new source of software")
     add.add_argument("metadata_dir", help="directory where to find metadata files")
@@ -156,9 +147,9 @@ def _enable_or_disable(args):
         return
 
     if value is True:
-        _trust(args)
+        _enable_source(args)
     else:
-        _untrust(args)
+        _disable_source(args)
 
 
 def _reset(args):
@@ -254,8 +245,14 @@ def _list(args):
         _print_method(s, trusted.get(s["name"], None))
 
 
-def _write_trust_state(args, value):
-    name = args.name
+def _write_bootstrapping_source_status(name, enabled, scope=None):
+    """Write if a bootstrapping source is enable or disabled to config file.
+
+    Args:
+        name (str): name of the bootstrapping source.
+        enabled (bool): True if the source is enabled, False if it is disabled.
+        scope (None or str): configuration scope to modify. If none use the default scope.
+    """
     sources = spack.config.get("bootstrap:sources")
 
     matches = [s for s in sources if s["name"] == name]
@@ -277,30 +274,18 @@ def _write_trust_state(args, value):
 
     # Setting the scope explicitly is needed to not copy over to a new scope
     # the entire default configuration for bootstrap.yaml
-    scope = args.scope or spack.config.default_modify_scope("bootstrap")
-    spack.config.add("bootstrap:trusted:{0}:{1}".format(name, str(value)), scope=scope)
+    scope = scope or spack.config.default_modify_scope("bootstrap")
+    spack.config.add("bootstrap:trusted:{0}:{1}".format(name, str(enabled)), scope=scope)
 
 
-def _deprecate_command(deprecated_cmd, suggested_cmd):
-    msg = (
-        "the 'spack bootstrap {} ...' command is deprecated and will be "
-        "removed in v0.20, use 'spack bootstrap {} ...' instead"
-    )
-    warnings.warn(msg.format(deprecated_cmd, suggested_cmd))
-
-
-def _trust(args):
-    if args.subcommand == "trust":
-        _deprecate_command("trust", "enable")
-    _write_trust_state(args, value=True)
+def _enable_source(args):
+    _write_bootstrapping_source_status(args.name, enabled=True, scope=args.scope)
     msg = '"{0}" is now enabled for bootstrapping'
     llnl.util.tty.msg(msg.format(args.name))
 
 
-def _untrust(args):
-    if args.subcommand == "untrust":
-        _deprecate_command("untrust", "disable")
-    _write_trust_state(args, value=False)
+def _disable_source(args):
+    _write_bootstrapping_source_status(args.name, enabled=False, scope=args.scope)
     msg = '"{0}" is now disabled and will not be used for bootstrapping'
     llnl.util.tty.msg(msg.format(args.name))
 
@@ -364,7 +349,7 @@ def _add(args):
     msg = 'New bootstrapping source "{0}" added in the "{1}" configuration scope'
     llnl.util.tty.msg(msg.format(args.name, write_scope))
     if args.trust:
-        _trust(args)
+        _enable_source(args)
 
 
 def _remove(args):
@@ -465,8 +450,6 @@ def bootstrap(parser, args):
         "reset": _reset,
         "root": _root,
         "list": _list,
-        "trust": _trust,
-        "untrust": _untrust,
         "add": _add,
         "remove": _remove,
         "mirror": _mirror,

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -109,10 +109,8 @@ def test_list_sources(capsys):
     assert "No method available" in output
 
 
-@pytest.mark.parametrize(
-    "command,value", [("enable", True), ("disable", False), ("trust", True), ("untrust", False)]
-)
-def test_trust_or_untrust_sources(mutable_config, command, value):
+@pytest.mark.parametrize("command,value", [("enable", True), ("disable", False)])
+def test_enable_or_disable_sources(mutable_config, command, value):
     key = "bootstrap:trusted:github-actions"
     trusted = spack.config.get(key, default=None)
     assert trusted is None
@@ -122,12 +120,12 @@ def test_trust_or_untrust_sources(mutable_config, command, value):
     assert trusted is value
 
 
-def test_trust_or_untrust_fails_with_no_method(mutable_config):
+def test_enable_or_disable_fails_with_no_method(mutable_config):
     with pytest.raises(RuntimeError, match="no bootstrapping method"):
-        _bootstrap("trust", "foo")
+        _bootstrap("enable", "foo")
 
 
-def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
+def test_enable_or_disable_fails_with_more_than_one_method(mutable_config):
     wrong_config = {
         "sources": [
             {"name": "github-actions", "metadata": "$spack/share/spack/bootstrap/github-actions"},

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -403,7 +403,7 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="now status enable disable reset root list trust untrust add remove mirror"
+        SPACK_COMPREPLY="now status enable disable reset root list add remove mirror"
     fi
 }
 
@@ -448,24 +448,6 @@ _spack_bootstrap_root() {
 
 _spack_bootstrap_list() {
     SPACK_COMPREPLY="-h --help --scope"
-}
-
-_spack_bootstrap_trust() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --scope"
-    else
-        SPACK_COMPREPLY=""
-    fi
-}
-
-_spack_bootstrap_untrust() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --scope"
-    else
-        SPACK_COMPREPLY=""
-    fi
 }
 
 _spack_bootstrap_add() {


### PR DESCRIPTION
These commands are slated for removal in v0.20