### PR TITLE
external python extensions: more robust external python finding

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import archspec
 import inspect
 import os
 import re

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -2,12 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import archspec
 import inspect
 import os
 import re
 import shutil
 from typing import Optional
+
+import archspec
 
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -298,7 +298,9 @@ class PythonPackage(PythonExtension):
         )
 
         python_externals_detected = [
-            d.spec for d in python_externals_detection.get("python", []) if d.prefix == self.spec.external_path
+            d.spec
+            for d in python_externals_detection.get("python", [])
+            if d.prefix == self.spec.external_path
         ]
         if python_externals_detected:
             return python_externals_detected[0]

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -277,6 +277,9 @@ class PythonPackage(PythonExtension):
         First search: an "installed" external that shares a prefix with this package
         Second search: a configured external that shares a prefix with this package
         Third search: search this prefix for a python package
+
+        Returns:
+          spack.spec.Spec: The external Spec for python most likely to be compatible with self.spec
         """
         python_externals_installed = [
             s for s in spack.store.db.query("python") if s.prefix == self.spec.external_path

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -253,7 +253,8 @@ class PythonPackage(PythonExtension):
 
         python_external_config = spack.config.get("packages:python:externals", [])
         python_externals_configured = [
-            spack.spec.Spec(item["spec"]) for item in python_external_config
+            spack.spec.Spec(item["spec"])
+            for item in python_external_config
             if item["prefix"] == self.prefix
         ]
         if python_externals_configured:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -288,10 +288,6 @@ class PythonPackage(PythonExtension):
             return python_externals_installed[0]
 
         python_external_config = spack.config.get("packages:python:externals", [])
-        print(python_external_config)
-        print([spack.spec.Spec(item["spec"]) for item in python_external_config])
-        print(self.spec.external_path)
-        print(self.spec.external)
         python_externals_configured = [
             spack.spec.Spec(item["spec"])
             for item in python_external_config

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -259,7 +259,7 @@ class PythonPackage(PythonExtension):
                         if not python.architecture.os:
                             python.architecture.os = "default_os"
                         if not python.architecture.target:
-                            python.architecture.target = archspec.cpu.host().family
+                            python.architecture.target = archspec.cpu.host().family.name
 
                     # Ensure compiler information is present
                     if not python.compiler:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -290,7 +290,8 @@ class PythonPackage(PythonExtension):
         python_external_config = spack.config.get("packages:python:externals", [])
         print(python_external_config)
         print([spack.spec.Spec(item["spec"]) for item in python_external_config])
-        print(self.external_path)
+        print(self.spec.external_path)
+        print(self.spec.external)
         python_externals_configured = [
             spack.spec.Spec(item["spec"])
             for item in python_external_config

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -288,6 +288,9 @@ class PythonPackage(PythonExtension):
             return python_externals_installed[0]
 
         python_external_config = spack.config.get("packages:python:externals", [])
+        print(python_external_config)
+        print([spack.spec.Spec(item["spec"]) for item in python_external_config])
+        print(self.external_path)
         python_externals_configured = [
             spack.spec.Spec(item["spec"])
             for item in python_external_config

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -912,7 +912,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         return self._implement_all_urls_for_version(version)[0]
 
-    def update_external_dependencies(self):
+    def update_external_dependencies(self, extendee_spec=None):
         """
         Method to override in package classes to handle external dependencies
         """

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2247,8 +2247,9 @@ class SpecBuilder(object):
 
         # If this is an extension, update the dependencies to include the extendee
         package = self._specs[pkg].package_class(self._specs[pkg])
-        extendee_name = package.extendee_spec.name
-        package.update_external_dependencies(self._specs.get(extendee_name, None))
+        extendee_spec = package.extendee_spec
+        if extendee_spec:
+            package.update_external_dependencies(self._specs.get(extendee_spec.name, None))
 
     def depends_on(self, pkg, dep, type):
         dependencies = self._specs[pkg].edges_to_dependencies(name=dep)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2317,6 +2317,15 @@ class SpecBuilder(object):
 
     @staticmethod
     def sort_fn(function_tuple):
+        """Ensure attributes are evaluated in the correct order.
+
+        hash attributes are handled first, since they imply entire concrete specs
+        node attributes are handled next, since they instantiate nodes
+        node_compiler attributes are handled next to ensure they come before node_compiler_version
+        external_spec_selected attributes are handled last, so that external extensions can find
+        the concrete specs on which they depend because all nodes are fully constructed before we
+        consider which ones are external.
+        """
         name = function_tuple[0]
         if name == "hash":
             return (-5, 0)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2001,3 +2001,17 @@ class TestConcretize(object):
         assert "python" in spec["py-extension1"]
         assert spec["python"].prefix == prefix
         assert spec["python"] == python_spec
+
+    def test_external_python_extension_find_unified_python(self, monkeypatch):
+        """Test that python extensions use the same python as other specs in unified env"""
+        external_conf = {
+            "py-extension1": {
+                "buildable": False,
+                "externals": [{"spec": "py-extension1@2.0", "prefix": "/fake"}],
+            }
+        }
+        spack.config.set("packages", external_conf)
+
+        abstract_specs = [spack.spec.Spec(s) for s in ["py-extension1", "python"]]
+        specs = spack.concretize.concretize_specs_together(*abstract_specs)
+        assert specs[0]["python"] == specs[1]["python"]

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1965,7 +1965,7 @@ class TestConcretize(object):
             },
             "python": {
                 "externals": [{"spec": "python@configured", "prefix": "/fake"}],
-            }
+            },
         }
         spack.config.set("packages", external_conf)
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2002,7 +2002,7 @@ class TestConcretize(object):
         assert spec["python"].prefix == prefix
         assert spec["python"] == python_spec
 
-    def test_external_python_extension_find_unified_python(self, monkeypatch):
+    def test_external_python_extension_find_unified_python(self):
         """Test that python extensions use the same python as other specs in unified env"""
         external_conf = {
             "py-extension1": {

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1983,7 +1983,7 @@ class TestConcretize(object):
 
         when python isn't otherwise in the DAG"""
         python_spec = spack.spec.Spec("python@detected")
-        prefix = "/fake"
+        prefix = os.path.sep + "fake"
 
         def find_fake_python(classes, path_hints):
             return {"python": [spack.detection.DetectedPackage(python_spec, prefix=path_hints[0])]}
@@ -2008,7 +2008,7 @@ class TestConcretize(object):
         external_conf = {
             "py-extension1": {
                 "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": "/fake"}],
+                "externals": [{"spec": "py-extension1@2.0", "prefix": os.path.sep + "fake"}],
             }
         }
         spack.config.set("packages", external_conf)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1958,13 +1958,14 @@ class TestConcretize(object):
         assert spec["python"] == spec["py-extension1"]["python"]
 
     def test_external_python_extension_find_dependency_from_config(self):
+        fake_path = os.path.sep + "fake"
         external_conf = {
             "py-extension1": {
                 "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": os.path.sep + "fake"}],
+                "externals": [{"spec": "py-extension1@2.0", "prefix": fake_path}],
             },
             "python": {
-                "externals": [{"spec": "python@configured", "prefix": os.path.sep + "fake"}],
+                "externals": [{"spec": "python@configured", "prefix": fake_path}],
             },
         }
         spack.config.set("packages", external_conf)
@@ -1972,7 +1973,7 @@ class TestConcretize(object):
         spec = Spec("py-extension1").concretized()
 
         assert "python" in spec["py-extension1"]
-        assert spec["python"].prefix == "/fake"
+        assert spec["python"].prefix == fake_path
         # The spec is not equal to spack.spec.Spec("python@configured") because it gets a
         # namespace and an external prefix before marking concrete
         assert spec["python"].satisfies("python@configured")

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1957,7 +1957,15 @@ class TestConcretize(object):
         assert "python" in spec["py-extension1"]
         assert spec["python"] == spec["py-extension1"]["python"]
 
-    def test_external_python_extension_find_dependency_from_config(self):
+    target = spack.platforms.test.Test.default
+
+    @pytest.mark.parametrize("python_spec", [
+        "python@configured",
+        "python@configured platform=test",
+        "python@configured os=debian",
+        "python@configured target=%s" % target,
+    ])
+    def test_external_python_extension_find_dependency_from_config(self, python_spec):
         fake_path = os.path.sep + "fake"
 
         external_conf = {
@@ -1966,7 +1974,7 @@ class TestConcretize(object):
                 "externals": [{"spec": "py-extension1@2.0", "prefix": fake_path}],
             },
             "python": {
-                "externals": [{"spec": "python@configured platform=test", "prefix": fake_path}],
+                "externals": [{"spec": python_spec, "prefix": fake_path}],
             },
         }
         spack.config.set("packages", external_conf)
@@ -1977,7 +1985,7 @@ class TestConcretize(object):
         assert spec["python"].prefix == fake_path
         # The spec is not equal to spack.spec.Spec("python@configured") because it gets a
         # namespace and an external prefix before marking concrete
-        assert spec["python"].satisfies("python@configured")
+        assert spec["python"].satisfies(python_spec)
 
     def test_external_python_extension_find_dependency_from_detection(self, monkeypatch):
         """Test that python extensions have access to a python dependency

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1961,10 +1961,10 @@ class TestConcretize(object):
         external_conf = {
             "py-extension1": {
                 "buildable": False,
-                "externals": [{"spec": "py-extension1@2.0", "prefix": "/fake"}],
+                "externals": [{"spec": "py-extension1@2.0", "prefix": os.path.sep + "fake"}],
             },
             "python": {
-                "externals": [{"spec": "python@configured", "prefix": "/fake"}],
+                "externals": [{"spec": "python@configured", "prefix": os.path.sep + "fake"}],
             },
         }
         spack.config.set("packages", external_conf)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1959,12 +1959,15 @@ class TestConcretize(object):
 
     target = spack.platforms.test.Test.default
 
-    @pytest.mark.parametrize("python_spec", [
-        "python@configured",
-        "python@configured platform=test",
-        "python@configured os=debian",
-        "python@configured target=%s" % target,
-    ])
+    @pytest.mark.parametrize(
+        "python_spec",
+        [
+            "python@configured",
+            "python@configured platform=test",
+            "python@configured os=debian",
+            "python@configured target=%s" % target,
+        ],
+    )
     def test_external_python_extension_find_dependency_from_config(self, python_spec):
         fake_path = os.path.sep + "fake"
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1959,13 +1959,14 @@ class TestConcretize(object):
 
     def test_external_python_extension_find_dependency_from_config(self):
         fake_path = os.path.sep + "fake"
+
         external_conf = {
             "py-extension1": {
                 "buildable": False,
                 "externals": [{"spec": "py-extension1@2.0", "prefix": fake_path}],
             },
             "python": {
-                "externals": [{"spec": "python@configured", "prefix": fake_path}],
+                "externals": [{"spec": "python@configured platform=test", "prefix": fake_path}],
             },
         }
         spack.config.set("packages", external_conf)


### PR DESCRIPTION
This fixes an error found by @scheibelp with the implementation in #33777, in which python externals were being constructed that were not sufficiently fleshed out for the install logic to succeed.

This should result in usable python external dependencies for external python extensions.

@tgamblin you asked me to put you on this as well when I mentioned it.