### PR TITLE
Fix forced dependencies in petsc

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -492,7 +492,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 useinc = True
                 uselib = True
 
-            library_requested = spacklibname.split(":")[0] in direct_dependencies
+            dependency_name = spacklibname.split(":")[0]
+            dependency_names = [d.name for d in spec.dependencies()]
+            library_requested = dependency_name in direct_dependencies and dependency_name in dependency_names
             options.append(
                 "--with-{library}={value}".format(
                     library=petsclibname, value=("1" if library_requested else "0")


### PR DESCRIPTION
This commit fixes multiple virtual dependencies all being added to petsc, even if we don't want them.

Example: we're building with intel-mkl which provides scalapack, so we're automatically building with scalapack which we don't want.