### PR TITLE
intel-oneapi-* conflicts for non linux, x86

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -10,6 +10,7 @@ from os.path import basename, dirname, isdir
 
 from llnl.util.filesystem import find_headers, find_libraries, join_path
 
+from spack.directives import conflicts
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 
@@ -24,6 +25,16 @@ class IntelOneApiPackage(Package):
     # oneAPI license does not allow mirroring outside of the
     # organization (e.g. University/Company).
     redistribute_source = False
+
+    for c in [
+        "target=ppc64:",
+        "target=ppc64le:",
+        "target=aarch64:",
+        "platform=darwin:",
+        "platform=cray:",
+        "platform=windows:",
+    ]:
+        conflicts(c, msg="This package in only available for x86_64 and Linux")
 
     @staticmethod
     def update_description(cls):

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -26,37 +24,36 @@ class IntelOneapiAdvisor(IntelOneApiPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/advisor.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2022.3.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18985/l_oneapi_advisor_p_2022.3.1.15323_offline.sh",
-            sha256="f05b58c2f13972b3ac979e4796bcc12a234b1e077400b5d00fc5df46cd228899",
-            expand=False,
-        )
-        version(
-            "2022.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18872/l_oneapi_advisor_p_2022.3.0.8704_offline.sh",
-            sha256="ae1e542e6030b04f70f3b9831b5e92def97ce4692c974da44e7e9d802f25dfa7",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18730/l_oneapi_advisor_p_2022.1.0.171_offline.sh",
-            sha256="b627dbfefa779b44e7ab40dfa37614e56caa6e245feaed402d51826e6a7cb73b",
-            expand=False,
-        )
-        version(
-            "2022.0.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh",
-            sha256="f1c4317c2222c56fb2e292513f7eec7ec27eb1049d3600cb975bc08ed1477993",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18220/l_oneapi_advisor_p_2021.4.0.389_offline.sh",
-            sha256="dd948f7312629d9975e12a57664f736b8e011de948771b4c05ad444438532be8",
-            expand=False,
-        )
+    version(
+        "2022.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18985/l_oneapi_advisor_p_2022.3.1.15323_offline.sh",
+        sha256="f05b58c2f13972b3ac979e4796bcc12a234b1e077400b5d00fc5df46cd228899",
+        expand=False,
+    )
+    version(
+        "2022.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18872/l_oneapi_advisor_p_2022.3.0.8704_offline.sh",
+        sha256="ae1e542e6030b04f70f3b9831b5e92def97ce4692c974da44e7e9d802f25dfa7",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18730/l_oneapi_advisor_p_2022.1.0.171_offline.sh",
+        sha256="b627dbfefa779b44e7ab40dfa37614e56caa6e245feaed402d51826e6a7cb73b",
+        expand=False,
+    )
+    version(
+        "2022.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh",
+        sha256="f1c4317c2222c56fb2e292513f7eec7ec27eb1049d3600cb975bc08ed1477993",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18220/l_oneapi_advisor_p_2021.4.0.389_offline.sh",
+        sha256="dd948f7312629d9975e12a57664f736b8e011de948771b4c05ad444438532be8",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -29,61 +27,60 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
 
     depends_on("intel-oneapi-mpi")
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19029/l_oneapi_ccl_p_2021.7.1.16948_offline.sh",
-            sha256="daab05a0779db343b600253df8fea93ab0ed20bd630d89883dd651b6b540b1b2",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18891/l_oneapi_ccl_p_2021.7.0.8733_offline.sh",
-            sha256="a0e64db03868081fe075afce8abf4cb94236effc6c52e5049118cfb2ef81a6c7",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18697/l_oneapi_ccl_p_2021.6.0.568.sh",
-            sha256="e3c50c9cbeb350e8f28488b2e8fee54156116548db8010bb2c2443048715d3ea",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh",
-            sha256="237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e",
-            expand=False,
-        )
-        version(
-            "2021.5.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh",
-            sha256="47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18188/l_oneapi_ccl_p_2021.4.0.433_offline.sh",
-            sha256="004031629d97ef99267d8ea962b666dc4be1560d7d32bd510f97bc81d9251ef6",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17920/l_oneapi_ccl_p_2021.3.0.343_offline.sh",
-            sha256="0bb63e2077215cc161973b2e5029919c55e84aea7620ee9a848f6c2cc1245e3f",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh",
-            sha256="18b7875030243295b75471e235e91e5f7b4fc15caf18c07d941a6d47fba378d7",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh",
-            sha256="de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49",
-            expand=False,
-        )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19029/l_oneapi_ccl_p_2021.7.1.16948_offline.sh",
+        sha256="daab05a0779db343b600253df8fea93ab0ed20bd630d89883dd651b6b540b1b2",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18891/l_oneapi_ccl_p_2021.7.0.8733_offline.sh",
+        sha256="a0e64db03868081fe075afce8abf4cb94236effc6c52e5049118cfb2ef81a6c7",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18697/l_oneapi_ccl_p_2021.6.0.568.sh",
+        sha256="e3c50c9cbeb350e8f28488b2e8fee54156116548db8010bb2c2443048715d3ea",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh",
+        sha256="237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e",
+        expand=False,
+    )
+    version(
+        "2021.5.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh",
+        sha256="47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18188/l_oneapi_ccl_p_2021.4.0.433_offline.sh",
+        sha256="004031629d97ef99267d8ea962b666dc4be1560d7d32bd510f97bc81d9251ef6",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17920/l_oneapi_ccl_p_2021.3.0.343_offline.sh",
+        sha256="0bb63e2077215cc161973b2e5029919c55e84aea7620ee9a848f6c2cc1245e3f",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh",
+        sha256="18b7875030243295b75471e235e91e5f7b4fc15caf18c07d941a6d47fba378d7",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh",
+        sha256="de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -3,13 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 import spack.compilers
 from spack.build_environment import dso_suffix
 from spack.package import *
 
-linux_versions = [
+versions = [
     {
         "version": "2022.2.1",
         "cpp": {
@@ -134,16 +132,15 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 "%{0}".format(__compiler), msg="intel-oneapi-compilers must be installed with %gcc"
             )
 
-    if platform.system() == "Linux":
-        for v in linux_versions:
-            version(v["version"], expand=False, **v["cpp"])
-            resource(
-                name="fortran-installer",
-                placement="fortran-installer",
-                when="@{0}".format(v["version"]),
-                expand=False,
-                **v["ftn"]
-            )
+    for v in versions:
+        version(v["version"], expand=False, **v["cpp"])
+        resource(
+            name="fortran-installer",
+            placement="fortran-installer",
+            when="@{0}".format(v["version"]),
+            expand=False,
+            **v["ftn"],
+        )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -28,61 +26,60 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19032/l_daal_oneapi_p_2021.7.1.16996_offline.sh",
-            sha256="2328927480b0ba5d380028f981717b63ee323f8a1616a491a160a0a0b239e285",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18895/l_daal_oneapi_p_2021.7.0.8746_offline.sh",
-            sha256="c18e68df120c2b1db17877cfcbb1b5c93a47b2f4756a3444c663d0f03be4eee3",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18698/l_daal_oneapi_p_2021.6.0.915_offline.sh",
-            sha256="bc9a430f372a5f9603c19ec25207c83ffd9d59fe517599c734d465e32afc9790",
-            expand=False,
-        )
-        version(
-            "2021.5.3",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh",
-            sha256="6d3503cf7be2908bbb7bd18e67b8f2e96ad9aec53d4813c9be620adaa2db390f",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh",
-            sha256="bba7bee3caef14fbb54ad40615222e5da429496455edf7375f11fd84a72c87ba",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18218/l_daal_oneapi_p_2021.4.0.729_offline.sh",
-            sha256="61da9d2a40c75edadff65d052fd84ef3db1da5d94f86ad3956979e6988549dda",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17905/l_daal_oneapi_p_2021.3.0.557_offline.sh",
-            sha256="4c2e77a3a2fa5f8a09b7d68760dfca6c07f3949010836cd6da34075463467995",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh",
-            sha256="cbf4e64dbd21c10179f2d1d7e8b8b0f12eeffe6921602df33276cd0ebd1f8e34",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh",
-            sha256="6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e",
-            expand=False,
-        )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19032/l_daal_oneapi_p_2021.7.1.16996_offline.sh",
+        sha256="2328927480b0ba5d380028f981717b63ee323f8a1616a491a160a0a0b239e285",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18895/l_daal_oneapi_p_2021.7.0.8746_offline.sh",
+        sha256="c18e68df120c2b1db17877cfcbb1b5c93a47b2f4756a3444c663d0f03be4eee3",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18698/l_daal_oneapi_p_2021.6.0.915_offline.sh",
+        sha256="bc9a430f372a5f9603c19ec25207c83ffd9d59fe517599c734d465e32afc9790",
+        expand=False,
+    )
+    version(
+        "2021.5.3",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh",
+        sha256="6d3503cf7be2908bbb7bd18e67b8f2e96ad9aec53d4813c9be620adaa2db390f",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh",
+        sha256="bba7bee3caef14fbb54ad40615222e5da429496455edf7375f11fd84a72c87ba",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18218/l_daal_oneapi_p_2021.4.0.729_offline.sh",
+        sha256="61da9d2a40c75edadff65d052fd84ef3db1da5d94f86ad3956979e6988549dda",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17905/l_daal_oneapi_p_2021.3.0.557_offline.sh",
+        sha256="4c2e77a3a2fa5f8a09b7d68760dfca6c07f3949010836cd6da34075463467995",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh",
+        sha256="cbf4e64dbd21c10179f2d1d7e8b8b0f12eeffe6921602df33276cd0ebd1f8e34",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh",
+        sha256="6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e",
+        expand=False,
+    )
 
     depends_on("intel-oneapi-tbb")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -28,61 +26,60 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2022.2.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19035/l_onednn_p_2022.2.1.16994_offline.sh",
-            sha256="2102964a36a5b58b529385706e6829456ee5225111c33dfce6326fff5175aace",
-            expand=False,
-        )
-        version(
-            "2022.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18933/l_onednn_p_2022.2.0.8750_offline.sh",
-            sha256="920833cd1f05f2fdafb942c96946c3925eb734d4458d52f22f2cc755133cb9e0",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18725/l_onednn_p_2022.1.0.132_offline.sh",
-            sha256="0b9a7efe8dd0f0b5132b353a8ee99226f75bae4bab188a453817263a0684cc93",
-            expand=False,
-        )
-        version(
-            "2022.0.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18476/l_onednn_p_2022.0.2.43_offline.sh",
-            sha256="a2a953542b4f632b51a2527d84bd76c3140a41c8085420da4237e2877c27c280",
-            expand=False,
-        )
-        version(
-            "2022.0.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18441/l_onednn_p_2022.0.1.26_offline.sh",
-            sha256="8339806300d83d2629952e6e2f2758b52f517c072a20b7b7fc5642cf1e2a5410",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18221/l_onednn_p_2021.4.0.467_offline.sh",
-            sha256="30cc601467f6a94b3d7e14f4639faf0b12fdf6d98df148b07acdb4dfdfb971db",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17923/l_onednn_p_2021.3.0.344_offline.sh",
-            sha256="1521f6cbffcf9ce0c7b5dfcf1a2546a4a0c8d8abc99f3011709039aaa9e0859a",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17751/l_onednn_p_2021.2.0.228_offline.sh",
-            sha256="62121a3355298211a124ff4e71c42fc172bf1061019be6c6120830a1a502aa88",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17385/l_onednn_p_2021.1.1.55_offline.sh",
-            sha256="24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3",
-            expand=False,
-        )
+    version(
+        "2022.2.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19035/l_onednn_p_2022.2.1.16994_offline.sh",
+        sha256="2102964a36a5b58b529385706e6829456ee5225111c33dfce6326fff5175aace",
+        expand=False,
+    )
+    version(
+        "2022.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18933/l_onednn_p_2022.2.0.8750_offline.sh",
+        sha256="920833cd1f05f2fdafb942c96946c3925eb734d4458d52f22f2cc755133cb9e0",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18725/l_onednn_p_2022.1.0.132_offline.sh",
+        sha256="0b9a7efe8dd0f0b5132b353a8ee99226f75bae4bab188a453817263a0684cc93",
+        expand=False,
+    )
+    version(
+        "2022.0.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18476/l_onednn_p_2022.0.2.43_offline.sh",
+        sha256="a2a953542b4f632b51a2527d84bd76c3140a41c8085420da4237e2877c27c280",
+        expand=False,
+    )
+    version(
+        "2022.0.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18441/l_onednn_p_2022.0.1.26_offline.sh",
+        sha256="8339806300d83d2629952e6e2f2758b52f517c072a20b7b7fc5642cf1e2a5410",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18221/l_onednn_p_2021.4.0.467_offline.sh",
+        sha256="30cc601467f6a94b3d7e14f4639faf0b12fdf6d98df148b07acdb4dfdfb971db",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17923/l_onednn_p_2021.3.0.344_offline.sh",
+        sha256="1521f6cbffcf9ce0c7b5dfcf1a2546a4a0c8d8abc99f3011709039aaa9e0859a",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17751/l_onednn_p_2021.2.0.228_offline.sh",
+        sha256="62121a3355298211a124ff4e71c42fc172bf1061019be6c6120830a1a502aa88",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17385/l_onednn_p_2021.1.1.55_offline.sh",
+        sha256="24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3",
+        expand=False,
+    )
 
     depends_on("intel-oneapi-tbb")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -21,25 +19,24 @@ class IntelOneapiDpct(IntelOneApiPackage):
 
     homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compatibility-tool.html#gs.2p8km6"
 
-    if platform.system() == "Linux":
-        version(
-            "2022.2.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18991/l_dpcpp-ct_p_2022.2.1.14994_offline.sh",
-            sha256="ea2fbe36de70eb3c78c97133f81e0b2a2fbcfc9525e77125a183d7af446ef3e6",
-            expand=False,
-        )
-        version(
-            "2022.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18908/l_dpcpp-ct_p_2022.2.0.8701_offline.sh",
-            sha256="ca79b89ba4b97accb868578a1b7ba0e38dc5e4457d45c6c2552ba33d71b52128",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18746/l_dpcpp-ct_p_2022.1.0.172_offline.sh",
-            sha256="ec42f4df3f9daf1af587b14b8b6644c773a0b270e03dd22ac9e2f49131e3e40c",
-            expand=False,
-        )
+    version(
+        "2022.2.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18991/l_dpcpp-ct_p_2022.2.1.14994_offline.sh",
+        sha256="ea2fbe36de70eb3c78c97133f81e0b2a2fbcfc9525e77125a183d7af446ef3e6",
+        expand=False,
+    )
+    version(
+        "2022.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18908/l_dpcpp-ct_p_2022.2.0.8701_offline.sh",
+        sha256="ca79b89ba4b97accb868578a1b7ba0e38dc5e4457d45c6c2552ba33d71b52128",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18746/l_dpcpp-ct_p_2022.1.0.172_offline.sh",
+        sha256="ec42f4df3f9daf1af587b14b8b6644c773a0b270e03dd22ac9e2f49131e3e40c",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -24,43 +22,42 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
 
     homepage = "https://github.com/oneapi-src/oneDPL"
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19046/l_oneDPL_p_2021.7.2.15007_offline.sh",
-            sha256="84d60a6b1978ff45d2c416f18ca7df542eaa8c0b18dc3abf4bb0824a91b4fc44",
-            expand=False,
-        )
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18846/l_oneDPL_p_2021.7.1.8713_offline.sh",
-            sha256="275c935427e3ad0eb995034b05ff2ffd13c55ee58069c3702aa383f68a1e5485",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18752/l_oneDPL_p_2021.7.0.631_offline.sh",
-            sha256="1e2d735d5eccfe8058e18f96d733eda8de5b7a07d613447b7d483fd3f9cec600",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18372/l_oneDPL_p_2021.6.0.501_offline.sh",
-            sha256="0225f133a6c38b36d08635986870284a958e5286c55ca4b56a4058bd736f8f4f",
-            expand=False,
-        )
-        version(
-            "2021.5.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18189/l_oneDPL_p_2021.5.0.445_offline.sh",
-            sha256="7d4adf300a18f779c3ab517070c61dba10e3952287d5aef37c38f739e9041a68",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17889/l_oneDPL_p_2021.4.0.337_offline.sh",
-            sha256="540ef0d308c4b0f13ea10168a90edd42a56dc0883024f6f1a678b94c10b5c170",
-            expand=False,
-        )
+    version(
+        "2021.7.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19046/l_oneDPL_p_2021.7.2.15007_offline.sh",
+        sha256="84d60a6b1978ff45d2c416f18ca7df542eaa8c0b18dc3abf4bb0824a91b4fc44",
+        expand=False,
+    )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18846/l_oneDPL_p_2021.7.1.8713_offline.sh",
+        sha256="275c935427e3ad0eb995034b05ff2ffd13c55ee58069c3702aa383f68a1e5485",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18752/l_oneDPL_p_2021.7.0.631_offline.sh",
+        sha256="1e2d735d5eccfe8058e18f96d733eda8de5b7a07d613447b7d483fd3f9cec600",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18372/l_oneDPL_p_2021.6.0.501_offline.sh",
+        sha256="0225f133a6c38b36d08635986870284a958e5286c55ca4b56a4058bd736f8f4f",
+        expand=False,
+    )
+    version(
+        "2021.5.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18189/l_oneDPL_p_2021.5.0.445_offline.sh",
+        sha256="7d4adf300a18f779c3ab517070c61dba10e3952287d5aef37c38f739e9041a68",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17889/l_oneDPL_p_2021.4.0.337_offline.sh",
+        sha256="540ef0d308c4b0f13ea10168a90edd42a56dc0883024f6f1a678b94c10b5c170",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -26,43 +24,42 @@ class IntelOneapiInspector(IntelOneApiPackage):
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/inspector.html"
 
-    if platform.system() == "Linux":
-        version(
-            "2022.3.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19005/l_inspector_oneapi_p_2022.3.1.15318_offline.sh",
-            sha256="62aa2abf6928c0f4fc60ccfb69375297f823c183aea2519d7344e09c9734c1f8",
-            expand=False,
-        )
-        version(
-            "2022.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18924/l_inspector_oneapi_p_2022.3.0.8706_offline.sh",
-            sha256="c239b93769afae0ef5f7d3b8584d739bf4a839051bd428f1e6be3e8ca5d4aefa",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18712/l_inspector_oneapi_p_2022.1.0.123_offline.sh",
-            sha256="8551180aa30be3abea11308fb11ea9a296f0e056ab07d9254585448a0b23333e",
-            expand=False,
-        )
-        version(
-            "2022.0.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh",
-            sha256="79a0eb2ae3f1de1e3456076685680c468702922469c3fda3e074718fb0bea741",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18239/l_inspector_oneapi_p_2021.4.0.266_offline.sh",
-            sha256="c8210cbcd0e07cc75e773249a5e4a02cf34894ec80a213939f3a20e6c5705274",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17946/l_inspector_oneapi_p_2021.3.0.217_offline.sh",
-            sha256="1371ca74be2a6d4b069cdb3f8f2d6109abbc3261a81f437f0fe5412a7b659b43",
-            expand=False,
-        )
+    version(
+        "2022.3.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19005/l_inspector_oneapi_p_2022.3.1.15318_offline.sh",
+        sha256="62aa2abf6928c0f4fc60ccfb69375297f823c183aea2519d7344e09c9734c1f8",
+        expand=False,
+    )
+    version(
+        "2022.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18924/l_inspector_oneapi_p_2022.3.0.8706_offline.sh",
+        sha256="c239b93769afae0ef5f7d3b8584d739bf4a839051bd428f1e6be3e8ca5d4aefa",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18712/l_inspector_oneapi_p_2022.1.0.123_offline.sh",
+        sha256="8551180aa30be3abea11308fb11ea9a296f0e056ab07d9254585448a0b23333e",
+        expand=False,
+    )
+    version(
+        "2022.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh",
+        sha256="79a0eb2ae3f1de1e3456076685680c468702922469c3fda3e074718fb0bea741",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18239/l_inspector_oneapi_p_2021.4.0.266_offline.sh",
+        sha256="c8210cbcd0e07cc75e773249a5e4a02cf34894ec80a213939f3a20e6c5705274",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17946/l_inspector_oneapi_p_2021.3.0.217_offline.sh",
+        sha256="1371ca74be2a6d4b069cdb3f8f2d6109abbc3261a81f437f0fe5412a7b659b43",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -29,61 +27,60 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2021.6.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19007/l_ipp_oneapi_p_2021.6.2.16995_offline.sh",
-            sha256="23ae49afa9f13c2bed0c8a32e447e1c6b3528685cebdd32e4aa2a9736827cc4e",
-            expand=False,
-        )
-        version(
-            "2021.6.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18925/l_ipp_oneapi_p_2021.6.1.8749_offline.sh",
-            sha256="3f8705bf57c07b71d822295bfad49b531a38b6c3a4ca1119e4c52236cb664f57",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18748/l_ipp_oneapi_p_2021.6.0.626_offline.sh",
-            sha256="cf09b5229dd38d75671fa1ab1af47e4d5f9f16dc7c9c22a4313a221a184774aa",
-            expand=False,
-        )
-        version(
-            "2021.5.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh",
-            sha256="ba48d91ab1447d0ae3d3a5448e3f08e460393258b60630c743be88281e51608e",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh",
-            sha256="be99f9b0b2cc815e017188681ab997f3ace94e3010738fa6f702f2416dac0de4",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18219/l_ipp_oneapi_p_2021.4.0.459_offline.sh",
-            sha256="1a7a8fe5502ae61c10f5c432b7662c6fa542e5832a40494eb1c3a2d8e27c9f3e",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17958/l_ipp_oneapi_p_2021.3.0.333_offline.sh",
-            sha256="67e75c80813ec9a30d5fda5860f76122ae66fa2128a48c8461f5e6b100b38bbb",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh",
-            sha256="ccdfc81f77203822d80151b40ce9e8fd82bb2de85a9b132ceed12d24d3f3ff52",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh",
-            sha256="2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86",
-            expand=False,
-        )
+    version(
+        "2021.6.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19007/l_ipp_oneapi_p_2021.6.2.16995_offline.sh",
+        sha256="23ae49afa9f13c2bed0c8a32e447e1c6b3528685cebdd32e4aa2a9736827cc4e",
+        expand=False,
+    )
+    version(
+        "2021.6.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18925/l_ipp_oneapi_p_2021.6.1.8749_offline.sh",
+        sha256="3f8705bf57c07b71d822295bfad49b531a38b6c3a4ca1119e4c52236cb664f57",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18748/l_ipp_oneapi_p_2021.6.0.626_offline.sh",
+        sha256="cf09b5229dd38d75671fa1ab1af47e4d5f9f16dc7c9c22a4313a221a184774aa",
+        expand=False,
+    )
+    version(
+        "2021.5.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh",
+        sha256="ba48d91ab1447d0ae3d3a5448e3f08e460393258b60630c743be88281e51608e",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh",
+        sha256="be99f9b0b2cc815e017188681ab997f3ace94e3010738fa6f702f2416dac0de4",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18219/l_ipp_oneapi_p_2021.4.0.459_offline.sh",
+        sha256="1a7a8fe5502ae61c10f5c432b7662c6fa542e5832a40494eb1c3a2d8e27c9f3e",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17958/l_ipp_oneapi_p_2021.3.0.333_offline.sh",
+        sha256="67e75c80813ec9a30d5fda5860f76122ae66fa2128a48c8461f5e6b100b38bbb",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh",
+        sha256="ccdfc81f77203822d80151b40ce9e8fd82bb2de85a9b132ceed12d24d3f3ff52",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh",
+        sha256="2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86",
+        expand=False,
+    )
 
     depends_on("intel-oneapi-tbb")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -30,61 +28,60 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2021.6.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18999/l_ippcp_oneapi_p_2021.6.2.15006_offline.sh",
-            sha256="3c285c12da98a4d16e9a5ba237c8c51780475af54b1d1162185480ac891f16ee",
-            expand=False,
-        )
-        version(
-            "2021.6.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18923/l_ippcp_oneapi_p_2021.6.1.8714_offline.sh",
-            sha256="a83c2e74f78ea00aae877259df38baab31e78bc04c0a387a1de36fff712eb225",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18709/l_ippcp_oneapi_p_2021.6.0.536_offline.sh",
-            sha256="dac90862b408a6418f3782a5c4bf940939b1307ff4841ecfc6a29322976a2d43",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh",
-            sha256="7ec058abbc1cdfd240320228d6426c65e5a855fd3a27e11fbd1ad2523f64812a",
-            expand=False,
-        )
-        version(
-            "2021.5.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh",
-            sha256="e71aee288cc970b9c9fe21f7d5c300dbc2a4ea0687c7028f200d6b87e6c895a1",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18187/l_ippcp_oneapi_p_2021.4.0.401_offline.sh",
-            sha256="2ca2320f733ee75b4a27865185a1b0730879fe2c47596e570b1bd50d0b8ac608",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17886/l_ippcp_oneapi_p_2021.3.0.315_offline.sh",
-            sha256="0214d132d8e64b02e9cc63182e2099fb9caebf8c240fb1629ae898c2e1f72fb9",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh",
-            sha256="64cd5924b42f924b6a8128a8bf8e686f5dc52b98f586ffac6c2e2f1585e3aba9",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh",
-            sha256="c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936",
-            expand=False,
-        )
+    version(
+        "2021.6.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18999/l_ippcp_oneapi_p_2021.6.2.15006_offline.sh",
+        sha256="3c285c12da98a4d16e9a5ba237c8c51780475af54b1d1162185480ac891f16ee",
+        expand=False,
+    )
+    version(
+        "2021.6.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18923/l_ippcp_oneapi_p_2021.6.1.8714_offline.sh",
+        sha256="a83c2e74f78ea00aae877259df38baab31e78bc04c0a387a1de36fff712eb225",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18709/l_ippcp_oneapi_p_2021.6.0.536_offline.sh",
+        sha256="dac90862b408a6418f3782a5c4bf940939b1307ff4841ecfc6a29322976a2d43",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh",
+        sha256="7ec058abbc1cdfd240320228d6426c65e5a855fd3a27e11fbd1ad2523f64812a",
+        expand=False,
+    )
+    version(
+        "2021.5.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh",
+        sha256="e71aee288cc970b9c9fe21f7d5c300dbc2a4ea0687c7028f200d6b87e6c895a1",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18187/l_ippcp_oneapi_p_2021.4.0.401_offline.sh",
+        sha256="2ca2320f733ee75b4a27865185a1b0730879fe2c47596e570b1bd50d0b8ac608",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17886/l_ippcp_oneapi_p_2021.3.0.315_offline.sh",
+        sha256="0214d132d8e64b02e9cc63182e2099fb9caebf8c240fb1629ae898c2e1f72fb9",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh",
+        sha256="64cd5924b42f924b6a8128a8bf8e686f5dc52b98f586ffac6c2e2f1585e3aba9",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh",
+        sha256="c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -29,25 +27,24 @@ class IntelOneapiItac(IntelOneApiPackage):
 
     maintainers = ["rscohn2"]
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19024/l_itac_oneapi_p_2021.7.1.15324_offline.sh",
-            sha256="fb26689efdb7369e211b5cf05f3e30d491a2787f24fef174b23241b997cc442f",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18886/l_itac_oneapi_p_2021.7.0.8707_offline.sh",
-            sha256="719faeccfb1478f28110b72b1558187590a6f44cce067158f407ab335a7395bd",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18694/l_itac_oneapi_p_2021.6.0.434_offline.sh",
-            sha256="1ecc2735da960041b051e377cadb9f6ab2f44e8aa44d0f642529a56a3cbba436",
-            expand=False,
-        )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19024/l_itac_oneapi_p_2021.7.1.15324_offline.sh",
+        sha256="fb26689efdb7369e211b5cf05f3e30d491a2787f24fef174b23241b997cc442f",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18886/l_itac_oneapi_p_2021.7.0.8707_offline.sh",
+        sha256="719faeccfb1478f28110b72b1558187590a6f44cce067158f407ab335a7395bd",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18694/l_itac_oneapi_p_2021.6.0.434_offline.sh",
+        sha256="1ecc2735da960041b051e377cadb9f6ab2f44e8aa44d0f642529a56a3cbba436",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -26,61 +24,60 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2022.2.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19038/l_onemkl_p_2022.2.1.16993_offline.sh",
-            sha256="eedd4b795720de776b1fc5f542ae0fac37ec235cdb567f7c2ee3182e73e3e59d",
-            expand=False,
-        )
-        version(
-            "2022.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18898/l_onemkl_p_2022.2.0.8748_offline.sh",
-            sha256="07d7caedd4b9f025c6fd439a0d2c2f279b18ecbbb63cadb864f6c63c1ed942db",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223_offline.sh",
-            sha256="4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e",
-            expand=False,
-        )
-        version(
-            "2022.0.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136_offline.sh",
-            sha256="134b748825a474acc862bb4a7fada99741a15b7627cfaa6ba0fb05ec0b902b5e",
-            expand=False,
-        )
-        version(
-            "2022.0.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18444/l_onemkl_p_2022.0.1.117_offline.sh",
-            sha256="22afafbe2f3762eca052ac21ec40b845ff2f3646077295c88c2f37f80a0cc160",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18222/l_onemkl_p_2021.4.0.640_offline.sh",
-            sha256="9ad546f05a421b4f439e8557fd0f2d83d5e299b0d9bd84bdd86be6feba0c3915",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17901/l_onemkl_p_2021.3.0.520_offline.sh",
-            sha256="a06e1cdbfd8becc63440b473b153659885f25a6e3c4dcb2907ad9cd0c3ad59ce",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17757/l_onemkl_p_2021.2.0.296_offline.sh",
-            sha256="816e9df26ff331d6c0751b86ed5f7d243f9f172e76f14e83b32bf4d1d619dbae",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17402/l_onemkl_p_2021.1.1.52_offline.sh",
-            sha256="818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c",
-            expand=False,
-        )
+    version(
+        "2022.2.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19038/l_onemkl_p_2022.2.1.16993_offline.sh",
+        sha256="eedd4b795720de776b1fc5f542ae0fac37ec235cdb567f7c2ee3182e73e3e59d",
+        expand=False,
+    )
+    version(
+        "2022.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18898/l_onemkl_p_2022.2.0.8748_offline.sh",
+        sha256="07d7caedd4b9f025c6fd439a0d2c2f279b18ecbbb63cadb864f6c63c1ed942db",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223_offline.sh",
+        sha256="4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e",
+        expand=False,
+    )
+    version(
+        "2022.0.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136_offline.sh",
+        sha256="134b748825a474acc862bb4a7fada99741a15b7627cfaa6ba0fb05ec0b902b5e",
+        expand=False,
+    )
+    version(
+        "2022.0.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18444/l_onemkl_p_2022.0.1.117_offline.sh",
+        sha256="22afafbe2f3762eca052ac21ec40b845ff2f3646077295c88c2f37f80a0cc160",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18222/l_onemkl_p_2021.4.0.640_offline.sh",
+        sha256="9ad546f05a421b4f439e8557fd0f2d83d5e299b0d9bd84bdd86be6feba0c3915",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17901/l_onemkl_p_2021.3.0.520_offline.sh",
+        sha256="a06e1cdbfd8becc63440b473b153659885f25a6e3c4dcb2907ad9cd0c3ad59ce",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17757/l_onemkl_p_2021.2.0.296_offline.sh",
+        sha256="816e9df26ff331d6c0751b86ed5f7d243f9f172e76f14e83b32bf4d1d619dbae",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17402/l_onemkl_p_2021.1.1.52_offline.sh",
+        sha256="818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c",
+        expand=False,
+    )
 
     variant("shared", default=True, description="Builds shared library")
     variant("ilp64", default=False, description="Build with ILP64 support")

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -25,61 +23,60 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html"
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19010/l_mpi_oneapi_p_2021.7.1.16815_offline.sh",
-            sha256="90e7804f2367d457cd4cbf7aa29f1c5676287aa9b34f93e7c9a19e4b8583fff7",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18926/l_mpi_oneapi_p_2021.7.0.8711_offline.sh",
-            sha256="4eb1e1487b67b98857bc9b7b37bcac4998e0aa6d1b892b2c87b003bf84fb38e9",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh",
-            sha256="e85db63788c434d43c1378e5e2bf7927a75d11aee8e6b78ee0d933da920977a6",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh",
-            sha256="b992573959e39752e503e691564a0d876b099547c38b322d5775c5b06ec07a7f",
-            expand=False,
-        )
-        version(
-            "2021.5.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh",
-            sha256="3aae53fe77f7c6aac7a32b299c25d6ca9a00ba4e2d512a26edd90811e59e7471",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18186/l_mpi_oneapi_p_2021.4.0.441_offline.sh",
-            sha256="cc4b7072c61d0bd02b1c431b22d2ea3b84b967b59d2e587e77a9e7b2c24f2a29",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17947/l_mpi_oneapi_p_2021.3.0.294_offline.sh",
-            sha256="04c48f864ee4c723b1b4ca62f2bea8c04d5d7e3de19171fd62b17868bc79bc36",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh",
-            sha256="d0d4cdd11edaff2e7285e38f537defccff38e37a3067c02f4af43a3629ad4aa3",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh",
-            sha256="8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe",
-            expand=False,
-        )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19010/l_mpi_oneapi_p_2021.7.1.16815_offline.sh",
+        sha256="90e7804f2367d457cd4cbf7aa29f1c5676287aa9b34f93e7c9a19e4b8583fff7",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18926/l_mpi_oneapi_p_2021.7.0.8711_offline.sh",
+        sha256="4eb1e1487b67b98857bc9b7b37bcac4998e0aa6d1b892b2c87b003bf84fb38e9",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh",
+        sha256="e85db63788c434d43c1378e5e2bf7927a75d11aee8e6b78ee0d933da920977a6",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh",
+        sha256="b992573959e39752e503e691564a0d876b099547c38b322d5775c5b06ec07a7f",
+        expand=False,
+    )
+    version(
+        "2021.5.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh",
+        sha256="3aae53fe77f7c6aac7a32b299c25d6ca9a00ba4e2d512a26edd90811e59e7471",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18186/l_mpi_oneapi_p_2021.4.0.441_offline.sh",
+        sha256="cc4b7072c61d0bd02b1c431b22d2ea3b84b967b59d2e587e77a9e7b2c24f2a29",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17947/l_mpi_oneapi_p_2021.3.0.294_offline.sh",
+        sha256="04c48f864ee4c723b1b4ca62f2bea8c04d5d7e3de19171fd62b17868bc79bc36",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh",
+        sha256="d0d4cdd11edaff2e7285e38f537defccff38e37a3067c02f4af43a3629ad4aa3",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh",
+        sha256="8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe",
+        expand=False,
+    )
 
     variant("ilp64", default=False, description="Build with ILP64 support")
     variant(

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import platform
-
 from spack.package import *
 
 
@@ -24,61 +22,60 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19041/l_tbb_oneapi_p_2021.7.1.15005_offline.sh",
-            sha256="f13a8e740d69347b5985c1be496a3259a86d64ec94933b3d26100dbc2f059fd4",
-            expand=False,
-        )
-        version(
-            "2021.7.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18901/l_tbb_oneapi_p_2021.7.0.8712_offline.sh",
-            sha256="879bd2004b8e93bc12c53c43eab44cd843433e3da7a976baa8bf07a1069a87c5",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18728/l_tbb_oneapi_p_2021.6.0.835_offline.sh",
-            sha256="e9ede40a3d7745de6d711d43818f820c8486ab544a45610a71118fbca20698e5",
-            expand=False,
-        )
-        version(
-            "2021.5.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh",
-            sha256="c154749f1f370e4cde11a0a7c80452d479e2dfa53ff2b1b97003d9c0d99c91e3",
-            expand=False,
-        )
-        version(
-            "2021.5.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh",
-            sha256="6ff7890a74a43ae02e0fa2d9c5533fce70a49dff8e73278b546a0995367fec5e",
-            expand=False,
-        )
-        version(
-            "2021.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18194/l_tbb_oneapi_p_2021.4.0.643_offline.sh",
-            sha256="33332012ff8ffe7987b1a20bea794d76f7d8050ccff04fa6e1990974c336ee24",
-            expand=False,
-        )
-        version(
-            "2021.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17952/l_tbb_oneapi_p_2021.3.0.511_offline.sh",
-            sha256="b83f5e018e3d262e42e9c96881845bbc09c3f036c265e65023422ca8e8637633",
-            expand=False,
-        )
-        version(
-            "2021.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh",
-            sha256="c1c3623c5bef547b30eac009e7a444611bf714c758d7472c114e9be9d5700eba",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh",
-            sha256="535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b",
-            expand=False,
-        )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19041/l_tbb_oneapi_p_2021.7.1.15005_offline.sh",
+        sha256="f13a8e740d69347b5985c1be496a3259a86d64ec94933b3d26100dbc2f059fd4",
+        expand=False,
+    )
+    version(
+        "2021.7.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18901/l_tbb_oneapi_p_2021.7.0.8712_offline.sh",
+        sha256="879bd2004b8e93bc12c53c43eab44cd843433e3da7a976baa8bf07a1069a87c5",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18728/l_tbb_oneapi_p_2021.6.0.835_offline.sh",
+        sha256="e9ede40a3d7745de6d711d43818f820c8486ab544a45610a71118fbca20698e5",
+        expand=False,
+    )
+    version(
+        "2021.5.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh",
+        sha256="c154749f1f370e4cde11a0a7c80452d479e2dfa53ff2b1b97003d9c0d99c91e3",
+        expand=False,
+    )
+    version(
+        "2021.5.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh",
+        sha256="6ff7890a74a43ae02e0fa2d9c5533fce70a49dff8e73278b546a0995367fec5e",
+        expand=False,
+    )
+    version(
+        "2021.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18194/l_tbb_oneapi_p_2021.4.0.643_offline.sh",
+        sha256="33332012ff8ffe7987b1a20bea794d76f7d8050ccff04fa6e1990974c336ee24",
+        expand=False,
+    )
+    version(
+        "2021.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17952/l_tbb_oneapi_p_2021.3.0.511_offline.sh",
+        sha256="b83f5e018e3d262e42e9c96881845bbc09c3f036c265e65023422ca8e8637633",
+        expand=False,
+    )
+    version(
+        "2021.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh",
+        sha256="c1c3623c5bef547b30eac009e7a444611bf714c758d7472c114e9be9d5700eba",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh",
+        sha256="535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b",
+        expand=False,
+    )
 
     provides("tbb")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -27,43 +25,42 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
         "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html"
     )
 
-    if platform.system() == "Linux":
-        version(
-            "2022.2.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18903/l_oneVPL_p_2022.2.0.8703_offline.sh",
-            sha256="cb8af222d194ebb4b1dafe12e0b70cbbdee204f9fcfe9eafb46b287ee33b3797",
-            expand=False,
-        )
-        version(
-            "2022.1.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18750/l_oneVPL_p_2022.1.0.154_offline.sh",
-            sha256="486cca918c9772a43f62da77e07cdf54dabb92ecebf494eb8c89c4492ab43447",
-            expand=False,
-        )
-        version(
-            "2022.0.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18375/l_oneVPL_p_2022.0.0.58_offline.sh",
-            sha256="600b8566e1aa523b97291bed6b08f69a04bc7c4c75c035942a64a38f45a1a7f0",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18190/l_oneVPL_p_2021.6.0.458_offline.sh",
-            sha256="40c50008be3f03d17cc8c0c34324593c1d419ee4c45af5543aa5a2d5fb11071f",
-            expand=False,
-        )
-        version(
-            "2021.2.2",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17733/l_oneVPL_p_2021.2.2.212_offline.sh",
-            sha256="21106ba5cde22f3e31fd55280fbccf263508fa054030f12d5dff4a5379ef3bb7",
-            expand=False,
-        )
-        version(
-            "2021.1.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh",
-            sha256="0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed",
-            expand=False,
-        )
+    version(
+        "2022.2.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18903/l_oneVPL_p_2022.2.0.8703_offline.sh",
+        sha256="cb8af222d194ebb4b1dafe12e0b70cbbdee204f9fcfe9eafb46b287ee33b3797",
+        expand=False,
+    )
+    version(
+        "2022.1.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18750/l_oneVPL_p_2022.1.0.154_offline.sh",
+        sha256="486cca918c9772a43f62da77e07cdf54dabb92ecebf494eb8c89c4492ab43447",
+        expand=False,
+    )
+    version(
+        "2022.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18375/l_oneVPL_p_2022.0.0.58_offline.sh",
+        sha256="600b8566e1aa523b97291bed6b08f69a04bc7c4c75c035942a64a38f45a1a7f0",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18190/l_oneVPL_p_2021.6.0.458_offline.sh",
+        sha256="40c50008be3f03d17cc8c0c34324593c1d419ee4c45af5543aa5a2d5fb11071f",
+        expand=False,
+    )
+    version(
+        "2021.2.2",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17733/l_oneVPL_p_2021.2.2.212_offline.sh",
+        sha256="21106ba5cde22f3e31fd55280fbccf263508fa054030f12d5dff4a5379ef3bb7",
+        expand=False,
+    )
+    version(
+        "2021.1.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh",
+        sha256="0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed",
+        expand=False,
+    )
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.package import *
 
 
@@ -27,43 +25,42 @@ class IntelOneapiVtune(IntelOneApiPackage):
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html"
 
-    if platform.system() == "Linux":
-        version(
-            "2022.4.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19027/l_oneapi_vtune_p_2022.4.1.16919_offline.sh",
-            sha256="eb4b4da61eea52c08fc139dbf4630e2c52cbcfaea8f1376c545c0863839366d1",
-            expand=False,
-        )
-        version(
-            "2022.4.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18888/l_oneapi_vtune_p_2022.4.0.8705_offline.sh",
-            sha256="8c5a144ed61ef9addaa41abe7fbfceeedb6a8fe1c5392e3e265aada1f545b0fe",
-            expand=False,
-        )
-        version(
-            "2022.3.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18656/l_oneapi_vtune_p_2022.3.0.195_offline.sh",
-            sha256="7921fce7fcc3b82575be22d9c36beec961ba2a9fb5262ba16a04090bcbd2e1a6",
-            expand=False,
-        )
-        version(
-            "2022.0.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh",
-            sha256="aa4d575c22e7be0c950b87d67d9e371f470f682906864c4f9b68e530ecd22bd7",
-            expand=False,
-        )
-        version(
-            "2021.7.1",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18086/l_oneapi_vtune_p_2021.7.1.492_offline.sh",
-            sha256="4cf17078ae6e09f26f70bd9d0b726af234cc30c342ae4a8fda69941b40139b26",
-            expand=False,
-        )
-        version(
-            "2021.6.0",
-            url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18012/l_oneapi_vtune_p_2021.6.0.411_offline.sh",
-            sha256="6b1df7da713337aa665bcc6ff23e4a006695b5bfaf71dffd305cbadca2e5560c",
-            expand=False,
-        )
+    version(
+        "2022.4.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19027/l_oneapi_vtune_p_2022.4.1.16919_offline.sh",
+        sha256="eb4b4da61eea52c08fc139dbf4630e2c52cbcfaea8f1376c545c0863839366d1",
+        expand=False,
+    )
+    version(
+        "2022.4.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18888/l_oneapi_vtune_p_2022.4.0.8705_offline.sh",
+        sha256="8c5a144ed61ef9addaa41abe7fbfceeedb6a8fe1c5392e3e265aada1f545b0fe",
+        expand=False,
+    )
+    version(
+        "2022.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18656/l_oneapi_vtune_p_2022.3.0.195_offline.sh",
+        sha256="7921fce7fcc3b82575be22d9c36beec961ba2a9fb5262ba16a04090bcbd2e1a6",
+        expand=False,
+    )
+    version(
+        "2022.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh",
+        sha256="aa4d575c22e7be0c950b87d67d9e371f470f682906864c4f9b68e530ecd22bd7",
+        expand=False,
+    )
+    version(
+        "2021.7.1",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18086/l_oneapi_vtune_p_2021.7.1.492_offline.sh",
+        sha256="4cf17078ae6e09f26f70bd9d0b726af234cc30c342ae4a8fda69941b40139b26",
+        expand=False,
+    )
+    version(
+        "2021.6.0",
+        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18012/l_oneapi_vtune_p_2021.6.0.411_offline.sh",
+        sha256="6b1df7da713337aa665bcc6ff23e4a006695b5bfaf71dffd305cbadca2e5560c",
+        expand=False,
+    )
 
     @property
     def component_dir(self):


### PR DESCRIPTION
Add conflicts for all the intel-oneapi packages with everything but x86 linux.

Most of the diffs come from removing an `if` and unindenting the body.