### PR TITLE
Add restic v0.14.0

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -17,6 +17,7 @@ class Restic(Package):
     version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")
     version("0.12.1", sha256="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb")
 
+    depends_on("go@1.15:", type="build", when="@0.14.0:")
     depends_on("go", type="build")
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -14,6 +14,7 @@ class Restic(Package):
 
     maintainers = ["alecbcs"]
 
+    version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")
     version("0.12.1", sha256="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb")
 
     depends_on("go", type="build")


### PR DESCRIPTION
Add restic v0.14.0 which includes new features and bug fixes.

**Summarized Changelog:**
- List snapshots in backend at most once to resolve snapshot IDs.
- Fix rare 'not found in repository' error for copy command.
- The diff command incorrectly listed some files as added.
- Directory sync errors for repositories accessed via SMB.
- The stats command miscalculated restore size for multiple snapshots.
- Yield error on invalid policy to forget.
- Print "wrong password" to stderr instead of stdout.
- Correctly rebuild index for legacy repositories.
- Limit number of key files tested while opening a repository.
- Update dependencies and require Go 1.15 or newer.
- Support pruning even when the disk is full.
- Add compression support.
- Adaptive IO concurrency based on backend connections.

Full changelog can be found [here](https://github.com/restic/restic/releases/tag/v0.14.0).

**Test Plan:**
Tested v0.14.0 by building locally and running an example backup to an s3 backed remote.