### PR TITLE
spack external find: library detection improvements

### DIFF
--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -120,6 +120,21 @@ def test_parser_doesnt_deal_with_nonzero_offset():
         elf.parse_elf(elf_at_offset_one)
 
 
+def test_only_header():
+    # When passing only_header=True parsing a file that is literally just a header
+    # without any sections/segments should not error.
+
+    # 32 bit
+    elf_32 = elf.parse_elf(io.BytesIO(b"\x7fELF\x01\x01" + b"\x00" * 46), only_header=True)
+    assert not elf_32.is_64_bit
+    assert elf_32.is_little_endian
+
+    # 64 bit
+    elf_64 = elf.parse_elf(io.BytesIO(b"\x7fELF\x02\x01" + b"\x00" * 58), only_header=True)
+    assert elf_64.is_64_bit
+    assert elf_64.is_little_endian
+
+
 @pytest.mark.requires_executables("gcc")
 @skip_unless_linux
 def test_elf_get_and_replace_rpaths(binary_with_rpaths):

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -377,7 +377,7 @@ def parse_header(f, elf):
     elf.elf_hdr = ElfHeader._make(unpack(elf_header_fmt, data))
 
 
-def _do_parse_elf(f, interpreter=True, dynamic_section=True):
+def _do_parse_elf(f, interpreter=True, dynamic_section=True, only_header=False):
     # We don't (yet?) allow parsing ELF files at a nonzero offset, we just
     # jump to absolute offsets as they are specified in the ELF file.
     if f.tell() != 0:
@@ -385,6 +385,9 @@ def _do_parse_elf(f, interpreter=True, dynamic_section=True):
 
     elf = ElfFile()
     parse_header(f, elf)
+
+    if only_header:
+        return elf
 
     # We don't handle anything but executables and shared libraries now.
     if elf.elf_hdr.e_type not in (ELF_CONSTANTS.ET_EXEC, ELF_CONSTANTS.ET_DYN):
@@ -403,11 +406,11 @@ def _do_parse_elf(f, interpreter=True, dynamic_section=True):
     return elf
 
 
-def parse_elf(f, interpreter=False, dynamic_section=False):
+def parse_elf(f, interpreter=False, dynamic_section=False, only_header=False):
     """Given a file handle f for an ELF file opened in binary mode, return an ElfFile
     object that is stores data about rpaths"""
     try:
-        return _do_parse_elf(f, interpreter, dynamic_section)
+        return _do_parse_elf(f, interpreter, dynamic_section, only_header)
     except (DeprecationWarning, struct.error):
         # According to the docs old versions of Python can throw DeprecationWarning
         # instead of struct.error.


### PR DESCRIPTION
- Ensure that we use the correct env variable per platform
- Dedupe dir paths (e.g. /usr/lib == /lib)
- On ELF platforms ensure that shared libraries are only added when they are host-compatible (checked against current Python interpreter's own EI_CLASS, EI_DATA and e_machine).

The third point is relevant for multi-arch distros, such as Ubuntu, where sometimes i686 directories have higher priority than x86_64. For executables we typically inspect `exe --version` which also ensures host-compatibility, so to me it makes sense if for libraries we verify "is the lib compatible with the Python interpreter we're currently running".

This doesn't deal with static libraries, nor with Darwin.
