### PR TITLE
boost: At least with older Xcode, boost can't build with lzma

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -524,6 +524,9 @@ class Boost(Package):
                     "ZSTD_LIBPATH=%s" % spec["zstd"].prefix.lib,
                 ]
             )
+            # At least with older Xcode, _lzma_cputhreads is missing (#33998)
+            if "platform=darwin" in self.spec:
+                options.extend(["-s", "NO_LZMA=1"])
 
         link_types = ["static"]
         if "+shared" in spec:


### PR DESCRIPTION
Reference: https://lists.boost.org/Archives/boost/2019/11/247380.php
As reported at the end of #33998 and this link, liblzma on older Xcode
misses _lzma_cputhreads, so boost's can't use liblzma on those.

@balay confirmed in https://github.com/spack/spack/pull/33998#issuecomment-1324501170 this fixes it:

```py
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -524,6 +524,9 @@ def determine_b2_options(self, spec, options):
                     "ZSTD_LIBPATH=%s" % spec["zstd"].prefix.lib,
                 ]
             )
+            # At least with older Xcode, _lzma_cputhreads is missing (#33998)
+            if "platform=darwin" in self.spec:
+                options.extend(["-s", "NO_LZMA=1"])
 
         link_types = ["static"]
         if "+shared" in spec:
```