### PR TITLE
cray-mpich package: enable use of manifest description

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -29,6 +29,9 @@ class CrayMpich(Package):
     version("7.7.14")
     version("7.7.13")
 
+    depends_on("cray-pmi")
+    depends_on("libfabric")
+
     # cray-mpich 8.1.7: features MPI compiler wrappers
     variant("wrappers", default=True, when="@8.1.7:", description="enable MPI wrappers")
 


### PR DESCRIPTION
@lukebroskop I believe this will fix the issue we discussed on Monday, I'm curious if you are able to confirm
@psakievich adding you since you mentioned you wanted to be notified on PRs related to manifest usage

Cray systems provide manifest files that describe already-installed packages. One such manifest includes a `cray-mpich` installation which depends on libfabric and cray-pmi, but the corresponding package.py for cray-mpich does not mention these as dependencies. It turns out that prior installed specs cannot be reused if they have dependencies that are not listed in their corresponding package.py. This PR addresses the issue specifically for `cray-mpich` by adding the dependencies to its package.py file.

In some sense this PR is a stopgap measure since in general it should be possible to reuse specs with "extra" dependencies, but this change will address the issue in the short term, and including these dependencies in the `cray-mpich` package more-accurately reflects what that package needs.

Note that adding these dependencies will not affect the use of `cray-mpich` external entries (in packages.yaml), because externals generally truncate dependencies.