### PR TITLE
Add back depends_on directives needed to bootstrap on Python 3.6

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -41,7 +41,7 @@ class PythonExtension(spack.package_base.PackageBase):
         in the source tarball directory. If the module names are incorrectly
         detected, this property can be overridden by the package.
 
-        Return:
+        Returns:
             list: list of strings of module names
         """
         modules = []

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -41,7 +41,7 @@ class PythonExtension(spack.package_base.PackageBase):
         in the source tarball directory. If the module names are incorrectly
         detected, this property can be overridden by the package.
 
-        Returns:
+        Return:
             list: list of strings of module names
         """
         modules = []

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class PyPip(Package):
+class PyPip(Package, PythonExtension):
     """The PyPA recommended tool for installing Python packages."""
 
     homepage = "https://pip.pypa.io/"

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class PyPip(Package, PythonExtension):
+class PyPip(Package):
     """The PyPA recommended tool for installing Python packages."""
 
     homepage = "https://pip.pypa.io/"
@@ -74,6 +74,12 @@ class PyPip(Package, PythonExtension):
     )
 
     extends("python")
+    depends_on("python@3.7:", when="@22:", type=("build", "run"))
+    depends_on("python@3.6:", when="@21:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.5:", when="@19.2:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.4:", when="@18:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.3:", when="@10:", type=("build", "run"))
+    depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/p/pip/pip-{1}-{0}-none-any.whl"

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -6,15 +6,13 @@
 from spack.package import *
 
 
-class PySetuptools(Package):
+class PySetuptools(Package, PythonExtension):
     """A Python utility that aids in the process of downloading, building,
     upgrading, installing, and uninstalling Python packages."""
 
     homepage = "https://github.com/pypa/setuptools"
     url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/setuptools/"
-
-    maintainers = ["adamjstewart"]
 
     version(
         "65.5.0",

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -6,13 +6,15 @@
 from spack.package import *
 
 
-class PySetuptools(Package, PythonExtension):
+class PySetuptools(Package):
     """A Python utility that aids in the process of downloading, building,
     upgrading, installing, and uninstalling Python packages."""
 
     homepage = "https://github.com/pypa/setuptools"
     url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/setuptools/"
+
+    maintainers = ["adamjstewart"]
 
     version(
         "65.5.0",
@@ -176,6 +178,11 @@ class PySetuptools(Package, PythonExtension):
     )
 
     extends("python")
+    depends_on("python@3.7:", when="@59.7:", type=("build", "run"))
+    depends_on("python@3.6:", when="@51:", type=("build", "run"))
+    depends_on("python@3.5:", when="@45:50", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.5:", when="@44", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.4:", when="@:43", type=("build", "run"))
     depends_on("py-pip", type="build")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyWheel(Package):
+class PyWheel(Package, PythonExtension):
     """A built-package format for Python."""
 
     homepage = "https://github.com/pypa/wheel"
@@ -14,8 +14,6 @@ class PyWheel(Package):
         "https://files.pythonhosted.org/packages/py2.py3/w/wheel/wheel-0.34.2-py2.py3-none-any.whl"
     )
     list_url = "https://pypi.org/simple/wheel/"
-
-    maintainers = ["adamjstewart"]
 
     version(
         "0.37.1",

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyWheel(Package, PythonExtension):
+class PyWheel(Package):
     """A built-package format for Python."""
 
     homepage = "https://github.com/pypa/wheel"
@@ -14,6 +14,8 @@ class PyWheel(Package, PythonExtension):
         "https://files.pythonhosted.org/packages/py2.py3/w/wheel/wheel-0.34.2-py2.py3-none-any.whl"
     )
     list_url = "https://pypi.org/simple/wheel/"
+
+    maintainers = ["adamjstewart"]
 
     version(
         "0.37.1",
@@ -72,6 +74,9 @@ class PyWheel(Package, PythonExtension):
     )
 
     extends("python")
+    depends_on("python@2.7:2.8,3.5:", when="@0.34:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.4:", when="@0.30:", type=("build", "run"))
+    depends_on("python@2.6:2.8,3.2:", type=("build", "run"))
     depends_on("py-pip", type="build")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Reverts spack/spack#34137

@adamjstewart Trying to check if this broke bootstrapping when merged to develop