### PR TITLE
Add type hints to Prefix class

### DIFF
--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -7,16 +7,21 @@
 This file contains utilities for managing the installation prefix of a package.
 """
 import os
+from typing import Dict, Union
+
+
+# https://peps.python.org/pep-0519/#provide-specific-type-hinting-support
+_PathLike = Union[str, bytes, os.PathLike]
 
 
 class Prefix(str):
-    """This class represents an installation prefix, but provides useful
-    attributes for referring to directories inside the prefix.
+    """This class represents an installation prefix, but provides useful attributes for referring
+    to directories inside the prefix.
 
-    Attributes of this object are created on the fly when you request them,
-    so any of the following is valid:
+    Attributes of this object are created on the fly when you request them, so any of the following
+    are valid:
 
-    >>> prefix = Prefix('/usr')
+    >>> prefix = Prefix("/usr")
     >>> prefix.bin
     /usr/bin
     >>> prefix.lib64
@@ -25,34 +30,56 @@ class Prefix(str):
     /usr/share/man
     >>> prefix.foo.bar.baz
     /usr/foo/bar/baz
-    >>> prefix.join('dashed-directory').bin64
+    >>> prefix.join("dashed-directory").bin64
     /usr/dashed-directory/bin64
 
-    Prefix objects behave identically to strings. In fact, they
-    subclass ``str``. So operators like ``+`` are legal::
+    Prefix objects behave identically to strings. In fact, they subclass ``str``, so operators like
+    ``+`` are legal::
 
-        print('foobar ' + prefix)
+        print("foobar " + prefix)
 
-    This prints ``foobar /usr``. All of this is meant to make custom
-    installs easy.
+    This prints ``foobar /usr``. All of this is meant to make custom installs easy.
     """
 
-    def __getattr__(self, attr):
-        return Prefix(os.path.join(self, attr))
+    def __getattr__(self, name: _PathLike) -> "Prefix":
+        """Concatenate a string to a prefix.
 
-    def join(self, string):
-        """Concatenates a string to a prefix.
+        Useful for strings that are valid variable names.
 
-        Parameters:
-            string (str): the string to append to the prefix
+        Args:
+            name: the string to append to the prefix
 
         Returns:
-            Prefix: the newly created installation prefix
+            the newly created installation prefix
+        """
+        return Prefix(os.path.join(self, attr))
+
+    def join(self, string: _PathLike) -> "Prefix":
+        """Concatenate a string to a prefix.
+
+        Useful for strings that are not valid variable names. This includes strings containing
+        characters like ``-`` and ``.``.
+
+        Args:
+            string: the string to append to the prefix
+
+        Returns:
+            the newly created installation prefix
         """
         return Prefix(os.path.join(self, string))
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, str]:
+        """Control how object is pickled.
+
+        Returns:
+            current state of the object
+        """
         return self.__dict__
 
-    def __setstate__(self, d):
+    def __setstate__(self, state: Dict[str, str]) -> None:
+        """Control how object is unpickled.
+
+        Args:
+            new state of the object
+        """
         self.__dict__.update(d)

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -9,7 +9,6 @@ This file contains utilities for managing the installation prefix of a package.
 import os
 from typing import Dict, Union
 
-
 # https://peps.python.org/pep-0519/#provide-specific-type-hinting-support
 _PathLike = Union[str, bytes, os.PathLike]
 
@@ -52,9 +51,9 @@ class Prefix(str):
         Returns:
             the newly created installation prefix
         """
-        return Prefix(os.path.join(self, attr))
+        return Prefix(os.path.join(self, name))
 
-    def join(self, string: _PathLike) -> "Prefix":
+    def join(self, string: _PathLike) -> "Prefix":  # type: ignore[override]
         """Concatenate a string to a prefix.
 
         Useful for strings that are not valid variable names. This includes strings containing
@@ -82,4 +81,4 @@ class Prefix(str):
         Args:
             new state of the object
         """
-        self.__dict__.update(d)
+        self.__dict__.update(state)

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -7,10 +7,7 @@
 This file contains utilities for managing the installation prefix of a package.
 """
 import os
-from typing import Dict, Union
-
-# https://peps.python.org/pep-0519/#provide-specific-type-hinting-support
-_PathLike = Union[str, bytes, os.PathLike]
+from typing import Dict
 
 
 class Prefix(str):
@@ -40,7 +37,7 @@ class Prefix(str):
     This prints ``foobar /usr``. All of this is meant to make custom installs easy.
     """
 
-    def __getattr__(self, name: _PathLike) -> "Prefix":
+    def __getattr__(self, name: str) -> "Prefix":
         """Concatenate a string to a prefix.
 
         Useful for strings that are valid variable names.
@@ -53,7 +50,7 @@ class Prefix(str):
         """
         return Prefix(os.path.join(self, name))
 
-    def join(self, string: _PathLike) -> "Prefix":  # type: ignore[override]
+    def join(self, string: str) -> "Prefix":  # type: ignore[override]
         """Concatenate a string to a prefix.
 
         Useful for strings that are not valid variable names. This includes strings containing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ src_paths = "lib"
 honor_noqa = true
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.11
 files = ['lib/spack/llnl/**/*.py', 'lib/spack/spack/**/*.py', './var/spack/repos/builtin/packages/*/package.py']
 mypy_path = ['bin', 'lib/spack', 'lib/spack/external', 'var/spack/repos/builtin']
 allow_redefinition = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ src_paths = "lib"
 honor_noqa = true
 
 [tool.mypy]
-python_version = 3.11
+python_version = 3.7
 files = ['lib/spack/llnl/**/*.py', 'lib/spack/spack/**/*.py', './var/spack/repos/builtin/packages/*/package.py']
 mypy_path = ['bin', 'lib/spack', 'lib/spack/external', 'var/spack/repos/builtin']
 allow_redefinition = true


### PR DESCRIPTION
Pretty sure these are correct, but we'll see what the tests find. `__dict__` might be wrong, maybe `Dict[str, object]`?

Do our tests run mypy on all files or only modified files?