### PR TITLE
py-torchvision: fix typo in version restriction for ffmpeg

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -112,7 +112,7 @@ class PyTorchvision(PythonPackage):
     depends_on("jpeg")  # seems to be required for all backends
 
     depends_on("ffmpeg@3.1:4.4", when="@0.4.2:0.12.0")
-    depends_on("ffmpeg@3.1:", when="@13.0:")
+    depends_on("ffmpeg@3.1:", when="@0.13.0:")
 
     # Many of the datasets require additional dependencies to use.
     # These can be installed after the fact.


### PR DESCRIPTION
Was looking through my semi-recent PRs incidentally and spotted a typo.