### PR TITLE
intel-mkl: It is only available for x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -139,6 +139,10 @@ class IntelMkl(IntelPackage):
 
     depends_on("cpio", type="build")
 
+    conflicts("target=ppc64:", msg="intel-mkl is only available for x86_64")
+    conflicts("target=ppc64le:", msg="intel-mkl is only available for x86_64")
+    conflicts("target=aarch64:", msg="intel-mkl is only available for x86_64")
+
     variant("shared", default=True, description="Builds shared library")
     variant("ilp64", default=False, description="64 bit integers")
     variant(


### PR DESCRIPTION
When trying to build other packages there were attempts to build intel-mkl on arm64 and ppc64, but they failed as it is only provided for x86_64 by Intel. Copied from e.g. povray and others:
```py
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=aarch64:", msg="Intel MKL only runs on x86")
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=ppc64:", msg="Intel MKL only runs on x86")
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=ppc64le:", msg="Intel MKL only runs on x86")
```