### PR TITLE
Skip build step for `stdexec`

### DIFF
--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -19,3 +19,6 @@ class Stdexec(CMakePackage):
 
     conflicts("%gcc@:10")
     conflicts("%clang@:13")
+
+    def build(self, spec, prefix):
+        pass


### PR DESCRIPTION
Since it's a header-only library there's nothing to build. However, the default targets include tests and examples which take a bit of time to build. There's no option to turn them off during configuration time, so this instead simply skips the build stage.