### PR TITLE
vecgeom: add new 1.2.1 version

### DIFF
--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -60,7 +60,11 @@ class Vecgeom(CMakePackage, CudaPackage):
     depends_on("veccore@0.4.2", when="@:1.0")
 
     conflicts("+cuda", when="@:1.1.5")
-    conflicts("%gcc@11.3:", when="+cuda ^cuda@:11.6", msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7")
+    conflicts(
+        "%gcc@11.3:",
+        when="+cuda ^cuda@:11.6",
+        msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7"
+    )
     conflicts("cxxstd=14", when="@1.2:")
     conflicts("cxxstd=11", when="@1.2:")
 

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -60,6 +60,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     depends_on("veccore@0.4.2", when="@:1.0")
 
     conflicts("+cuda", when="@:1.1.5")
+    conflicts("%gcc@11.3:", when="+cuda ^cuda@:11.6", msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7")
     conflicts("cxxstd=14", when="@1.2:")
     conflicts("cxxstd=11", when="@1.2:")
 

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -63,7 +63,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     conflicts(
         "%gcc@11.3:",
         when="+cuda ^cuda@:11.6",
-        msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7"
+        msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7",
     )
     conflicts("cxxstd=14", when="@1.2:")
     conflicts("cxxstd=11", when="@1.2:")

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -20,6 +20,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers = ["drbenmorgan", "sethrj"]
 
     version("master", branch="master")
+    version("1.2.1", sha256="2b47f0d23f6d25ca4fc0601b93a98167bbfb4b8aa6a1bba16d0391569e99e6f0")
     version("1.2.0", sha256="3448606fceb98ceb72d687d2d3b7ad44c67793d799def4ece9601b8e39c2868a")
     version("1.1.20", sha256="e1c75e480fc72bca8f8072ea00320878a9ae375eed7401628b15cddd097ed7fd")
     version("1.1.19", sha256="4c586b57fd4e30be044366c9be983249c7fa8bec629624523f5f69fd9caaa05b")


### PR DESCRIPTION
Adds the just released patch version 1.2.1, which will also be the required minimum for the upcoming Geant4 minor release.

@sethrj, as we noted elsewhere, this, and earlier versions (at least 1.1.18-1.1.20) do not build with GCC 11.3 and CUDA >=11.6 (GCC 11.**2** and compatible CUDAs works though!). Should we use a `conflict` to express this?