### PR TITLE
doxygen: add build-tools tag

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -39,6 +39,8 @@ class Doxygen(CMakePackage):
 
     variant("mscgen", default=False, description="Build with support for code graphs from mscgen.")
 
+    tags = ["build-tools"]
+
     executables = ["doxygen"]
 
     @classmethod

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -43,6 +43,8 @@ class Doxygen(CMakePackage):
 
     executables = ["doxygen"]
 
+    maintainers = ["sethrj"]
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("-v", output=str, error=str)


### PR DESCRIPTION
This allows it to be included automatically as an external. No one links against doxygen so this should be ok.