### PR TITLE
make/ninja: correct jobs

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -5,7 +5,7 @@
 
 import re
 
-from spack.build_environment import MakeExecutable
+from spack.build_environment import MakeExecutable, determine_number_of_jobs
 from spack.package import *
 
 
@@ -89,5 +89,9 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
             symlink("make", "gmake")
 
     def setup_dependent_package(self, module, dspec):
-        module.make = MakeExecutable(self.spec.prefix.bin.make, make_jobs)
-        module.gmake = MakeExecutable(self.spec.prefix.bin.gmake, make_jobs)
+        module.make = MakeExecutable(
+            self.spec.prefix.bin.make, determine_number_of_jobs(parallel=dspec.package.parallel)
+        )
+        module.gmake = MakeExecutable(
+            self.spec.prefix.bin.gmake, determine_number_of_jobs(parallel=dspec.package.parallel)
+        )

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -3,7 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_environment import MakeExecutable, determine_number_of_jobs
 from spack.package import *
+from spack.util.executable import which_string
 
 
 class NinjaFortran(Package):
@@ -92,6 +94,6 @@ class NinjaFortran(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=self.parallel),
+            determine_number_of_jobs(parallel=dspec.package.parallel),
             supports_jobserver=True,  # This fork supports jobserver
         )

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -79,6 +79,6 @@ class Ninja(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=self.parallel),
+            determine_number_of_jobs(parallel=dspec.package.parallel),
             supports_jobserver=self.spec.version == ver("kitware"),
         )


### PR DESCRIPTION
`gmake` / `ninja` use their own `parallel` attribute instead of the dependent's
to determine the number of jobs, when used as a build dep.