### PR TITLE
openblas: fix bound :7.3 to :7.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -182,7 +182,9 @@ class Openblas(MakefilePackage):
     )
 
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
-    conflicts("%gcc@7.0.0:7.3,8.0.0:8.2", when="@0.3.11:")
+    # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
+    # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)
+    conflicts("%gcc@7:7.3.0,8:8.2", when="@0.3.11:")
 
     # See https://github.com/xianyi/OpenBLAS/issues/3074
     conflicts("%gcc@:10.1", when="@0.3.13 target=ppc64le:")


### PR DESCRIPTION
This patch:

https://gcc.gnu.org/legacy-ml/gcc-patches/2018-01/msg01962.html

is actually in Amazon Linux GCC 7.3.1, which we use in CI.

So we should not hold OpenBLAS back to something ancient because of it.

Old versions of OpenBLAS fail to detect the host arch of some of the AVX512 cpus of build nodes, causing build failures.

Of course we should try to set ARCH properly in OpenBLAS to avoid that it looks up the build arch, but that's quite some work.