### PR TITLE
Restore usage of  file URL handling method on Win

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -371,14 +371,13 @@ def url_exists(url, curl=None):
         _ = curl_exe(*curl_args, fail_on_error=False, output=os.devnull)
         return curl_exe.returncode == 0
 
-    # Otherwise use urllib.
+    # If we get here, then the only other fetch method option is urllib.
+    # So try to "read" from the URL and assume that *any* non-throwing
+    #  response contains the resource represented by the URL.
     try:
-        urlopen(
-            Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
-            timeout=spack.config.get("config:connect_timeout", 10),
-        )
+        read_from_url(url)
         return True
-    except URLError as e:
+    except (SpackWebError, URLError) as e:
         tty.debug("Failure reading URL: " + str(e))
         return False
 


### PR DESCRIPTION
#34324 Introduces a regression that precludes the usage of filepath URLs on Windows. This PR resolves this regression.

the `urlopen` method cannot be directly invoked on Windows as filepath urls do not place nicely with that module. Perhaps the `read_from_url` method could use some optimization, but it is imperative that it be used.