### PR TITLE
OpenBLAS: change make target to all

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -445,12 +445,7 @@ class Openblas(MakefilePackage):
 
     @property
     def build_targets(self):
-        targets = ["libs", "netlib"]
-
-        # Build shared if variant is set.
-        if "+shared" in self.spec:
-            targets += ["shared"]
-
+        targets = ["all"]
         return self.make_defs + targets
 
     @run_after("build")


### PR DESCRIPTION
This causes the Makefile to serialize the make targets by calling the target all.  If the make runs multiple targets they will run in parallel causing compile errors.