### PR TITLE
Fixes to the silo packages for 4.11.

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -52,7 +52,8 @@ class Silo(AutotoolsPackage):
     depends_on("automake", type="build", when="+shared")
     depends_on("libtool", type="build", when="+shared")
     depends_on("mpi", when="+mpi")
-    depends_on("hdf5@1.8:", when="+hdf5")
+    depends_on("hdf5@1.8", when="@:4.10+hdf5")
+    depends_on("hdf5@1.12:", when="@4.11:+hdf5")
     depends_on("qt+gui~framework@4.8:4.9", when="+silex")
     depends_on("libx11", when="+silex")
     # Xmu dependency is required on Ubuntu 18-20
@@ -83,6 +84,9 @@ class Silo(AutotoolsPackage):
     # hzip and fpzip are not available in the BSD releases
     conflicts("+hzip", when="@4.10.2-bsd,4.11-bsd")
     conflicts("+fpzip", when="@4.10.2-bsd,4.11-bsd")
+
+    # zfp include missing
+    patch("zfp_error.patch", when="@4.11: +hdf5")
 
     def flag_handler(self, name, flags):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -86,7 +86,7 @@ class Silo(AutotoolsPackage):
     conflicts("+fpzip", when="@4.10.2-bsd,4.11-bsd")
 
     # zfp include missing
-    patch("zfp_error.patch", when="@4.11: +hdf5")
+    patch("zfp_error.patch", when="@4.11 +hdf5")
 
     def flag_handler(self, name, flags):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/silo/zfp_error.patch
+++ b/var/spack/repos/builtin/packages/silo/zfp_error.patch
@@ -5,7 +5,7 @@ diff -ru silo/src/hdf5_drv/silo_hdf5.c silo.fixed/src/hdf5_drv/silo_hdf5.c
  #endif
  #ifdef HAVE_ZFP
  #include "H5Zzfp.h"
-+#include "zfp.h"
++extern void zfp_init_zfp();
  #endif
  
  /* Defining these to check overhead of PROTECT */

--- a/var/spack/repos/builtin/packages/silo/zfp_error.patch
+++ b/var/spack/repos/builtin/packages/silo/zfp_error.patch
@@ -1,0 +1,11 @@
+diff -ru silo/src/hdf5_drv/silo_hdf5.c silo.fixed/src/hdf5_drv/silo_hdf5.c
+--- silo/src/hdf5_drv/silo_hdf5.c	2021-09-09 12:35:00.000000000 -0700
++++ silo.fixed/src/hdf5_drv/silo_hdf5.c	2022-12-02 10:34:34.560531000 -0800
+@@ -198,6 +198,7 @@
+ #endif
+ #ifdef HAVE_ZFP
+ #include "H5Zzfp.h"
++#include "zfp.h"
+ #endif
+ 
+ /* Defining these to check overhead of PROTECT */


### PR DESCRIPTION
Specifically I can't get ZFP working for silo. This simple patch fixes this.

The patch command needs to be changed if this gets fixed in 4.12.

Also updated hdf5 dependencies after a conversation with Mike Collette.