### PR TITLE
py-nilearn: fix version specification of dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-nilearn/package.py
+++ b/var/spack/repos/builtin/packages/py-nilearn/package.py
@@ -62,7 +62,7 @@ class PyNilearn(PythonPackage):
     # older py-nilearn versions use matplotlib.cm.revcmap which was deprecated
     # in py-matplotlib@3.4:
     depends_on("py-matplotlib@1.5.1:3.3", when="@:0.5 +plotting", type=("build", "run"))
-    depends_on("py-matplotlib@1.1.1:3.3", when="0.4.2 +plotting", type=("build", "run"))
+    depends_on("py-matplotlib@1.1.1:3.3", when="@0.4.2 +plotting", type=("build", "run"))
 
     @property
     def skip_modules(self):


### PR DESCRIPTION
There was a missing "@" in the version specification of a dependency resulting in the concretizer to fail.