### PR TITLE
spdlog: Conflict with external fmt if ~fmt_external

### DIFF
--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -58,6 +58,9 @@ class Spdlog(CMakePackage):
     depends_on("fmt@7:", when="@1.7: +fmt_external")
     depends_on("fmt@8:", when="@1.9: +fmt_external")
 
+    # Can only use one fmtlib per spec: the one bundled here, or the "real" one (fmt)
+    conflicts("fmt", when="@1.4.0: ~fmt_external")
+
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
Fixes #34213

`spdlog ~fmt_external` bundles a version of `fmt` (`@8.1.1` or so in this case) which becomes part of the ABI for `libspdlog.so`. If a dependency also uses `fmt` (e.g. default `@9.1.0`) the build will fail due to the version mismatch on the `fmt` library.

This PR adds a conflict so `spdlog ~fmt_external` never allows another (separate) `fmt` to exist in the spec.