### PR TITLE
flux-core: add conflicts to limit builds to linux platforms

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -111,6 +111,10 @@ class FluxCore(AutotoolsPackage):
     variant("docs", default=False, description="Build flux manpages and docs")
     variant("cuda", default=False, description="Build dependencies with support for CUDA")
 
+    # Restrict flux to Linux based platforms where builds are possible.
+    conflicts("platform=darwin", msg="flux-core does not support MacOS based platforms.")
+    conflicts("platform=windows", msg="flux-core does not support Windows based platforms.")
+
     depends_on("libarchive", when="@0.38.0:")
     depends_on("ncurses@6.2:", when="@0.32.0:")
     depends_on("libzmq@4.0.4:")


### PR DESCRIPTION
As per the discussion over at flux-framework/flux-core#2892, Flux doesn't currently support building on non-Linux based platforms. Thus this PR adds conflict statements to prevent folks from getting all the way through a long dependency tree before getting a failed flux-core build.