### PR TITLE
automake: depend_on "perl+threads" (it requires Thread::Queue)

### DIFF
--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -24,7 +24,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     version("1.11.6", sha256="53dbf1945401c43f4ce19c1971baecdbf8bc32e0f37fa3f49fe7b6992d0d2030")
 
     depends_on("autoconf", type="build")
-    depends_on("perl", type=("build", "run"))
+    depends_on("perl+threads", type=("build", "run"))
 
     build_directory = "spack-build"
 


### PR DESCRIPTION
Motivation:

1. `perl-Thread-Queue` may not always be pre-installed on new RedHat-based hosts by default.
2. This, in combination with `spack external find perl` breaks the build of `automake` (which uses `Threads::Queue`)

So lets fix this.

The fix is pretty simple, tested and also obvious to review:
```diff
-    depends_on("perl", type=("build", "run"))
+    depends_on("perl+threads", type=("build", "run"))
```

Full Background story:

To completely and really fix this, #34074 is also needed (see it for details on that)