### PR TITLE
papi: more fixes for Intel OneAPI compiler

### DIFF
--- a/var/spack/repos/builtin/packages/papi/intel-oneapi-compiler-fixes.patch
+++ b/var/spack/repos/builtin/packages/papi/intel-oneapi-compiler-fixes.patch
@@ -1,0 +1,37 @@
+diff --git a/src/configure.in b/src/configure.in
+index 3cf47edc..ef5463ff 100644
+--- a/src/configure.in
++++ b/src/configure.in
+@@ -566,7 +566,7 @@ AC_ARG_WITH(tls,
+                            #include <unistd.h>
+                            extern __thread int i;
+                            static int res1, res2;
+-                           void thread_main (void *arg) {
++                           void *thread_main (void *arg) {
+                              i = (int)arg;
+                              sleep (1);
+                              if ((int)arg == 1)
+diff --git a/src/libpfm4/lib/pfmlib_common.c b/src/libpfm4/lib/pfmlib_common.c
+index 335155e2..38f3f957 100644
+--- a/src/libpfm4/lib/pfmlib_common.c
++++ b/src/libpfm4/lib/pfmlib_common.c
+@@ -1749,7 +1749,7 @@ pfmlib_pmu_validate_encoding(pfmlib_pmu_t *pmu, FILE *fp)
+ 	pfmlib_event_attr_info_t ainfo;
+ 	char *buf;
+ 	size_t maxlen = 0, len;
+-	int i, u, n = 0, um;
++	int i, u, um;
+ 	int ret, retval = PFM_SUCCESS;
+ 
+ 	pfmlib_for_each_pmu_event(pmu, i) {
+@@ -1838,7 +1838,6 @@ pfmlib_pmu_validate_encoding(pfmlib_pmu_t *pmu, FILE *fp)
+ 				continue;
+ 			}
+ 		}
+-		n++;
+ 	}
+ 	free(buf);
+ 
+-- 
+2.27.0
+

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -114,6 +114,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
 
     setup_run_environment = setup_build_environment
 
+    @when("@6.0.0:%oneapi")
     def autoreconf(self, spec, prefix):
         bash = which("bash")
         bash("-c", "cd src && autoreconf -ivf")

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -82,6 +82,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
         when="@5.4.0:5.6%gcc@8:",
     )
     patch("crayftn-fixes.patch", when="@6.0.0:%cce@9:")
+    patch("intel-oneapi-compiler-fixes.patch", when="@6.0.0:%oneapi")
 
     configure_directory = "src"
 
@@ -112,6 +113,10 @@ class Papi(AutotoolsPackage, ROCmPackage):
             env.set("DBG", "")
 
     setup_run_environment = setup_build_environment
+
+    def autoreconf(self, spec, prefix):
+        bash = which("bash")
+        bash("-c", "cd src && autoreconf -ivf")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
The Intel OneAPI's extreme pickiness continues to bring out buggy/noncompliant code.

This patch fixes an error in the configure.in embedded 'c' test code and also in a file with an initialized, but unused, variable.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>