### PR TITLE
pip/wheel/setuptools: extend PythonExtension

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class PyPip(PythonExtension):
+class PyPip(Package, PythonExtension):
     """The PyPA recommended tool for installing Python packages."""
 
     homepage = "https://pip.pypa.io/"
@@ -72,6 +72,8 @@ class PyPip(PythonExtension):
         sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0",
         expand=False,
     )
+
+    extends("python")
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/p/pip/pip-{1}-{0}-none-any.whl"

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class PyPip(Package):
+class PyPip(PythonExtension):
     """The PyPA recommended tool for installing Python packages."""
 
     homepage = "https://pip.pypa.io/"
@@ -72,14 +72,6 @@ class PyPip(Package):
         sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0",
         expand=False,
     )
-
-    extends("python")
-    depends_on("python@3.7:", when="@22:", type=("build", "run"))
-    depends_on("python@3.6:", when="@21:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.5:", when="@19.2:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", when="@18:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.3:", when="@10:", type=("build", "run"))
-    depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/p/pip/pip-{1}-{0}-none-any.whl"

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PySetuptools(PythonExtension):
+class PySetuptools(Package, PythonExtension):
     """A Python utility that aids in the process of downloading, building,
     upgrading, installing, and uninstalling Python packages."""
 
@@ -175,6 +175,7 @@ class PySetuptools(PythonExtension):
         expand=False,
     )
 
+    extends("python")
     depends_on("py-pip", type="build")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -6,15 +6,13 @@
 from spack.package import *
 
 
-class PySetuptools(Package):
+class PySetuptools(PythonExtension):
     """A Python utility that aids in the process of downloading, building,
     upgrading, installing, and uninstalling Python packages."""
 
     homepage = "https://github.com/pypa/setuptools"
     url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/setuptools/"
-
-    maintainers = ["adamjstewart"]
 
     version(
         "65.5.0",
@@ -177,12 +175,6 @@ class PySetuptools(Package):
         expand=False,
     )
 
-    extends("python")
-    depends_on("python@3.7:", when="@59.7:", type=("build", "run"))
-    depends_on("python@3.6:", when="@51:", type=("build", "run"))
-    depends_on("python@3.5:", when="@45:50", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.5:", when="@44", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", when="@:43", type=("build", "run"))
     depends_on("py-pip", type="build")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyWheel(PythonExtension):
+class PyWheel(Package, PythonExtension):
     """A built-package format for Python."""
 
     homepage = "https://github.com/pypa/wheel"
@@ -71,6 +71,7 @@ class PyWheel(PythonExtension):
         expand=False,
     )
 
+    extends("python")
     depends_on("py-pip", type="build")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyWheel(Package):
+class PyWheel(PythonExtension):
     """A built-package format for Python."""
 
     homepage = "https://github.com/pypa/wheel"
@@ -14,8 +14,6 @@ class PyWheel(Package):
         "https://files.pythonhosted.org/packages/py2.py3/w/wheel/wheel-0.34.2-py2.py3-none-any.whl"
     )
     list_url = "https://pypi.org/simple/wheel/"
-
-    maintainers = ["adamjstewart"]
 
     version(
         "0.37.1",
@@ -73,10 +71,6 @@ class PyWheel(Package):
         expand=False,
     )
 
-    extends("python")
-    depends_on("python@2.7:2.8,3.5:", when="@0.34:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", when="@0.30:", type=("build", "run"))
-    depends_on("python@2.6:2.8,3.2:", type=("build", "run"))
     depends_on("py-pip", type="build")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This allows us to run post-install import tests and other niceties of PythonPackage while still avoiding circular deps.