### PR TITLE
Added build time dependency for libxcrypt on perl

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -30,8 +30,8 @@ class Libxcrypt(AutotoolsPackage):
 
     variant("obsolete_api", default=False, when="@4.4.30:")
 
-    depends_on("perl", type="build", when="4.4.30:")
-    
+    depends_on("perl", type="build", when="@4.4.30:")
+
     patch("truncating-conversion.patch", when="@4.4.30")
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -30,6 +30,8 @@ class Libxcrypt(AutotoolsPackage):
 
     variant("obsolete_api", default=False, when="@4.4.30:")
 
+    depends_on("perl", type="build", when="4.4.30:")
+    
     patch("truncating-conversion.patch", when="@4.4.30")
 
     def configure_args(self):


### PR DESCRIPTION
If I do not add Perl as a build-time dependency it produces the following error:

```
checking for Python 3.>=6 with Passlib... (cached) not found
configure: Disabling the "regen-ka-table" target, missing Python requirements.
checking whether all ucontext.h functions are available... yes
Can't locate open.pm in @INC (you may need to install the open module) (@INC contains: /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./build-aux/scripts/expand-selected-hashes line 20.
BEGIN failed--compilation aborted at ./build-aux/scripts/expand-selected-hashes line 20.
configure: error: bad value 'all' for --enable-hashes
==> Error: ProcessError: Command exited with status 1:
    '/tmp/swadm/spack-stage/spack-stage-libxcrypt-4.4.33-37kj3glfmdimfcjc4rmkluwy3o26pq6x/spack-src/configure' '--prefix=/uochb/soft/a/spack/20221129-git/opt/spack/linux-almalinux9-skylake_avx512/gcc-11.3.0/libxcrypt-4.4.33-37kj3glfmdimfcjc4rmkluwy3o26pq6x' 'ac_cv_path_python3_passlib=not found' '--disable-werror' '--disable-obsolete-api'

1 error found in build log:
     160    checking for valgrind... no
     161    checking for Python 3.>=6 with Passlib... (cached) not found
     162    configure: Disabling the "regen-ka-table" target, missing Python requirements.
     163    checking whether all ucontext.h functions are available... yes
     164    Can't locate open.pm in @INC (you may need to install the open module) (@INC contains: /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 
            /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./build-aux/scripts/expand-selected-hashes line
             20.
     165    BEGIN failed--compilation aborted at ./build-aux/scripts/expand-selected-hashes line 20.
  >> 166    configure: error: bad value 'all' for --enable-hashes

See build log for details:
  /tmp/swadm/spack-stage/spack-stage-libxcrypt-4.4.33-37kj3glfmdimfcjc4rmkluwy3o26pq6x/spack-build-out.txt
```
I am not sure how far back in version it needs to go.