### PR TITLE
evtgen: add v02.02.00

### DIFF
--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -54,15 +54,13 @@ class Evtgen(CMakePackage):
 
     @property
     def root_cmakelists_dir(self):
-          # deal with inconsistent intermediate folders of tarballs
-          # 02.00.00 only has 'R02-00-00'
-          # but 02.02.00 has 'EvtGen/R02-02-00'
-          if self.spec.satisfies("@02.02.00:"):
-              return "R" + str(self.version).replace('.', '-')
-          else:
-              return ""
-
-
+        # deal with inconsistent intermediate folders of tarballs
+        # 02.00.00 only has 'R02-00-00'
+        # but 02.02.00 has 'EvtGen/R02-02-00'
+        if self.spec.satisfies("@02.02.00:"):
+            return "R" + str(self.version).replace(".", "-")
+        else:
+            return ""
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -17,6 +17,7 @@ class Evtgen(CMakePackage):
 
     maintainers = ["vvolkl"]
 
+    version("02.02.00", sha256="0c626e51cb17e799ad0ffd0beea5cb94d7ac8a5f8777b746aa1944dd26071ecf")
     version("02.00.00", sha256="02372308e1261b8369d10538a3aa65fe60728ab343fcb64b224dac7313deb719")
     # switched to cmake in 02.00.00
     version(
@@ -51,6 +52,18 @@ class Evtgen(CMakePackage):
     )
     conflicts("+hepmc3", when="@:01", msg="hepmc3 support was added in 02.00.00")
 
+    @property
+    def root_cmakelists_dir(self):
+          # deal with inconsistent intermediate folders of tarballs
+          # 02.00.00 only has 'R02-00-00'
+          # but 02.02.00 has 'EvtGen/R02-02-00'
+          if self.spec.satisfies("@02.02.00:"):
+              return "R" + str(self.version).replace('.', '-')
+          else:
+              return ""
+
+
+
     def cmake_args(self):
         args = []
 
@@ -66,7 +79,7 @@ class Evtgen(CMakePackage):
         # the `-undefined dynamic_lookup` flag enables weak linking on Mac
         # Patch taken from CMS recipe:
         # https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_1_X/master/evtgen.spec#L48
-        if not self.spec.satisfies("platform=darwin"):
+        if not self.spec.satisfies("%gcc platform=darwin"):
             return
 
         filter_file("-shared", "-dynamiclib -undefined dynamic_lookup", "make.inc")


### PR DESCRIPTION
The  release tarballs are unfortunately a bit inconsistent, but the latest version exports its CMake targets! :tada: 

Also, the patch function errored for me when building on macOS with apple-clang, seems like this  is gcc specific.