### PR TITLE
Remove `pmull` feature from A64FX

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2302,7 +2302,6 @@
         "fp",
         "asimd",
         "evtstrm",
-        "pmull",
         "sha1",
         "sha2",
         "crc32",


### PR DESCRIPTION
With this change in Spack I finally get on Ookami
```console
$ spack arch
linux-rocky8-a64fx
```

This was missed in #44.  Should fix #23.  Again.