### PR TITLE
typing: move from comment type hints to Python 3.6 hints

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -16,6 +16,7 @@ import re
 import sys
 import sysconfig
 import uuid
+from typing import List
 
 import archspec.cpu
 
@@ -84,10 +85,10 @@ def _try_import_from_store(module, query_spec, query_info=None):
 
     for candidate_spec in installed_specs:
         pkg = candidate_spec["python"].package
-        module_paths = [
+        module_paths: List[str] = [
             os.path.join(candidate_spec.prefix, pkg.purelib),
             os.path.join(candidate_spec.prefix, pkg.platlib),
-        ]  # type: list[str]
+        ]
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -41,6 +41,7 @@ import shutil
 import sys
 import traceback
 import types
+from typing import List, Tuple
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import install, install_tree, mkdirp
@@ -287,7 +288,7 @@ def clean_environment():
 def _add_werror_handling(keep_werror, env):
     keep_flags = set()
     # set of pairs
-    replace_flags = []  # type: List[Tuple[str,str]]
+    replace_flags: List[Tuple[str, str]] = []
     if keep_werror == "all":
         keep_flags.add("-Werror*")
     else:

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -138,7 +138,7 @@ class AutotoolsBuilder(BaseBuilder):
     patch_libtool = True
 
     #: Targets for ``make`` during the :py:meth:`~.AutotoolsBuilder.build` phase
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
     #: Targets for ``make`` during the :py:meth:`~.AutotoolsBuilder.install` phase
     install_targets = ["install"]
 
@@ -152,7 +152,7 @@ class AutotoolsBuilder(BaseBuilder):
     force_autoreconf = False
 
     #: Options to be passed to autoreconf when using the default implementation
-    autoreconf_extra_args = []  # type: List[str]
+    autoreconf_extra_args: List[str] = []
 
     #: If False deletes all the .la files in the prefix folder after the installation.
     #: If True instead it installs them.

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -34,22 +34,22 @@ class CachedCMakeBuilder(CMakeBuilder):
 
     #: Phases of a Cached CMake package
     #: Note: the initconfig phase is used for developer builds as a final phase to stop on
-    phases = ("initconfig", "cmake", "build", "install")  # type: Tuple[str, ...]
+    phases: Tuple[str, ...] = ("initconfig", "cmake", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = CMakeBuilder.legacy_methods + (
+    legacy_methods: Tuple[str, ...] = CMakeBuilder.legacy_methods + (
         "initconfig_compiler_entries",
         "initconfig_mpi_entries",
         "initconfig_hardware_entries",
         "std_initconfig_entries",
         "initconfig_package_entries",
-    )  # type: Tuple[str, ...]
+    )
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = CMakeBuilder.legacy_attributes + (
+    legacy_attributes: Tuple[str, ...] = CMakeBuilder.legacy_attributes + (
         "cache_name",
         "cache_path",
-    )  # type: Tuple[str, ...]
+    )
 
     @property
     def cache_name(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -153,13 +153,13 @@ class CMakeBuilder(BaseBuilder):
     """
 
     #: Phases of a CMake package
-    phases = ("cmake", "build", "install")  # type: Tuple[str, ...]
+    phases: Tuple[str, ...] = ("cmake", "build", "install")
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("cmake_args", "check")  # type: Tuple[str, ...]
+    legacy_methods: Tuple[str, ...] = ("cmake_args", "check")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = (
+    legacy_attributes: Tuple[str, ...] = (
         "generator",
         "build_targets",
         "install_targets",
@@ -169,7 +169,7 @@ class CMakeBuilder(BaseBuilder):
         "std_cmake_args",
         "build_dirname",
         "build_directory",
-    )  # type: Tuple[str, ...]
+    )
 
     #: The build system generator to use.
     #:
@@ -182,7 +182,7 @@ class CMakeBuilder(BaseBuilder):
     generator = "Ninja" if sys.platform == "win32" else "Unix Makefiles"
 
     #: Targets to be used during the build phase
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
     #: Targets to be used during the install phase
     install_targets = ["install"]
     #: Callback names for build-time test

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -35,10 +35,10 @@ class GenericBuilder(BaseBuilder):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ()  # type: Tuple[str, ...]
+    legacy_methods: Tuple[str, ...] = ()
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = ("archive_files",)  # type: Tuple[str, ...]
+    legacy_attributes: Tuple[str, ...] = ("archive_files",)
 
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
     spack.builder.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)

--- a/lib/spack/spack/build_systems/gnu.py
+++ b/lib/spack/spack/build_systems/gnu.py
@@ -13,7 +13,7 @@ class GNUMirrorPackage(spack.package_base.PackageBase):
     """Mixin that takes care of setting url and mirrors for GNU packages."""
 
     #: Path of the package in a GNU mirror
-    gnu_mirror_path = None  # type: Optional[str]
+    gnu_mirror_path: Optional[str] = None
 
     #: List of GNU mirrors used by Spack
     base_mirrors = [

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -77,7 +77,7 @@ class MakefileBuilder(BaseBuilder):
     )
 
     #: Targets for ``make`` during the :py:meth:`~.MakefileBuilder.build` phase
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
     #: Targets for ``make`` during the :py:meth:`~.MakefileBuilder.install` phase
     install_targets = ["install"]
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -95,7 +95,7 @@ class MesonBuilder(BaseBuilder):
         "build_directory",
     )
 
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
     install_targets = ["install"]
 
     build_time_test_callbacks = ["check"]

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -72,7 +72,7 @@ class NMakeBuilder(BaseBuilder):
     )
 
     #: Targets for ``make`` during the :py:meth:`~.NMakeBuilder.build` phase
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
     #: Targets for ``make`` during the :py:meth:`~.NMakeBuilder.install` phase
     install_targets = ["install"]
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -177,7 +177,7 @@ class PythonPackage(PythonExtension):
     """Specialized class for packages that are built using pip."""
 
     #: Package name, version, and extension on PyPI
-    pypi = None  # type: Optional[str]
+    pypi: Optional[str] = None
 
     maintainers = ["adamjstewart", "pradyunsg"]
 
@@ -200,7 +200,7 @@ class PythonPackage(PythonExtension):
         # package manually
         depends_on("py-wheel", type="build")
 
-    py_namespace = None  # type: Optional[str]
+    py_namespace: Optional[str] = None
 
     @lang.classproperty
     def homepage(cls):

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -22,10 +22,10 @@ class RBuilder(GenericBuilder):
     """
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = (
+    legacy_methods: Tuple[str, ...] = (
         "configure_args",
         "configure_vars",
-    ) + GenericBuilder.legacy_methods  # type: Tuple[str, ...]
+    ) + GenericBuilder.legacy_methods
 
     def configure_args(self):
         """Arguments to pass to install via ``--configure-args``."""
@@ -64,10 +64,10 @@ class RPackage(Package):
     # package attributes that can be expanded to set the homepage, url,
     # list_url, and git values
     # For CRAN packages
-    cran = None  # type: Optional[str]
+    cran: Optional[str] = None
 
     # For Bioconductor packages
-    bioc = None  # type: Optional[str]
+    bioc: Optional[str] = None
 
     GenericBuilder = RBuilder
 

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -34,7 +34,7 @@ class RacketPackage(PackageBase):
 
     extends("racket", when="build_system=racket")
 
-    racket_name = None  # type: Optional[str]
+    racket_name: Optional[str] = None
     parallel = True
 
     @lang.classproperty
@@ -51,7 +51,7 @@ class RacketBuilder(spack.builder.Builder):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = tuple()  # type: Tuple[str, ...]
+    legacy_methods: Tuple[str, ...] = tuple()
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = ("build_directory", "build_time_test_callbacks", "subdirectory")
@@ -59,7 +59,7 @@ class RacketBuilder(spack.builder.Builder):
     #: Callback names for build-time test
     build_time_test_callbacks = ["check"]
 
-    racket_name = None  # type: Optional[str]
+    racket_name: Optional[str] = None
 
     @property
     def subdirectory(self):

--- a/lib/spack/spack/build_systems/sourceforge.py
+++ b/lib/spack/spack/build_systems/sourceforge.py
@@ -14,7 +14,7 @@ class SourceforgePackage(spack.package_base.PackageBase):
     packages."""
 
     #: Path of the package in a Sourceforge mirror
-    sourceforge_mirror_path = None  # type: Optional[str]
+    sourceforge_mirror_path: Optional[str] = None
 
     #: List of Sourceforge mirrors used by Spack
     base_mirrors = [

--- a/lib/spack/spack/build_systems/sourceware.py
+++ b/lib/spack/spack/build_systems/sourceware.py
@@ -13,7 +13,7 @@ class SourcewarePackage(spack.package_base.PackageBase):
     packages."""
 
     #: Path of the package in a Sourceware mirror
-    sourceware_mirror_path = None  # type: Optional[str]
+    sourceware_mirror_path: Optional[str] = None
 
     #: List of Sourceware mirrors used by Spack
     base_mirrors = [

--- a/lib/spack/spack/build_systems/xorg.py
+++ b/lib/spack/spack/build_systems/xorg.py
@@ -14,7 +14,7 @@ class XorgPackage(spack.package_base.PackageBase):
     packages."""
 
     #: Path of the package in a x.org mirror
-    xorg_mirror_path = None  # type: Optional[str]
+    xorg_mirror_path: Optional[str] = None
 
     #: List of x.org mirrors used by Spack
     #  Note: x.org mirrors are a bit tricky, since many are out-of-sync or off.

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -466,19 +466,19 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
     """
 
     #: Sequence of phases. Must be defined in derived classes
-    phases = ()  # type: Tuple[str, ...]
+    phases: Tuple[str, ...] = ()
     #: Build system name. Must also be defined in derived classes.
-    build_system = None  # type: Optional[str]
+    build_system: Optional[str] = None
 
-    legacy_methods = ()  # type: Tuple[str, ...]
-    legacy_attributes = ()  # type: Tuple[str, ...]
+    legacy_methods: Tuple[str, ...] = ()
+    legacy_attributes: Tuple[str, ...] = ()
 
     #: List of glob expressions. Each expression must either be
     #: absolute or relative to the package source path.
     #: Matching artifacts found at the end of the build process will be
     #: copied in the same directory tree as _spack_build_logfile and
     #: _spack_build_envfile.
-    archive_files = []  # type: List[str]
+    archive_files: List[str] = []
 
     def __init__(self, pkg):
         self.pkg = pkg

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -11,7 +11,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
-from typing import List, Tuple
+from typing import List, Match, Tuple
 
 import ruamel.yaml as yaml
 from ruamel.yaml.error import MarkedYAMLError
@@ -165,18 +165,15 @@ class _UnquotedFlags(object):
         )
     )
 
-    def __init__(self, all_unquoted_flag_pairs):
-        # type: (List[Tuple[re.Match, str]]) -> None
+    def __init__(self, all_unquoted_flag_pairs: List[Tuple[Match[str], str]]):
         self._flag_pairs = all_unquoted_flag_pairs
 
-    def __bool__(self):
-        # type: () -> bool
+    def __bool__(self) -> bool:
         return bool(self._flag_pairs)
 
     @classmethod
-    def extract(cls, sargs):
-        # type: (str) -> _UnquotedFlags
-        all_unquoted_flag_pairs = []  # type: List[Tuple[re.Match, str]]
+    def extract(cls, sargs: str) -> "_UnquotedFlags":
+        all_unquoted_flag_pairs: List[Tuple[Match[str], str]] = []
         prev_flags_arg = None
         for arg in shlex.split(sargs):
             if prev_flags_arg is not None:
@@ -184,8 +181,7 @@ class _UnquotedFlags(object):
             prev_flags_arg = cls.flags_arg_pattern.match(arg)
         return cls(all_unquoted_flag_pairs)
 
-    def report(self):
-        # type: () -> str
+    def report(self) -> str:
         single_errors = [
             "({0}) {1} {2} => {3}".format(
                 i + 1,

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -13,7 +13,7 @@ section = "user environment"
 level = "short"
 
 
-_subcommands = {}  # type: Dict[str, Callable]
+_subcommands: Dict[str, Callable] = {}
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -10,7 +10,7 @@ import platform
 import re
 import shutil
 import tempfile
-from typing import List, Sequence  # novm
+from typing import List, Optional, Sequence  # novm
 
 import llnl.util.lang
 import llnl.util.tty as tty
@@ -195,20 +195,20 @@ class Compiler(object):
     and how to identify the particular type of compiler."""
 
     # Subclasses use possible names of C compiler
-    cc_names = []  # type: List[str]
+    cc_names: List[str] = []
 
     # Subclasses use possible names of C++ compiler
-    cxx_names = []  # type: List[str]
+    cxx_names: List[str] = []
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = []  # type: List[str]
+    f77_names: List[str] = []
 
     # Subclasses use possible names of Fortran 90 compiler
-    fc_names = []  # type: List[str]
+    fc_names: List[str] = []
 
     # Optional prefix regexes for searching for this type of compiler.
     # Prefixes are sometimes used for toolchains
-    prefixes = []  # type: List[str]
+    prefixes: List[str] = []
 
     # Optional suffix regexes for searching for this type of compiler.
     # Suffixes are used by some frameworks, e.g. macports uses an '-mp-X.Y'
@@ -219,7 +219,7 @@ class Compiler(object):
     version_argument = "-dumpversion"
 
     #: Return values to ignore when invoking the compiler to get its version
-    ignore_version_errors = ()  # type: Sequence[int]
+    ignore_version_errors: Sequence[int] = ()
 
     #: Regex used to extract version from compiler's output
     version_regex = "(.*)"
@@ -271,9 +271,9 @@ class Compiler(object):
         return ["-O", "-O0", "-O1", "-O2", "-O3"]
 
     # Cray PrgEnv name that can be used to load this compiler
-    PrgEnv = None  # type: str
+    PrgEnv: Optional[str] = None
     # Name of module used to switch versions of this compiler
-    PrgEnv_compiler = None  # type: str
+    PrgEnv_compiler: Optional[str] = None
 
     def __init__(
         self,
@@ -286,7 +286,7 @@ class Compiler(object):
         environment=None,
         extra_rpaths=None,
         enable_implicit_rpaths=None,
-        **kwargs
+        **kwargs,
     ):
         self.spec = cspec
         self.operating_system = str(operating_system)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -41,7 +41,7 @@ _cache_config_file = []
 # TODO: Caches at module level make it difficult to mock configurations in
 # TODO: unit tests. It might be worth reworking their implementation.
 #: cache of compilers constructed from config data, keyed by config entry id.
-_compiler_cache = {}  # type: Dict[str, spack.compiler.Compiler]
+_compiler_cache: Dict[str, "spack.compiler.Compiler"] = {}
 
 _compiler_to_pkg = {
     "clang": "llvm+clang",

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -18,8 +18,8 @@ from spack.compiler import Compiler
 from spack.error import SpackError
 from spack.version import Version
 
-avail_fc_version = set()  # type: Set[str]
-fc_path = dict()  # type: Dict[str, str]
+avail_fc_version: Set[str] = set()
+fc_path: Dict[str, str] = dict()
 
 fortran_mapping = {
     "2021.3.0": "19.29.30133",
@@ -42,16 +42,16 @@ def get_valid_fortran_pth(comp_ver):
 
 class Msvc(Compiler):
     # Subclasses use possible names of C compiler
-    cc_names = ["cl.exe"]  # type: List[str]
+    cc_names: List[str] = ["cl.exe"]
 
     # Subclasses use possible names of C++ compiler
-    cxx_names = ["cl.exe"]  # type: List[str]
+    cxx_names: List[str] = ["cl.exe"]
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["ifx.exe"]  # type: List[str]
+    f77_names: List[str] = ["ifx.exe"]
 
     # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["ifx.exe"]  # type: List[str]
+    fc_names: List[str] = ["ifx.exe"]
 
     # Named wrapper links within build_env_path
     # Due to the challenges of supporting compiler wrappers

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -11,10 +11,10 @@ import spack.compiler
 
 class Nag(spack.compiler.Compiler):
     # Subclasses use possible names of C compiler
-    cc_names = []  # type: List[str]
+    cc_names: List[str] = []
 
     # Subclasses use possible names of C++ compiler
-    cxx_names = []  # type: List[str]
+    cxx_names: List[str] = []
 
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["nagfor"]

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -304,10 +304,10 @@ class Database(object):
 
     """Per-process lock objects for each install prefix."""
 
-    _prefix_locks = {}  # type: Dict[str, lk.Lock]
+    _prefix_locks: Dict[str, lk.Lock] = {}
 
     """Per-process failure (lock) objects for each install prefix."""
-    _prefix_failures = {}  # type: Dict[str, lk.Lock]
+    _prefix_failures: Dict[str, lk.Lock] = {}
 
     def __init__(
         self,

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -122,9 +122,9 @@ class DirectiveMeta(type):
     """
 
     # Set of all known directives
-    _directive_dict_names = set()  # type: Set[str]
-    _directives_to_be_executed = []  # type: List[str]
-    _when_constraints_from_context = []  # type: List[str]
+    _directive_dict_names: Set[str] = set()
+    _directives_to_be_executed: List[str] = []
+    _when_constraints_from_context: List[str] = []
 
     def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -588,7 +588,7 @@ class BaseFileLayout(object):
     """
 
     #: This needs to be redefined
-    extension = None  # type: Optional[str]
+    extension: Optional[str] = None
 
     def __init__(self, configuration):
         self.conf = configuration

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -30,7 +30,7 @@ def configuration(module_set_name):
 
 
 # Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[str, Any]
+configuration_registry: Dict[str, Any] = {}
 
 
 def make_configuration(spec, module_set_name):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -27,7 +27,7 @@ def configuration(module_set_name):
 
 
 # Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[str, Any]
+configuration_registry: Dict[str, Any] = {}
 
 
 def make_configuration(spec, module_set_name):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -548,7 +548,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     #: Keep -Werror flags, matches config:flags:keep_werror to override config
     # NOTE: should be type Optional[Literal['all', 'specific', 'none']] in 3.8+
-    keep_werror = None  # type: Optional[str]
+    keep_werror: Optional[str] = None
 
     #: Most packages are NOT extendable. Set to True if you want extensions.
     extendable = False
@@ -564,17 +564,17 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: for it. Note: accepts both file names and directory names, for example
     #: ``["libcuda.so", "stubs"]`` will ensure libcuda.so and all libraries in the
     #: stubs directory are not bound by path."""
-    non_bindable_shared_objects = []  # type: List[str]
+    non_bindable_shared_objects: List[str] = []
 
     #: List of prefix-relative file paths (or a single path). If these do
     #: not exist after install, or if they exist but are not files,
     #: sanity checks fail.
-    sanity_check_is_file = []  # type: List[str]
+    sanity_check_is_file: List[str] = []
 
     #: List of prefix-relative directory paths (or a single path). If
     #: these do not exist after install, or if they exist but are not
     #: directories, sanity checks will fail.
-    sanity_check_is_dir = []  # type: List[str]
+    sanity_check_is_dir: List[str] = []
 
     #: Boolean. Set to ``True`` for packages that require a manual download.
     #: This is currently used by package sanity tests and generation of a
@@ -582,7 +582,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     manual_download = False
 
     #: Set of additional options used when fetching package versions.
-    fetch_options = {}  # type: Dict[str, Any]
+    fetch_options: Dict[str, Any] = {}
 
     #
     # Set default licensing information
@@ -600,12 +600,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: looking for a license. All file paths must be relative to the
     #: installation directory. More complex packages like Intel may require
     #: multiple licenses for individual components. Defaults to the empty list.
-    license_files = []  # type: List[str]
+    license_files: List[str] = []
 
     #: List of strings. Environment variables that can be set to tell the
     #: software where to look for a license if it is not in the usual location.
     #: Defaults to the empty list.
-    license_vars = []  # type: List[str]
+    license_vars: List[str] = []
 
     #: String. A URL pointing to license setup instructions for the software.
     #: Defaults to the empty string.
@@ -618,17 +618,17 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     _patches_by_hash = None
 
     #: Package homepage where users can find more information about the package
-    homepage = None  # type: str
+    homepage: Optional[str] = None
 
     #: Default list URL (place to find available versions)
-    list_url = None  # type: str
+    list_url: Optional[str] = None
 
     #: Link depth to which list_url should be searched for new versions
     list_depth = 0
 
     #: List of strings which contains GitHub usernames of package maintainers.
     #: Do not include @ here in order not to unnecessarily ping the users.
-    maintainers = []  # type: List[str]
+    maintainers: List[str] = []
 
     #: List of attributes to be excluded from a package's hash.
     metadata_attrs = [
@@ -2073,24 +2073,21 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         return self.install_log_path if self.spec.installed else self.log_path
 
     @classmethod
-    def inject_flags(cls, name, flags):
-        # type: (Type, str, Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE
+    def inject_flags(cls: Type, name: str, flags: Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE:
         """
         flag_handler that injects all flags through the compiler wrapper.
         """
         return flags, None, None
 
     @classmethod
-    def env_flags(cls, name, flags):
-        # type: (Type, str, Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE
+    def env_flags(cls: Type, name: str, flags: Iterable[str]):
         """
         flag_handler that adds all flags to canonical environment variables.
         """
         return None, flags, None
 
     @classmethod
-    def build_system_flags(cls, name, flags):
-        # type: (Type, str, Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE
+    def build_system_flags(cls: Type, name: str, flags: Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE:
         """
         flag_handler that passes flags to the build system arguments.  Any
         package using `build_system_flags` must also implement
@@ -2169,18 +2166,16 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         pass
 
-    _flag_handler = None  # type: Optional[FLAG_HANDLER_TYPE]
+    _flag_handler: Optional[FLAG_HANDLER_TYPE] = None
 
     @property
-    def flag_handler(self):
-        # type: () -> FLAG_HANDLER_TYPE
+    def flag_handler(self) -> FLAG_HANDLER_TYPE:
         if self._flag_handler is None:
             self._flag_handler = PackageBase.inject_flags
         return self._flag_handler
 
     @flag_handler.setter
-    def flag_handler(self, var):
-        # type: (FLAG_HANDLER_TYPE) -> None
+    def flag_handler(self, var: FLAG_HANDLER_TYPE):
         self._flag_handler = var
 
     # The flag handler method is called for each of the allowed compiler flags.

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import Optional
+
 import llnl.util.lang
 
 import spack.error
@@ -37,18 +39,18 @@ class Platform(object):
     """
 
     # Subclass sets number. Controls detection order
-    priority = None  # type: int
+    priority: Optional[int] = None
 
     #: binary formats used on this platform; used by relocation logic
     binary_formats = ["elf"]
 
-    front_end = None  # type: str
-    back_end = None  # type: str
-    default = None  # type: str # The default back end target.
+    front_end: Optional[str] = None
+    back_end: Optional[str] = None
+    default: Optional[str] = None  # The default back end target.
 
-    front_os = None  # type: str
-    back_os = None  # type: str
-    default_os = None  # type: str
+    front_os: Optional[str] = None
+    back_os: Optional[str] = None
+    default_os: Optional[str] = None
 
     reserved_targets = ["default_target", "frontend", "fe", "backend", "be"]
     reserved_oss = ["default_os", "frontend", "fe", "backend", "be"]

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -366,7 +366,7 @@ class FastPackageChecker(collections.abc.Mapping):
     """
 
     #: Global cache, reused by every instance
-    _paths_cache = {}  # type: Dict[str, Dict[str, os.stat_result]]
+    _paths_cache: Dict[str, Dict[str, os.stat_result]] = {}
 
     def __init__(self, packages_path):
         # The path of the repository managed by this instance
@@ -384,7 +384,7 @@ class FastPackageChecker(collections.abc.Mapping):
         self._paths_cache[self.packages_path] = self._create_new_cache()
         self._packages_to_stats = self._paths_cache[self.packages_path]
 
-    def _create_new_cache(self):  # type: () -> Dict[str, os.stat_result]
+    def _create_new_cache(self) -> Dict[str, os.stat_result]:
         """Create a new cache for packages in a repo.
 
         The implementation here should try to minimize filesystem
@@ -394,7 +394,7 @@ class FastPackageChecker(collections.abc.Mapping):
         """
         # Create a dictionary that will store the mapping between a
         # package name and its stat info
-        cache = {}  # type: Dict[str, os.stat_result]
+        cache: Dict[str, os.stat_result] = {}
         for pkg_name in os.listdir(self.packages_path):
             # Skip non-directories in the package root.
             pkg_dir = os.path.join(self.packages_path, pkg_name)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -49,9 +49,7 @@ _source_path_subdir = "spack-src"
 stage_prefix = "spack-stage-"
 
 
-def create_stage_root(path):
-    # type: (str) -> None
-
+def create_stage_root(path: str) -> None:
     """Create the stage root directory and ensure appropriate access perms."""
     assert os.path.isabs(path) and len(path.strip()) > 1
 
@@ -235,7 +233,7 @@ class Stage(object):
     """
 
     """Shared dict of all stage locks."""
-    stage_locks = {}  # type: Dict[str, spack.util.lock.Lock]
+    stage_locks: Dict[str, spack.util.lock.Lock] = {}
 
     """Most staging is managed by Spack.  DIYStage is one exception."""
     managed_by_spack = True

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -20,7 +20,7 @@ class ContextMeta(type):
 
     #: Keeps track of the context properties that have been added
     #: by the class that is being defined
-    _new_context_properties = []  # type: List[str]
+    _new_context_properties: List[str] = []
 
     def __new__(cls, name, bases, attr_dict):
         # Merge all the context properties that are coming from base classes

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -11,10 +11,8 @@ import os
 import signal
 import sys
 import time
-from typing import TYPE_CHECKING, Optional  # novm
-
-if TYPE_CHECKING:
-    from types import ModuleType  # novm
+from types import ModuleType
+from typing import Optional
 
 import pytest
 
@@ -24,7 +22,7 @@ import llnl.util.tty.pty as pty
 
 from spack.util.executable import which
 
-termios = None  # type: Optional[ModuleType]
+termios: Optional[ModuleType] = None
 try:
     import termios as term_mod
 

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -22,7 +22,7 @@ _deprecated_hash_algorithms = ["md5"]
 
 
 #: cache of hash functions generated
-_hash_functions = {}  # type: Dict[str, Callable[[], Any]]
+_hash_functions: Dict[str, Callable[[], Any]] = {}
 
 
 class DeprecatedHash(object):

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -14,8 +14,7 @@ __all__ = ["load", "dump", "SpackJSONError", "encode_json_dict", "decode_json_di
 _json_dump_args = {"indent": 2, "separators": (",", ": ")}
 
 
-def load(stream):
-    # type: (Any) -> Dict
+def load(stream: Any) -> Dict:
     """Spack JSON needs to be ordered to support specs."""
     if isinstance(stream, str):
         load = json.loads  # type: ignore[assignment]
@@ -25,14 +24,12 @@ def load(stream):
     return _strify(load(stream, object_hook=_strify), ignore_dicts=True)
 
 
-def encode_json_dict(data):
-    # type: (Dict) -> Dict
+def encode_json_dict(data: Dict) -> Dict:
     """Converts python 2 unicodes to str in JSON data."""
     return _strify(data)
 
 
-def dump(data, stream=None):
-    # type: (Dict, Optional[Any]) -> Optional[str]
+def dump(data: Dict, stream: Optional[Any] = None) -> Optional[str]:
     """Dump JSON with a reasonable amount of indentation and separation."""
     data = _strify(data)
     if stream is None:
@@ -41,14 +38,12 @@ def dump(data, stream=None):
     return None
 
 
-def decode_json_dict(data):
-    # type: (Dict) -> Dict
+def decode_json_dict(data: Dict) -> Dict:
     """Converts str to python 2 unicodes in JSON data."""
     return _strify(data)
 
 
-def _strify(data, ignore_dicts=False):
-    # type: (Dict, bool) -> Dict
+def _strify(data: Dict, ignore_dicts: bool = False) -> Dict:
     """Helper method for ``encode_json_dict()`` and ``decode_json_dict()``.
 
     Converts python 2 unicodes to str in JSON data, or the other way around."""
@@ -59,6 +54,5 @@ def _strify(data, ignore_dicts=False):
 class SpackJSONError(spack.error.SpackError):
     """Raised when there are issues with JSON parsing."""
 
-    def __init__(self, msg, json_error):
-        # type: (str, BaseException) -> None
+    def __init__(self, msg: str, json_error: BaseException):
         super(SpackJSONError, self).__init__(msg, str(json_error))

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -225,7 +225,7 @@ def file_line(mark):
 #: This is nasty but YAML doesn't give us many ways to pass arguments --
 #: yaml.dump() takes a class (not an instance) and instantiates the dumper
 #: itself, so we can't just pass an instance
-_annotations = []  # type: List[str]
+_annotations: List[str] = []
 
 
 class LineAnnotationDumper(OrderedLineDumper):

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -65,7 +65,7 @@ class Timer(object):
             now: function that gives the seconds since e.g. epoch
         """
         self._now = now
-        self._timers = OrderedDict()  # type: OrderedDict[str,Interval]
+        self._timers: OrderedDict[str, Interval] = OrderedDict()
 
         # _global is the overal timer since the instance was created
         self._timers[global_timer_name] = Interval(self._now(), end=None)

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -235,8 +235,7 @@ class VersionBase(object):
         "string",
     ]
 
-    def __init__(self, string):
-        # type: (str) -> None
+    def __init__(self, string: str) -> None:
         if not isinstance(string, str):
             string = str(string)
 


### PR DESCRIPTION
We've stopped supporting Python 2, and contributors are noticing that our CI no longer allows Python 2.7 comment type hints. They end up having to adapt them, but this adds extra unrelated work to PRs.

- [x] Move to 3.6 type hints across the entire code base