### PR TITLE
intel-oneapi-tbb: It is only available for x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -82,6 +82,10 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
 
     provides("tbb")
 
+    conflicts("target=ppc64:", msg="intel-oneapi-tbb is only available for x86_64")
+    conflicts("target=ppc64le:", msg="intel-oneapi-tbb is only available for x86_64")
+    conflicts("target=aarch64:", msg="intel-oneapi-tbb is only available for x86_64")
+
     @property
     def component_dir(self):
         return "tbb"


### PR DESCRIPTION
When trying to build other packages there were attempts to build intel-oneapi-tbb on arm64 and ppc64, but they failed as it is only provided for x86_64 by Intel. Copied from e.g. povray and others:
```py
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=aarch64:", msg="Intel MKL only runs on x86")
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=ppc64:", msg="Intel MKL only runs on x86")
var/spack/repos/builtin/packages/povray/package.py:    conflicts("+mkl", when="target=ppc64le:", msg="Intel MKL only runs on x86")
```