### PR TITLE
[darshan-runtime, darshan-util, py-darshan]: darshan 3.4.1 release updates

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -69,7 +69,12 @@ class DarshanRuntime(AutotoolsPackage):
 
     variant("mpi", default=True, description="Compile with MPI support")
     variant("hdf5", default=False, description="Compile with HDF5 module", when="@3.2:")
-    variant("parallel-netcdf", default=False, description="Compile with Parallel NetCDF module", when="@3.4.1:")
+    variant(
+        "parallel-netcdf",
+        default=False,
+        description="Compile with Parallel NetCDF module",
+        when="@3.4.1:",
+    )
     variant("apmpi", default=False, description="Compile with AutoPerf MPI module", when="@3.3:")
     variant(
         "apmpi_sync",

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -26,9 +26,13 @@ class DarshanRuntime(AutotoolsPackage):
 
     version("main", branch="main", submodules=True)
     version(
+        "3.4.1",
+        sha256="77c0a4675d94a0f9df5710e5b8658cc9ef0f0981a6dafb114d0389b1af64774c",
+        preferred=True,
+    )
+    version(
         "3.4.0",
         sha256="7cc88b7c130ec3b574f6b73c63c3c05deec67b1350245de6d39ca91d4cff0842",
-        preferred=True,
     )
     version(
         "3.4.0-pre1", sha256="57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09"
@@ -52,6 +56,7 @@ class DarshanRuntime(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("zlib")
     depends_on("hdf5", when="+hdf5")
+    depends_on("parallel-netcdf", when="+parallel-netcdf")
     depends_on("papi", when="+apxc")
     depends_on("autoconf", type="build", when="@main")
     depends_on("automake", type="build", when="@main")
@@ -64,6 +69,7 @@ class DarshanRuntime(AutotoolsPackage):
 
     variant("mpi", default=True, description="Compile with MPI support")
     variant("hdf5", default=False, description="Compile with HDF5 module", when="@3.2:")
+    variant("parallel-netcdf", default=False, description="Compile with Parallel NetCDF module", when="@3.4.1:")
     variant("apmpi", default=False, description="Compile with AutoPerf MPI module", when="@3.3:")
     variant(
         "apmpi_sync",
@@ -103,6 +109,8 @@ class DarshanRuntime(AutotoolsPackage):
                 extra_args.append("--enable-hdf5-mod=%s" % spec["hdf5"].prefix)
             else:
                 extra_args.append("--enable-hdf5-mod")
+        if "+parallel-netcdf" in spec:
+            extra_args.append("--enable-pnetcdf-mod")
         if "+apmpi" in spec:
             extra_args.append("--enable-apmpi-mod")
         if "+apmpi_sync" in spec:

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -22,9 +22,13 @@ class DarshanUtil(AutotoolsPackage):
 
     version("main", branch="main", submodules="True")
     version(
+        "3.4.1",
+        sha256="77c0a4675d94a0f9df5710e5b8658cc9ef0f0981a6dafb114d0389b1af64774c",
+        preferred=True,
+    )
+    version(
         "3.4.0",
         sha256="7cc88b7c130ec3b574f6b73c63c3c05deec67b1350245de6d39ca91d4cff0842",
-        preferred=True,
     )
     version(
         "3.4.0-pre1", sha256="57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09"

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -14,7 +14,11 @@ class PyDarshan(PythonPackage):
 
     maintainers = ["jeanbez", "shanedsnyder"]
 
-    version("3.4.1.0", sha256="41a033ebac6fcd0ca05b8ccf07e11191286dee923ec334b876a7ec8e8a6add84", preferred=True)
+    version(
+        "3.4.1.0",
+        sha256="41a033ebac6fcd0ca05b8ccf07e11191286dee923ec334b876a7ec8e8a6add84",
+        preferred=True,
+    )
     version("3.4.0.1", sha256="0142fc7c0b12a9e5c22358aa26cca7083d28af42aeea7dfcc5698c56b6aee6b7")
 
     depends_on("python@3.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -14,6 +14,7 @@ class PyDarshan(PythonPackage):
 
     maintainers = ["jeanbez", "shanedsnyder"]
 
+    version("3.4.1.0", sha256="41a033ebac6fcd0ca05b8ccf07e11191286dee923ec334b876a7ec8e8a6add84", preferred=True)
     version("3.4.0.1", sha256="0142fc7c0b12a9e5c22358aa26cca7083d28af42aeea7dfcc5698c56b6aee6b7")
 
     depends_on("python@3.6:", type=("build", "run"))


### PR DESCRIPTION
* new package versions for darshan-runtime, darshan-util, and py-darshan
* added new 'parallel-netcdf' variant to darshan-runtime to enable support for PnetCDF instrumentation available as part of Darshan 3.4.1 release