### PR TITLE
OpenFileTracker: close by inode, add deleter

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import time
 from datetime import datetime
-from typing import Dict, Tuple  # novm
+from typing import Dict, Tuple
 
 import llnl.util.tty as tty
 from llnl.util.lang import pretty_seconds
@@ -81,7 +81,7 @@ class OpenFileTracker(object):
 
     def __init__(self):
         """Create a new ``OpenFileTracker``."""
-        self._descriptors = {}  # type: Dict[Tuple[int, int], OpenFile]
+        self._descriptors: Dict[Tuple[int, int], OpenFile] = {}
 
     def get_fh(self, path):
         """Get a filehandle for a lockfile.

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -158,6 +158,10 @@ class OpenFileTracker(object):
 
         self.release_inode(inode)
 
+    def __del__(self):
+        for open_file in self._descriptors.values():
+            open_file.fh.close()
+
 
 #: Open file descriptors for locks in this process. Used to prevent one process
 #: from opening the sam file many times for different byte range locks

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -158,10 +158,6 @@ class OpenFileTracker(object):
 
         self.release_inode(inode)
 
-    def __del__(self):
-        for open_file in self._descriptors.values():
-            open_file.fh.close()
-
 
 #: Open file descriptors for locks in this process. Used to prevent one process
 #: from opening the sam file many times for different byte range locks


### PR DESCRIPTION
I'm having a hard time reproducing the exact issue in #34085, but in any case,
to me it looks safer to close file handlers by fstat instead of stat'ing their
path.



