### PR TITLE
py-mne: add 1.2.2, 1.2.3 and dependency packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5io/package.py
+++ b/var/spack/repos/builtin/packages/py-h5io/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyH5io(PythonPackage):
+    """Python Objects Onto HDF5."""
+
+    homepage = "http://h5io.github.io"
+    pypi = "h5io/h5io-0.1.7.tar.gz"
+    git = "https://github.com/h5io/h5io.git"
+
+    version("0.1.7", sha256="be2684e678a28a5d59140de838f0165f095af865e48b8e498a279a3c2b89303e")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-h5py", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -13,6 +13,7 @@ class PyMne(PythonPackage):
     pypi = "mne/mne-0.23.4.tar.gz"
     git = "https://github.com/mne-tools/mne-python.git"
 
+    version("1.2.3", sha256="b300dcee69ffb878cdbc5c02490e877df385c1b9482622e3aa1da06a604a6e37")
     version("1.2.2", sha256="d40743d6ca7ae3919a557166fd5fc4c00a9719e40c07346baad57964e15f02bb")
     version("0.23.4", sha256="ecace5caacf10961ebb74cc5e0ead4d4dbc55fed006eab1e644da144092354e9")
     version("0.18.2", sha256="aa2e72ad3225efdad39b05e67cd5c88dbd5c3fabf5e1705e459347131f114bc6")

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -42,8 +42,8 @@ class PyMne(PythonPackage):
     depends_on("py-jinja2", when="@1:", type=("build", "run"))
 
     with when("+hdf5"):
-        depends_on("py-h5io", when="@1:", type=("build", "run"))
-        depends_on("py-pymatreader", when="@1:", type=("build", "run"))
+        depends_on("py-h5io", type=("build", "run"))
+        depends_on("py-pymatreader", type=("build", "run"))
 
     with when("+full"):
         # requirements.txt with versions specified in README.rst (marked with *)

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -11,20 +11,38 @@ class PyMne(PythonPackage):
 
     homepage = "http://mne.tools/"
     pypi = "mne/mne-0.23.4.tar.gz"
+    git = "https://github.com/mne-tools/mne-python.git"
 
+    version("1.2.2", sha256="d40743d6ca7ae3919a557166fd5fc4c00a9719e40c07346baad57964e15f02bb")
     version("0.23.4", sha256="ecace5caacf10961ebb74cc5e0ead4d4dbc55fed006eab1e644da144092354e9")
     version("0.18.2", sha256="aa2e72ad3225efdad39b05e67cd5c88dbd5c3fabf5e1705e459347131f114bc6")
 
-    variant("full", default=False, description="Enable full functionality.")
+    # don't support full variant for newer versions (for now) because dependencies get out of hand
+    variant("full", default=False, when="@:23", description="Enable full functionality.")
+    variant("hdf5", default=False, when="@1:", description="Enable hdf5 functionality.")
 
+    depends_on("python@3.7:", when="@0.24:", type=("build", "run"))
     depends_on("python@3.6:", when="@0.23:", type=("build", "run"))
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
+    # requirements_base.txt with versions specified in README.rst (marked with *)
+    depends_on("py-numpy@1.18.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-numpy@1.15.4:", when="@0.23:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"))
+    depends_on("py-scipy@1.4.1:", when="@1:", type=("build", "run"))  # *
     depends_on("py-scipy@1.1.0:", when="@0.23:", type=("build", "run"))
     depends_on("py-scipy@0.17.1:", type=("build", "run"))
+    depends_on("py-matplotlib@3.1:", when="@1:", type=("build", "run"))  # *
+    depends_on("py-tqdm", when="@1:", type=("build", "run"))
+    depends_on("py-pooch@1.5:", when="@1:", type=("build", "run"))
+    depends_on("py-decorator", when="@1:", type=("build", "run"))
+    depends_on("py-packaging", when="@1:", type=("build", "run"))
+    depends_on("py-jinja2", when="@1:", type=("build", "run"))
+
+    with when("+hdf5"):
+        depends_on("py-h5io", when="@1:", type=("build", "run"))
+        depends_on("py-pymatreader", when="@1:", type=("build", "run"))
 
     with when("+full"):
         # requirements.txt with versions specified in README.rst (marked with *)
@@ -63,6 +81,4 @@ class PyMne(PythonPackage):
         depends_on("py-ipyvtk-simple", type=("build", "run"))
 
         # README.rst
-
-
-#        depends_on('py-cupy@4.0:', type=('build', 'run'))  # not yet in spack
+        # depends_on('py-cupy@4.0:', type=('build', 'run'))  # not yet in spack

--- a/var/spack/repos/builtin/packages/py-pymatreader/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatreader/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPymatreader(PythonPackage):
+    """Convenient reader for Matlab mat files."""
+
+    homepage = "https://gitlab.com/obob/pymatreader"
+    pypi = "pymatreader/pymatreader-0.0.30.tar.gz"
+
+    version("0.0.30", sha256="c8187b6ee77a9b1ec0d8ccae9b22c9031d01104a412737cc4a71e6d993a1a12b")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-scipy@:1.6,1.7.1:", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-xmltodict", type=("build", "run"))
+    depends_on("py-future", type=("build", "run"))


### PR DESCRIPTION
https://github.com/mne-tools/mne-python/tree/v1.2.2
I did not update the `full` variant because it is not installable via pip anyway and the dependencies get kind of out of hand.

https://github.com/h5io/h5io/tree/h5io-0.1.7
https://gitlab.com/obob/pymatreader/-/tree/v0.0.30