### PR TITLE
Partially revert #32137

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -266,9 +266,6 @@ class BinaryCacheIndex(object):
                 None, just assumes all configured mirrors.
         """
         if find_hash not in self._mirrors_for_spec:
-            # Not found in the cached index, pull the latest from the server.
-            self.update(with_cooldown=True)
-        if find_hash not in self._mirrors_for_spec:
             return None
         results = self._mirrors_for_spec[find_hash]
         if not mirrors_to_check:


### PR DESCRIPTION
PR #32137 was based on the wrong assumption that direct fetches from
mirrors are necessarily slow.

The solution (fetch the index to locally see if something is in it) is
not scalable.

Instead, there's plenty of space to improve the current s3:// fetch
logic: it shouldn't create a client every time, the number of 404s can
be halved through #34325, etc.

Also, there's a work around for some of the slowness, since aws
credentials can be stored in ~/.aws/credentials or env variables,
which avoid online authentication with amazon (which presumably
generates some temporary access token).