### PR TITLE
kripke: add cuda and rocm support

### DIFF
--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -17,7 +17,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers = ["vsrana01"]
 
-    version("spackify", branch="feature/spackify", submodules=False)
+    version("develop", branch="develop", submodules=False)
     version("1.2.4", submodules=False, tag="v1.2.4")
     version("1.2.3", submodules=True, tag="v1.2.3")
     version("1.2.2", submodules=True, tag="v1.2.2-CORAL2")

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-import os
-
 
 class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     """Kripke is a simple, scalable, 3D Sn deterministic particle

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -17,7 +17,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
 
     tags = ["SN-neutronics proxy-app"]
 
-    maintainers = ["vsrana"]
+    maintainers = ["vsrana01"]
 
     version("spackify", branch="feature/spackify", submodules=False)
     version("1.2.4", submodules=False, tag="v1.2.4")

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+import os
 
 
-class Kripke(CMakePackage):
+class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     """Kripke is a simple, scalable, 3D Sn deterministic particle
     transport proxy/mini app.
     """
@@ -14,33 +15,84 @@ class Kripke(CMakePackage):
     homepage = "https://computing.llnl.gov/projects/co-design/kripke"
     git = "https://github.com/LLNL/Kripke.git"
 
-    tags = ["proxy-app"]
-    version("1.2.4", submodules=True, tag="v1.2.4")
+    tags = ["SN-neutronics proxy-app"]
+
+    maintainers = ["vsrana"]
+
+    version("spackify", branch="feature/spackify", submodules=False)
+    version("1.2.4", submodules=False, tag="v1.2.4")
     version("1.2.3", submodules=True, tag="v1.2.3")
     version("1.2.2", submodules=True, tag="v1.2.2-CORAL2")
     version("1.2.1", submodules=True, tag="v1.2.1-CORAL2")
     version("1.2.0", submodules=True, tag="v1.2.0-CORAL2")
 
     variant("mpi", default=True, description="Build with MPI.")
-    variant("openmp", default=True, description="Build with OpenMP enabled.")
+    variant("openmp", default=False, description="Build with OpenMP enabled.")
+    variant("rocm", default=False, description="Build with ROCM enabled.")
+    variant("cuda", default=False, description="Build with CUDA enabled.")
     variant("caliper", default=False, description="Build with Caliper support enabled.")
 
     depends_on("mpi", when="+mpi")
-    depends_on("cmake@3.0:", type="build")
+    depends_on("blt")
+    depends_on("cmake")
     depends_on("caliper", when="+caliper")
+    depends_on("chai~examples+raja")
+    depends_on("raja~exercises~examples")
+    depends_on("umpire~examples")
+    depends_on("chai+raja+cuda", when="+cuda")
+    depends_on("raja+cuda", when="+cuda")
+    depends_on("umpire+cuda", when="+cuda")
+    depends_on("chai+raja+rocm", when="+rocm")
+    depends_on("raja+rocm", when="+rocm")
+    depends_on("umpire+rocm", when="+rocm")
 
     def cmake_args(self):
-        def enabled(variant):
-            return 1 if variant in self.spec else 0
+        spec = self.spec
+        args = []
 
-        return [
-            "-DENABLE_OPENMP=%d" % enabled("+openmp"),
-            "-DENABLE_MPI=%d" % enabled("+mpi"),
-            "-DENABLE_CALIPER=%d" % enabled("+caliper"),
-        ]
+        args.extend(["-DCAMP_DIR=%s" % self.spec['camp'].prefix,
+        "-DBLT_SOURCE_DIR=%s" % self.spec['blt'].prefix,
+        "-Dumpire_DIR=%s" % self.spec['umpire'].prefix,
+        "-DRAJA_DIR=%s" % self.spec['raja'].prefix,
+        "-Dchai_DIR=%s" % self.spec['chai'].prefix, "-DENABLE_CHAI=ON"])
+
+        if '+caliper' in spec:
+           args.append('-DENABLE_CALIPER=ON')
+
+        if '+mpi' in spec:
+           args.append('-DENABLE_MPI=ON')
+           args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
+
+        if '+rocm' in spec:
+            # Set up the hip macros needed by the build
+            args.append(
+                '-DENABLE_HIP=ON')
+            args.append('-DHIP_ROOT_DIR={0}'.format(spec['hip'].prefix))
+            rocm_archs = spec.variants['amdgpu_target'].value
+            if 'none' not in rocm_archs:
+                args.append('-DHIP_HIPCC_FLAGS=--amdgpu-target={0}'
+                            .format(",".join(rocm_archs)))
+                args.append('-DCMAKE_HIP_ARCHITECTURES={0}'.format(rocm_archs))
+        else:
+            # Ensure build with hip is disabled
+            args.append('-DENABLE_HIP=OFF')
+
+        if "+cuda" in spec:
+            args.append('-DENABLE_CUDA=ON')
+            args.append(self.define("CMAKE_CUDA_HOST_COMPILER", self.spec["mpi"].mpicxx))
+            if not spec.satisfies("cuda_arch=none"):
+                cuda_arch = spec.variants["cuda_arch"].value
+                args.append('-DCUDA_ARCH={0}'.format(cuda_arch[0]))
+                args.append('-DCMAKE_CUDA_ARCHITECTURES={0}'.format(cuda_arch[0]))
+                args.append("-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I%s -I=%s" % (self.spec['cub'].prefix.include, self.spec["mpi"].prefix.include))
+        else:
+            args.append('-DENABLE_CUDA=OFF')
+
+
+        return args
 
     def install(self, spec, prefix):
         # Kripke does not provide install target, so we have to copy
         # things into place.
         mkdirp(prefix.bin)
-        install(join_path(self.build_directory, "bin/kripke.exe"), prefix.bin)
+        install(join_path(self.build_directory, "kripke.exe"), prefix.bin)

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -15,7 +15,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://computing.llnl.gov/projects/co-design/kripke"
     git = "https://github.com/LLNL/Kripke.git"
 
-    tags = ["SN-neutronics proxy-app"]
+    tags = ["proxy-app"]
 
     maintainers = ["vsrana01"]
 
@@ -28,8 +28,6 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("mpi", default=True, description="Build with MPI.")
     variant("openmp", default=False, description="Build with OpenMP enabled.")
-    variant("rocm", default=False, description="Build with ROCM enabled.")
-    variant("cuda", default=False, description="Build with CUDA enabled.")
     variant("caliper", default=False, description="Build with Caliper support enabled.")
 
     depends_on("mpi", when="+mpi")
@@ -39,12 +37,6 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("chai~examples+raja")
     depends_on("raja~exercises~examples")
     depends_on("umpire~examples")
-    depends_on("chai+raja+cuda", when="+cuda")
-    depends_on("raja+cuda", when="+cuda")
-    depends_on("umpire+cuda", when="+cuda")
-    depends_on("chai+raja+rocm", when="+rocm")
-    depends_on("raja+rocm", when="+rocm")
-    depends_on("umpire+rocm", when="+rocm")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     """Kripke is a simple, scalable, 3D Sn deterministic particle
     transport proxy/mini app.
@@ -40,44 +41,49 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         args = []
 
-        args.extend(["-DCAMP_DIR=%s" % self.spec['camp'].prefix,
-        "-DBLT_SOURCE_DIR=%s" % self.spec['blt'].prefix,
-        "-Dumpire_DIR=%s" % self.spec['umpire'].prefix,
-        "-DRAJA_DIR=%s" % self.spec['raja'].prefix,
-        "-Dchai_DIR=%s" % self.spec['chai'].prefix, "-DENABLE_CHAI=ON"])
+        args.extend(
+            [
+                "-DCAMP_DIR=%s" % self.spec["camp"].prefix,
+                "-DBLT_SOURCE_DIR=%s" % self.spec["blt"].prefix,
+                "-Dumpire_DIR=%s" % self.spec["umpire"].prefix,
+                "-DRAJA_DIR=%s" % self.spec["raja"].prefix,
+                "-Dchai_DIR=%s" % self.spec["chai"].prefix,
+                "-DENABLE_CHAI=ON",
+            ]
+        )
 
-        if '+caliper' in spec:
-           args.append('-DENABLE_CALIPER=ON')
+        if "+caliper" in spec:
+            args.append("-DENABLE_CALIPER=ON")
 
-        if '+mpi' in spec:
-           args.append('-DENABLE_MPI=ON')
-           args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
+        if "+mpi" in spec:
+            args.append("-DENABLE_MPI=ON")
+            args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
 
-        if '+rocm' in spec:
+        if "+rocm" in spec:
             # Set up the hip macros needed by the build
-            args.append(
-                '-DENABLE_HIP=ON')
-            args.append('-DHIP_ROOT_DIR={0}'.format(spec['hip'].prefix))
-            rocm_archs = spec.variants['amdgpu_target'].value
-            if 'none' not in rocm_archs:
-                args.append('-DHIP_HIPCC_FLAGS=--amdgpu-target={0}'
-                            .format(",".join(rocm_archs)))
-                args.append('-DCMAKE_HIP_ARCHITECTURES={0}'.format(rocm_archs))
+            args.append("-DENABLE_HIP=ON")
+            args.append("-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix))
+            rocm_archs = spec.variants["amdgpu_target"].value
+            if "none" not in rocm_archs:
+                args.append("-DHIP_HIPCC_FLAGS=--amdgpu-target={0}".format(",".join(rocm_archs)))
+                args.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(rocm_archs))
         else:
             # Ensure build with hip is disabled
-            args.append('-DENABLE_HIP=OFF')
+            args.append("-DENABLE_HIP=OFF")
 
         if "+cuda" in spec:
-            args.append('-DENABLE_CUDA=ON')
+            args.append("-DENABLE_CUDA=ON")
             args.append(self.define("CMAKE_CUDA_HOST_COMPILER", self.spec["mpi"].mpicxx))
             if not spec.satisfies("cuda_arch=none"):
                 cuda_arch = spec.variants["cuda_arch"].value
-                args.append('-DCUDA_ARCH={0}'.format(cuda_arch[0]))
-                args.append('-DCMAKE_CUDA_ARCHITECTURES={0}'.format(cuda_arch[0]))
-                args.append("-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I%s -I=%s" % (self.spec['cub'].prefix.include, self.spec["mpi"].prefix.include))
+                args.append("-DCUDA_ARCH={0}".format(cuda_arch[0]))
+                args.append("-DCMAKE_CUDA_ARCHITECTURES={0}".format(cuda_arch[0]))
+                args.append(
+                    "-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I%s -I=%s"
+                    % (self.spec["cub"].prefix.include, self.spec["mpi"].prefix.include)
+                )
         else:
-            args.append('-DENABLE_CUDA=OFF')
-
+            args.append("-DENABLE_CUDA=OFF")
 
         return args
 


### PR DESCRIPTION
This MR adds the SN-Neutronics proxy-app Kripke