### PR TITLE
spack install: fix permissions of intermediary module directories

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -863,8 +863,10 @@ class BaseModuleFileWriter(object):
         # If the directory where the module should reside does not exist
         # create it
         module_dir = os.path.dirname(self.layout.filename)
+        parent_dir = os.path.dirname(self.layout.dirname())
+        perms = os.stat(parent_dir).st_mode
         if not os.path.exists(module_dir):
-            llnl.util.filesystem.mkdirp(module_dir)
+            llnl.util.filesystem.mkdirp(module_dir, mode=perms)
 
         # Get the template for the module
         template_name = self._get_template()


### PR DESCRIPTION
As part of installing a spack package, a module file is also created. For TCL modules this is typically under: $spack/share/spack/modules/$arch/ This path may not exist before the package has been installed if it is the first time a package is installed for this $arch. In this case spack helpfully creates the necessary directory. While the module file itself correctly inherits the permissions of the package, the intermediary directories (.../modules/$arch/...) are created using the OS default permissions. On Linux this means using the users current  umask.

This is an issue in use-cases where the spack instance is shared among many users and machines _and_ the umask of these users is restricted such as disallowing writes for the group (g-w). This means that user A may install a first package on system X and user B will receive a permission denied error when trying to install a second package on system X since they do not have permission to add a file to the intermediary directory.

To workaround this users must currently be aware of whether it is the first time they are installing any package on a given machine and manually ensure that the permissions of those intermediary folders are suitable for other users.

The package install directory already solves the same issue by inheriting the permissions of the parent directory and applying it to the intermediary directories. This patch follows the same approach.