### PR TITLE
Update ecflow packages with changes from JCSDA-EMC fork

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -19,24 +19,46 @@ class Ecflow(CMakePackage):
     homepage = "https://confluence.ecmwf.int/display/ECFLOW/"
     url = "https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-4.11.1-Source.tar.gz"
 
+    maintainers = ["climbfuji"]
+
+    # https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.3-Source.tar.gz?api=v2
+    version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")
     version("4.13.0", sha256="c743896e0ec1d705edd2abf2ee5a47f4b6f7b1818d8c159b521bdff50a403e39")
     version("4.12.0", sha256="566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1")
     version("4.11.1", sha256="b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c")
 
-    variant(
-        "static_boost", default=False, description="Use also static boost libraries when compiling"
-    )
-
+    variant("ssl", default=True,
+            description="Enable SSL")
+    variant("static_boost", default=False,
+            description="Use also static boost libraries when compiling")
     variant("ui", default=False, description="Enable ecflow_ui")
 
-    # Boost-1.7X release not working well on serialization
-    depends_on("boost@1.53:1.69+python")
-    depends_on("boost@1.53:1.69+pic", when="+static_boost")
+    extends("python")
 
+    depends_on("python@3:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy", type="build")
+    depends_on("py-pip", type="build")
+
+    # v4: Boost-1.7X release not working well on serialization
+    depends_on("boost@1.53:1.69+python", when="@:4")
+    depends_on("boost@1.53:1.69+pic", when="@:4 +static_boost")
     # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
+    # for instance depends_on("boost +filesystem")
     # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on(Boost.with_default_variants, when="@:4")
+
+    # Use newer boost with v5
+    depends_on(
+        "boost@1.72:+chrono+date_time+exception+filesystem+program_options+python+regex+serialization+system+test+thread+timer",  # noqa
+        when="@5:"
+    )
+    depends_on(
+        "boost@1.72:+chrono+date_time+exception+filesystem+program_options+python+regex+serialization+system+test+thread+timer+pic",  # noqa
+        when="@5: +static_boost"
+    )
+
+    depends_on("openssl@1:", when="@5:")
     depends_on("qt@5:", when="+ui")
     depends_on("cmake@2.12.11:", type="build")
 
@@ -44,10 +66,13 @@ class Ecflow(CMakePackage):
         boost_lib = self.spec["boost"].prefix.lib
         args = ["-DBoost_PYTHON_LIBRARY_RELEASE=" + boost_lib]
 
-        ecflow_ui = "ON" if "+ui" in self.spec else "OFF"
         # https://jira.ecmwf.int/browse/SUP-2641#comment-208943
         use_static_boost = "ON" if "+static_boost" in self.spec else "OFF"
         args.append("-DENABLE_STATIC_BOOST_LIBS=" + use_static_boost)
 
+        ssl = "ON" if "+ssl" in self.spec else "OFF"
+        args.append("-DENABLE_SSL=" + ssl)
+
+        ecflow_ui = "ON" if "+ui" in self.spec else "OFF"
         args.extend(["-DENABLE_UI=" + ecflow_ui, "-DENABLE_GUI=" + ecflow_ui])
         return args

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -27,10 +27,10 @@ class Ecflow(CMakePackage):
     version("4.12.0", sha256="566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1")
     version("4.11.1", sha256="b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c")
 
-    variant("ssl", default=True,
-            description="Enable SSL")
-    variant("static_boost", default=False,
-            description="Use also static boost libraries when compiling")
+    variant("ssl", default=True, description="Enable SSL")
+    variant(
+        "static_boost", default=False, description="Use also static boost libraries when compiling"
+    )
     variant("ui", default=False, description="Enable ecflow_ui")
 
     extends("python")
@@ -51,11 +51,11 @@ class Ecflow(CMakePackage):
     # Use newer boost with v5
     depends_on(
         "boost@1.72:+chrono+date_time+exception+filesystem+program_options+python+regex+serialization+system+test+thread+timer",  # noqa
-        when="@5:"
+        when="@5:",
     )
     depends_on(
         "boost@1.72:+chrono+date_time+exception+filesystem+program_options+python+regex+serialization+system+test+thread+timer+pic",  # noqa
-        when="@5: +static_boost"
+        when="@5: +static_boost",
     )
 
     depends_on("openssl@1:", when="@5:")


### PR DESCRIPTION
## Description

Update ecflow packages with changes from JCSDA-EMC fork. Add version 5.8.3, which requires a newer version of boost. Require Python3 to make maintenance of this package easier.

## Testing

We install this version regularly in our CI builds on Ubuntu 20.04 with gnu and intel, and on macOS with gnu and clang.