### PR TITLE
aws-parallelcluster: Add v2.11.9

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -13,7 +13,7 @@ class AwsParallelcluster(PythonPackage):
     tool to deploy and manage HPC clusters in the AWS cloud."""
 
     homepage = "https://github.com/aws/aws-parallelcluster"
-    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.8.tar.gz"
+    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.9.tar.gz"
 
     maintainers = [
         "charlesg3",
@@ -26,6 +26,7 @@ class AwsParallelcluster(PythonPackage):
         "lukeseawalker",
     ]
 
+    version("2.11.9", sha256="615de4d59d9fd56a31d4feb3aeefe685346538a8dd0c1c35b660029f891d4dfd")
     version("2.11.8", sha256="acf33f48f8e48b0bc7be20f539d61baa1e27248765ba355df753bdfca4abd3cb")
     version("2.11.7", sha256="f7c51cf1c94787f56e0661e39860ecc9275efeacc88716b7c9f14053ec7fbd35")
     version("2.11.6", sha256="4df4bcf966f523bcdf5b4f68ed0ef347eebae70a074cd098b15bc8a6be27217c")


### PR DESCRIPTION
Manual test:
```
==> Installing aws-parallelcluster-2.11.9-i5wm4axwkhw7wwx7k55s4rfr2skgnk6q
==> No binary for aws-parallelcluster-2.11.9-i5wm4axwkhw7wwx7k55s4rfr2skgnk6q found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/aws-parallelcluster/aws-parallelcluster-2.11.9.tar.gz
==> No patches needed for aws-parallelcluster
==> aws-parallelcluster: Executing phase: 'install'
==> aws-parallelcluster: Successfully installed aws-parallelcluster-2.11.9-i5wm4axwkhw7wwx7k55s4rfr2skgnk6q
  Stage: 1.31s.  Install: 1.90s.  Total: 3.40s
[+] /home/ec2-user/spack/opt/spack/linux-amzn2-haswell/gcc-7.3.1/aws-parallelcluster-2.11.9-i5wm4axwkhw7wwx7k55s4rfr2skgnk6q
```