### PR TITLE
mfem +rocm: depends_on rocsparse

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -238,6 +238,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     conflicts("^mpich@4:", when="@:4.3+mpi")
 
     depends_on("mpi", when="+mpi")
+    depends_on("rocsparse", when="@4.4.0:+rocm")
     depends_on("hipsparse", when="@4.4.0:+rocm")
     depends_on("hypre@2.10.0:2.13", when="@:3.3+mpi")
     depends_on("hypre@:2.20.0", when="@3.4:4.2+mpi")


### PR DESCRIPTION
`mfem +rocm` needs explicit dependency on `rocsparse` in order to resolve this error when trying to install `mfem+rocm` against an externally provided ROCm stack:
```
==> Installing mfem-4.5.0-qc4qy7hqqdf36k6qtmforan6uqwk5je5
==> No binary for mfem-4.5.0-qc4qy7hqqdf36k6qtmforan6uqwk5je5 found: installing from source
==> Fetching https://bit.ly/mfem-4-5
==> No patches needed for mfem
==> mfem: Executing phase: 'configure'
==> Error: KeyError: 'No spec with name rocsparse in mfem@4.5.0 ...
```

@acfisher @goxberry @markcmiller86 @tzanio @v-dobrev 

CC @wspear 