### PR TITLE
Build System docs: consistent headers

### DIFF
--- a/lib/spack/docs/build_systems/cachedcmakepackage.rst
+++ b/lib/spack/docs/build_systems/cachedcmakepackage.rst
@@ -5,9 +5,9 @@
 
 .. _cachedcmakepackage:
 
-------------------
-CachedCMakePackage
-------------------
+-----------
+CachedCMake
+-----------
 
 The CachedCMakePackage base class is used for CMake-based workflows
 that create a CMake cache file prior to running ``cmake``. This is

--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -5,9 +5,9 @@
 
 .. _cudapackage:
 
------------
-CudaPackage
------------
+----
+Cuda
+----
 
 Different from other packages, ``CudaPackage`` does not represent a build system.
 Instead its goal is to simplify and unify usage of ``CUDA`` in other packages by providing a `mixin-class <https://en.wikipedia.org/wiki/Mixin>`_.
@@ -80,7 +80,7 @@ standard CUDA compiler flags.
 
 **cuda_flags**
 
-    This built-in static method returns a list of command line flags 
+    This built-in static method returns a list of command line flags
     for the chosen ``cuda_arch`` value(s).  The flags are intended to
     be passed to the CUDA compiler driver (i.e., ``nvcc``).
 

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -6,9 +6,9 @@
 .. _inteloneapipackage:
 
 
-====================
- IntelOneapiPackage
-====================
+===========
+IntelOneapi
+===========
 
 
 .. contents::
@@ -36,7 +36,7 @@ For more information on a specific package, do::
 
 Intel no longer releases new versions of Parallel Studio, which can be
 used in Spack via the :ref:`intelpackage`. All of its components can
-now be found in oneAPI. 
+now be found in oneAPI.
 
 Examples
 ========

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -5,9 +5,9 @@
 
 .. _intelpackage:
 
-------------
-IntelPackage
-------------
+-----
+Intel
+-----
 
 .. contents::
 

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -5,9 +5,9 @@
 
 .. _pythonpackage:
 
--------------
-PythonPackage
--------------
+------
+Python
+------
 
 Python packages and modules have their own special build system. This
 documentation covers everything you'll need to know in order to write

--- a/lib/spack/docs/build_systems/rocmpackage.rst
+++ b/lib/spack/docs/build_systems/rocmpackage.rst
@@ -5,9 +5,9 @@
 
 .. _rocmpackage:
 
------------
-ROCmPackage
------------
+----
+ROCm
+----
 
 The ``ROCmPackage`` is not a build system but a helper package. Like ``CudaPackage``,
 it provides standard variants, dependencies, and conflicts to facilitate building
@@ -25,7 +25,7 @@ This package provides the following variants:
 
 * **rocm**
 
-  This variant is used to enable/disable building with ``rocm``.  
+  This variant is used to enable/disable building with ``rocm``.
   The default is disabled (or ``False``).
 
 * **amdgpu_target**

--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -5,9 +5,9 @@
 
 .. _rpackage:
 
---------
-RPackage
---------
+--
+R
+--
 
 Like Python, R has its own built-in build system.
 

--- a/lib/spack/docs/build_systems/sourceforgepackage.rst
+++ b/lib/spack/docs/build_systems/sourceforgepackage.rst
@@ -5,15 +5,15 @@
 
 .. _sourceforgepackage:
 
-------------------
-SourceforgePackage
-------------------
+-----------
+Sourceforge
+-----------
 
-``SourceforgePackage`` is a 
+``SourceforgePackage`` is a
 `mixin-class <https://en.wikipedia.org/wiki/Mixin>`_. It automatically
 sets the URL based on a list of Sourceforge mirrors listed in
 `sourceforge_mirror_path`, which defaults to a half dozen known mirrors.
-Refer to the package source 
+Refer to the package source
 (`<https://github.com/spack/spack/blob/develop/lib/spack/spack/build_systems/sourceforge.py>`__) for the current list of mirrors used by Spack.
 
 
@@ -29,7 +29,7 @@ This package provides a method for populating mirror URLs.
     It is decorated with `property` so its results are treated as
     a package attribute.
 
-    Refer to 
+    Refer to
     `<https://spack.readthedocs.io/en/latest/packaging_guide.html#mirrors-of-the-main-url>`__
     for information on how Spack uses the `urls` attribute during
     fetching.


### PR DESCRIPTION
Things are pretty inconsistent at the moment: https://spack.readthedocs.io/en/latest/build_systems.html