### PR TITLE
Add a pytest plugin to time concretization

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -217,13 +217,12 @@ def parse_specs(args, **kwargs):
     unquoted_flags = _UnquotedFlags.extract(sargs)
 
     try:
-        specs = spack.spec.parse(sargs)
-        for spec in specs:
-            if concretize:
-                spec.concretize(tests=tests)  # implies normalize
-            elif normalize:
-                spec.normalize(tests=tests)
-        return specs
+        abstract_specs = spack.spec.parse(sargs)
+        if concretize:
+            return [s.concretized(tests=tests) for s in abstract_specs]
+        if normalize:
+            return [s.normalized(tests=tests) for s in abstract_specs]
+        return abstract_specs
 
     except spack.error.SpecError as e:
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3398,12 +3398,12 @@ class Spec(object):
         self._normal = True
         return any_change
 
-    def normalized(self):
+    def normalized(self, tests=False):
         """
         Return a normalized copy of this spec without modifying this spec.
         """
         clone = self.copy()
-        clone.normalize()
+        clone.normalize(tests=tests)
         return clone
 
     def validate_or_raise(self):


### PR DESCRIPTION
depends on #34029 (to pass tests on rhel8)

This PR adds a new cutom option to `pytest` so that we can do:
```console
$ spack unit-test --time-concretization
```
and get a summary of the time spent in concretization. Currently, it doesn't work with `xdist`, but I think it might already be useful to other developers.

Example:
![Screenshot from 2022-11-22 12-11-02](https://user-images.githubusercontent.com/4199709/203299757-c038d9a4-35e2-4e7e-b367-0c2d5096afb5.png)


