### PR TITLE
bcache: support external gettext when `libintl` is in glibc

### DIFF
--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -25,7 +25,9 @@ class Bcache(MakefilePackage):
     depends_on("pkgconfig", type="build")
 
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+        # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
+        if "libintl" in self.spec["gettext"].libs.joined():
+            env.append_flags("LDFLAGS", "-lintl")
 
     patch(
         "func_crc64.patch",

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -26,7 +26,7 @@ class Bcache(MakefilePackage):
 
     def setup_build_environment(self, env):
         # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
-        if "libintl" in self.spec["gettext"].libs.joined():
+        if any("libintl" in filename for filename in self.libs):
             env.append_flags("LDFLAGS", "-lintl")
 
     patch(


### PR DESCRIPTION
Hi!

I've used `spack external find --all` on Rocky Linux 8 (RHEL 8) and built loads of packages with it.

glibc-based systems like Ubuntu, RHEL, etc don't provide `libintl` as a separate library,
because the `libintl` **functions used by gettext are already provided by the system's GNU libc**.

As a result, on these systems, **the system-provided `gettext` packages do not install a separate `libintl`**!

A few packages failed to build with this setup because their recipes assume that there is always a `libintl` with `gettext`.

`bcache` was one of these:

This is easy to fix by asking the gettext recipe if it was able to find a separate libintl library and not using it if not.

Tested with `spack external find gettext` in these environments to make sure it works in both situations (with libintl and without):
* **musl**-based Alpine Linux (not a glibc-based system hence no libintl in libc) chroot
* **glibc**-based Linux using external gettext

