### PR TITLE
ROOT: new versions with associated dependency constraints

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -233,8 +233,8 @@ class Root(CMakePackage):
 
     # Python
     depends_on("python@2.7:", when="+python", type=("build", "run"))
-    depends_on("python@2.7:3.6", when=":6.13 +python", type=("build", "run"))
     depends_on("python@2.7:3.10", when=":6.26.09 +python", type=("build", "run"))
+    depends_on("python@2.7:3.6", when=":6.13 +python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"), when="+tmva")
     # This numpy dependency was not intended and will hopefully
     # be fixed in 6.20.06.

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -234,7 +234,6 @@ class Root(CMakePackage):
     # Python
     depends_on("python@2.7:", when="+python", type=("build", "run"))
     depends_on("python@2.7:3.10", when="@:6.26.09 +python", type=("build", "run"))
-    depends_on("python@2.7:3.6", when="@:6.13 +python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"), when="+tmva")
     # This numpy dependency was not intended and will hopefully
     # be fixed in 6.20.06.
@@ -319,6 +318,9 @@ class Root(CMakePackage):
     # See https://github.com/root-project/root/issues/11714
     if sys.platform == "darwin" and macos_version() >= Version("13"):
         conflicts("@:6.26.09", msg="macOS 13 support was added in 6.26.10")
+
+    # ROOT <6.14 is incompatible with Python >=3.7, which is the minimum supported by spack
+    conflicts("+python", when="@:6.13", msg="Spack wants python >=3.7, too new for ROOT <6.14")
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -292,7 +292,9 @@ class Root(CMakePackage):
 
     # Python incompatibilities
     conflicts("^python@3.7:", when="@:6.13 +python", msg="Python 3.7+ support was added in 6.14")
-    conflicts("^python@3.11:", when="@:6.26.09 +python", msg="Python 3.11+ support was added in 6.26.10")
+    conflicts(
+        "^python@3.11:", when="@:6.26.09 +python", msg="Python 3.11+ support was added in 6.26.10"
+    )
 
     # See https://github.com/root-project/root/issues/9297
     conflicts("target=ppc64le:", when="@:6.24")
@@ -316,7 +318,11 @@ class Root(CMakePackage):
     conflicts("+vmc", when="@6.26:", msg="VMC was removed in ROOT v6.26.00.")
 
     # nlohmann_json incompatibilities
-    conflicts("^nlohmann-json@3.11:", when="@:6.26.07", msg="nlohmann_json 3.11+ support was added in 6.26.08")
+    conflicts(
+        "^nlohmann-json@3.11:",
+        when="@:6.26.07",
+        msg="nlohmann_json 3.11+ support was added in 6.26.08"
+    )
 
     # Clang incompatibilities
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -31,6 +31,8 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version("6.26.10", sha256="8e56bec397104017aa54f9eb554de7a1a134474fe0b3bb0f43a70fc4fabd625f")
+    version("6.26.08", sha256="4dda043e7918b40743ad0299ddd8d526b7078f0a3822fd06066df948af47940e")
     version("6.26.06", sha256="b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb")
     version("6.26.04", sha256="a271cf82782d6ed2c87ea5eef6681803f2e69e17b3036df9d863636e9358421e")
     version("6.26.02", sha256="7ba96772271a726079506c5bf629c3ceb21bf0682567ed6145be30606d7cd9bb")
@@ -288,8 +290,9 @@ class Root(CMakePackage):
     # GCC 9.2.1, which we can safely extrapolate to the GCC 9 series.
     conflicts("%gcc@9.0.0:", when="@:6.11")
 
-    # ROOT <6.14 was incompatible with Python 3.7+
-    conflicts("^python@3.7:", when="@:6.13 +python")
+    # Python incompatibilities
+    conflicts("^python@3.7:", when="@:6.13 +python", msg="Python 3.7+ support was added in 6.14")
+    conflicts("^python@3.11:", when="@:6.26.09 +python", msg="Python 3.11+ support was added in 6.26.10")
 
     # See https://github.com/root-project/root/issues/9297
     conflicts("target=ppc64le:", when="@:6.24")
@@ -297,6 +300,8 @@ class Root(CMakePackage):
     # Incompatible variants
     if sys.platform != "darwin":
         conflicts("+opengl", when="~x", msg="OpenGL requires X")
+        # TODO: Query os.uname() to check if we're dealing with macOS >= 13.
+        #       If so add conflict with @:6.26.09, support was added in .10
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")
     conflicts("+tmva", when="~mlp", msg="TVMA requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
@@ -309,6 +314,12 @@ class Root(CMakePackage):
 
     # Feature removed in 6.26.00:
     conflicts("+vmc", when="@6.26:", msg="VMC was removed in ROOT v6.26.00.")
+
+    # nlohmann_json incompatibilities
+    conflicts("^nlohmann-json@3.11:", when="@:6.26.07", msg="nlohmann_json 3.11+ support was added in 6.26.08")
+
+    # Clang incompatibilities
+    conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
 import sys
 
+from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -317,11 +317,8 @@ class Root(CMakePackage):
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")
 
     # See https://github.com/root-project/root/issues/11714
-    if sys.platform == "darwin":
-        version = platform.mac_ver()(0)
-        major_version = int(version.split(".")(0))
-        if major_version >= 13:
-            conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
+    if sys.platform == "darwin" and macos_version() >= Version("13"):
+        conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import platform
 import sys
 
 from spack.package import *
@@ -299,8 +300,10 @@ class Root(CMakePackage):
     # Incompatible variants
     if sys.platform != "darwin":
         conflicts("+opengl", when="~x", msg="OpenGL requires X")
-        # TODO: Query os.uname() to check if we're dealing with macOS >= 13.
-        #       If so add conflict with @:6.26.09, support was added in .10
+        version, _, _ = platform.mac_ver()
+        major_version = version.split('.')[0]
+        if major_version >= 13:
+            conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")
     conflicts("+tmva", when="~mlp", msg="TVMA requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -300,10 +300,6 @@ class Root(CMakePackage):
     # Incompatible variants
     if sys.platform != "darwin":
         conflicts("+opengl", when="~x", msg="OpenGL requires X")
-        version = platform.mac_ver()(0)
-        major_version = int(version.split('.')(0))
-        if major_version >= 13:
-            conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")
     conflicts("+tmva", when="~mlp", msg="TVMA requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
@@ -317,8 +313,15 @@ class Root(CMakePackage):
     # Feature removed in 6.26.00:
     conflicts("+vmc", when="@6.26:", msg="VMC was removed in ROOT v6.26.00.")
 
-    # Clang incompatibilities
+    # See https://github.com/root-project/root/issues/11128
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")
+
+    # See https://github.com/root-project/root/issues/11714
+    if sys.platform == "darwin":
+        version = platform.mac_ver()(0)
+        major_version = int(version.split(".")(0))
+        if major_version >= 13:
+            conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -233,8 +233,8 @@ class Root(CMakePackage):
 
     # Python
     depends_on("python@2.7:", when="+python", type=("build", "run"))
-    depends_on("python@2.7:3.10", when=":6.26.09 +python", type=("build", "run"))
-    depends_on("python@2.7:3.6", when=":6.13 +python", type=("build", "run"))
+    depends_on("python@2.7:3.10", when="@:6.26.09 +python", type=("build", "run"))
+    depends_on("python@2.7:3.6", when="@:6.13 +python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"), when="+tmva")
     # This numpy dependency was not intended and will hopefully
     # be fixed in 6.20.06.
@@ -318,7 +318,7 @@ class Root(CMakePackage):
 
     # See https://github.com/root-project/root/issues/11714
     if sys.platform == "darwin" and macos_version() >= Version("13"):
-        conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
+        conflicts("@:6.26.09", msg="macOS 13 support was added in 6.26.10")
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -206,6 +206,7 @@ class Root(CMakePackage):
     depends_on("lz4", when="@6.13.02:")  # See cmake_args, below.
     depends_on("ncurses")
     depends_on("nlohmann-json", when="@6.24:")
+    depends_on("nlohmann-json@:3.10", when="@6.24:6.26.07")
     depends_on("pcre")
     depends_on("xxhash", when="@6.13.02:")  # See cmake_args, below.
     depends_on("xz")
@@ -231,6 +232,8 @@ class Root(CMakePackage):
 
     # Python
     depends_on("python@2.7:", when="+python", type=("build", "run"))
+    depends_on("python@2.7:3.6", when=":6.13 +python", type=("build", "run"))
+    depends_on("python@2.7:3.10", when=":6.26.09 +python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"), when="+tmva")
     # This numpy dependency was not intended and will hopefully
     # be fixed in 6.20.06.
@@ -290,12 +293,6 @@ class Root(CMakePackage):
     # GCC 9.2.1, which we can safely extrapolate to the GCC 9 series.
     conflicts("%gcc@9.0.0:", when="@:6.11")
 
-    # Python incompatibilities
-    conflicts("^python@3.7:", when="@:6.13 +python", msg="Python 3.7+ support was added in 6.14")
-    conflicts(
-        "^python@3.11:", when="@:6.26.09 +python", msg="Python 3.11+ support was added in 6.26.10"
-    )
-
     # See https://github.com/root-project/root/issues/9297
     conflicts("target=ppc64le:", when="@:6.24")
 
@@ -316,13 +313,6 @@ class Root(CMakePackage):
 
     # Feature removed in 6.26.00:
     conflicts("+vmc", when="@6.26:", msg="VMC was removed in ROOT v6.26.00.")
-
-    # nlohmann_json incompatibilities
-    conflicts(
-        "^nlohmann-json@3.11:",
-        when="@:6.26.07",
-        msg="nlohmann_json 3.11+ support was added in 6.26.08"
-    )
 
     # Clang incompatibilities
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in 6.26.08")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -300,8 +300,8 @@ class Root(CMakePackage):
     # Incompatible variants
     if sys.platform != "darwin":
         conflicts("+opengl", when="~x", msg="OpenGL requires X")
-        version, _, _ = platform.mac_ver()
-        major_version = version.split('.')[0]
+        version = platform.mac_ver()(0)
+        major_version = int(version.split('.')(0))
         if major_version >= 13:
             conflicts(":6.26.09", msg="macOS 13 support was added in 6.26.10")
     conflicts("+tmva", when="~gsl", msg="TVMA requires GSL")


### PR DESCRIPTION
@wdconinc Here's my take on the dependency constraints, so that the info on your closed PR don't get lost :)

I couldn't spell out the macOS conflict because I don't have access to a Mac so I can't check how macOS fills uname information.

Feel free to test/approve this once you have the time.