### PR TITLE
Experiment: Fix install from buildcache on MacOS using codesign

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -562,6 +562,14 @@ def _replace_prefix_bin(filename, prefix_to_prefix):
         apply_binary_replacements(f, prefix_to_prefix)
 
 
+def macos_codesign(macho_binary):
+    codesign = executable.which("codesign")
+    if codesign:
+        codesign("--force", "--verbose", "--sign", "-", macho_binary)
+    else:
+        tty.warn("codesign tool for signing relocated MacOS binaries not found")
+
+
 def relocate_macho_binaries(
     path_names,
     old_layout_root,
@@ -616,6 +624,7 @@ def relocate_macho_binaries(
             # replace the new paths with relativized paths in the new prefix
             if is_macos:
                 modify_macho_object(path_name, rpaths, deps, idpath, paths_to_paths)
+                macos_codesign(path_name)
             else:
                 modify_object_macholib(path_name, paths_to_paths)
         else:
@@ -628,6 +637,7 @@ def relocate_macho_binaries(
             # replace the old paths with new paths
             if is_macos:
                 modify_macho_object(path_name, rpaths, deps, idpath, paths_to_paths)
+                macos_codesign(path_name)
             else:
                 modify_object_macholib(path_name, paths_to_paths)
 
@@ -755,6 +765,7 @@ def make_macho_binaries_relative(cur_path_names, orig_path_names, old_layout_roo
             orig_path, old_layout_root, rpaths, deps, idpath
         )
         modify_macho_object(cur_path, rpaths, deps, idpath, paths_to_paths)
+        # macos_codesign(path_name) ? - in make_macho_binaries_relative ?
 
 
 def make_elf_binaries_relative(new_binaries, orig_binaries, orig_layout_root):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -179,13 +179,13 @@ class Cmake(Package):
     # a build dependency, and its libs will not interfere with others in
     # the build.
     variant("ownlibs", default=True, description="Use CMake-provided third-party libraries")
-    variant("qt", default=False, description="Enables the build of cmake-gui")
+    variant("qt", default=False, description="Enable the build of cmake-gui")
     variant(
         "doc",
         default=False,
-        description="Enables the generation of html and man page documentation",
+        description="Enable the generation of html and man page documentation",
     )
-    variant("ncurses", default=not is_windows, description="Enables the build of the ncurses gui")
+    variant("ncurses", default=not is_windows, description="Enable the build of the ncurses gui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(


### PR DESCRIPTION
Obsolete - New iteration: #33990

Tries to fix gitlab-ci by using `codesign` after `modify_macho_object` to sign relocated macho binaries.

RFC - Untested:

I have no access to an Apple M1 running Monterey, to be checked by gitlab-ci pipeline `e4s-mac-pr-build`

If this does not fix the gitlab-ci pipeline `e4s-mac-pr-build`, we'll have to disable the buildcache for M1 MacOS.