### PR TITLE
Don't build tests for `fmt`

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -106,4 +106,7 @@ class Fmt(CMakePackage):
         # and call to build "doc" target
         args.append("-DFMT_DOC=OFF")
 
+        # Don't build tests
+        args.append(self.define("FMT_TEST", self.run_tests))
+
         return args


### PR DESCRIPTION
Building the tests take a decent amount of time and is not necessary, so this turns the tests off.