### PR TITLE
bugfix: `spack load` shell test can fail on macos

### DIFF
--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -111,7 +111,8 @@ contains "b@" echo $LIST_CONTENT
 does_not_contain "a@" echo $LIST_CONTENT
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
-contains "export PATH=$(spack -m location -i a)/bin:$(spack -m location -i b)/bin" spack -m load --sh a
+contains "export PATH=$(spack -m location -i a)/bin" spack -m load --sh a
+contains "export PATH=$(spack -m location -i b)/bin" spack -m load --sh b
 succeeds spack -m load --only dependencies a
 succeeds spack -m load --only package a
 fails spack -m load d


### PR DESCRIPTION
At some point the `a` mock package became an `AutotoolsPackage`, and that means it depends on `gnuconfig` on macOS. This was causing one of our shell tests to fail on macOS because it was testing for `{a.prefix.bin}:{b.prefix.bin}` in `PATH`, but `gnuconfig` was showing up between them.

- [x] fix test to check `spack load --sh a` and `spack load --sh b` separately