### PR TITLE
Speed-up a few unit-tests

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -954,7 +954,7 @@ def test_ci_rebuild_mock_success(
             assert "Cannot copy test logs" in out
 
 
-@pytest.mark.xfail(reason="fails intermittently and covered by gitlab ci")
+@pytest.mark.skip(reason="fails intermittently and covered by gitlab ci")
 def test_ci_rebuild(
     tmpdir,
     working_env,

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -33,7 +33,7 @@ def test_listing_possible_os():
 def test_bootstrap_phase(minimal_configuration, config_dumper, capsys):
     minimal_configuration["spack"]["container"]["images"] = {
         "os": "amazonlinux:2",
-        "spack": {"resolve_sha": True},
+        "spack": {"resolve_sha": False},
     }
     spack_yaml_dir = config_dumper(minimal_configuration)
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -43,7 +43,7 @@ def test_test_log_pathname(mock_packages, config):
     assert test_suite.test_log_name(spec) in logfile
 
 
-def test_test_ensure_stage(mock_test_stage):
+def test_test_ensure_stage(mock_test_stage, mock_packages):
     """Make sure test stage directory is properly set up."""
     spec = spack.spec.Spec("libdwarf").concretized()
 


### PR DESCRIPTION
Modifications:
- [x] `test_suite.py` now uses mock packages instead of the builtin repository
- [x] `container/cli.py` is not resolving `sha` (which is cloning spack)
- [x] A long running test in `cmd/ci.py` that is marked `xfail` is now marked `skip`