### PR TITLE
rocm: add minimum versions for amdgpu_targets

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -159,6 +159,29 @@ class ROCmPackage(PackageBase):
     # depends_on('hip@:6.0', when='amdgpu_target=gfx701')
     # to indicate minimum version for each architecture.
 
+    # Add compiler minimum versions based on the first release where the
+    # processor is included in llvm/lib/Support/TargetParser.cpp
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx900:xnack-")
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx906:xnack-")
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx908:xnack-")
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx90c")
+    depends_on("llvm-amdgpu@4.3.0:", when="amdgpu_target=gfx90a")
+    depends_on("llvm-amdgpu@4.3.0:", when="amdgpu_target=gfx90a:xnack-")
+    depends_on("llvm-amdgpu@4.3.0:", when="amdgpu_target=gfx90a:xnack+")
+    depends_on("llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx940")
+    depends_on("llvm-amdgpu@4.5.0:", when="amdgpu_target=gfx1013")
+    depends_on("llvm-amdgpu@3.8.0:", when="amdgpu_target=gfx1030")
+    depends_on("llvm-amdgpu@3.9.0:", when="amdgpu_target=gfx1031")
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx1032")
+    depends_on("llvm-amdgpu@4.1.0:", when="amdgpu_target=gfx1033")
+    depends_on("llvm-amdgpu@4.3.0:", when="amdgpu_target=gfx1034")
+    depends_on("llvm-amdgpu@4.5.0:", when="amdgpu_target=gfx1035")
+    depends_on("llvm-amdgpu@5.2.0:", when="amdgpu_target=gfx1036")
+    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1100")
+    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1101")
+    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1102")
+    depends_on("llvm-amdgpu@5.3.0:", when="amdgpu_target=gfx1103")
+
     # Compiler conflicts
 
     # TODO: add conflicts statements along the lines of


### PR DESCRIPTION
This change adds the compiler minimum versions for various architectures. In theory, the runtime minimum version might be different.

The values were determined by examining https://github.com/RadeonOpenCompute/llvm-project/blob/rocm-5.3.3/llvm/lib/Support/TargetParser.cpp#L64-L123 and comparing against earlier versions of the same file.