### PR TITLE
Use `urllib` handler for `s3://` and `gs://`, improve `url_exists` through HEAD requests

### DIFF
--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import urllib.response
+from urllib.error import URLError
+from urllib.request import BaseHandler
 
 import spack.util.url as url_util
-import spack.util.web as web_util
 
 
 def gcs_open(req, *args, **kwargs):
@@ -16,8 +17,13 @@ def gcs_open(req, *args, **kwargs):
     gcsblob = gcs_util.GCSBlob(url)
 
     if not gcsblob.exists():
-        raise web_util.SpackWebError("GCS blob {0} does not exist".format(gcsblob.blob_path))
+        raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
     stream = gcsblob.get_blob_byte_stream()
     headers = gcsblob.get_blob_headers()
 
     return urllib.response.addinfourl(stream, headers, url)
+
+
+class GCSHandler(BaseHandler):
+    def gs_open(self, req):
+        return gcs_open(req)

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -76,5 +76,5 @@ def _s3_open(url, method="GET"):
 class UrllibS3Handler(urllib.request.BaseHandler):
     def s3_open(self, req):
         orig_url = req.get_full_url()
-        url, headers, stream = _s3_open(orig_url, method=req.method)
+        url, headers, stream = _s3_open(orig_url, method=req.get_method())
         return urllib.response.addinfourl(stream, headers, url)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -245,13 +245,21 @@ class MockS3Client(object):
     def get_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return True
+            return {
+                "ResponseMetadata": {
+                    "HTTPHeaders": {}
+                }
+            }
         raise self.ClientError
 
     def head_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return True
+            return {
+                "ResponseMetadata": {
+                    "HTTPHeaders": {}
+                }
+            }
         raise self.ClientError
 
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -245,21 +245,13 @@ class MockS3Client(object):
     def get_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {
-                "ResponseMetadata": {
-                    "HTTPHeaders": {}
-                }
-            }
+            return {"ResponseMetadata": {"HTTPHeaders": {}}}
         raise self.ClientError
 
     def head_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {
-                "ResponseMetadata": {
-                    "HTTPHeaders": {}
-                }
-            }
+            return {"ResponseMetadata": {"HTTPHeaders": {}}}
         raise self.ClientError
 
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -223,7 +223,10 @@ class MockPaginator(object):
 
 class MockClientError(Exception):
     def __init__(self):
-        self.response = {"Error": {"Code": "NoSuchKey"}}
+        self.response = {
+            "Error": {"Code": "NoSuchKey"},
+            "ResponseMetadata": {"HTTPStatusCode": 404},
+        }
 
 
 class MockS3Client(object):
@@ -240,6 +243,12 @@ class MockS3Client(object):
         pass
 
     def get_object(self, Bucket=None, Key=None):
+        self.ClientError = MockClientError
+        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
+            return True
+        raise self.ClientError
+
+    def head_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
             return True

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -355,7 +355,9 @@ def url_exists(url, curl=None):
     url_result = url_util.parse(url)
 
     # Use curl if configured to do so
-    use_curl = spack.config.get("config:url_fetch_method", "urllib") == "curl" and url_result.scheme not in ("gs", "s3")
+    use_curl = spack.config.get(
+        "config:url_fetch_method", "urllib"
+    ) == "curl" and url_result.scheme not in ("gs", "s3")
     if use_curl:
         curl_exe = _curl(curl)
         if not curl_exe:


### PR DESCRIPTION
- The idea of `urllib` is to add handlers for custom protocols [through `<protocol>_open(req)`](https://docs.python.org/3/library/urllib.request.html#basehandler-objects), so let's do that for `s3://` and `gs://`.

- Use `head_object` for `Request("s3://...", method="HEAD")` requests

- Use `HEAD` requests in `url_exists` to avoid expensive downloads from s3.

- Create a "custom" `urlopen` that instantiates an opener once and only once.

- Keep using the standard `HTTPRedirectHandler` for `HEAD` requests; in a previous iteration of this PR, I redirected HEAD requests as HEAD requests which led to issues when downloading from BitBucket.

Before:

```python
In [1]: import spack.util.web

In [2]: %timeit spack.util.web.url_exists("s3://spack-binaries/develop/aws-ahug-aarch64/build_cache/index.json")
526 ms ± 11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: %timeit spack.util.web.url_exists("https://binaries.spack.io/develop/aws-ahug-aarch64/build_cache/index.json")
558 ms ± 9.17 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:

```python
In [1]: import spack.util.web

In [2]: %timeit spack.util.web.url_exists("s3://spack-binaries/develop/aws-ahug-aarch64/build_cache/index.json")
104 ms ± 2.89 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: %timeit spack.util.web.url_exists("https://binaries.spack.io/develop/aws-ahug-aarch64/build_cache/index.json")
146 ms ± 3.57 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```