### PR TITLE
julia: have recipe use Spack compiler wrapper

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -274,6 +274,12 @@ class Julia(MakefilePackage):
         options.append("USEGCC:={}".format("1" if "%gcc" in spec else "0"))
         options.append("USECLANG:={}".format("1" if "%clang" in spec else "0"))
 
+        options.extend([
+            "override CC:={0}".format(spack_cc),
+            "override CXX:={0}".format(spack_cxx),
+            "override FC:={0}".format(spack_fc),
+        ])
+
         # libm or openlibm?
         if spec.variants["openlibm"].value:
             options.append("USE_SYSTEM_LIBM=0")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -274,11 +274,13 @@ class Julia(MakefilePackage):
         options.append("USEGCC:={}".format("1" if "%gcc" in spec else "0"))
         options.append("USECLANG:={}".format("1" if "%clang" in spec else "0"))
 
-        options.extend([
-            "override CC:={0}".format(spack_cc),
-            "override CXX:={0}".format(spack_cxx),
-            "override FC:={0}".format(spack_fc),
-        ])
+        options.extend(
+            [
+                "override CC:={0}".format(spack_cc),
+                "override CXX:={0}".format(spack_cxx),
+                "override FC:={0}".format(spack_fc),
+            ]
+        )
 
         # libm or openlibm?
         if spec.variants["openlibm"].value:


### PR DESCRIPTION
The julia build does not currently use the Spack compiler wrapper.
```
 gcc -march=cascadelake -m64 -O3 -ggdb2 -falign-functions -momit-leaf-frame-pointer -DDEP_LIBS="\"$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib/julia/libgcc_s.so.1):$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib/julia/libopenlibm.so):@$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib/libjulia-internal.so.1):@$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/lib/libjulia-codegen.so.1):\"" -std=gnu99 -pipe -fPIC -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -DSYSTEM_LIBUNWIND -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/src -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/src -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/src/support -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/usr/include -ffreestanding -c /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-ldwjvuzfg7ztmt5e4a4l4vy2aruntqzh/spack-src/cli/loader_exe.c -o loader_exe.o
```
This PR overrides the CC, CXX, and FC variables to point to the Spack compiler wrapper.
```
 /opt/packages/gpjohnsn/spack/lib/spack/env/gcc/gcc -O3 -ggdb2 -falign-functions -momit-leaf-frame-pointer -DDEP_LIBS="\"$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib/julia/libgcc_s.so.1):$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib/julia/libopenlibm.so):@$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib/libjulia-internal.so.1):@$("/usr/bin/python" /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/contrib/relative_path.py /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/lib/libjulia-codegen.so.1):\"" -std=gnu99 -pipe -fPIC -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -DSYSTEM_LIBUNWIND -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/src -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/src -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/src/support -I/tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/usr/include -ffreestanding -c /tmp/gpjohnsn/spack-stage/spack-stage-julia-1.8.3-4fdx4oye5vmxwimr6q2v63imv3ukrjn2/spack-src/cli/loader_exe.c -o loader_exe.o
```