### PR TITLE
darshan-util: fix location of input for darshan-util tests

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -93,20 +93,24 @@ class DarshanUtil(AutotoolsPackage):
         return extra_args
 
     @property
-    def basepath(self):
-        return join_path("darshan-test", "example-output")
+    def test_log_path(self):
+        if self.version < Version("3.4.1"):
+            return join_path("darshan-test", "example-output",
+                "mpi-io-test-x86_64-{0}.darshan".format(self.version))
+        else:
+            return join_path("darshan-util", "pydarshan", "darshan", "tests", "input",
+                "sample.darshan")
 
     @run_after("install")
     def _copy_test_inputs(self):
-        # add darshan-test/example-output/mpi-io-test-spack-expected.txt"
         test_inputs = [
-            join_path(self.basepath, "mpi-io-test-x86_64-{0}.darshan".format(self.spec.version))
+            self.test_log_path
         ]
         self.cache_extra_test_sources(test_inputs)
 
     def _test_parser(self):
         purpose = "Verify darshan-parser can parse an example log \
-                   from the current version and check some expected counter values"
+                   and check some expected counter values"
         # Switch to loading the expected strings from the darshan source in future
         # filename = self.test_suite.current_test_cache_dir.
         #            join(join_path(self.basepath, "mpi-io-test-spack-expected.txt"))
@@ -117,7 +121,7 @@ class DarshanUtil(AutotoolsPackage):
             r"STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+",
         ]
         logname = self.test_suite.current_test_cache_dir.join(
-            join_path(self.basepath, "mpi-io-test-x86_64-{0}.darshan".format(self.spec.version))
+            self.test_log_path
         )
         exe = "darshan-parser"
         options = [logname]

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -103,9 +103,7 @@ class DarshanUtil(AutotoolsPackage):
 
     @run_after("install")
     def _copy_test_inputs(self):
-        test_inputs = [
-            self.test_log_path
-        ]
+        test_inputs = [self.test_log_path]
         self.cache_extra_test_sources(test_inputs)
 
     def _test_parser(self):
@@ -120,9 +118,7 @@ class DarshanUtil(AutotoolsPackage):
             r"MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
             r"STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+",
         ]
-        logname = self.test_suite.current_test_cache_dir.join(
-            self.test_log_path
-        )
+        logname = self.test_suite.current_test_cache_dir.join(self.test_log_path)
         exe = "darshan-parser"
         options = [logname]
         status = [0]

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -98,7 +98,7 @@ class DarshanUtil(AutotoolsPackage):
             return join_path(
                 "darshan-test",
                 "example-output",
-                "mpi-io-test-x86_64-{0}.darshan".format(self.version)
+                "mpi-io-test-x86_64-{0}.darshan".format(self.version),
             )
         else:
             return join_path(

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -95,11 +95,15 @@ class DarshanUtil(AutotoolsPackage):
     @property
     def test_log_path(self):
         if self.version < Version("3.4.1"):
-            return join_path("darshan-test", "example-output",
-                "mpi-io-test-x86_64-{0}.darshan".format(self.version))
+            return join_path(
+                "darshan-test",
+                "example-output",
+                "mpi-io-test-x86_64-{0}.darshan".format(self.version)
+            )
         else:
-            return join_path("darshan-util", "pydarshan", "darshan", "tests", "input",
-                "sample.darshan")
+            return join_path(
+                "darshan-util", "pydarshan", "darshan", "tests", "input", "sample.darshan"
+            )
 
     @run_after("install")
     def _copy_test_inputs(self):


### PR DESCRIPTION
Darshan log file used for test input was removed from the Darshan repo after the 3.4.0 release. This commit adds logic to use a different log file as test input for later Darshan versions.