### PR TITLE
Avoid stat call in `llnl.util.symlink` on non-windows

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -24,7 +24,7 @@ def symlink(real_path, link_path):
     On Windows, use junctions if os.symlink fails.
     """
     if not is_windows or _win32_can_symlink():
-        os.symlink(real_path, link_path, target_is_directory=os.path.isdir(real_path))
+        os.symlink(real_path, link_path)
     else:
         try:
             # Try to use junctions

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -23,8 +23,11 @@ def symlink(real_path, link_path):
 
     On Windows, use junctions if os.symlink fails.
     """
-    if not is_windows or _win32_can_symlink():
+    if not is_windows:
         os.symlink(real_path, link_path)
+    elif _win32_can_symlink():
+        # Windows requires target_is_directory=True when the target is a dir.
+        os.symlink(real_path, link_path, target_is_directory=os.path.isdir(real_path))
     else:
         try:
             # Try to use junctions


### PR DESCRIPTION
Avoid the redundant stat call on non-windows introduced in #33021

When creating environment views etc we really don't want to double the stat calls.