### PR TITLE
Fix openblas build with intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/f_check-intel.patch
+++ b/var/spack/repos/builtin/packages/openblas/f_check-intel.patch
@@ -1,0 +1,11 @@
+--- a/f_check	2022-08-07 15:36:26.000000000 -0500
++++ b/f_check	2022-12-09 14:30:44.692615122 -0600
+@@ -102,7 +102,7 @@
+                             vendor=FLANG
+                             openmp='-fopenmp'
+                             ;;
+-                        *ifx*)
++                        *ifort*|*ifx*)
+                             vendor=INTEL
+                             openmp='-fopenmp'
+                             ;;

--- a/var/spack/repos/builtin/packages/openblas/f_check-intel.patch
+++ b/var/spack/repos/builtin/packages/openblas/f_check-intel.patch
@@ -1,5 +1,6 @@
+diff -ur a/f_check b/f_check
 --- a/f_check	2022-08-07 15:36:26.000000000 -0500
-+++ b/f_check	2022-12-09 14:30:44.692615122 -0600
++++ b/f_check	2022-12-09 16:17:43.475278869 -0600
 @@ -102,7 +102,7 @@
                              vendor=FLANG
                              openmp='-fopenmp'
@@ -9,3 +10,15 @@
                              vendor=INTEL
                              openmp='-fopenmp'
                              ;;
+diff -ur a/f_check.pl b/f_check.pl
+--- a/f_check.pl	2022-08-07 15:36:26.000000000 -0500
++++ b/f_check.pl	2022-12-09 16:18:59.982923288 -0600
+@@ -95,7 +95,7 @@
+ 		if ($compiler =~ /flang/) {
+ 		    $vendor = FLANG;
+ 		    $openmp = "-fopenmp";
+-	    } elsif ($compiler =~ /ifx/) {
++	    } elsif ($compiler =~ /ifort/ || $compiler =~ /ifx/) {
+ 		    $vendor = INTEL;
+ 		    $openmp = "-fopenmp";
+ 	    } elsif ($compiler =~ /pgf/ || $compiler =~ /nvf/) {

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -94,6 +94,7 @@ class Openblas(MakefilePackage):
 
     # https://github.com/spack/spack/issues/31732
     patch("f_check-oneapi.patch", when="@0.3.20 %oneapi")
+    patch("f_check-intel.patch", when="@0.3.21 %intel")
 
     # OpenBLAS >=3.0 has an official way to disable internal parallel builds
     patch("make.patch", when="@0.2.16:0.2.20")


### PR DESCRIPTION
This PR patches the f_check script to detect the ifort compiler and ensure that F_COMPILER is iset to INTEL. This problem was introduced with openblas-0.3.21. Without this patch, the value of F_COMPILER falls back to G77 and icc rather than ifort is used for the linking stage. That results in the openblas library missing libifcore, which in turn means many Fotran programs can not be compiled with ifort.