### PR TITLE
hdf5: "hdf5@1.13:" depends on "cmake@3.18:"

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -193,6 +193,7 @@ class Hdf5(CMakePackage):
     )
 
     depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.18:", type="build", when="@1.13:")
 
     depends_on("msmpi", when="+mpi platform=windows")
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
Fixes build error: `CMake 3.18 or higher is required. You are running ...` from:
```py
spack install hdf5@1.13 # (or also: spack install hdf-vol-async@1.4) 
```