### PR TITLE
Use file paths/urls correctly

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1186,7 +1186,7 @@ def generate_key_index(key_prefix, tmpdir=None):
 
 def _build_tarball(
     spec,
-    outdir,
+    out_url,
     force=False,
     relative=False,
     unsigned=False,
@@ -1209,8 +1209,7 @@ def _build_tarball(
     tarfile_dir = os.path.join(cache_prefix, tarball_directory_name(spec))
     tarfile_path = os.path.join(tarfile_dir, tarfile_name)
     spackfile_path = os.path.join(cache_prefix, tarball_path_name(spec, ".spack"))
-
-    remote_spackfile_path = url_util.join(outdir, os.path.relpath(spackfile_path, tmpdir))
+    remote_spackfile_path = url_util.join(out_url, os.path.relpath(spackfile_path, tmpdir))
 
     mkdirp(tarfile_dir)
     if web_util.url_exists(remote_spackfile_path):
@@ -1229,7 +1228,7 @@ def _build_tarball(
     signed_specfile_path = "{0}.sig".format(specfile_path)
 
     remote_specfile_path = url_util.join(
-        outdir, os.path.relpath(specfile_path, os.path.realpath(tmpdir))
+        out_url, os.path.relpath(specfile_path, os.path.realpath(tmpdir))
     )
     remote_signed_specfile_path = "{0}.sig".format(remote_specfile_path)
 
@@ -1334,12 +1333,12 @@ def _build_tarball(
         # push the key to the build cache's _pgp directory so it can be
         # imported
         if not unsigned:
-            push_keys(outdir, keys=[key], regenerate_index=regenerate_index, tmpdir=tmpdir)
+            push_keys(out_url, keys=[key], regenerate_index=regenerate_index, tmpdir=tmpdir)
 
         # create an index.json for the build_cache directory so specs can be
         # found
         if regenerate_index:
-            generate_package_index(url_util.join(outdir, os.path.relpath(cache_prefix, tmpdir)))
+            generate_package_index(url_util.join(out_url, os.path.relpath(cache_prefix, tmpdir)))
     finally:
         shutil.rmtree(tmpdir)
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
+import urllib.parse
 
 import llnl.util.tty as tty
 
@@ -45,7 +46,7 @@ def setup_parser(subparser):
         "-r",
         "--rel",
         action="store_true",
-        help="make all rpaths relative" + " before creating tarballs.",
+        help="make all rpaths relative before creating tarballs.",
     )
     create.add_argument(
         "-f", "--force", action="store_true", help="overwrite tarball if it exists."
@@ -54,13 +55,13 @@ def setup_parser(subparser):
         "-u",
         "--unsigned",
         action="store_true",
-        help="create unsigned buildcache" + " tarballs for testing",
+        help="create unsigned buildcache tarballs for testing",
     )
     create.add_argument(
         "-a",
         "--allow-root",
         action="store_true",
-        help="allow install root string in binary files " + "after RPATH substitution",
+        help="allow install root string in binary files after RPATH substitution",
     )
     create.add_argument(
         "-k", "--key", metavar="key", type=str, default=None, help="Key for signing."
@@ -71,31 +72,31 @@ def setup_parser(subparser):
         "--directory",
         metavar="directory",
         type=str,
-        help="local directory where " + "buildcaches will be written.",
+        help="local directory where buildcaches will be written.",
     )
     output.add_argument(
         "-m",
         "--mirror-name",
         metavar="mirror-name",
         type=str,
-        help="name of the mirror where " + "buildcaches will be written.",
+        help="name of the mirror where buildcaches will be written.",
     )
     output.add_argument(
         "--mirror-url",
         metavar="mirror-url",
         type=str,
-        help="URL of the mirror where " + "buildcaches will be written.",
+        help="URL of the mirror where buildcaches will be written.",
     )
     create.add_argument(
         "--rebuild-index",
         action="store_true",
         default=False,
-        help="Regenerate buildcache index " + "after building package(s)",
+        help="Regenerate buildcache index after building package(s)",
     )
     create.add_argument(
         "--spec-file",
         default=None,
-        help=("Create buildcache entry for spec from json or " + "yaml file"),
+        help="Create buildcache entry for spec from json or yaml file",
     )
     create.add_argument(
         "--only",
@@ -124,19 +125,19 @@ def setup_parser(subparser):
         "-a",
         "--allow-root",
         action="store_true",
-        help="allow install root string in binary files " + "after RPATH substitution",
+        help="allow install root string in binary files after RPATH substitution",
     )
     install.add_argument(
         "-u",
         "--unsigned",
         action="store_true",
-        help="install unsigned buildcache" + " tarballs for testing",
+        help="install unsigned buildcache tarballs for testing",
     )
     install.add_argument(
         "-o",
         "--otherarch",
         action="store_true",
-        help="install specs from other architectures" + " instead of default platform and OS",
+        help="install specs from other architectures instead of default platform and OS",
     )
 
     arguments.add_common_arguments(install, ["specs"])
@@ -155,7 +156,7 @@ def setup_parser(subparser):
         "-a",
         "--allarch",
         action="store_true",
-        help="list specs for all available architectures" + " instead of default platform and OS",
+        help="list specs for all available architectures instead of default platform and OS",
     )
     arguments.add_common_arguments(listcache, ["specs"])
     listcache.set_defaults(func=list_fn)
@@ -204,7 +205,7 @@ def setup_parser(subparser):
     check.add_argument(
         "--spec-file",
         default=None,
-        help=("Check single spec from json or yaml file instead of release " + "specs file"),
+        help=("Check single spec from json or yaml file instead of release specs file"),
     )
 
     check.set_defaults(func=check_fn)
@@ -217,7 +218,7 @@ def setup_parser(subparser):
     download.add_argument(
         "--spec-file",
         default=None,
-        help=("Download built tarball for spec (from json or yaml file) " + "from mirror"),
+        help=("Download built tarball for spec (from json or yaml file) from mirror"),
     )
     download.add_argument(
         "-p", "--path", default=None, help="Path to directory where tarball should be downloaded"
@@ -234,7 +235,7 @@ def setup_parser(subparser):
     getbuildcachename.add_argument(
         "--spec-file",
         default=None,
-        help=("Path to spec json or yaml file for which buildcache name is " + "desired"),
+        help=("Path to spec json or yaml file for which buildcache name is desired"),
     )
     getbuildcachename.set_defaults(func=get_buildcache_name_fn)
 
@@ -294,7 +295,27 @@ def setup_parser(subparser):
 
     # Update buildcache index without copying any additional packages
     update_index = subparsers.add_parser("update-index", help=update_index_fn.__doc__)
-    update_index.add_argument("-d", "--mirror-url", default=None, help="Destination mirror url")
+    update_index_out = update_index.add_mutually_exclusive_group(required=True)
+    update_index_out.add_argument(
+        "-d",
+        "--directory",
+        metavar="directory",
+        type=str,
+        help="local directory where buildcaches will be written.",
+    )
+    update_index_out.add_argument(
+        "-m",
+        "--mirror-name",
+        metavar="mirror-name",
+        type=str,
+        help="name of the mirror where buildcaches will be written.",
+    )
+    update_index_out.add_argument(
+        "--mirror-url",
+        metavar="mirror-url",
+        type=str,
+        help="URL of the mirror where buildcaches will be written.",
+    )
     update_index.add_argument(
         "-k",
         "--keys",
@@ -323,9 +344,9 @@ def _matching_specs(args):
 
     tty.die(
         "build cache file creation requires at least one"
-        + " installed package spec, an active environment,"
-        + " or else a path to a json or yaml file containing a spec"
-        + " to install"
+        " installed package spec, an active environment,"
+        " or else a path to a json or yaml file containing a spec"
+        " to install"
     )
 
 
@@ -575,11 +596,11 @@ def sync_fn(args):
     source_location = None
     if args.src_directory:
         source_location = args.src_directory
-        scheme = url_util.parse(source_location, scheme="<missing>").scheme
+        scheme = urllib.parse.urlparse(source_location, scheme="<missing>").scheme
         if scheme != "<missing>":
             raise ValueError('"--src-directory" expected a local path; got a URL, instead')
         # Ensure that the mirror lookup does not mistake this for named mirror
-        source_location = "file://" + source_location
+        source_location = url_util.path_to_file_url(source_location)
     elif args.src_mirror_name:
         source_location = args.src_mirror_name
         result = spack.mirror.MirrorCollection().lookup(source_location)
@@ -587,7 +608,7 @@ def sync_fn(args):
             raise ValueError('no configured mirror named "{name}"'.format(name=source_location))
     elif args.src_mirror_url:
         source_location = args.src_mirror_url
-        scheme = url_util.parse(source_location, scheme="<missing>").scheme
+        scheme = urllib.parse.urlparse(source_location, scheme="<missing>").scheme
         if scheme == "<missing>":
             raise ValueError('"{url}" is not a valid URL'.format(url=source_location))
 
@@ -598,11 +619,11 @@ def sync_fn(args):
     dest_location = None
     if args.dest_directory:
         dest_location = args.dest_directory
-        scheme = url_util.parse(dest_location, scheme="<missing>").scheme
+        scheme = urllib.parse.urlparse(dest_location, scheme="<missing>").scheme
         if scheme != "<missing>":
             raise ValueError('"--dest-directory" expected a local path; got a URL, instead')
         # Ensure that the mirror lookup does not mistake this for named mirror
-        dest_location = "file://" + dest_location
+        dest_location = url_util.path_to_file_url(dest_location)
     elif args.dest_mirror_name:
         dest_location = args.dest_mirror_name
         result = spack.mirror.MirrorCollection().lookup(dest_location)
@@ -610,7 +631,7 @@ def sync_fn(args):
             raise ValueError('no configured mirror named "{name}"'.format(name=dest_location))
     elif args.dest_mirror_url:
         dest_location = args.dest_mirror_url
-        scheme = url_util.parse(dest_location, scheme="<missing>").scheme
+        scheme = urllib.parse.urlparse(dest_location, scheme="<missing>").scheme
         if scheme == "<missing>":
             raise ValueError('"{url}" is not a valid URL'.format(url=dest_location))
 
@@ -692,11 +713,16 @@ def update_index(mirror_url, update_keys=False):
 
 def update_index_fn(args):
     """Update a buildcache index."""
-    outdir = "file://."
-    if args.mirror_url:
-        outdir = args.mirror_url
+    if args.directory:
+        push_url = spack.mirror.push_url_from_directory(args.directory)
 
-    update_index(outdir, update_keys=args.keys)
+    if args.mirror_name:
+        push_url = spack.mirror.push_url_from_mirror_name(args.mirror_name)
+
+    if args.mirror_url:
+        push_url = spack.mirror.push_url_from_mirror_url(args.mirror_url)
+
+    update_index(push_url, update_keys=args.keys)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -326,6 +326,15 @@ def setup_parser(subparser):
     update_index.set_defaults(func=update_index_fn)
 
 
+def _mirror_url_from_args(args):
+    if args.directory:
+        return spack.mirror.push_url_from_directory(args.directory)
+    if args.mirror_name:
+        return spack.mirror.push_url_from_mirror_name(args.mirror_name)
+    if args.mirror_url:
+        return spack.mirror.push_url_from_mirror_url(args.mirror_url)
+
+
 def _matching_specs(args):
     """Return a list of matching specs read from either a spec file (JSON or YAML),
     a query over the store or a query over the active environment.
@@ -374,15 +383,7 @@ def _concrete_spec_from_args(args):
 
 def create_fn(args):
     """create a binary package and push it to a mirror"""
-    if args.directory:
-        push_url = spack.mirror.push_url_from_directory(args.directory)
-
-    if args.mirror_name:
-        push_url = spack.mirror.push_url_from_mirror_name(args.mirror_name)
-
-    if args.mirror_url:
-        push_url = spack.mirror.push_url_from_mirror_url(args.mirror_url)
-
+    push_url = _mirror_url_from_args(args)
     matches = _matching_specs(args)
 
     msg = "Pushing binary packages to {0}/build_cache".format(push_url)
@@ -713,15 +714,7 @@ def update_index(mirror_url, update_keys=False):
 
 def update_index_fn(args):
     """Update a buildcache index."""
-    if args.directory:
-        push_url = spack.mirror.push_url_from_directory(args.directory)
-
-    if args.mirror_name:
-        push_url = spack.mirror.push_url_from_mirror_name(args.mirror_name)
-
-    if args.mirror_url:
-        push_url = spack.mirror.push_url_from_mirror_url(args.mirror_url)
-
+    push_url = _mirror_url_from_args(args)
     update_index(push_url, update_keys=args.keys)
 
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -356,7 +356,7 @@ def ci_rebuild(args):
             # dependencies from previous stages available since we do not
             # allow pushing binaries to the remote mirror during PR pipelines.
             enable_artifacts_mirror = True
-            pipeline_mirror_url = "file://" + local_mirror_dir
+            pipeline_mirror_url = url_util.path_to_file_url(local_mirror_dir)
             mirror_msg = "artifact buildcache enabled, mirror url: {0}".format(pipeline_mirror_url)
             tty.debug(mirror_msg)
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import os
 import re
+import urllib.parse
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
@@ -827,8 +828,8 @@ def get_versions(args, name):
 
     valid_url = True
     try:
-        spack.util.url.require_url_format(args.url)
-        if args.url.startswith("file://"):
+        parsed = urllib.parse.urlparse(args.url)
+        if not parsed.scheme or parsed.scheme != "file":
             valid_url = False  # No point in spidering these
     except (ValueError, TypeError):
         valid_url = False

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -11,6 +11,7 @@ import spack.cmd.common.arguments as arguments
 import spack.mirror
 import spack.paths
 import spack.util.gpg
+import spack.util.url
 
 description = "handle GPG actions for spack"
 section = "packaging"
@@ -98,7 +99,7 @@ def setup_parser(subparser):
         "--directory",
         metavar="directory",
         type=str,
-        help="local directory where " + "keys will be published.",
+        help="local directory where keys will be published.",
     )
     output.add_argument(
         "-m",
@@ -212,7 +213,8 @@ def gpg_publish(args):
 
     mirror = None
     if args.directory:
-        mirror = spack.mirror.Mirror(args.directory, args.directory)
+        url = spack.util.url.path_to_file_url(args.directory)
+        mirror = spack.mirror.Mirror(url, url)
     elif args.mirror_name:
         mirror = spack.mirror.MirrorCollection().lookup(args.mirror_name)
     elif args.mirror_url:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -357,11 +357,10 @@ def versions_per_spec(args):
 
 
 def create_mirror_for_individual_specs(mirror_specs, directory_hint, skip_unstable_versions):
-    local_push_url = local_mirror_url_from_user(directory_hint)
     present, mirrored, error = spack.mirror.create(
-        local_push_url, mirror_specs, skip_unstable_versions
+        directory_hint, mirror_specs, skip_unstable_versions
     )
-    tty.msg("Summary for mirror in {}".format(local_push_url))
+    tty.msg("Summary for mirror in {}".format(directory_hint))
     process_mirror_stats(present, mirrored, error)
 
 
@@ -389,9 +388,7 @@ def local_mirror_url_from_user(directory_hint):
     mirror_directory = spack.util.path.canonicalize_path(
         directory_hint or spack.config.get("config:source_cache")
     )
-    tmp_mirror = spack.mirror.Mirror(mirror_directory)
-    local_url = url_util.format(tmp_mirror.push_url)
-    return local_url
+    return url_util.path_to_file_url(mirror_directory)
 
 
 def mirror_create(args):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -11,6 +11,8 @@ import shutil
 import stat
 import sys
 import time
+import urllib.parse
+import urllib.request
 
 import ruamel.yaml as yaml
 
@@ -42,6 +44,7 @@ import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+import spack.util.url
 from spack.filesystem_view import (
     SimpleFilesystemView,
     inverse_view_func_parser,
@@ -926,46 +929,54 @@ class Environment(object):
             # allow paths to contain spack config/environment variables, etc.
             config_path = substitute_path_variables(config_path)
 
-            # strip file URL prefix, if needed, to avoid unnecessary remote
-            # config processing for local files
-            config_path = config_path.replace("file://", "")
+            include_url = urllib.parse.urlparse(config_path)
 
-            if not os.path.exists(config_path):
+            # Transform file:// URLs to direct includes.
+            if include_url.scheme == "file":
+                config_path = urllib.request.url2pathname(include_url.path)
+
+            # Any other URL should be fetched.
+            elif include_url.scheme in ("http", "https", "ftp"):
                 # Stage any remote configuration file(s)
-                if spack.util.url.is_url_format(config_path):
-                    staged_configs = (
-                        os.listdir(self.config_stage_dir)
-                        if os.path.exists(self.config_stage_dir)
-                        else []
+                staged_configs = (
+                    os.listdir(self.config_stage_dir)
+                    if os.path.exists(self.config_stage_dir)
+                    else []
+                )
+                remote_path = urllib.request.url2pathname(include_url.path)
+                basename = os.path.basename(remote_path)
+                if basename in staged_configs:
+                    # Do NOT re-stage configuration files over existing
+                    # ones with the same name since there is a risk of
+                    # losing changes (e.g., from 'spack config update').
+                    tty.warn(
+                        "Will not re-stage configuration from {0} to avoid "
+                        "losing changes to the already staged file of the "
+                        "same name.".format(remote_path)
                     )
-                    basename = os.path.basename(config_path)
-                    if basename in staged_configs:
-                        # Do NOT re-stage configuration files over existing
-                        # ones with the same name since there is a risk of
-                        # losing changes (e.g., from 'spack config update').
-                        tty.warn(
-                            "Will not re-stage configuration from {0} to avoid "
-                            "losing changes to the already staged file of the "
-                            "same name.".format(config_path)
-                        )
 
-                        # Recognize the configuration stage directory
-                        # is flattened to ensure a single copy of each
-                        # configuration file.
-                        config_path = self.config_stage_dir
-                        if basename.endswith(".yaml"):
-                            config_path = os.path.join(config_path, basename)
-                    else:
-                        staged_path = spack.config.fetch_remote_configs(
-                            config_path,
-                            self.config_stage_dir,
-                            skip_existing=True,
+                    # Recognize the configuration stage directory
+                    # is flattened to ensure a single copy of each
+                    # configuration file.
+                    config_path = self.config_stage_dir
+                    if basename.endswith(".yaml"):
+                        config_path = os.path.join(config_path, basename)
+                else:
+                    staged_path = spack.config.fetch_remote_configs(
+                        config_path,
+                        self.config_stage_dir,
+                        skip_existing=True,
+                    )
+                    if not staged_path:
+                        raise SpackEnvironmentError(
+                            "Unable to fetch remote configuration {0}".format(config_path)
                         )
-                        if not staged_path:
-                            raise SpackEnvironmentError(
-                                "Unable to fetch remote configuration {0}".format(config_path)
-                            )
-                        config_path = staged_path
+                    config_path = staged_path
+
+            elif include_url.scheme:
+                raise ValueError(
+                    "Unsupported URL scheme for environment include: {}".format(config_path)
+                )
 
             # treat relative paths as relative to the environment
             if not os.path.isabs(config_path):
@@ -995,7 +1006,7 @@ class Environment(object):
         if missing:
             msg = "Detected {0} missing include path(s):".format(len(missing))
             msg += "\n   {0}".format("\n   ".join(missing))
-            tty.die("{0}\nPlease correct and try again.".format(msg))
+            raise spack.config.ConfigFileError(msg)
 
         return scopes
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -314,17 +314,7 @@ class URLFetchStrategy(FetchStrategy):
 
     @property
     def candidate_urls(self):
-        urls = []
-
-        for url in [self.url] + (self.mirrors or []):
-            # This must be skipped on Windows due to URL encoding
-            # of ':' characters on filepaths on Windows
-            if sys.platform != "win32" and url.startswith("file://"):
-                path = urllib.parse.quote(url[len("file://") :])
-                url = "file://" + path
-            urls.append(url)
-
-        return urls
+        return [self.url] + (self.mirrors or [])
 
     @_needs_stage
     def fetch(self):
@@ -496,7 +486,9 @@ class URLFetchStrategy(FetchStrategy):
         if not self.archive_file:
             raise NoArchiveFileError("Cannot call archive() before fetching.")
 
-        web_util.push_to_url(self.archive_file, destination, keep_original=True)
+        web_util.push_to_url(
+            self.archive_file, url_util.path_to_file_url(destination), keep_original=True
+        )
 
     @_needs_stage
     def check(self):
@@ -549,8 +541,7 @@ class CacheURLFetchStrategy(URLFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        reg_str = r"^file://"
-        path = re.sub(reg_str, "", self.url)
+        path = url_util.file_url_string_to_path(self.url)
 
         # check whether the cache file exists.
         if not os.path.isfile(path):
@@ -799,7 +790,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     def mirror_id(self):
         repo_ref = self.commit or self.tag or self.branch
         if repo_ref:
-            repo_path = url_util.parse(self.url).path
+            repo_path = urllib.parse.urlparse(self.url).path
             result = os.path.sep.join(["git", repo_path, repo_ref])
             return result
 
@@ -1145,7 +1136,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
 
     def mirror_id(self):
         if self.revision:
-            repo_path = url_util.parse(self.url).path
+            repo_path = urllib.parse.urlparse(self.url).path
             result = os.path.sep.join(["svn", repo_path, self.revision])
             return result
 
@@ -1256,7 +1247,7 @@ class HgFetchStrategy(VCSFetchStrategy):
 
     def mirror_id(self):
         if self.revision:
-            repo_path = url_util.parse(self.url).path
+            repo_path = urllib.parse.urlparse(self.url).path
             result = os.path.sep.join(["hg", repo_path, self.revision])
             return result
 
@@ -1328,7 +1319,7 @@ class S3FetchStrategy(URLFetchStrategy):
             tty.debug("Already downloaded {0}".format(self.archive_file))
             return
 
-        parsed_url = url_util.parse(self.url)
+        parsed_url = urllib.parse.urlparse(self.url)
         if parsed_url.scheme != "s3":
             raise web_util.FetchError("S3FetchStrategy can only fetch from s3:// urls.")
 
@@ -1375,7 +1366,7 @@ class GCSFetchStrategy(URLFetchStrategy):
             tty.debug("Already downloaded {0}".format(self.archive_file))
             return
 
-        parsed_url = url_util.parse(self.url)
+        parsed_url = urllib.parse.urlparse(self.url)
         if parsed_url.scheme != "gs":
             raise web_util.FetchError("GCSFetchStrategy can only fetch from gs:// urls.")
 
@@ -1680,7 +1671,8 @@ class FsCache(object):
 
     def fetcher(self, target_path, digest, **kwargs):
         path = os.path.join(self.root, target_path)
-        return CacheURLFetchStrategy(path, digest, **kwargs)
+        url = url_util.path_to_file_url(path)
+        return CacheURLFetchStrategy(url, digest, **kwargs)
 
     def destroy(self):
         shutil.rmtree(self.root, ignore_errors=True)

--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -2,9 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import urllib.parse
 import urllib.response
 
-import spack.util.url as url_util
 import spack.util.web as web_util
 
 
@@ -12,7 +12,7 @@ def gcs_open(req, *args, **kwargs):
     """Open a reader stream to a blob object on GCS"""
     import spack.util.gcs as gcs_util
 
-    url = url_util.parse(req.get_full_url())
+    url = urllib.parse.urlparse(req.get_full_url())
     gcsblob = gcs_util.GCSBlob(url)
 
     if not gcsblob.exists():

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import urllib.error
+import urllib.parse
 import urllib.request
 import urllib.response
 from io import BufferedReader, IOBase
 
 import spack.util.s3 as s3_util
-import spack.util.url as url_util
 
 
 # NOTE(opadron): Workaround issue in boto where its StreamingBody
@@ -43,7 +43,7 @@ class WrapStream(BufferedReader):
 
 
 def _s3_open(url):
-    parsed = url_util.parse(url)
+    parsed = urllib.parse.urlparse(url)
     s3 = s3_util.get_s3_session(url, method="fetch")
 
     bucket = parsed.netloc

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -505,7 +505,7 @@ class Stage(object):
 
         def print_errors(errors):
             for msg in errors:
-                tty.warn(msg)
+                tty.debug(msg)
 
         errors = []
         for fetcher in generate_fetchers():
@@ -518,8 +518,8 @@ class Stage(object):
                 # Don't bother reporting when something is not cached.
                 continue
             except spack.error.SpackError as e:
-                errors.append("Fetching from {0} failed: {1}".format(fetcher, str(e)))
-                tty.warn(e)
+                errors.append("Fetching from {0} failed.".format(fetcher))
+                tty.debug(e)
                 continue
         else:
             print_errors(errors)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -505,7 +505,7 @@ class Stage(object):
 
         def print_errors(errors):
             for msg in errors:
-                tty.debug(msg)
+                tty.warn(msg)
 
         errors = []
         for fetcher in generate_fetchers():
@@ -518,8 +518,8 @@ class Stage(object):
                 # Don't bother reporting when something is not cached.
                 continue
             except spack.error.SpackError as e:
-                errors.append("Fetching from {0} failed.".format(fetcher))
-                tty.debug(e)
+                errors.append("Fetching from {0} failed: {1}".format(fetcher, str(e)))
+                tty.warn(e)
                 continue
         else:
             print_errors(errors)

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -10,20 +10,13 @@ import sys
 import pytest
 
 import spack.binary_distribution
+import spack.main
 import spack.spec
+import spack.util.url
 
 install = spack.main.SpackCommand("install")
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-
-
-def _validate_url(url):
-    return
-
-
-@pytest.fixture(autouse=True)
-def url_check(monkeypatch):
-    monkeypatch.setattr(spack.util.url, "require_url_format", _validate_url)
 
 
 def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmpdir):
@@ -33,12 +26,13 @@ def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmpdi
         install(str(spec))
 
         # Runs fine the first time, throws the second time
-        spack.binary_distribution._build_tarball(spec, ".", unsigned=True)
+        out_url = spack.util.url.path_to_file_url(str(tmpdir))
+        spack.binary_distribution._build_tarball(spec, out_url, unsigned=True)
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
-            spack.binary_distribution._build_tarball(spec, ".", unsigned=True)
+            spack.binary_distribution._build_tarball(spec, out_url, unsigned=True)
 
         # Should work fine with force=True
-        spack.binary_distribution._build_tarball(spec, ".", force=True, unsigned=True)
+        spack.binary_distribution._build_tarball(spec, out_url, force=True, unsigned=True)
 
         # Remove the tarball and try again.
         # This must *also* throw, because of the existing .spec.json file
@@ -51,4 +45,4 @@ def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmpdi
         )
 
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
-            spack.binary_distribution._build_tarball(spec, ".", unsigned=True)
+            spack.binary_distribution._build_tarball(spec, out_url, unsigned=True)

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -10,6 +10,7 @@ import pytest
 import spack.cmd.create
 import spack.stage
 import spack.util.executable
+import spack.util.url as url_util
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
@@ -50,7 +51,7 @@ def url_and_build_system(request, tmpdir):
     filename, system = request.param
     tmpdir.ensure("archive", filename)
     tar("czf", "archive.tar.gz", "archive")
-    url = "file://" + str(tmpdir.join("archive.tar.gz"))
+    url = url_util.path_to_file_url(str(tmpdir.join("archive.tar.gz")))
     yield url, system
     orig_dir.chdir()
 

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -11,6 +11,7 @@ import pytest
 from llnl.util.filesystem import mkdirp, touch
 
 import spack.config
+import spack.util.url as url_util
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 from spack.stage import Stage
 
@@ -23,7 +24,7 @@ def test_fetch_missing_cache(tmpdir, _fetch_method):
     testpath = str(tmpdir)
     with spack.config.override("config:url_fetch_method", _fetch_method):
         abs_pref = "" if is_windows else "/"
-        url = "file://" + abs_pref + "not-a-real-cache-file"
+        url = url_util.path_to_file_url(abs_pref + "not-a-real-cache-file")
         fetcher = CacheURLFetchStrategy(url=url)
         with Stage(fetcher, path=testpath):
             with pytest.raises(NoCacheError, match=r"No cache"):
@@ -36,11 +37,7 @@ def test_fetch(tmpdir, _fetch_method):
     testpath = str(tmpdir)
     cache = os.path.join(testpath, "cache.tar.gz")
     touch(cache)
-    if is_windows:
-        url_stub = "{0}"
-    else:
-        url_stub = "/{0}"
-    url = "file://" + url_stub.format(cache)
+    url = url_util.path_to_file_url(cache)
     with spack.config.override("config:url_fetch_method", _fetch_method):
         fetcher = CacheURLFetchStrategy(url=url)
         with Stage(fetcher, path=testpath) as stage:

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -15,16 +14,14 @@ import spack.util.url as url_util
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 from spack.stage import Stage
 
-is_windows = sys.platform == "win32"
-
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 def test_fetch_missing_cache(tmpdir, _fetch_method):
     """Ensure raise a missing cache file."""
     testpath = str(tmpdir)
+    non_existing = os.path.join(testpath, "non-existing")
     with spack.config.override("config:url_fetch_method", _fetch_method):
-        abs_pref = "" if is_windows else "/"
-        url = url_util.path_to_file_url(abs_pref + "not-a-real-cache-file")
+        url = url_util.path_to_file_url(non_existing)
         fetcher = CacheURLFetchStrategy(url=url)
         with Stage(fetcher, path=testpath):
             with pytest.raises(NoCacheError, match=r"No cache"):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -810,10 +810,10 @@ def create_rebuild_env(tmpdir, pkg_name, broken_tests=False):
     env_dir = working_dir.join("concrete_env")
 
     mirror_dir = working_dir.join("mirror")
-    mirror_url = "file://{0}".format(mirror_dir.strpath)
+    mirror_url = url_util.path_to_file_url(mirror_dir.strpath)
 
     broken_specs_path = os.path.join(working_dir.strpath, "naughty-list")
-    broken_specs_url = url_util.join("file://", broken_specs_path)
+    broken_specs_url = url_util.path_to_file_url(broken_specs_path)
     temp_storage_url = "file:///path/to/per/pipeline/storage"
 
     broken_tests_packages = [pkg_name] if broken_tests else []

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -16,6 +16,7 @@ import llnl.util.filesystem as fs
 import llnl.util.link_tree
 
 import spack.cmd.env
+import spack.config
 import spack.environment as ev
 import spack.environment.shell
 import spack.error
@@ -29,7 +30,6 @@ from spack.spec import Spec
 from spack.stage import stage_prefix
 from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
-from spack.util.web import FetchError
 from spack.version import Version
 
 # TODO-27021
@@ -707,9 +707,9 @@ spack:
             e.concretize()
 
     err = str(exc)
-    assert "not retrieve configuration" in err
-    assert os.path.join("no", "such", "directory") in err
-
+    assert "missing include" in err
+    assert "/no/such/directory" in err
+    assert os.path.join("no", "such", "file.yaml") in err
     assert ev.active_environment() is None
 
 
@@ -827,7 +827,7 @@ def test_env_with_included_config_missing_file(tmpdir, mutable_empty_config):
         f.write("spack:\n  include:\n    - {0}\n".format(missing_file.strpath))
 
     env = ev.Environment(tmpdir.strpath)
-    with pytest.raises(FetchError, match="No such file or directory"):
+    with pytest.raises(spack.config.ConfigError, match="missing include path"):
         ev.activate(env)
 
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -11,6 +11,8 @@ import pytest
 import spack.cmd.mirror
 import spack.config
 import spack.environment as ev
+import spack.spec
+import spack.util.url as url_util
 from spack.main import SpackCommand, SpackCommandError
 
 mirror = SpackCommand("mirror")
@@ -41,15 +43,6 @@ def tmp_scope():
 
     with spack.config.override(spack.config.InternalConfigScope(scope_name)):
         yield scope_name
-
-
-def _validate_url(url):
-    return
-
-
-@pytest.fixture(autouse=True)
-def url_check(monkeypatch):
-    monkeypatch.setattr(spack.util.url, "require_url_format", _validate_url)
 
 
 @pytest.mark.disable_clean_stage_check
@@ -89,7 +82,7 @@ def source_for_pkg_with_hash(mock_packages, tmpdir):
     local_path = os.path.join(str(tmpdir), local_url_basename)
     with open(local_path, "w") as f:
         f.write(s.package.hashed_content)
-    local_url = "file://" + local_path
+    local_url = url_util.path_to_file_url(local_path)
     s.package.versions[spack.version.Version("1.0")]["url"] = local_url
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -48,6 +48,7 @@ import spack.test.cray_manifest
 import spack.util.executable
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
+import spack.util.url as url_util
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.util.pattern import Bunch
 from spack.util.web import FetchError
@@ -1130,7 +1131,7 @@ def mock_archive(request, tmpdir_factory):
         "Archive", ["url", "path", "archive_file", "expanded_archive_basedir"]
     )
     archive_file = str(tmpdir.join(archive_name))
-    url = "file://" + archive_file
+    url = url_util.path_to_file_url(archive_file)
 
     # Return the url
     yield Archive(
@@ -1331,7 +1332,7 @@ def mock_git_repository(tmpdir_factory):
         tmpdir = tmpdir_factory.mktemp("mock-git-repo-submodule-dir-{0}".format(submodule_count))
         tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
         repodir = tmpdir.join(spack.stage._source_path_subdir)
-        suburls.append((submodule_count, "file://" + str(repodir)))
+        suburls.append((submodule_count, url_util.path_to_file_url(str(repodir))))
 
         with repodir.as_cwd():
             git("init")
@@ -1359,7 +1360,7 @@ def mock_git_repository(tmpdir_factory):
         git("init")
         git("config", "user.name", "Spack")
         git("config", "user.email", "spack@spack.io")
-        url = "file://" + str(repodir)
+        url = url_util.path_to_file_url(str(repodir))
         for number, suburl in suburls:
             git("submodule", "add", suburl, "third_party/submodule{0}".format(number))
 
@@ -1461,7 +1462,7 @@ def mock_hg_repository(tmpdir_factory):
 
     # Initialize the repository
     with repodir.as_cwd():
-        url = "file://" + str(repodir)
+        url = url_util.path_to_file_url(str(repodir))
         hg("init")
 
         # Commit file r0
@@ -1495,7 +1496,7 @@ def mock_svn_repository(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp("mock-svn-stage")
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
     repodir = tmpdir.join(spack.stage._source_path_subdir)
-    url = "file://" + str(repodir)
+    url = url_util.path_to_file_url(str(repodir))
 
     # Initialize the repository
     with repodir.as_cwd():

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -15,6 +15,7 @@ import spack.mirror
 import spack.repo
 import spack.util.executable
 import spack.util.spack_json as sjson
+import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which
@@ -54,7 +55,7 @@ def check_mirror():
     with Stage("spack-mirror-test") as stage:
         mirror_root = os.path.join(stage.path, "test-mirror")
         # register mirror with spack config
-        mirrors = {"spack-mirror-test": "file://" + mirror_root}
+        mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_root)}
         with spack.config.override("mirrors", mirrors):
             with spack.config.override("config:checksum", False):
                 specs = [Spec(x).concretized() for x in repos]

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -25,6 +25,7 @@ import spack.package_base
 import spack.repo
 import spack.store
 import spack.util.gpg
+import spack.util.url as url_util
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.paths import mock_gpg_keys_path
 from spack.relocate import (
@@ -89,7 +90,7 @@ echo $PATH"""
     spack.mirror.create(mirror_path, specs=[])
 
     # register mirror with spack config
-    mirrors = {"spack-mirror-test": "file://" + mirror_path}
+    mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_path)}
     spack.config.set("mirrors", mirrors)
 
     stage = spack.stage.Stage(mirrors["spack-mirror-test"], name="build_cache", keep=True)

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -16,6 +16,7 @@ import spack.patch
 import spack.paths
 import spack.repo
 import spack.util.compression
+import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import Executable
@@ -87,7 +88,7 @@ data_path = os.path.join(spack.paths.test_path, "data", "patch")
 )
 def test_url_patch(mock_patch_stage, filename, sha256, archive_sha256, config):
     # Make a patch object
-    url = "file://" + filename
+    url = url_util.path_to_file_url(filename)
     s = Spec("patch").concretized()
     patch = spack.patch.UrlPatch(s.package, url, sha256=sha256, archive_sha256=archive_sha256)
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -19,6 +19,7 @@ from llnl.util.filesystem import getuid, mkdirp, partition_path, touch, working_
 import spack.paths
 import spack.stage
 import spack.util.executable
+import spack.util.url as url_util
 from spack.resource import Resource
 from spack.stage import DIYStage, ResourceStage, Stage, StageComposite
 from spack.util.path import canonicalize_path
@@ -40,10 +41,6 @@ _readme_contents = "hello world!\n"
 _include_readme = 1
 _include_hidden = 2
 _include_extra = 3
-
-_file_prefix = "file://"
-if sys.platform == "win32":
-    _file_prefix += "/"
 
 
 # Mock fetch directories are expected to appear as follows:
@@ -218,7 +215,7 @@ def mock_stage_archive(tmp_build_stage_dir):
         # Create the archive directory and associated file
         archive_dir = tmpdir.join(_archive_base)
         archive = tmpdir.join(_archive_fn)
-        archive_url = _file_prefix + str(archive)
+        archive_url = url_util.path_to_file_url(str(archive))
         archive_dir.ensure(dir=True)
 
         # Create the optional files as requested and make sure expanded
@@ -283,7 +280,7 @@ def mock_expand_resource(tmpdir):
 
     archive_name = "resource.tar.gz"
     archive = tmpdir.join(archive_name)
-    archive_url = _file_prefix + str(archive)
+    archive_url = url_util.path_to_file_url(str(archive))
 
     filename = "resource-file.txt"
     test_file = resource_dir.join(filename)
@@ -414,7 +411,7 @@ class TestStage(object):
         property of the stage should refer to the path of that file.
         """
         test_noexpand_fetcher = spack.fetch_strategy.from_kwargs(
-            url=_file_prefix + mock_noexpand_resource, expand=False
+            url=url_util.path_to_file_url(mock_noexpand_resource), expand=False
         )
         with Stage(test_noexpand_fetcher) as stage:
             stage.fetch()
@@ -432,7 +429,7 @@ class TestStage(object):
 
         resource_dst_name = "resource-dst-name.sh"
         test_resource_fetcher = spack.fetch_strategy.from_kwargs(
-            url=_file_prefix + mock_noexpand_resource, expand=False
+            url=url_util.path_to_file_url(mock_noexpand_resource), expand=False
         )
         test_resource = Resource("test_resource", test_resource_fetcher, resource_dst_name, None)
         resource_stage = ResourceStage(test_resource_fetcher, root_stage, test_resource)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import os
-import posixpath
 import sys
 
 import pytest
@@ -15,13 +14,14 @@ import spack.config
 import spack.mirror
 import spack.paths
 import spack.util.s3
+import spack.util.url as url_util
 import spack.util.web
 from spack.version import ver
 
 
 def _create_url(relative_url):
-    web_data_path = posixpath.join(spack.paths.test_path, "data", "web")
-    return "file://" + posixpath.join(web_data_path, relative_url)
+    web_data_path = os.path.join(spack.paths.test_path, "data", "web")
+    return url_util.path_to_file_url(os.path.join(web_data_path, relative_url))
 
 
 root = _create_url("index.html")
@@ -185,6 +185,7 @@ def test_get_header():
 @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_list_url(tmpdir):
     testpath = str(tmpdir)
+    testpath_url = url_util.path_to_file_url(testpath)
 
     os.mkdir(os.path.join(testpath, "dir"))
 
@@ -199,7 +200,7 @@ def test_list_url(tmpdir):
         pass
 
     list_url = lambda recursive: list(
-        sorted(spack.util.web.list_url(testpath, recursive=recursive))
+        sorted(spack.util.web.list_url(testpath_url, recursive=recursive))
     )
 
     assert list_url(False) == ["file-0.txt", "file-1.txt", "file-2.txt"]

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -28,7 +28,7 @@ def get_s3_session(url, method="fetch"):
     global s3_client_cache
 
     # Get a (recycled) s3 session for a particular URL
-    url = url_util.parse(url)
+    url = urllib.parse.urlparse(url)
 
     url_str = url_util.format(url)
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Tuple
 
 import spack
 import spack.config
-import spack.util.url as url_util
 
 #: Map (mirror name, method) tuples to s3 client instances.
 s3_client_cache: Dict[Tuple[str, str], Any] = dict()
@@ -27,10 +26,10 @@ def get_s3_session(url, method="fetch"):
 
     global s3_client_cache
 
-    # Get a (recycled) s3 session for a particular URL
-    url = urllib.parse.urlparse(url)
-
-    url_str = url_util.format(url)
+    # Parse the URL if not already done.
+    if not isinstance(url, urllib.parse.ParseResult):
+        url = urllib.parse.urlparse(url)
+    url_str = url.geturl()
 
     def get_mirror_url(mirror):
         return mirror.fetch_url if method == "fetch" else mirror.push_url

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -53,6 +53,7 @@ default:
   variables:
     KUBERNETES_CPU_REQUEST: 4000m
     KUBERNETES_MEMORY_REQUEST: 8G
+    SPACK_BACKTRACE: 1
   interruptible: true
   retry:
     max: 2

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -53,7 +53,6 @@ default:
   variables:
     KUBERNETES_CPU_REQUEST: 4000m
     KUBERNETES_MEMORY_REQUEST: 8G
-    SPACK_BACKTRACE: 1
   interruptible: true
   retry:
     max: 2

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -556,7 +556,7 @@ _spack_buildcache_sync() {
 }
 
 _spack_buildcache_update_index() {
-    SPACK_COMPREPLY="-h --help -d --mirror-url -k --keys"
+    SPACK_COMPREPLY="-h --help -d --directory -m --mirror-name --mirror-url -k --keys"
 }
 
 _spack_cd() {


### PR DESCRIPTION
The main issue that's fixed is that Spack passes paths (as strings) to
functions that require urls. That wasn't an issue on unix, since there
you can simply concatenate `file://` and `path` and all is good, but on
Windows that gives invalid file urls.

Instead of all sorts of ad-hoc `if windows: fix_broken_file_url` this PR
adds two helper functions around Python's own path2url and reverse.
`spack.util.url.path_to_file_url` / `spack.util.url.file_url_string_to_path`

This allows me to remove the custom `spack.util.url.parse` function.
That function is generally broken, as it has its own interpretation of
the `file://` protocol: it tries to be smart about relative paths, but the
truth is that this is simply not supported by design, so any attempt
to make `file://x/y` mean the relative local path `x/y` is plain wrong.
This URI has a meaning: `hostname=x` and `path=/y`.

Also the variable interpolation in `spack.util.url.parse` has similar
issues, where Spack just tries to be too smart, disagreeing with
the specification, and not particularly following the principle of
least surprise. Just let the call-site interpolate variables if necessary.

Also fixes what I think is a bug, where some `spack buildcache` commands
used `-d` as a flag to mean `--mirror-url` requiring a URL, and others
`--directory`, requiring a path. (For @scottwittenburg)

Adding @tldahlgren as a reviewer for the environment include URL
stuff; fyi it also fixes a bug where a non-existing local path would
result in a FetchError, which is weird. See the updated test.