### PR TITLE
Stand-alone testing: Make recipe support and processing spack-/pytest-like

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -217,6 +217,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),
+    ("py:class", "spack.package_base.PackageBase"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -217,7 +217,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),
-    ("py:class", "spack.package_base.PackageBase"),
+    ("py:class", "spack.install_test.Pb"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -26,7 +26,7 @@ package author can understand.  Packages allow the packager to
 encapsulate the build logic for different versions, compilers,
 options, platforms, and dependency combinations in one place.
 Essentially, a package translates a spec into build logic. It
-also allow the packager to write spec-specific tests of the
+also allows the packager to write spec-specific tests of the
 installed software.
 
 Packages in Spack are written in pure Python, so you can do anything
@@ -4973,82 +4973,92 @@ be left in the build stage directory as illustrated below:
 Stand-alone tests
 ^^^^^^^^^^^^^^^^^
 
-While build-time tests are integrated with the installation process,
-stand-alone tests are independent, allowing them to run days and weeks
-after the software is installed. Tests are defined in the package using
-methods whose names begin ``test_``, allowing for multiple independent
-checks. The methods themselves can contain embedded test parts. Files
-from the installation process can be saved off for use by the tests
-(e.g., compilation). Extra files, such as source, data, and expected
-outputs, can also be stored with the package. Both sets of files are
-automatically copied to the spec's test stage directory prior to execution
-of the test methods.
+While build-time tests are integrated with the build process, stand-alone
+tests are expected to run days, weeks, even months after the software is
+installed. The goal is to provide a mechanism for gaining confidence that
+packages work as installed **and** *continue* to work as the underlying
+software evolves. Packages can add and inherit stand-alone tests. The
+`spack test`` command is used to manage stand-alone testing.
 
 .. note::
 
-    Execution speed is important because these tests are intended to
-    quickly assess whether the installed spec works on the system.
-    Consequently, they should run relatively quickly -- as in on the
-    order of at most a few minutes while ideally executing all, or at
-    least key, aspects of the installed software.
+    Execution speed is important since these tests are intended to quickly
+    assess whether installed specs work on the system. Consequently, they
+    should run relatively quickly -- as in on the order of at most a few
+    minutes -- while ideally executing all, or at least key aspects of the
+    installed software.
 
-    Failing stand-alone tests are an indicator that there is an issue
-    with the installation and, therefore, no reason to proceed with more
-    resource-intensive tests.
+.. note::
 
-    Passing stand-alone tests can indicate that more thorough testing,
-    such as extensive unit or regression tests, or tests that run at
-    scale are in order.
+    Failing stand-alone tests indicate problems with the installation and,
+    therefore, there is no reason to proceed with more resource-intensive
+    tests until those have been investigated.
+
+    Passing stand-alone tests indicate that more thorough testing, such
+    as running extensive unit or regression tests, or tests that run at
+    scale can proceed without wasting resources on a problematic installation.
+
+Tests are defined in the package using methods with names beginning ``test_``.
+This allows Spack to support multiple independent checks, or parts. Files
+needed for testing, such as source, data, and expected outputs, may be saved
+from the build and or stored with the package in the repository. Regardless
+of origin, these files are automatically copied to the spec's test stage
+directory prior to execution of the test method(s). Spack also provides some
+helper functions to facilitate processing.
+
+.. _configure-test-stage:
 
 """"""""""""""""""""""""""""""""""""
 Configuring the test stage directory
 """"""""""""""""""""""""""""""""""""
 
-Stand-alone tests rely on a test stage directory for building, running,
-and tracking results in the same way Spack relies on a stage directory
-during builds. The default test stage, ``~/.spack/test``, is defined in
-:ref:`etc/spack/defaults/config.yaml <config-yaml>`. You can configure
-the location in the high-level ``config`` by adding or changing the
-``test_stage`` path in the appropriate ``config.yaml`` file such that:
+Stand-alone tests utilize a test stage directory for building, running,
+and tracking results in the same way Spack uses a build stage directory.
+The default test stage root directory, ``~/.spack/test``, is defined in
+:ref:`etc/spack/defaults/config.yaml <config-yaml>`. This location is
+customizable by adding or changing the ``test_stage`` path in the high-level
+``config`` of the appropriate ``config.yaml`` file such that:
 
 .. code-block:: yaml
 
    config:
      test_stage: /path/to/test/stage
 
-The package can access this path **during test processing** using
-`self.test_suite.stage`.
+Packages can use the ``self.test_suite.stage`` property to access this setting.
+Other package properties that provide access to spec-specific subdirectories
+and files are described in :ref:`accessing staged files <accessing-files>`.
 
 .. note::
 
-   The test stage path is established for the entire suite. That
-   means it is the root directory for **all specs** being tested
-   with the same `spack test run` command and each spec gets its
-   own subdirectory.
+   The test stage path is the root directory for the **entire suite**.
+   In other words, it is the root directory for **all specs** being
+   tested by the ``spack test run`` command. Each spec gets its own
+   stage subdirectory. Use ``self.test_suite.test_dir_for_spec(self.spec)``
+   to access the spec-specific test stage directory.
 
-   Use ``self.test_suite.test_dir_for_spec(self.spec)`` to access
-   the stage directory for the spec currently being tested. Refer to
-   :ref:`accessing staged files <accessing-files>` for more information.
 
+.. _adding-standalone-tests:
 
 """"""""""""""""""""""""
 Adding stand-alone tests
 """"""""""""""""""""""""
 
-Tests are defined in the package using methods with names beginning
-``test_``, which means multiple independent tests can be implemented
-to check the installation. The tests can be customized to the source
-build since Spack tracks options, compilers, and dependencies. Standard
-python ``assert`` statements and other error reporting mechanisms can
-be used in these methods. Spack will report such errors as test failures.
+Test recipes are defined in the package using methods with names beginning
+``test_``. This allows for the implementation of multiple independent tests.
+Each method has access to the information Spack tracks on the package, such
+as options, compilers, and dependencies, supporting the customization of tests
+to the build. Standard python ``assert`` statements and other error reporting
+mechanisms are available. Such exceptions are automatically caught and reported
+as test failures.
 
-Each test method is an implicit test part whose name is the name of
-the method and whose purpose is the method's docstring. The purpose is 
-provides context that can be helpful during debugging. Spack will output
-the test name and purpose prior to running the test part.
-
-For example, the ``MyPackage`` package below provides a skeleton for
-the test method.
+Each test method is an implicit test part named by the method and whose
+purpose is the method's docstring. Providing a purpose gives context for
+aiding debugging. A test method may contain embedded test parts. Spack
+outputs the test name and purpose prior to running each test method and
+any embedded test parts. For example, ``MyPackage`` below provides two basic
+examples of installation tests: ``test_always_fails`` and ``test_example``.
+As the name indicates, the first always fails. The second simply runs the
+installed example.
 
 .. code-block:: python
 
@@ -5064,9 +5074,19 @@ the test method.
            example = which(self.prefix.bin.example)
            example()
 
-You can implement multiple test parts within a stand-alone test method
-using the ``test_part`` context manager. Each test part is treated as
-an independent check with subsequent test executed even after a failure.
+Spack outputs ``test_always_fails: use assert to always fail`` before running
+``test_always_fails``. Similarly, it logs ``test_example: run installed example`` 
+before running ``test_example``.
+
+
+.. note::
+
+   If ``MyPackage`` were a recipe for a library, the tests should build
+   an example or test program that is then executed.
+
+A test method can include test parts using the ``test_part`` context manager.
+Each part is treated as an independent check to allow subsequent test parts
+to execute even after a test part fails.
 
 .. _test-part:
 
@@ -5074,40 +5094,23 @@ The signature for ``test_part`` is:
 
 .. code-block:: python
 
-   @contextlib.contextmanager
    def test_part(pkg, test_name, purpose, work_dir=".", verbose=False):
 
 where each argument has the following meaning:
 
 * ``pkg`` is an instance of the package for the spec under test.
 
-* ``test_name`` is the name of the test part and needs to start with ``test_``
+* ``test_name`` is the name of the test part, which must start with ``test_``.
 
-  The name of every ``test_`` method is automatically the name of
-  its implicit test part. 
-  
-  It is recommended that embedded test parts extend the name of the test
-  method. For example, if there are examples called ``ex10`` and ``ex51``
-  run within the ``test_example`` method, then the test parts would be
-  called ``test_example_ex10`` and ``test_example_ex51``, respectively.
+* ``purpose`` is a brief description used as a heading for the test part.
 
-* ``purpose`` is the heading describing the test part.
+  Output from the test is written to a test log file allowing the test name
+  and purpose to be searched for test part confirmation and debugging.
 
-  The docstring of every ``test_`` method is automatically the name of
-  its implicit test part.
+* ``work_dir`` is the path to the directory in which the test will run.
 
-  Output from the test is written to a test log file so this argument
-  serves as a searchable heading in text logs to highlight the start
-  of the test part. 
-  
-  Having a description can be helpful when debugging failing tests.
-
-* ``work_dir`` is the path to the directory from which the executable
-  will run.
-
-  The default of ``None`` corresponds to the current directory (``"."``),
-  which is the spec's test stage (i.e.,
-  ``self.test_suite.test_dir_for_spec(self.spec)``).
+  The default of ``None``, or ``"."``, corresponds to the the spec's test
+  stage (i.e., ``self.test_suite.test_dir_for_spec(self.spec)``.
 
 .. admonition:: Tests should **not** run under the installation directory.
 
@@ -5117,7 +5120,8 @@ where each argument has the following meaning:
    read-only file systems or directories.
 
 Suppose ``MyPackage`` actually installs two examples we want to use for tests.
-These checks could be embedded test parts implemented below.
+These checks can be implemented as separate checks or, as illustrated below,
+embedded test parts.
 
 .. code-block:: python
 
@@ -5135,13 +5139,24 @@ These checks could be embedded test parts implemented below.
                     exe = which(join_path(self.prefix.bin, example))
                     exe()
 
+Spack will output ``test_example: run installed examples`` before executing
+``test_example``, then ``test_example_ex1: run installed ex1`` before the first
+test part and ``test_example_ex2: run installed ex2`` before the second test
+part. The test ``test_example_ex2`` will run whether or not ``test_example_ex1``
+succeeds.
+
+.. warning::
+
+   Test results reporting requires that each test method and embedded
+   test part for a package have a unique name.
+
 Stand-alone tests run in an environment that provides access to information
 Spack has on how the software was built, such as build options, dependencies,
 and compilers. Build options and dependencies are accessed with the normal
 spec checks. Examples of checking :ref:`variant settings <variants>` and
-:ref:`spec constraints <testing-specs>` can be found at those links.
-Accessing compilers used by the build in stand-alone tests requires another
-step described :ref:`below <test-compilation>`.
+:ref:`spec constraints <testing-specs>` can be found at the provided links.
+Accessing compilers in stand-alone tests that are used by the build requires
+setting a package property as described :ref:`below <test-compilation>`.
 
 
 .. _test-compilation:
@@ -5150,20 +5165,21 @@ step described :ref:`below <test-compilation>`.
 Enabling test compilation
 """""""""""""""""""""""""
 
-If you want to build tests before running them, then you'll want to tell
+If you want to build and run binaries in tests, then you'll need to tell
 Spack to load the package's compiler configuration. This is accomplished
 by setting the package's ``test_requires_compiler`` property to ``True``.
-Doing so allows you to access the compiler through the canonical environment
-variables (e.g., ``CC``, ``CXX``, ``FC``, ``F77``). If appropriate, it
-also gives access to build dependencies like ``cmake`` through
-``self.spec["cmake"].prefix.bin.cmake``.
+
+Setting the property to ``True`` ensures access to the compiler through
+canonical environment variables (e.g., ``CC``, ``CXX``, ``FC``, ``F77``).
+It also gives access to build dependencies like ``cmake`` through their
+``spec objects`` (e.g., ``self.spec["cmake"].prefix.bin.cmake``).
 
 .. note::
 
-   We recommend adding the property at the top of the package with the
-   other attributes, such as ``homepage`` and ``url``.
+   The ``test_requires_compiler`` property should be added at the top of
+   the package near other attributes, such as the ``homepage`` and ``url``.
 
-Below is an example using this feature to compile an example.
+Below illustrates using this feature to compile an example.
 
 .. code-block:: python
 
@@ -5192,15 +5208,20 @@ Below is an example using this feature to compile an example.
 .. _cache_extra_test_sources:
 
 """""""""""""""""""""""
-Adding build-time files
+Saving build-time files
 """""""""""""""""""""""
 
 .. note::
 
-    We highly recommend re-using build-time tests and input files
-    for testing installed software. These files are easier to keep
-    synchronized since they reside within the software's repository
-    than maintaining custom install test files with the Spack package.
+    We highly recommend re-using build-time test sources and pared down
+    input files for testing installed software. These files are easier
+    to keep synchronized with software capabilities since they reside
+    within the software's repository. 
+    
+    If that is not possible, you can add test-related files to the package
+    repository (see :ref:`adding custom files <cache_custom_files>`). It
+    will be important to maintain them so they work across listed or supported
+    versions of the package.
 
 You can use the ``cache_extra_test_sources`` method to copy directories
 and or files from the source build stage directory to the package's
@@ -5212,15 +5233,17 @@ The signature for ``cache_extra_test_sources`` is:
 
    def cache_extra_test_sources(self, srcs):
 
-where ``srcs`` is a string *or* a list of strings corresponding to
-the paths for the files and or subdirectories, relative to the staged
-source, that are to be copied to the corresponding relative test path
-under the prefix. All of the contents within each subdirectory will
-also be copied.
+where ``srcs`` is a string *or* a list of strings corresponding to the
+paths of subdirectories and or files needed for stand-alone testing. 
+The paths must be relative to the staged source directory. Contents of
+subdirectories and files are copied to a special test cache subdirectory
+of the installation prefix. They are automatically copied to the appropriate
+relative paths under the test stage directory prior to executing stand-alone
+tests.
 
 For example, a package method for copying everything in the ``tests``
 subdirectory plus the ``foo.c`` and ``bar.c`` files from ``examples``
-can be implemented as shown below.
+and using ``foo.c`` in a test method is illustrated below.
 
 .. code-block:: python
 
@@ -5228,7 +5251,7 @@ can be implemented as shown below.
        ...
 
        @run_after("install")
-       def copy_test_sources(self):
+       def copy_test_files(self):
            srcs = ["tests",
                    join_path("examples", "foo.c"),
                    join_path("examples", "bar.c")]
@@ -5239,29 +5262,36 @@ can be implemented as shown below.
            src_dir = join_path(
                self.test_suite.current_test_cache_dir, "examples"
            )
-           ...
-           # TODO: Compile foo using source in src_dir
+           cc = which(os.environ["CC"])
+           cc(
+               "-L{0}".format(self.prefix.lib),
+               "-I{0}".format(self.prefix.include),
+               "{0}.c".format(exe),
+               "-o",
+               exe
+           )
            foo = which(exe)
            foo()
 
 In this case, the method copies the associated files from the build
-stage **after** the software is installed to the package's metadata
-directory. 
+stage, **after** the software is installed, to the package's test
+cache directory. Then ``test_foo`` builds ``foo`` using ``foo.c``
+before running the program.
 
 .. note::
 
-   The method name ``copy_test_sources`` here is for illustration
-   purposes. You are free to use a name that is more suited to your
-   package.
+   The method name ``copy_test_files`` here is for illustration purposes.
+   You are free to use a name that is more suited to your package.
 
-   The key to copying the files at build time for stand-alone testing
-   is use of the ``run_after`` directive, which ensures the associated
-   files are copied **after** the provided build stage.
+   The key to copying files for stand-alone testing at build time is use
+   of the ``run_after`` directive, which ensures the associated files are
+   copied **after** the provided build stage where the files **and**
+   installation prefix are available.
 
-These paths are **automatically copied** to the test stage directory
-during stand-alone testing. The package's stand-alone test method can access
-them using the ``self.test_suite.current_test_cache_dir`` property.
-In our example, the method can use the following paths to reference
+These paths are **automatically copied** from cache to the test stage
+directory prior to the execution of any stand-alone tests. Tests access
+the files using the ``self.test_suite.current_test_cache_dir`` property.
+In our example above, test methods can use the following paths to reference
 the copy of each entry listed in ``srcs``, respectively:
 
 * ``join_path(self.test_suite.current_test_cache_dir, "tests")``
@@ -5276,22 +5306,21 @@ the copy of each entry listed in ``srcs``, respectively:
 .. note::
 
     While source and input files are generally recommended, binaries
-    **may** also be cached by the build process for install testing.
-    Only you, as the package writer or maintainer, know whether these
-    would be appropriate for ensuring the installed software continues
-    to work as the underlying system evolves.
+    **may** also be cached by the build process. Only you, as the package
+    writer or maintainer, know whether these files would be appropriate
+    for testing the installed software weeks to months later.
 
 .. note::
 
-    If one or more of the copied files needs to be modified to the
-    installation, it is recommended that those changes are made
-    **once** in the ``copy_test_sources`` method after the call to
-    ``self.cache_extra_test_sources()``.  This will reduce the 
-    amount of unnecessary work in the test method **and** avoid
-    problems testing shared instances and facility deployments.
+    If one or more of the copied files needs to be modified to reference
+    the installed software, it is recommended that those changes be made
+    to the cached files **once** in the ``copy_test_sources`` method and
+    ***after** the call to ``self.cache_extra_test_sources()``. This will
+    reduce the amount of unnecessary work in the test method **and** avoid
+    problems testing in shared instances and facility deployments.
 
-    The ``filter_file`` function can be quite useful for such
-    changes. See :ref:`file manipulation <file-manipulation>`.
+    The ``filter_file`` function can be quite useful for such changes.
+    See :ref:`file manipulation <file-manipulation>`.
 
 
 .. _cache_custom_files:
@@ -5300,19 +5329,24 @@ the copy of each entry listed in ``srcs``, respectively:
 Adding custom files
 """""""""""""""""""
 
-Some tests may require additional files not available from the (source) build.
-Examples include:
+In some cases it can be useful to have files that can be used to build or
+check the results of tests.  Examples include:
 
 - test source files
 - test input files
 - test build scripts
-- expected test output
+- expected test outputs
 
-These extra files should be added to the ``test`` subdirectory of the
-package in the Spack repository.
+While obtaining such files from the software repository is preferred (see
+:ref:`adding build-time files  <cache_extra_test_sources>`), there are
+circumstances where that is not feasible (e.g., the software is not being
+actively maintained). When test files can't be obtained from the repository
+or as a supplement to files that can, Spack supports the inclusion of
+additional files under the ``test`` subdirectory of the package in the
+Spack repository.
 
-Spack will **automatically copy** the contents of that directory to the
-test staging directory prior to running stand-alone tests, which can
+Spack **automatically copies** the contents of that directory to the
+test staging directory prior to running stand-alone tests. Test methods
 access those files using the ``self.test_suite.current_test_data_dir``
 property as shown below.
 
@@ -5329,10 +5363,9 @@ property as shown below.
            data_dir = self.test_suite.current_test_data_dir
            exe = "custom-example"
            src = datadir.join("{0}.cpp".format(exe))
-
            ...
-           # TODO: Compile foo using source in src_dir
-
+           # TODO: Build custom-example using src and exe
+           ...
            custom_example = which(exe)
            custom_example()
 
@@ -5345,7 +5378,8 @@ Reading expected output from a file
 
 The helper function ``get_escaped_text_output`` is available for packages
 to retrieve and properly format the text from a file that contains the
-expected output from running an executable.
+expected output from running an executable that may contain special 
+characters.
 
 The signature for ``get_escaped_text_output`` is:
 
@@ -5356,10 +5390,13 @@ The signature for ``get_escaped_text_output`` is:
 where ``filename`` is the path to the file containing the expected output.
 
 The ``filename`` for a :ref:`custom file <cache_custom_files>` can be
-accessed and used as illustrated by a simplified version of an ``sqlite``
-package check:
+accessed by tests using the ``self.test_suite.current_test_data_dir``
+property. The example below illustrates how to read a file that was
+added to the package's ``test`` subdirectory.
 
 .. code-block:: python
+
+   import re
 
    class Sqlite(AutotoolsPackage):
        ...
@@ -5369,54 +5406,66 @@ package check:
            test_data_dir = self.test_suite.current_test_data_dir
            db_filename = test_data_dir.join("packages.db")
            ..
-
            expected = get_escaped_text_output(test_data_dir.join("dump.out"))
            sqlite3 = which(self.prefix.bin.sqlite3)
            out = sqlite3(
                db_filename, ".dump", output=str.split, error=str.split
            )
-           check_outputs(expected, out)
+           for exp in expected:
+               assert re.search(exp, out), "Expected '{0}' in output".format(exp)
 
-
-.. note::
-
-    Expected outputs do not have to be stored with the Spack package.
-    Maintaining them with the source is actually preferable.
-
-Suppose a package's source has ``examples/foo.c`` and ``examples/foo.out``
-files that are copied for stand-alone test purposes using
-:ref:`cache_extra_test_sources <cache_extra_test_sources>` and the
-stand-alone test method builds the executable ``examples/foo``. The package
-can retrieve the expected output from ``examples/foo.out`` using:
+If the file was instead copied from the ``tests`` subdirectory of the staged
+source code, the path would be obtained as shown below.
 
 .. code-block:: python
 
-   class MyFooPackage(Package):
-       ...
+       def test_example(self):
+           """check example table dump"""
+           test_cache_dir = self.test_suite.current_test_cache_dir
+           db_filename = test_cache_dir.join("packages.db")
 
-       def test_foo_example(self):
-           ..
-           filename = join_path(
-               self.test_suite.current_test_cache_dir, "examples", "foo.out"
-           )
-           expected = get_escaped_text_output(filename)
-           ..
-
-Alternatively, suppose ``MyFooPackage`` **installs** tests in ``share/tests``
-and their outputs in ``share/tests/outputs``. The expected output for
-``foo``, assuming it is still called ``foo.out``, can be retrieved as
+Alternatively, if the file was copied to the ``share/tests`` subdirectory
+as part of the installation process, the test could access the path as 
 follows:
 
 .. code-block:: python
 
-   class MyFooPackage(Package):
-       ...
+       def test_example(self):
+           """check example table dump"""
+           db_filename = join_path(self.prefix.share.tests, "packages.db")
 
-       def test_foo(self):
-           ..
-           filename = join_path(self.prefix.share.tests.outputs, "foo.out")
-           expected = get_escaped_text_output(filename)
-           ..
+
+.. _check_outputs:
+
+""""""""""""""""""""""""""""""""""""
+Comparing expected to actual outputs
+""""""""""""""""""""""""""""""""""""
+
+The helper function ``check_outputs`` is available for packages to ensure
+the expected outputs from running an executable are contained within the
+actual outputs.
+
+The signature for ``check_outputs`` is:
+
+.. code-block:: python
+
+   def check_outputs(expected, actual):
+
+where each argument has the expected type and meaning:
+
+* ``expected`` is a string or list of strings containing the expected (raw)
+  output.
+
+* ``actual`` is a string containing the actual output from executing the command
+
+Invoking the method is the equivalent of:
+
+.. code-block:: python
+
+   for check in expected:
+       if not re.search(check, actual):
+           raise RuntimeError("Expected '{0}' in output '{1}'".format(check, actual))
+
 
 .. _accessing-files:
 
@@ -5426,11 +5475,14 @@ Accessing package- and test-related files
 
 You may need to access files from one or more locations when writing
 stand-alone tests. This can happen if the software's repository does not
-include test source files or includes files but has no way to build the
-executables using the installed headers and libraries. In these cases,
-you may need to reference the files relative to one or more root
-directory. The properties containing package- (or spec-) and test-related
-directory paths are provided in the table below.
+include test source files or includes them but has no way to build the
+executables using the installed headers and libraries. In these cases
+you may need to reference the files relative to one or more root directory.
+The table below lists relevant path properties and provides additional
+examples of their use.
+:ref:`Reading expected output <expected_test_output_from_file>` provides
+examples of accessing files saved from the software repository, package
+repository, and installation.
 
 .. list-table:: Directory-to-property mapping
    :header-rows: 1
@@ -5448,7 +5500,7 @@ directory paths are provided in the table below.
      - ``self.test_suite.stage``
      - ``join_path(self.test_suite.stage, "results.txt")``
    * - Spec's Test Stage
-     - ``self.test_suite.test_dir_for_spec``
+     - ``self.test_suite.test_dir_for_spec(<spec>)``
      - ``self.test_suite.test_dir_for_spec(self.spec)``
    * - Current Spec's Build-time Files
      - ``self.test_suite.current_test_cache_dir``
@@ -5457,15 +5509,20 @@ directory paths are provided in the table below.
      - ``self.test_suite.current_test_data_dir``
      - ``join_path(self.test_suite.current_test_data_dir, "hello.f90")``
 
+
+.. _inheriting-tests:
+
 """"""""""""""""""""""""""""
 Inheriting stand-alone tests
 """"""""""""""""""""""""""""
 
 Stand-alone tests defined in parent (.e.g., :ref:`build-systems`) and
 virtual (e.g., :ref:`virtual-dependencies`) packages are executed by
-packages that inherit from or provide interfaces for those packages,
-respectively. The table below summarizes the tests that will be included
-with those provided in the package itself when executing stand-alone tests.
+packages that inherit from or provide interface implementations for those
+packages, respectively. 
+
+The table below summarizes the stand-alone tests that will be executed along
+with those implemented in the package itself.
 
 .. list-table:: Inherited/provided stand-alone tests
    :header-rows: 1
@@ -5489,77 +5546,59 @@ with those provided in the package itself when executing stand-alone tests.
    * - :ref:`SipPackage <sippackage>`
      - Imports modules listed in the ``self.import_modules`` property with defaults derived from the tarball
 
-These tests are very generic so it is important that package
-developers and maintainers provide additional stand-alone tests
-customized to the package.
+These tests are very basic so it is important that package developers and
+maintainers provide additional stand-alone tests customized to the package.
 
-One example of a package that adds its own stand-alone (or smoke)
-tests is the `Openmpi package
+.. warning::
+
+   Any package that implements a test method with the same name as an
+   inherited method overrides the inherited method. If that is not the
+   goal and you are not explicitly calling and adding functionality to
+   the inherited method for the test, then make sure that all test methods
+   and embedded test parts have unique test names.
+
+One example of a package that adds its own stand-alone tests to those
+"inherited" by the virtual package it provides an implementation for is
+the `Openmpi package
 <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/openmpi/package.py>`_.
-The preliminary set of tests for the package performed the
-following checks:
 
-- installed binaries with the ``--version`` option return the expected
-  version;
-- outputs from (selected) installed binaries match expectations;
-- ``make all`` succeeds when building examples that were copied from the
-  source directory during package installation; and
-- outputs from running the copied and built examples match expectations.
-
-Below is an example of running and viewing the stand-alone tests,
-where only the outputs for the first of each set are shown:
+Below are snippets from running and viewing the stand-alone test results
+for ``openmpi``:
 
 .. code-block:: console
 
-   $ spack test run --alias openmpi-4.0.5 openmpi@4.0.5
-   ==> Spack test openmpi-4.0.5
-   ==> Testing package openmpi-4.0.5-eygjgve
-   $ spack test results -l openmpi-4.0.5
-   ==> Spack test openmpi-4.0.5
-   ==> Testing package openmpi-4.0.5-eygjgve
-   ==> Results for test suite "openmpi-4.0.5":
-   ==>   openmpi-4.0.5-eygjgve PASSED
-   ==> Testing package openmpi-4.0.5-eygjgve
-   ==> [2021-04-26-17:35:20.259650] test: ensuring version of mpiCC is 8.3.1
-   ==> [2021-04-26-17:35:20.260155] "$SPACK_ROOT/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.0.5-eygjgvek35awfor2qaljltjind2oa67r/bin/mpiCC" "--version"
-   g++ (GCC) 8.3.1 20190311 (Red Hat 8.3.1-3)
-   Copyright (C) 2018 Free Software Foundation, Inc.
-   This is free software; see the source for copying conditions.  There is NO
-   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+   $ spack test run --alias openmpi openmpi@4.1.4
+   ==> Spack test openmpi
+   ==> Testing package openmpi-4.1.4-ubmrigj
+   ============================== 1 passed of 1 spec ==============================
 
-   PASSED
+   $ spack test results -l openmpi
+   ==> Results for test suite 'openmpi':
+   ==> test specs:
+   ==>   openmpi-4.1.4-ubmrigj PASSED
+   ==> Testing package openmpi-4.1.4-ubmrigj
+   ==> [2023-03-10-16:03:56.160361] Installing $spack/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.1.4-ubmrigjrqcafh3hffqcx7yz2nc5jstra/.spack/test to $test_stage/xez37ekynfbi4e7h4zdndfemzufftnym/openmpi-4.1.4-ubmrigj/cache/openmpi
+   ==> [2023-03-10-16:03:56.625204] test: test_bin: test installed binaries
+   ==> [2023-03-10-16:03:56.625439] test: test_bin_mpirun: run and check output of mpirun
+   ==> [2023-03-10-16:03:56.629807] '$spack/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.1.4-ubmrigjrqcafh3hffqcx7yz2nc5jstra/bin/mpirun' '-n' '1' 'ls' '..'
+   openmpi-4.1.4-ubmrigj            repo
+   openmpi-4.1.4-ubmrigj-test-out.txt  test_suite.lock
+   PASSED: test_bin_mpirun
    ...
-   ==> [2021-04-26-17:35:20.493921] test: checking mpirun output
-   ==> [2021-04-26-17:35:20.494461] "$SPACK_ROOT/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.0.5-eygjgvek35awfor2qaljltjind2oa67r/bin/mpirun" "-n" "1" "ls" ".."
-   openmpi-4.0.5-eygjgve           repo     test_suite.lock
-   openmpi-4.0.5-eygjgve-test-out.txt  results.txt
-   PASSED
+   ==> [2023-03-10-16:04:01.486977] test: test_version_oshcc: ensure version of oshcc is 8.3.1
+   SKIPPED: test_version_oshcc: oshcc is not installed
    ...
-   ==> [2021-04-26-17:35:20.630452] test: ensuring ability to build the examples
-   ==> [2021-04-26-17:35:20.630943] "/usr/bin/make" "all"
-   mpicc -g  hello_c.c  -o hello_c
-   mpicc -g  ring_c.c  -o ring_c
-   mpicc -g  connectivity_c.c  -o connectivity_c
-   mpicc -g  spc_example.c  -o spc_example
+   ==> [2023-03-10-16:04:02.215227] Completed testing
+   ==> [2023-03-10-16:04:02.215597] 
+   ======================== SUMMARY: openmpi-4.1.4-ubmrigj ========================
+   Openmpi::test_bin_mpirun .. PASSED
+   Openmpi::test_bin_ompi_info .. PASSED
+   Openmpi::test_bin_oshmem_info .. SKIPPED
+   Openmpi::test_bin_oshrun .. SKIPPED
+   Openmpi::test_bin_shmemrun .. SKIPPED
+   Openmpi::test_bin .. PASSED
    ...
-   PASSED
-   ==> [2021-04-26-17:35:23.291214] test: checking hello_c example output and status (0)
-   ==> [2021-04-26-17:35:23.291841] "./hello_c"
-   Hello, world, I am 0 of 1, (Open MPI v4.0.5, package: Open MPI dahlgren@quartz2300 Distribution, ident: 4.0.5, repo rev: v4.0.5, Aug 26, 2020, 114)
-   PASSED
-   ...
-   ==> [2021-04-26-17:35:24.603152] test: ensuring copied examples cleaned up
-   ==> [2021-04-26-17:35:24.603807] "/usr/bin/make" "clean"
-   rm -f hello_c hello_cxx hello_mpifh hello_usempi hello_usempif08 hello_oshmem hello_oshmemcxx hello_oshmemfh Hello.class ring_c ring_cxx ring_mpifh ring_usempi ring_usempif08 ring_oshmem ring_oshmemfh Ring.class connectivity_c oshmem_shmalloc oshmem_circular_shift oshmem_max_reduction oshmem_strided_puts oshmem_symmetric_data spc_example *~ *.o
-   PASSED
-   ==> [2021-04-26-17:35:24.643360] test: mpicc: expect command status in [0]
-   ==> [2021-04-26-17:35:24.643834] "$SPACK_ROOT/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.0.5-eygjgvek35awfor2qaljltjind2oa67r/bin/mpicc" "-o" "mpi_hello_c" "$HOME/.spack/test/hyzq5eqlqfog6fawlzxwg3prqy5vjhms/openmpi-4.0.5-eygjgve/data/mpi/mpi_hello.c"
-   PASSED
-   ==> [2021-04-26-17:35:24.776765] test: mpirun: expect command status in [0]
-   ==> [2021-04-26-17:35:24.777194] "$SPACK_ROOT/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/openmpi-4.0.5-eygjgvek35awfor2qaljltjind2oa67r/bin/mpirun" "-np" "1" "mpi_hello_c"
-   Hello world! From rank 0 of 1
-   PASSED
-   ...
+   ============================== 1 passed of 1 spec ==============================
 
 
 .. _cmd-spack-test-list:
@@ -5573,8 +5612,8 @@ Packages available for install testing can be found using the
 packages that have defined stand-alone test methods.
 
 Alternatively you can use the ``--all`` option to get a list of
-all packages that have stand-alone methods even if they are
-not installed.
+all packages that have stand-alone test methods even if the packages
+are not installed.
 
 For more information, refer to `spack test list
 <https://spack.readthedocs.io/en/latest/command_index.html#spack-test-list>`_.
@@ -5586,22 +5625,22 @@ For more information, refer to `spack test list
 """"""""""""""""""
 
 Install tests can be run for one or more installed packages using
-the ``spack test run`` command. A ``test suite`` is created from
-the provided specs. If no specs are provided it will test all specs
-in the active environment or all specs installed in Spack if no
-environment is active.
+the ``spack test run`` command. A ``test suite`` is created for all
+of the provided specs. The command accepts the same arguments provided
+to ``spack install`` (see :ref:`sec-specs`). If no specs are provided
+the command tests all specs in the active environment or all specs
+installed in the Spack instance if no environment is active.
 
 Test suites can be named using the ``--alias`` option. Unaliased
-Test suites will use the content hash of their specs as their name.
+test suites use the content hash of their specs as their name.
 
 Some of the more commonly used debugging options are:
 
 - ``--fail-fast`` stops testing each package after the first failure
 - ``--fail-first`` stops testing packages after the first failure
 
-Test output is written to a text log file by default but ``junit``
-and ``cdash`` are outputs are available through the ``--log-format``
-option.
+Test output is written to a text log file by default though ``junit``
+and ``cdash`` are outputs available through the ``--log-format`` option.
 
 For more information, refer to `spack test run
 <https://spack.readthedocs.io/en/latest/command_index.html#spack-test-run>`_.
@@ -5614,8 +5653,8 @@ For more information, refer to `spack test run
 """"""""""""""""""""""
 
 The ``spack test results`` command shows results for all completed
-test suites. Providing the alias or content hash limits reporting
-to the corresponding test suite.
+test suites by default. The alias or content hash can be provided to
+limit reporting to the corresponding test suite.
 
 The ``--logs`` option includes the output generated by the associated
 test(s) to facilitate debugging.
@@ -5645,11 +5684,12 @@ For more information, refer to `spack test find
 """""""""""""""""""""
 
 The ``spack test remove`` command removes test suites to declutter
-the test results directory. You are prompted to confirm the removal
+the test stage directory. You are prompted to confirm the removal
 of each test suite **unless** you use the ``--yes-to-all`` option.
 
 For more information, refer to `spack test remove
 <https://spack.readthedocs.io/en/latest/command_index.html#spack-test-remove>`_.
+
 
 .. _file-manipulation:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1466,7 +1466,6 @@ Go cannot be used to fetch a particular commit or branch, it always
 downloads the head of the repository. This download method is untrusted,
 and is not recommended. Use another fetch strategy whenever possible.
 
-
 .. _variants:
 
 --------
@@ -5029,7 +5028,7 @@ The package can access this path **during test processing** using
 
    Use ``self.test_suite.test_dir_for_spec(self.spec)`` to access
    the stage directory for the spec currently being tested. Refer to
-   :ref:`accessing staged files <_accessing-files>` for more information.
+   :ref:`accessing staged files <accessing-files>` for more information.
 
 
 """"""""""""""""""""""""
@@ -5139,10 +5138,10 @@ These checks could be embedded test parts implemented below.
 Stand-alone tests run in an environment that provides access to information
 Spack has on how the software was built, such as build options, dependencies,
 and compilers. Build options and dependencies are accessed with the normal
-spec checks. Examples of checking :ref:`variant settings <_variants>` and
-:ref:`spec constraints <_testing-specs>` can be found at those links.
+spec checks. Examples of checking :ref:`variant settings <variants>` and
+:ref:`spec constraints <testing-specs>` can be found at those links.
 Accessing compilers used by the build in stand-alone tests requires another
-step described :ref:`below <_test-compilation>`.
+step described :ref:`below <test-compilation>`.
 
 
 .. _test-compilation:
@@ -5292,7 +5291,7 @@ the copy of each entry listed in ``srcs``, respectively:
     problems testing shared instances and facility deployments.
 
     The ``filter_file`` function can be quite useful for such
-    changes. See :ref:`file manipulation <_file-manipulation>`.
+    changes. See :ref:`file manipulation <file-manipulation>`.
 
 
 .. _cache_custom_files:
@@ -5418,7 +5417,6 @@ follows:
            filename = join_path(self.prefix.share.tests.outputs, "foo.out")
            expected = get_escaped_text_output(filename)
            ..
-
 
 .. _accessing-files:
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -289,6 +289,7 @@ def _check_build_test_callbacks(pkgs, error_cls):
         pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
         test_callbacks = getattr(pkg_cls, "build_time_test_callbacks", None)
 
+        # TODO: change "test" and "test*" to "test_" and "test_*" once remove "test"
         has_test_method = test_callbacks and any([m.startswith("test") for m in test_callbacks])
         if has_test_method:
             msg = '{0} package contains "test*" method(s) in ' "build_time_test_callbacks"

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -289,9 +289,12 @@ def _check_build_test_callbacks(pkgs, error_cls):
         pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
         test_callbacks = getattr(pkg_cls, "build_time_test_callbacks", None)
 
-        if test_callbacks and "test" in test_callbacks:
-            msg = '{0} package contains "test" method in ' "build_time_test_callbacks"
-            instr = 'Remove "test" from: [{0}]'.format(", ".join(test_callbacks))
+        has_test_method = test_callbacks and any([m.startswith("test") for m in test_callbacks])
+        if has_test_method:
+            msg = '{0} package contains "test*" method(s) in ' "build_time_test_callbacks"
+            instr = 'Remove all methods whose names start with "test" from: [{0}]'.format(
+                ", ".join(test_callbacks)
+            )
             errors.append(error_cls(msg.format(pkg_name), [instr]))
 
     return errors

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -289,7 +289,8 @@ def _check_build_test_callbacks(pkgs, error_cls):
         pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
         test_callbacks = getattr(pkg_cls, "build_time_test_callbacks", None)
 
-        # TODO: change "test" and "test*" to "test_" and "test_*" once remove "test"
+        # TODO (post-34236): "test*"->"test_*" once remove deprecated methods
+        # TODO (post-34236): "test"->"test_" once remove deprecated methods
         has_test_method = test_callbacks and any([m.startswith("test") for m in test_callbacks])
         if has_test_method:
             msg = '{0} package contains "test*" method(s) in ' "build_time_test_callbacks"

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -53,7 +53,6 @@ import spack.build_systems.meson
 import spack.build_systems.python
 import spack.builder
 import spack.config
-import spack.install_test
 import spack.main
 import spack.package_base
 import spack.paths
@@ -1075,19 +1074,18 @@ def _setup_pkg_and_run(
                 # 'pkg' is not defined yet
                 pass
         elif context == "test":
-            logfile = os.path.join(
-                pkg.test_suite.stage, spack.install_test.TestSuite.test_log_name(pkg.spec)
-            )
+            logfile = os.path.join(pkg.test_suite.stage, pkg.test_suite.test_log_name(pkg.spec))
 
         error_msg = str(exc)
         if isinstance(exc, (spack.multimethod.NoSuchMethodError, AttributeError)):
+            process = "test the installation" if context == "test" else "build from sources"
             error_msg = (
-                "The '{}' package cannot find an attribute while trying to build "
-                "from sources. This might be due to a change in Spack's package format "
+                "The '{}' package cannot find an attribute while trying to {}. "
+                "This might be due to a change in Spack's package format "
                 "to support multiple build-systems for a single package. You can fix this "
-                "by updating the build recipe, and you can also report the issue as a bug. "
+                "by updating the {} recipe, and you can also report the issue as a bug. "
                 "More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure"
-            ).format(pkg.name)
+            ).format(pkg.name, process, context)
             error_msg = colorize("@*R{{{}}}".format(error_msg))
             error_msg = "{}\n\n{}".format(str(exc), error_msg)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1358,6 +1358,16 @@ class ChildError(InstallError):
             out.write("See {0} log for details:\n".format(self.log_type))
             out.write("  {0}\n".format(self.log_name))
 
+        # # TODO: Ensure this is the process when rebase to include 35315
+        # # Also output the test log path IF it exists
+        # if self.context != "test":
+        #     test_log = join_path(
+        #         os.path.dirname(self.log_name), spack.package_base.spack_install_test_log
+        #     )
+        #     if os.path.isfile(test_log):
+        #         out.write("\nSee test log for details:\n")
+        #         out.write("  {0}n".format(test_log))
+
         return out.getvalue()
 
     def __str__(self):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -43,6 +43,7 @@ import types
 from typing import List, Tuple
 
 import llnl.util.tty as tty
+from llnl.util.filesystem import join_path
 from llnl.util.lang import dedupe
 from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
@@ -65,6 +66,7 @@ import spack.user_environment
 import spack.util.path
 import spack.util.pattern
 from spack.error import NoHeadersError, NoLibrariesError
+from spack.install_test import spack_install_test_log
 from spack.installer import InstallError
 from spack.util.cpus import cpus_available
 from spack.util.environment import (
@@ -1358,15 +1360,12 @@ class ChildError(InstallError):
             out.write("See {0} log for details:\n".format(self.log_type))
             out.write("  {0}\n".format(self.log_name))
 
-        # # TODO: Ensure this is the process when rebase to include 35315
-        # # Also output the test log path IF it exists
-        # if self.context != "test":
-        #     test_log = join_path(
-        #         os.path.dirname(self.log_name), spack.package_base.spack_install_test_log
-        #     )
-        #     if os.path.isfile(test_log):
-        #         out.write("\nSee test log for details:\n")
-        #         out.write("  {0}n".format(test_log))
+        # Also output the test log path IF it exists
+        if self.context != "test":
+            test_log = join_path(os.path.dirname(self.log_name), spack_install_test_log)
+            if os.path.isfile(test_log):
+                out.write("\nSee test log for details:\n")
+                out.write("  {0}n".format(test_log))
 
         return out.getvalue()
 

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -12,7 +12,6 @@ import spack.installer
 import spack.relocate
 import spack.spec
 import spack.store
-from spack.install_test import test_phase_callbacks
 
 
 def sanity_check_prefix(builder: spack.builder.Builder):
@@ -109,7 +108,10 @@ def execute_build_time_tests(builder: spack.builder.Builder):
         builder: builder prescribing the test callbacks. The name of the callbacks is
             stored as a list of strings in the ``build_time_test_callbacks`` attribute.
     """
-    test_phase_callbacks(builder, "build", builder.build_time_test_callbacks)
+    if not builder.pkg.run_tests or not builder.build_time_test_callbacks:
+        return
+
+    builder.pkg.tester.phase_tests(builder, "build", builder.build_time_test_callbacks)
 
 
 def execute_install_time_tests(builder: spack.builder.Builder):
@@ -119,7 +121,10 @@ def execute_install_time_tests(builder: spack.builder.Builder):
         builder: builder prescribing the test callbacks. The name of the callbacks is
             stored as a list of strings in the ``install_time_test_callbacks`` attribute.
     """
-    test_phase_callbacks(builder, "install", builder.install_time_test_callbacks)
+    if not builder.pkg.run_tests or not builder.install_time_test_callbacks:
+        return
+
+    builder.pkg.tester.phase_tests(builder, "install", builder.install_time_test_callbacks)
 
 
 class BaseBuilder(spack.builder.Builder):

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -12,6 +12,7 @@ import spack.installer
 import spack.relocate
 import spack.spec
 import spack.store
+from spack.install_test import test_phase_callbacks
 
 
 def sanity_check_prefix(builder: spack.builder.Builder):
@@ -108,7 +109,7 @@ def execute_build_time_tests(builder: spack.builder.Builder):
         builder: builder prescribing the test callbacks. The name of the callbacks is
             stored as a list of strings in the ``build_time_test_callbacks`` attribute.
     """
-    builder.pkg.run_test_callbacks(builder, builder.build_time_test_callbacks, "build")
+    test_phase_callbacks(builder, "build", builder.build_time_test_callbacks)
 
 
 def execute_install_time_tests(builder: spack.builder.Builder):
@@ -118,7 +119,7 @@ def execute_install_time_tests(builder: spack.builder.Builder):
         builder: builder prescribing the test callbacks. The name of the callbacks is
             stored as a list of strings in the ``install_time_test_callbacks`` attribute.
     """
-    builder.pkg.run_test_callbacks(builder, builder.install_time_test_callbacks, "install")
+    test_phase_callbacks(builder, "install", builder.install_time_test_callbacks)
 
 
 class BaseBuilder(spack.builder.Builder):

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -130,9 +130,11 @@ def _create(pkg):
                 bases,
                 {
                     "run_tests": property(lambda x: x.wrapped_package_object.run_tests),
-                    "test_log_file": property(lambda x: x.wrapped_package_object.test_log_file),
-                    "test_failures": property(lambda x: x.wrapped_package_object.test_failures),
+                    "test_requires_compiler": property(
+                        lambda x: x.wrapped_package_object.test_requires_compiler
+                    ),
                     "test_suite": property(lambda x: x.wrapped_package_object.test_suite),
+                    "tester": property(lambda x: x.wrapped_package_object.tester),
                 },
             )
             new_cls.__module__ = package_cls.__module__

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2457,6 +2457,8 @@ class CDashHandler(object):
             tty.warn(msg)
 
     def report_skipped(self, spec, directory_name, reason):
+        """Explicitly report skipping testing of a spec (e.g., CI install
+        failed, spec known to have failing tests."""
         configuration = CDashConfiguration(
             upload_url=self.upload_url,
             packages=[spec.name],

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2456,10 +2456,16 @@ class CDashHandler(object):
             msg = "Error response code ({0}) in populate_buildgroup".format(response_code)
             tty.warn(msg)
 
-    def report_skipped(self, spec, directory_name, reason):
+    def report_skipped(self, spec: spack.spec.Spec, report_dir: str, reason: Optional[str]):
         """Explicitly report skipping testing of a spec (e.g., it's CI
         configuration identifies it as known to have broken tests or
-        the CI installation failed)."""
+        the CI installation failed).
+
+        Args:
+            spec: spec being tested
+            report_dir: directory where the report will be written
+            reason: reason the test is being skipped
+        """
         configuration = CDashConfiguration(
             upload_url=self.upload_url,
             packages=[spec.name],
@@ -2469,7 +2475,7 @@ class CDashHandler(object):
             track=None,
         )
         reporter = CDash(configuration=configuration)
-        reporter.test_skipped_report(directory_name, spec, reason)
+        reporter.test_skipped_report(report_dir, spec, reason)
 
 
 def translate_deprecated_config(config):

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2457,8 +2457,9 @@ class CDashHandler(object):
             tty.warn(msg)
 
     def report_skipped(self, spec, directory_name, reason):
-        """Explicitly report skipping testing of a spec (e.g., CI install
-        failed, spec known to have failing tests."""
+        """Explicitly report skipping testing of a spec (e.g., it's CI
+        configuration identifies it as known to have broken tests or
+        the CI installation failed)."""
         configuration = CDashConfiguration(
             upload_url=self.upload_url,
             packages=[spec.name],

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -14,9 +14,9 @@ from llnl.util.tty.colify import colify
 
 import spack.cmd.common.arguments as arguments
 import spack.fetch_strategy as fs
+import spack.install_test
 import spack.repo
 import spack.spec
-from spack.install_test import test_functions
 from spack.package_base import preferred_version
 
 description = "get detailed information on a particular package"
@@ -261,7 +261,7 @@ def print_tests(pkg):
     # if it has been overridden and, therefore, assumed to be implemented.
     color.cprint("")
     color.cprint(section_title("Stand-Alone/Smoke Test Methods:"))
-    names = test_functions(pkg, add_virtuals=True, names=True)
+    names = spack.install_test.test_functions(pkg, add_virtuals=True, names=True)
     if names:
         colify(sorted(names), indent=4)
     else:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -17,7 +17,8 @@ import spack.cmd.common.arguments as arguments
 import spack.fetch_strategy as fs
 import spack.repo
 import spack.spec
-from spack.package_base import has_test_method, preferred_version
+from spack.install_test import test_functions, virtuals
+from spack.package_base import preferred_version
 
 description = "get detailed information on a particular package"
 section = "basic"
@@ -261,41 +262,7 @@ def print_tests(pkg):
     # if it has been overridden and, therefore, assumed to be implemented.
     color.cprint("")
     color.cprint(section_title("Stand-Alone/Smoke Test Methods:"))
-    names = []
-    pkg_cls = pkg if inspect.isclass(pkg) else pkg.__class__
-    if has_test_method(pkg_cls):
-        pkg_base = spack.package_base.PackageBase
-        test_pkgs = [
-            str(cls.test)
-            for cls in inspect.getmro(pkg_cls)
-            if issubclass(cls, pkg_base) and cls.test != pkg_base.test
-        ]
-        test_pkgs = list(set(test_pkgs))
-        names.extend([(test.split()[1]).lower() for test in test_pkgs])
-
-    # TODO Refactor START
-    # Use code from package_base.py's test_process IF this functionality is
-    # accepted.
-    v_names = list(set([vspec.name for vspec in pkg.virtuals_provided]))
-
-    # hack for compilers that are not dependencies (yet)
-    # TODO: this all eventually goes away
-    c_names = ("gcc", "intel", "intel-parallel-studio", "pgi")
-    if pkg.name in c_names:
-        v_names.extend(["c", "cxx", "fortran"])
-    if pkg.spec.intersects("llvm+clang"):
-        v_names.extend(["c", "cxx"])
-    # TODO Refactor END
-
-    v_specs = [spack.spec.Spec(v_name) for v_name in v_names]
-    for v_spec in v_specs:
-        try:
-            pkg_cls = spack.repo.path.get_pkg_class(v_spec.name)
-            if has_test_method(pkg_cls):
-                names.append("{0}.test".format(pkg_cls.name.lower()))
-        except spack.repo.UnknownPackageError:
-            pass
-
+    names = test_functions(pkg, add_virtuals=True, names=True)
     if names:
         colify(sorted(names), indent=4)
     else:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -261,7 +261,7 @@ def print_tests(pkg):
     # if it has been overridden and, therefore, assumed to be implemented.
     color.cprint("")
     color.cprint(section_title("Stand-Alone/Smoke Test Methods:"))
-    names = spack.install_test.test_functions(pkg, add_virtuals=True, names=True)
+    names = spack.install_test.test_function_names(pkg, add_virtuals=True)
     if names:
         colify(sorted(names), indent=4)
     else:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import inspect
 import textwrap
 from itertools import zip_longest
 
@@ -17,7 +16,7 @@ import spack.cmd.common.arguments as arguments
 import spack.fetch_strategy as fs
 import spack.repo
 import spack.spec
-from spack.install_test import test_functions, virtuals
+from spack.install_test import test_functions
 from spack.package_base import preferred_version
 
 description = "get detailed information on a particular package"

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -237,7 +237,7 @@ def test_list(args):
     tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag else set()
 
     def has_test_and_tags(pkg_class):
-        return spack.install_test.test_functions(pkg_class) and (
+        return spack.install_test.test_functions(pkg_class, add_virtuals=True) and (
             not args.tag or pkg_class.name in tagged
         )
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -11,6 +11,7 @@ import os
 import re
 import shutil
 import sys
+from collections import Counter
 
 from llnl.util import lang, tty
 from llnl.util.tty import colify
@@ -236,7 +237,7 @@ def test_list(args):
     tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag else set()
 
     def has_test_and_tags(pkg_class):
-        return spack.package_base.has_test_method(pkg_class) and (
+        return spack.install_test.test_functions(pkg_class) and (
             not args.tag or pkg_class.name in tagged
         )
 
@@ -358,18 +359,17 @@ def _report_suite_results(test_suite, args, constraints):
 
         tty.msg("test specs:")
 
-        failed, skipped, untested = 0, 0, 0
+        counts = Counter()
         for pkg_id in test_specs:
             if pkg_id in results:
                 status = results[pkg_id]
-                if status == "FAILED":
-                    failed += 1
-                elif status == "NO-TESTS":
-                    untested += 1
-                elif status == "SKIPPED":
-                    skipped += 1
+                # Backward-compatibility:  NO-TESTS => NO_TESTS
+                status = "NO_TESTS" if status == "NO-TESTS" else status
 
-                if args.failed and status != "FAILED":
+                status = spack.install_test.TestStatus[status]
+                counts[status] += 1
+
+                if args.failed and status != spack.install_test.TestStatus.FAILED:
                     continue
 
                 msg = "  {0} {1}".format(pkg_id, status)
@@ -381,7 +381,7 @@ def _report_suite_results(test_suite, args, constraints):
                             msg += "\n{0}".format("".join(f.readlines()))
                 tty.msg(msg)
 
-        spack.install_test.write_test_summary(failed, skipped, untested, len(test_specs))
+        spack.install_test.write_test_summary(counts)
     else:
         msg = "Test %s has no results.\n" % test_suite.name
         msg += "        Check if it is running with "

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -237,9 +237,8 @@ def test_list(args):
     tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag else set()
 
     def has_test_and_tags(pkg_class):
-        return spack.install_test.test_functions(pkg_class, add_virtuals=True) and (
-            not args.tag or pkg_class.name in tagged
-        )
+        tests = spack.install_test.test_functions(pkg_class)
+        return len(tests) and (not args.tag or pkg_class.name in tagged)
 
     if args.list_all:
         report_packages = [

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -552,7 +552,7 @@ def copy_test_files(pkg, test_spec):
     pkg_cls = package_class(test_spec)
     if not pkg_cls:
         tty.debug(
-            "{0}: skipping test data copy since no package class found".format(test_specspec.name)
+            "{0}: skipping test data copy since no package class found".format(test_spec.name)
         )
         return
 
@@ -570,7 +570,7 @@ def test_functions(spec_or_pkg, add_virtuals=False, names=False):
 
     Args:
         spec_or_pkg (spack.spec.Spec or spack.package_base.PackageBase): spec or package (class)
-        add_virtuals (bool): True will add any test methods of provided virtuals when a package is provided
+        add_virtuals (bool): True to add test methods of provided package virtual
         names (bool): True results in the return of test function names
 
     Returns: list of test functions or function names

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -641,7 +641,12 @@ def test_parts_process(
             test_suite.current_test_spec = spec
 
             # grab test functions associated with the spec, which may be virtual
-            tests = test_functions(spec.package_class)
+            try:
+                tests = test_functions(spec.package_class)
+            except spack.repo.UnknownPackageError:
+                # some virtuals don't have a package
+                tests = []
+
             if len(tests) == 0:
                 tester.status("", TestStatus.NO_TESTS)
                 continue

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -312,7 +312,8 @@ class PackageTest(object):
             builder.pkg.test_suite.current_test_spec = builder.pkg.spec
             builder.pkg.test_suite.current_base_spec = builder.pkg.spec
 
-            if "test" in method_names:
+            have_tests = any(name.startswith("test") for name in method_names)
+            if have_tests:
                 copy_test_files(builder.pkg, builder.pkg.spec)
 
             for name in method_names:
@@ -333,7 +334,7 @@ class PackageTest(object):
                     if fail_fast:
                         break
 
-            if "test" in method_names:
+            if have_tests:
                 print_message(logger, "Completed testing", True)
 
             # Raise any collected failures here
@@ -427,6 +428,12 @@ def test_part(pkg, test_name, purpose, work_dir=".", verbose=False):
     assert test_name and test_name.startswith(
         "test"
     ), "Test name must start with 'test' but {0} was provided".format(test_name)
+
+    if test_name == "test":
+        tty.warn(
+            "{0}: the 'test' method is deprecated. Convert stand-alone "
+            "test(s) to methods with names starting 'test_'.".format(pkg.name)
+        )
 
     title = "test: {0}: {1}".format(test_name, purpose or "")
     with fs.working_dir(wdir, create=True):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -323,7 +323,8 @@ class PackageTest:
 
             for name in method_names:
                 try:
-                    fn = getattr(builder, name)
+                    # Prefer the method in the package over the builder's
+                    fn = getattr(builder.pkg, name, getattr(builder, name))
 
                     msg = f"RUN-TESTS: {phase_name}-time tests [{name}]"
                     print_message(logger, msg, verbose)

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -347,7 +347,9 @@ class PackageTest:
 
             for name in method_names:
                 try:
-                    # Prefer the method in the package over the builder's
+                    # Prefer the method in the package over the builder's.
+                    # We need this primarily to pick up arbitrarily named test
+                    # methods but also some build-time checks.
                     fn = getattr(builder.pkg, name, getattr(builder, name))
 
                     msg = f"RUN-TESTS: {phase_name}-time tests [{name}]"

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -589,7 +589,7 @@ def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tup
     def skip(line):
         # This should match the lines in the deprecated test() method
         ln = line.strip()
-        return ln.startswith("#") or (ln.startswith("tty.warn") and "deprecated" in ln)
+        return ln.startswith("#") or ("warn" in ln and "deprecated" in ln)
 
     doc_regex = r'\s+("""[\w\s\(\)\-\,\;\:]+""")'
     tests = []

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -44,7 +44,7 @@ ListOrStringType = Union[str, List[str]]
 LogType = Union["tty.log.nixlog", "tty.log.winlog"]
 
 Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
-TestPackageType = Union[Pb, Type[Pb]]
+PackageObjectOrClass = Union[Pb, Type[Pb]]
 
 
 class TestStatus(enum.Enum):
@@ -536,7 +536,7 @@ def copy_test_files(pkg: Pb, test_spec: spack.spec.Spec):
         shutil.copytree(data_source, data_dir)
 
 
-def test_function_names(pkg: TestPackageType, add_virtuals: bool = False) -> List[str]:
+def test_function_names(pkg: PackageObjectOrClass, add_virtuals: bool = False) -> List[str]:
     """Grab the names of all non-empty test functions.
 
     Args:
@@ -554,7 +554,9 @@ def test_function_names(pkg: TestPackageType, add_virtuals: bool = False) -> Lis
     return [f"{cls_name}.{fn.__name__}" for (cls_name, fn) in fns]
 
 
-def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tuple[str, Callable]]:
+def test_functions(
+    pkg: PackageObjectOrClass, add_virtuals: bool = False
+) -> List[Tuple[str, Callable]]:
     """Grab all non-empty test functions.
 
     Args:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -136,9 +136,12 @@ def check_outputs(expected: Union[list, set, str], actual: str):
         RuntimeError: the expected output is not found in the actual output
     """
     expected = expected if isinstance(expected, (list, set)) else [expected]
+    errors = []
     for check in expected:
         if not re.search(check, actual):
-            raise RuntimeError("Expected '{0}' in output '{1}'".format(check, actual))
+            errors.append(f"Expected '{check}' in output '{actual}'")
+    if errors:
+        raise RuntimeError("\n  ".join(errors))
 
 
 def find_required_file(

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -623,7 +623,7 @@ def test_functions(
     return tests
 
 
-def test_parts_process(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool = False):
+def process_test_parts(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool = False):
     """Process test parts associated with the package.
 
     Args:
@@ -716,7 +716,7 @@ def test_process(pkg: Pb, kwargs):
         # run test methods from the package and all virtuals it provides
         v_names = virtuals(pkg)
         test_specs = [pkg.spec] + [spack.spec.Spec(v_name) for v_name in sorted(v_names)]
-        test_parts_process(pkg, test_specs, verbose)
+        process_test_parts(pkg, test_specs, verbose)
 
 
 def virtuals(pkg):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -43,6 +43,9 @@ spack_install_test_log = "install-time-test-log.txt"
 ListOrStringType = Union[str, List[str]]
 LogType = Union["tty.log.nixlog", "tty.log.winlog"]
 
+Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
+TestPackageType = Union[Pb, Type[Pb]]
+
 
 class TestStatus(enum.Enum):
     """Names of different stand-alone test states."""
@@ -91,7 +94,7 @@ def get_test_stage_dir():
     )
 
 
-def cache_extra_test_sources(pkg: "spack.package_base.PackageBase", srcs: ListOrStringType):
+def cache_extra_test_sources(pkg: Pb, srcs: ListOrStringType):
     """Copy relative source paths to the corresponding install test subdir
 
     This routine is intended as an optional install test setup helper for
@@ -179,7 +182,7 @@ def find_required_file(
     return paths[0] if expected == 1 else paths
 
 
-def install_test_root(pkg: "spack.package_base.PackageBase"):
+def install_test_root(pkg: Pb):
     """The install test root directory.
 
     Args:
@@ -207,7 +210,7 @@ def print_message(logger: LogType, msg: str, verbose: bool = False):
 class PackageTest(object):
     """The class that manages stand-alone (post-install) package tests."""
 
-    def __init__(self, pkg: "spack.package_base.PackageBase"):
+    def __init__(self, pkg: Pb):
         """
         Args:
             pkg: package being tested
@@ -392,13 +395,7 @@ class PackageTest(object):
 
 
 @contextlib.contextmanager
-def test_part(
-    pkg: "spack.package_base.PackageBase",
-    test_name: str,
-    purpose: str,
-    work_dir: str = ".",
-    verbose: bool = False,
-):
+def test_part(pkg: Pb, test_name: str, purpose: str, work_dir: str = ".", verbose: bool = False):
     wdir = "." if work_dir is None else work_dir
     tester = pkg.tester
     # TODO: Replace "test" with "test_" when remove run_test, etc.
@@ -501,7 +498,7 @@ def test_phase_callbacks(builder: spack.builder.Builder, phase_name: str, method
     builder.pkg.tester.phase_tests(builder, phase_name, method_names)
 
 
-def copy_test_files(pkg: "spack.package_base.PackageBase", test_spec: spack.spec.Spec):
+def copy_test_files(pkg: Pb, test_spec: spack.spec.Spec):
     """Copy the spec's cached and custom test files to the test stage directory.
 
     Args:
@@ -543,10 +540,6 @@ def copy_test_files(pkg: "spack.package_base.PackageBase", test_spec: spack.spec
         # We assume data dir is used read-only
         # maybe enforce this later
         shutil.copytree(data_source, data_dir)
-
-
-U = TypeVar("U", bound="spack.package_base.PackageBase")
-TestPackageType = Union[U, Type[U]]
 
 
 def test_function_names(pkg: TestPackageType, add_virtuals: bool = False) -> List[str]:
@@ -616,9 +609,7 @@ def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tup
     return tests
 
 
-def test_parts_process(
-    pkg: "spack.package_base.PackageBase", test_specs: List[spack.spec.Spec], verbose: bool = False
-):
+def test_parts_process(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool = False):
     """Process test parts associated with the package.
 
     Args:
@@ -693,7 +684,7 @@ def test_parts_process(
             tty.msg("No tests to run")
 
 
-def test_process(pkg: "spack.package_base.PackageBase", kwargs):
+def test_process(pkg: Pb, kwargs):
     verbose = kwargs.get("verbose", True)
     externals = kwargs.get("externals", False)
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -1152,7 +1152,7 @@ def _add_msg_to_file(filename, msg):
         f.write("{0}\n".format(msg))
 
 
-class SkipTest(spack.error.SpackError):
+class SkipTest(Exception):
     """Raised when a test (part) is being skipped."""
 
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -316,7 +316,7 @@ class PackageTest:
             builder.pkg.test_suite.current_test_spec = builder.pkg.spec
             builder.pkg.test_suite.current_base_spec = builder.pkg.spec
 
-            # TODO: Change "test" to "test_" once remove package's test()
+            # TODO (post-34236): "test"->"test_" once remove deprecated methods
             have_tests = any(name.startswith("test") for name in method_names)
             if have_tests:
                 copy_test_files(builder.pkg, builder.pkg.spec)
@@ -398,7 +398,7 @@ class PackageTest:
 def test_part(pkg: Pb, test_name: str, purpose: str, work_dir: str = ".", verbose: bool = False):
     wdir = "." if work_dir is None else work_dir
     tester = pkg.tester
-    # TODO: Replace "test" with "test_" when remove run_test, etc.
+    # TODO (post-34236): "test"->"test_" once remove deprecated methods
     assert test_name and test_name.startswith(
         "test"
     ), f"Test name must start with 'test' but {test_name} was provided"
@@ -591,12 +591,12 @@ def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tup
     for clss in classes:
         methods = inspect.getmembers(clss, predicate=lambda x: inspect.isfunction(x))
         for name, test_fn in methods:
-            # TODO: Change to test_ once remove deprecated run_test(), etc.
+            # TODO (post-34236): "test"->"test_" once remove deprecated methods
             if not name.startswith("test"):
                 continue
 
-            # TODO: Could remove empty method check once remove
-            # TODO: deprecated run_test(), etc.
+            # TODO (post-34236): Could remove empty method check once remove
+            # TODO (post-34236): deprecated methods
             source = re.sub(doc_regex, r"", inspect.getsource(test_fn)).splitlines()[1:]
             lines = [ln.strip() for ln in source if not ln.strip().startswith("#")]
             if len(lines) > 0 and lines[0] == "pass":

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -3,22 +3,58 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import base64
+import contextlib
+import enum
 import hashlib
+import inspect
+import io
 import os
 import re
 import shutil
+import sys
+from collections import Counter
+from typing import List, Tuple
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.lang import nullcontext
+from llnl.util.tty.color import colorize
 
 import spack.error
 import spack.paths
 import spack.util.spack_json as sjson
 from spack.spec import Spec
 from spack.util.prefix import Prefix
+from spack.util.string import plural
 
+#: Stand-alone test failure info type
+TEST_FAILURE_TYPE = Tuple[Exception, str]
+
+#: Name of the test suite's (JSON) lock file
 test_suite_filename = "test_suite.lock"
+
+#: Name of the test suite results (summary) file
 results_filename = "results.txt"
+
+#: Name of the Spack install phase-time test log file
+spack_install_test_log = "install-time-test-log.txt"
+
+
+@enum.unique
+class TestStatus(enum.Enum):
+    """Names of different stand-alone test states."""
+
+    NO_TESTS = -1
+    SKIPPED = 0
+    FAILED = 1
+    PASSED = 2
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def lower(self):
+        name = f"{self.name}"
+        return name.lower()
 
 
 def get_escaped_text_output(filename):
@@ -50,6 +86,611 @@ def get_test_stage_dir():
     return spack.util.path.canonicalize_path(
         spack.config.get("config:test_stage", spack.paths.default_test_path)
     )
+
+
+def cache_extra_test_sources(pkg, srcs):
+    """Copy relative source paths to the corresponding install test subdir
+
+    This routine is intended as an optional install test setup helper for
+    grabbing source files/directories during the installation process and
+    copying them to the installation test subdirectory for subsequent use
+    during install testing.
+
+    Args:
+        pkg (spack.package_base.PackageBase): package being tested
+        srcs (str or list): relative path for files and or
+            subdirectories located in the staged source path that are to
+            be copied to the corresponding location(s) under the install
+            testing directory.
+    """
+    paths = [srcs] if isinstance(srcs, str) else srcs
+
+    for path in paths:
+        src_path = os.path.join(pkg.stage.source_path, path)
+        dest_path = os.path.join(install_test_root(pkg), path)
+        if os.path.isdir(src_path):
+            fs.install_tree(src_path, dest_path)
+        else:
+            fs.mkdirp(os.path.dirname(dest_path))
+            fs.copy(src_path, dest_path)
+
+
+def check_outputs(expected, actual):
+    """Ensure the expected outputs are contained in the actual outputs.
+
+    Args:
+        expected (list): list of expected raw output strings
+        actual (list): list of actual output strings
+
+    Raises:
+        AssertionError: raised if the expected output does not match actual
+    """
+    for check in expected:
+        msg = "Expected '{0}' to match actual output".format(check)
+        msg += "\n\nOutput: {0}".format(actual)
+        assert re.search(check, actual), msg
+
+
+def find_required_file(root, filename, expected=1, recursive=True):
+    """Find the required file(s) under the root directory.
+
+    Args:
+       root (str): root directory for the search
+       filename (str): name of the file being located
+       expected (int): expected number of files to be found under the directory
+           (default is 1)
+       recursive (bool): True if subdirectories are to be searched, else False
+           (default is True)
+
+    Returns: str or list: the path or paths, relative to root, to the file(s)
+
+    Raises:
+        Exception: Skip Test when number detected does not match expected
+    """
+
+    def copies(num):
+        if num == 0:
+            return "no copies"
+        if num == 1:
+            return "1 copy"
+        return "{0} copies"
+
+    paths = fs.find(root, filename, recursive=recursive)
+    num_paths = len(paths)
+    if num_paths != expected:
+        files = ": {0}".format(", ".join(paths)) if num_paths else ""
+        raise SkipTest(
+            "Expected {0} of {1} under {2} but {3} found{4}".format(
+                copies(expected), filename, root, copies(num_paths), files
+            )
+        )
+
+    return paths[0] if expected == 1 else paths
+
+
+def install_test_root(pkg):
+    """The install test root directory.
+
+    Args:
+        pkg (spack.package_base.PackageBase): package being tested
+    """
+    return os.path.join(pkg.metadata_dir, "test")
+
+
+def package_class(spec):
+    """Return the spec's package class.
+
+    Args:
+        spec (spack.spec.Spec): spec instance
+    """
+    try:
+        cls = spec.package.__class__
+    except AssertionError as e:
+        try:
+            cls = spec.package_class
+        except spack.repo.UnknownPackageError as e:
+            tty.debug("{0}: Cannot retrieve class from spec: {1}".format(spec.name, str(e)))
+            return None
+
+    return cls
+
+
+def print_message(logger, msg, verbose=False):
+    """Print the message to the log, optionally echoing.
+
+    Args:
+        logger (object): output logger (e.g. nixlog or winlog)
+        msg (str): message being output
+        verbose (bool): Display verbose output (suppress by default)
+    """
+    if verbose:
+        with logger.force_echo():
+            tty.info(msg, format="*g")
+    else:
+        tty.info(msg, format="*g")
+
+
+class PackageTest(object):
+    """The class that manages stand-alone (post-install) package tests."""
+
+    def __init__(self, pkg):
+        """
+        Args:
+            pkg (spack.package_base.PackageBase): package being tested
+
+        Raises:
+            ValueError: if the package is not concrete
+        """
+        if not pkg.spec.concrete:
+            raise ValueError("Stand-alone tests require a concrete package")
+
+        self.pkg = pkg
+        self.test_failures: List[TEST_FAILURE_TYPE] = []
+        self.test_parts = []  # tuple of (test name, TestStatus)
+        self.counts = Counter()
+
+        if pkg.test_suite:
+            self.test_log_file = pkg.test_suite.log_file_for_spec(pkg.spec)
+            self.tested_file = pkg.test_suite.tested_file_for_spec(pkg.spec)
+            self.pkg_id = pkg.test_suite.test_pkg_id(pkg.spec)
+        else:
+            self.test_log_file = fs.join_path(pkg.stage.path, spack_install_test_log)
+            self.pkg_id = pkg.spec.format("{name}-{version}-{hash:7}")
+
+        fs.touch(self.test_log_file)  # otherwise log_parse complains
+
+        # Internal logger for test part processing
+        self._logger = None
+
+    @property
+    def logger(self):
+        """The current logger or, if none, sets to one."""
+        if not self._logger:
+            self._logger = tty.log.log_output(self.test_log_file)
+
+        return self._logger
+
+    @contextlib.contextmanager
+    def test_logger(self, verbose, externals):
+        """Context manager for setting up the test logger
+
+        Args:
+            verbose (bool): Display verbose output, including echoing to stdout,
+                otherwise suppress it
+            externals (bool): ``True`` for performing tests if external package,
+                otherwise, don't perform the tests
+        """
+        with tty.log.log_output(self.test_log_file, verbose) as logger:
+            with logger.force_echo():
+                tty.msg("Testing package {0}".format(self.pkg_id))
+
+            # use debug print levels for log file to record commands
+            old_debug = tty.is_debug()
+            tty.set_debug(True)
+
+            try:
+                self._logger = logger
+                yield logger
+            finally:
+                # reset debug level
+                tty.set_debug(old_debug)
+
+    @property
+    def archived_install_test_log(self):
+        return fs.join_path(self.pkg.metadata_dir, spack_install_test_log)
+
+    def archive_install_test_log(self, dest_dir):
+        if os.path.exists(self.test_log_file):
+            fs.install(self.test_log_file, self.archived_install_test_log)
+
+    def add_failure(self, exception, msg):
+        """Add the failure details to the current list."""
+        self.test_failures.append((exception, msg))
+
+    def status(self, name, status):
+        """Log the test status (TestStatus) for the part name."""
+        extra = "::{0}".format(name) if name else ""
+        part_name = "{0}{1}".format(self.pkg.__class__.__name__, extra)
+        self.test_parts.append((part_name, status))
+        self.counts[status] += 1
+
+    def phase_tests(self, builder, phase_name, method_names):
+        """Execute the builder's package phase-time tests.
+
+        Args:
+            builder (spack.builder.Builder): builder for package being tested
+            phase_name (str): the name of the build-time phase (e.g.,
+                ``build``, ``install``)
+            method_names (list): list of phase-specific callback method names
+        """
+        verbose = tty.is_verbose()
+        fail_fast = spack.config.get("config:fail_fast", False)
+
+        with self.test_logger(verbose=verbose, externals=False) as logger:
+            # Report running each of the methods in the build log
+            print_message(logger, "Running {0}-time tests".format(phase_name), True)
+            builder.pkg.test_suite.current_test_spec = builder.pkg.spec
+            builder.pkg.test_suite.current_base_spec = builder.pkg.spec
+
+            if "test" in method_names:
+                copy_test_files(builder.pkg, builder.pkg.spec)
+
+            for name in method_names:
+                try:
+                    fn = getattr(builder, name)
+
+                    msg = "RUN-TESTS: {0}-time tests [{1}]".format(phase_name, name)
+                    print_message(logger, msg, True)
+
+                    fn()
+
+                # TODO/TLD: Catch other exception to support test_* methods
+                except AttributeError as e:
+                    msg = "RUN-TESTS: method not implemented [{0}]".format(name)
+                    print_message(logger, msg, True)
+
+                    self.add_failure(e, msg)
+                    if fail_fast:
+                        break
+
+            if "test" in method_names:
+                print_message(logger, "Completed testing", True)
+
+            # Raise any collected failures here
+            if self.test_failures:
+                raise TestFailure(self.test_failures)
+
+    def stand_alone_tests(self, kwargs):
+        """Run the package's stand-alone tests.
+
+        Args:
+            kwargs (dict): arguments to be used by the test process
+        """
+        import spack.build_environment
+
+        spack.build_environment.start_build_process(self.pkg, test_process, kwargs)
+
+    def parts(self):
+        """The total number of (checked) test parts."""
+        try:
+            # New in Python 3.10
+            total = self.counts.total()
+        except AttributeError:
+            nums = [n for _, n in self.counts.items()]
+            total = sum(nums)
+        return total
+
+    def print_log(self, verbose: bool = False):
+        """Print the test log file location and, optionally, contents
+
+        Args:
+            verbose (bool):  True if want to print log file contents
+        """
+        log = self.archived_install_test_log
+        if not os.path.exists(log):
+            log = self.test_log_file
+            if not os.path.exists(log):
+                tty.debug("The test results log {0} does not exist".format(self.test_log_file))
+            return
+
+        if verbose:
+            with open(log, "r") as f:
+                for ln in f.readlines():
+                    if ln.startswith("==>"):
+                        ln = colorize("@*g{==>}") + ln[3:]
+                    print(ln.strip("\n"))
+
+        if self.test_failures:
+            print("\nSee test results at:\n  {0}".format(log))
+
+    def ran_tests(self):
+        """True if ran tests, False otherwise."""
+        return self.parts() > self.counts[TestStatus.NO_TESTS]
+
+    def summarize(self):
+        """Collect test results summary lines for this spec."""
+        lines = []
+        lines.append("{:=^80}".format(" SUMMARY: {0} ".format(self.pkg_id)))
+        for name, status in self.test_parts:
+            # TODO/TBD/TLD: Should the pkg_id be listed?  If so, remove above
+            # msg = "{0}::{1} .. {2}\n".format(self.pkg_id, name, status)
+            msg = "{0} .. {1}".format(name, status)
+            lines.append(msg)
+
+        summary = ["{0} {1}".format(n, s.lower()) for s, n in self.counts.items() if n > 0]
+        totals = " {0} of {1} parts ".format(", ".join(summary), self.parts())
+        lines.append("{:=^80}".format(totals))
+        return lines
+
+    # TBD/TLD: Remove if this continues to not be used
+    def write_summary(self, filename, mode="w"):
+        lines = self.summarize()
+        with open(filename, mode) as f:
+            f.write("\n{0}\n".format("\n".join(lines)))
+
+
+def ensure_expected(output, expected):
+    """Ensure expected strings are in output."""
+    expected = expected if isinstance(expected, (list, set)) else [expected]
+    for check in expected:
+        msg = "Expected '{0}' in output '{1}'".format(check, output)
+        assert re.search(check, output), msg
+
+
+# TBD/TLD: Needs to replace run_test
+# TBD/TLD: Provide decorator/wrapper to auto pass name and (docstring) purpose
+# TBD/TLD:   *if* embedded within a test method
+@contextlib.contextmanager
+def test_part(pkg, test_name, purpose, work_dir=".", verbose=False):
+    wdir = "." if work_dir is None else work_dir
+    tester = pkg.tester
+    assert test_name and test_name.startswith(
+        "test"
+    ), "Test name must start with 'test' but {0} was provided".format(test_name)
+
+    title = "test: {0}: {1}".format(test_name, purpose or "")
+    with fs.working_dir(wdir, create=True):
+        try:
+            status = TestStatus.PASSED
+            context = tester.logger.force_echo if verbose else nullcontext
+            with context():
+                tty.msg(title)
+                yield
+            print("{0}: {1}".format(status, test_name))
+            tester.status(test_name, status)
+
+        except SkipTest as e:
+            status = TestStatus.SKIPPED
+            print("{0}: {1}: {2}".format(status, test_name, e))
+            tester.status(test_name, status)
+
+        except (AssertionError, BaseException) as e:
+            # print a summary of the error to the log file
+            # so that cdash and junit reporters know about it
+            exc_type, _, tb = sys.exc_info()
+            status = TestStatus.FAILED
+            print("{0}: {1}: {2}".format(status, test_name, e))
+            tester.status(test_name, status)
+
+            import traceback
+
+            # remove the current call frame to exclude the extract_stack
+            # call from the error
+            stack = traceback.extract_stack()[:-1]
+
+            # Package files have a line added at import time, so we re-read
+            # the file to make line numbers match. We have to subtract two
+            # from the line number because the original line number is
+            # inflated once by the import statement and the lines are
+            # displaced one by the import statement.
+            for i, entry in enumerate(stack):
+                filename, lineno, function, text = entry
+                if spack.repo.is_package_file(filename):
+                    with open(filename, "r") as f:
+                        lines = f.readlines()
+                    new_lineno = lineno - 2
+                    text = lines[new_lineno]
+                    stack[i] = (filename, new_lineno, function, text)
+
+            # Format the stack to print and print it
+            out = traceback.format_list(stack)
+            for line in out:
+                print(line.rstrip("\n"))
+
+            if exc_type is spack.util.executable.ProcessError:
+                out = io.StringIO()
+                spack.build_environment.write_log_summary(
+                    out, "test", tester.test_log_file, last=1
+                )
+                m = out.getvalue()
+            else:
+                # We're below the package context, so get context from
+                # stack instead of from traceback.
+                # The traceback is truncated here, so we can't use it to
+                # traverse the stack.
+                m = "\n".join(spack.build_environment.get_package_context(tb))
+
+            exc = e  # e is deleted after this block
+
+            # If we fail fast, raise another error
+            if spack.config.get("config:fail_fast", False):
+                raise TestFailure([(exc, m)])
+            else:
+                tester.add_failure(exc, m)
+
+
+def test_phase_callbacks(builder, phase_name, method_names):
+    """Execute the builder's package phase-time tests.
+
+    Args:
+        builder (spack.builder.Builder): builder for package being tested
+        phase_name (str): the name of the build-time phase (e.g., ``build``,
+            ``install``)
+        method_names (list): list of phase-specific callback method names
+    """
+    if not builder.pkg.run_tests or not method_names:
+        return
+
+    builder.pkg.tester.phase_tests(builder, phase_name, method_names)
+
+
+def virtuals(pkg):
+    """Return a list of unique virtuals for the package.
+
+    Args:
+        pkg (spack.package_base.PackageBase): package of interest
+    """
+    # provided virtuals have to be deduped by name
+    v_names = list(set([vspec.name for vspec in pkg.virtuals_provided]))
+
+    # hack for compilers that are not dependencies (yet)
+    # TODO: this all eventually goes away
+    c_names = ("gcc", "intel", "intel-parallel-studio", "pgi")
+    if pkg.name in c_names:
+        v_names.extend(["c", "cxx", "fortran"])
+    if pkg.spec.satisfies("llvm+clang"):
+        v_names.extend(["c", "cxx"])
+    return v_names
+
+
+def copy_test_files(pkg, test_spec):
+    """Copy the spec's cached and custom test files to the test stage directory.
+
+    Args:
+        pkg (spack.package_base.PackageBase): package being tested
+        test_spec (spack.spec.Spec): spec being tested, where the spec may
+            be virtual
+    """
+    # copy installed test sources cache into test stage dir
+    if test_spec.concrete:
+        cache_source = install_test_root(test_spec.package)
+        cache_dir = pkg.test_suite.current_test_cache_dir
+        if os.path.isdir(cache_source) and not os.path.exists(cache_dir):
+            fs.install_tree(cache_source, cache_dir)
+
+    # copy test data into test stage data dir
+    pkg_cls = package_class(test_spec)
+    if not pkg_cls:
+        tty.debug("{0}: skipping test data copy since no package class found".format(spec.name))
+        return
+
+    package_dir = spack.package_base.package_directory(pkg_cls)
+    data_source = Prefix(package_dir).test
+    data_dir = pkg.test_suite.current_test_data_dir
+    if os.path.isdir(data_source) and not os.path.exists(data_dir):
+        # We assume data dir is used read-only
+        # maybe enforce this later
+        shutil.copytree(data_source, data_dir)
+
+
+def test_functions(spec_or_pkg, add_virtuals=False, names=False):
+    """Grab all non-pass-only test functions (names) associated with the spec or package.
+
+    Args:
+        spec_or_pkg (spack.spec.Spec or spack.package_base.PackageBase): spec or package (class)
+        add_virtuals (bool): True will add any test methods of provided virtuals when a package is provided
+        names (bool): True results in the return of test function names
+
+    Returns: list of test functions or function names
+
+    Raises: ValueError:
+    """
+    if isinstance(spec_or_pkg, spack.spec.Spec):
+        spec = spec_or_pkg
+        cls = package_class(spec)
+        if not cls:
+            tty.debug("Skipping {0}: no package class found".format(spec.name))
+            return []
+    elif isinstance(spec_or_pkg, spack.package_base.PackageBase):
+        pkg = spec_or_pkg
+        cls = pkg.__class__
+        if add_virtuals:
+            methods = []
+            v_names = virtuals(pkg)
+            test_specs = [pkg.spec] + [spack.spec.Spec(v_name) for v_name in sorted(v_names)]
+            for spec in test_specs:
+                methods.extend(test_functions(spec, names=names))
+            return methods
+
+    elif inspect.isclass(spec_or_pkg):
+        cls = spec_or_pkg
+
+    else:
+        raise ValueError("Cannot retrieve test methods for {0}".format(spec_or_pkg))
+
+    methods = inspect.getmembers(cls, predicate=lambda x: inspect.isfunction(x))
+    tests = []
+    for name, test_fn in methods:
+        if not name.startswith("test"):
+            continue
+
+        source = (inspect.getsource(test_fn)).splitlines()[1:]
+        lines = (ln.strip() for ln in source)
+        statements = [ln for ln in lines if not ln.startswith("#")]
+        empty = len(statements) > 0 and statements[0] == "pass"
+        if not empty:
+            tests.append("{0}.{1}".format(cls.name.lower(), name) if names else test_fn)
+    return tests
+
+
+def test_parts_process(pkg, test_specs, logger, verbose=False):
+    """Process test parts associated with the package.
+
+    Args:
+        pkg (spack.package_base.PackageBase): package being tested
+        test_specs (list): list of test specs
+        logger (object): output logger (e.g. nixlog or winlog)
+        verbose (bool): Display verbose output (suppress by default)
+    """
+    test_suite = pkg.test_suite
+    tester = pkg.tester
+    try:
+        work_dir = test_suite.test_dir_for_spec(pkg.spec)
+        for spec in test_specs:
+            test_suite.current_test_spec = spec
+
+            # grab test functions associated with the spec, which may be a
+            # virtual spec
+            tests = test_functions(spec, names=False)
+            if len(tests) == 0:
+                tester.status("", TestStatus.NO_TESTS)
+                continue
+
+            # copy custom and cached test files to the test stage directory
+            copy_test_files(pkg, spec)
+
+            # Run the tests
+            for test_fn in tests:
+                with test_part(
+                    pkg,
+                    test_fn.__name__,
+                    purpose=getattr(test_fn, "__doc__"),
+                    work_dir=work_dir,
+                    verbose=verbose,
+                ):
+                    test_fn(pkg)
+
+        # If fail-fast was on, we error out above
+        # If we collect errors, raise them in batch here
+        if tester.test_failures:
+            raise TestFailure(tester.test_failures)
+
+    finally:
+        if tester.ran_tests():
+            fs.touch(tester.tested_file)
+
+            # log one more test message to provide a completion timestamp
+            # for CDash reporting
+            tty.msg("Completed testing")
+
+            lines = tester.summarize()
+            tty.msg("\n{0}".format("\n".join(lines)))
+
+            # Print the test log file path
+            tty.msg("\n\nSee test results at:\n  {0}".format(tester.test_log_file))
+        else:
+            tty.msg("No tests to run")
+
+
+def test_process(pkg, kwargs):
+    verbose = kwargs.get("verbose", True)
+    externals = kwargs.get("externals", False)
+
+    with pkg.tester.test_logger(verbose, externals) as logger:
+        if pkg.spec.external and not externals:
+            print_message(logger, "Skipped tests for external package", verbose)
+            pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
+            return
+
+        if not pkg.spec.installed:
+            print_message(logger, "Skipped not installed package", verbose)
+            pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
+            return
+
+        # run test methods from the package and all virtuals it provides
+        v_names = virtuals(pkg)
+        test_specs = [pkg.spec] + [spack.spec.Spec(v_name) for v_name in sorted(v_names)]
+        test_parts_process(pkg, test_specs, logger, verbose)
 
 
 def get_all_test_suites():
@@ -116,21 +757,19 @@ def write_test_suite_file(suite):
         sjson.dump(suite.to_dict(), stream=f)
 
 
-def write_test_summary(num_failed, num_skipped, num_untested, num_specs):
+def write_test_summary(counts):
     """Write a well formatted summary of the totals for each relevant status
     category."""
-    failed = "{0} failed, ".format(num_failed) if num_failed else ""
-    skipped = "{0} skipped, ".format(num_skipped) if num_skipped else ""
-    no_tests = "{0} no-tests, ".format(num_untested) if num_untested else ""
-    num_passed = num_specs - num_failed - num_untested - num_skipped
+    summary = ["{0} {1}".format(n, s.lower()) for s, n in counts.items() if n > 0]
+    try:
+        # New in Python 3.10
+        total = counts.total()
+    except AttributeError:
+        nums = [n for _, n in counts.items()]
+        total = sum(nums)
 
-    print(
-        "{:=^80}".format(
-            " {0}{1}{2}{3} passed of {4} specs ".format(
-                failed, no_tests, skipped, num_passed, num_specs
-            )
-        )
-    )
+    if total:
+        print("{:=^80}".format(" {0} of {1} ".format(", ".join(summary), plural(total, "spec"))))
 
 
 class TestSuite(object):
@@ -147,7 +786,7 @@ class TestSuite(object):
         self._hash = None
         self._stage = None
 
-        self.fails = 0
+        self.counts = Counter()
 
     @property
     def name(self):
@@ -173,7 +812,6 @@ class TestSuite(object):
         fail_first = kwargs.get("fail_first", False)
         externals = kwargs.get("externals", False)
 
-        skipped, untested = 0, 0
         for spec in self.specs:
             try:
                 if spec.package.test_suite:
@@ -201,45 +839,54 @@ class TestSuite(object):
                 if remove_directory:
                     shutil.rmtree(test_dir)
 
-                # Log test status based on whether any non-pass-only test
-                # functions were called
+                # TODO/TBD/TLD: Extract test parts from the tested file???
                 tested = os.path.exists(self.tested_file_for_spec(spec))
                 if tested:
-                    status = "PASSED"
+                    status = TestStatus.PASSED
                 else:
                     self.ensure_stage()
                     if spec.external and not externals:
-                        status = "SKIPPED"
-                        skipped += 1
+                        status = TestStatus.SKIPPED
                     elif not spec.installed:
-                        status = "SKIPPED"
-                        skipped += 1
+                        status = TestStatus.SKIPPED
                     else:
-                        status = "NO-TESTS"
-                        untested += 1
+                        status = TestStatus.NO_TESTS
+                self.counts[status] += 1
 
                 self.write_test_result(spec, status)
             except BaseException as exc:
-                self.fails += 1
-                tty.debug("Test failure: {0}".format(str(exc)))
+                status = TestStatus.FAILED
+                self.counts[status] += 1
                 if isinstance(exc, (SyntaxError, TestSuiteSpecError)):
                     # Create the test log file and report the error.
                     self.ensure_stage()
                     msg = "Testing package {0}\n{1}".format(self.test_pkg_id(spec), str(exc))
                     _add_msg_to_file(self.log_file_for_spec(spec), msg)
 
-                self.write_test_result(spec, "FAILED")
+                msg = "Test failure: {0}".format(str(exc))
+                _add_msg_to_file(self.log_file_for_spec(spec), msg)
+                self.write_test_result(spec, TestStatus.FAILED)
                 if fail_first:
                     break
+
             finally:
                 spec.package.test_suite = None
                 self.current_test_spec = None
                 self.current_base_spec = None
 
-        write_test_summary(self.fails, skipped, untested, len(self.specs))
+        write_test_summary(self.counts)
 
-        if self.fails:
-            raise TestSuiteFailure(self.fails)
+        for spec in self.specs:
+            print(
+                "\nSee {0} test results at:\n  {1}".format(
+                    spec.format("{name}-{version}-{hash:7}"),
+                    self.log_file_for_spec(spec),
+                )
+            )
+
+        failures = self.counts[TestStatus.FAILED]
+        if failures:
+            raise TestSuiteFailure(failures)
 
     def ensure_stage(self):
         """Ensure the test suite stage directory exists."""
@@ -458,12 +1105,17 @@ def _add_msg_to_file(filename, msg):
         f.write("{0}\n".format(msg))
 
 
+class SkipTest(spack.error.SpackError):
+    """Raised when a test (part) is being skipped."""
+
+
 class TestFailure(spack.error.SpackError):
     """Raised when package tests have failed for an installation."""
 
     def __init__(self, failures):
         # Failures are all exceptions
-        msg = "%d tests failed.\n" % len(failures)
+        num = len(failures)
+        msg = "{0} failed.\n".format(plural(num, "test"))
         for failure, message in failures:
             msg += "\n\n%s\n" % str(failure)
             msg += "\n%s\n" % message

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -578,7 +578,7 @@ def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tup
         ValueError: occurs if pkg is not a package class
     """
     instance = isinstance(pkg, spack.package_base.PackageBase)
-    if not (instance or issubclass(pkg, spack.package_base.PackageBase)):
+    if not (instance or issubclass(pkg, spack.package_base.PackageBase)):  # type: ignore[arg-type]
         raise ValueError("Expected a package (class), not {0} ({1})".format(pkg, type(pkg)))
 
     pkg_cls = pkg.__class__ if instance else pkg
@@ -606,7 +606,7 @@ def test_functions(pkg: TestPackageType, add_virtuals: bool = False) -> List[Tup
             if len(lines) > 0 and lines[0] == "pass":
                 continue
 
-            tests.append((clss.__name__, test_fn))
+            tests.append((clss.__name__, test_fn))  # type: ignore[union-attr]
 
     return tests
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -144,8 +144,8 @@ def find_required_file(
        filename: name of the file being located
        expected: expected number of files to be found under the directory
            (default is 1)
-       recursive: ``True`` if subdirectories are to be searched, else ``False``
-           (default is ``True``)
+       recursive: ``True`` if subdirectories are to be recursively searched,
+           else ``False`` (default is ``True``)
 
     Returns: the path(s), relative to root, to the required file(s)
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -425,6 +425,7 @@ def ensure_expected(output, expected):
 def test_part(pkg, test_name, purpose, work_dir=".", verbose=False):
     wdir = "." if work_dir is None else work_dir
     tester = pkg.tester
+    # TODO: Replace "test" with "test_" when remove run_test, etc.
     assert test_name and test_name.startswith(
         "test"
     ), "Test name must start with 'test' but {0} was provided".format(test_name)

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -13,7 +13,7 @@ import re
 import shutil
 import sys
 from collections import Counter
-from typing import Callable, List, Optional, Tuple, Type, Union
+from typing import Callable, List, Optional, Tuple, Type, TypeVar, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -545,7 +545,8 @@ def copy_test_files(pkg: "spack.package_base.PackageBase", test_spec: spack.spec
         shutil.copytree(data_source, data_dir)
 
 
-TestPackageType = Union["spack.package_base.PackageBase", Type]
+U = TypeVar("U", bound="spack.package_base.PackageBase")
+TestPackageType = Union[U, Type[U]]
 
 
 def test_function_names(pkg: TestPackageType, add_virtuals: bool = False) -> List[str]:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -484,20 +484,6 @@ def test_part(pkg: Pb, test_name: str, purpose: str, work_dir: str = ".", verbos
                 tester.add_failure(exc, m)
 
 
-def test_phase_callbacks(builder: spack.builder.Builder, phase_name: str, method_names: List[str]):
-    """Execute the builder's package phase-time tests.
-
-    Args:
-        builder: builder for package being tested
-        phase_name: the name of the build-time phase (e.g., ``build``, ``install``)
-        method_names: phase-specific callback method names
-    """
-    if not builder.pkg.run_tests or not method_names:
-        return
-
-    builder.pkg.tester.phase_tests(builder, phase_name, method_names)
-
-
 def copy_test_files(pkg: Pb, test_spec: spack.spec.Spec):
     """Copy the spec's cached and custom test files to the test stage directory.
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -61,14 +61,14 @@ class TestStatus(enum.Enum):
         return name.lower()
 
 
-def get_escaped_text_output(filename):
+def get_escaped_text_output(filename: str) -> List[str]:
     """Retrieve and escape the expected text output from the file
 
     Args:
-        filename (str): path to the file
+        filename: path to the file
 
     Returns:
-        list: escaped text lines read from the file
+        escaped text lines read from the file
     """
     with open(filename, "r") as f:
         # Ensure special characters are escaped as needed

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -185,7 +185,7 @@ def package_class(spec):
     """
     try:
         cls = spec.package.__class__
-    except AssertionError as e:
+    except AssertionError:
         try:
             cls = spec.package_class
         except spack.repo.UnknownPackageError as e:
@@ -551,7 +551,9 @@ def copy_test_files(pkg, test_spec):
     # copy test data into test stage data dir
     pkg_cls = package_class(test_spec)
     if not pkg_cls:
-        tty.debug("{0}: skipping test data copy since no package class found".format(spec.name))
+        tty.debug(
+            "{0}: skipping test data copy since no package class found".format(test_specspec.name)
+        )
         return
 
     package_dir = spack.package_base.package_directory(pkg_cls)
@@ -879,8 +881,7 @@ class TestSuite(object):
         for spec in self.specs:
             print(
                 "\nSee {0} test results at:\n  {1}".format(
-                    spec.format("{name}-{version}-{hash:7}"),
-                    self.log_file_for_spec(spec),
+                    spec.format("{name}-{version}-{hash:7}"), self.log_file_for_spec(spec)
                 )
             )
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -542,8 +542,7 @@ def copy_test_files(pkg: "spack.package_base.PackageBase", test_spec: spack.spec
         shutil.copytree(data_source, data_dir)
 
 
-Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
-TestPackageType = Union["spack.package_base.PackageBase", Type(Pb)]
+TestPackageType = Union["spack.package_base.PackageBase", Type]
 FunctionType = Union[str, Callable]
 FunctionResult = List[FunctionType]
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -473,7 +473,7 @@ def test_part(pkg: Pb, test_name: str, purpose: str, work_dir: str = ".", verbos
             for line in out:
                 print(line.rstrip("\n"))
 
-            if exc_type is spack.util.executable.ProcessError:
+            if exc_type is spack.util.executable.ProcessError or exc_type is TypeError:
                 iostr = io.StringIO()
                 spack.build_environment.write_log_summary(
                     iostr, "test", tester.test_log_file, last=1

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -517,8 +517,7 @@ def copy_test_files(pkg: Pb, test_spec: spack.spec.Spec):
         tty.debug(f"{test_spec.name}: skipping test data copy since no package class found")
         return
 
-    package_dir = spack.package_base.package_directory(pkg_cls)
-    data_source = Prefix(package_dir).test
+    data_source = Prefix(pkg_cls.package_dir).test
     data_dir = pkg.test_suite.current_test_data_dir
     if os.path.isdir(data_source) and not os.path.exists(data_dir):
         # We assume data dir is used read-only

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -278,19 +278,18 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
-def _print_install_test_log(pkg: "spack.package_base.PackageBase", verbose: bool):
-    """Output install test log file information.
+def _print_install_test_log(pkg: "spack.package_base.PackageBase"):
+    """Output install test log file information but onlly if have test failures.
 
     Args:
         pkg: package of interest
-        verbose:  True if the test log contents are to be printed
     """
-    if not pkg.run_tests:
-        # The tests were not run
+    if not pkg.run_tests or not pkg.test_failures:
+        # The tests were not run or there were no test failures
         return
 
     try:
-        pkg.tester.print_log()
+        pkg.tester.print_log_path()
     except Exception as e:
         # TODO/TLD: Narrow the exceptions
         tty.error("{0} was not tested: {1}".format(package_id(pkg), str(e)))

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -278,13 +278,13 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
-def _print_install_test_log(pkg: "spack.package_base.PackageBase"):
-    """Output install test log file information but onlly if have test failures.
+def print_install_test_log(pkg: "spack.package_base.PackageBase"):
+    """Output install test log file path but only if have test failures.
 
     Args:
-        pkg: package of interest
+        pkg: instance of the package under test
     """
-    if not pkg.run_tests or not pkg.test_failures:
+    if not pkg.run_tests or not (pkg.tester and pkg.tester.test_failures):
         # The tests were not run or there were no test failures
         return
 
@@ -1967,7 +1967,7 @@ class BuildProcessInstaller(object):
             with open(self.pkg.times_log_path, "w") as timelog:
                 self.timer.write_json(timelog)
 
-        _print_install_test_log(self.pkg, self.verbose)
+        print_install_test_log(self.pkg)
         _print_timer(pre=self.pre, pkg_id=self.pkg_id, timer=self.timer)
         _print_installed_pkg(self.pkg.prefix)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -288,11 +288,7 @@ def print_install_test_log(pkg: "spack.package_base.PackageBase"):
         # The tests were not run or there were no test failures
         return
 
-    try:
-        pkg.tester.print_log_path()
-    except Exception as e:
-        # TODO/TBD: Narrow the exceptions
-        tty.error("{0} was not tested: {1}".format(package_id(pkg), str(e)))
+    pkg.tester.print_log_path()
 
 
 def _print_timer(pre, pkg_id, timer):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -278,7 +278,7 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
-def _print_install_test_log(pkg: "spack.package.PackageBase", verbose: bool):
+def _print_install_test_log(pkg: "spack.package_base.PackageBase", verbose: bool):
     """Output install test log file information.
 
     Args:
@@ -807,7 +807,7 @@ class PackageInstaller(object):
                 associated dependents
         """
         packages = _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs)
-        for (comp_pkg, is_compiler) in packages:
+        for comp_pkg, is_compiler in packages:
             pkgid = package_id(comp_pkg)
             if pkgid not in self.build_tasks:
                 self._add_init_task(comp_pkg, request, is_compiler, all_deps)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -291,7 +291,7 @@ def print_install_test_log(pkg: "spack.package_base.PackageBase"):
     try:
         pkg.tester.print_log_path()
     except Exception as e:
-        # TODO/TLD: Narrow the exceptions
+        # TODO/TBD: Narrow the exceptions
         tty.error("{0} was not tested: {1}".format(package_id(pkg), str(e)))
 
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -69,7 +69,15 @@ from spack.build_systems.xorg import XorgPackage
 from spack.builder import run_after, run_before
 from spack.dependency import all_deptypes
 from spack.directives import *
-from spack.install_test import get_escaped_text_output
+from spack.install_test import (
+    SkipTest,
+    cache_extra_test_sources,
+    check_outputs,
+    find_required_file,
+    get_escaped_text_output,
+    install_test_root,
+    test_part,
+)
 from spack.installer import (
     ExternalPackageError,
     InstallError,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1150,8 +1150,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """Return the configure args file path on successful installation."""
         return os.path.join(self.metadata_dir, _spack_configure_argsfile)
 
-    # TODO: Update tests and all packages that use this as a package method
-    # TODO: to the routine made available in package so can remove this.
+    # TODO (post-34236): Update tests and all packages that use this as a
+    # TODO (post-34236): package method to the routine made available in
+    # TODO (post-34236): package so can remove this.
+    # TODO/TLD (per alalazo): Add warning with instructions on updating and
+    # TODO/TLD (per alalazo): say the property will not be supported anymore
+    # TODO/TLD (per alalazo): in v0.21
     @property
     def install_test_root(self):
         """Return the install test root directory."""
@@ -1840,8 +1844,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         builder = PackageInstaller([(self, kwargs)])
         builder.install()
 
-    # TODO: Update tests and all packages that use this as a package method to
-    # TODO: use the routine from package so can remove this.
+    # TODO (post-34236): Update tests and all packages that use this as a
+    # TODO (post-34236): package method to the routine made available in
+    # TODO (post-34236): package so can remove this.
+    # TODO/TLD (per alalazo): add warning that will be removed and remove on
+    # TODO/TLD (per alalazo): develop when working towards v0.21
     def cache_extra_test_sources(self, srcs):
         """Copy relative source paths to the corresponding install test subdir
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -111,11 +111,6 @@ def deprecated_version(pkg, version):
     return False
 
 
-def package_directory(cls):
-    """Returns the path to the package class directory."""
-    return os.path.abspath(os.path.dirname(cls.module.__file__))
-
-
 def preferred_version(pkg):
     """
     Returns a sorted list of the preferred versions of the package.
@@ -777,7 +772,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     @classproperty
     def package_dir(cls):
         """Directory where the package.py file lives."""
-        return package_directory(cls)
+        return os.path.abspath(os.path.dirname(cls.module.__file__))
 
     @classproperty
     def module(cls):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1856,11 +1856,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 be copied to the corresponding location(s) under the install
                 testing directory.
         """
-        tty.warn(
+        msg = (
             "'pkg.cache_extra_test_sources(srcs) is deprecated with removal "
             "expected in v0.21. Use 'cache_extra_test_sources(pkg, srcs)' "
             "instead."
         )
+        warnings.warn(msg)
         cache_extra_test_sources(self, srcs)
 
     def do_test(self, dirty=False, externals=False):
@@ -1888,10 +1889,15 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     # TODO (post-34236): Remove this deprecated method when eliminate test,
     # TODO (post-34236): run_test, etc.
+    def _test_deprecated_warning(self):
+        alt = f"Use any name starting with 'test_' instead in {self.spec.name}."
+        return f"The 'test' method is deprecated. {alt}"
+
+    # TODO (post-34236): Remove this deprecated method when eliminate test,
+    # TODO (post-34236): run_test, etc.
     def test(self):
         # Defer tests to virtual and concrete packages
-        msg = f"starting with 'test_' instead in {self.spec.name}."
-        tty.warn(f"The 'test' method is deprecated. Use any name {msg}")
+        warnings.warn(self._test_deprecated_warning)
 
     # TODO (post-34236): Remove this deprecated method when eliminate test,
     # TODO (post-34236): run_test, etc.
@@ -1942,8 +1948,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             return f"test: {test_name}: {purpose}"
 
         base_exe = os.path.basename(exe)
-        msg = f"instead for {self.spec.name} to process {base_exe}."
-        tty.warn(f"The 'run_test' method is deprecated. Use 'test_part' {msg}")
+        alternate = f"Use 'test_part' instead for {self.spec.name} to process {base_exe}."
+        warnings.warn(f"The 'run_test' method is deprecated. {alternate}")
 
         details = (
             [options] if isinstance(options, str) else [os.path.basename(opt) for opt in options]

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2004,7 +2004,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         options = [options] if isinstance(options, str) else options
 
         if purpose:
-            tty.msg(purpose)
+            tty.info(purpose, format="g")
         else:
             tty.debug("test: {0}: expect command status in {1}".format(runner.name, status))
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -87,11 +87,11 @@ _spack_build_envfile = "spack-build-env.txt"
 #: Filename for the Spack build/install environment modifications file.
 _spack_build_envmodsfile = "spack-build-env-mods.txt"
 
-#: Filename of json with total build and phase times (seconds)
-_spack_times_log = "install_times.json"
-
 #: Filename for the Spack configure args file.
 _spack_configure_argsfile = "spack-configure-args.txt"
+
+#: Filename of json with total build and phase times (seconds)
+spack_times_log = "install_times.json"
 
 
 def deprecated_version(pkg, version):
@@ -1156,7 +1156,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     @property
     def times_log_path(self):
         """Return the times log json file."""
-        return os.path.join(self.metadata_dir, _spack_times_log)
+        return os.path.join(self.metadata_dir, spack_times_log)
 
     @property
     def install_configure_args_path(self):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1889,6 +1889,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     # TODO (post-34236): Remove this deprecated method when eliminate test,
     # TODO (post-34236): run_test, etc.
+    @property
     def _test_deprecated_warning(self):
         alt = f"Use any name starting with 'test_' instead in {self.spec.name}."
         return f"The 'test' method is deprecated. {alt}"
@@ -1897,8 +1898,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     # TODO (post-34236): run_test, etc.
     def test(self):
         # Defer tests to virtual and concrete packages
-        # Ensure passing warn() a string for python 3.6/rhel8,ubuntu,etc.
-        warnings.warn(str(self._test_deprecated_warning))
+        warnings.warn(self._test_deprecated_warning)
 
     # TODO (post-34236): Remove this deprecated method when eliminate test,
     # TODO (post-34236): run_test, etc.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -188,8 +188,8 @@ class DetectablePackageMeta(object):
     def __init__(cls, name, bases, attr_dict):
         if hasattr(cls, "executables") and hasattr(cls, "libraries"):
             msg = "a package can have either an 'executables' or 'libraries' attribute"
-            msg += " [package '{0.name}' defines both]"
-            raise spack.error.SpackError(msg.format(cls))
+            msg += " [package '{0}' defines both]"
+            raise spack.error.SpackError(msg.format(name))
 
         # On windows, extend the list of regular expressions to look for
         # filenames ending with ".exe"
@@ -2475,16 +2475,6 @@ class PackageError(spack.error.SpackError):
 
     def __init__(self, message, long_msg=None):
         super(PackageError, self).__init__(message, long_msg)
-
-
-class PackageVersionError(PackageError):
-    """Raised when a version URL cannot automatically be determined."""
-
-    def __init__(self, version):
-        super(PackageVersionError, self).__init__(
-            "Cannot determine a URL automatically for version %s" % version,
-            "Please provide a url for this version in the package.py file.",
-        )
 
 
 class NoURLError(PackageError):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1886,12 +1886,14 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.tester.stand_alone_tests(kwargs)
 
-    # Deprecated: Remove this once eliminate test() methods from packages
+    # TODO (post-34236): Remove this deprecated method when eliminate test,
+    # TODO (post-34236): run_test, etc.
     def test(self):
         # Defer tests to virtual and concrete packages
-        pass
+        tty.warn("This method is deprecated. Use any name starting with 'test_' instead.")
 
-    # Deprecated: Begin run_test functionality to be replaced with test_part
+    # TODO (post-34236): Remove this deprecated method when eliminate test,
+    # TODO (post-34236): run_test, etc.
     def run_test(
         self,
         exe,
@@ -1921,7 +1923,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 in the install prefix bin directory or the provided work_dir
             work_dir (str or None): path to the smoke test directory
         """
-        tty.warn("This method is deprecated.  Use 'test_part' instead.")
+        tty.warn("This method is deprecated. Use 'test_part' instead.")
         wdir = "." if work_dir is None else work_dir
         with fsys.working_dir(wdir, create=True):
             try:
@@ -1985,7 +1987,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     self.tester.add_failure(exc, m)
                 return False
 
-    # Deprecated: remove when remove test() methods
+    # TODO (post-34236): Remove this deprecated method when eliminate test,
+    # TODO (post-34236): run_test, etc.
     def _run_test_helper(self, runner, options, expected, status, installed, purpose):
         status = [status] if isinstance(status, int) else status
         expected = [expected] if isinstance(expected, str) else expected

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -183,8 +183,7 @@ class DetectablePackageMeta(object):
     def __init__(cls, name, bases, attr_dict):
         if hasattr(cls, "executables") and hasattr(cls, "libraries"):
             msg = "a package can have either an 'executables' or 'libraries' attribute"
-            msg += " [package '{0}' defines both]"
-            raise spack.error.SpackError(msg.format(name))
+            raise spack.error.SpackError(f"{msg} [package '{name}' defines both]")
 
         # On windows, extend the list of regular expressions to look for
         # filenames ending with ".exe"

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -648,19 +648,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         "tags",
     ]
 
-    #: Boolean. If set to ``True``, the smoke/install test requires a compiler.
-    #: This is currently used by smoke tests to ensure a compiler is available
-    #: to build a custom test code.
-    test_requires_compiler = False
+    #: Set to ``True`` to indicate the stand-alone test requires a compiler.
+    #: It is used to ensure a compiler and build dependencies like 'cmake'
+    #: are available to build a custom test code.
+    test_requires_compiler: bool = False
 
-    #: List of test failures encountered during a smoke/install test run.
-    test_failures = None
-
-    #: TestSuite instance used to manage smoke/install tests for one or more specs.
-    test_suite = None
-
-    #: Path to the log file used for tests
-    test_log_file = None
+    #: TestSuite instance used to manage stand-alone tests for 1+ specs.
+    test_suite: Optional["TestSuite"] = None
 
     def __init__(self, spec):
         # this determines how the package should be built.
@@ -682,7 +676,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # init internal variables
         self._stage = None
         self._fetcher = None
-        self._tester = None
+        self._tester: Optional["PackageTest"] = None
 
         # Set up timing variables
         self._fetch_time = 0.0

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1897,7 +1897,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     # TODO (post-34236): run_test, etc.
     def test(self):
         # Defer tests to virtual and concrete packages
-        warnings.warn(self._test_deprecated_warning)
+        # Ensure passing warn() a string for python 3.6/rhel8,ubuntu,etc.
+        warnings.warn(str(self._test_deprecated_warning))
 
     # TODO (post-34236): Remove this deprecated method when eliminate test,
     # TODO (post-34236): run_test, etc.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1151,14 +1151,15 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return os.path.join(self.metadata_dir, _spack_configure_argsfile)
 
     # TODO (post-34236): Update tests and all packages that use this as a
-    # TODO (post-34236): package method to the routine made available in
-    # TODO (post-34236): package so can remove this.
-    # TODO/TLD (per alalazo): Add warning with instructions on updating and
-    # TODO/TLD (per alalazo): say the property will not be supported anymore
-    # TODO/TLD (per alalazo): in v0.21
+    # TODO (post-34236): package method to the function already available
+    # TODO (post-34236): to packages. Once done, remove this property.
     @property
     def install_test_root(self):
         """Return the install test root directory."""
+        tty.warn(
+            "This method is deprecated with removal expected v0.21. Use "
+            "'install_test_root(pkg)' instead."
+        )
         return install_test_root(self)
 
     def archive_install_test_log(self):
@@ -1845,10 +1846,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         builder.install()
 
     # TODO (post-34236): Update tests and all packages that use this as a
-    # TODO (post-34236): package method to the routine made available in
-    # TODO (post-34236): package so can remove this.
-    # TODO/TLD (per alalazo): add warning that will be removed and remove on
-    # TODO/TLD (per alalazo): develop when working towards v0.21
+    # TODO (post-34236): package method to the routine made available to
+    # TODO (post-34236): packages. Once done, remove this method.
     def cache_extra_test_sources(self, srcs):
         """Copy relative source paths to the corresponding install test subdir
 
@@ -1863,6 +1862,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 be copied to the corresponding location(s) under the install
                 testing directory.
         """
+        tty.warn(
+            "This method is deprecated with removal expected in v0.21. Use "
+            "'cache_extra_test_sources(pkg, srcs)' instead."
+        )
         cache_extra_test_sources(self, srcs)
 
     def do_test(self, dirty=False, externals=False):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2039,6 +2039,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             msg += f"found in {runner.path} instead"
             assert runner.path.startswith(self.spec.prefix), msg
 
+        tty.msg(f"Expecting return code in {status}")
+
         try:
             output = runner(*options, output=str.split, error=str.split)
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1926,6 +1926,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
 
         def test_title(purpose, test_name):
+            if not purpose:
+                return f"test: {test_name}: execute {test_name}"
+
             match = re.search(r"test: ([^:]*): (.*)", purpose)
             if match:
                 # The test title has all the expected parts
@@ -1954,8 +1957,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             try:
                 runner = which(exe)
                 if runner is None and skip_missing:
+                    tty.info(f"Skipping test: {exe} is missing")
                     return
-                assert runner is not None, "Failed to find executable '{0}'".format(exe)
+                assert runner is not None, f"Failed to find executable '{exe}'"
 
                 self._run_test_helper(runner, options, expected, status, installed, purpose)
                 status = TestStatus.PASSED

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -430,19 +430,6 @@ class PackageViewMixin(object):
         view.remove_files(merge_map.values())
 
 
-def test_log_pathname(test_stage, spec):
-    """Build the pathname of the test log file
-
-    Args:
-        test_stage (str): path to the test stage directory
-        spec (spack.spec.Spec): instance of the spec under test
-
-    Returns:
-        (str): the pathname of the test log file
-    """
-    return os.path.join(test_stage, "test-{0}-out.txt".format(TestSuite.test_pkg_id(spec)))
-
-
 Pb = TypeVar("Pb", bound="PackageBase")
 
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1900,12 +1900,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.tester.stand_alone_tests(kwargs)
 
-    # TLD: Remove this once eliminate test() methods from packages
+    # Deprecated: Remove this once eliminate test() methods from packages
     def test(self):
         # Defer tests to virtual and concrete packages
         pass
 
-    # TODO/TLD: Begin run_test functionality to be replaced with test_part
+    # Deprecated: Begin run_test functionality to be replaced with test_part
     def run_test(
         self,
         exe,
@@ -1935,6 +1935,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 in the install prefix bin directory or the provided work_dir
             work_dir (str or None): path to the smoke test directory
         """
+        tty.warn("This method is deprecated.  Use 'test_part' instead.")
         wdir = "." if work_dir is None else work_dir
         with fsys.working_dir(wdir, create=True):
             try:
@@ -1998,6 +1999,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     self.tester.add_failure(exc, m)
                 return False
 
+    # Deprecated: remove when remove test() methods
     def _run_test_helper(self, runner, options, expected, status, installed, purpose):
         status = [status] if isinstance(status, int) else status
         expected = [expected] if isinstance(expected, str) else expected
@@ -2028,8 +2030,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             msg = "Expected '{0}' to match output of `{1}`".format(check, cmd)
             msg += "\n\nOutput: {0}".format(output)
             assert re.search(check, output), msg
-
-    # TODO/TLD: End run_test functionality to replace
 
     def unit_test_check(self):
         """Hook for unit tests to assert things about package internals.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1067,7 +1067,6 @@ class Repo(object):
         fs.mkdirp(path)
         try:
             for patch in itertools.chain.from_iterable(spec.package.patches.values()):
-
                 if patch.path:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1063,20 +1063,15 @@ class Repo(object):
                 "Repository %s does not contain package %s." % (self.namespace, spec.fullname)
             )
 
-        # Install patch files needed by the package.
+        # Install patch files needed by the (concrete) package.
         fs.mkdirp(path)
-        try:
+        if spec.concrete:
             for patch in itertools.chain.from_iterable(spec.package.patches.values()):
                 if patch.path:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)
                     else:
                         tty.warn("Patch file did not exist: %s" % patch.path)
-        except AssertionError as e:
-            # virtual specs won't have patches to install
-            tty.debug(
-                "Could not copy patch files for virtual package {0}: {1}".format(spec.name, str(e))
-            )
 
         # Install the package.py file itself.
         try:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1063,6 +1063,12 @@ class Repo(object):
                 "Repository %s does not contain package %s." % (self.namespace, spec.fullname)
             )
 
+        package_path = self.filename_for_package_name(spec.name)
+        if not os.path.exists(package_path):
+            # Spec has no files (e.g., package, patches) to copy
+            tty.debug(f"{spec.name} does not have a package to dump")
+            return
+
         # Install patch files needed by the (concrete) package.
         fs.mkdirp(path)
         if spec.concrete:
@@ -1074,11 +1080,7 @@ class Repo(object):
                         tty.warn("Patch file did not exist: %s" % patch.path)
 
         # Install the package.py file itself.
-        try:
-            fs.install(self.filename_for_package_name(spec.name), path)
-        except IOError as e:
-            # package-less virtuals won't have a package.py to copy
-            tty.debug("Could not copy package.py for {0}: {1}".format(spec.name, str(e)))
+        fs.install(self.filename_for_package_name(spec.name), path)
 
     def purge(self):
         """Clear entire package instance cache."""

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -133,8 +133,9 @@ class InfoCollector:
                     # Everything else is an error (the installation
                     # failed outside of the child process)
                     package["result"] = "error"
-                    package["stdout"] = self.fetch_log(pkg)
                     package["message"] = str(exc) or "Unknown error"
+                    package["stdout"] = self.fetch_log(pkg)
+                    package["stdout"] += package["message"]
                     package["exception"] = traceback.format_exc()
                     raise
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -331,6 +331,10 @@ class CDash(Reporter):
         self.finalize_report()
 
     def test_skipped_report(self, directory_name, spec, reason=None):
+        """Explicitly report spec as being skipped (e.g., CI).
+
+        Examples the installation failed or the package is known to have
+        broken tests."""
         output = "Skipped {0} package".format(spec.name)
         if reason:
             output += "\n{0}".format(reason)

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -12,7 +12,7 @@ import re
 import socket
 import time
 import xml.sax.saxutils
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import urlencode
 from urllib.request import HTTPHandler, Request, build_opener
 
@@ -113,14 +113,14 @@ class CDash(Reporter):
             else self.base_buildname
         )
 
-    def build_report_for_package(self, directory_name, package, duration):
+    def build_report_for_package(self, report_dir, package, duration):
         if "stdout" not in package:
-            # Skip reporting on packages that did not generate any output.
+            # Skip reporting on packages that do not generate output.
             return
 
         self.current_package_name = package["name"]
         self.buildname = self.report_build_name(self.current_package_name)
-        report_data = self.initialize_report(directory_name)
+        report_data = self.initialize_report(report_dir)
         for phase in CDASH_PHASES:
             report_data[phase] = {}
             report_data[phase]["loglines"] = []
@@ -215,7 +215,7 @@ class CDash(Reporter):
                 report_file_name = package["name"] + "_" + report_name
             else:
                 report_file_name = report_name
-            phase_report = os.path.join(directory_name, report_file_name)
+            phase_report = os.path.join(report_dir, report_file_name)
 
             with codecs.open(phase_report, "w", "utf-8") as f:
                 env = spack.tengine.make_environment()
@@ -231,7 +231,7 @@ class CDash(Reporter):
                 f.write(t.render(report_data))
             self.upload(phase_report)
 
-    def build_report(self, directory_name, specs):
+    def build_report(self, report_dir, specs):
         # Do an initial scan to determine if we are generating reports for more
         # than one package. When we're only reporting on a single package we
         # do not explicitly include the package's name in the CDash build name.
@@ -260,7 +260,7 @@ class CDash(Reporter):
             if "time" in spec:
                 duration = int(spec["time"])
             for package in spec["packages"]:
-                self.build_report_for_package(directory_name, package, duration)
+                self.build_report_for_package(report_dir, package, duration)
         self.finalize_report()
 
     def extract_standalone_test_data(self, package, phases, report_data):
@@ -273,13 +273,13 @@ class CDash(Reporter):
         testing["generator"] = self.generator
         testing["parts"] = extract_test_parts(package["name"], package["stdout"].splitlines())
 
-    def report_test_data(self, directory_name, package, phases, report_data):
+    def report_test_data(self, report_dir, package, phases, report_data):
         """Generate and upload the test report(s) for the package."""
         for phase in phases:
             # Write the report.
             report_name = phase.capitalize() + ".xml"
             report_file_name = package["name"] + "_" + report_name
-            phase_report = os.path.join(directory_name, report_file_name)
+            phase_report = os.path.join(report_dir, report_file_name)
 
             with codecs.open(phase_report, "w", "utf-8") as f:
                 env = spack.tengine.make_environment()
@@ -297,7 +297,7 @@ class CDash(Reporter):
             tty.debug("Preparing to upload {0}".format(phase_report))
             self.upload(phase_report)
 
-    def test_report_for_package(self, directory_name, package, duration):
+    def test_report_for_package(self, report_dir, package, duration):
         if "stdout" not in package:
             # Skip reporting on packages that did not generate any output.
             tty.debug("Skipping report for {0}: No generated output".format(package["name"]))
@@ -311,14 +311,14 @@ class CDash(Reporter):
             self.buildname = self.report_build_name(self.current_package_name)
         self.starttime = self.endtime - duration
 
-        report_data = self.initialize_report(directory_name)
+        report_data = self.initialize_report(report_dir)
         report_data["hostname"] = socket.gethostname()
         phases = ["testing"]
         self.extract_standalone_test_data(package, phases, report_data)
 
-        self.report_test_data(directory_name, package, phases, report_data)
+        self.report_test_data(report_dir, package, phases, report_data)
 
-    def test_report(self, directory_name, specs):
+    def test_report(self, report_dir, specs):
         """Generate reports for each package in each spec."""
         tty.debug("Processing test report")
         for spec in specs:
@@ -326,25 +326,33 @@ class CDash(Reporter):
             if "time" in spec:
                 duration = int(spec["time"])
             for package in spec["packages"]:
-                self.test_report_for_package(directory_name, package, duration)
+                self.test_report_for_package(report_dir, package, duration)
 
         self.finalize_report()
 
-    def test_skipped_report(self, directory_name, spec, reason=None):
+    def test_skipped_report(
+        self, report_dir: str, spec: spack.spec.Spec, reason: Optional[str] = None
+    ):
         """Explicitly report spec as being skipped (e.g., CI).
 
-        Examples the installation failed or the package is known to have
-        broken tests."""
+        Examples are the installation failed or the package is known to have
+        broken tests.
+
+        Args:
+            report_dir: directory where the report is to be written
+            spec: spec being tested
+            reason: optional reason the test is being skipped
+        """
         output = "Skipped {0} package".format(spec.name)
         if reason:
             output += "\n{0}".format(reason)
 
         package = {"name": spec.name, "id": spec.dag_hash(), "result": "skipped", "stdout": output}
-        self.test_report_for_package(directory_name, package, duration=0.0)
+        self.test_report_for_package(report_dir, package, duration=0.0)
 
-    def concretization_report(self, directory_name, msg):
+    def concretization_report(self, report_dir, msg):
         self.buildname = self.base_buildname
-        report_data = self.initialize_report(directory_name)
+        report_data = self.initialize_report(report_dir)
         report_data["update"] = {}
         report_data["update"]["starttime"] = self.endtime
         report_data["update"]["endtime"] = self.endtime
@@ -354,7 +362,7 @@ class CDash(Reporter):
         env = spack.tengine.make_environment()
         update_template = posixpath.join(self.template_dir, "Update.xml")
         t = env.get_template(update_template)
-        output_filename = os.path.join(directory_name, "Update.xml")
+        output_filename = os.path.join(report_dir, "Update.xml")
         with open(output_filename, "w") as f:
             f.write(t.render(report_data))
         # We don't have a current package when reporting on concretization
@@ -364,9 +372,9 @@ class CDash(Reporter):
         self.success = False
         self.finalize_report()
 
-    def initialize_report(self, directory_name):
-        if not os.path.exists(directory_name):
-            os.mkdir(directory_name)
+    def initialize_report(self, report_dir):
+        if not os.path.exists(report_dir):
+            os.mkdir(report_dir)
         report_data = {}
         report_data["buildname"] = self.buildname
         report_data["buildstamp"] = self.buildstamp

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -278,7 +278,7 @@ class CDash(Reporter):
         for phase in phases:
             # Write the report.
             report_name = phase.capitalize() + ".xml"
-            report_file_name = package["name"] + "_" + report_name
+            report_file_name = "_".join([package["name"], package["id"], report_name])
             phase_report = os.path.join(report_dir, report_file_name)
 
             with codecs.open(phase_report, "w", "utf-8") as f:

--- a/lib/spack/spack/reporters/extract.py
+++ b/lib/spack/spack/reporters/extract.py
@@ -159,6 +159,7 @@ def extract_test_parts(default_name, outputs):
                 if msg.startswith("Expecting return code"):
                     if part:
                         part["desc"] += f"; {msg}"
+                    continue
 
                 # Terminate without further parsing if no more test messages
                 if "Completed testing" in msg:

--- a/lib/spack/spack/reporters/extract.py
+++ b/lib/spack/spack/reporters/extract.py
@@ -42,8 +42,8 @@ def elapsed(current, previous):
     return diff.total_seconds()
 
 
-# TODO: Should remove with deprecated run_test(), etc. since don't have an XFAIL
-# TODO: mechanism with the new test_part() approach.
+# TODO (post-34236): Should remove with deprecated test methods since don't
+# TODO (post-34236): have an XFAIL mechanism with the new test_part() approach.
 def expected_failure(line):
     if not line:
         return False
@@ -66,7 +66,7 @@ def new_part():
     }
 
 
-# TODO: Remove this when remove deprecated test_part(), etc.
+# TODO (post-34236): Remove this when remove deprecated methods
 def part_name(source):
     elements = []
     for e in source.replace("'", "").split(" "):
@@ -81,8 +81,8 @@ def process_part_end(part, curr_time, last_time):
 
         stat = part["status"]
         if stat in completed:
-            # TODO: remove the expected failure mapping along with removal of
-            # TODO: deprecated run_test(), etc.
+            # TODO (post-34236): remove the expected failure mapping when
+            # TODO (post-34236): remove deprecated test methods
             if stat == "passed" and expected_failure(part["desc"]):
                 part["completed"] = "Expected to fail"
             elif part["completed"] == "Unknown":
@@ -116,7 +116,7 @@ def extract_test_parts(default_name, outputs):
     last_time = None
     curr_time = None
 
-    # TODO: Remove these once remove deprecated run_test() processing
+    # TODO (post-34236): Remove once remove deprecated test processing
     testdesc = ""
     using_deprecated_tests = True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1632,7 +1632,9 @@ class Spec(object):
 
     @property
     def package(self):
-        assert self.concrete, "Spec.package can only be called on concrete specs"
+        assert self.concrete, "{0}: Spec.package can only be called on concrete specs".format(
+            self.name
+        )
         if not self._package:
             self._package = spack.repo.path.get(self)
         return self._package

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1644,6 +1644,8 @@ class Spec(object):
         """Internal package call gets only the class object for a package.
         Use this to just get package metadata.
         """
+        if self.concrete:
+            return self._package.__class__
         return spack.repo.path.get_pkg_class(self.fullname)
 
     @property

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1644,8 +1644,6 @@ class Spec(object):
         """Internal package call gets only the class object for a package.
         Use this to just get package metadata.
         """
-        if self.concrete:
-            return self._package.__class__
         return spack.repo.path.get_pkg_class(self.fullname)
 
     @property

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -21,7 +21,7 @@ import spack.config
         (["wrong-variant-in-depends-on"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
         # This package has a GitHub patch URL without full_index=1
         (["invalid-github-patch-url"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
-        # This package has a stand-alone 'test' method in build-time callbacks
+        # This package has a stand-alone 'test*' method in build-time callbacks
         (["fail-test-audit"], ["PKG-DIRECTIVES", "PKG-PROPERTIES"]),
         # This package has no issues
         (["mpileaks"], None),

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -127,6 +127,7 @@ def test_build_time_tests_are_executed_from_default_builder():
 @pytest.mark.regression("34518")
 @pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
 def test_monkey_patching_wrapped_pkg():
+    """Confirm 'run_tests' is accessible through wrappers."""
     s = spack.spec.Spec("old-style-autotools").concretized()
     builder = spack.builder.create(s.package)
     assert s.package.run_tests is False
@@ -141,6 +142,7 @@ def test_monkey_patching_wrapped_pkg():
 @pytest.mark.regression("34440")
 @pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
 def test_monkey_patching_test_log_file():
+    """Confirm 'test_log_file' is accessible through wrappers."""
     s = spack.spec.Spec("old-style-autotools").concretized()
     builder = spack.builder.create(s.package)
 
@@ -150,6 +152,7 @@ def test_monkey_patching_test_log_file():
 
 
 def test_install_time_test_callback(tmpdir, config, mock_packages, mock_stage):
+    """Confirm able to run stand-alone test as a post-install callback."""
     s = spack.spec.Spec("py-test-callback").concretized()
     builder = spack.builder.create(s.package)
     builder.pkg.run_tests = True

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -141,10 +141,7 @@ def test_monkey_patching_wrapped_pkg():
 def test_monkey_patching_test_log_file():
     s = spack.spec.Spec("old-style-autotools").concretized()
     builder = spack.builder.create(s.package)
-    assert s.package.test_log_file is None
-    assert builder.pkg.test_log_file is None
-    assert builder.pkg_with_dispatcher.test_log_file is None
 
-    s.package.test_log_file = "/some/file"
-    assert builder.pkg.test_log_file == "/some/file"
-    assert builder.pkg_with_dispatcher.test_log_file == "/some/file"
+    s.package.tester.test_log_file = "/some/file"
+    assert builder.pkg.tester.test_log_file == "/some/file"
+    assert builder.pkg_with_dispatcher.tester.test_log_file == "/some/file"

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -151,6 +151,9 @@ def test_monkey_patching_test_log_file():
     assert builder.pkg_with_dispatcher.tester.test_log_file == "/some/file"
 
 
+# Windows context manager's __exit__ fails with ValueError ("I/O operation
+# on closed file").
+@pytest.mark.skipif(sys.platform == "win32", reason="Does not run on windows")
 def test_install_time_test_callback(tmpdir, config, mock_packages, mock_stage):
     """Confirm able to run stand-alone test as a post-install callback."""
     s = spack.spec.Spec("py-test-callback").concretized()

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -594,9 +594,10 @@ def test_ci_skipped_report(tmpdir, mock_packages, config):
     reason = "Testing skip"
     handler.report_skipped(spec, tmpdir.strpath, reason=reason)
 
-    report = fs.join_path(tmpdir, "{0}_Testing.xml".format(pkg))
-    expected = "Skipped {0} package".format(pkg)
-    with open(report, "r") as f:
+    reports = [name for name in tmpdir.listdir() if str(name).endswith("Testing.xml")]
+    assert len(reports) == 1
+    expected = f"Skipped {pkg} package"
+    with open(reports[0], "r") as f:
         have = [0, 0]
         for line in f:
             if expected in line:

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -566,8 +566,7 @@ def test_ci_run_standalone_tests_not_installed_cdash(
     ci.run_standalone_tests(**args)
     out = capfd.readouterr()[0]
     # CDash *and* log file output means log file ignored
-    assert "xml option is ignored" in out
-    assert "0 passed of 0" in out
+    assert "xml option is ignored with CDash" in out
 
     # copy test results (though none)
     artifacts_dir = tmp_path / "artifacts"

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -713,9 +713,7 @@ spack:
         with e:
             e.concretize()
 
-    err = str(exc)
-    print(err)
-    assert "2 missing include path" in err
+    assert "2 missing include path" in str(exc)
     assert ev.active_environment() is None
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -709,11 +709,10 @@ spack:
   - no/such/file.yaml
 """
     )
-    with pytest.raises(spack.config.ConfigFileError) as exc:
+    with pytest.raises(spack.config.ConfigFileError, match="2 missing include path"):
         with e:
             e.concretize()
 
-    assert "2 missing include path" in str(exc)
     assert ev.active_environment() is None
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -701,6 +701,7 @@ spack:
 
 
 def test_with_config_bad_include(environment_from_manifest):
+    """Confirm missing include paths raise expected exception and error."""
     e = environment_from_manifest(
         """
 spack:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -714,9 +714,8 @@ spack:
             e.concretize()
 
     err = str(exc)
-    assert "missing include" in err
-    assert "/no/such/directory" in err
-    assert os.path.join("no", "such", "file.yaml") in err
+    print(err)
+    assert "2 missing include path" in err
     assert ev.active_environment() is None
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1076,7 +1076,7 @@ def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
 
     assert output.count(method) == 2
     assert output.count("method not implemented") == 1
-    assert output.count("TestFailure: 1 tests failed") == 1
+    assert output.count("TestFailure: 1 test failed") == 1
 
 
 def test_install_use_buildcache(

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1072,11 +1072,18 @@ def test_install_empty_env(
     ],
 )
 def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
+    """Confirm build-time tests with unknown methods fail."""
     output = install("--test=root", "--no-cache", name, fail_on_error=False)
 
+    # Check that there is a single test failure reported
+    assert output.count("TestFailure: 1 test failed") == 1
+
+    # Check that the method appears twice: no attribute error and in message
     assert output.count(method) == 2
     assert output.count("method not implemented") == 1
-    assert output.count("TestFailure: 1 test failed") == 1
+
+    # Check that the path to the test log file is also output
+    assert "See test log for details" in output
 
 
 def test_install_use_buildcache(
@@ -1175,9 +1182,3 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     specs = spack.cmd.install.concrete_specs_from_cli(args, {})
     filename = spack.cmd.install.report_filename(args, specs)
     assert filename != "https://blahblah/submit.php?project=debugging"
-
-
-@pytest.mark.disable_clean_stage_check
-def test_install_runtests_root_log(install_mockery_mutable_config, mock_fetch):
-    output = install("--test=root", "--no-cache", "test-install-callbacks", fail_on_error=False)
-    assert "See test log for details" in output

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1175,3 +1175,9 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     specs = spack.cmd.install.concrete_specs_from_cli(args, {})
     filename = spack.cmd.install.report_filename(args, specs)
     assert filename != "https://blahblah/submit.php?project=debugging"
+
+
+@pytest.mark.disable_clean_stage_check
+def test_install_runtests_root_log(install_mockery_mutable_config, mock_fetch):
+    output = install("--test=root", "--no-cache", "test-install-callbacks", fail_on_error=False)
+    assert "See test log for details" in output

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -41,7 +41,7 @@ def _module_files(module_type, *specs):
         ["rm", "doesnotexist"],  # Try to remove a non existing module
         ["find", "mpileaks"],  # Try to find a module with multiple matches
         ["find", "doesnotexist"],  # Try to find a module with no matches
-        ["find", "--unkown_args"],  # Try to give an unknown argument
+        ["find", "--unknown_args"],  # Try to give an unknown argument
     ]
 )
 def failure_args(request):

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -85,6 +85,10 @@ def mock_pkg_git_repo(git, tmpdir_factory):
 @pytest.fixture(scope="module")
 def mock_pkg_names():
     repo = spack.repo.path.get_repo("builtin.mock")
+
+    # Be sure to include virtual packages since packages with stand-alone
+    # tests may inherit additional tests from the virtuals they provide,
+    # such as packages that implement `mpi`.
     names = set(
         name
         for name in repo.all_package_names(include_virtuals=True)

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -85,7 +85,11 @@ def mock_pkg_git_repo(git, tmpdir_factory):
 @pytest.fixture(scope="module")
 def mock_pkg_names():
     repo = spack.repo.path.get_repo("builtin.mock")
-    names = set(name for name in repo.all_package_names() if not name.startswith("pkg-"))
+    names = set(
+        name
+        for name in repo.all_package_names(include_virtuals=True)
+        if not name.startswith("pkg-")
+    )
     return names
 
 

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -239,6 +239,7 @@ def test_test_list_all(mock_packages):
     assert set(pkgs) == set(
         [
             "fail-test-audit",
+            "mpich",
             "printing-package",
             "py-extension1",
             "py-extension2",

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -180,11 +180,9 @@ def test_cdash_output_test_error(
             fail_on_error=False,
         )
         report_dir = tmpdir.join("cdash_reports")
-        print(tmpdir.listdir())
-        assert report_dir in tmpdir.listdir()
-        report_file = report_dir.join("test-error_Testing.xml")
-        assert report_file in report_dir.listdir()
-        content = report_file.open().read()
+        reports = [name for name in report_dir.listdir() if str(name).endswith("Testing.xml")]
+        assert len(reports) == 1
+        content = reports[0].open().read()
         assert "Command exited with status 1" in content
 
 
@@ -200,10 +198,9 @@ def test_cdash_upload_clean_test(
     with tmpdir.as_cwd():
         spack_test("run", "--log-file=cdash_reports", "--log-format=cdash", "printing-package")
         report_dir = tmpdir.join("cdash_reports")
-        assert report_dir in tmpdir.listdir()
-        report_file = report_dir.join("printing-package_Testing.xml")
-        assert report_file in report_dir.listdir()
-        content = report_file.open().read()
+        reports = [name for name in report_dir.listdir() if str(name).endswith("Testing.xml")]
+        assert len(reports) == 1
+        content = reports[0].open().read()
         assert "passed" in content
         assert "Running test_print" in content, "Expected first command output"
         assert "second command" in content, "Expected second command output"

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -238,13 +238,14 @@ def test_test_list_all(mock_packages):
     pkgs = spack_test("list", "--all").strip().split()
     assert set(pkgs) == set(
         [
+            "fail-test-audit",
             "printing-package",
             "py-extension1",
             "py-extension2",
+            "py-test-callback",
             "simple-standalone-test",
             "test-error",
             "test-fail",
-            "fail-test-audit",
         ]
     )
 

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -109,7 +109,7 @@ def test_test_output_on_failure(
 ):
     install("test-fail")
     out = spack_test("run", "test-fail", fail_on_error=False)
-    lines = [ln for ln in out.split("\n") if ln]
+    lines = [ln for ln in out.splitlines() if ln]
     lines = lines[2:]
     assert "TestFailure" in out
     assert "not callable" in out

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -103,10 +103,6 @@ def test_test_output_on_error(
     with capfd.disabled():
         out = spack_test("run", "test-error", fail_on_error=False)
 
-    # Aid debugging
-    for ln in out.split("\n"):
-        print(ln)
-
     assert "TestFailure" in out
     assert "Command exited with status 1" in out
 
@@ -122,10 +118,6 @@ def test_test_output_on_failure(
             err_msg = str(e)
             assert "noop" in err_msg
             assert "not defined" in err_msg
-
-    # Aid debugging
-    for ln in out.split("\n"):
-        print(ln)
 
     assert "TestFailure" in out
     assert "Command exited with status 1" in out

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -96,31 +96,23 @@ def test_test_output(
 
 
 def test_test_output_on_error(
-    mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config, capfd, mock_test_stage
+    mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config, mock_test_stage
 ):
     install("test-error")
-    # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        out = spack_test("run", "test-error", fail_on_error=False)
-
+    out = spack_test("run", "test-error", fail_on_error=False)
     assert "TestFailure" in out
     assert "Command exited with status 1" in out
 
 
 def test_test_output_on_failure(
-    mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config, capfd, mock_test_stage
+    mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config, mock_test_stage
 ):
     install("test-fail")
-    with capfd.disabled():
-        try:
-            out = spack_test("run", "test-fail", fail_on_error=False)
-        except NameError as e:
-            err_msg = str(e)
-            assert "noop" in err_msg
-            assert "not defined" in err_msg
-
+    out = spack_test("run", "test-fail", fail_on_error=False)
+    lines = [ln for ln in out.split("\n") if ln]
+    lines = lines[2:]
     assert "TestFailure" in out
-    assert "Command exited with status 1" in out
+    assert "not callable" in out
 
 
 def test_show_log_on_error(
@@ -142,7 +134,7 @@ def test_show_log_on_error(
     "pkg_name,msgs",
     [
         ("test-error", ["exited with status 1", "TestFailure"]),
-        ("test-fail", ["not defined", "TestFailure"]),
+        ("test-fail", ["not callable", "TestFailure"]),
     ],
 )
 def test_junit_output_with_failures(tmpdir, mock_test_stage, pkg_name, msgs):

--- a/lib/spack/spack/test/data/test/test_stage/gavrxt67t7yaiwfek7dds7lgokmoaiin/printing-package-1.0-hzgcoow-test-out.txt
+++ b/lib/spack/spack/test/data/test/test_stage/gavrxt67t7yaiwfek7dds7lgokmoaiin/printing-package-1.0-hzgcoow-test-out.txt
@@ -1,6 +1,7 @@
 ==> Testing package printing-package-1.0-hzgcoow
-BEFORE TEST
-==> [2022-02-28-20:21:46.510616] test: true: expect command status in [0]
-==> [2022-02-28-20:21:46.510937] '/bin/true'
-PASSED
-AFTER TEST
+==> [2022-12-06-20:21:46.550943] test: test_print: Test python print example.
+==> [2022-12-06-20:21:46.553219] '/usr/tce/bin/python' '-c' 'print("Running test_print")'
+Running test_print
+==> [2022-12-06-20:21:46.721077] '/usr/tce/bin/python' '-c' 'print("Running test_print")'
+PASSED: test_print
+==> [2022-12-06-20:21:46.822608] Completed testing

--- a/lib/spack/spack/test/data/unparse/legion.txt
+++ b/lib/spack/spack/test/data/unparse/legion.txt
@@ -34,7 +34,7 @@ class Legion(CMakePackage):
     homepage = "https://legion.stanford.edu/"
     git = "https://github.com/StanfordLegion/legion.git"
 
-    maintainers = ['pmccormick', 'streichler']
+    maintainers('pmccormick', 'streichler')
     tags = ['e4s']
     version('21.03.0', tag='legion-21.03.0')
     version('stable', branch='stable')
@@ -355,7 +355,7 @@ class Legion(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([join_path('examples', 'local_function_tasks')])
+        cache_extra_test_sources(self, [join_path('examples', 'local_function_tasks')])
 
     def run_local_function_tasks_test(self):
         """Run stand alone test: local_function_tasks"""

--- a/lib/spack/spack/test/data/unparse/mfem.txt
+++ b/lib/spack/spack/test/data/unparse/mfem.txt
@@ -27,8 +27,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     homepage = 'http://www.mfem.org'
     git      = 'https://github.com/mfem/mfem.git'
 
-    maintainers = ['v-dobrev', 'tzanio', 'acfisher',
-                   'goxberry', 'markcmiller86']
+    maintainers('v-dobrev', 'tzanio', 'acfisher', 'goxberry', 'markcmiller86')
 
     test_requires_compiler = True
 
@@ -815,8 +814,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([self.examples_src_dir,
-                                       self.examples_data_dir])
+        cache_extra_test_sources(self, [self.examples_src_dir, self.examples_data_dir])
 
     def test(self):
         test_dir = join_path(

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -252,7 +252,7 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
 
     # The order should be maintained
     phases = [x["name"] for x in times["phases"]]
-    assert phases == ["stage", "one", "two", "three", "install"]
+    assert phases == ["stage", "one", "two", "three", "install", "post-install"]
     assert all(isinstance(x["seconds"], float) for x in times["phases"])
 
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -23,6 +23,7 @@ from spack.package_base import (
     _spack_build_envfile,
     _spack_build_logfile,
     _spack_configure_argsfile,
+    spack_times_log,
 )
 from spack.spec import Spec
 
@@ -243,7 +244,7 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
     spec.package.do_install()
 
     # Ensure dependency directory exists after the installation.
-    install_times = os.path.join(spec.package.prefix, ".spack", "install_times.json")
+    install_times = os.path.join(spec.package.prefix, ".spack", spack_times_log)
     assert os.path.isfile(install_times)
 
     # Ensure the phases are included

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1386,27 +1386,30 @@ def test_single_external_implicit_install(install_mockery, explicit_args, is_exp
     assert spack.store.db.get_record(pkg).explicit == is_explicit
 
 
-def test_print_install_test_log(tmpdir, install_mockery, mock_packages, ensure_debug, capfd):
+@pytest.mark.parametrize("run_tests", [True, False])
+def test_print_install_test_log_skipped(install_mockery, mock_packages, capfd, run_tests):
+    """Confirm printing of install log skipped if not run/no failures."""
     name = "trivial-install-test-package"
     s = spack.spec.Spec(name).concretized()
     pkg = s.package
 
+    pkg.run_tests = run_tests
     spack.installer.print_install_test_log(pkg)
     out = capfd.readouterr()[0]
     assert out == ""
+
+
+def test_print_install_test_log_missing(
+    tmpdir, install_mockery, mock_packages, ensure_debug, capfd
+):
+    """Confirm expected error on attempt to print missing test log file."""
+    name = "trivial-install-test-package"
+    s = spack.spec.Spec(name).concretized()
+    pkg = s.package
 
     pkg.run_tests = True
-    spack.installer.print_install_test_log(pkg)
-    out = capfd.readouterr()[0]
-    assert out == ""
-
     pkg.tester.test_log_file = str(tmpdir.join("test-log.txt"))
     pkg.tester.add_failure(AssertionError("test"), "test-failure")
     spack.installer.print_install_test_log(pkg)
     err = capfd.readouterr()[1]
     assert "no test log file" in err
-
-    fs.touch(pkg.tester.test_log_file)
-    spack.installer.print_install_test_log(pkg)
-    out, err = capfd.readouterr()
-    assert pkg.tester.test_log_file in out

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -27,6 +27,9 @@ import spack.store
 import spack.util.lock as lk
 import spack.version
 
+# TODO/TLD: from spack.install_test import PackageTest, TestSuite, spack_install_test_log
+# TODO/TLD: from spack.util.prefix import Prefix
+
 
 def _mock_repo(root, namespace):
     """Create an empty repository at the specified root
@@ -1384,3 +1387,49 @@ def test_single_external_implicit_install(install_mockery, explicit_args, is_exp
     s.external_path = "/usr"
     create_installer([(s, explicit_args)]).install()
     assert spack.store.db.get_record(pkg).explicit == is_explicit
+
+
+# # TODO/TLD: Need to determine if this chicken-and-egg issue is worthwhile anymore.
+# @pytest.mark.parametrize(
+#     "installed,staged,fails",
+#     [
+#         (False, False, True),  # no output file available
+#         (False, True, True),  # staged log file, print path
+#         (False, True, False),  # staged log file, don't print path
+#         (True, False, True),  # install log file, print path
+#     ],
+# )
+# def test_print_install_test_log(
+#     tmpdir, mock_packages, install_mockery, capsys, monkeypatch, installed, staged, fails
+# ):
+#     pkg = "py-test-callback"
+#     spec = spack.spec.Spec(pkg).concretized()
+#     spec.package._stage = Prefix(str(tmpdir))
+#
+#     def create_log(package):
+#         if installed:
+#             log = package.tester.archived_install_test_log
+#         elif staged:
+#             package.test_suite = TestSuite([spec])
+#             package.test_suite._stage = tmpdir
+#             log = package.tester.test_log_file
+#         else:
+#             return
+#
+#     expected = []
+#     if installed or staged:
+#         create_log(spec.package)
+#         if fails:
+#             expected.append("See test results")
+#     else:
+#         monkeypatch.setattr(tty, "_debug", 1)
+#         expected.append("There is no test log file")
+#
+#     spec.package.run_tests = True
+#     if fails:
+#         spec.package.test_failures = [(AssertionError("Fake failure"), "Fake test failure")]
+#     inst.print_install_test_log(spec.package)
+#     captured = str(capsys.readouterr())
+#
+#     for e in expected:
+#         assert e in captured, "Expected '{0}' to be printed".format(e)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -27,9 +27,6 @@ import spack.store
 import spack.util.lock as lk
 import spack.version
 
-# TODO/TLD: from spack.install_test import PackageTest, TestSuite, spack_install_test_log
-# TODO/TLD: from spack.util.prefix import Prefix
-
 
 def _mock_repo(root, namespace):
     """Create an empty repository at the specified root
@@ -1387,49 +1384,3 @@ def test_single_external_implicit_install(install_mockery, explicit_args, is_exp
     s.external_path = "/usr"
     create_installer([(s, explicit_args)]).install()
     assert spack.store.db.get_record(pkg).explicit == is_explicit
-
-
-# # TODO/TLD: Need to determine if this chicken-and-egg issue is worthwhile anymore.
-# @pytest.mark.parametrize(
-#     "installed,staged,fails",
-#     [
-#         (False, False, True),  # no output file available
-#         (False, True, True),  # staged log file, print path
-#         (False, True, False),  # staged log file, don't print path
-#         (True, False, True),  # install log file, print path
-#     ],
-# )
-# def test_print_install_test_log(
-#     tmpdir, mock_packages, install_mockery, capsys, monkeypatch, installed, staged, fails
-# ):
-#     pkg = "py-test-callback"
-#     spec = spack.spec.Spec(pkg).concretized()
-#     spec.package._stage = Prefix(str(tmpdir))
-#
-#     def create_log(package):
-#         if installed:
-#             log = package.tester.archived_install_test_log
-#         elif staged:
-#             package.test_suite = TestSuite([spec])
-#             package.test_suite._stage = tmpdir
-#             log = package.tester.test_log_file
-#         else:
-#             return
-#
-#     expected = []
-#     if installed or staged:
-#         create_log(spec.package)
-#         if fails:
-#             expected.append("See test results")
-#     else:
-#         monkeypatch.setattr(tty, "_debug", 1)
-#         expected.append("There is no test log file")
-#
-#     spec.package.run_tests = True
-#     if fails:
-#         spec.package.test_failures = [(AssertionError("Fake failure"), "Fake test failure")]
-#     inst.print_install_test_log(spec.package)
-#     captured = str(capsys.readouterr())
-#
-#     for e in expected:
-#         assert e in captured, "Expected '{0}' to be printed".format(e)

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -333,7 +333,7 @@ def test_package_run_test(install_mockery_mutable_config, mock_fetch, capfd):
     result = pkg.run_test("no-possible-program", skip_missing=True)
     output = capfd.readouterr()[0]
     assert result is None
-    assert not output
+    assert "missing" in output
 
     # Reset the tester instance before proceeding
     pkg._tester = spack.install_test.PackageTest(pkg)

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -269,3 +269,47 @@ def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
     error = capfd.readouterr()[1]
     assert "Skipping tests for package" in error
     assert "test requires missing compiler" in error
+
+
+# TODO: Deprecated. Remove when remote test(), run_test(), etc.
+def test_package_run_test(install_mockery_mutable_config, mock_fetch, capfd):
+    s = spack.spec.Spec("trivial-smoke-test").concretized()
+    pkg = s.package
+
+    # First a successful test
+    msg = "do-nothing"
+    pkg.run_test("echo", msg, expected=[msg], purpose="test: echo", work_dir=".")
+    output, error = capfd.readouterr()
+    assert msg in output
+    assert "method is deprecated" in error
+
+    # Successful but not installed
+    msg = "not installed"
+    pkg.run_test(
+        "echo",
+        msg,
+        expected=[msg],
+        installed=True,
+        purpose="test: echo not installed",
+        work_dir=".",
+    )
+    output, error = capfd.readouterr()
+    assert "expected in prefix" in output
+
+    # Now try a missing runner that we'll skip
+    result = pkg.run_test("no-possible-program", skip_missing=True)
+    output = capfd.readouterr()[0]
+    assert result is None
+    assert not output
+
+    # Reset the tester instance before proceeding
+    pkg._tester = spack.install_test.PackageTest(pkg)
+
+    # Missing runner, no skip, fail fast
+    with spack.config.override("config:fail_fast", True):
+        with pytest.raises(spack.install_test.TestFailure, match="Failed to find executable"):
+            pkg.run_test("no-possible-program")
+
+    # Missing runner, no skip, don't fail fast
+    pkg.run_test("no-possible-program")
+    assert len(pkg.tester.test_failures) == 1

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -195,6 +195,17 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
     shutil.rmtree(os.path.dirname(source_path))
 
 
+def test_cache_extra_sources_fails(install_mockery):
+    s = spack.spec.Spec("a").concretized()
+    s.package.spec.concretize()
+
+    with pytest.raises(ValueError, match="Only relative paths"):
+        s.package.cache_extra_test_sources(["a/b", "/c/d"])
+
+    with pytest.raises(IOError, match="does not exist"):
+        s.package.cache_extra_test_sources("no-such-file")
+
+
 def test_package_exes_and_libs():
     with pytest.raises(spack.error.SpackError, match="defines both"):
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -283,7 +283,7 @@ def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
     assert "test requires missing compiler" in error
 
 
-# TODO: Remove when remove deprecated run_test(), etc.
+# TODO (post-34236): Remove when remove deprecated run_test(), etc.
 def test_package_run_test(install_mockery_mutable_config, mock_fetch, capfd):
     s = spack.spec.Spec("trivial-smoke-test").concretized()
     pkg = s.package

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -210,7 +210,7 @@ def test_package_url_and_urls():
 
     s = spack.spec.Spec("a")
     with pytest.raises(ValueError, match="defines both"):
-        _ = URLsPackage(s)
+        URLsPackage(s)
 
 
 def test_package_license():
@@ -234,21 +234,21 @@ def test_package_version_fails():
     s = spack.spec.Spec("a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="does not have a concrete version"):
-        _ = pkg.version()
+        pkg.version()
 
 
 def test_package_tester_fails():
     s = spack.spec.Spec("a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
-        _ = pkg.tester()
+        pkg.tester()
 
 
 def test_package_fetcher_fails():
     s = spack.spec.Spec("a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
-        _ = pkg.fetcher
+        pkg.fetcher
 
 
 def test_package_no_extendees():
@@ -272,7 +272,7 @@ def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
     assert "test requires missing compiler" in error
 
 
-# TODO: Deprecated. Remove when remote test(), run_test(), etc.
+# TODO: Remove when remove deprecated run_test(), etc.
 def test_package_run_test(install_mockery_mutable_config, mock_fetch, capfd):
     s = spack.spec.Spec("trivial-smoke-test").concretized()
     pkg = s.package

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -208,25 +208,6 @@ def test_cache_extra_sources_fails(install_mockery):
         spack.install_test.cache_extra_test_sources(s.package, "no-such-file")
 
 
-# TODO (post-34236): Remove this test case when remove install_test_root
-# TODO (post-34236): and cache_extra_test_sources package methods.
-def test_cache_extra_sources_warnings(install_mockery, capfd):
-    s = spack.spec.Spec("a").concretized()
-    s.package.spec.concretize()
-    source = "example.cpp"
-
-    _ = s.package.install_test_root
-    err = capfd.readouterr()[1]
-    assert "deprecated" in err
-    assert "install_test_root(pkg)" in err
-
-    with pytest.raises(OSError):
-        s.package.cache_extra_test_sources(source)
-    out, err = capfd.readouterr()
-    assert "deprecated" in err
-    assert "cache_extra_test_sources(pkg, srcs)" in err
-
-
 def test_package_exes_and_libs():
     with pytest.raises(spack.error.SpackError, match="defines both"):
 
@@ -312,9 +293,8 @@ def test_package_run_test(install_mockery_mutable_config, mock_fetch, capfd):
     # First a successful test
     msg = "do-nothing"
     pkg.run_test("echo", msg, expected=[msg], purpose="test: echo", work_dir=".")
-    output, error = capfd.readouterr()
+    output = capfd.readouterr()[0]
     assert msg in output
-    assert "method is deprecated" in error
 
     # Successful but not installed
     msg = "not installed"

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -21,6 +21,7 @@ import spack.install_test
 import spack.package_base
 import spack.repo
 from spack.build_systems.generic import Package
+from spack.installer import InstallError
 
 
 @pytest.fixture(scope="module")
@@ -201,11 +202,12 @@ def test_cache_extra_sources_fails(install_mockery):
     s = spack.spec.Spec("a").concretized()
     s.package.spec.concretize()
 
-    with pytest.raises(ValueError, match="Only relative paths"):
-        spack.install_test.cache_extra_test_sources(s.package, ["a/b", "/c/d"])
+    with pytest.raises(InstallError) as exc_info:
+        spack.install_test.cache_extra_test_sources(s.package, ["/a/b", "no-such-file"])
 
-    with pytest.raises(OSError, match="does not exist"):
-        spack.install_test.cache_extra_test_sources(s.package, "no-such-file")
+    errors = str(exc_info.value)
+    assert "'/a/b') must be relative" in errors
+    assert "'no-such-file') for the copy does not exist" in errors
 
 
 def test_package_exes_and_libs():

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -19,6 +19,7 @@ import llnl.util.filesystem as fs
 
 import spack.package_base
 import spack.repo
+from spack.build_systems.generic import Package
 
 
 @pytest.fixture(scope="module")
@@ -225,7 +226,7 @@ def test_package_license():
     assert os.path.basename(pkg.global_license_file) == pkg.license_files[0]
 
 
-class BaseTestPackage(spack.package.Package):
+class BaseTestPackage(Package):
     extendees = None  # currently a required attribute for is_extension()
 
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -202,7 +202,7 @@ def test_cache_extra_sources_fails(install_mockery):
     with pytest.raises(ValueError, match="Only relative paths"):
         s.package.cache_extra_test_sources(["a/b", "/c/d"])
 
-    with pytest.raises(IOError, match="does not exist"):
+    with pytest.raises(OSError, match="does not exist"):
         s.package.cache_extra_test_sources("no-such-file")
 
 

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -312,14 +312,6 @@ def test_fetch_options(version_str, digest_end, extra_options):
     assert fetcher.extra_options == extra_options
 
 
-def test_has_test_method_fails(capsys):
-    with pytest.raises(SystemExit):
-        spack.package_base.has_test_method("printing-package")
-
-    captured = capsys.readouterr()[1]
-    assert "is not a class" in captured
-
-
 def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
     pkg_cls = spack.repo.path.get_pkg_class(spec.name)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -152,3 +152,17 @@ def test_repo_path_handles_package_removal(tmpdir, mock_packages):
     with spack.repo.use_repositories(builder.root, override=False) as repos:
         r = repos.repo_for_pkg("c")
         assert r.namespace == "builtin.mock"
+
+
+def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_debug, capsys):
+    # Start with a package-less virtual
+    vspec = spack.spec.Spec("something")
+    mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    captured = capsys.readouterr()[1]
+    assert "Could not copy package" in captured
+
+    # Now with a virtual with a package
+    vspec = spack.spec.Spec("externalvirtual")
+    mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    captured = capsys.readouterr()[1]
+    assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -159,10 +159,11 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
     vspec = spack.spec.Spec("something")
     mutable_mock_repo.dump_provenance(vspec, tmpdir)
     captured = capsys.readouterr()[1]
-    assert "Could not copy package" in captured
+    assert "does not have a package" in captured
 
     # Now with a virtual with a package
     vspec = spack.spec.Spec("externalvirtual")
     mutable_mock_repo.dump_provenance(vspec, tmpdir)
     captured = capsys.readouterr()[1]
+    assert "Installing" in captured
     assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -122,7 +122,7 @@ def test_reporters_extract_missing_desc():
 
 
 # TODO (post-34236): Remove this test when removing deprecated run_test(), etc.
-def test_reporters_extract_empty_and_xfail():
+def test_reporters_extract_xfail():
     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
     outputs = """
 ==> Testing package fake-1.0-abcdefg
@@ -137,7 +137,7 @@ def test_reporters_extract_empty_and_xfail():
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 
     assert len(parts) == 1
-    parts[0]["command"] == "unkown"
+    parts[0]["command"] == fake_bin
     parts[0]["completed"] == "Expected to fail"
 
 

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -126,7 +126,7 @@ def test_reporters_extract_empty_and_xfail():
     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
     outputs = """
 ==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] Checking fake imports
+==> [2022-02-15-18:44:21.250165] test: test_fake: Checking fake imports
 ==> [2022-02-15-18:44:21.250175] Expecting return code in [3]
 ==> [2022-02-15-18:44:21.250200] '{0}'
 {1}
@@ -136,9 +136,9 @@ def test_reporters_extract_empty_and_xfail():
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 
-    assert len(parts) == 2
+    assert len(parts) == 1
     parts[0]["command"] == "unkown"
-    parts[1]["completed"] == "Expected to fail"
+    parts[0]["completed"] == "Expected to fail"
 
 
 @pytest.mark.parametrize("state", [("not installed"), ("external")])
@@ -169,7 +169,7 @@ def test_reporters_skip():
 ==> Testing package fake-1.0-abcdefg
 ==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
 ==> {0}
-==> [2022-02-15-18:44:21.250175, 123456] running fake program
+==> [2022-02-15-18:44:21.250175, 123456] test: test_fake: running fake program
 ==> [2022-02-15-18:44:21.250200, 123456] '{1}'
 INVALID
 Results for test suite abcdefghijklmn

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -108,23 +108,22 @@ def test_reporters_extract_missing_desc():
         assert parts[i]["status"] == status.lower()
 
 
-# # TODO/TBD: How will we support this now?
-# def test_reporters_extract_xfail():
-#     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
-#     outputs = """
-# ==> Testing package fake-1.0-abcdefg
-# ==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
-# ==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
-# ==> [2022-02-15-18:44:21.250200] '{0}'
-# {1}
-# """.format(
-#         fake_bin, TestStatus.PASSED
-#     ).splitlines()
-#
-#     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
-#
-#     assert len(parts) == 1
-#     parts[0]["completed"] == "Expected to fail"
+# TODO: Remove this test when removing deprecated run_test(), etc.
+def test_reporters_extract_xfail():
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
+==> [2022-02-15-18:44:21.250200] '{0}'
+{1}
+""".format(
+        fake_bin, str(TestStatus.PASSED)
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    parts[0]["completed"] == "Expected to fail"
 
 
 @pytest.mark.parametrize("state", [("not installed"), ("external")])
@@ -143,32 +142,53 @@ def test_reporters_extract_skipped(state):
     parts[0]["completed"] == expected
 
 
-# # TODO/TBD: How will skip tests be handled now?
-# def test_reporters_skip():
-#     # This test ticks 3 boxes:
-#     # 1) covers an as yet uncovered skip messages
-#     # 2) covers debug timestamps
-#     # 3) unrecognized output
-#     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
-#     unknown_message = "missing timestamp"
-#     outputs = """
-# ==> Testing package fake-1.0-abcdefg
-# ==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
-# ==> {0}
-# ==> [2022-02-15-18:44:21.250175, 123456] running fake program
-# ==> [2022-02-15-18:44:21.250200, 123456] '{1}'
-# INVALID
-# Results for test suite abcdefghijklmn
-# """.format(
-#         unknown_message, fake_bin
-#     ).splitlines()
-#
-#     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
-#
-#     assert len(parts) == 1
-#     assert fake_bin in parts[0]["command"]
-#     assert parts[0]["loglines"] == ["INVALID"]
-#     assert parts[0]["elapsed"] == 0.0
+# TODO: Remove this test when removing deprecated run_test(), etc.
+def test_reporters_skip():
+    # This test ticks 3 boxes:
+    # 1) covers an as yet uncovered skip messages
+    # 2) covers debug timestamps
+    # 3) unrecognized output
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
+    unknown_message = "missing timestamp"
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
+==> {0}
+==> [2022-02-15-18:44:21.250175, 123456] running fake program
+==> [2022-02-15-18:44:21.250200, 123456] '{1}'
+INVALID
+Results for test suite abcdefghijklmn
+""".format(
+        unknown_message, fake_bin
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    assert fake_bin in parts[0]["command"]
+    assert parts[0]["loglines"] == ["INVALID"]
+    assert parts[0]["elapsed"] == 0.0
+
+
+def test_reporters_skip_new():
+    outputs = """
+==> [2023-04-06-15:55:13.094025] test: test_skip:
+SKIPPED: test_skip: Package must be built with +python
+==> [2023-04-06-15:55:13.540029] Completed testing
+==> [2023-04-06-15:55:13.540275]
+======================= SUMMARY: fake-1.0-abcdefg ========================
+fake::test_skip .. SKIPPED
+=========================== 1 skipped of 1 part ==========================
+""".splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    part = parts[0]
+    assert part["name"] == "test_skip"
+    assert part["status"] == "skipped"
+    assert part["completed"] == "Completed"
+    assert part["loglines"][0].startswith("SKIPPED:")
 
 
 def test_reporters_report_for_package_no_stdout(tmpdir, monkeypatch, capfd):

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
 import pytest
 
 import llnl.util.filesystem as fs
@@ -9,10 +11,12 @@ import llnl.util.tty as tty
 
 import spack.reporters.extract
 import spack.spec
+from spack.install_test import TestStatus
 from spack.reporters import CDash, CDashConfiguration
 
 # Use a path variable to appease Spack style line length checks
 fake_install_prefix = fs.join_path(
+    os.sep,
     "usr",
     "spack",
     "spack",
@@ -28,17 +32,41 @@ fake_test_cache = fs.join_path(
 )
 
 
+def test_reporters_extract_basics():
+    # This test has a description, command, and status
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
+    name = "test_no_status"
+    desc = "basic description"
+    status = TestStatus.PASSED
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165] test: {0}: {1}
+==> [2022-02-15-18:44:21.250200] '{2}'
+{3}: {0}
+""".format(
+        name, desc, fake_bin, status
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+    assert len(parts) == 1
+    assert parts[0]["command"] == "{0}".format(fake_bin)
+    assert parts[0]["desc"] == desc
+    assert parts[0]["loglines"] == ["{0}: {1}".format(status, name)]
+    assert parts[0]["status"] == status.lower()
+
+
 def test_reporters_extract_no_parts(capfd):
     # This test ticks three boxes:
     #  1) has Installing, which is skipped;
     #  2) does not define any test parts;
     #  3) has a status value without a part so generates a warning
+    status = TestStatus.NO_TESTS
     outputs = """
 ==> Testing package fake-1.0-abcdefg
 ==> [2022-02-11-17:14:38.875259] Installing {0} to {1}
-NO-TESTS
+{2}
 """.format(
-        fake_install_test_root, fake_test_cache
+        fake_install_test_root, fake_test_cache, status
     ).splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
@@ -49,62 +77,54 @@ NO-TESTS
     assert "No part to add status" in err
 
 
-def test_reporters_extract_no_command():
-    # This test ticks 2 boxes:
-    # 1) has a test description with no command or status
-    # 2) has a test description, command, and status
-    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
-    outputs = """
-==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] command with no status
-==> [2022-02-15-18:44:21.250175] running test program
-==> [2022-02-15-18:44:21.250200] '{0}'
-PASSED
-""".format(
-        fake_bin
-    ).splitlines()
-
-    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
-    assert len(parts) == 2
-    assert parts[0]["command"] == "unknown"
-    assert parts[1]["loglines"] == ["PASSED"]
-    assert parts[1]["elapsed"] == 0.0
-
-
 def test_reporters_extract_missing_desc():
+    # This test includes one part without a description and another with one
     fake_bin = fs.join_path(fake_install_prefix, "bin", "importer")
+    names = ["test_fake_bin", "test_fake_util"]
+    descs = ["", "import fake util module"]
+    failed = TestStatus.FAILED
+    passed = TestStatus.PASSED
+    results = [passed, failed]
     outputs = """
 ==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] '{0}' '-c' 'import fake.bin'
-PASSED
-==> [2022-02-15-18:44:21.250200] '{0}' '-c' 'import fake.util'
-PASSED
+==> [2022-02-15-18:44:21.250165] test: {0}:
+==> [2022-02-15-18:44:21.250170] '{1}' '-c' 'import fake.bin'
+{2}: {0}
+==> [2022-02-15-18:44:21.250185] test: {3}: {4}
+==> [2022-02-15-18:44:21.250200] '{5}' '-c' 'import fake.util'
+{6}: {3}
 """.format(
-        fake_bin
+        names[0], descs[0], results[0], names[1], descs[1], fake_bin, results[1]
     ).splitlines()
+    for ln in outputs:
+        print(ln)
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 
     assert len(parts) == 2
-    assert parts[0]["desc"] is None
-    assert parts[1]["desc"] is None
+    for i, (name, desc, status) in enumerate(zip(names, descs, results)):
+        assert parts[i]["name"] == name
+        assert parts[i]["desc"] == desc
+        assert parts[i]["status"] == status.lower()
 
 
-def test_reporters_extract_xfail():
-    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
-    outputs = """
-==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
-==> [2022-02-15-18:44:21.250200] '{0}'
-PASSED
-""".format(
-        fake_bin
-    ).splitlines()
-
-    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
-
-    assert len(parts) == 1
-    parts[0]["completed"] == "Expected to fail"
+# # TBD/TLD: How will we support this now?
+# def test_reporters_extract_xfail():
+#     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
+#     outputs = """
+# ==> Testing package fake-1.0-abcdefg
+# ==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
+# ==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
+# ==> [2022-02-15-18:44:21.250200] '{0}'
+# {1}
+# """.format(
+#         fake_bin, TestStatus.PASSED
+#     ).splitlines()
+#
+#     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+#
+#     assert len(parts) == 1
+#     parts[0]["completed"] == "Expected to fail"
 
 
 @pytest.mark.parametrize("state", [("not installed"), ("external")])
@@ -123,31 +143,32 @@ def test_reporters_extract_skipped(state):
     parts[0]["completed"] == expected
 
 
-def test_reporters_skip():
-    # This test ticks 3 boxes:
-    # 1) covers an as yet uncovered skip messages
-    # 2) covers debug timestamps
-    # 3) unrecognized output
-    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
-    unknown_message = "missing timestamp"
-    outputs = """
-==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
-==> {0}
-==> [2022-02-15-18:44:21.250175, 123456] running fake program
-==> [2022-02-15-18:44:21.250200, 123456] '{1}'
-INVALID
-Results for test suite abcdefghijklmn
-""".format(
-        unknown_message, fake_bin
-    ).splitlines()
-
-    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
-
-    assert len(parts) == 1
-    assert fake_bin in parts[0]["command"]
-    assert parts[0]["loglines"] == ["INVALID"]
-    assert parts[0]["elapsed"] == 0.0
+# # TBD/TLD: How will this appear and be handled?
+# def test_reporters_skip():
+#     # This test ticks 3 boxes:
+#     # 1) covers an as yet uncovered skip messages
+#     # 2) covers debug timestamps
+#     # 3) unrecognized output
+#     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
+#     unknown_message = "missing timestamp"
+#     outputs = """
+# ==> Testing package fake-1.0-abcdefg
+# ==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
+# ==> {0}
+# ==> [2022-02-15-18:44:21.250175, 123456] running fake program
+# ==> [2022-02-15-18:44:21.250200, 123456] '{1}'
+# INVALID
+# Results for test suite abcdefghijklmn
+# """.format(
+#         unknown_message, fake_bin
+#     ).splitlines()
+#
+#     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+#
+#     assert len(parts) == 1
+#     assert fake_bin in parts[0]["command"]
+#     assert parts[0]["loglines"] == ["INVALID"]
+#     assert parts[0]["elapsed"] == 0.0
 
 
 def test_reporters_report_for_package_no_stdout(tmpdir, monkeypatch, capfd):

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -108,7 +108,7 @@ def test_reporters_extract_missing_desc():
         assert parts[i]["status"] == status.lower()
 
 
-# # TBD/TLD: How will we support this now?
+# # TODO/TBD: How will we support this now?
 # def test_reporters_extract_xfail():
 #     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
 #     outputs = """
@@ -143,7 +143,7 @@ def test_reporters_extract_skipped(state):
     parts[0]["completed"] == expected
 
 
-# # TBD/TLD: How will this appear and be handled?
+# # TODO/TBD: How will skip tests be handled now?
 # def test_reporters_skip():
 #     # This test ticks 3 boxes:
 #     # 1) covers an as yet uncovered skip messages

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -121,7 +121,7 @@ def test_reporters_extract_missing_desc():
     assert parts[2]["command"] == "exe1 1; exe2 2"
 
 
-# TODO: Remove this test when removing deprecated run_test(), etc.
+# TODO (post-34236): Remove this test when removing deprecated run_test(), etc.
 def test_reporters_extract_empty_and_xfail():
     fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
     outputs = """
@@ -157,7 +157,7 @@ def test_reporters_extract_skipped(state):
     parts[0]["completed"] == expected
 
 
-# TODO: Remove this test when removing deprecated run_test(), etc.
+# TODO (post-34236): Remove this test when removing deprecated run_test(), etc.
 def test_reporters_skip():
     # This test ticks 3 boxes:
     # 1) covers an as yet uncovered skip messages

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -340,6 +340,11 @@ COMMIT;
     expected = spack.install_test.get_escaped_text_output(filename)
     spack.install_test.check_outputs(expected, contents)
 
+    # Let's also cover case where something expected is NOT in the output
+    expected.append("should not find me")
+    with pytest.raises(RuntimeError, match="Expected"):
+        spack.install_test.check_outputs(expected, contents)
+
 
 def test_find_required_file(tmpdir):
     filename = "myexe"
@@ -367,3 +372,12 @@ def test_find_required_file(tmpdir):
     # Now make sure we get all of the files
     results = spack.install_test.find_required_file(tmpdir, filename, expected=3, recursive=True)
     assert isinstance(results, list) and len(results) == 3
+
+
+def test_packagetest_fails(mock_packages):
+    MyPackage = collections.namedtuple("MyPackage", ["spec"])
+
+    s = spack.spec.Spec("a")
+    pkg = MyPackage(s)
+    with pytest.raises(ValueError, match="requires a concrete package"):
+        spack.install_test.PackageTest(pkg)

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -272,11 +272,11 @@ def test_package_copy_test_files_skips(mock_packages, ensure_debug, capsys):
     assert "no package class found" in out
 
 
-def test_test_parts_process_fails(mock_packages):
-    """Confirm test_parts_process fails as expected without package or test_suite."""
+def test_process_test_parts(mock_packages):
+    """Confirm process_test_parts fails as expected without package or test_suite."""
     # Try without a package
     with pytest.raises(spack.install_test.TestSuiteError) as exc_info:
-        spack.install_test.test_parts_process(None, [])
+        spack.install_test.process_test_parts(None, [])
     assert "without a package" in str(exc_info)
 
     # Try with a package without a test suite
@@ -284,7 +284,7 @@ def test_test_parts_process_fails(mock_packages):
     pkg = MyPackage("SomePackage", None)
 
     with pytest.raises(spack.install_test.TestSuiteError) as exc_info:
-        spack.install_test.test_parts_process(pkg, [])
+        spack.install_test.process_test_parts(pkg, [])
     assert "test suite is missing" in str(exc_info)
 
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -29,7 +29,7 @@ def ensure_results(filename, expected):
         assert have
 
 
-def test_test_log_pathname(mock_packages, config):
+def test_test_log_name(mock_packages, config):
     """Ensure test log path is reasonable."""
     spec = spack.spec.Spec("libdwarf").concretized()
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -381,3 +381,15 @@ def test_packagetest_fails(mock_packages):
     pkg = MyPackage(s)
     with pytest.raises(ValueError, match="require a concrete package"):
         spack.install_test.PackageTest(pkg)
+
+
+# TODO (post-34236): Remove this test when remove deprecated test() method, etc.
+def test_test_spec_warn(mock_packages, install_mockery, mock_test_stage, monkeypatch):
+    spec = spack.spec.Spec("py-test-callback").concretized()
+    monkeypatch.setattr(spack.spec.Spec, "installed", _true)
+    test_suite = spack.install_test.TestSuite([spec])
+    test_suite()
+
+    ensure_results(
+        test_suite.log_file_for_spec(spec), "Use any name starting with 'test_' instead"
+    )

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -320,3 +320,22 @@ def test_test_part_skip(install_mockery_mutable_config, mock_fetch, mock_test_st
     name, status = pkg.tester.test_parts[0]
     assert name.endswith("test_skip")
     assert status == spack.install_test.TestStatus.SKIPPED
+
+
+def test_check_special_outputs(tmpdir):
+    """This test covers two related helper methods"""
+    contents = """CREATE TABLE packages (
+name varchar(80) primary key,
+has_code integer,
+url varchar(160));
+INSERT INTO packages VALUES('sqlite',1,'https://www.sqlite.org');
+INSERT INTO packages VALUES('readline',1,'https://tiswww.case.edu/php/chet/readline/rltop.html');
+INSERT INTO packages VALUES('xsdk',0,'http://xsdk.info');
+COMMIT;
+"""
+    filename = tmpdir.join("special.txt")
+    with open(filename, "w") as f:
+        f.write(contents)
+
+    expected = spack.install_test.get_escaped_text_output(filename)
+    spack.install_test.check_outputs(expected, contents)

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -192,7 +192,7 @@ def test_get_test_suite_too_many(mock_packages, mock_test_stage):
 )
 def test_test_functions(mock_packages, install_mockery, virtuals, names):
     spec = spack.spec.Spec("printing-package").concretized()
-    expected = "printing-package.test_print" if names else "test_print"
+    expected = "PrintingPackage.test_print" if names else "test_print"
 
     fns = spack.install_test.test_functions(spec.package, add_virtuals=virtuals, names=names)
     tests = fns if names else [f.__name__ for f in fns]

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -187,13 +187,7 @@ def test_get_test_suite_too_many(mock_packages, mock_test_stage):
 
 
 @pytest.mark.parametrize(
-    "virtuals,names",
-    [
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ],
+    "virtuals,names", [(False, False), (False, True), (True, False), (True, True)]
 )
 def test_test_functions(mock_packages, install_mockery, virtuals, names):
     spec = spack.spec.Spec("printing-package").concretized()
@@ -208,8 +202,6 @@ def test_test_functions(mock_packages, install_mockery, virtuals, names):
     check_results(fns)
 
     fns = spack.install_test.test_functions(
-        spec.package.__class__,
-        add_virtuals=virtuals,
-        names=names,
+        spec.package.__class__, add_virtuals=virtuals, names=names
     )
     check_results(fns)

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -379,5 +379,5 @@ def test_packagetest_fails(mock_packages):
 
     s = spack.spec.Spec("a")
     pkg = MyPackage(s)
-    with pytest.raises(ValueError, match="requires a concrete package"):
+    with pytest.raises(ValueError, match="require a concrete package"):
         spack.install_test.PackageTest(pkg)

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -337,15 +337,15 @@ def test_remove_complex_package_logic_filtered():
         ("grads", "rrlmwml3f2frdnqavmro3ias66h5b2ce"),
         ("llvm", "nufffum5dabmaf4l5tpfcblnbfjknvd3"),
         # has @when("@4.1.0") and raw unicode literals
-        ("mfem", "tiiv7uq7v2xtv24vdij5ptcv76dpazrw"),
-        ("mfem@4.0.0", "tiiv7uq7v2xtv24vdij5ptcv76dpazrw"),
-        ("mfem@4.1.0", "gxastq64to74qt4he4knpyjfdhh5auel"),
+        ("mfem", "qtneutm6khd6epd2rhyuv2y6zavsxbed"),
+        ("mfem@4.0.0", "qtneutm6khd6epd2rhyuv2y6zavsxbed"),
+        ("mfem@4.1.0", "uit2ydzhra3b2mlvnq262qlrqqmuwq3d"),
         # has @when("@1.5.0:")
         ("py-torch", "qs7djgqn7dy7r3ps4g7hv2pjvjk4qkhd"),
         ("py-torch@1.0", "qs7djgqn7dy7r3ps4g7hv2pjvjk4qkhd"),
         ("py-torch@1.6", "p4ine4hc6f2ik2f2wyuwieslqbozll5w"),
         # has a print with multiple arguments
-        ("legion", "zdpawm4avw3fllxcutvmqb5c3bj5twqt"),
+        ("legion", "sffy6vz3dusxnxeetofoomlaieukygoj"),
         # has nested `with when()` blocks and loops
         ("trilinos", "vqrgscjrla4hi7bllink7v6v6dwxgc2p"),
     ],

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -14,6 +14,7 @@ import spack.filesystem_view
 import spack.store
 import spack.util.file_permissions as fp
 import spack.util.spack_json as sjson
+from spack.package_base import spack_times_log
 
 
 def compute_hash(path: str, block_size: int = 1048576) -> str:
@@ -159,6 +160,10 @@ def check_spec_manifest(spec):
 
             # Do not check manifest file. Can't store your own hash
             if path == manifest_file:
+                continue
+
+            # Do not check the install times log file.
+            if entry == spack_times_log:
                 continue
 
             data = manifest.pop(path, {})

--- a/var/spack/repos/builtin.mock/packages/fail-test-audit/package.py
+++ b/var/spack/repos/builtin.mock/packages/fail-test-audit/package.py
@@ -14,8 +14,8 @@ class FailTestAudit(MakefilePackage):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
     version("2.0", md5="abcdef0123456789abcdef0123456789")
 
-    build_time_test_callbacks = ["test"]
+    build_time_test_callbacks = ["test_build_callbacks"]
 
-    def test(self):
-        print("test: test-install-callbacks")
-        print("PASSED")
+    def test_build_callbacks(self):
+        """test build time test callbacks"""
+        print("test-build-callbacks")

--- a/var/spack/repos/builtin.mock/packages/mpi/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpi/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Mpi(Package):
+    """Virtual package for the Message Passing Interface."""
+
+    homepage = "https://www.mpi-forum.org/"
+    virtual = True
+
+    def test_hello(self):
+        print("Hello there!")

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -28,3 +28,6 @@ class Mpich(Package):
 
     def install(self, spec, prefix):
         touch(prefix.mpich)
+
+    def test_mpich(self):
+        print("Testing mpich")

--- a/var/spack/repos/builtin.mock/packages/printing-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/printing-package/package.py
@@ -26,7 +26,9 @@ class PrintingPackage(Package):
 
         print("AFTER INSTALL")
 
-    def test(self):
-        print("BEFORE TEST")
-        self.run_test("true")  # run /bin/true
-        print("AFTER TEST")
+    def test_print(self):
+        """Test python print example."""
+        python = which("python")
+        # Have to include output and error args to retain for test reporting
+        python("-c", 'print("Running test_print")', output=str.split, error=str.split)
+        python("-c", 'print("And a second command")', output=str.split, error=str.split)

--- a/var/spack/repos/builtin.mock/packages/printing-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/printing-package/package.py
@@ -27,8 +27,7 @@ class PrintingPackage(Package):
         print("AFTER INSTALL")
 
     def test_print(self):
-        """Test python print example."""
-        python = which("python")
-        # Have to include output and error args to retain for test reporting
-        python("-c", 'print("Running test_print")', output=str.split, error=str.split)
-        python("-c", 'print("And a second command")', output=str.split, error=str.split)
+        """Test print example."""
+
+        print("Running test_print")
+        print("And a second command")

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.pkg.builtin.mock.python as mp
+from spack.package import *
+
+
+class PyTestCallback(mp.Python):
+    """A package for testing stand-alone test methods as a callback."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/test-callback-1.0.tar.gz"
+
+    version("1.0", "00000000000000000000000000000110")
+    version("2.0", "00000000000000000000000000000120")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+
+    def test(self):
+        super(PyTestCallback, self).test()
+
+        print("PyTestCallback test")

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -19,6 +19,7 @@ class PyTestCallback(mp.Python):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
+    # TODO (post-34236): "test" -> "test_callback" once remove "test" method
     def test(self):
         super(PyTestCallback, self).test()
 

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -13,13 +13,16 @@ class PyTestCallback(mp.Python):
     homepage = "http://www.example.com"
     url = "http://www.example.com/test-callback-1.0.tar.gz"
 
+    # TODO (post-34236): "test" -> "test_callback" once remove "test" support
+    install_time_test_callbacks = ["test"]
+
     version("1.0", "00000000000000000000000000000110")
     version("2.0", "00000000000000000000000000000120")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-    # TODO (post-34236): "test" -> "test_callback" once remove "test" method
+    # TODO (post-34236): "test" -> "test_callback" once remove "test" support
     def test(self):
         super(PyTestCallback, self).test()
 

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -14,6 +14,8 @@ class SimpleStandaloneTest(Package):
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
+    provides("standalone-test")
+
     def test_echo(self):
         """simple stand-alone test"""
         echo = which("echo")

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -14,6 +14,7 @@ class SimpleStandaloneTest(Package):
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    def test(self):
-        msg = "simple stand-alone test"
-        self.run_test("echo", [msg], expected=[msg], purpose="test: running {0}".format(msg))
+    def test_echo(self):
+        """simple stand-alone test"""
+        echo = which("echo")
+        echo("testing echo", output=str.split, error=str.split)

--- a/var/spack/repos/builtin.mock/packages/test-error/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-error/package.py
@@ -17,5 +17,7 @@ class TestError(Package):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-    def test(self):
-        self.run_test("false")
+    def test_false(self):
+        """TestError test"""
+        false = which("false")
+        false(output=str.split, error=str.split)

--- a/var/spack/repos/builtin.mock/packages/test-error/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-error/package.py
@@ -20,4 +20,4 @@ class TestError(Package):
     def test_false(self):
         """TestError test"""
         false = which("false")
-        false(output=str.split, error=str.split)
+        false()

--- a/var/spack/repos/builtin.mock/packages/test-fail/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-fail/package.py
@@ -17,9 +17,7 @@ class TestFail(Package):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-    def test_noop(self):
+    def test_fails(self):
         """trigger test failure"""
-        python = which("python")
-
-        # Deliberately trigger a command failure
-        python("-c", "noop", output=str.split, error=str.split)
+        unknown = which("unknown-program")
+        unknown()

--- a/var/spack/repos/builtin.mock/packages/test-fail/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-fail/package.py
@@ -17,5 +17,9 @@ class TestFail(Package):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-    def test(self):
-        self.run_test("true", expected=["not in the output"])
+    def test_noop(self):
+        """trigger test failure"""
+        python = which("python")
+
+        # Deliberately trigger a command failure
+        python("-c", "noop", output=str.split, error=str.split)


### PR DESCRIPTION
fixes #35519

This PR is a refactor of Spack's stand-alone test process to be more spack- and pytest-like.  It is more spack-like in that test parts are no longer "hidden" in a package's `run_test()` method and pytest-like in that any package method whose name starts `test_` (i.e., a "test" method) is a test part.  We also support the ability to embed test parts in a test method when that makes sense.

Test methods are now implicit test parts.  The docstring is the purpose for the test part.  The name of the method is the name of the test part.  The working directory is the active spec's test stage directory.  You can embed test parts using the `test_part` context manager.

This PR adds other functionality (in part because it was originally tested here).

PR highlights:
- adds support for multiple `test_*` stand-alone package test methods, each of which is an implicit `test_part` for execution and reporting purposes;
- deprecates package use of `run_test()`;
- exposes some functionality from `run_test()` as optional helper methods;
- adds a `SkipTest` exception that can be used to flag stand-alone tests as being skipped;
- updates the packaging guide section on stand-alone tests to provide more examples (per feedback from multiple people);
- restores the ability to run tests "inherited" from provided virtual packages (was also in #35380);
- prints the test log path (like we currently do for build log paths) (was also in #35315);
- times and reports the post-install process (since it can include post-install tests) (was also in #35315); and
- corrects context-related error message to distinguish test recipes from build recipes. 