### PR TITLE
add perl dep to libxcrypt

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -32,6 +32,8 @@ class Libxcrypt(AutotoolsPackage):
 
     patch("truncating-conversion.patch", when="@4.4.30")
 
+    depends_on("perl@5.14:")
+
     def configure_args(self):
         args = [
             # Disable test dependency on Python (Python itself depends on libxcrypt).


### PR DESCRIPTION
added a missing depencency that was preventing me from building `libxcrpyt` on my machine

https://github.com/besser82/libxcrypt#build-requirements-and-instructions