### PR TITLE
Add Hugo v0.106.0

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -16,6 +16,9 @@ class Hugo(Package):
 
     executables = ["^hugo$"]
 
+    maintainers = ["alecbcs"]
+
+    version("0.106.0", sha256="9219434beb51466487b9f8518edcbc671027c1998e5a5820d76d517e1dfbd96a")
     version("0.74.3", sha256="9b296fa0396c20956fa6a1f7afadaa78739af62c277b6c0cfae79a91b0fe823f")
     version("0.68.3", sha256="38e743605e45e3aafd9563feb9e78477e72d79535ce83b56b243ff991d3a2b6e")
     version("0.53", sha256="48e65a33d3b10527101d13c354538379d9df698e5c38f60f4660386f4232e65c")
@@ -23,6 +26,7 @@ class Hugo(Package):
     # Uses go modules.
     # See https://gohugo.io/getting-started/installing/#fetch-from-github
     depends_on("go@1.11:", when="@0.48:", type="build")
+    depends_on("go@1.18:", when="@0.106:", type="build")
 
     variant("extended", default=False, description="Enable extended features")
 
@@ -40,7 +44,6 @@ class Hugo(Package):
         if self.spec.satisfies("+extended"):
             go_args.extend(["--tags", "extended"])
 
-        go = which("go")
         go(*go_args)
-        mkdir(prefix.bin)
+        mkdirp(prefix.bin)
         install("hugo", prefix.bin)


### PR DESCRIPTION
Add Hugo v0.106.0 which includes multiple bug fixes and dependency updates.

**Summarized Changelog:**
- Fix taxonomy weight sort regression.
- tlp/resources: resources.Get returns nil when given empty string.
- tpl/internal: Sync go_templates.

Full changelog for v0.106.0 can be found [here](https://github.com/gohugoio/hugo/releases/tag/v0.106.0).

**Test Plan:**
Tested v0.106.0 by building locally and compiling an example site.