### PR TITLE
vermin: remove all novm comments from code

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -7,7 +7,7 @@ import os
 import os.path
 import stat
 import subprocess
-from typing import List  # novm
+from typing import List
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
-from typing import List  # novm
+from typing import List
 
 import llnl.util.filesystem as fs
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 import os
-from typing import List  # novm
+from typing import List
 
 import llnl.util.filesystem as fs
 

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
-from typing import List  # novm
+from typing import List
 
 import llnl.util.filesystem as fs
 

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from typing import Callable, Dict  # novm
+from typing import Callable, Dict
 
 import spack.cmd.modules.lmod
 import spack.cmd.modules.tcl

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -10,7 +10,7 @@ import platform
 import re
 import shutil
 import tempfile
-from typing import List, Optional, Sequence  # novm
+from typing import List, Optional, Sequence
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -10,7 +10,7 @@ import collections
 import itertools
 import multiprocessing.pool
 import os
-from typing import Dict  # novm
+from typing import Dict
 
 import archspec.cpu
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 from distutils.version import StrictVersion
-from typing import Dict, List, Set  # novm
+from typing import Dict, List, Set
 
 import spack.compiler
 import spack.operating_systems.windows_os

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from typing import List  # novm
+from typing import List
 
 import spack.compiler
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -36,7 +36,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import List  # novm
+from typing import List
 
 import ruamel.yaml as yaml
 from ruamel.yaml.error import MarkedYAMLError

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -26,7 +26,7 @@ import os
 import socket
 import sys
 import time
-from typing import Dict  # novm
+from typing import Dict
 
 try:
     import uuid

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -32,7 +32,7 @@ import collections.abc
 import functools
 import os.path
 import re
-from typing import List, Set  # novm
+from typing import List, Set
 
 import llnl.util.lang
 import llnl.util.tty.color

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -30,7 +30,7 @@ import re
 import shutil
 import sys
 import urllib.parse
-from typing import List, Optional  # novm
+from typing import List, Optional
 
 import llnl.util
 import llnl.util.filesystem as fs

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -34,7 +34,7 @@ import datetime
 import inspect
 import os.path
 import re
-from typing import Optional  # novm
+from typing import Optional
 
 import llnl.util.filesystem
 import llnl.util.tty as tty

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -7,7 +7,7 @@ import collections
 import itertools
 import os.path
 import posixpath
-from typing import Any, Dict  # novm
+from typing import Any, Dict
 
 import llnl.util.lang as lang
 

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -8,7 +8,7 @@ non-hierarchical modules.
 """
 import posixpath
 import string
-from typing import Any, Dict  # novm
+from typing import Any, Dict
 
 import llnl.util.tty as tty
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -27,7 +27,7 @@ import time
 import traceback
 import types
 import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type  # novm
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -9,7 +9,7 @@ import contextlib
 import errno
 import functools
 import importlib
-import importlib.machinery  # novm
+import importlib.machinery
 import importlib.util
 import inspect
 import itertools
@@ -24,7 +24,7 @@ import sys
 import traceback
 import types
 import uuid
-from typing import Dict  # novm
+from typing import Dict
 
 import ruamel.yaml as yaml
 
@@ -79,7 +79,7 @@ def namespace_from_fullname(fullname):
     return namespace
 
 
-class _PrependFileLoader(importlib.machinery.SourceFileLoader):  # novm
+class _PrependFileLoader(importlib.machinery.SourceFileLoader):
     def __init__(self, fullname, path, prepend=None):
         super(_PrependFileLoader, self).__init__(fullname, path)
         self.prepend = prepend
@@ -144,7 +144,7 @@ class ReposFinder(object):
         loader = self.compute_loader(fullname)
         if loader is None:
             return None
-        return importlib.util.spec_from_loader(fullname, loader)  # novm
+        return importlib.util.spec_from_loader(fullname, loader)
 
     def compute_loader(self, fullname):
         # namespaces are added to repo, and package modules are leaves.

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -14,7 +14,7 @@ import shutil
 import stat
 import sys
 import tempfile
-from typing import Dict  # novm
+from typing import Dict
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import itertools
 import textwrap
-from typing import List  # novm
+from typing import List
 
 import llnl.util.lang
 

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -91,7 +91,7 @@ def test_module_suffixes(module_suffixes_schema):
     ["compilers", "config", "env", "merged", "mirrors", "modules", "packages", "repos"],
 )
 def test_schema_validation(meta_schema, config_name):
-    import importlib  # novm
+    import importlib
 
     module_name = "spack.schema.{0}".format(config_name)
     module = importlib.import_module(module_name)

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -5,7 +5,7 @@
 
 """Simple wrapper around JSON to guarantee consistent use of load/dump. """
 import json
-from typing import Any, Dict, Optional  # novm
+from typing import Any, Dict, Optional
 
 import spack.error
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -17,7 +17,7 @@ import collections.abc
 import ctypes
 import io
 import re
-from typing import List  # novm
+from typing import List
 
 import ruamel.yaml as yaml
 from ruamel.yaml import RoundTripDumper, RoundTripLoader


### PR DESCRIPTION
All of our vermin `#novm` annotations are for optional features introduced in early Python 3 versions. We no longer need any of them, as we only support Python 3.6+. If we start optionally using features from newer Pythons than 3.6, we will need more vermin annotations.