### PR TITLE
Add back missing dependencies after #33898

### DIFF
--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -52,6 +52,9 @@ class PyBlack(PythonPackage):
     depends_on("py-ipython@7.8:", when="+jupyter", type=("build", "run"))
     depends_on("py-tokenize-rt@3.2:", when="+jupyter", type=("build", "run"))
 
+    # Needed because this package is used to bootstrap Spack (Spack supports Python 3.6+)
+    depends_on("py-dataclasses@0.6:", when="^python@:3.6", type=("build", "run"))
+
     # see: https://github.com/psf/black/issues/2964
     # note that pip doesn't know this constraint.
     depends_on("py-click@:8.0", when="@:22.2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-dataclasses/package.py
+++ b/var/spack/repos/builtin/packages/py-dataclasses/package.py
@@ -15,5 +15,5 @@ class PyDataclasses(PythonPackage):
     version("0.8", sha256="8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97")
     version("0.7", sha256="494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6")
 
-    depends_on("python@3.6.00:3.6", type=("build", "run"))
+    depends_on("python@3.6", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-dataclasses/package.py
+++ b/var/spack/repos/builtin/packages/py-dataclasses/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDataclasses(PythonPackage):
+    """A backport of the dataclasses module for Python 3.6"""
+
+    homepage = "https://github.com/ericvsmith/dataclasses"
+    pypi = "dataclasses/dataclasses-0.7.tar.gz"
+
+    version("0.8", sha256="8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97")
+    version("0.7", sha256="494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6")
+
+    depends_on("python@3.6.00:3.6", type=("build", "run"))
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -42,7 +42,7 @@ class Python(Package):
 
     #: phase
     install_targets = ["install"]
-    build_targets = []  # type: List[str]
+    build_targets: List[str] = []
 
     version("3.11.0", sha256="64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb")
     version(
@@ -233,7 +233,7 @@ class Python(Package):
     conflicts("%nvhpc")
 
     # Used to cache various attributes that are expensive to compute
-    _config_vars = {}  # type: Dict[str, Dict[str, str]]
+    _config_vars: Dict[str, Dict[str, str]] = {}
 
     # An in-source build with --enable-optimizations fails for python@3.X
     build_directory = "spack-build"

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -107,6 +107,13 @@ class Python(Package):
     version("3.7.1", sha256="36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06")
     version("3.7.0", sha256="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d")
 
+    # Python 3.6.15 has been added back only to allow bootstrapping Spack on Python 3.6
+    version(
+        "3.6.15",
+        sha256="54570b7e339e2cfd72b29c7e2fdb47c0b7b18b7412e61de5b463fc087c13b043",
+        deprecated=True,
+    )
+
     extendable = True
 
     # Variants to avoid cyclical dependencies for concretizer


### PR DESCRIPTION
Cherry-picked from #34029

Modifications:
- [x] Add back a few packages that are needed by Spack to bootstrap dev dependencies when running under Python 3.6 