### PR TITLE
Add texinfo dependency for binutils through version 2.38

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -81,12 +81,9 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     depends_on("m4", type="build", when="@:2.29 +gold")
     depends_on("bison", type="build", when="@:2.29 +gold")
 
-    # 2.38 with +gas needs makeinfo due to a bug, see:
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=28909
-    depends_on("texinfo", type="build", when="@2.38 +gas")
-    # 2.34 needs makeinfo due to a bug, see:
+    # 2.34:2.38 needs makeinfo due to a bug, see:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=25491
-    depends_on("texinfo", type="build", when="@2.34")
+    depends_on("texinfo", type="build", when="@2.34:2.38")
 
     conflicts("+gold", when="platform=darwin", msg="Binutils cannot build linkers on macOS")
 


### PR DESCRIPTION
Personally I think it should just be `depends_on("texinfo", type="build")` to be safe. However, I still see:
```
  >> 3066    WARNING: 'makeinfo' is missing on your system.
     3067             You should only need it if you modified a '.texi' file, or
     3068             any other file indirectly affecting the aspect of the manual.
     3069             You might want to install the Texinfo package:
     3070             <http://www.gnu.org/software/texinfo/>
     3071             The spurious makeinfo call might also be the consequence of
     3072             using a buggy 'make' (AIX, DU, IRIX), in which case you might
     3073             want to install GNU make:
     3074             <http://www.gnu.org/software/make/>
```
in 2.38 so I think `texinfo` should be required through 2.38. The build also fails on my machine without `texinfo` installed, and this change allows the build to succeed.