### PR TITLE
py-torch: add note about MPS variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -66,7 +66,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     variant(
         "mps",
         default=is_darwin and macos_version() >= Version("12.3"),
-        description="Use MPS for macOS build",
+        description="Use MPS for macOS build (requires full Xcode suite)",
         when="@1.12: platform=darwin",
     )
     variant("nccl", default=True, description="Use NCCL", when="+cuda platform=linux")


### PR DESCRIPTION
The Xcode command line tools are not sufficient to build with MPS support, the full Xcode suite is required. We don't currently have a way to test for this in the spec syntax, so the best we can do is add a note.