### PR TITLE
Add direnv v2.32.2

### DIFF
--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -12,8 +12,9 @@ class Direnv(Package):
     homepage = "https://direnv.net/"
     url = "https://github.com/direnv/direnv/archive/v2.11.3.tar.gz"
 
-    maintainers = ["acastanedam"]
+    maintainers = ["acastanedam", "alecbcs"]
 
+    version("2.32.2", sha256="352b3a65e8945d13caba92e13e5666e1854d41749aca2e230938ac6c64fa8ef9")
     version("2.32.1", sha256="dc7df9a9e253e1124748aa74da94bf2b96f5a61d581c60d52d3f8e8dc86ecfde")
     version("2.31.0", sha256="f82694202f584d281a166bd5b7e877565f96a94807af96325c8f43643d76cb44")
     version("2.30.2", sha256="a2ee14ebdbd9274ba8bf0896eeb94e98947a056611058dedd4dbb43167e076f3")


### PR DESCRIPTION
Add direnv v2.32.2 which includes a few new features, multiple bug fixes, and dependency updates.

**Summarized Changelog:**
- feat: Update layout anaconda to accept a path to a yml file.
- feat: install.sh: can specify direnv version.
- fix: elvish: replace deprecated except with catch.
- fix: installer.sh: make direnv executable for all.
- fix: path escaping.
- fix: stdlib: only use ANSI escape on TTY.
- fix: test: remove mentions of DIRENV_MTIME.
- fix: test: use lowercase -d flag for base64 decoding of DIRENV_DIFF.
- update: build(deps): bump github.com/BurntSushi/toml from 1.1.0 to 1.2.0.

Full changelog for v2.32.2 can be found [here](https://github.com/direnv/direnv/releases/tag/v2.32.2).

**Test Plan:**
Tested v2.32.2 by building locally then testing loading and unloading example .envrc files. 