### PR TITLE
bugfix: make texinfo build properly with gettext

### DIFF
--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -34,6 +34,7 @@ class Texinfo(AutotoolsPackage, GNUMirrorPackage):
     version("5.0", sha256="2c579345a39a2a0bb4b8c28533f0b61356504a202da6a25d17d4d866af7f5803")
 
     depends_on("perl")
+    depends_on("gettext")
 
     # sanity check
     sanity_check_is_file = [
@@ -60,6 +61,12 @@ class Texinfo(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies("@7.0:"):
             targets.append("CFLAGS={}".format(self.compiler.c11_flag))
         return targets
+
+    def setup_build_environment(self, env):
+        # texinfo builds Perl XS modules internally, and by default it overrides the
+        # CC that the top-level configure reports. This loses the Spack wrappers unless
+        # we set PERL_EXT_CC
+        env.set("PERL_EXT_CC", spack_cc)
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Fixes #34269.

`texinfo` depends on `gettext`, and it builds a perl module that uses gettext via XS module FFI. Unfortunately, the XS modules build asks perl to tell it what compiler to use instead of respecting the one passed to configure.

Without this change, the build fails with this error:

```
parsetexi/api.c:33:10: fatal error: 'libintl.h' file not found
         ^~~~~~~~~~~
```

We need the gettext dependency and the spack wrappers to ensure XS builds properly.

- [x] Add needed `gettext` dependency to `texinfo`
- [x] Override XS compiler with `PERL_EXT_CC`