### PR TITLE
Bump libxcrypt minimum automake to v1.14:

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -42,6 +42,6 @@ class Libxcrypt(AutotoolsPackage):
 
     with when("@:4.4.17"):
         depends_on("autoconf", type="build")
-        depends_on("automake", type="build")
+        depends_on("automake@1.14:", type="build")
         depends_on("libtool", type="build")
         depends_on("m4", type="build")


### PR DESCRIPTION
According to the projects documentation it requires a version of automake 1.14 or newer.