### PR TITLE
trilinos: +teko conflicts with ~ml

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -232,6 +232,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         conflicts("+epetraextexperimental")
         conflicts("+epetraextgraphreorderings")
     with when("+teko"):
+        conflicts("~ml")
         conflicts("~stratimikos")
         conflicts("@:12 gotype=long")
     with when("+piro"):


### PR DESCRIPTION
Was trying to build `trilinos@13.4.0 +teko ~ml ...` today and it failed, saying `teko` depends on disabled package `ml`.

@jwillenbring @keitat @kuberry @psakievich @sethrj @wspear 