### PR TITLE
openblas: Fix build on ARM Neoverse with gcc@:9 (no sve2+bf16)

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -168,6 +168,19 @@ class Openblas(MakefilePackage):
     # See <https://github.com/xianyi/OpenBLAS/issues/3760>
     patch("linktest.patch", when="@0.3.20")
 
+    # Fix build on ARM Neoverse N1 when using gcc@:9. The 1st patch is context for the 2nd patch:
+    patch(
+        "https://github.com/xianyi/OpenBLAS/commit/68277282df4adaafaf9b4a01c2eeb629eed99528.patch?full_index=1",
+        sha256="a4c642fbaeafbf4178558368212594e99c74a7b6c2a119fd0627f7b54f1ebfb3",
+        when="@0.3.21 %gcc@:9",
+    )
+    # gcc@:9 doesn't support sve2 and bf16 architecture features, apply upstream fix:
+    patch(
+        "https://github.com/xianyi/OpenBLAS/commit/c957ad684ed6b8ca64f332221b376f2ad0fdc51a.patch?full_index=1",
+        sha256="c20f5188a9145395c37c22ae5c1f72bfc24edfbccbb636cc8f9227345615daa8",
+        when="@0.3.21 %gcc@:9",
+    )
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     conflicts("%gcc@7.0.0:7.3,8.0.0:8.2", when="@0.3.11:")
 
@@ -223,7 +236,10 @@ class Openblas(MakefilePackage):
         # a f2c translated LAPACK version
         #   https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.21
         if self.compiler.fc is None and "~fortran" not in self.spec:
-            raise InstallError("OpenBLAS requires both C and Fortran compilers!")
+            raise InstallError(
+                self.compiler.cc
+                + " has no Fortran compiler added in spack. Add it or use openblas~fortran!"
+            )
 
     @staticmethod
     def _read_targets(target_file):


### PR DESCRIPTION
Fixes this build failure when building openblas@0.3.21 on a system with an ARM Neoverse CPU from `gcc@:9`:
```yaml
cc1: error: invalid feature modifier 'sve2' in '-march=armv8.5-a+sve+sve2+bf16'
```
- Apply the upstream fix: Do not use `sve2+bf16` when using `gcc@:9` with this version (requires `gcc@10:` or `clang`)

- Also improve the `InstallError` message when using `+fortran` but no `FC` was added.