### PR TITLE
icc@2021.6.0 does not support gcc@12 headers

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -36,6 +36,9 @@ class IntelOneapiCompilersClassic(Package):
         version(ver)
         depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")
 
+    # icc@2021.6.0 does not support gcc@12 headers
+    conflicts("%gcc@12:", when="@:2021.6.0")
+
     @property
     def oneapi_compiler_prefix(self):
         oneapi_version = self.spec["intel-oneapi-compilers"].version


### PR DESCRIPTION
Error message:
```
/shared/spack/opt/spack/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.2.0-4tairupdxg2tg2yhvjdlbs7xbd7wudl3/bin/../include/c++/12.2.0/bits/random.h(104): error: expected a declaration
{ extension using type = unsigned __int128; };
^
```

Fixes https://github.com/spack/spack/issues/34181