### PR TITLE
mercurial/py-pybind11: print_string no longer exists

### DIFF
--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -69,8 +69,7 @@ class Mercurial(PythonPackage):
         hgrc_filename = etc_dir.hgrc
 
         # Use certifi to find the location of the CA certificate
-        print_str = self.spec["python"].package.print_string("certifi.where()")
-        certificate = python("-c", "import certifi; " + print_str, output=str)
+        certificate = python("-c", "import certifi; print(certifi.where())", output=str)
 
         if not certificate:
             tty.warn(

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -105,8 +105,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             python = self.spec["python"].command
             py_inc = python(
                 "-c",
-                "import pybind11 as py; "
-                + self.spec["python"].package.print_string("py.get_include()"),
+                "import pybind11 as py; print(py.get_include())",
                 output=str,
             ).strip()
             for inc in [py_inc, self.prefix.include]:


### PR DESCRIPTION
Mercurial currently fails with python missing the `print_string` method.  This change fixes it by specifying use of `print()` making it python3-specific, but that's okay now.