### PR TITLE
Fix dependency specification for CuSolver variant in HiOp.

### DIFF
--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -63,7 +63,12 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         description="Ultra safety checks - " "used for increased robustness and self-diagnostics",
     )
     variant("ginkgo", default=False, description="Enable/disable ginkgo solver")
-    variant("cusolver_lu", default=False, when="@0.7.1:", description="Enable/disable cuSovler LU refactorization")
+    variant(
+        "cusolver_lu",
+        default=False,
+        when="@0.7.1:",
+        description="Enable/disable cuSovler LU refactorization",
+    )
     depends_on("lapack")
     depends_on("blas")
     depends_on("cmake@3.18:", type="build")
@@ -97,7 +102,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("cuda@11:", when="@develop:+cuda")
     conflicts("+cusolver_lu", when="~cuda", msg="Cusolver LU refactorization requires CUDA")
-    conflicts("+cusolver_lu", when="~suite-sparse", msg="Cusolver LU refactorization requires KLU from SuiteSparse library")
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
     depends_on("raja+openmp", when="+raja~cuda~rocm")

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -63,8 +63,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         description="Ultra safety checks - " "used for increased robustness and self-diagnostics",
     )
     variant("ginkgo", default=False, description="Enable/disable ginkgo solver")
-    variant("cusolver_lu", default=False, when="@0.7.1:", description="Enable/disable cuSovler")
-
+    variant("cusolver_lu", default=False, when="@0.7.1:", description="Enable/disable cuSovler LU refactorization")
     depends_on("lapack")
     depends_on("blas")
     depends_on("cmake@3.18:", type="build")

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -66,7 +66,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "cusolver_lu",
         default=False,
-        when="@0.7.1:",
+        when="+cuda @0.7.1:",
         description="Enable/disable cuSovler LU refactorization",
     )
     depends_on("lapack")
@@ -101,7 +101,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("magma@{0}:".format(magma_v), when="@{0}:+rocm".format(hiop_v))
 
     depends_on("cuda@11:", when="@develop:+cuda")
-    conflicts("+cusolver_lu", when="~cuda", msg="Cusolver LU refactorization requires CUDA")
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
     depends_on("raja+openmp", when="+raja~cuda~rocm")

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -63,7 +63,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         description="Ultra safety checks - " "used for increased robustness and self-diagnostics",
     )
     variant("ginkgo", default=False, description="Enable/disable ginkgo solver")
-    variant("cusolver", default=False, description="Enable/disable cuSovler")
+    variant("cusolver_lu", default=False, when="@0.7.1:", description="Enable/disable cuSovler")
 
     depends_on("lapack")
     depends_on("blas")
@@ -97,6 +97,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("magma@{0}:".format(magma_v), when="@{0}:+rocm".format(hiop_v))
 
     depends_on("cuda@11:", when="@develop:+cuda")
+    conflicts("+cusolver_lu", when="~cuda", msg="Cusolver requires CUDA")
 
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
@@ -111,6 +112,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipsparse", when="+rocm")
 
     depends_on("suite-sparse", when="+kron")
+    depends_on("suite-sparse", when="+cusolver_lu")
 
     depends_on("coinhsl+blas", when="+sparse")
     depends_on("metis", when="+sparse")
@@ -122,8 +124,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         when="+cuda+raja",
         msg="umpire+cuda exports device code and requires static libs",
     )
-    conflicts("+cusolver", when="~cuda", msg="Cusolver requires CUDA")
-    conflicts("+cusolver", when="@:0.5", msg="Cusolver support was introduced in HiOp 0.6")
 
     flag_handler = build_system_flags
 
@@ -159,7 +159,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("HIOP_USE_COINHSL", "sparse"),
                 self.define_from_variant("HIOP_TEST_WITH_BSUB", "jsrun"),
                 self.define_from_variant("HIOP_USE_GINKGO", "ginkgo"),
-                self.define_from_variant("HIOP_USE_CUSOLVER", "cusolver"),
+                self.define_from_variant("HIOP_USE_CUSOLVER_LU", "cusolver_lu"),
             ]
         )
 

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -96,8 +96,8 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("magma@{0}:".format(magma_v), when="@{0}:+rocm".format(hiop_v))
 
     depends_on("cuda@11:", when="@develop:+cuda")
-    conflicts("+cusolver_lu", when="~cuda", msg="Cusolver requires CUDA")
-
+    conflicts("+cusolver_lu", when="~cuda", msg="Cusolver LU refactorization requires CUDA")
+    conflicts("+cusolver_lu", when="~suite-sparse", msg="Cusolver LU refactorization requires KLU from SuiteSparse library")
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
     depends_on("raja+openmp", when="+raja~cuda~rocm")


### PR DESCRIPTION
Closes https://github.com/LLNL/hiop/issues/571.

Not sure if a conflict is the correct way to require `cuda` with `cusolver_lu`.

cc @pelesh 