### PR TITLE
Cray manifest: automatically convert 'cray' platform to 'linux'

### DIFF
--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -61,9 +61,17 @@ def compiler_from_entry(entry):
 def spec_from_entry(entry):
     arch_str = ""
     if "arch" in entry:
+        local_platform = spack.spec.ArchSpec.default_arch().platform
+        spec_platform = entry["arch"]["platform"]
+        # Note that Cray systems are now treated as Linux. Specs
+        # in the manifest which specify "cray" as the platform
+        # should be registered in the DB as "linux"
+        if local_platform == "linux" and spec_platform.lower() == "cray":
+            spec_platform = "linux"
+
         arch_format = "arch={platform}-{os}-{target}"
         arch_str = arch_format.format(
-            platform=entry["arch"]["platform"],
+            platform=spec_platform,
             os=entry["arch"]["platform_os"],
             target=entry["arch"]["target"]["name"],
         )

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -61,17 +61,9 @@ def compiler_from_entry(entry):
 def spec_from_entry(entry):
     arch_str = ""
     if "arch" in entry:
-        local_platform = spack.spec.ArchSpec.default_arch().platform
-        spec_platform = entry["arch"]["platform"]
-        # Note that Cray systems are now treated as Linux. Specs
-        # in the manifest which specify "cray" as the platform
-        # should be registered in the DB as "linux"
-        if local_platform == "linux" and spec_platform.lower() == "cray":
-            spec_platform = "linux"
-
         arch_format = "arch={platform}-{os}-{target}"
         arch_str = arch_format.format(
-            platform=spec_platform,
+            platform=entry["arch"]["platform"],
             os=entry["arch"]["platform_os"],
             target=entry["arch"]["target"]["name"],
         )

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -61,9 +61,16 @@ def compiler_from_entry(entry):
 def spec_from_entry(entry):
     arch_str = ""
     if "arch" in entry:
+        local_platform = spack.platforms.host()
+        spec_platform = entry["arch"]["platform"]
+        # Note that Cray systems are now treated as Linux. Specs
+        # in the manifest which specify "cray" as the platform
+        # should be registered in the DB as "linux"
+        if local_platform.name == "linux" and spec_platform.lower() == "cray":
+            spec_platform = "linux"
         arch_format = "arch={platform}-{os}-{target}"
         arch_str = arch_format.format(
-            platform=entry["arch"]["platform"],
+            platform=spec_platform,
             os=entry["arch"]["platform_os"],
             target=entry["arch"]["target"]["name"],
         )

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -29,8 +29,9 @@ class Test(Platform):
     back_os = "debian6"
     default_os = "debian6"
 
-    def __init__(self):
-        super(Test, self).__init__("test")
+    def __init__(self, name=None):
+        name = name or "test"
+        super(Test, self).__init__(name)
         self.add_target(self.default, spack.target.Target(self.default))
         self.add_target(self.front_end, spack.target.Target(self.front_end))
 

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -234,6 +234,10 @@ def test_generate_specs_from_manifest():
 
 
 def test_translate_cray_platform_to_linux(monkeypatch):
+    """Manifests might list specs on newer Cray platforms as being "cray",
+    but Spack identifies such platforms as "linux". Make sure we
+    automaticaly transform these entries.
+    """
     test_linux_platform = spack.platforms.test.Test("linux")
 
     def the_host_is_linux():

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -233,6 +233,30 @@ def test_generate_specs_from_manifest():
     assert openmpi_spec["hwloc"]
 
 
+def test_translate_cray_platform_to_linux(monkeypatch):
+    test_linux_platform = spack.platforms.test.Test("linux")
+
+    def the_host_is_linux():
+        return test_linux_platform
+
+    monkeypatch.setattr(spack.platforms, "host", the_host_is_linux)
+
+    cray_arch = JsonArchEntry(platform="cray", os="rhel8", target="x86_64").to_dict()
+    spec_json = JsonSpecEntry(
+        name="cray-mpich",
+        hash="craympichfakehashaaa",
+        prefix="/path/to/cray-mpich/",
+        version="1.0.0",
+        arch=cray_arch,
+        compiler=_common_compiler.spec_json(),
+        dependencies={},
+        parameters={},
+    ).to_dict()
+
+    (spec,) = entries_to_specs([spec_json]).values()
+    assert spec.architecture.platform == "linux"
+
+
 def test_translate_compiler_name():
     nvidia_compiler = JsonCompilerEntry(
         name="nvidia",


### PR DESCRIPTION
Spack now recognizes Cray systems as being Linux (i.e. `spack arch` on Cray systems will list "linux" as the platform). For manifests which continue to list the platform as Cray, this PR automatically converts them so they are considered compatible with other packages built on the system by Spack.