### PR TITLE
geant4-data: depends_on g4emlow@7.9.1 when @10.6

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -86,7 +86,6 @@ class Geant4Data(BundlePackage):
         ],
         "10.6.0:10.6": [
             "g4ndl@4.6",
-            "g4emlow@7.9",
             "g4emlow@7.9.1",
             "g4photonevaporation@5.5",
             "g4radioactivedecay@5.4",


### PR DESCRIPTION
Per https://geant4.web.cern.ch/node/1837 the correct dependency for 10.6 is on `g4emlow@7.9.1`, not on both `g4emlow@7.9` and `g4emlow@7.9.1`.

This is a minor cosmetic fix. The concretization for 10.6 works just fine here. But this removes the duplicate entry.