### PR TITLE
acl: support using external gettext when `libintl` is in glibc

### DIFF
--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,7 +27,9 @@ class Acl(AutotoolsPackage):
     depends_on("gettext")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+        # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
+        if "libintl" in self.spec["gettext"].libs.joined():
+            env.append_flags("LDFLAGS", "-lintl")
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")


### PR DESCRIPTION
Many glibc-based Linux systems don't have `gettext`'s `libintl`,
because `libintl` is included in the standard system's `glibc` (libc) itself.

When using `spack external find gettext` on those,
packages like `acl` which unconditionally to link using `-lintl` fail to link with -lintl.

Description of the fix:

The `libs` property of spack's gettext recipe returns the list of libs,
so when gettext provides libintl, use it.

When not, there is no separate liblint library and the libintl API is provided by glibc.

 Tested
* with `spack external find gettext` on glibc-based Linux and
* in musl-based Alpine Linux to make sure that when -lintl is really needed, it is really used and nothing breaks.