### PR TITLE
spack find: remove deprecated "--bootstrap" option

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -140,13 +140,6 @@ def setup_parser(subparser):
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")
     subparser.add_argument("--end-date", help="latest date of installation [YYYY-MM-DD]")
-    subparser.add_argument(
-        "-b",
-        "--bootstrap",
-        action="store_true",
-        help="show software in the internal bootstrap store",
-    )
-
     arguments.add_common_arguments(subparser, ["constraint"])
 
 
@@ -251,23 +244,6 @@ def display_env(env, args, decorator, results):
 
 
 def find(parser, args):
-    if args.bootstrap:
-        tty.warn(
-            "`spack find --bootstrap` is deprecated and will be removed in v0.19.",
-            "Use `spack --bootstrap find` instead.",
-        )
-
-    if args.bootstrap:
-        bootstrap_store_path = spack.bootstrap.store_path()
-        with spack.bootstrap.ensure_bootstrap_configuration():
-            msg = 'Showing internal bootstrap store at "{0}"'
-            tty.msg(msg.format(bootstrap_store_path))
-            _find(parser, args)
-        return
-    _find(parser, args)
-
-
-def _find(parser, args):
     q_args = query_arguments(args)
     results = args.specs(**q_args)
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -373,8 +373,3 @@ def test_find_loaded(database, working_env):
     output = find("--loaded")
     expected = find()
     assert output == expected
-
-
-def test_bootstrap_deprecated():
-    output = find("--bootstrap")
-    assert "`spack find --bootstrap` is deprecated" in output

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1047,7 +1047,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date -b --bootstrap"
+        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
     else
         _installed_packages
     fi


### PR DESCRIPTION
The option was slated for removal in v0.19 but will be removed in v0.20 :slightly_smiling_face: 