### PR TITLE
perl: ensure use of spack compiler wrapper

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -349,25 +349,25 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 maker()
                 maker("install")
 
-    def _setup_dependent_env(self, env, dependent_spec, deptype):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         """Set PATH and PERL5LIB to include the extension and
         any other perl extensions it depends on,
         assuming they were installed with INSTALL_BASE defined."""
         perl_lib_dirs = [self.spack_config]
-        for d in dependent_spec.traverse(deptype=deptype):
+        for d in dependent_spec.traverse(deptype=("build", "run", "test")):
             if d.package.extends(self.spec):
                 perl_lib_dirs.append(d.prefix.lib.perl5)
         if perl_lib_dirs:
             perl_lib_path = ":".join(perl_lib_dirs)
-            env.prepend_path("PERL5LIB", perl_lib_path)
+            env.set("PERL5LIB", perl_lib_path)
         if sys.platform == "win32":
             env.append_path("PATH", self.prefix.bin)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self._setup_dependent_env(env, dependent_spec, deptype=("build", "run", "test"))
-
     def setup_dependent_run_environment(self, env, dependent_spec):
-        self._setup_dependent_env(env, dependent_spec, deptype=("run",))
+        if dependent_spec.package.extends(self.spec):
+            env.prepend_path("PERL5LIB", join_path(dependent_spec.prefix.lib.perl5))
+        if is_windows:
+            env.append_path("PATH", self.prefix.bin)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before perl modules' install() methods.

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -366,7 +366,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def setup_dependent_run_environment(self, env, dependent_spec):
         if dependent_spec.package.extends(self.spec):
             env.prepend_path("PERL5LIB", join_path(dependent_spec.prefix.lib.perl5))
-        if is_windows:
+        if sys.platform == "win32":
             env.append_path("PATH", self.prefix.bin)
 
     def setup_dependent_package(self, module, dependent_spec):

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -241,6 +241,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             "-Dprefix={0}".format(prefix),
             "-Dlocincpth=" + self.spec["gdbm"].prefix.include,
             "-Dloclibpth=" + self.spec["gdbm"].prefix.lib,
+            "-Dcc=" + spack_cc,
         ]
 
         # Extensions are installed into their private tree via


### PR DESCRIPTION
Currently, the building of perl and perl extensions does not use the Spack compiler wrapper. This PR fixes that by 
1. specifying the `cc` to be the Spack compiler wrapper.
2. ensuring that the configuration files use the Spack compiler wrapper for building extensions in Spack.

Extensions built outside of Spack will use the actual compiler.