### PR TITLE
libjpeg-turbo: build_system settings should be comprehensive

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -48,7 +48,7 @@ class LibjpegTurbo(CMakePackage, AutotoolsPackage):
     provides("jpeg")
 
     build_system(
-        conditional("autotools", when="@1.3.1:1.5.3"),
+        conditional("autotools", when="@:1.5.3"),
         conditional("cmake", when="@1.5.90:"),
         default="cmake",
     )


### PR DESCRIPTION
The covered version range for `build_system` should be comprehensive
rather than simply "known versions." Otherwise, externals declared in
`packages.yaml` with non-checksummed versions will cause perplexing
concretization errors.

