### PR TITLE
[quantum-espresso] Parallel make fails for 6.{6,7}

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -581,7 +581,7 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
                 zlib_libs = spec["zlib"].prefix.lib + " -lz"
                 filter_file(zlib_libs, format(spec["zlib"].libs.ld_flags), make_inc)
 
-        # QE 6.6 and later has parallel builds fixed
+        # QE 6.8 and later has parallel builds fixed
         if spec.satisfies("@:6.7"):
             parallel_build_on = False
         else:

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -582,7 +582,7 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
                 filter_file(zlib_libs, format(spec["zlib"].libs.ld_flags), make_inc)
 
         # QE 6.6 and later has parallel builds fixed
-        if spec.satisfies("@:6.5"):
+        if spec.satisfies("@:6.7"):
             parallel_build_on = False
         else:
             parallel_build_on = True


### PR DESCRIPTION
I run into a race condition in `make` with Intel compiler on icelake when building QE 6.6 and 6.7.