### PR TITLE
texinfo: added version 7.0

### DIFF
--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -23,6 +23,7 @@ class Texinfo(AutotoolsPackage, GNUMirrorPackage):
 
     tags = ["build-tools"]
 
+    version("7.0", sha256="9261d4ee11cdf6b61895e213ffcd6b746a61a64fe38b9741a3aaa73125b35170")
     version("6.8", sha256="8e09cf753ad1833695d2bac0f57dc3bd6bcbbfbf279450e1ba3bc2d7fb297d08")
     version("6.7", sha256="a52d05076b90032cb2523673c50e53185938746482cf3ca0213e9b4b50ac2d3e")
     version("6.6", sha256="900723b220baa4672c4214a873a69ecbe1cb5f14c926a1a4bbb230ac309294cb")


### PR DESCRIPTION
Added the latest version of `texinfo`. No patches are needed on my systems. It solves installation issues with `almalinux 9.1` that contains `glibc@2.34`.