### PR TITLE
Revert "Use `urllib` handler for `s3://` and `gs://`, improve `url_exists` through HEAD requests"

### DIFF
--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -3,10 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import urllib.response
-from urllib.error import URLError
-from urllib.request import BaseHandler
 
 import spack.util.url as url_util
+import spack.util.web as web_util
 
 
 def gcs_open(req, *args, **kwargs):
@@ -17,13 +16,8 @@ def gcs_open(req, *args, **kwargs):
     gcsblob = gcs_util.GCSBlob(url)
 
     if not gcsblob.exists():
-        raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
+        raise web_util.SpackWebError("GCS blob {0} does not exist".format(gcsblob.blob_path))
     stream = gcsblob.get_blob_byte_stream()
     headers = gcsblob.get_blob_headers()
 
     return urllib.response.addinfourl(stream, headers, url)
-
-
-class GCSHandler(BaseHandler):
-    def gs_open(self, req):
-        return gcs_open(req)

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -6,7 +6,7 @@
 import urllib.error
 import urllib.request
 import urllib.response
-from io import BufferedReader, BytesIO, IOBase
+from io import BufferedReader, IOBase
 
 import spack.util.s3 as s3_util
 import spack.util.url as url_util
@@ -42,7 +42,7 @@ class WrapStream(BufferedReader):
         return getattr(self.raw, key)
 
 
-def _s3_open(url, method="GET"):
+def _s3_open(url):
     parsed = url_util.parse(url)
     s3 = s3_util.get_s3_session(url, method="fetch")
 
@@ -52,29 +52,27 @@ def _s3_open(url, method="GET"):
     if key.startswith("/"):
         key = key[1:]
 
-    if method not in ("GET", "HEAD"):
-        raise urllib.error.URLError(
-            "Only GET and HEAD verbs are currently supported for the s3:// scheme"
-        )
+    obj = s3.get_object(Bucket=bucket, Key=key)
 
-    try:
-        if method == "GET":
-            obj = s3.get_object(Bucket=bucket, Key=key)
-            # NOTE(opadron): Apply workaround here (see above)
-            stream = WrapStream(obj["Body"])
-        elif method == "HEAD":
-            obj = s3.head_object(Bucket=bucket, Key=key)
-            stream = BytesIO()
-    except s3.ClientError as e:
-        raise urllib.error.URLError(e) from e
-
+    # NOTE(opadron): Apply workaround here (see above)
+    stream = WrapStream(obj["Body"])
     headers = obj["ResponseMetadata"]["HTTPHeaders"]
 
     return url, headers, stream
 
 
-class UrllibS3Handler(urllib.request.BaseHandler):
+class UrllibS3Handler(urllib.request.HTTPSHandler):
     def s3_open(self, req):
         orig_url = req.get_full_url()
-        url, headers, stream = _s3_open(orig_url, method=req.get_method())
-        return urllib.response.addinfourl(stream, headers, url)
+        from botocore.exceptions import ClientError  # type: ignore[import]
+
+        try:
+            url, headers, stream = _s3_open(orig_url)
+            return urllib.response.addinfourl(stream, headers, url)
+        except ClientError as err:
+            raise urllib.error.URLError(err) from err
+
+
+S3OpenerDirector = urllib.request.build_opener(UrllibS3Handler())
+
+open = S3OpenerDirector.open

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -297,19 +297,19 @@ def test_pkg_hash(mock_packages):
 
 
 @pytest.mark.skipif(not spack.cmd.pkg.get_grep(), reason="grep is not installed")
-def test_pkg_grep(mock_packages, capsys):
+def test_pkg_grep(mock_packages, capfd):
     # only splice-* mock packages have the string "splice" in them
-    with capsys.disabled():
-        output = pkg("grep", "-l", "splice", output=str)
-
+    pkg("grep", "-l", "splice", output=str)
+    output, _ = capfd.readouterr()
     assert output.strip() == "\n".join(
         spack.repo.path.get_pkg_class(name).module.__file__
         for name in ["splice-a", "splice-h", "splice-t", "splice-vh", "splice-z"]
     )
 
     # ensure that this string isn't fouhnd
-    output = pkg("grep", "abcdefghijklmnopqrstuvwxyz", output=str, fail_on_error=False)
+    pkg("grep", "abcdefghijklmnopqrstuvwxyz", output=str, fail_on_error=False)
     assert pkg.returncode == 1
+    output, _ = capfd.readouterr()
     assert output.strip() == ""
 
     # ensure that we return > 1 for an error

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -223,10 +223,7 @@ class MockPaginator(object):
 
 class MockClientError(Exception):
     def __init__(self):
-        self.response = {
-            "Error": {"Code": "NoSuchKey"},
-            "ResponseMetadata": {"HTTPStatusCode": 404},
-        }
+        self.response = {"Error": {"Code": "NoSuchKey"}}
 
 
 class MockS3Client(object):
@@ -245,13 +242,7 @@ class MockS3Client(object):
     def get_object(self, Bucket=None, Key=None):
         self.ClientError = MockClientError
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {"ResponseMetadata": {"HTTPHeaders": {}}}
-        raise self.ClientError
-
-    def head_object(self, Bucket=None, Key=None):
-        self.ClientError = MockClientError
-        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {"ResponseMetadata": {"HTTPHeaders": {}}}
+            return True
         raise self.ClientError
 
 


### PR DESCRIPTION
Reverts spack/spack#34324

Attempting to fix windows CI -- fetch errors started appearing in `develop` after this PR.