### PR TITLE
Revert "warn about removal of deprecated format strings"

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "${architecture}/${compiler.name}-${compiler.version}/${name}-${version}-${hash}"
+      all: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4418,10 +4418,7 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        tty.warn(
-            "Using the old Spec.format method."
-            " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20"
-        )
+
         color = kwargs.get("color", False)
 
         # Dictionary of transformations for named tokens

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -59,7 +59,7 @@ def test_yaml_directory_layout_parameters(tmpdir, default_mock_concretization):
     arch_scheme = (
         "{architecture.platform}/{architecture.target}/{architecture.os}/{name}/{version}/{hash:7}"
     )
-    ns_scheme = "${architecture}/${namespace}/${name}-${version}-${hash:7}"
+    ns_scheme = "${ARCHITECTURE}/${NAMESPACE}/${PACKAGE}-${VERSION}-${HASH:7}"
     arch_ns_scheme_projections = {"all": arch_scheme, "python": ns_scheme}
     layout_arch_ns = DirectoryLayout(str(tmpdir), projections=arch_ns_scheme_projections)
 

--- a/share/spack/qa/configuration/windows_config.yaml
+++ b/share/spack/qa/configuration/windows_config.yaml
@@ -3,6 +3,6 @@ config:
   install_tree:
     root: $spack\opt\spack
     projections:
-      all: '${architecture}\${compiler.name}-${compiler.version}\${name}-${version}-${hash}'
+      all: '${ARCHITECTURE}\${COMPILERNAME}-${COMPILERVER}\${PACKAGE}-${VERSION}-${HASH}'
   build_stage:
     - ~/.spack/stage


### PR DESCRIPTION
Reverts spack/spack#33829

Some update was missed, which causes:
![Screenshot from 2022-11-22 12-29-55](https://user-images.githubusercontent.com/4199709/203303831-8100e717-ebdb-4077-a476-24b317d4139b.png)
