### PR TITLE
concrete specs are not virtual

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -890,7 +890,7 @@ class RepoPath(object):
             pkg_name (str): name of the package we want to check
         """
         have_name = self._have_name(pkg_name)
-        return have_name and pkg_name in self.provider_index
+        return have_name and pkg_name != "all" and pkg_name in self.provider_index
 
     def is_virtual_safe(self, pkg_name):
         """Return True if the package with this name is virtual, False otherwise.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1647,7 +1647,7 @@ class Spec(object):
 
     @property
     def virtual(self):
-        return spack.repo.path.is_virtual(self.name)
+        return not self.concrete and spack.repo.path.is_virtual(self.name)
 
     @property
     def concrete(self):


### PR DESCRIPTION
Checking this ahead of time avoids hitting the repo cache.

Should make bootstrapping of gnupg in CI fast again, since it regressed
in de8c827.

Edit: hm, since `de8c827` we almost always trigger provider cache indexing :(
This PR just delays it (at least it doesn't feel like a download is broken).