### PR TITLE
prmon: depends_on py-numpy, py-pandas when +plot

### DIFF
--- a/var/spack/repos/builtin/packages/prmon/package.py
+++ b/var/spack/repos/builtin/packages/prmon/package.py
@@ -30,6 +30,8 @@ class Prmon(CMakePackage):
     depends_on("cmake@3.3:", type="build")
     depends_on("spdlog", when="@3.0.0:")
     depends_on("py-matplotlib", type="run", when="+plot")
+    depends_on("py-numpy", type="run", when="+plot")
+    depends_on("py-pandas", type="run", when="+plot")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Since at least version 1.0.0 there has been a dependency on matplotlib, numpy, and pandas (https://github.com/HSF/prmon/commit/c914a723de546967b5cc9c822e89c39615e2932e). Without this dependency, and with `+plot` we get the following output:
```
13:06:20 wdconinc@menelaos /data/LOG $ prmon_plot.py pythia8NCDIS_18x275_minQ2\=1_beamEffects_xAngle\=-0.025_hiDiv_vtxfix_1.0001.npsim.prmon.json 
ERROR:: This script needs numpy, pandas and matplotlib.
ERROR:: Looks like at least one of these modules is missing.
ERROR:: Please install them first and then retry.
```