### PR TITLE
berkeleygw: Fix build (no change to attribute spec.compiler_flags)

### DIFF
--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -121,9 +121,12 @@ class Berkeleygw(MakefilePackage):
         if "+mpi" in spec:
             paraflags.append("-DMPI")
 
+        # We need to copy fflags in case we append to it (#34019):
+        fflags = spec.compiler_flags["fflags"][:]
         if "+openmp" in spec:
             paraflags.append("-DOMP")
             spec.compiler_flags["fflags"].append(self.compiler.openmp_flag)
+            fflags.append(self.compiler.openmp_flag)
 
         buildopts.append("C_PARAFLAG=-DPARA")
         buildopts.append("PARAFLAG=%s" % " ".join(paraflags))
@@ -138,7 +141,7 @@ class Berkeleygw(MakefilePackage):
         buildopts.append("LINK=%s" % spec["mpi"].mpifc)
         buildopts.append("C_LINK=%s" % spec["mpi"].mpicxx)
 
-        buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
+        buildopts.append("FOPTS=%s" % " ".join(fflags))
         buildopts.append("C_OPTS=%s" % " ".join(spec.compiler_flags["cflags"]))
 
         mathflags = []
@@ -163,7 +166,7 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("CC_COMP=%s" % spec["mpi"].mpicxx)
             buildopts.append("BLACSDIR=%s" % spec["scalapack"].libs)
             buildopts.append("BLACS=%s" % spec["scalapack"].libs.ld_flags)
-            buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
+            buildopts.append("FOPTS=%s" % " ".join(fflags))
         elif spec.satisfies("%gcc"):
             c_flags = "-std=c99"
             cxx_flags = "-std=c++0x"
@@ -178,7 +181,7 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("FCPP=cpp -C -nostdinc")
             buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
             buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
-            buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
+            buildopts.append("FOPTS=%s" % " ".join(fflags))
         elif spec.satisfies("%fj"):
             c_flags = "-std=c99"
             cxx_flags = "-std=c++0x"
@@ -189,9 +192,7 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("FCPP=cpp -C -nostdinc")
             buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
             buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
-            buildopts.append(
-                "FOPTS=-Kfast -Knotemparraystack %s" % " ".join(spec.compiler_flags["fflags"])
-            )
+            buildopts.append("FOPTS=-Kfast -Knotemparraystack %s" % " ".join(fflags))
         else:
             raise InstallError(
                 "Spack does not yet have support for building "

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -125,7 +125,6 @@ class Berkeleygw(MakefilePackage):
         fflags = spec.compiler_flags["fflags"][:]
         if "+openmp" in spec:
             paraflags.append("-DOMP")
-            spec.compiler_flags["fflags"].append(self.compiler.openmp_flag)
             fflags.append(self.compiler.openmp_flag)
 
         buildopts.append("C_PARAFLAG=-DPARA")


### PR DESCRIPTION
**Summary:** This fixes the build of `berkeleygw`:

`spec.compiler_flags["fflags"].append(...)` in `berkeleygw` caused is (triggered by #29761 - Enable/Disable Propagation for Compiler Flags & Variants which added propagation):
``` py
AttributeError: 'str' object has no attribute 'propagate'
```