### PR TITLE
gmake: build from build.sh, add dependency to autotools/makefile packages

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -43,6 +43,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
     build_system("autotools")
 
     with when("build_system=autotools"):
+        depends_on("gmake", type="build")
         depends_on("gnuconfig", type="build", when="target=ppc64le:")
         depends_on("gnuconfig", type="build", when="target=aarch64:")
         depends_on("gnuconfig", type="build", when="target=riscv64:")

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -9,7 +9,7 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
-from spack.directives import build_system, conflicts
+from spack.directives import build_system, conflicts, depends_on
 
 from ._checks import (
     BaseBuilder,
@@ -29,6 +29,7 @@ class MakefilePackage(spack.package_base.PackageBase):
     legacy_buildsystem = "makefile"
 
     build_system("makefile")
+    depends_on("gmake", type="build")
     conflicts("platform=windows", when="build_system=makefile")
 
 

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -10,6 +10,7 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on
+from spack.multimethod import when
 
 from ._checks import (
     BaseBuilder,
@@ -29,8 +30,10 @@ class MakefilePackage(spack.package_base.PackageBase):
     legacy_buildsystem = "makefile"
 
     build_system("makefile")
-    depends_on("gmake", type="build")
-    conflicts("platform=windows", when="build_system=makefile")
+
+    with when("build_system=makefile"):
+        depends_on("gmake", type="build")
+        conflicts("platform=windows")
 
 
 @spack.builder.builder("makefile")

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -218,7 +218,7 @@ def test_concretize_target_ranges(root_target_range, dep_target_range, result, m
     with spack.concretize.disable_compiler_existence_check():
         spec.concretize()
 
-    assert str(spec).count("arch=test-debian6-%s" % result) == 2
+    assert spec.target == spec.dependencies("b")[0].target == result
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -21,7 +21,10 @@ env = SpackCommand("env")
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
+    # TODO: ensure that "keep stage" only applies to dev-build spec, so we can get rid
+    # of @pytest.mark.disable_clean_stage_check.
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
 
@@ -40,6 +43,7 @@ def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_before(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -57,6 +61,7 @@ def test_dev_build_before(tmpdir, mock_packages, install_mockery):
     assert not os.path.exists(spec.prefix)
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -75,6 +80,7 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     assert not spack.store.db.query(spec, installed=True)
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
     # Test that we ignore the last_phase argument if it is already last
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
@@ -95,6 +101,7 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery, capsys):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -133,6 +140,7 @@ def mock_module_noop(*args):
     pass
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, working_env):
     monkeypatch.setattr(os, "execvp", print_spack_cc)
 
@@ -143,6 +151,7 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, 
         assert "lib/spack/env" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_already_installed(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -156,21 +165,25 @@ def test_dev_build_fails_already_installed(tmpdir, mock_packages, install_mocker
         assert "Already installed in %s" % spec.prefix in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_no_spec():
     output = dev_build(fail_on_error=False)
     assert "requires a package spec argument" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_multiple_specs(mock_packages):
     output = dev_build("libelf", "libdwarf", fail_on_error=False)
     assert "only takes one spec" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_nonexistent_package_name(mock_packages):
     output = dev_build("no_such_package", fail_on_error=False)
     assert "No package for 'no_such_package' was found" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_no_version(mock_packages):
     output = dev_build("dev-build-test-install", fail_on_error=False)
     assert "dev-build spec must have a single, concrete version" in output

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -660,13 +660,12 @@ def test_check_deps_status_external(install_mockery, monkeypatch):
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
-    # Mock the known dependent, b, as external so assumed to be installed
+    # Mock the known dependencies as external so assumed to be installed
     monkeypatch.setattr(spack.spec.Spec, "external", True)
     installer._check_deps_status(request)
 
-    # exotic architectures will add dependencies on gnuconfig, which we want to ignore
-    installed = [x for x in installer.installed if not x.startswith("gnuconfig")]
-    assert installed[0].startswith("b")
+    for s in request.spec.traverse(root=False):
+        assert inst.package_id(s.package) in installer.installed
 
 
 def test_check_deps_status_upstream(install_mockery, monkeypatch):
@@ -674,13 +673,12 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
-    # Mock the known dependent, b, as installed upstream
+    # Mock the known dependencies as installed upstream
     monkeypatch.setattr(spack.spec.Spec, "installed_upstream", True)
     installer._check_deps_status(request)
 
-    # exotic architectures will add dependencies on gnuconfig, which we want to ignore
-    installed = [x for x in installer.installed if not x.startswith("gnuconfig")]
-    assert installed[0].startswith("b")
+    for s in request.spec.traverse(root=False):
+        assert inst.package_id(s.package) in installer.installed
 
 
 def test_add_bootstrap_compilers(install_mockery, monkeypatch):

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -341,7 +341,9 @@ set LIST_CONTENT (spack -m load b; spack load --list)
 spt_contains "b@" echo $LIST_CONTENT
 spt_does_not_contain "a@" echo $LIST_CONTENT
 # test a variable MacOS clears and one it doesn't for recursive loads
-spt_contains "set -gx PATH $_a_bin:$_b_bin" spack -m load --fish a
+set LOAD_CONTENT (spack -m load --fish a | awk '/set -gx PATH/')
+spt_contains "$_a_bin" printf "$LOAD_CONTENT"
+spt_contains "$_b_bin" printf "$LOAD_CONTENT"
 spt_succeeds spack -m load --only dependencies a
 spt_succeeds spack -m load --only package a
 spt_fails spack -m load d

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -111,7 +111,9 @@ contains "b@" echo $LIST_CONTENT
 does_not_contain "a@" echo $LIST_CONTENT
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
-contains "export PATH=$(spack -m location -i a)/bin:$(spack -m location -i b)/bin" spack -m load --sh a
+LOAD_CONTENT=`spack -m load --sh a | awk '/^export PATH=/'`
+contains "$(spack -m location -i a)/bin" printf "$LOAD_CONTENT"
+contains "$(spack -m location -i b)/bin" printf "$LOAD_CONTENT"
 succeeds spack -m load --only dependencies a
 succeeds spack -m load --only package a
 fails spack -m load d

--- a/var/spack/repos/builder.test/packages/gmake/package.py
+++ b/var/spack/repos/builder.test/packages/gmake/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gmake(Package):
+    """Gmake package"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/gmake-1.0.tar.gz"
+    has_code = False
+
+    version("1.0")

--- a/var/spack/repos/builtin.mock/packages/gmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/gmake/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gmake(Package):
+    """Gmake package"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/gmake-1.0.tar.gz"
+    has_code = False
+
+    version("1.0")

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -6,7 +6,7 @@
 import os
 import re
 
-from spack.build_environment import MakeExecutable
+from spack.build_environment import MakeExecutable, determine_number_of_jobs
 from spack.package import *
 
 
@@ -84,8 +84,12 @@ class Gmake(Package, GNUMirrorPackage):
         return match.group(1) if match else None
 
     def setup_dependent_package(self, module, dspec):
-        module.make = MakeExecutable(self.spec.prefix.bin.make, make_jobs)
-        module.gmake = MakeExecutable(self.spec.prefix.bin.gmake, make_jobs)
+        module.make = MakeExecutable(
+            self.spec.prefix.bin.make, determine_number_of_jobs(parallel=dspec.package.parallel)
+        )
+        module.gmake = MakeExecutable(
+            self.spec.prefix.bin.gmake, determine_number_of_jobs(parallel=dspec.package.parallel)
+        )
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -10,13 +10,24 @@ from spack.build_environment import MakeExecutable
 from spack.package import *
 
 
-class Gmake(AutotoolsPackage, GNUMirrorPackage):
+class Gmake(Package, GNUMirrorPackage):
     """GNU Make is a tool which controls the generation of executables and
     other non-source files of a program from the program's source files."""
 
     homepage = "https://www.gnu.org/software/make/"
     gnu_mirror_path = "make/make-4.2.1.tar.gz"
     maintainers = ["haampie"]
+
+    # We want to use the Autotools build system because of all the things it
+    # does when it comes to patching configure / config.sub / config.guess etc.
+    # But we don't want to inherit from AutotoolsPackage, because it adds a build
+    # dependency on gmake.
+    build_system("autotools")
+
+    depends_on("gnuconfig", type="build", when="target=ppc64le:")
+    depends_on("gnuconfig", type="build", when="target=aarch64:")
+    depends_on("gnuconfig", type="build", when="target=riscv64:")
+    conflicts("platform=windows")
 
     # Alpha releases
     version(

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -3,7 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_environment import MakeExecutable, determine_number_of_jobs
 from spack.package import *
+from spack.util.executable import which_string
 
 
 class NinjaFortran(Package):
@@ -92,6 +94,6 @@ class NinjaFortran(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=self.parallel),
+            determine_number_of_jobs(parallel=dspec.package.parallel),
             supports_jobserver=True,  # This fork supports jobserver
         )

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -79,6 +79,6 @@ class Ninja(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=self.parallel),
+            determine_number_of_jobs(parallel=dspec.package.parallel),
             supports_jobserver=self.spec.version == ver("kitware"),
         )


### PR DESCRIPTION
- gmake: allow build w/o gmake
- gmake: build dep in MakefilePackage and AutotoolsPackage
- fix tests

Apart from that we can think of making CMakePackage use generator=make/ninja so
that the relevant build deps can be added.


(addresses an 8 year old TODO: [`203fd86`](https://github.com/spack/spack/commit/203fd861aa1ab3d29477fa9954717ad46890801f#diff-a493ca2ca45c40f1a67e6ef60fe57654cb2077e3d20b50ceee9b85d0ec16c8e3R174))
