### PR TITLE
pixman: libs property: Use lib64 if it exists, else lib

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -54,7 +54,11 @@ class Pixman(AutotoolsPackage):
 
     @property
     def libs(self):
-        return find_libraries("libpixman-1", self.prefix, shared=True, recursive=True)
+        if os.path.exists(self.prefix.lib64):
+            libdir = self.prefix.lib64
+        else:
+            libdir = self.prefix.lib
+        return find_libraries("libpixman-1", libdir, shared=True, recursive=True)
 
     def configure_args(self):
         args = [


### PR DESCRIPTION
@glennpj: After seeing alalzo's comment in #34288, I want to make sure to restrict the libs search
to .lib64 (if it exists, that should work on SUSE distros) or .lib.

@glennpj  Do you have a testcase for `spec["pixman"].libs` that you can test this with?