### PR TITLE
Mochi-Margo: needs to link with pthread for examples

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -64,3 +64,10 @@ class MochiMargo(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         sh = which("sh")
         sh("./prepare.sh")
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags":
+            flags.append("-pthread")
+            return (None, flags, None)
+
+        return (flags, None, None)


### PR DESCRIPTION
Missing link flag prevents builds on crusher

CC: @eugeneswalker 