### PR TITLE
[WIP] ML CI stack: matrix of targets

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -20,7 +20,7 @@ spack:
       variants: ~cuda~rocm
 
   definitions:
-    packages:
+    - packages:
       # Horovod
       - py-horovod
 
@@ -86,7 +86,7 @@ spack:
       # - r-xgboost
       - xgboost
 
-    targets:
+    - targets:
       - x86_64_v3
       - aarch64
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -87,13 +87,13 @@ spack:
       - xgboost
 
     - targets:
-      - x86_64_v3
-      - aarch64
+      - target=x86_64_v3
+      - target=aarch64
 
   specs:
     - matrix:
       - [$packages]
-      - [target=$targets]
+      - [$targets]
 
   mirrors: { "mirror": "s3://spack-binaries/develop/ml-cpu" }
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -17,74 +17,83 @@ spack:
   packages:
     all:
       compiler: [gcc@11.2.0]
-      target: [x86_64_v3]
       variants: ~cuda~rocm
 
+  definitions:
+    packages:
+      # Horovod
+      - py-horovod
+
+      # Hugging Face
+      - py-transformers
+
+      # JAX
+      - py-jax
+      - py-jaxlib
+
+      # Keras
+      - py-keras
+      - py-keras-applications
+      - py-keras-preprocessing
+      - py-keras2onnx
+
+      # PyTorch
+      - py-botorch
+      - py-efficientnet-pytorch
+      - py-gpytorch
+      - py-kornia
+      - py-pytorch-gradual-warmup-lr
+      - py-pytorch-lightning
+      - py-segmentation-models-pytorch
+      - py-timm
+      - py-torch
+      - py-torch-cluster
+      - py-torch-geometric
+      - py-torch-nvidia-apex
+      - py-torch-scatter
+      - py-torch-sparse
+      - py-torch-spline-conv
+      - py-torchaudio
+      - py-torchdata
+      - py-torchfile
+      - py-torchgeo
+      - py-torchmeta
+      - py-torchmetrics
+      - py-torchtext
+      - py-torchvision
+      - py-vector-quantize-pytorch
+
+      # scikit-learn
+      - py-scikit-learn
+      - py-scikit-learn-extra
+
+      # TensorBoard
+      - py-tensorboard
+      - py-tensorboard-data-server
+      - py-tensorboard-plugin-wit
+      - py-tensorboardx
+
+      # TensorFlow
+      - py-tensorflow
+      - py-tensorflow-datasets
+      - py-tensorflow-estimator
+      - py-tensorflow-hub
+      - py-tensorflow-metadata
+      - py-tensorflow-probability
+
+      # XGBoost
+      - py-xgboost
+      # - r-xgboost
+      - xgboost
+
+    targets:
+      - x86_64_v3
+      - aarch64
+
   specs:
-    # Horovod
-    - py-horovod
-
-    # Hugging Face
-    - py-transformers
-
-    # JAX
-    - py-jax
-    - py-jaxlib
-
-    # Keras
-    - py-keras
-    - py-keras-applications
-    - py-keras-preprocessing
-    - py-keras2onnx
-
-    # PyTorch
-    - py-botorch
-    - py-efficientnet-pytorch
-    - py-gpytorch
-    - py-kornia
-    - py-pytorch-gradual-warmup-lr
-    - py-pytorch-lightning
-    - py-segmentation-models-pytorch
-    - py-timm
-    - py-torch
-    - py-torch-cluster
-    - py-torch-geometric
-    - py-torch-nvidia-apex
-    - py-torch-scatter
-    - py-torch-sparse
-    - py-torch-spline-conv
-    - py-torchaudio
-    - py-torchdata
-    - py-torchfile
-    - py-torchgeo
-    - py-torchmeta
-    - py-torchmetrics
-    - py-torchtext
-    - py-torchvision
-    - py-vector-quantize-pytorch
-
-    # scikit-learn
-    - py-scikit-learn
-    - py-scikit-learn-extra
-
-    # TensorBoard
-    - py-tensorboard
-    - py-tensorboard-data-server
-    - py-tensorboard-plugin-wit
-    - py-tensorboardx
-
-    # TensorFlow
-    - py-tensorflow
-    - py-tensorflow-datasets
-    - py-tensorflow-estimator
-    - py-tensorflow-hub
-    - py-tensorflow-metadata
-    - py-tensorflow-probability
-
-    # XGBoost
-    - py-xgboost
-    # - r-xgboost
-    - xgboost
+    - matrix:
+      - [$packages]
+      - [target=$targets]
 
   mirrors: { "mirror": "s3://spack-binaries/develop/ml-cpu" }
 
@@ -112,7 +121,7 @@ spack:
     match_behavior: first
     mappings:
       - match:
-          - llvm
+          - "llvm target=x86_64_v3"
         runner-attributes:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
@@ -120,9 +129,25 @@ spack:
             KUBERNETES_CPU_REQUEST: 11000m
             KUBERNETES_MEMORY_REQUEST: 42G
       - match:
-          - "@:"
+          - "target=x86_64_v3"
         runner-attributes:
           tags: [ "spack", "large", "x86_64_v4" ]
+          variables:
+            CI_JOB_SIZE: large
+            KUBERNETES_CPU_REQUEST: 8000m
+            KUBERNETES_MEMORY_REQUEST: 12G
+      - match:
+          - "llvm target=aarch64"
+        runner-attributes:
+          tags: [ "spack", "huge", "aarch64" ]
+          variables:
+            CI_JOB_SIZE: huge
+            KUBERNETES_CPU_REQUEST: 11000m
+            KUBERNETES_MEMORY_REQUEST: 42G
+      - match:
+          - "target=aarch64"
+        runner-attributes:
+          tags: [ "spack", "large", "aarch64" ]
           variables:
             CI_JOB_SIZE: large
             KUBERNETES_CPU_REQUEST: 8000m


### PR DESCRIPTION
Instead of having separate pipelines for every OS/target, this PR attempts to create a matrix of OS/targets on which we want to build our ML stack. If this works, the long-term plan is to add the cross product of:

* all ML packages
* on macOS and Linux
* on x86_64, aarch64, and ppc64le
* with the following variants:
  * +cuda ~rocm cuda_arch=...
  * +rocm ~cuda admgpu_target=...
  * ~cuda ~rocm

I'm going to start with a small subset of this for testing and expand once we get it working.