### PR TITLE
bcache: fixup check for libintl correctly

### DIFF
--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -26,7 +26,7 @@ class Bcache(MakefilePackage):
 
     def setup_build_environment(self, env):
         # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
-        if any("libintl" in filename for filename in self.libs):
+        if any("libintl." in filename.split("/")[-1] for filename in self.spec["gettext"].libs):
             env.append_flags("LDFLAGS", "-lintl")
 
     patch(


### PR DESCRIPTION
Hi @sethrj it's best if you review this fixup for #34114: 

The applied suggestion to #34114 broke `spack install bcache`:
> The 'bcache' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe...
```py

/data/spack/spack/lib/spack/spack/builder.py:132, in __getattr__:
  >>    132        def __getattr__(self, item):
```
The suggested check in `self.libs` (which does not exist) is the cause of this error from `__getattr__`.

### Checking for the `libs` property from `gettext` if it contains a `libintl` is what is needed.

That is what how I tested and pushed it initially for #34114 as well.

Here is the implementation of `spec["gettext"].libs` from `var/spack/repos/builtin/packages/gettext/package.py`:
```py
   @property
    def libs(self):
        return find_libraries(
            ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "libintl"],
            root=self.prefix,
            recursive=True,
```
It looks for the gettext libs provided in the prefix of that package (external or internal) and gives a list of the libs it has found.

The fix is:
```py
-        if any("libintl" in filename for filename in self.libs):
+        if any("libintl." in filename.split("/")[-1] for filename in self.spec["gettext"].libs):
```
This checks that a `libintl` library (**checks the file name, not the path to it**) is provided by gettext before adding `-lintl`.

#### Test of this change:

This is the output line from `spack install -v bcache ^gettext@0.21.1` (at gettext with libintl):
`spack/lib/spack/env/gcc/gcc -O2 -Wall -g -std=gnu99  -lintl  ...`
When building against the external gettext, libintl is not found by `self.spec["gettext"].libs` and ` `-lintl` is not added.

Both builds work as expected, the fix from this PR works in both cases.