### PR TITLE
trnascan-se: adding missing build dep

### DIFF
--- a/var/spack/repos/builtin/packages/trnascan-se/package.py
+++ b/var/spack/repos/builtin/packages/trnascan-se/package.py
@@ -15,6 +15,7 @@ class TrnascanSe(AutotoolsPackage):
     version("2.0.11", sha256="29b74edd0f84ad88139035e119b66397c54a37428e0b61c66a1b3d4733adcd1e")
     version("2.0.0", sha256="0dde1c07142e4bf77b21d53ddf3eeb1ef8c52248005a42323d13f8d7c798100c")
 
+    depends_on("autoconf", type="build")
     depends_on("infernal@1.1:", type="run", when="@2.0.0:")
 
     def patch(self):


### PR DESCRIPTION
This calls autoheader during the build phase. 