### PR TITLE
 `spack python`: use `Executable` instead of `InteractiveConsole`

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -39,6 +39,7 @@ class LazyRepoImporter:
 
     def find_spec(self, fullname, python_path, target=None):
         if fullname.startswith(ROOT_PYTHON_NAMESPACE):
+            sys.meta_path.remove(self)  # remove so we don't do this twice
             import spack.repo  # noqa: F401
         return None
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
+
+import sys
+
 __version__ = "0.22.0.dev0"
 spack_version = __version__
 
@@ -17,6 +20,35 @@ def __try_int(v):
 
 #: (major, minor, micro, dev release) tuple
 spack_version_info = tuple([__try_int(v) for v in __version__.split(".")])
+
+
+#: Package modules are imported as spack.pkg.<repo-namespace>.<pkg-name>
+#: This is a special namespace because it's generated dynamically from package repos.
+ROOT_PYTHON_NAMESPACE = "spack.pkg"
+
+
+# To import `spack.pkg`, `spack.repo` *must* be imported first. This class lazily
+# imports `spack.repo` (in case it hasn't been imported already) when `spack.pkg` is
+# imported, allowing `import spack.pkg...` to be the first thing you import.
+class LazyRepoImporter:
+    """Fake loader for ``sys.meta_path``.
+
+    Ensures ``spack.repo`` is always imported before ``spack.pkg``.
+
+    """
+
+    def find_spec(self, fullname, python_path, target=None):
+        if fullname.startswith(ROOT_PYTHON_NAMESPACE):
+            import spack.repo  # noqa: F401
+        return None
+
+    def compute_loader(self, fullname):
+        return None
+
+
+# ensure our LazyRepoImporter is the first thing on the PATH. We could just import
+# `spack.repo` here, but this allows us to only load it when needed.
+sys.meta_path.insert(0, LazyRepoImporter())
 
 
 __all__ = ["spack_version_info", "spack_version"]

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -17,7 +17,6 @@ from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
 import spack.config
-import spack.environment as ev
 import spack.error
 import spack.extensions
 import spack.parser
@@ -184,6 +183,8 @@ def matching_spec_from_env(spec):
     If no matching spec is found in the environment (or if no environment is
     active), this will return the given spec but concretized.
     """
+    import spack.environment as ev
+
     env = ev.active_environment()
     if env:
         return env.matching_spec(spec) or spec.concretized()
@@ -526,6 +527,8 @@ def require_active_env(cmd_name):
     Returns:
         (spack.environment.Environment): the active environment
     """
+    import spack.environment as ev
+
     env = ev.active_environment()
 
     if env:
@@ -555,6 +558,7 @@ def find_environment(args):
     Returns:
         (spack.environment.Environment): a found environment, or ``None``
     """
+    import spack.environment as ev
 
     # treat env as a name
     env = args.env

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -24,7 +24,6 @@ import spack.paths
 import spack.spec
 import spack.store
 import spack.traverse as traverse
-import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
@@ -448,6 +447,8 @@ def display_specs(specs, args=None, **kwargs):
 def filter_loaded_specs(specs):
     """Filter a list of specs returning only those that are
     currently loaded."""
+    import spack.user_environment as uenv
+
     hashes = os.environ.get(uenv.spack_loaded_hashes_var, "").split(":")
     return [x for x in specs if x.dag_hash() in hashes]
 

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -8,6 +8,8 @@ import os
 import platform
 import sys
 
+import spack_installable.main as sim
+
 import llnl.util.tty as tty
 
 import spack
@@ -38,12 +40,6 @@ def setup_parser(subparser):
     ex.add_argument("-c", dest="python_command", metavar="COMMAND", help="command to execute")
     ex.add_argument("-m", dest="module", action="store", help="run library module as a script")
 
-    subparser.add_argument(
-        "-u",
-        dest="unbuffered",
-        action="store_true",
-        help="for compatibility with xdist, do not use without adding -u to the interpreter",
-    )
     subparser.add_argument(
         "-i",
         dest="python_interpreter",
@@ -129,8 +125,9 @@ def python_interpreter(args, unknown_args):
     # create a new environment for the spack python instance that sets PYTHONPATH to
     # include Spack packages.
     mods = sue.EnvironmentModifications()
-    mods.prepend_path("PYTHONPATH", spack.paths.lib_path)
-    mods.prepend_path("PYTHONPATH", spack.paths.external_path)
+    sys_paths = sim.get_spack_sys_paths(spack.paths.prefix)
+    for path in reversed(sys_paths):
+        mods.prepend_path("PYTHONPATH", path)
 
     env = os.environ.copy()
     mods.apply_modifications(env)

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -115,7 +115,6 @@ def ipython_interpreter(args, unknown_args):
 
     print_spack_version_if_interactive(args)
 
-    # if args.python_args or args.module or args.python_command:
     python_args = construct_python_args(args, unknown_args)
     IPython.start_ipython(argv=python_args)
 

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import code
 import os
 import platform
-import runpy
 import sys
 
 import llnl.util.tty as tty
@@ -23,14 +21,23 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument(
+    ex = subparser.add_mutually_exclusive_group()
+    ex.add_argument(
         "-V",
         "--version",
         action="store_true",
         dest="python_version",
         help="print the Python version number and exit",
     )
-    subparser.add_argument("-c", dest="python_command", help="command to execute")
+    ex.add_argument(
+        "--path",
+        action="store_true",
+        dest="show_path",
+        help="show path to python interpreter that spack uses",
+    )
+    ex.add_argument("-c", dest="python_command", metavar="COMMAND", help="command to execute")
+    ex.add_argument("-m", dest="module", action="store", help="run library module as a script")
+
     subparser.add_argument(
         "-u",
         dest="unbuffered",
@@ -44,15 +51,11 @@ def setup_parser(subparser):
         choices=["python", "ipython"],
         default="python",
     )
+
     subparser.add_argument(
-        "-m", dest="module", action="store", help="run library module as a script"
+        "-I", dest="ipython", action="store_true", help="run with IPython instead of python"
     )
-    subparser.add_argument(
-        "--path",
-        action="store_true",
-        dest="show_path",
-        help="show path to python interpreter that spack uses",
-    )
+
     subparser.add_argument(
         "python_args", nargs=argparse.REMAINDER, help="file to run plus arguments"
     )
@@ -67,103 +70,76 @@ def python(parser, args, unknown_args):
         print(sys.executable)
         return
 
-    if args.module:
-        sys.argv = ["spack-python"] + unknown_args + args.python_args
-        runpy.run_module(args.module, run_name="__main__", alter_sys=True)
-        return
-
-    if unknown_args:
-        tty.die("Unknown arguments:", " ".join(unknown_args))
-
     # Unexpected behavior from supplying both
     if args.python_command and args.python_args:
         tty.die("You can only specify a command OR script, but not both.")
 
     # Run user choice of interpreter
     if args.python_interpreter == "ipython":
-        return spack.cmd.python.ipython_interpreter(args)
-    return spack.cmd.python.python_interpreter(args)
+        tty.warn(
+            "The `-i ipython` option is deprecated and will be removed in 0.21.", "Use -I instead."
+        )
+        args.ipython = True
+
+    if args.ipython:
+        return spack.cmd.python.ipython_interpreter(args, unknown_args)
+    else:
+        return spack.cmd.python.python_interpreter(args, unknown_args)
 
 
-def ipython_interpreter(args):
+def construct_python_args(args, unknown_args):
+    """Create python command args from argparse args."""
+    python_args = []
+
+    # add these two back as they're explicitly parsed
+    if args.python_command:
+        python_args += ["-c", args.python_command]
+    if args.module:
+        python_args += ["-m", args.module]
+
+    python_args += unknown_args
+    python_args += args.python_args
+    return python_args
+
+
+def print_spack_version_if_interactive(args):
+    interactive = not any((args.python_command, args.python_args, args.module))
+    if interactive:
+        print(f"Spack version {spack.spack_version}")
+
+
+def ipython_interpreter(args, unknown_args):
     """An ipython interpreter is intended to be interactive, so it doesn't
     support running a script or arguments
     """
     try:
         import IPython  # type: ignore[import]
     except ImportError:
-        tty.die("ipython is not installed, install and try again.")
+        tty.die("IPython is not installed, install and try again.")
 
-    if "PYTHONSTARTUP" in os.environ:
-        startup_file = os.environ["PYTHONSTARTUP"]
-        if os.path.isfile(startup_file):
-            with open(startup_file) as startup:
-                exec(startup.read())
+    print_spack_version_if_interactive(args)
 
-    # IPython can also support running a script OR command, not both
-    if args.python_args:
-        IPython.start_ipython(argv=args.python_args)
-    elif args.python_command:
-        IPython.start_ipython(argv=["-c", args.python_command])
-    else:
-        header = "Spack version %s\nPython %s, %s %s" % (
-            spack.spack_version,
-            platform.python_version(),
-            platform.system(),
-            platform.machine(),
-        )
-
-        __name__ = "__main__"  # noqa: F841
-        IPython.embed(module="__main__", header=header)
+    # if args.python_args or args.module or args.python_command:
+    python_args = construct_python_args(args, unknown_args)
+    IPython.start_ipython(argv=python_args)
 
 
-def python_interpreter(args):
+def python_interpreter(args, unknown_args):
     """A python interpreter is the default interpreter"""
-    if args.python_command or args.python_args:
-        # create a new environment for the spack python instance that sets PYTHONPATH to
-        # include Spack packages.
-        mods = sue.EnvironmentModifications()
-        mods.prepend_path("PYTHONPATH", spack.paths.lib_path)
-        mods.prepend_path("PYTHONPATH", spack.paths.external_path)
+    # create a new environment for the spack python instance that sets PYTHONPATH to
+    # include Spack packages.
+    mods = sue.EnvironmentModifications()
+    mods.prepend_path("PYTHONPATH", spack.paths.lib_path)
+    mods.prepend_path("PYTHONPATH", spack.paths.external_path)
 
-        env = os.environ.copy()
-        mods.apply_modifications(env)
+    env = os.environ.copy()
+    mods.apply_modifications(env)
 
-        # if we're not running an interactive console, exec python and don't bother with
-        # an interactive interpreter, since that means things like the __main__ module
-        # will not be defined, and multiprocessing won't work.
-        python_args = []
-        if args.python_command:
-            python_args += ["-c", args.python_command]
-        if args.python_args:
-            python_args += args.python_args
+    print_spack_version_if_interactive(args)
 
-        python = exe.Executable(sys.executable)
-        python(*python_args, env=env)
-
-    else:
-        # if we're running interactively, use InteractiveConsole and set up a little
-        # readline help.
-        console = code.InteractiveConsole({"spack": spack})
-        if "PYTHONSTARTUP" in os.environ:
-            startup_file = os.environ["PYTHONSTARTUP"]
-            if os.path.isfile(startup_file):
-                with open(startup_file) as startup:
-                    console.runsource(startup.read(), startup_file, "exec")
-
-        # Provides readline support, allowing user to use arrow keys
-        console.push("import readline")
-        # Provide tabcompletion
-        console.push("from rlcompleter import Completer")
-        console.push("readline.set_completer(Completer(locals()).complete)")
-        console.push('readline.parse_and_bind("tab: complete")')
-
-        console.interact(
-            "Spack version %s\nPython %s, %s %s"
-            % (
-                spack.spack_version,
-                platform.python_version(),
-                platform.system(),
-                platform.machine(),
-            )
-        )
+    # note: this used to use code.InteractiveConsole, but exec'ing python and not using
+    # interactive mode ensures that things like the __main__ module will be defined and
+    # that multiprocessing will work.
+    python_args = construct_python_args(args, unknown_args)
+    python = exe.Executable(sys.executable)
+    python(*python_args, env=env)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -567,6 +567,8 @@ def send_warning_to_tty(message, *args):
 
 def setup_main_options(args):
     """Configure spack globals based on the basic options."""
+    import spack.util.debug
+
     # Assign a custom function to show warnings
     warnings.showwarning = send_warning_to_tty
 
@@ -584,8 +586,6 @@ def setup_main_options(args):
         SHOW_BACKTRACE = True
 
     if args.debug:
-        import spack.util.debug
-
         spack.util.debug.register_interrupt_handler()
         spack.config.set("config:debug", True, scope="command_line")
         spack.util.environment.TRACING_ENABLED = True

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,7 +42,6 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.store
-import spack.util.debug
 import spack.util.environment
 import spack.util.git
 import spack.util.path
@@ -585,6 +584,8 @@ def setup_main_options(args):
         SHOW_BACKTRACE = True
 
     if args.debug:
+        import spack.util.debug
+
         spack.util.debug.register_interrupt_handler()
         spack.config.set("config:debug", True, scope="command_line")
         spack.util.environment.TRACING_ENABLED = True

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -58,7 +58,8 @@ def python_package_for_repo(namespace):
     Args:
         namespace (str): repo namespace
     """
-    return "{0}.{1}".format(spack.ROOT_PYTHON_NAMESPACE, namespace)
+    #    return "{0}.{1}".format(spack.ROOT_PYTHON_NAMESPACE, namespace)
+    return f"{spack.ROOT_PYTHON_NAMESPACE}.{namespace}"
 
 
 def namespace_from_fullname(fullname):
@@ -72,7 +73,7 @@ def namespace_from_fullname(fullname):
         fullname (str): full name for the Python module
     """
     namespace, dot, module = fullname.rpartition(".")
-    prefix_and_dot = "{0}.".format(spack.ROOT_PYTHON_NAMESPACE)
+    prefix_and_dot = f"{spack.ROOT_PYTHON_NAMESPACE}."
     if namespace.startswith(prefix_and_dot):
         namespace = namespace[len(prefix_and_dot) :]
     return namespace

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -33,6 +33,7 @@ import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
+import spack
 import spack.caches
 import spack.config
 import spack.error
@@ -46,9 +47,6 @@ import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
 
-#: Package modules are imported as spack.pkg.<repo-namespace>.<pkg-name>
-ROOT_PYTHON_NAMESPACE = "spack.pkg"
-
 
 def python_package_for_repo(namespace):
     """Returns the full namespace of a repository, given its relative one
@@ -60,7 +58,7 @@ def python_package_for_repo(namespace):
     Args:
         namespace (str): repo namespace
     """
-    return "{0}.{1}".format(ROOT_PYTHON_NAMESPACE, namespace)
+    return "{0}.{1}".format(spack.ROOT_PYTHON_NAMESPACE, namespace)
 
 
 def namespace_from_fullname(fullname):
@@ -74,7 +72,7 @@ def namespace_from_fullname(fullname):
         fullname (str): full name for the Python module
     """
     namespace, dot, module = fullname.rpartition(".")
-    prefix_and_dot = "{0}.".format(ROOT_PYTHON_NAMESPACE)
+    prefix_and_dot = "{0}.".format(spack.ROOT_PYTHON_NAMESPACE)
     if namespace.startswith(prefix_and_dot):
         namespace = namespace[len(prefix_and_dot) :]
     return namespace
@@ -137,7 +135,7 @@ class ReposFinder:
             raise RuntimeError('cannot reload module "{0}"'.format(fullname))
 
         # Preferred API from https://peps.python.org/pep-0451/
-        if not fullname.startswith(ROOT_PYTHON_NAMESPACE):
+        if not fullname.startswith(spack.ROOT_PYTHON_NAMESPACE):
             return None
 
         loader = self.compute_loader(fullname)

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -30,15 +30,12 @@ def test_python_version():
     assert platform.python_version() in out
 
 
-def test_python_with_module():
-    # pytest rewrites a lot of modules, which interferes with runpy, so
-    # it's hard to test this.  Trying to import a module like sys, that
-    # has no code associated with it, raises an error reliably in python
-    # 2 and 3, which indicates we successfully ran runpy.run_module.
-    with pytest.raises(ImportError, match="No code object"):
-        python("-m", "sys")
+def test_python_with_module(capsys):
+    with capsys.disabled():
+        out = python("-m", "sys", fail_on_error=False)
+        assert "No code object" in out
 
 
-def test_python_raises():
-    out = python("--foobar", fail_on_error=False)
-    assert "Error: Unknown arguments" in out
+def test_python_raises_on_bad_arg():
+    with pytest.raises(spack.util.executable.ProcessError):
+        python("--foobar")

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -13,27 +13,43 @@ from spack.main import SpackCommand
 
 python = SpackCommand("python")
 
+try:
+    import IPython  # noqa: F401
 
-def test_python(capsys):
-    with capsys.disabled():
-        out = python("-c", "import spack; print(spack.spack_version)")
+    have_ipython = True
+except ImportError:
+    have_ipython = False
+
+
+def test_python(capfd):
+    python("-c", "import spack; print(spack.spack_version)")
+    out, _ = capfd.readouterr()
     assert out.strip() == spack.spack_version
 
 
-def test_python_interpreter_path():
-    out = python("--path")
+@pytest.mark.skipif(not have_ipython, reason="requires IPython to be installed")
+def test_ipython(capfd):
+    with capfd.disabled():
+        out = python("-I", "-c", "import spack; print(spack.spack_version)")
+    assert out.strip() == spack.spack_version
+
+
+def test_python_interpreter_path(capfd):
+    with capfd.disabled():
+        out = python("--path")
     assert out.strip() == sys.executable
 
 
-def test_python_version():
-    out = python("-V")
+def test_python_version(capfd):
+    with capfd.disabled():
+        out = python("-V")
     assert platform.python_version() in out
 
 
-def test_python_with_module(capsys):
+def test_python_with_module(capfd):
     python("-m", "sys", fail_on_error=False)
-    out, _ = capsys.readouterr()
-    assert "No code object" in out
+    _, err = capfd.readouterr()
+    assert "No code object" in err
 
 
 def test_python_raises_on_bad_arg():

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -15,8 +15,8 @@ python = SpackCommand("python")
 
 
 def test_python(capsys):
-    python("-c", "import spack; print(spack.spack_version)")
-    out, _ = capsys.readouterr()
+    with capsys.disabled():
+        out = python("-c", "import spack; print(spack.spack_version)")
     assert out.strip() == spack.spack_version
 
 

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -15,9 +15,9 @@ python = SpackCommand("python")
 
 
 def test_python(capsys):
-    with capsys.disabled():
-        out = python("-c", "import spack; print(spack.spack_version)")
-        assert out.strip() == spack.spack_version
+    python("-c", "import spack; print(spack.spack_version)")
+    out, _ = capsys.readouterr()
+    assert out.strip() == spack.spack_version
 
 
 def test_python_interpreter_path():
@@ -31,9 +31,9 @@ def test_python_version():
 
 
 def test_python_with_module(capsys):
-    with capsys.disabled():
-        out = python("-m", "sys", fail_on_error=False)
-        assert "No code object" in out
+    python("-m", "sys", fail_on_error=False)
+    out, _ = capsys.readouterr()
+    assert "No code object" in out
 
 
 def test_python_raises_on_bad_arg():

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -14,9 +14,10 @@ from spack.main import SpackCommand
 python = SpackCommand("python")
 
 
-def test_python():
-    out = python("-c", "import spack; print(spack.spack_version)")
-    assert out.strip() == spack.spack_version
+def test_python(capsys):
+    with capsys.disabled():
+        out = python("-c", "import spack; print(spack.spack_version)")
+        assert out.strip() == spack.spack_version
 
 
 def test_python_interpreter_path():

--- a/lib/spack/spack_installable/main.py
+++ b/lib/spack/spack_installable/main.py
@@ -7,19 +7,24 @@ import sys
 from os.path import dirname as dn
 
 
+def get_spack_sys_paths(spack_prefix):
+    """Given a spack prefix, return all the paths Spack needs to function."""
+    spack_libs = os.path.join(spack_prefix, "lib", "spack")
+    external_libs = os.path.join(spack_libs, "external")
+    vendored_libs = os.path.join(external_libs, "_vendoring")
+
+    # spack externals take precedence, then vendored packages, then spack itself
+    return [external_libs, vendored_libs, spack_libs]
+
+
 def main(argv=None):
     # Find spack's location and its prefix.
     this_file = os.path.realpath(os.path.expanduser(__file__))
     spack_prefix = dn(dn(dn(dn(this_file))))
 
-    # Allow spack libs to be imported in our scripts
-    spack_lib_path = os.path.join(spack_prefix, "lib", "spack")
-    sys.path.insert(0, spack_lib_path)
+    # Add all the sys paths that allow spack libs to be imported
+    sys.path[:0] = get_spack_sys_paths(spack_prefix)
 
-    # Add external libs
-    spack_external_libs = os.path.join(spack_lib_path, "external")
-    sys.path.insert(0, os.path.join(spack_external_libs, "_vendoring"))
-    sys.path.insert(0, spack_external_libs)
     # Here we delete ruamel.yaml in case it has been already imported from site
     # (see #9206 for a broader description of the issue).
     #

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1688,7 +1688,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -V --version -c -u -i -m --path"
+        SPACK_COMPREPLY="-h --help -V --version --path -c -m -u -i -I"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1688,7 +1688,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -V --version --path -c -m -u -i -I"
+        SPACK_COMPREPLY="-h --help -V --version --path -c -m -i -I"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2521,22 +2521,22 @@ complete -c spack -n '__fish_spack_using_command pydoc' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command pydoc' -s h -l help -d 'show this help message and exit'
 
 # spack python
-set -g __fish_spack_optspecs_spack_python h/help V/version c/= u/ i/= m/= path
+set -g __fish_spack_optspecs_spack_python h/help V/version path c/= m/= i/= I/
 
 complete -c spack -n '__fish_spack_using_command python' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command python' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command python' -s V -l version -f -a python_version
 complete -c spack -n '__fish_spack_using_command python' -s V -l version -d 'print the Python version number and exit'
-complete -c spack -n '__fish_spack_using_command python' -s c -r -f -a python_command
-complete -c spack -n '__fish_spack_using_command python' -s c -r -d 'command to execute'
-complete -c spack -n '__fish_spack_using_command python' -s u -f -a unbuffered
-complete -c spack -n '__fish_spack_using_command python' -s u -d 'for compatibility with xdist, do not use without adding -u to the interpreter'
-complete -c spack -n '__fish_spack_using_command python' -s i -r -f -a 'python ipython'
-complete -c spack -n '__fish_spack_using_command python' -s i -r -d 'python interpreter'
-complete -c spack -n '__fish_spack_using_command python' -s m -r -f -a module
-complete -c spack -n '__fish_spack_using_command python' -s m -r -d 'run library module as a script'
 complete -c spack -n '__fish_spack_using_command python' -l path -f -a show_path
 complete -c spack -n '__fish_spack_using_command python' -l path -d 'show path to python interpreter that spack uses'
+complete -c spack -n '__fish_spack_using_command python' -s c -r -f -a python_command
+complete -c spack -n '__fish_spack_using_command python' -s c -r -d 'command to execute'
+complete -c spack -n '__fish_spack_using_command python' -s m -r -f -a module
+complete -c spack -n '__fish_spack_using_command python' -s m -r -d 'run library module as a script'
+complete -c spack -n '__fish_spack_using_command python' -s i -r -f -a 'python ipython'
+complete -c spack -n '__fish_spack_using_command python' -s i -r -d 'python interpreter'
+complete -c spack -n '__fish_spack_using_command python' -s I -f -a ipython
+complete -c spack -n '__fish_spack_using_command python' -s I -d 'run with IPython instead of python'
 
 # spack reindex
 set -g __fish_spack_optspecs_spack_reindex h/help


### PR DESCRIPTION
Running a `spack-python` script like this:

```python

import spack
import multiprocessing

def echo(args):
    print(args)

if __name__ == "__main__":
    pool = multiprocessing.Pool(2)
    pool.map(echo, range(10))
```

will fail in `develop` with an error like this:

```console
_pickle.PicklingError: Can't pickle <function echo at 0x104865820>: attribute lookup echo on __main__ failed
```

Python expects to be able to look up the method `echo` in `sys.path["__main__"]` in
subprocesses spawned by `multiprocessing`, but because we use `InteractiveConsole` to
run `spack python`, the executed file isn't considered to be the `__main__` module, and
lookups in subprocesses fail. We tried to fake this by setting `__name__` to `__main__`
in the `spack python` command, but that doesn't fix the fact that no `__main__` module
exists.

Another annoyance with `InteractiveConsole` is that `__file__` is not defined in the
main script scope, so you can't use it in your scripts.

We can fix this by using `spack.util.executable.Executable` to launch `spack python`
instead of using `InteractiveConsole`. This makes `spack python` behave more like
normal python. After this change:

```console
> ./test.py
0
1
2
3
4
5
6
7
8
9
```

- [x] Use `Executable` to launch non-interactive `spack python` invocations
- [x] Only use `InteractiveConsole` for interactive `spack python`