### PR TITLE
exago@develop %gcc@11.2.0: CXXFLAGS=-Wno-error=non-pod-varargs

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -140,6 +140,10 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     flag_handler = build_system_flags
 
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("@develop %gcc@11.2.0:"):
+            env.set("CXXFLAGS", "-Wno-error=non-pod-varargs")
+
     def cmake_args(self):
         args = []
         spec = self.spec


### PR DESCRIPTION
Building `exago@develop %gcc@11.2.0` without this fix I see these errors:
```
...
  >> 188    /tmp/eugeneswalker/spack-stage/spack-stage-exago-develop-6mgccbqrryevycnpjix2irtzi4mwuecw/spack-src/src/utils/utils.cpp:122:29: error: cannot pass
             non-trivial object of type 'const std::string' (aka 'const basic_string<char>') to variadic function; expected type from format string was '
            char *' [-Wnon-pod-varargs]
     189      sprintf(sbuf, "%s%s", opt.default_value,
```

@CameronRutherford @pelesh @ryandanehy 