### PR TITLE
spack/package.py: improve editor support for some +/- static props

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -37,14 +37,12 @@ import io
 import multiprocessing
 import os
 import re
-import shutil
 import sys
 import traceback
 import types
 from typing import List, Tuple
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import install, install_tree, mkdirp
 from llnl.util.lang import dedupe
 from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
@@ -586,9 +584,6 @@ def set_module_variables_for_package(pkg):
     m.gmake = MakeExecutable("gmake", jobs)
     m.ninja = MakeExecutable("ninja", jobs, supports_jobserver=False)
 
-    # easy shortcut to os.environ
-    m.env = os.environ
-
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.
     m.configure = Executable("./configure")
@@ -607,21 +602,6 @@ def set_module_variables_for_package(pkg):
     m.spack_cxx = os.path.join(link_dir, pkg.compiler.link_paths["cxx"])
     m.spack_f77 = os.path.join(link_dir, pkg.compiler.link_paths["f77"])
     m.spack_fc = os.path.join(link_dir, pkg.compiler.link_paths["fc"])
-
-    # Emulate some shell commands for convenience
-    m.pwd = os.getcwd
-    m.cd = os.chdir
-    m.mkdir = os.mkdir
-    m.makedirs = os.makedirs
-    m.remove = os.remove
-    m.removedirs = os.removedirs
-    m.symlink = symlink
-
-    m.mkdirp = mkdirp
-    m.install = install
-    m.install_tree = install_tree
-    m.rmtree = shutil.rmtree
-    m.move = shutil.move
 
     # Useful directories within the prefix are encapsulated in
     # a Prefix object.

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -50,6 +50,7 @@ from llnl.util.tty.log import MultiProcessFd
 
 import spack.build_systems.cmake
 import spack.build_systems.meson
+import spack.build_systems.python
 import spack.builder
 import spack.config
 import spack.install_test

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *
+from llnl.util.symlink import symlink
 
 import spack.util.executable
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -8,6 +8,14 @@
 
 Everything in this module is automatically imported into Spack package files.
 """
+from os import chdir, environ, getcwd, makedirs, mkdir, remove, removedirs
+from shutil import move, rmtree
+
+# Emulate some shell commands for convenience
+env = environ
+cd = chdir
+pwd = getcwd
+
 # import most common types used in packages
 from typing import Dict, List, Optional
 
@@ -15,6 +23,9 @@ import llnl.util.filesystem
 from llnl.util.filesystem import *
 
 import spack.util.executable
+
+# These props will be overridden when the build env is set up.
+from spack.build_environment import MakeExecutable
 from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.bundle import BundlePackage
@@ -83,3 +94,10 @@ from spack.variant import (
     disjoint_sets,
 )
 from spack.version import Version, ver
+
+# These are just here for editor support; they will be replaced when the build env
+# is set up.
+make = MakeExecutable("make", jobs=1)
+gmake = MakeExecutable("gmake", jobs=1)
+ninja = MakeExecutable("ninja", jobs=1)
+configure = Executable(join_path(".", "configure"))


### PR DESCRIPTION
Move some non-package specific props into spack.package so that editor support is improved

(Also add a placeholder for build tools, although they will be overridden anyways)