### PR TITLE
Add toggle for autoloading upstream modules

### DIFF
--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -88,6 +88,7 @@ module_type_configuration = {
                 "include": array_of_strings,
                 "exclude": array_of_strings,
                 "exclude_implicits": {"type": "boolean", "default": False},
+                "exclude_upstream_autoloads": {"type": "boolean", "default": False},
                 "defaults": array_of_strings,
                 "naming_scheme": {"type": "string"},  # Can we be more specific here?
                 "projections": projections_scheme,


### PR DESCRIPTION
Currently, if you tell Spack to autoload modules, `depends_on` statements will be added for both local instance and upstream instance dependencies. This behavior could be fine/desired if you add both module trees to the MODULEPATH, but some users may want to load dependencies built in the local instance but ignore ones built in the upstream (since they may not exist!).

This PR adds a *modules.yaml* toggle called `exclude_upstream_autoloads`, similar to `exclude_implicits`, that if **true** allows the user to ignore upstream packages when generating `depends_on` statements.