### PR TITLE
geant4: version bumps for Geant4 11.1.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -18,6 +18,7 @@ class G4emlow(Package):
     maintainers = ["drbenmorgan"]
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("8.2", sha256="3d7768264ff5a53bcb96087604bbe11c60b7fea90aaac8f7d1252183e1a8e427")
     version("8.0", sha256="d919a8e5838688257b9248a613910eb2a7633059e030c8b50c0a2c2ad9fd2b3b")
     version("7.13", sha256="374896b649be776c6c10fea80abe6cf32f9136df0b6ab7c7236d571d49fb8c69")
     version("7.9.1", sha256="820c106e501c64c617df6c9e33a0f0a3822ffad059871930f74b8cc37f043ccb")

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -17,6 +17,7 @@ class G4ndl(Package):
 
     maintainers = ["drbenmorgan"]
 
+    version("4.7", sha256="7e7d3d2621102dc614f753ad928730a290d19660eed96304a9d24b453d670309")
     version("4.6", sha256="9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408")
     version("4.5", sha256="cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e")
 

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ["hep"]
 
+    version("11.1.0")
     version("11.0.0")
     version("10.7.3")
     version("10.7.2")
@@ -39,7 +40,20 @@ class Geant4Data(BundlePackage):
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
     _datasets = {
-        "11.0:11": [
+        "11.1.0:11.1": [
+            "g4ndl@4.7",
+            "g4emlow@8.2",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4particlexs@4.0",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.1",
+            "g4incl@1.0",
+            "g4ensdfstate@2.3",
+        ],
+        "11.0.0:11.0": [
             "g4ndl@4.6",
             "g4emlow@8.0",
             "g4photonevaporation@5.7",

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -21,6 +21,7 @@ class Geant4(CMakePackage):
 
     maintainers = ["drbenmorgan"]
 
+    version("11.1.0", sha256="c4a23f2f502efeab56de43a4412b21f65c7ca1b0877b9bc1d7e845ee12edf70a")
     version("11.0.3", sha256="1e6560b802aa84e17255b83987dfc98a1457154fb603d0f340fae978238de3e7")
     version("11.0.2", sha256="661e1ab6f42e58910472d771e76ffd16a2b411398eed70f39808762db707799e")
     version("11.0.1", sha256="fa76d0774346b7347b1fb1424e1c1e0502264a83e185995f3c462372994f84fa")
@@ -59,7 +60,7 @@ class Geant4(CMakePackage):
     variant("x11", default=False, description="Optional X11 support")
     variant("motif", default=False, description="Optional motif support")
     variant("qt", default=False, description="Enable Qt support")
-    variant("python", default=False, when="@10.6.2:", description="Enable Python bindings")
+    variant("python", default=False, description="Enable Python bindings", when="@10.6.2:10.7")
     variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
     variant("vtk", default=False, description="Enable VTK support", when="@11:")
 
@@ -80,7 +81,8 @@ class Geant4(CMakePackage):
         "10.7.1",
         "10.7.2",
         "10.7.3",
-        "11.0:",
+        "11.0.0:11.0",
+        "11.1:",
     ]:
         depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
 
@@ -96,6 +98,8 @@ class Geant4(CMakePackage):
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed
+        depends_on("clhep@2.4.6.0: cxxstd=" + std, when="@11.1: cxxstd=" + std)
+
         depends_on("clhep@2.4.5.1: cxxstd=" + std, when="@11.0.0: cxxstd=" + std)
 
         depends_on("clhep@2.4.4.0: cxxstd=" + std, when="@10.7.0: cxxstd=" + std)
@@ -106,8 +110,9 @@ class Geant4(CMakePackage):
         depends_on("xerces-c netaccessor=curl cxxstd=" + std, when="cxxstd=" + std)
 
         # Vecgeom specific versions for each Geant4 version
-        depends_on("vecgeom@1.1.18:1.1 cxxstd=" + std, when="@11.0.0: +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@1.1.8:1.1 cxxstd=" + std, when="@10.7.0: +vecgeom cxxstd=" + std)
+        depends_on("vecgeom@1.2.0: cxxstd=" + std, when="@11.1: +vecgeom cxxstd=" + std)
+        depends_on("vecgeom@1.1.18:1.1 cxxstd=" + std, when="@11.0.0:11.0 +vecgeom cxxstd=" + std)
+        depends_on("vecgeom@1.1.8:1.1 cxxstd=" + std, when="@10.7.0:10.7 +vecgeom cxxstd=" + std)
         depends_on("vecgeom@1.1.5 cxxstd=" + std, when="@10.6.0:10.6 +vecgeom cxxstd=" + std)
         depends_on("vecgeom@1.1.0 cxxstd=" + std, when="@10.5.0:10.5 +vecgeom cxxstd=" + std)
         depends_on("vecgeom@0.5.2 cxxstd=" + std, when="@10.4.0:10.4 +vecgeom cxxstd=" + std)

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -60,7 +60,7 @@ class Geant4(CMakePackage):
     variant("x11", default=False, description="Optional X11 support")
     variant("motif", default=False, description="Optional motif support")
     variant("qt", default=False, description="Enable Qt support")
-    variant("python", default=False, description="Enable Python bindings", when="@10.6.2:10.7")
+    variant("python", default=False, description="Enable Python bindings", when="@10.6.2:11.0")
     variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
     variant("vtk", default=False, description="Enable VTK support", when="@11:")
 


### PR DESCRIPTION
This is mostly just version bumps for the main Geant4 package, plus two new data libraries and the data meta package:

- geant4@11.1.0
- geant4-data@11.1
- g4ndl@4.7
- g4emlow@8.2

There are some changes to variants and dependencies:

- The `+python` variant is only supported up version 11.0 due to removal of Geant4Py from Geant4 11.1
- CLHEP dependency is bumped to at least 2.4.6.0 for this release
- VecGeom dependency to at least 1.2.0 for this release. Version ranges for older Geant4 versions were bookended to VecGeom 1.1 to prevent the solver finding multiple versions satisfying the new requirement.

I've tested locally in a GCC 11.3 environment, and a full build seems to work o.k., but CI/review might throw something up, let's see.