### PR TITLE
gnuplot: fix build with Apple Clang

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -158,5 +158,7 @@ class Gnuplot(AutotoolsPackage):
         # TODO: --with-aquaterm  depends_on('aquaterm')
         options.append("--without-aquaterm")
 
-        os.environ["LDFLAGS"] = "-Wl,--copy-dt-needed-entries"
+        if spec.satisfies("%gcc@11:"):
+            os.environ["LDFLAGS"] = "-Wl,--copy-dt-needed-entries"
+
         return options


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 (arm64) with Apple Clang 14.0.0.

Closes #32859 

@TBird2001 @haralmha can one of you test this?