### PR TITLE
Add py-python-lsp-server and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-docstring-to-markdown/package.py
+++ b/var/spack/repos/builtin/packages/py-docstring-to-markdown/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDocstringToMarkdown(PythonPackage):
+    """On the fly conversion of Python docstrings to markdown."""
+
+    homepage = "https://github.com/python-lsp/docstring-to-markdown"
+    pypi = "docstring-to-markdown/docstring-to-markdown-0.10.tar.gz"
+
+    maintainers = ["alecbcs"]
+
+    version("0.10", sha256="12f75b0c7b7572defea2d9e24b57ef7ac38c3e26e91c0e5547cfc02b1c168bf6")
+
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
@@ -16,6 +16,6 @@ class PyPythonLspJsonrpc(PythonPackage):
 
     version("1.0.0", sha256="7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd")
 
-    depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@61.2.0:", type="build")
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
     depends_on("py-ujson@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPythonLspJsonrpc(PythonPackage):
+    """A Python 3.7+ server implementation of the JSON RPC 2.0 protocol."""
+
+    homepage = "https://github.com/python-lsp/python-lsp-jsonrpc"
+    pypi = "python-lsp-jsonrpc/python-lsp-jsonrpc-1.0.0.tar.gz"
+
+    maintainers = ["alecbcs"]
+
+    version("1.0.0", sha256="7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools@61.2.0:", type="build")
+    depends_on("py-ujson@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-jsonrpc/package.py
@@ -16,6 +16,5 @@ class PyPythonLspJsonrpc(PythonPackage):
 
     version("1.0.0", sha256="7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd")
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-ujson@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -17,8 +17,8 @@ class PyPythonLspServer(PythonPackage):
     version("1.6.0", sha256="d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@61.2.0:", type="build")
-    depends_on("py-setuptools-scm@3.4.3:+toml", type="build")
+    depends_on("py-setuptools@61.2.0:", type=("build", "run"))
+    depends_on("py-setuptools-scm@3.4.3:+toml", type=("build", "run"))
     depends_on("py-docstring-to-markdown", type=("build", "run"))
     depends_on("py-jedi@0.17.2:0.18", type=("build", "run"))
     depends_on("py-pluggy@1.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -18,8 +18,9 @@ class PyPythonLspServer(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools@61.2.0:", type="build")
-    depends_on("py-jedi@0.17.2:0.18", type=("build", "run"))
-    depends_on("py-python-lsp-jsonrpc@1.0.0:", type=("build", "run"))
-    depends_on("py-pluggy@1.0.0:", type=("build", "run"))
+    depends_on("py-setuptools-scm@3.4.3:+toml", type="build")
     depends_on("py-docstring-to-markdown", type=("build", "run"))
+    depends_on("py-jedi@0.17.2:0.18", type=("build", "run"))
+    depends_on("py-pluggy@1.0.0:", type=("build", "run"))
+    depends_on("py-python-lsp-jsonrpc@1.0.0:", type=("build", "run"))
     depends_on("py-ujson@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPythonLspServer(PythonPackage):
+    """A Python 3.7+ implementation of the Language Server Protocol."""
+
+    homepage = "https://github.com/python-lsp/python-lsp-server"
+    pypi = "python-lsp-server/python-lsp-server-1.6.0.tar.gz"
+
+    maintainers = ["alecbcs"]
+
+    version("1.6.0", sha256="d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools@61.2.0:", type="build")
+    depends_on("py-jedi@0.17.2:0.19.0", type=("build", "run"))
+    depends_on("py-python-lsp-jsonrpc@1.0.0:", type=("build", "run"))
+    depends_on("py-pluggy@1.0.0:", type=("build", "run"))
+    depends_on("py-docstring-to-markdown", type=("build", "run"))
+    depends_on("py-ujson@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -18,7 +18,7 @@ class PyPythonLspServer(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools@61.2.0:", type=("build", "run"))
-    depends_on("py-setuptools-scm@3.4.3:+toml", type=("build", "run"))
+    depends_on("py-setuptools-scm@3.4.3:+toml", type="build")
     depends_on("py-docstring-to-markdown", type=("build", "run"))
     depends_on("py-jedi@0.17.2:0.18", type=("build", "run"))
     depends_on("py-pluggy@1.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -18,7 +18,7 @@ class PyPythonLspServer(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools@61.2.0:", type="build")
-    depends_on("py-jedi@0.17.2:0.19.0", type=("build", "run"))
+    depends_on("py-jedi@0.17.2:0.18", type=("build", "run"))
     depends_on("py-python-lsp-jsonrpc@1.0.0:", type=("build", "run"))
     depends_on("py-pluggy@1.0.0:", type=("build", "run"))
     depends_on("py-docstring-to-markdown", type=("build", "run"))


### PR DESCRIPTION
Add `python-lsp-server` and its required dependencies (`python-lsp-jsonrpc` and `docstring-to-markdown`). 

Python-lsp-server is a language server using jedi to provide ide-like autocompletion in text editors like emacs and vim for python.