### PR TITLE
Add conflicts between gcc@12.2.0 and rocblas@5.2.1:5.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -106,6 +106,8 @@ class Rocblas(CMakePackage):
     conflicts("amdgpu_target=gfx1011", when="@:4.2.1")
     conflicts("amdgpu_target=gfx1012", when="@:4.2.1")
     conflicts("amdgpu_target=gfx1030", when="@:4.2.1")
+    # https://reviews.llvm.org/D124866
+    conflicts("%gcc@12", when="@5.2.1:5.2.3")
 
     depends_on("cmake@3.16.8:", type="build", when="@4.2.0:")
     depends_on("cmake@3.8:", type="build", when="@3.9.0:")

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -107,6 +107,8 @@ class Rocblas(CMakePackage):
     conflicts("amdgpu_target=gfx1012", when="@:4.2.1")
     conflicts("amdgpu_target=gfx1030", when="@:4.2.1")
     # https://reviews.llvm.org/D124866
+    # https://github.com/ROCm-Developer-Tools/HIP/issues/2678
+    # https://github.com/ROCm-Developer-Tools/hipamd/blob/rocm-5.2.x/include/hip/amd_detail/host_defines.h#L50
     conflicts("%gcc@12", when="@5.2.1:5.2.3")
 
     depends_on("cmake@3.16.8:", type="build", when="@4.2.0:")


### PR DESCRIPTION
Fails with error:
```
include/c++/12.2.0/bits/shared_ptr_base.h:196:22: error: use of undeclared identifier 'noinline'; did you mean 'inline'?
     1456          __attribute__((__noinline__))
     1457                         ^
include/hip/amd_detail/host_defines.h:50:37: note: expanded from macro '__noinline__'
     1459    #define __noinline__ __attribute__((noinline))
     1460                                        ^
```