### PR TITLE
psrcat: fixed typo/undefined variable problem

### DIFF
--- a/var/spack/repos/builtin/packages/psrcat/package.py
+++ b/var/spack/repos/builtin/packages/psrcat/package.py
@@ -22,4 +22,4 @@ class Psrcat(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install("psrcat", bindir)
+        install("psrcat", prefix.bin)


### PR DESCRIPTION
replaced the reference to the undefined "bindir" variable with prefix.bin