### PR TITLE
e4s ci: use 2022-12-01 runner images

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -275,11 +275,11 @@ e4s-mac-protected-build:
 
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
 
 e4s-protected-generate:
   extends: [ ".e4s", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -262,7 +262,7 @@ spack:
     after_script:
       - cat /proc/loadavg || true
 
-    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
     
     broken-tests-packages:
       - gptune
@@ -448,7 +448,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
       tags: ["spack", "public", "x86_64"]
 
     signing-job-attributes:


### PR DESCRIPTION
E4S CI: Use `2022-12-01` runner image:
* `/usr/bin/{gcc,g++,gfortran}` now set to GCC 11. Previously GCC 11 required `/usr/bin/{gcc,g++,gfortran}-11`
* AWS CLI tool now available in PATH for quicker build cache operations
* Security updates

CC @kwryankrattiger @wspear 