### PR TITLE
Add pika-algorithms package and pika 0.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -38,7 +38,7 @@ class Fmt(CMakePackage):
     variant(
         "cxxstd",
         default="11",
-        values=("98", "11", "14", "17"),
+        values=("98", "11", "14", "17", "20"),
         multi=False,
         description="Use the specified C++ standard when building",
     )

--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -1,0 +1,53 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PikaAlgorithms(CMakePackage):
+    """C++ parallel algorithms built on pika."""
+
+    homepage = "https://github.com/pika-org/pika-algorithms/"
+    url = "https://github.com/pika-org/pika-algorithms/archive/0.0.0.tar.gz"
+    git = "https://github.com/pika-org/pika-algorithms.git"
+    maintainers = ["msimberg", "albestro", "teonnik", "aurianer"]
+
+    version("0.1.0", sha256="64da008897dfa7373155595c46d2ce6b97a8a3cb5bea33ae7f2d1ff359f0d9b6")
+    version("main", branch="main")
+
+    generator = "Ninja"
+
+    map_cxxstd = lambda cxxstd: "2a" if cxxstd == "20" else cxxstd
+    cxxstds = ("17", "20")
+    variant(
+        "cxxstd",
+        default="17",
+        values=cxxstds,
+        description="Use the specified C++ standard when building",
+    )
+
+    # Build dependencies
+    depends_on("git", type="build")
+    depends_on("ninja", type="build")
+    depends_on("cmake@3.22:", type="build")
+
+    conflicts("%gcc@:8")
+    conflicts("%clang@:8")
+
+    # Other dependencies
+    depends_on("boost@1.71:")
+    depends_on("fmt@0.9:")
+    depends_on("pika@0.11:")
+
+    for cxxstd in cxxstds:
+        depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))
+        depends_on("fmt cxxstd={0}".format(cxxstd), when="cxxstd={0}".format(cxxstd))
+        depends_on("pika cxxstd={0}".format(cxxstd), when="cxxstd={0}".format(cxxstd))
+
+    def cmake_args(self):
+        return [
+            self.define("PIKA_ALGORITHMS_WITH_CXX_STANDARD", self.spec.variants["cxxstd"].value)
+        ]

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -17,6 +17,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pika-org/pika.git"
     maintainers = ["msimberg", "albestro", "teonnik", "aurianer"]
 
+    version("0.11.0", sha256="3c3d94ca1a3960884bad7272bb9434d61723f4047ebdb097fcf522c6301c3fda")
     version("0.10.0", sha256="3b443b8f0f75b9a558accbaef0334a113a71b0205770e6c7ff02ea2d7c6aca5b")
     version("0.9.0", sha256="c349b2a96476d6974d2421288ca4d2e14ef9e5897d44cd7d5343165faa2d1299")
     version("0.8.0", sha256="058e82d7c8f95badabe52bbb4682d55aadf340d67ced1226c0673b4529adc182")
@@ -82,8 +83,9 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+p2300", when="cxxstd=17")
 
     # Other dependencies
-    depends_on("hwloc@1.11.5:")
     depends_on("boost@1.71:")
+    depends_on("fmt@0.9:", when="@0.11:")
+    depends_on("hwloc@1.11.5:")
 
     depends_on("gperftools", when="malloc=tcmalloc")
     depends_on("jemalloc", when="malloc=jemalloc")
@@ -105,6 +107,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     for cxxstd in cxxstds:
         depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))
+        depends_on("fmt cxxstd={0}".format(cxxstd), when="cxxstd={0}".format(cxxstd))
 
     # COROUTINES
     # ~generic_coroutines conflict is not fully implemented

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -66,7 +66,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
         "p2300",
         default=False,
         description="Use P2300 reference implementation for sender/receiver functionality",
-        when="@main",
+        when="@0.9:",
     )
 
     # Build dependencies


### PR DESCRIPTION
Adds a new version of pika and a new package pika-algorithms. I'm adding them together because pika-algorithms is split out from pika, and requires pika 0.11.0.

This also adds some minor fixes and changes to the pika package:
- adds fmt as a dependency from 0.11.0 onwards
- adds 20 as a valid option for `cxxstd` in the fmt package 
- fixes the `when` clause for the `+p2300` variant

@albestro, @aurianer, @teonnik I've added you "by default" as maintainers as well since you're listed on the pika package. Let me know if you'd prefer not to be there.