### PR TITLE
expat: Add latest release 2.5.0 with security fixes

### DIFF
--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -14,21 +14,28 @@ class Expat(AutotoolsPackage):
     homepage = "https://libexpat.github.io/"
     url = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
-    version("2.4.8", sha256="a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16")
-    version("2.4.7", sha256="e149bdd8b90254c62b3d195da53a09bd531a4d63a963b0d8a5268d48dd2f6a65")
-    # deprecate release 2.4.6 because of a (severe) regression
+    version("2.5.0", sha256="6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67")
+    # deprecate all releases before 2.5.0 because of security issues
+    version(
+        "2.4.8",
+        sha256="a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16",
+        deprecated=True,
+    )
+    version(
+        "2.4.7",
+        sha256="e149bdd8b90254c62b3d195da53a09bd531a4d63a963b0d8a5268d48dd2f6a65",
+        deprecated=True,
+    )
     version(
         "2.4.6",
         sha256="ce317706b07cae150f90cddd4253f5b4fba929607488af5ac47bf2bc08e31f09",
         deprecated=True,
     )
-    # deprecate release 2.4.5 because of a (severe) regression
     version(
         "2.4.5",
         sha256="fbb430f964c7a2db2626452b6769e6a8d5d23593a453ccbc21701b74deabedff",
         deprecated=True,
     )
-    # deprecate all releases before 2.4.5 because of security issues
     version(
         "2.4.4",
         sha256="14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a",


### PR DESCRIPTION
Hi!

[libexpat 2.5.0](https://github.com/libexpat/libexpat/releases/tag/R_2_5_0) with **security fixes** has been released, the upstream [change log](https://github.com/libexpat/libexpat/blob/R_2_5_0/expat/Changes) has more details.

Thanks for updating! :pray: 

Best, Sebastian