### PR TITLE
feat(Hermes)!: add yaml-cpp dependency

### DIFF
--- a/var/spack/repos/builtin/packages/hermes/package.py
+++ b/var/spack/repos/builtin/packages/hermes/package.py
@@ -31,6 +31,7 @@ class Hermes(CMakePackage):
     depends_on("glog@0.4.0:")
     depends_on("mpi")
     depends_on("hdf5@1.13.0:", when="+vfd")
+    depends_on("yaml-cpp")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
The 0.9.0-beta requires yaml-cpp for parsing the configuration file format in YAML.

P.S. I'm using https://www.conventionalcommits.org/en/v1.0.0/#specification for this commit message.