### PR TITLE
warn about removal of deprecated format strings

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+      all: "${architecture}/${compiler.name}-${compiler.version}/${name}-${version}-${hash}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path
@@ -219,4 +219,3 @@ config:
   flags:
     # Whether to keep -Werror flags active in package builds.
     keep_werror: 'none'
-

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "${architecture}/${compiler.name}-${compiler.version}/${name}-${version}-${hash}"
+      all: "{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4420,7 +4420,7 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        tty.warn(
+        warnings.warn(
             "Using the old Spec.format method."
             " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20"
         )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4418,8 +4418,10 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        tty.warn("Using the old Spec.format method."
-                 " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20")
+        tty.warn(
+            "Using the old Spec.format method."
+            " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20"
+        )
         color = kwargs.get("color", False)
 
         # Dictionary of transformations for named tokens

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4418,7 +4418,8 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-
+        tty.warn("Using the old Spec.format method."
+                 " This method was deprecated in Spack v0.15 and will be removed in Spack v0.20")
         color = kwargs.get("color", False)
 
         # Dictionary of transformations for named tokens

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4332,7 +4332,9 @@ class Spec(object):
                     attribute += c
             else:
                 if c == "}":
-                    raise SpecFormatStringError("Encountered closing } before opening {")
+                    raise SpecFormatStringError(
+                        "Encountered closing } before opening { in %s" % format_string
+                    )
                 elif c == "{":
                     in_attribute = True
                 else:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1254,6 +1254,13 @@ def test_user_config_path_is_default_when_env_var_is_empty(working_env):
     assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_config_path()
 
 
+def test_default_install_tree(monkeypatch):
+    s = spack.spec.Spec("nonexistent@x.y.z %none@a.b.c arch=foo-bar-baz")
+    monkeypatch.setattr(s, "dag_hash", lambda: "abc123")
+    projection = spack.config.get("config:install_tree:projections:all", scope="defaults")
+    assert s.format(projection) == "foo-bar-baz/none-a.b.c/nonexistent-x.y.z-abc123"
+
+
 def test_local_config_can_be_disabled(working_env):
     os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
     cfg = spack.config._config()

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -59,7 +59,7 @@ def test_yaml_directory_layout_parameters(tmpdir, default_mock_concretization):
     arch_scheme = (
         "{architecture.platform}/{architecture.target}/{architecture.os}/{name}/{version}/{hash:7}"
     )
-    ns_scheme = "${architecture}/${namespace}/${name}-${version}-${hash:7}"
+    ns_scheme = "{architecture}/{namespace}/{name}-{version}-{hash:7}"
     arch_ns_scheme_projections = {"all": arch_scheme, "python": ns_scheme}
     layout_arch_ns = DirectoryLayout(str(tmpdir), projections=arch_ns_scheme_projections)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -59,7 +59,7 @@ def test_yaml_directory_layout_parameters(tmpdir, default_mock_concretization):
     arch_scheme = (
         "{architecture.platform}/{architecture.target}/{architecture.os}/{name}/{version}/{hash:7}"
     )
-    ns_scheme = "${ARCHITECTURE}/${NAMESPACE}/${PACKAGE}-${VERSION}-${HASH:7}"
+    ns_scheme = "${architecture}/${namespace}/${name}-${version}-${hash:7}"
     arch_ns_scheme_projections = {"all": arch_scheme, "python": ns_scheme}
     layout_arch_ns = DirectoryLayout(str(tmpdir), projections=arch_ns_scheme_projections)
 

--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -86,6 +86,7 @@ def test_config_blame_defaults():
         if match:
             filename, line, key, val = match.groups()
             line = int(line)
+            val = val.strip("'\"")
 
             if val.lower() in ("true", "false"):
                 val = val.lower()

--- a/share/spack/qa/configuration/windows_config.yaml
+++ b/share/spack/qa/configuration/windows_config.yaml
@@ -3,6 +3,6 @@ config:
   install_tree:
     root: $spack\opt\spack
     projections:
-      all: '{architecture}\{compiler.name}-{compiler.version}\{name}-{version}-{hash}'
+      all: '{architecture}\\{compiler.name}-{compiler.version}\\{name}-{version}-{hash}'
   build_stage:
     - ~/.spack/stage

--- a/share/spack/qa/configuration/windows_config.yaml
+++ b/share/spack/qa/configuration/windows_config.yaml
@@ -3,6 +3,6 @@ config:
   install_tree:
     root: $spack\opt\spack
     projections:
-      all: '${architecture}\${compiler.name}-${compiler.version}\${name}-${version}-${hash}'
+      all: '{architecture}\{compiler.name}-{compiler.version}\{name}-{version}-{hash}'
   build_stage:
     - ~/.spack/stage

--- a/share/spack/qa/configuration/windows_config.yaml
+++ b/share/spack/qa/configuration/windows_config.yaml
@@ -3,6 +3,6 @@ config:
   install_tree:
     root: $spack\opt\spack
     projections:
-      all: '${ARCHITECTURE}\${COMPILERNAME}-${COMPILERVER}\${PACKAGE}-${VERSION}-${HASH}'
+      all: '${architecture}\${compiler.name}-${compiler.version}\${name}-${version}-${hash}'
   build_stage:
     - ~/.spack/stage


### PR DESCRIPTION
Fixes bug in [#33829](https://github.com/spack/spack/pull/33829) which was reverted

@alalazo 