### PR TITLE
binary cache: do not create separate `spec.json.sig` files

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1559,7 +1559,7 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                 continue
 
             # In case the spec.json is not clearsigned, it means it's a legacy
-            # format, where either the signature is in the tarball with binaries, or 
+            # format, where either the signature is in the tarball with binaries, or
             # the package is unsigned. Verification
             # is then postponed.
             spackfile_url = mirror["spackfile"]

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1559,7 +1559,8 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                 continue
 
             # In case the spec.json is not clearsigned, it means it's a legacy
-            # format, where the signature is in the tarball with binaries. Verification
+            # format, where either the signature is in the tarball with binaries, or 
+            # the package is unsigned. Verification
             # is then postponed.
             spackfile_url = mirror["spackfile"]
             tarball_stage = try_fetch(spackfile_url)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -190,16 +190,6 @@ default_format = "{name}{@version}"
 default_format += "{%compiler.name}{@compiler.version}{compiler_flags}"
 default_format += "{variants}{arch=architecture}"
 
-#: Regular expression to pull spec contents out of clearsigned signature
-#: file.
-CLEARSIGN_FILE_REGEX = re.compile(
-    (
-        r"^-----BEGIN PGP SIGNED MESSAGE-----"
-        r"\s+Hash:\s+[^\s]+\s+(.+)-----BEGIN PGP SIGNATURE-----"
-    ),
-    re.MULTILINE | re.DOTALL,
-)
-
 #: specfile format version. Must increase monotonically
 specfile_format_version = 3
 
@@ -2480,27 +2470,6 @@ class Spec(object):
             return Spec.from_dict(data)
         except Exception as e:
             raise sjson.SpackJSONError("error parsing JSON spec:", str(e)) from e
-
-    @staticmethod
-    def extract_json_from_clearsig(data):
-        m = CLEARSIGN_FILE_REGEX.search(data)
-        if m:
-            return sjson.load(m.group(1))
-        return sjson.load(data)
-
-    @staticmethod
-    def from_signed_json(stream):
-        """Construct a spec from clearsigned json spec file.
-
-        Args:
-            stream: string or file object to read from.
-        """
-        data = stream
-        if hasattr(stream, "read"):
-            data = stream.read()
-
-        extracted_json = Spec.extract_json_from_clearsig(data)
-        return Spec.from_dict(extracted_json)
 
     @staticmethod
     def from_detection(spec_str, extra_attributes=None):

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import glob
+import io
+import json
 import os
 import platform
 import sys
@@ -666,3 +668,96 @@ def test_text_relocate_if_needed(install_mockery, mock_fetch, monkeypatch, capfd
     assert join_path("bin", "exe") in manifest["text_to_relocate"]
     assert join_path("bin", "otherexe") not in manifest["text_to_relocate"]
     assert join_path("bin", "secretexe") not in manifest["text_to_relocate"]
+
+
+def test_read_spec_from_signed_json():
+    spec_dir = os.path.join(test_path, "data", "mirrors", "signed_json")
+    file_name = (
+        "linux-ubuntu18.04-haswell-gcc-8.4.0-"
+        "zlib-1.2.12-g7otk5dra3hifqxej36m5qzm7uyghqgb.spec.json.sig"
+    )
+    spec_path = os.path.join(spec_dir, file_name)
+
+    def check_spec(spec_to_check):
+        assert spec_to_check.name == "zlib"
+        assert spec_to_check._hash == "g7otk5dra3hifqxej36m5qzm7uyghqgb"
+
+    with open(spec_path) as fd:
+        s = Spec.from_dict(bindist.load_possibly_clearsigned_json(fd))
+        check_spec(s)
+
+
+def test_load_clearsigned_json():
+    obj = {"hello": "world"}
+    clearsigned = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+xyz
+-----END PGP SIGNATURE-----""".format(
+        json.dumps(obj)
+    )
+
+    # Should accept strings and streams
+    assert bindist.load_possibly_clearsigned_json(clearsigned) == obj
+    assert bindist.load_possibly_clearsigned_json(io.StringIO(clearsigned)) == obj
+
+
+def test_load_without_clearsigned_json():
+    obj = {"hello": "world"}
+    not_clearsigned = json.dumps(obj)
+
+    # Should accept strings and streams
+    assert bindist.load_possibly_clearsigned_json(not_clearsigned) == obj
+    assert bindist.load_possibly_clearsigned_json(io.StringIO(not_clearsigned)) == obj
+
+
+def test_json_containing_clearsigned_message_is_json():
+    # Test that we don't interpret json with a PGP signed message as a string somewhere
+    # as a clearsigned message. It should just deserialize the json contents.
+    val = """\
+"-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+signature
+-----END PGP SIGNATURE-----
+"""
+    input = json.dumps({"key": val})
+    assert bindist.load_possibly_clearsigned_json(input)["key"] == val
+
+
+def test_clearsign_signature_part_of_json_string():
+    # Check if we can deal with a string in json containing the string that is used
+    # at the start of a PGP signature.
+    obj = {"-----BEGIN PGP SIGNATURE-----": "-----BEGIN PGP SIGNATURE-----"}
+    input = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+signature
+-----END PGP SIGNATURE-----
+""".format(
+        json.dumps(obj)
+    )
+    assert bindist.load_possibly_clearsigned_json(input) == obj
+
+
+def test_broken_clearsign_signature():
+    # In this test there is no PGP signature.
+    obj = {"-----BEGIN PGP SIGNATURE-----": "-----BEGIN PGP SIGNATURE-----"}
+    input = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+""".format(
+        json.dumps(obj)
+    )
+    with pytest.raises(ValueError, match="Could not find PGP signature"):
+        bindist.load_possibly_clearsigned_json(input)

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -47,27 +47,6 @@ def test_simple_spec():
     check_json_round_trip(spec)
 
 
-def test_read_spec_from_signed_json():
-    spec_dir = os.path.join(spack.paths.test_path, "data", "mirrors", "signed_json")
-    file_name = (
-        "linux-ubuntu18.04-haswell-gcc-8.4.0-"
-        "zlib-1.2.12-g7otk5dra3hifqxej36m5qzm7uyghqgb.spec.json.sig"
-    )
-    spec_path = os.path.join(spec_dir, file_name)
-
-    def check_spec(spec_to_check):
-        assert spec_to_check.name == "zlib"
-        assert spec_to_check._hash == "g7otk5dra3hifqxej36m5qzm7uyghqgb"
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd)
-        check_spec(s)
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd.read())
-        check_spec(s)
-
-
 def test_normal_spec(mock_packages):
     spec = Spec("mpileaks+debug~opt")
     spec.normalize()


### PR DESCRIPTION
There's no reason to generate a separate `spec.json.sig` file, instead we
can peek into the `spec.json` file and see if it is clearsigned json.

This PR also changes the iteration order: outer loop iterates over
extension types, inner loop over mirrors, since in time we'd expect
*.json to always be correct, whether signed or unsigned, so on a
(binary) cache hit, at most 1 request per mirror for the specfile is
necessary.

In the future we can stop using `spec.json.sig` files in general to avoid
404s. (In the near future we could also just add a config option to stop
looking for these `spec.json.sig` files.)
