### PR TITLE
[mochi-margo] fixed dependency to Argobots

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -55,6 +55,7 @@ class MochiMargo(AutotoolsPackage):
     depends_on("libtool", type=("build"))
     depends_on("pkgconfig", type=("build"))
     depends_on("argobots@1.0:")
+    depends_on("argobots@1.1:", when="@0.11:")
     # "breadcrumb" support not available in mercury-1.0
     depends_on("mercury@1.0.0:", type=("build", "link", "run"), when="@:0.5.1")
     depends_on("mercury@2.0.0:", type=("build", "link", "run"), when="@0.5.2:")


### PR DESCRIPTION
This PR fixes the dependency to Argobots: margo 0.11 requires argobots 1.1 or greater.