### PR TITLE
Drop support for older rocm releases - 4.5.0 till 5.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/atmi/package.py
+++ b/var/spack/repos/builtin/packages/atmi/package.py
@@ -25,10 +25,26 @@ class Atmi(CMakePackage):
     version("5.2.0", sha256="33e77905a607734157d46c736c924c7c50b6b13f2b2ddbf711cb08e37f2efa4f")
     version("5.1.3", sha256="a43448d77705b2b07e1758ffe8035aa6ba146abc2167984e8cb0f1615797b341")
     version("5.1.0", sha256="6a758f5a8332e6774cd8e14a4e5ce05e43b1e05298d817b4068c35fa1793d333")
-    version("5.0.2", sha256="3aea040f5a246539ab118f2183cf3e802a21e0e6215a53025eda77f382341747")
-    version("5.0.0", sha256="208c1773170722b60b74357e264e698df5871e9d9d490d64011e6ea76750d9cf")
-    version("4.5.2", sha256="c235cfb8bdd89deafecf9123264217b8cc5577a5469e3e1f24587fa820d0792e")
-    version("4.5.0", sha256="64eeb0244cedae99db7dfdb365e0ad624106cc1090a531f94885ae81e254aabf")
+    version(
+        "5.0.2",
+        sha256="3aea040f5a246539ab118f2183cf3e802a21e0e6215a53025eda77f382341747",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="208c1773170722b60b74357e264e698df5871e9d9d490d64011e6ea76750d9cf",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="c235cfb8bdd89deafecf9123264217b8cc5577a5469e3e1f24587fa820d0792e",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="64eeb0244cedae99db7dfdb365e0ad624106cc1090a531f94885ae81e254aabf",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="4497fa6d33547b946e2a51619f2777ec36e9cff1b07fd534eb8a5ef0d8e30650",

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -30,6 +30,7 @@ class Comgr(CMakePackage):
     version(
         "5.0.2",
         sha256="20d733f70d8edb573d8c92707f663d7d46dcaff08026cd6addbb83266679f92a",
+        deprecated=True,
     )
     version(
         "5.0.0",

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -27,10 +27,25 @@ class Comgr(CMakePackage):
     version("5.2.0", sha256="5f63fa93739ee9230756ef93c53019474b6cdddea3b588492d785dae1b08c087")
     version("5.1.3", sha256="3078c10e9a852fe8357712a263ad775b15944e083f93a879935c877511066ac9")
     version("5.1.0", sha256="1cdcfe5acb768ef50fb0026d4ee7ba01e615251ad3c27bb2593cdcf8c070a894")
-    version("5.0.2", sha256="20d733f70d8edb573d8c92707f663d7d46dcaff08026cd6addbb83266679f92a")
-    version("5.0.0", sha256="da1bbc694bd930a504406eb0a0018c2e317d8b2c136fb2cab8de426870efe9a8")
-    version("4.5.2", sha256="e45f387fb6635fc1713714d09364204cd28fea97655b313c857beb1f8524e593")
-    version("4.5.0", sha256="03c5880e0922fcff31306f7da2eb9d3a3709d9b5b75b3524dcfae85f4b181678")
+    version(
+        "5.0.2",
+        sha256="20d733f70d8edb573d8c92707f663d7d46dcaff08026cd6addbb83266679f92a",
+    )
+    version(
+        "5.0.0",
+        sha256="da1bbc694bd930a504406eb0a0018c2e317d8b2c136fb2cab8de426870efe9a8",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="e45f387fb6635fc1713714d09364204cd28fea97655b313c857beb1f8524e593",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="03c5880e0922fcff31306f7da2eb9d3a3709d9b5b75b3524dcfae85f4b181678",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="f1d99550383ed7b3a01d304eedc3d86a8e45b271aa5a80b1dd099c22fda3f745",

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -38,12 +38,12 @@ class HipRocclr(CMakePackage):
         deprecated=True,
     )
     version(
-        "5.0.0", 
+        "5.0.0",
         sha256="6b72faf8819628a5c109b2ade515ab9009606d10f11316f0d7e4c4c998d7f724",
         deprecated=True,
     )
     version(
-        "4.5.2", 
+        "4.5.2",
         sha256="6581916a3303a31f76454f12f86e020fb5e5c019f3dbb0780436a8f73792c4d1",
         deprecated=True,
     )

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -32,10 +32,26 @@ class HipRocclr(CMakePackage):
     version("5.2.0", sha256="37f5fce04348183bce2ece8bac1117f6ef7e710ca68371ff82ab08e93368bafb")
     version("5.1.3", sha256="ddee63cdc6515c90bab89572b13e1627b145916cb8ede075ef8446cbb83f0a48")
     version("5.1.0", sha256="f4f265604b534795a275af902b2c814f416434d9c9e16db81b3ed5d062187dfa")
-    version("5.0.2", sha256="34decd84652268dde865f38e66f8fb4750a08c2457fea52ad962bced82a03e5e")
-    version("5.0.0", sha256="6b72faf8819628a5c109b2ade515ab9009606d10f11316f0d7e4c4c998d7f724")
-    version("4.5.2", sha256="6581916a3303a31f76454f12f86e020fb5e5c019f3dbb0780436a8f73792c4d1")
-    version("4.5.0", sha256="ca8d6305ff0e620d9cb69ff7ac3898917db9e9b6996a7320244b48ab6511dd8e")
+    version(
+        "5.0.2",
+        sha256="34decd84652268dde865f38e66f8fb4750a08c2457fea52ad962bced82a03e5e",
+        deprecated=True,
+    )
+    version(
+        "5.0.0", 
+        sha256="6b72faf8819628a5c109b2ade515ab9009606d10f11316f0d7e4c4c998d7f724",
+        deprecated=True,
+    )
+    version(
+        "4.5.2", 
+        sha256="6581916a3303a31f76454f12f86e020fb5e5c019f3dbb0780436a8f73792c4d1",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="ca8d6305ff0e620d9cb69ff7ac3898917db9e9b6996a7320244b48ab6511dd8e",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="bda52c65f03a69a9d8ab1a118d45646d76843249fb975d67e5141e63fa3acc79",

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -50,7 +50,7 @@ class Hip(CMakePackage):
         "4.5.0",
         sha256="4026f31fb4f8050e9aa9d4294f29c3410bfb38422dbbae4236ccd65fed4d55b2",
         deprecated=True,
-        )
+    )
     version(
         "4.3.1",
         sha256="955311193819f487f9a2d64bffe07c4b8c3a0dc644dc3ad984f7c66a325bdd6f",

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -31,10 +31,26 @@ class Hip(CMakePackage):
     version("5.2.0", sha256="a6e0515d4d25865c037b546035df9c51f0882cd2700e759c266ff7e199f37c3a")
     version("5.1.3", sha256="ce755ee6e407904eba3f6b3c9efcdd48eb4f58a26b06e1892166d05f19a75973")
     version("5.1.0", sha256="47e542183699f4005c48631d96f6a1fbdf27e07ad3402ccd7b5f707c2c602266")
-    version("5.0.2", sha256="e23601e6f4f62083899ea6356fffbe88d1deb20fa61f2c970e3c0474cd8886ca")
-    version("5.0.0", sha256="ae12fcda2d955f04a51c9e794bdb0fa96539cda88b6de8e377850e68e7c2a781")
-    version("4.5.2", sha256="c2113dc3c421b8084cd507d91b6fbc0170765a464b71fb0d96bb875df368f160")
-    version("4.5.0", sha256="4026f31fb4f8050e9aa9d4294f29c3410bfb38422dbbae4236ccd65fed4d55b2")
+    version(
+        "5.0.2",
+        sha256="e23601e6f4f62083899ea6356fffbe88d1deb20fa61f2c970e3c0474cd8886ca",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="ae12fcda2d955f04a51c9e794bdb0fa96539cda88b6de8e377850e68e7c2a781",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="c2113dc3c421b8084cd507d91b6fbc0170765a464b71fb0d96bb875df368f160",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="4026f31fb4f8050e9aa9d4294f29c3410bfb38422dbbae4236ccd65fed4d55b2",
+        deprecated=True,
+        )
     version(
         "4.3.1",
         sha256="955311193819f487f9a2d64bffe07c4b8c3a0dc644dc3ad984f7c66a325bdd6f",

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -28,10 +28,26 @@ class Hipblas(CMakePackage):
     version("5.2.0", sha256="5e9091dc4ef83896f5c3bc5ade1cb5db8e1a6afc451dbba4da19d8a7ec2b6f29")
     version("5.1.3", sha256="f0fdaa851971b41b48ec2e7d640746fbd6f9f433da2020c5fd95c91a7473d9e1")
     version("5.1.0", sha256="22faba3828e50a4c4e22f569a7d6441c797a11db1d472619c01d3515a3275e92")
-    version("5.0.2", sha256="201772bfc422ecb2c50e898dccd7d3d376cf34a2b795360e34bf71326aa37646")
-    version("5.0.0", sha256="63cffe748ed4a86fc80f408cb9e8a9c6c55c22a2b65c0eb9a76360b97bbb9d41")
-    version("4.5.2", sha256="82dd82a41bbadbb2a91a2a44a5d8e0d2e4f36d3078286ed4db3549b1fb6d6978")
-    version("4.5.0", sha256="187777ed49cc7c496c897e8ba80532d458c9afbc51a960e45f96923ad896c18e")
+    version(
+        "5.0.2",
+        sha256="201772bfc422ecb2c50e898dccd7d3d376cf34a2b795360e34bf71326aa37646",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="63cffe748ed4a86fc80f408cb9e8a9c6c55c22a2b65c0eb9a76360b97bbb9d41",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="82dd82a41bbadbb2a91a2a44a5d8e0d2e4f36d3078286ed4db3549b1fb6d6978",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="187777ed49cc7c496c897e8ba80532d458c9afbc51a960e45f96923ad896c18e",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="7b1f774774de5fa3d2b777e3a262328559d56165c32aa91b002505694362e7b2",

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -21,10 +21,26 @@ class Hipcub(CMakePackage):
     version("5.2.0", sha256="ac4dc2310f0eb657e1337c93d8cc4a5d8396f9544a7336eeceb455678a1f9139")
     version("5.1.3", sha256="dc75640689b6a5e15dd3acea643266bdf114ea63efc60be8272f484cf8f04494")
     version("5.1.0", sha256="b30d51fc5fca2584f0c9a6fa8dafc9fbdda96a3acff30288e49b397f8842f705")
-    version("5.0.2", sha256="22effb18f2c38d76fa379f14c9f9ee7a11987a5d1ae4a7e837af87232c8c9183")
-    version("5.0.0", sha256="09c4f1b88aa5f50f04043d379e4960dab556e0fbdf8e25ab03d02a07c1ff7b2f")
-    version("4.5.2", sha256="bec9ba1a6aa0475475ee292e54807accc839ed001338275f48da13e3bfb77514")
-    version("4.5.0", sha256="5902fae0485789f1d1cc6b8e81d9f1b39338170d3139844d5edf0d324f9694c9")
+    version(
+        "5.0.2",
+        sha256="22effb18f2c38d76fa379f14c9f9ee7a11987a5d1ae4a7e837af87232c8c9183",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="09c4f1b88aa5f50f04043d379e4960dab556e0fbdf8e25ab03d02a07c1ff7b2f",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="bec9ba1a6aa0475475ee292e54807accc839ed001338275f48da13e3bfb77514",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="5902fae0485789f1d1cc6b8e81d9f1b39338170d3139844d5edf0d324f9694c9",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="20fcd34323c541c182655b7ff6dc6ff268c0127596f0d9993884621c2b14b67a",

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -28,10 +28,26 @@ class Hipfft(CMakePackage):
     version("5.2.0", sha256="ec37edcd61837281c403802ccc1cb01ec3fa3ba135b5ab16617961b66d4cc3e2")
     version("5.1.3", sha256="c26fa64499293b25d0686bed04feb61378c878a4bb4a6d559e6cb7be1f6bf2ec")
     version("5.1.0", sha256="1bac7761c055355216cd262cdc0450aabb383addcb739b56ba849b2e6e013fa5")
-    version("5.0.2", sha256="9ef64694f5def0d6fb98dc89e46d7a3f7d005a61348ac0b52184a3b8e84c2383")
-    version("5.0.0", sha256="867d0bdc6c9769c6cebc0c4594b24d5f3504157cdcef97a6a1668dd493ca6a15")
-    version("4.5.2", sha256="32ba6a5f50cfede3777a43794371ffb1363302131d8a0382d96df90ed7bc911a")
-    version("4.5.0", sha256="96636713bc6cdafbd5a9c1e98e816895448960c86b380fc0c3c9ffa28f670844")
+    version(
+        "5.0.2",
+        sha256="9ef64694f5def0d6fb98dc89e46d7a3f7d005a61348ac0b52184a3b8e84c2383",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="867d0bdc6c9769c6cebc0c4594b24d5f3504157cdcef97a6a1668dd493ca6a15",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="32ba6a5f50cfede3777a43794371ffb1363302131d8a0382d96df90ed7bc911a",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="96636713bc6cdafbd5a9c1e98e816895448960c86b380fc0c3c9ffa28f670844",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="429cfd40415856da8f5c2c321b612800d6826ee121df5a4e6d1596cad5b51727",

--- a/var/spack/repos/builtin/packages/hipfort/package.py
+++ b/var/spack/repos/builtin/packages/hipfort/package.py
@@ -21,10 +21,26 @@ class Hipfort(CMakePackage):
     version("5.2.0", sha256="a0af1fe62757993600a41af6bb6c4b8c6cfdfba650389645ac1f995f7623785c")
     version("5.1.3", sha256="8f8849d8d0972366bafa41be35cf6a7a59480ed584d1ddff39768cb14247e9d4")
     version("5.1.0", sha256="1ddd46c00bb6bcd539a921d6a94d858f4e4408a35cb6910186c7517f375ae8ab")
-    version("5.0.2", sha256="fcee6e62482ab15f365681dbc12bd9ae26b0fab2f2848a3c14de8ec63004a7aa")
-    version("5.0.0", sha256="af0f332fec082a03ca0403618ab20d31baadf3103e3371db9edc39dc9474ef4c")
-    version("4.5.2", sha256="14599d027b57189c6734b04ace7792d2ae5c409cf7983c0970b086fb4e634dd8")
-    version("4.5.0", sha256="48626dfb15bb5dcb044c9e1d4dc4b0654a2cd0abfc69485aa285dc20d7f40d51")
+    version(
+        "5.0.2",
+        sha256="fcee6e62482ab15f365681dbc12bd9ae26b0fab2f2848a3c14de8ec63004a7aa",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="af0f332fec082a03ca0403618ab20d31baadf3103e3371db9edc39dc9474ef4c",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="14599d027b57189c6734b04ace7792d2ae5c409cf7983c0970b086fb4e634dd8",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="48626dfb15bb5dcb044c9e1d4dc4b0654a2cd0abfc69485aa285dc20d7f40d51",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="279a35edbc0c22fa930a4355e663a86adf4d0316c5b1b6b9ccc6ee5c19c8c2e4",

--- a/var/spack/repos/builtin/packages/hipify-clang/package.py
+++ b/var/spack/repos/builtin/packages/hipify-clang/package.py
@@ -24,10 +24,26 @@ class HipifyClang(CMakePackage):
     version("5.2.0", sha256="dcd5f44daceb984bb654a209e78debf81e1cdeaf9202444a1e110b45ad6c3f4f")
     version("5.1.3", sha256="6354b08b8ab2f4c481398fb768652bae00bb78c4cec7a11d5f6c7e4cb831ddf1")
     version("5.1.0", sha256="ba792294cbdcc880e0f02e38ee352dff8d4a2c183430e13d1c5ed176bd46cfc5")
-    version("5.0.2", sha256="812bccfeb044483a1c7df89f45843afcb28d8146f348c792f082b693cbff3984")
-    version("5.0.0", sha256="06fbb3259b6d014bc24fb3c05f71026bc39ae564559d40f2ca37236044c7ba17")
-    version("4.5.2", sha256="f0d401e634642a1d6659b9163a38661ee38da1e1aceabb1f16f78f8fce048a4e")
-    version("4.5.0", sha256="1f6e1bd4b9d64eed67f519c453fa65b362a20583df1f35fd09d08de831f3c8de")
+    version(
+        "5.0.2",
+        sha256="812bccfeb044483a1c7df89f45843afcb28d8146f348c792f082b693cbff3984",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="06fbb3259b6d014bc24fb3c05f71026bc39ae564559d40f2ca37236044c7ba17",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="f0d401e634642a1d6659b9163a38661ee38da1e1aceabb1f16f78f8fce048a4e",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="1f6e1bd4b9d64eed67f519c453fa65b362a20583df1f35fd09d08de831f3c8de",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="c5754f7c2c68ea4f65cc0ffc1e8ccc30634181525b25c10817e07eaa75ca8157",

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -32,10 +32,26 @@ class Hipsolver(CMakePackage):
     version("5.2.0", sha256="96927410e0a2cc0f50172604ef6437e15d2cf4b62d22b2035f13aae21f43dc82")
     version("5.1.3", sha256="96faa799a2db8078b72f9c3b5c199179875a7c20dc1064371b22a6a63397c145")
     version("5.1.0", sha256="697ba2b2814e7ac6f79680e6455b4b5e0def1bee2014b6940f47be7d13c0ae74")
-    version("5.0.2", sha256="cabeada451686ed7904a452c5f8fd3776721507db1c06f426cd8d7189ff4a441")
-    version("5.0.0", sha256="c59a5783dbbcb6a601c0e73d85d4a64d6d2c8f46009c01cb2b9886323f11e02b")
-    version("4.5.2", sha256="9807bf1da0da25940b546cf5d5d6064d46d837907e354e10c6eeb2ef7c296a93")
-    version("4.5.0", sha256="ee1176e977736a6e6fcba507fe6f56fcb3cefd6ba741cceb28464ea8bc476cd8")
+    version(
+        "5.0.2",
+        sha256="cabeada451686ed7904a452c5f8fd3776721507db1c06f426cd8d7189ff4a441",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="c59a5783dbbcb6a601c0e73d85d4a64d6d2c8f46009c01cb2b9886323f11e02b",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="9807bf1da0da25940b546cf5d5d6064d46d837907e354e10c6eeb2ef7c296a93",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="ee1176e977736a6e6fcba507fe6f56fcb3cefd6ba741cceb28464ea8bc476cd8",
+        deprecated=True,
+    )
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -25,10 +25,26 @@ class Hipsparse(CMakePackage):
     version("5.2.0", sha256="4fdab6ec953c6d2d000687c5979077deafd37208cd722554b5a6ede1e5ba170c")
     version("5.1.3", sha256="6e6a0752654f0d391533df8cedf4b630a78ad34c99087741520c582963ce1602")
     version("5.1.0", sha256="f41329534f2ff477a0db6b7f77a72bb062f117800970c122d676db8b207ce80b")
-    version("5.0.2", sha256="a266e8b3bbdea04617260f51b3d85cc672af6ca417cae0812d04fd9702429c47")
-    version("5.0.0", sha256="0a1754508e06d3a6b17593a71a3c57a3e25d3b46d88573098fda11442853196c")
-    version("4.5.2", sha256="81ca24491fbf2bc8e5aa477a6c38776877579ac9f4241ddadeca76a579a7ebb5")
-    version("4.5.0", sha256="1049c490fc2008d701a16d14e11004e3bc5b4da993aa48b117e3c44be5677e3c")
+    version(
+        "5.0.2",
+        sha256="a266e8b3bbdea04617260f51b3d85cc672af6ca417cae0812d04fd9702429c47",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="0a1754508e06d3a6b17593a71a3c57a3e25d3b46d88573098fda11442853196c",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="81ca24491fbf2bc8e5aa477a6c38776877579ac9f4241ddadeca76a579a7ebb5",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="1049c490fc2008d701a16d14e11004e3bc5b4da993aa48b117e3c44be5677e3c",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="e5757b5213b880237ae0f24616088f79c449c2955cf2133642dbbc9c655f4691",

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -30,10 +30,26 @@ class HsaRocrDev(CMakePackage):
     version("5.2.0", sha256="529e49693dd9f6459586dd0a26f14dd77dbdf8c0b45fb54830b294eba7babd27")
     version("5.1.3", sha256="479340ec34cdffbbdb1002c85a47d1fccd23e8394631a1f001ef6130be08287d")
     version("5.1.0", sha256="a5f7245059c3d28dbc037e1e6fa3f09084e29147096dd61f7ce5560291ab330f")
-    version("5.0.2", sha256="94ce313f3b37e6571778dc6865d73dafa798cbaf4de63b5307382c4a2418e99f")
-    version("5.0.0", sha256="61644365ea2b09fa7ec22f3dbdb74f2b6b1daa34b180138da9e0c856006a373e")
-    version("4.5.2", sha256="d99eddedce0a97d9970932b64b0bb4743e47d2740e8db0288dbda7bec3cefa80")
-    version("4.5.0", sha256="fbf550f243dddfef46a716e360b77c43886fed3eef67215ab9dab1c82f3851ca")
+    version(
+        "5.0.2",
+        sha256="94ce313f3b37e6571778dc6865d73dafa798cbaf4de63b5307382c4a2418e99f",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="61644365ea2b09fa7ec22f3dbdb74f2b6b1daa34b180138da9e0c856006a373e",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="d99eddedce0a97d9970932b64b0bb4743e47d2740e8db0288dbda7bec3cefa80",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="fbf550f243dddfef46a716e360b77c43886fed3eef67215ab9dab1c82f3851ca",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="85fbd1645120b71635844090ce8bd9f7af0a3d1065d5fae476879f99ba0c0475",

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -25,10 +25,26 @@ class HsakmtRoct(CMakePackage):
     version("5.2.0", sha256="3797cb0eafbec3fd3d4a2b53f789eb8cdbab30729f13dbcca0a10bc1bafd2187")
     version("5.1.3", sha256="3c66b1aa7451571ce8bee10e601d34b93c9416b9be476610ee5685dbad81034a")
     version("5.1.0", sha256="032717e80b1aefed59f11399e575564ee86ee7c125e889f7c79c2afdfab1eb93")
-    version("5.0.2", sha256="f2a27ac18aada1dc0dba6455beb7dd7d88a4457c1917024ea372fecb03356e97")
-    version("5.0.0", sha256="1d803572eac0d6186260b5671268bad7513aa9433f9c2e99f14c8bf766c02122")
-    version("4.5.2", sha256="fb8e44226b9e393baf51bfcb9873f63ce7e4fcf7ee7f530979cf51857ea4d24b")
-    version("4.5.0", sha256="620b39959e0ee5d709b8cf6eb3cc06c8356d72838343756230c638899b10bb9a")
+    version(
+        "5.0.2",
+        sha256="f2a27ac18aada1dc0dba6455beb7dd7d88a4457c1917024ea372fecb03356e97",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="1d803572eac0d6186260b5671268bad7513aa9433f9c2e99f14c8bf766c02122",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="fb8e44226b9e393baf51bfcb9873f63ce7e4fcf7ee7f530979cf51857ea4d24b",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="620b39959e0ee5d709b8cf6eb3cc06c8356d72838343756230c638899b10bb9a",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="9d0727e746d4ae6e2709e3534d91046640be511a71c027f47db25e529fe3b4d4",

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -27,10 +27,26 @@ class LlvmAmdgpu(CMakePackage):
     version("5.2.0", sha256="0f892174111b78a02d1a00f8f46d9f80b9abb95513a7af38ecf2a5a0882fe87f")
     version("5.1.3", sha256="d236a2064363c0278f7ba1bb2ff1545ee4c52278c50640e8bb2b9cfef8a2f128")
     version("5.1.0", sha256="db5d45c4a7842a908527c1b7b8d4a40c688225a41d23cfa382eab23edfffdd10")
-    version("5.0.2", sha256="99a14394b406263576ed3d8d10334de7c78d42b349109f375d178b11492eecaf")
-    version("5.0.0", sha256="bca2db4aaab71541cac588d6a708fde60f0ebe744809bde8a3847044a1a77413")
-    version("4.5.2", sha256="36a4f7dd961cf373b743fc679bdf622089d2a905de2cfd6fd6c9e7ff8d8ad61f")
-    version("4.5.0", sha256="b71451bf26650ba06c0c5c4c7df70f13975151eaa673ef0cc77c1ab0000ccc97")
+    version(
+        "5.0.2",
+        sha256="99a14394b406263576ed3d8d10334de7c78d42b349109f375d178b11492eecaf",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="bca2db4aaab71541cac588d6a708fde60f0ebe744809bde8a3847044a1a77413",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="36a4f7dd961cf373b743fc679bdf622089d2a905de2cfd6fd6c9e7ff8d8ad61f",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="b71451bf26650ba06c0c5c4c7df70f13975151eaa673ef0cc77c1ab0000ccc97",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="b53c6b13be7d77dc93a7c62e4adbb414701e4e601e1af2d1e98da4ee07c9837f",

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -24,10 +24,26 @@ class Migraphx(CMakePackage):
     version("5.2.0", sha256="33afcdf52c6e0e3a2f939fcf30e87f712b8e8ef3633a3dc03a19fea359704925")
     version("5.1.3", sha256="686e068774500a46b6e6488370bbf5bd0bba6d19ecdb00636f951704d19c9ef2")
     version("5.1.0", sha256="6398efaef18a74f2a475aa21bd34bc7c077332a430ee3f6ba4fde6e6a6aa9f89")
-    version("5.0.2", sha256="3ef48ac03b909d1a1aa1f91f365ce64af2ce66635b6efb5ad0b207dc51ff2fd6")
-    version("5.0.0", sha256="779a91ccfa4c2576251189f0c646ff7707c3646319c7d5dd137872beb52d2953")
-    version("4.5.2", sha256="ecfd9a8e7967076f056d5b6a90b22f8919b82226443769b181193f16ebf58b83")
-    version("4.5.0", sha256="8d243a48406af7f960c03bc28a16fad931de8e008ae848799adae504cc5f1355")
+    version(
+        "5.0.2",
+        sha256="3ef48ac03b909d1a1aa1f91f365ce64af2ce66635b6efb5ad0b207dc51ff2fd6",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="779a91ccfa4c2576251189f0c646ff7707c3646319c7d5dd137872beb52d2953",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="ecfd9a8e7967076f056d5b6a90b22f8919b82226443769b181193f16ebf58b83",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="8d243a48406af7f960c03bc28a16fad931de8e008ae848799adae504cc5f1355",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="e0b04da37aed937a2b2218059c189559a15460c191b5e9b00c7366c81c90b06e",

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -25,10 +25,26 @@ class MiopenHip(CMakePackage):
     version("5.2.0", sha256="5fda69426e81df9f8fb6658e579176b9c4fcce3516fc8488d3cfd2b6f6f2b3b4")
     version("5.1.3", sha256="510461f5c5bdbcf8dc889099d1e5960b9f84bd845a9fc9154588a9898c701c1d")
     version("5.1.0", sha256="bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd")
-    version("5.0.2", sha256="e73c18c6e0791d6ca8958508d899072ce12fc6c27cf78792d0c2a5c7e34427be")
-    version("5.0.0", sha256="4a46a2bdd11a2597c83cdb0c5e208b81728fab2ff7c585dabfca5aa05ee7a4f7")
-    version("4.5.2", sha256="cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc")
-    version("4.5.0", sha256="be2f5ce962e15e62d427978422498c0ddf821b91fd40777a1ba915a2794d6fda")
+    version(
+        "5.0.2",
+        sha256="e73c18c6e0791d6ca8958508d899072ce12fc6c27cf78792d0c2a5c7e34427be",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="4a46a2bdd11a2597c83cdb0c5e208b81728fab2ff7c585dabfca5aa05ee7a4f7",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="be2f5ce962e15e62d427978422498c0ddf821b91fd40777a1ba915a2794d6fda",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="1fb2fd8b24f984174ec5338a58b7964e128b74dafb101373a41c8ed33955251a",

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -25,10 +25,26 @@ class MiopenOpencl(CMakePackage):
     version("5.2.0", sha256="5fda69426e81df9f8fb6658e579176b9c4fcce3516fc8488d3cfd2b6f6f2b3b4")
     version("5.1.3", sha256="510461f5c5bdbcf8dc889099d1e5960b9f84bd845a9fc9154588a9898c701c1d")
     version("5.1.0", sha256="bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd")
-    version("5.0.2", sha256="e73c18c6e0791d6ca8958508d899072ce12fc6c27cf78792d0c2a5c7e34427be")
-    version("5.0.0", sha256="4a46a2bdd11a2597c83cdb0c5e208b81728fab2ff7c585dabfca5aa05ee7a4f7")
-    version("4.5.2", sha256="cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc")
-    version("4.5.0", sha256="be2f5ce962e15e62d427978422498c0ddf821b91fd40777a1ba915a2794d6fda")
+    version(
+        "5.0.2",
+        sha256="e73c18c6e0791d6ca8958508d899072ce12fc6c27cf78792d0c2a5c7e34427be",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="4a46a2bdd11a2597c83cdb0c5e208b81728fab2ff7c585dabfca5aa05ee7a4f7",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="be2f5ce962e15e62d427978422498c0ddf821b91fd40777a1ba915a2794d6fda",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="1fb2fd8b24f984174ec5338a58b7964e128b74dafb101373a41c8ed33955251a",

--- a/var/spack/repos/builtin/packages/miopen-tensile/package.py
+++ b/var/spack/repos/builtin/packages/miopen-tensile/package.py
@@ -21,10 +21,26 @@ class MiopenTensile(CMakePackage):
     libraries = ["libMIOpenTensile"]
 
     version("5.1.0", sha256="f1ae57bd4df8c154357b3f17caf0cfd5f80ba16ffff67bf6219a56f1eb5f897d")
-    version("5.0.2", sha256="7b85a6a37d0905b0a3baa8361fd71a5a32ad90f3a562fd5e1af7e2ba68099fa6")
-    version("5.0.0", sha256="276ada52e2e8431851296a60df538e0171f8a1c4e9894de8954ffa9306cda2d8")
-    version("4.5.2", sha256="eae14b20aec5ad57815c85d0571b7aecc3704696147f3cdbe34287e88da0c9e9")
-    version("4.5.0", sha256="5f181f536040c0612bf889600f75951e7ec031ae5c4cb9c2c44f6ac3b15b004b")
+    version(
+        "5.0.2",
+        sha256="7b85a6a37d0905b0a3baa8361fd71a5a32ad90f3a562fd5e1af7e2ba68099fa6",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="276ada52e2e8431851296a60df538e0171f8a1c4e9894de8954ffa9306cda2d8",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="eae14b20aec5ad57815c85d0571b7aecc3704696147f3cdbe34287e88da0c9e9",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="5f181f536040c0612bf889600f75951e7ec031ae5c4cb9c2c44f6ac3b15b004b",
+        deprecated=True,
+    )
 
     tensile_architecture = ("all", "gfx906", "gfx908", "gfx803", "gfx900")
 

--- a/var/spack/repos/builtin/packages/miopengemm/package.py
+++ b/var/spack/repos/builtin/packages/miopengemm/package.py
@@ -31,10 +31,26 @@ class Miopengemm(CMakePackage):
     version("5.2.0", sha256="10458fb07b56a7fbe165595d588b7bf5f1300c57bda2f3133c3687c7bae39ea8")
     version("5.1.3", sha256="c70fc9e2a6d47356a612e24f5757bf16fdf26e671bd53a0975c1a0978da740b6")
     version("5.1.0", sha256="e2b20cdc20a745bcb7a554852e6b4bd39274c7dcc13fc19a81a282fb4dfa475f")
-    version("5.0.2", sha256="64a6bf7c902af63d85563e29361763e9daa1fd3699490a91c222b057673612cc")
-    version("5.0.0", sha256="122cfb4e79476092e84f73f48540701c90fb87e0dc20cdf39f202d92e9ff5544")
-    version("4.5.2", sha256="e778e0ccb123cd637ac459b2aecdf0fdead158580479bc0adfc9a28879e1d1c9")
-    version("4.5.0", sha256="54ec908109a91f9022b61e63e3a1b9706cdcf133ba6fb3b39a65ca0e79be7747")
+    version(
+        "5.0.2",
+        sha256="64a6bf7c902af63d85563e29361763e9daa1fd3699490a91c222b057673612cc",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="122cfb4e79476092e84f73f48540701c90fb87e0dc20cdf39f202d92e9ff5544",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="e778e0ccb123cd637ac459b2aecdf0fdead158580479bc0adfc9a28879e1d1c9",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="54ec908109a91f9022b61e63e3a1b9706cdcf133ba6fb3b39a65ca0e79be7747",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="0aee2281d9b8c625e9bda8efff3067237d6155a53f6c720dcb4e3b3ec8bf8d14",

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -30,10 +30,26 @@ class Mivisionx(CMakePackage):
     version("5.2.0", sha256="fee620a1edd3bce18b2cec9ef26ec2afe0a85d6da8a37ed713ab0d1342382503")
     version("5.1.3", sha256="62591d5caedc13832c3ccef629a88d9c2a43c884daad1124ddcb9c5f7d5470e9")
     version("5.1.0", sha256="e082415cc2fb859c53a6d6e5d72ca4529f6b4d56a4abe274dc374faaa5910513")
-    version("5.0.2", sha256="da730c2347b7f2d0cb7a262f8305750988f18e9f1eb206cf297bacaab2f6b408")
-    version("5.0.0", sha256="935113feb71eced2b5f21fffc2a90a188b4ef2fe009c50f0445504cb27fbc58c")
-    version("4.5.2", sha256="26fd7fbd2e319bf4a8657900ad2f81bba1ae66745c2ba95f2f87e33903cfe69c")
-    version("4.5.0", sha256="518834893d3fcdb7ecff179b3f3992ca1aacb30b6d95711c74918abb6f80b925")
+    version(
+        "5.0.2",
+        sha256="da730c2347b7f2d0cb7a262f8305750988f18e9f1eb206cf297bacaab2f6b408",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="935113feb71eced2b5f21fffc2a90a188b4ef2fe009c50f0445504cb27fbc58c",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="26fd7fbd2e319bf4a8657900ad2f81bba1ae66745c2ba95f2f87e33903cfe69c",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="518834893d3fcdb7ecff179b3f3992ca1aacb30b6d95711c74918abb6f80b925",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="d77d63c0f148870dcd2a39a823e94b28adef9e84d2c37dfc3b05db5de4d7af83",

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -27,10 +27,26 @@ class Rccl(CMakePackage):
     version("5.2.0", sha256="6ee3a04da0d16eb53f768a088633a7d8ecc4416a2d0c07f7ba8426ab7892b060")
     version("5.1.3", sha256="56491257f27b48bf85f4b91434a2a6e49a448337c889db181b02c8a4a260a4bc")
     version("5.1.0", sha256="02b0180857e615326f9cab775573436b9162899ad8e526830f54392b8a51b1f5")
-    version("5.0.2", sha256="a2377ad2332b93d3443a8ee74f4dd9f965ae8cbbfad473f8f57ca17905389a39")
-    version("5.0.0", sha256="80eb70243f11b80e215458a67c278cd5a655f6e486289962b92ba3504e50af5c")
-    version("4.5.2", sha256="36de0d3f3ffad491758d89c208ef72c5be5e0db766053a9c766e9c5c6a33a487")
-    version("4.5.0", sha256="f806f9f65c490abddc562cb4812e12701582bbb449e41cc4797d00e0dedf084e")
+    version(
+        "5.0.2",
+        sha256="a2377ad2332b93d3443a8ee74f4dd9f965ae8cbbfad473f8f57ca17905389a39",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="80eb70243f11b80e215458a67c278cd5a655f6e486289962b92ba3504e50af5c",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="36de0d3f3ffad491758d89c208ef72c5be5e0db766053a9c766e9c5c6a33a487",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="f806f9f65c490abddc562cb4812e12701582bbb449e41cc4797d00e0dedf084e",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="c5db71423dc654e8d2c3111e142e65c89436bc636827d95d41a09a87f44fe246",

--- a/var/spack/repos/builtin/packages/rdc/package.py
+++ b/var/spack/repos/builtin/packages/rdc/package.py
@@ -29,10 +29,26 @@ class Rdc(CMakePackage):
     version("5.2.0", sha256="2f35f74485e783f56ea724a7c69ce825f181fcdbe89de453d97ce6a3d3176ae0")
     version("5.1.3", sha256="ac3e594d7b245c787d6d9b63f551ca898d4d9403fbec0e4502f9970575e031b8")
     version("5.1.0", sha256="3cf58cb07ef241b3b73b23af83b6477194884feba642584a491e67deeceff038")
-    version("5.0.2", sha256="9e21fe7e9dd02b69425dab6be22a85469fee072bcebd2d2957633dfad8b45574")
-    version("5.0.0", sha256="68d45a319dc4222d94e1fb1ce10df5f3464de0b745d0d2e9aebbf273493adcc5")
-    version("4.5.2", sha256="1b467e2a473374488292ca1680562ec4e798f43847ea6464453f8f8297f12d8d")
-    version("4.5.0", sha256="e9bc53d068e9a4fdccff587e34c7fe0880f003a18652cd48c29faf031dd2c98f")
+    version(
+        "5.0.2",
+        sha256="9e21fe7e9dd02b69425dab6be22a85469fee072bcebd2d2957633dfad8b45574",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="68d45a319dc4222d94e1fb1ce10df5f3464de0b745d0d2e9aebbf273493adcc5",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="1b467e2a473374488292ca1680562ec4e798f43847ea6464453f8f8297f12d8d",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="e9bc53d068e9a4fdccff587e34c7fe0880f003a18652cd48c29faf031dd2c98f",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="aae028aae61eb0f4dd30708c4bbb8c5c57a426f10dae9b967b81500fb106d981",

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -29,10 +29,26 @@ class Rocalution(CMakePackage):
     version("5.2.0", sha256="a5aac471bbec87d019ad7c6db779c73327ad40ecdea09dc5ab2106e62cd6b7eb")
     version("5.1.3", sha256="7febe8179f120cbe58ea255bc233ad5d1b4c106f3934eb8e670135a8b7bd09c7")
     version("5.1.0", sha256="d9122189103ebafe7ec5aeb50e60f3e02af5c2747021f9071aab91e7f875c29e")
-    version("5.0.2", sha256="b01adaf858b9c3683523b087a55fafb655864f5db8e2a1acdbf588f53d6972e2")
-    version("5.0.0", sha256="df9e7eacb8cc1bd5c7c4071b20356a885ee8ae13e6ab5afdabf88a272ab32c7e")
-    version("4.5.2", sha256="8be38922320cd9d4fc465a30f0322843849f62c0c7dad2bdbe52290a1b69d2a0")
-    version("4.5.0", sha256="191629fef002fd1a0793a6b4fe5a6b8c43ac49d3cd173ba64a91359f54659e5b")
+    version(
+        "5.0.2",
+        sha256="b01adaf858b9c3683523b087a55fafb655864f5db8e2a1acdbf588f53d6972e2",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="df9e7eacb8cc1bd5c7c4071b20356a885ee8ae13e6ab5afdabf88a272ab32c7e",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="8be38922320cd9d4fc465a30f0322843849f62c0c7dad2bdbe52290a1b69d2a0",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="191629fef002fd1a0793a6b4fe5a6b8c43ac49d3cd173ba64a91359f54659e5b",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="d3a7b9290f99bdc7382d1d5259c3f5e0e66a43aef4d05b7c2cd78b0e4a5c59bc",

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -27,10 +27,26 @@ class Rocblas(CMakePackage):
     version("5.2.0", sha256="b178b7db5f0af55b21b5f744b8825f5e002daec69b4688e50df2bca2fac155bd")
     version("5.1.3", sha256="915374431db8f0cecdc2bf318a0ad33c3a8eceedc461d7a06b92ccb02b07313c")
     version("5.1.0", sha256="efa0c424b5ada697314aa8a78c19c93ade15f1612c4bfc8c53d71d1c9719aaa3")
-    version("5.0.2", sha256="358a0902fc279bfc80205659a90e96269cb7d83a80386b121e4e3dfe221fec23")
-    version("5.0.0", sha256="4b01fba937ada774f09c7ccb5e9fdc66e1a5d46c130be833e3706e6b5841b1da")
-    version("4.5.2", sha256="15d725e38f91d1ff7772c4204b97c1515af58fa7b8ec2a2014b99b6d337909c4")
-    version("4.5.0", sha256="22d15a1389a10f1324f5e0ceac1a6ec0758a2801a18419a55e37e2bc63793eaf")
+    version(
+        "5.0.2",
+        sha256="358a0902fc279bfc80205659a90e96269cb7d83a80386b121e4e3dfe221fec23",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="4b01fba937ada774f09c7ccb5e9fdc66e1a5d46c130be833e3706e6b5841b1da",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="15d725e38f91d1ff7772c4204b97c1515af58fa7b8ec2a2014b99b6d337909c4",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="22d15a1389a10f1324f5e0ceac1a6ec0758a2801a18419a55e37e2bc63793eaf",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="ad3c09573cb2bcfdb12bfb5a05e85f9c95073993fd610981df24dda792727b4b",

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -24,10 +24,26 @@ class Rocfft(CMakePackage):
     version("5.2.0", sha256="ebba280b7879fb4bc529a68072b98d4e815201f90d24144d672094bc241743d4")
     version("5.1.3", sha256="b4fcd03c1b07d465bb307ec33cc7fb50036dff688e497c5e52b2dec37f4cb618")
     version("5.1.0", sha256="dc11c9061753ae43a9d5db9c4674aa113a8adaf50818b2701cbb940894147f68")
-    version("5.0.2", sha256="30d4bd5fa85185ddafc69fa6d284edd8033c9d77d1e351fa328267242995eb0a")
-    version("5.0.0", sha256="c16374dac2f85fbaf145511653e93f6db3151425ce39b282187745c716b67405")
-    version("4.5.2", sha256="2724118ca00b9e97ac9578fe0b7e64a82d86c4fb0246d0da88d8ddd9c608b1e1")
-    version("4.5.0", sha256="045c1cf1737db6e7ee332c274dacdb565f99c976ed4cc5626a116878dc80a48c")
+    version(
+        "5.0.2",
+        sha256="30d4bd5fa85185ddafc69fa6d284edd8033c9d77d1e351fa328267242995eb0a",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="c16374dac2f85fbaf145511653e93f6db3151425ce39b282187745c716b67405",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="2724118ca00b9e97ac9578fe0b7e64a82d86c4fb0246d0da88d8ddd9c608b1e1",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="045c1cf1737db6e7ee332c274dacdb565f99c976ed4cc5626a116878dc80a48c",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="fcdc4d12b93d967b6f992b4045da98433eabf2ee0ba84fc6b6f81e380584fbc9",

--- a/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
+++ b/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
@@ -24,10 +24,26 @@ class RocmBandwidthTest(CMakePackage):
     version("5.2.0", sha256="046f2a6984c62899f57a557490136fbe7ab28e2fd334750abac71b03609226ef")
     version("5.1.3", sha256="6a6e7fb998c886951db75dcf34dca523d9caaff8d0ccf2b7431504a1808b1ff3")
     version("5.1.0", sha256="18fe51f0ba61760fc89ffc81f737fd4fa20fb4b00df3f35145be77c3e0a6162b")
-    version("5.0.2", sha256="c93f7dbb37233aa32d81057fa8b3fa88d7c7be9b7916430b5ffc701600a5ff45")
-    version("5.0.0", sha256="b33c6a12ad8de1d7ea9b8b380b8fa5db6b601ed426c3d3940134863f7d10740f")
-    version("4.5.2", sha256="559ca7ef582d81047c5dd5a908f3989cb2694e89577f7f556214e324ba65e75e")
-    version("4.5.0", sha256="4d20a6017ca6975df98f3ca61ba95fa0c7c62fbf63cd6abae3396c30a423933f")
+    version(
+        "5.0.2",
+        sha256="c93f7dbb37233aa32d81057fa8b3fa88d7c7be9b7916430b5ffc701600a5ff45",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="b33c6a12ad8de1d7ea9b8b380b8fa5db6b601ed426c3d3940134863f7d10740f",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="559ca7ef582d81047c5dd5a908f3989cb2694e89577f7f556214e324ba65e75e",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="4d20a6017ca6975df98f3ca61ba95fa0c7c62fbf63cd6abae3396c30a423933f",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="a4804c28586457c231594b4e7689872eaf91972119d892325468f3fe8fdbe5ef",

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -22,10 +22,26 @@ class RocmClangOcl(CMakePackage):
     version("5.2.0", sha256="a2059f6aeccc119abbd444cb37128e00e4854e22a88a47f120f8f8b947d862c5")
     version("5.1.3", sha256="e19ee15f26fc03309398ac73cc738508c0e1617deccfd667d369a3948b5d3552")
     version("5.1.0", sha256="38d9e2e98cff1a262fdd45c3239fd76a9f6ad5eff38a31aa19c3bb0faea53375")
-    version("5.0.2", sha256="5e8f39200227388817024ee7ce46a996e43e433ed308f8d5e8e4c03629d8a5e7")
-    version("5.0.0", sha256="0dff230754b790a417eb3d6be6f50c3727f944e0157686100354eba1e47d30f3")
-    version("4.5.2", sha256="8cc7b8658e81ef378c16bbb00fc6b29140c850da70adc4e520ecec9b4517beb8")
-    version("4.5.0", sha256="b9ab42629c8697f8ffdae99ffd25f939161fa8a7a1c49a9ce19d8b207bedbbae")
+    version(
+        "5.0.2",
+        sha256="5e8f39200227388817024ee7ce46a996e43e433ed308f8d5e8e4c03629d8a5e7",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="0dff230754b790a417eb3d6be6f50c3727f944e0157686100354eba1e47d30f3",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="8cc7b8658e81ef378c16bbb00fc6b29140c850da70adc4e520ecec9b4517beb8",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="b9ab42629c8697f8ffdae99ffd25f939161fa8a7a1c49a9ce19d8b207bedbbae",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="12461d4fd4f3f40710d2c041cfee37da83ccda9d2761d7708335349e7ec5ad87",

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -25,10 +25,26 @@ class RocmCmake(CMakePackage):
     version("5.2.0", sha256="be8646c4f7babfe9a103c97d0e9f369322f8ac6cfa528edacdbdcf7f3ef44943")
     version("5.1.3", sha256="19b2da0d56300aab454655b57435ab3ed9e101ecb96561336ea8865bbd993c23")
     version("5.1.0", sha256="2eff47b7cf5bd56d465ff3c110eb936d31860df60182a82ba511ba11bbcf23fc")
-    version("5.0.2", sha256="86a4ae0f84dcf5be95a252295eb732d6a7a271297eed37800a9d492c16474d0c")
-    version("5.0.0", sha256="45eb958fac33aafea86fb498127ebf8f567646ce9d7288d46afbd087500553a1")
-    version("4.5.2", sha256="85f2ef51327e4b09d81a221b4ad31c97923dabc1bc8ff127dd6c570742185751")
-    version("4.5.0", sha256="c77b71454010adbeea5357773aa98dd0725f655f51a411815807cabf29258395")
+    version(
+        "5.0.2",
+        sha256="86a4ae0f84dcf5be95a252295eb732d6a7a271297eed37800a9d492c16474d0c",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="45eb958fac33aafea86fb498127ebf8f567646ce9d7288d46afbd087500553a1",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="85f2ef51327e4b09d81a221b4ad31c97923dabc1bc8ff127dd6c570742185751",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="c77b71454010adbeea5357773aa98dd0725f655f51a411815807cabf29258395",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="acf2a58e2cd486f473194bf01247c52dbf20bd5f6465810fb221470298f2557f",

--- a/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
@@ -29,10 +29,26 @@ class RocmDbgapi(CMakePackage):
     version("5.2.0", sha256="44f0528a7583bc59b6585166d2289970b20115c4c70e3bcc218aff19fc242b3f")
     version("5.1.3", sha256="880f80ebf741e3451676837f720551e02cffd0b9346ca4dfa6cf7f7043282f2b")
     version("5.1.0", sha256="406db4b20bda12f6f32cbef88b03110aa001bf7bef6676f36e909b53c8354e43")
-    version("5.0.2", sha256="b7554dfe96bda6c2ee762ad6e3e5f91f0f52b5a525e3fb29d5e1fe6f003652b5")
-    version("5.0.0", sha256="cff72d7fe43ff791c4117fe87d57314cbebdbcb70002a0411b8a44761012a495")
-    version("4.5.2", sha256="9fa574e8389ef69d116caf714af2f938777e0aeeaadd7fad451cf5d2e6699c6e")
-    version("4.5.0", sha256="583bbf18df593f376c4cc70f25b68c191bd38fde20a336c0f5c8e5d85fda2fcf")
+    version(
+        "5.0.2",
+        sha256="b7554dfe96bda6c2ee762ad6e3e5f91f0f52b5a525e3fb29d5e1fe6f003652b5",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="cff72d7fe43ff791c4117fe87d57314cbebdbcb70002a0411b8a44761012a495",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="9fa574e8389ef69d116caf714af2f938777e0aeeaadd7fad451cf5d2e6699c6e",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="583bbf18df593f376c4cc70f25b68c191bd38fde20a336c0f5c8e5d85fda2fcf",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="dddf2549ad6bb806f7e5d5a5336f5a00fe87a124f2a778be18ec4dc41f891912",

--- a/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
+++ b/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
@@ -24,10 +24,26 @@ class RocmDebugAgent(CMakePackage):
     version("5.2.0", sha256="f8e8d5ad691033d0c0f1850d69f35c98ba9722ab4adc66c4251f22257f56f0a2")
     version("5.1.3", sha256="ef26130829f3348d503669467ab1ea39fb67d943d88d64e7ac04b9617ec6067d")
     version("5.1.0", sha256="e0ceeef575d8645385bc6e4c9c3accaa192a93c42d83545cf5626c848f59806b")
-    version("5.0.2", sha256="4ec3cdedc4ba774d05c3dc972186b3181b3aa823af08f3843238961d5ef90e57")
-    version("5.0.0", sha256="fb8ebe136bfa815116453bdcb4afb9617ab488f54501434c72eed9706857be3f")
-    version("4.5.2", sha256="85c7f19485defd9a58716fffdd1a0e065ed7f779c3f124467fca18755bc634a6")
-    version("4.5.0", sha256="6486b1a8515da4711d3c85f8e41886f8fe6ba37ca2c63664f00c811f6296ac20")
+    version(
+        "5.0.2",
+        sha256="4ec3cdedc4ba774d05c3dc972186b3181b3aa823af08f3843238961d5ef90e57",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="fb8ebe136bfa815116453bdcb4afb9617ab488f54501434c72eed9706857be3f",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="85c7f19485defd9a58716fffdd1a0e065ed7f779c3f124467fca18755bc634a6",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="6486b1a8515da4711d3c85f8e41886f8fe6ba37ca2c63664f00c811f6296ac20",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="7bee6be6c29883f03f47a8944c0d50b7cf43a6b5eeed734602f521c3c40a18d0",

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -24,10 +24,26 @@ class RocmDeviceLibs(CMakePackage):
     version("5.2.0", sha256="901674bc941115c72f82c5def61d42f2bebee687aefd30a460905996f838e16c")
     version("5.1.3", sha256="c41958560ec29c8bf91332b9f668793463904a2081c330c0d828bf2f91d4f04e")
     version("5.1.0", sha256="47dbcb41fb4739219cadc9f2b5f21358ed2f9895ce786d2f7a1b2c4fd044d30f")
-    version("5.0.2", sha256="49cfa8f8fc276ba27feef40546788a2aabe259a924a97af8bef24e295d19aa5e")
-    version("5.0.0", sha256="83ed7aa1c9322b4fc1f57c48a63fc7718eb4195ee6fde433009b4bc78cb363f0")
-    version("4.5.2", sha256="50e9e87ecd6b561cad0d471295d29f7220e195528e567fcabe2ec73838979f61")
-    version("4.5.0", sha256="78412fb10ceb215952b5cc722ed08fa82501b5848d599dc00744ae1bdc196f77")
+    version(
+        "5.0.2",
+        sha256="49cfa8f8fc276ba27feef40546788a2aabe259a924a97af8bef24e295d19aa5e",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="83ed7aa1c9322b4fc1f57c48a63fc7718eb4195ee6fde433009b4bc78cb363f0",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="50e9e87ecd6b561cad0d471295d29f7220e195528e567fcabe2ec73838979f61",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="78412fb10ceb215952b5cc722ed08fa82501b5848d599dc00744ae1bdc196f77",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="a7291813168e500bfa8aaa5d1dccf5250764ddfe27535def01b51eb5021d4592",

--- a/var/spack/repos/builtin/packages/rocm-gdb/package.py
+++ b/var/spack/repos/builtin/packages/rocm-gdb/package.py
@@ -22,10 +22,26 @@ class RocmGdb(AutotoolsPackage):
     version("5.2.0", sha256="70c5b443292b9bb114844eb63b72cfab1b65f083511ee39d55db7a633c63bf5a")
     version("5.1.3", sha256="81f5e368facdcc424a37cb5809f0b436bedb9a6d9af4d17785b3c446ab0a7821")
     version("5.1.0", sha256="cf638149b269f838aaec59c5801098b9c0fc42f6c86a39309a8995b56978b424")
-    version("5.0.2", sha256="0eced8cd5a2996cb4bcf254f2bd9defe24112d21c2f750e98f784ecdf94ba5c9")
-    version("5.0.0", sha256="aa311fb557bd95e35c6e4dfd245188f35c294a93bacb77fe4d3b178b1d0097e8")
-    version("4.5.2", sha256="e278abf50f1758ce396b26a6719d0af09a6053c195516a44ec9b2be925d79203")
-    version("4.5.0", sha256="dd37c8b1ea6bb41b1263183637575d7bf4746cabc573dbff888e23b0379877b0")
+    version(
+        "5.0.2",
+        sha256="0eced8cd5a2996cb4bcf254f2bd9defe24112d21c2f750e98f784ecdf94ba5c9",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="aa311fb557bd95e35c6e4dfd245188f35c294a93bacb77fe4d3b178b1d0097e8",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="e278abf50f1758ce396b26a6719d0af09a6053c195516a44ec9b2be925d79203",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="dd37c8b1ea6bb41b1263183637575d7bf4746cabc573dbff888e23b0379877b0",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="995756a24b1e1510647dac1476a3a9a8e3af8e9fd9f4af1d00dd2db28e7a4ef2",

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -34,10 +34,26 @@ class RocmOpencl(CMakePackage):
     version("5.2.0", sha256="80f73387effdcd987a150978775a87049a976aa74f5770d4420847b004dd59f0")
     version("5.1.3", sha256="44a7fac721abcd93470e1a7e466bdea0c668c253dee93e4f1ea9a72dbce4ba31")
     version("5.1.0", sha256="362d81303048cf7ed5d2f69fb65ed65425bc3da4734fff83e3b8fbdda51b0927")
-    version("5.0.2", sha256="3edb1992ba28b4a7f82dd66fbd121f62bd859c1afb7ceb47fa856bd68feedc95")
-    version("5.0.0", sha256="2aa3a628b336461f83866c4e76225ef5338359e31f802987699d6308515ae1be")
-    version("4.5.2", sha256="96b43f314899707810db92149caf518bdb7cf39f7c0ad86e98ad687ffb0d396d")
-    version("4.5.0", sha256="3a163aed24619b3faf5e8ba17325bdcedd1667a904ea20914ac6bdd33fcdbca8")
+    version(
+        "5.0.2",
+        sha256="3edb1992ba28b4a7f82dd66fbd121f62bd859c1afb7ceb47fa856bd68feedc95",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="2aa3a628b336461f83866c4e76225ef5338359e31f802987699d6308515ae1be",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="96b43f314899707810db92149caf518bdb7cf39f7c0ad86e98ad687ffb0d396d",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="3a163aed24619b3faf5e8ba17325bdcedd1667a904ea20914ac6bdd33fcdbca8",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="7f98f7d4707b4392f8aa7017aaca9e27cb20263428a1a81fb7ec7c552e60c4ca",

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -153,17 +153,61 @@ class RocmOpenmpExtras(Package):
     version("5.2.0", sha256=versions_dict["5.2.0"]["aomp"])
     version("5.1.3", sha256=versions_dict["5.1.3"]["aomp"])
     version("5.1.0", sha256=versions_dict["5.1.0"]["aomp"])
-    version("5.0.2", sha256=versions_dict["5.0.2"]["aomp"])
-    version("5.0.0", sha256=versions_dict["5.0.0"]["aomp"])
-    version("4.5.2", sha256=versions_dict["4.5.2"]["aomp"])
-    version("4.5.0", sha256=versions_dict["4.5.0"]["aomp"])
-    version("4.3.1", sha256=versions_dict["4.3.1"]["aomp"])
-    version("4.3.0", sha256=versions_dict["4.3.0"]["aomp"])
-    version("4.2.0", sha256=versions_dict["4.2.0"]["aomp"])
-    version("4.1.0", sha256=versions_dict["4.1.0"]["aomp"])
-    version("4.0.0", sha256=versions_dict["4.0.0"]["aomp"])
-    version("3.10.0", sha256=versions_dict["3.10.0"]["aomp"])
-    version("3.9.0", sha256=versions_dict["3.9.0"]["aomp"])
+    version(
+        "5.0.2",
+        sha256=versions_dict["5.0.2"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256=versions_dict["5.0.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256=versions_dict["4.5.2"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256=versions_dict["4.5.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.3.1",
+        sha256=versions_dict["4.3.1"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.3.0",
+        sha256=versions_dict["4.3.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.2.0",
+        sha256=versions_dict["4.2.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.1.0",
+        sha256=versions_dict["4.1.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "4.0.0",
+        sha256=versions_dict["4.0.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "3.10.0",
+        sha256=versions_dict["3.10.0"]["aomp"],
+        deprecated=True,
+    )
+    version(
+        "3.9.0",
+        sha256=versions_dict["3.9.0"]["aomp"],
+        deprecated=True,
+    )
 
     depends_on("cmake@3:", type="build")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-from typing import Dict
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -29,10 +29,26 @@ class RocmSmiLib(CMakePackage):
     version("5.2.0", sha256="7bce567ff4e087598eace2cae72d24c98b2bcc93af917eafa61ec9d1e8ef4477")
     version("5.1.3", sha256="8a19ce60dc9221545aa50e83e88d8c4be9bf7cde2425cefb13710131dc1d7b1b")
     version("5.1.0", sha256="21b31b43015b77a9119cf4c1d4ff3864f9ef1f34e2a52a38f985a3f710dc5f87")
-    version("5.0.2", sha256="a169129e4ecd1cca134039dc1bf91e1b3721768781abfae4ae61fad60a633472")
-    version("5.0.0", sha256="9d0e560072f815b441528a5d6124e901570a5a04e9cff1f21329861609b37203")
-    version("4.5.2", sha256="d4a34db26852defb62817aa44f08ef96d678c63a6f33425bc9d48c18e5e37b7a")
-    version("4.5.0", sha256="43a2cc2ec548cc28698ca4fa01a947a4414febd433936a8d9770bf6f6ed55e4f")
+    version(
+        "5.0.2",
+        sha256="a169129e4ecd1cca134039dc1bf91e1b3721768781abfae4ae61fad60a633472",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="9d0e560072f815b441528a5d6124e901570a5a04e9cff1f21329861609b37203",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="d4a34db26852defb62817aa44f08ef96d678c63a6f33425bc9d48c18e5e37b7a",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="43a2cc2ec548cc28698ca4fa01a947a4414febd433936a8d9770bf6f6ed55e4f",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="ea2f9d8a9999e4aac1cb969e6bf2a9f0b6d02f29d0c319b36cce26412ab8a8b0",

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -23,10 +23,26 @@ class RocmTensile(CMakePackage):
     version("5.2.0", sha256="aa6107944482ad278111d11d2e926393423fc70e7e1838574fe7ad9f553bdacf")
     version("5.1.3", sha256="87020ca268e3a1ed8853f629839d6497764d862bd70b8775e98de439f6c89f1d")
     version("5.1.0", sha256="0ac86a623597152c5b1d8bb5634aad3e55afa51959476aaa5e9869d259ddf375")
-    version("5.0.2", sha256="c6130de3b02f4f10635d18f913b3b88ea754fce2842c680e9caf5a6781da8f37")
-    version("5.0.0", sha256="2a814ee8576ff1f06cc5ac4556300c8e7cbf77ef8c87b56992f3e66d8862f213")
-    version("4.5.2", sha256="da20256224749c0a8b44aaede25fbcd66cfeac483081af5d22f1d1fcf49dffc1")
-    version("4.5.0", sha256="26a27659c864b5372ca4407671c6e8d4be3bbc05c64fc18762ad570cd3b3af1f")
+    version(
+        "5.0.2",
+        sha256="c6130de3b02f4f10635d18f913b3b88ea754fce2842c680e9caf5a6781da8f37",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="2a814ee8576ff1f06cc5ac4556300c8e7cbf77ef8c87b56992f3e66d8862f213",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="da20256224749c0a8b44aaede25fbcd66cfeac483081af5d22f1d1fcf49dffc1",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="26a27659c864b5372ca4407671c6e8d4be3bbc05c64fc18762ad570cd3b3af1f",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="6fce0ac22051a454fe984283766eb473dc50752cd30bad05acb3dbde6ef4f8b1",

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -26,10 +26,26 @@ class RocmValidationSuite(CMakePackage):
     version("5.2.0", sha256="2dfef5d66f544230957ac9aaf647b2f1dccf3cc7592cc322cae9fbdcf3321365")
     version("5.1.3", sha256="0140a4128c31749c078d9e1dc863cbbd690efc65843c34a4b80f0056e5b8c7b6")
     version("5.1.0", sha256="d9b9771b885bd94e5d0352290d3fe0fa12f94ce3f384c3844002cd7614880010")
-    version("5.0.2", sha256="f249fe700a5a96c6dabf12130a3e366ae6025fe1442a5d11d08801d6c0265af4")
-    version("5.0.0", sha256="d4ad31db0377096117714c9f4648cb37d6808ce618cd0bb5e4cc89cc9b4e37fd")
-    version("4.5.2", sha256="e2a128395367a60a17d4d0f62daee7d34358c75332ed582243b18da409589ab8")
-    version("4.5.0", sha256="54181dd5a132a7f4a34a9316d8c00d78343ec45c069c586134ce4e61e68747f5")
+    version(
+        "5.0.2",
+        sha256="f249fe700a5a96c6dabf12130a3e366ae6025fe1442a5d11d08801d6c0265af4",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="d4ad31db0377096117714c9f4648cb37d6808ce618cd0bb5e4cc89cc9b4e37fd",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="e2a128395367a60a17d4d0f62daee7d34358c75332ed582243b18da409589ab8",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="54181dd5a132a7f4a34a9316d8c00d78343ec45c069c586134ce4e61e68747f5",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="779a3b0afb53277e41cf863185e87f95d9b2bbb748fcb062cbb428d0b510fb69",

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -43,7 +43,7 @@ class Rocminfo(CMakePackage):
         "4.5.0",
         sha256="421ed55192780eb478f0341fd1ce47a0dd3ffafbec9d7a02109a411878a58ee5",
         deprecated=True,
-        )
+    )
     version(
         "4.3.1",
         sha256="d042947d3f29e943a2e3294a2a2d759ca436cebe31151ce048e49bc4f02d6993",

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -36,7 +36,7 @@ class Rocminfo(CMakePackage):
     )
     version(
         "4.5.2",
-        sha256="5ea839cd1f317cbc72ea1e3634a75f33a458ba0cb5bf48377f08bb329c29222d"
+        sha256="5ea839cd1f317cbc72ea1e3634a75f33a458ba0cb5bf48377f08bb329c29222d",
         deprecated=True,
     )
     version(

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -24,10 +24,26 @@ class Rocminfo(CMakePackage):
     version("5.2.0", sha256="e721eb81efd384abd22ff01cdcbb6245b11084dc11a867c74c8ad6b028aa0404")
     version("5.1.3", sha256="7aecd7b189e129b77c8f2af70be2926a0f3a5ee89814879bc8477924a7e6f2ae")
     version("5.1.0", sha256="76f6cc9e69d9fc7e692e5c7db35e89079d3b1d2d47632e4742d612e743c396d3")
-    version("5.0.2", sha256="5fd970f08c5d6591efe7379ece564ce5580cba87fb6237531dabbd5adcb6a899")
-    version("5.0.0", sha256="43e025de31bffa335d9cb682649add886afdd02c92090ee63e9bf77b3aaaa75b")
-    version("4.5.2", sha256="5ea839cd1f317cbc72ea1e3634a75f33a458ba0cb5bf48377f08bb329c29222d")
-    version("4.5.0", sha256="421ed55192780eb478f0341fd1ce47a0dd3ffafbec9d7a02109a411878a58ee5")
+    version(
+        "5.0.2",
+        sha256="5fd970f08c5d6591efe7379ece564ce5580cba87fb6237531dabbd5adcb6a899",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="43e025de31bffa335d9cb682649add886afdd02c92090ee63e9bf77b3aaaa75b",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="5ea839cd1f317cbc72ea1e3634a75f33a458ba0cb5bf48377f08bb329c29222d"
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="421ed55192780eb478f0341fd1ce47a0dd3ffafbec9d7a02109a411878a58ee5",
+        deprecated=True,
+        )
     version(
         "4.3.1",
         sha256="d042947d3f29e943a2e3294a2a2d759ca436cebe31151ce048e49bc4f02d6993",

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -21,10 +21,26 @@ class Rocprim(CMakePackage):
     version("5.2.0", sha256="f99eb7d2f6b1445742fba631a0dc8bb0d464a767a9c4fb79ac865d9570fe747b")
     version("5.1.3", sha256="b5a08d2e76388bd1ffa6c946009928fe95de846ab6b65a6475998070c0cf6dc1")
     version("5.1.0", sha256="dfe106c01155e00ed816f0231d1576ff8c08750cc8278fa453926f388dc6fe48")
-    version("5.0.2", sha256="a4280f15d470699a1c6a5f86bdd951c1387e0af227c6bee6f81cee658406f4b0")
-    version("5.0.0", sha256="0e7e7bda6a09b70a07ddd926986882df0c8d8ff3e0a34e12cb6d44f7d0a5840e")
-    version("4.5.2", sha256="0dc673847e67db672f2e239f299206fe16c324005ddd2e92c7cb7725bb6f4fa6")
-    version("4.5.0", sha256="6f0ca1da9a93064af662d6c61fbdb56bb313f8edca85615ead0dd284eb481089")
+    version(
+        "5.0.2",
+        sha256="a4280f15d470699a1c6a5f86bdd951c1387e0af227c6bee6f81cee658406f4b0",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="0e7e7bda6a09b70a07ddd926986882df0c8d8ff3e0a34e12cb6d44f7d0a5840e",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="0dc673847e67db672f2e239f299206fe16c324005ddd2e92c7cb7725bb6f4fa6",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="6f0ca1da9a93064af662d6c61fbdb56bb313f8edca85615ead0dd284eb481089",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="d29ffcb5dd1c6155c586b9952fa4c11b717d90073feb083db6b03ea74746194b",

--- a/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
@@ -24,10 +24,26 @@ class RocprofilerDev(CMakePackage):
     version("5.2.0", sha256="1f4db27b56ef1863d4c9e1d96bac9117d66be45156d0637cfe4fd38cae61a23a")
     version("5.1.3", sha256="eca7be451c7bf000fd9c75683e7f5dfbed32dbb385b5ac685d2251ee8c3abc96")
     version("5.1.0", sha256="4a1c6ed887b0159392406af8796508df2794353a4c3aacc801116044fb4a10a5")
-    version("5.0.2", sha256="48f58c3c16dd45fead2086f89a175f74636e81bc2437e30bb6e9361b1083e71d")
-    version("5.0.0", sha256="2ed521f400e4aafd17405c2f9ad2fb3b906a982d3767b233122d9c2964c3245f")
-    version("4.5.2", sha256="baa59826f8fb984993c03d05e2e3cdf0b830b08f8056b18ba206dfbaa367aca9")
-    version("4.5.0", sha256="9b47b086d28fc831dbe0f83ec7e4640057b97edc961f2f050a0968633f32a06b")
+    version(
+        "5.0.2",
+        sha256="48f58c3c16dd45fead2086f89a175f74636e81bc2437e30bb6e9361b1083e71d",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="2ed521f400e4aafd17405c2f9ad2fb3b906a982d3767b233122d9c2964c3245f",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="baa59826f8fb984993c03d05e2e3cdf0b830b08f8056b18ba206dfbaa367aca9",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="9b47b086d28fc831dbe0f83ec7e4640057b97edc961f2f050a0968633f32a06b",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="c6f5fa192c9cdb32553d24ed5c847107d312042e39fa3dd17c83e237c9542a2d",

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -27,10 +27,26 @@ class Rocrand(CMakePackage):
     version("5.2.0", sha256="ab3057e7c17a9fbe584f89ef98ec92a74d638a98d333e7d0f64daf7bc9051e38")
     version("5.1.3", sha256="4a19e1bcb60955a02a73ad64594c23886d6749afe06b0104e2b877dbe02c8d1c")
     version("5.1.0", sha256="0c6f114a775d0b38be71f3f621a10bde2104a1f655d5d68c5fecb79b8b51a815")
-    version("5.0.2", sha256="2dbce2a7fb273c2f9456c002adf3a510b9ec79f2ff32dfccdd59948f3ddb1505")
-    version("5.0.0", sha256="356a03a74d6d5df3ae2d38da07929f23d90bb4dee71f88792c25c25069e673bc")
-    version("4.5.2", sha256="1523997a21437c3b74d47a319d81f8cc44b8e96ec5174004944f2fb4629900db")
-    version("4.5.0", sha256="fd391f81b9ea0b57808d93e8b72d86eec1b4c3529180dfb99ed6d3e2aa1285c2")
+    version(
+        "5.0.2",
+        sha256="2dbce2a7fb273c2f9456c002adf3a510b9ec79f2ff32dfccdd59948f3ddb1505",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="356a03a74d6d5df3ae2d38da07929f23d90bb4dee71f88792c25c25069e673bc",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="1523997a21437c3b74d47a319d81f8cc44b8e96ec5174004944f2fb4629900db",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="fd391f81b9ea0b57808d93e8b72d86eec1b4c3529180dfb99ed6d3e2aa1285c2",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="b3d6ae0cdbbdfb56a73035690f8cb9e173fec1ccaaf9a4c5fdbe5e562e50c901",

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -40,10 +40,26 @@ class Rocsolver(CMakePackage):
     version("5.2.0", sha256="94d46ebe1266eaa05df50c1789dc27d3f2dbf3cb5af156e757777a82ed6ef356")
     version("5.1.3", sha256="5a8f3b95ac9a131c31538196e954ea53b863009c092cce0c0ef869a0cd5dd554")
     version("5.1.0", sha256="88de515a6e75eaa3c50c9c8ae1e7ae8e3b46e712e388f44f79b63fefa9fc0831")
-    version("5.0.2", sha256="298e0903f1ba8074055ab072690f967062d6e06a9371574de23e4e38d2997688")
-    version("5.0.0", sha256="d444ad5348eb8a2c04646ceae6923467a0e775441f2c73150892e228e585b2e1")
-    version("4.5.2", sha256="4639322bd1e77fedfdeb9032633bde6211a0b1cc16a612db7754f873f18a492f")
-    version("4.5.0", sha256="0295862da941f31f4d43b19195b79331bd17f5968032f75c89d2791a6f8c1e8c")
+    version(
+        "5.0.2",
+        sha256="298e0903f1ba8074055ab072690f967062d6e06a9371574de23e4e38d2997688",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="d444ad5348eb8a2c04646ceae6923467a0e775441f2c73150892e228e585b2e1",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="4639322bd1e77fedfdeb9032633bde6211a0b1cc16a612db7754f873f18a492f",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="0295862da941f31f4d43b19195b79331bd17f5968032f75c89d2791a6f8c1e8c",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="c6e7468d7041718ce6e1c7f50ec80a552439ac9cfed2dc3f753ae417dda5724f",

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -39,10 +39,26 @@ class Rocsparse(CMakePackage):
     version("5.2.0", sha256="7ed929af16d2502135024a6463997d9a95f03899b8a33aa95db7029575c89572")
     version("5.1.3", sha256="ef9641045b36c9aacc87e4fe7717b41b1e29d97e21432678dce7aca633a8edc2")
     version("5.1.0", sha256="a2f0f8cb02b95993480bd7264fc65e8b11464a90b86f2dcd0dd82a2e6d4bd704")
-    version("5.0.2", sha256="c9d9e1b7859e1c5aa5050f5dfdf86245cbd7c1296c0ce60d9ca5f3e22a9b748b")
-    version("5.0.0", sha256="6d352bf27dbed08e5115a58815aa76c59eb2008ec9dcc921aadf2efe20115d2a")
-    version("4.5.2", sha256="e37af2cd097e239a55a278df534183b5591ef4d985fe1a268a229bd11ada6599")
-    version("4.5.0", sha256="b120e9e17e7e141caee4c8c4288c9d1902bad0cec2ea76458d3ba11343376938")
+    version(
+        "5.0.2",
+        sha256="c9d9e1b7859e1c5aa5050f5dfdf86245cbd7c1296c0ce60d9ca5f3e22a9b748b",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="6d352bf27dbed08e5115a58815aa76c59eb2008ec9dcc921aadf2efe20115d2a",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="e37af2cd097e239a55a278df534183b5591ef4d985fe1a268a229bd11ada6599",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="b120e9e17e7e141caee4c8c4288c9d1902bad0cec2ea76458d3ba11343376938",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="fa5ea64f71e1cfbebe41618cc183f501b387824a6dc58486ab1214d7af5cbef2",

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -24,10 +24,26 @@ class Rocthrust(CMakePackage):
     version("5.2.0", sha256="afa126218485586682c78e97df8025ae4efd32f3751c340e84c436e08868c326")
     version("5.1.3", sha256="8d92de1e69815d92a423b7657f2f37c90f1d427f5bc92915c202d4c266254dad")
     version("5.1.0", sha256="fee779ae3d55b97327d87beca784fc090fa02bc95238d9c3bf3021e266e73979")
-    version("5.0.2", sha256="60f0cf1848cc7cd8663f15307bd695eee3c5b20d3ad3baa4bc696189ffdcfd53")
-    version("5.0.0", sha256="10b7b1be919881904d64f8084c2afe22aa00c560f8493a75dbf5df8386443ab4")
-    version("4.5.2", sha256="9171a05dd7438aebd4f6a939b1b33b7e87be1a0bd52d90a171b74539885cf591")
-    version("4.5.0", sha256="86cf897b01a6f5df668d978ce42d44a6ae9df9f8adc92d0a1a49a7c3bbead259")
+    version(
+        "5.0.2",
+        sha256="60f0cf1848cc7cd8663f15307bd695eee3c5b20d3ad3baa4bc696189ffdcfd53",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="10b7b1be919881904d64f8084c2afe22aa00c560f8493a75dbf5df8386443ab4",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="9171a05dd7438aebd4f6a939b1b33b7e87be1a0bd52d90a171b74539885cf591",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="86cf897b01a6f5df668d978ce42d44a6ae9df9f8adc92d0a1a49a7c3bbead259",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="86fcd3bc275efe9a485aed48afdc6d3351804c076caee43e3fb8bd69752865e9",

--- a/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
@@ -23,10 +23,26 @@ class RoctracerDevApi(Package):
     version("5.2.0", sha256="9747356ce61c57d22c2e0a6c90b66a055e435d235ba3459dc3e3f62aabae6a03")
     version("5.1.3", sha256="45f19875c15eb609b993788b47fd9c773b4216074749d7744f3a671be17ef33c")
     version("5.1.0", sha256="58b535f5d6772258190e4adcc23f37c916f775057a91b960e1f2ee1f40ed5aac")
-    version("5.0.2", sha256="5ee46f079e57dfe491678ffa4cdaf5f3b3d179cb3137948e4bcafca99ded47cc")
-    version("5.0.0", sha256="a21f4fb093cee4a806d53cbc0645d615d89db12fbde305e9eceee7e4150acdf2")
-    version("4.5.2", sha256="7012d18b79736dbe119161aab86f4976b78553ce0b2f4753a9386752d75d5074")
-    version("4.5.0", sha256="83dcd8987e129b14da0fe74e24ce8d027333f8fedc9247a402d3683765983296")
+    version(
+        "5.0.2",
+        sha256="5ee46f079e57dfe491678ffa4cdaf5f3b3d179cb3137948e4bcafca99ded47cc",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="a21f4fb093cee4a806d53cbc0645d615d89db12fbde305e9eceee7e4150acdf2",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="7012d18b79736dbe119161aab86f4976b78553ce0b2f4753a9386752d75d5074",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="83dcd8987e129b14da0fe74e24ce8d027333f8fedc9247a402d3683765983296",
+        deprecated=True,
+    )
     version(
         "4.3.1",
         sha256="88ada5f256a570792d1326a305663e94cf2c3b0cbd99f7e745326923882dafd2",

--- a/var/spack/repos/builtin/packages/roctracer-dev/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev/package.py
@@ -26,10 +26,26 @@ class RoctracerDev(CMakePackage):
     version("5.2.0", sha256="9747356ce61c57d22c2e0a6c90b66a055e435d235ba3459dc3e3f62aabae6a03")
     version("5.1.3", sha256="45f19875c15eb609b993788b47fd9c773b4216074749d7744f3a671be17ef33c")
     version("5.1.0", sha256="58b535f5d6772258190e4adcc23f37c916f775057a91b960e1f2ee1f40ed5aac")
-    version("5.0.2", sha256="5ee46f079e57dfe491678ffa4cdaf5f3b3d179cb3137948e4bcafca99ded47cc")
-    version("5.0.0", sha256="a21f4fb093cee4a806d53cbc0645d615d89db12fbde305e9eceee7e4150acdf2")
-    version("4.5.2", sha256="7012d18b79736dbe119161aab86f4976b78553ce0b2f4753a9386752d75d5074")
-    version("4.5.0", sha256="83dcd8987e129b14da0fe74e24ce8d027333f8fedc9247a402d3683765983296")
+    version(
+        "5.0.2",
+        sha256="5ee46f079e57dfe491678ffa4cdaf5f3b3d179cb3137948e4bcafca99ded47cc",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="a21f4fb093cee4a806d53cbc0645d615d89db12fbde305e9eceee7e4150acdf2",
+        deprecated=True,
+    )
+    version(
+        "4.5.2",
+        sha256="7012d18b79736dbe119161aab86f4976b78553ce0b2f4753a9386752d75d5074",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="83dcd8987e129b14da0fe74e24ce8d027333f8fedc9247a402d3683765983296",
+        deprecated=True,
+    )
 
     variant(
         "build_type",


### PR DESCRIPTION
this PR is meant to drop support for the older rocm-releases from 4.5.0 till 5.0.2
