### PR TITLE
Experiment: On M1 Mac, we need to run codesign after patching binaries

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1554,6 +1554,12 @@ def fix_darwin_install_name(path):
                 # in builddir). We thus only compare the basenames.
                 if os.path.basename(dep) == os.path.basename(loc):
                     install_name_tool("-change", dep, loc, lib)
+                    codesign = Executable("codesign")
+                    if codesign:
+                        print("codesign --verify {0}".format(lib))
+                        codesign("--verify", lib)
+                        print("codesign --sign with --force")
+                        codesign("--force", "--deep", "--sign", "-", lib)
                     break
 
 

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -159,3 +159,17 @@ class Bzip2(Package, SourcewarePackage):
                 force_remove("bunzip2", "bzcat")
                 symlink("bzip2", "bunzip2")
                 symlink("bzip2", "bzcat")
+
+        cmp = which("cmp")
+        print("cmp: {0}".cmp.path)
+        codesign = which("codesign")
+        if codesign:
+            print("codesign --verify {0}".format(cmp.path))
+            codesign("--verify", cmp.path)
+        spctl = which("spctl")
+        if spctl:
+            print("spctl --assess:")
+            spctl("--assess", cmp.path)
+        if codesign:
+            print("codesign --sign with --force:")
+            codesign("--force", "--deep", "--sign", "-", cmp.path)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -179,13 +179,13 @@ class Cmake(Package):
     # a build dependency, and its libs will not interfere with others in
     # the build.
     variant("ownlibs", default=True, description="Use CMake-provided third-party libraries")
-    variant("qt", default=False, description="Enables the build of cmake-gui")
+    variant("qt", default=False, description="Enable the build of cmake-gui")
     variant(
         "doc",
         default=False,
-        description="Enables the generation of html and man page documentation",
+        description="Enable the generation of html and man page documentation",
     )
-    variant("ncurses", default=not is_windows, description="Enables the build of the ncurses gui")
+    variant("ncurses", default=not is_windows, description="Enable the build of the ncurses gui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(


### PR DESCRIPTION
Tries to fix gitlab-ci by using `codesign` after `modify_macho_object` to sign relocated macho binaries.

RFC - Untested:

I have no access to an Apple M1 running Monterey, to be checked by gitlab-ci pipeline `e4s-mac-pr-build`

If this does not fix the gitlab-ci pipeline `e4s-mac-pr-build`, we'll have to disable the buildcache for M1 MacOS.