### PR TITLE
cernlib: depends_on libxaw libxt

### DIFF
--- a/var/spack/repos/builtin/packages/cernlib/package.py
+++ b/var/spack/repos/builtin/packages/cernlib/package.py
@@ -22,6 +22,8 @@ class Cernlib(CMakePackage):
 
     depends_on("motif")
     depends_on("libx11")
+    depends_on("libxaw")
+    depends_on("libxt")
 
     def cmake_args(self):
         args = ["-DCERNLIB_BUILD_SHARED:BOOL=ON"]


### PR DESCRIPTION
Based on the following lines in the top level `CMakeLists.txt` (I can't deep link since gitlab.cern.ch not public), `cernlib` needs an explicit dependency on `libxaw` and `libxt`:
```cmake
find_package(X11  REQUIRED)
message(STATUS "CERNLIB: X11_Xt_LIB=${X11_Xt_LIB} X11_Xaw_LIB=${X11_Xaw_LIB} X11_LIBRARIES=${X11_LIBRARIES}")
```