### PR TITLE
Add libxml2 for dap-enabled latest netcdf-c

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -98,6 +98,10 @@ class NetcdfC(AutotoolsPackage):
     depends_on("curl@7.18.0:", when="+dap")
     # depends_on("curl@7.18.0:", when='+cdmremote')
 
+    # Need to include libxml2 when using DAP in 4.9.0 and newer to build
+    # https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63
+    depends_on("libxml2", when="@4.9.0:+dap")
+
     depends_on("parallel-netcdf", when="+parallel-netcdf")
 
     # We need to build with MPI wrappers if any of the two


### PR DESCRIPTION
Currently, the netcdf-c@4.9.0 release does not successfully build with the `+dap` variant active because of a missing dependency on libxml2 (see [this commit](https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63)). Perhaps if you have development headers on your system in the right place, you will miss this error, but it occurs on one of our systems:

```
  >> 486    ncxml_xml2.c:5:10: fatal error: libxml2/libxml/parser.h: No such file or director
            y
     487        5 | #include <libxml2/libxml/parser.h>
     488          |          ^~~~~~~~~~~~~~~~~~~~~~~~~
     489    compilation terminated.
  >> 490    make[2]: *** [Makefile:565: ncxml_xml2.lo] Error 1
```

This PR adds a libxml2 dependency when `@4.9.0:+dap`.