### PR TITLE
[WIP] Refine CI configuration

### DIFF
--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -452,7 +452,7 @@ and site are used to specify the CDash instance to which build results should
 be reported.
 
 Take a look at the
-`schema <https://github.com/spack/spack/blob/develop/lib/spack/spack/schema/gitlab_ci.py>`_
+`schema <https://github.com/spack/spack/blob/develop/lib/spack/spack/schema/ci.py>`_
 for the gitlab-ci section of the spack environment file, to see precisely what
 syntax is allowed there.
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -384,6 +384,7 @@ def _can_build_spec(spec):
         return True
     return any(spec.satisfies(m) for m in bounds)
 
+
 def _remove_attributes(src_dict, dest_dict):
     if "tags" in src_dict and "tags" in dest_dict:
         # For 'tags', we remove any tags that are listed for removal
@@ -403,6 +404,7 @@ def _apply_job_config(job, kind, *, spec=None):
         elif key in config:
             job = cfg.merge_yaml(job, config[key])
         elif spec is not None and "submapping" in config:
+
             def match_clause(clause):
                 if any(spec.satisfies(m) for m in clause["match"]):
                     _remove_attributes(clause.get(rm_key, {}), job)
@@ -423,12 +425,14 @@ def _apply_job_config(job, kind, *, spec=None):
                 raise ValueError(behavior)
     return job
 
+
 def _finalize_job(job, reserved_tags=None):
     if "tags" in job:
         if reserved_tags is not None:
             job["tags"] = _remove_reserved_tags(job["tags"])
             job["tags"].extend(reserved_tags)
         job["tags"] = list(set(job["tags"]))
+
 
 def _format_job_needs(
     phase_name,
@@ -584,7 +588,7 @@ def generate_gitlab_ci_yaml(
             env.write()
 
     if not cfg.get("ci"):
-        tty.die("Environment does not have \"ci\" section")
+        tty.die('Environment does not have "ci" section')
 
     cdash_config = cfg.get("ci:cdash", None)
     if cdash_config is not None:
@@ -842,7 +846,11 @@ def generate_gitlab_ci_yaml(
                         continue
 
                 if not _can_build_spec(release_spec):
-                    tty.warn("Spec {0} does not match any entry in ci:build-if-matches, skipping it".format(release_spec))
+                    tty.warn(
+                        "Spec {0} does not match any entry in ci:build-if-matches, skipping it".format(
+                            release_spec
+                        )
+                    )
                     continue
 
                 job_object = {
@@ -1149,9 +1157,7 @@ def generate_gitlab_ci_yaml(
             final_job = {
                 "stage": "stage-rebuild-index",
                 "script": [
-                    "spack buildcache update-index --keys -d {0}".format(
-                        remote_mirror.push_url
-                    )
+                    "spack buildcache update-index --keys -d {0}".format(remote_mirror.push_url)
                 ],
                 "when": "always",
                 "retry": copy.deepcopy(service_job_retries),

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1043,6 +1043,7 @@ def _override(string):
     """
     return hasattr(string, "override") and string.override
 
+
 def _promoting_merge(string):
     """Test if a spack YAML string is a promoting merge.
 
@@ -1173,7 +1174,9 @@ def merge_yaml(dest, source):
                         old_dest_value = [old_dest_value]
                 elif isinstance(sv, dict):
                     if merge and not isinstance(old_dest_value, dict):
-                        raise ConfigError(f"Unable to merge {type(old_dest_value)} with dict for key {sk}")
+                        raise ConfigError(
+                            f"Unable to merge {type(old_dest_value)} with dict for key {sk}"
+                        )
                 else:
                     raise ConfigError(f"Unable to merge with {type(sv)} for key {sk}")
 
@@ -1217,7 +1220,10 @@ def process_config_path(path):
         elif front.endswith("+"):
             if seen_override_in_path:
                 raise syaml.SpackYAMLError(
-                    "Meaningless promoting merge `+:` after override indicator `::' in path `{0}'".format(path), ""
+                    "Meaningless promoting merge `+:` after override indicator `::' in path `{0}'".format(
+                        path
+                    ),
+                    "",
                 )
             front = front[:-1]
             front = syaml.syaml_str(front)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -77,6 +77,7 @@ section_schemas = {
     "config": spack.schema.config.schema,
     "upstreams": spack.schema.upstreams.schema,
     "bootstrap": spack.schema.bootstrap.schema,
+    "ci": spack.schema.ci.schema,
 }
 
 # Same as above, but including keys for environments

--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -46,7 +46,7 @@ def validate(configuration_file):
 
     # Remove attributes that are not needed / allowed in the
     # container recipe
-    for subsection in ("cdash", "gitlab_ci", "modules"):
+    for subsection in ("cdash", "ci", "modules"):
         if subsection in env_dict:
             msg = (
                 'the subsection "{0}" in "{1}" is not used when generating'

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -13,7 +13,6 @@ from llnl.util.lang import union_dicts
 
 import spack.schema.cdash
 
-
 remove_attributes_schema = {
     "type": "object",
     "additionalProperties": False,
@@ -28,38 +27,62 @@ attributes_schema = {
     "type": "object",
 }
 
-jobconfig_schema = { "anyOf": [
-    # Global generated job attributes, apply to all jobs
-    {"type": "object", "additionalProperties": False, "required": ["any-job"], "properties": {
-        "any-job": attributes_schema,
-    }},
-    attributes_schema,
-    # Attributes applied to jobs based on type
-    { "type": "object", "additionalProperties": False, "properties": {
-        "build-job": attributes_schema,
-        "reindex-job": attributes_schema,
-        "noop-job": attributes_schema,
-        "cleanup-job": attributes_schema,
-        "signing-job": attributes_schema,
-    }},
-    # Attributes applied to spec-specific jobs based on spec matching
-    { "type": "object", "additionalProperties": False, "properties": {
-        "match_behavior": {"type": "string", "enum": ["first", "merge"], "default": "first"},
-        "submapping": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": ["match"],
-                "additionalProperties": False,
-                "properties": {
-                    "match": {"anyOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]},
-                    "build-job-remove": remove_attributes_schema,
-                    "build-job": attributes_schema,
+jobconfig_schema = {
+    "anyOf": [
+        # Global generated job attributes, apply to all jobs
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["any-job"],
+            "properties": {
+                "any-job": attributes_schema,
+            },
+        },
+        attributes_schema,
+        # Attributes applied to jobs based on type
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "build-job": attributes_schema,
+                "reindex-job": attributes_schema,
+                "noop-job": attributes_schema,
+                "cleanup-job": attributes_schema,
+                "signing-job": attributes_schema,
+            },
+        },
+        # Attributes applied to spec-specific jobs based on spec matching
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "match_behavior": {
+                    "type": "string",
+                    "enum": ["first", "merge"],
+                    "default": "first",
+                },
+                "submapping": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["match"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "match": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "array", "items": {"type": "string"}},
+                                ]
+                            },
+                            "build-job-remove": remove_attributes_schema,
+                            "build-job": attributes_schema,
+                        },
+                    },
                 },
             },
         },
-    }},
-]}
+    ]
+}
 
 core_shared_properties = union_dicts(
     {
@@ -88,8 +111,10 @@ core_shared_properties = union_dicts(
             },
         },
         "pipeline-attributes": {"type": "object"},
-        "build-if-matches": {"anyOf": [{"type": "null"}, {"type": "array", "items": {"type": "string"}}]},
-        "job-configuration": { "type": "array", "items": jobconfig_schema },
+        "build-if-matches": {
+            "anyOf": [{"type": "null"}, {"type": "array", "items": {"type": "string"}}]
+        },
+        "job-configuration": {"type": "array", "items": jobconfig_schema},
         "rebuild-index": {"type": "boolean"},
         "broken-specs-url": {"type": "string"},
         "broken-tests-packages": {

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -11,11 +11,11 @@
 from llnl.util.lang import union_dicts
 
 import spack.schema.bootstrap
+import spack.schema.ci
 import spack.schema.compilers
 import spack.schema.concretizer
 import spack.schema.config
 import spack.schema.container
-import spack.schema.ci
 import spack.schema.mirrors
 import spack.schema.modules
 import spack.schema.packages

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -11,12 +11,11 @@
 from llnl.util.lang import union_dicts
 
 import spack.schema.bootstrap
-import spack.schema.cdash
 import spack.schema.compilers
 import spack.schema.concretizer
 import spack.schema.config
 import spack.schema.container
-import spack.schema.gitlab_ci
+import spack.schema.ci
 import spack.schema.mirrors
 import spack.schema.modules
 import spack.schema.packages
@@ -26,12 +25,11 @@ import spack.schema.upstreams
 #: Properties for inclusion in other schemas
 properties = union_dicts(
     spack.schema.bootstrap.properties,
-    spack.schema.cdash.properties,
     spack.schema.compilers.properties,
     spack.schema.concretizer.properties,
     spack.schema.config.properties,
     spack.schema.container.properties,
-    spack.schema.gitlab_ci.properties,
+    spack.schema.ci.properties,
     spack.schema.mirrors.properties,
     spack.schema.modules.properties,
     spack.schema.packages.properties,

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import contextlib
 import filecmp
 import json
 import os
 import shutil
 import sys
-import contextlib
 
 import pytest
 from jsonschema import ValidationError, validate
@@ -25,13 +25,13 @@ import spack.hash_types as ht
 import spack.main
 import spack.paths as spack_paths
 import spack.repo as repo
+import spack.util.environment as env_util
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
-import spack.util.environment as env_util
 from spack.schema.buildcache_spec import schema as specfile_schema
-from spack.schema.database_index import schema as db_idx_schema
 from spack.schema.ci import schema as ci_schema
+from spack.schema.database_index import schema as db_idx_schema
 from spack.spec import CompilerSpec, Spec
 from spack.util.executable import which
 from spack.util.pattern import Bunch
@@ -919,6 +919,7 @@ def activate_rebuild_env(tmpdir, pkg_name, rebuild_env):
     with ev.read("test"):
         with env_util.set_env(**environ):
             yield
+
 
 @pytest.mark.parametrize("broken_tests", [True, False])
 def test_ci_rebuild_mock_success(
@@ -1828,7 +1829,9 @@ spack:
                     assert the_elt["top"] == "added"
                     assert len(the_elt["tags"]) == 2
                     assert "specific-a" in the_elt["tags"]
-                    assert ("toplevel" if match_behavior == "first" else "specific-a-2") in the_elt["tags"]
+                    assert (
+                        "toplevel" if match_behavior == "first" else "specific-a-2"
+                    ) in the_elt["tags"]
                     assert the_elt["specific"] == "a"
                 if "(specs) dependency-install" in ci_key:
                     # Since the dependency-install match omits any

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1826,10 +1826,9 @@ spack:
                     # appear twice, but that a's specific extra tag does appear
                     the_elt = yaml_contents[ci_key]
                     assert the_elt["top"] == "added"
-                    if match_behavior == "merge":
-                        assert the_elt["tags"] == ["specific-a", "specific-a-2"]
-                    else:
-                        assert the_elt["tags"] == ["specific-a", "toplevel"]
+                    assert len(the_elt["tags"]) == 2
+                    assert "specific-a" in the_elt["tags"]
+                    assert ("toplevel" if match_behavior == "first" else "specific-a-2") in the_elt["tags"]
                     assert the_elt["specific"] == "a"
                 if "(specs) dependency-install" in ci_key:
                     # Since the dependency-install match omits any

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -38,6 +38,12 @@ config_low = {
         "build_stage": ["path1", "path2", "path3"],
     }
 }
+config_low2 = {
+    "config": {
+        "install_tree": {"root": "install_tree_path"},
+        "build_stage": "path4",
+    }
+}
 
 config_override_all = {"config:": {"install_tree:": {"root": "override_all"}}}
 
@@ -50,6 +56,19 @@ config_override_list = {"config": {"build_stage:": ["pathd", "pathe"]}}
 config_merge_dict = {"config": {"info": {"a": 3, "b": 4}}}
 
 config_override_dict = {"config": {"info:": {"a": 7, "c": 9}}}
+
+config_exmerge_errs = [
+    pytest.param({"config": {"shared_linking+": "new_key"}}, id="scalar"),
+    pytest.param({"config": {"build_stage+": "new_key"}}, id="toscalar"),
+    pytest.param({"config": {"build_stage+": {"a": 12}}}, id="todict1"),
+    pytest.param({"config": {"install_tree": {"root+": {"a": 12}}}}, id="todict2"),
+]
+
+config_exmerge_list = {"config": {"build_stage+": ["pathb", "pathc"]}}
+
+config_exmerge_tolist = {"config": {"build_stage+": ["pathd"]}}
+
+config_exmerge_dict = {"config+": {"info": {"a": 3, "b": 4}}}
 
 
 @pytest.fixture()
@@ -579,6 +598,38 @@ def test_read_config_override_list(mock_low_high_config, write_config_file):
     assert spack.config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": config_override_list["config"]["build_stage:"],
+    }
+
+@pytest.mark.parametrize("config_err", config_exmerge_errs)
+def test_read_config_exmerge_errors(mock_low_high_config, write_config_file, config_err):
+    write_config_file("config", config_low, "low")
+    write_config_file("config", config_err, "high")
+    with pytest.raises(spack.config.ConfigError):
+        spack.config.get("config")
+
+def test_read_config_exmerge_list(mock_low_high_config, write_config_file):
+    write_config_file("config", config_low, "low")
+    write_config_file("config", config_exmerge_list, "high")
+    assert spack.config.get("config") == {
+        "install_tree": {"root": "install_tree_path"},
+        "build_stage": ["pathb", "pathc", "path1", "path2", "path3"],
+    }
+
+def test_read_config_exmerge_tolist(mock_low_high_config, write_config_file):
+    write_config_file("config", config_low2, "low")
+    write_config_file("config", config_exmerge_tolist, "high")
+    assert spack.config.get("config") == {
+        "install_tree": {"root": "install_tree_path"},
+        "build_stage": ["pathd", "path4"],
+    }
+
+def test_read_config_exmerge_dict(mock_low_high_config, write_config_file):
+    write_config_file("config", config_low, "low")
+    write_config_file("config", config_exmerge_dict, "high")
+    assert spack.config.get("config") == {
+        "install_tree": {"root": "install_tree_path"},
+        "build_stage": ["path1", "path2", "path3"],
+        "info": {"a": 3, "b": 4},
     }
 
 
@@ -1183,6 +1234,11 @@ def test_set_bad_path(config):
 def test_bad_path_double_override(config):
     with pytest.raises(syaml.SpackYAMLError, match="Meaningless second override"):
         with spack.config.override("bad::double:override::directive", ""):
+            pass
+
+def test_bad_path_merge_after_override(config):
+    with pytest.raises(syaml.SpackYAMLError, match="Meaningless explicit merge"):
+        with spack.config.override("bad::merge:after:override+:directive", ""):
             pass
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -57,18 +57,18 @@ config_merge_dict = {"config": {"info": {"a": 3, "b": 4}}}
 
 config_override_dict = {"config": {"info:": {"a": 7, "c": 9}}}
 
-config_exmerge_errs = [
+config_promerge_errs = [
     pytest.param({"config": {"shared_linking+": "new_key"}}, id="scalar"),
     pytest.param({"config": {"build_stage+": "new_key"}}, id="toscalar"),
     pytest.param({"config": {"build_stage+": {"a": 12}}}, id="todict1"),
     pytest.param({"config": {"install_tree": {"root+": {"a": 12}}}}, id="todict2"),
 ]
 
-config_exmerge_list = {"config": {"build_stage+": ["pathb", "pathc"]}}
+config_promerge_list = {"config": {"build_stage+": ["pathb", "pathc"]}}
 
-config_exmerge_tolist = {"config": {"build_stage+": ["pathd"]}}
+config_promerge_tolist = {"config": {"build_stage+": ["pathd"]}}
 
-config_exmerge_dict = {"config+": {"info": {"a": 3, "b": 4}}}
+config_promerge_dict = {"config+": {"info": {"a": 3, "b": 4}}}
 
 
 @pytest.fixture()
@@ -600,32 +600,32 @@ def test_read_config_override_list(mock_low_high_config, write_config_file):
         "build_stage": config_override_list["config"]["build_stage:"],
     }
 
-@pytest.mark.parametrize("config_err", config_exmerge_errs)
-def test_read_config_exmerge_errors(mock_low_high_config, write_config_file, config_err):
+@pytest.mark.parametrize("config_err", config_promerge_errs)
+def test_read_config_promerge_errors(mock_low_high_config, write_config_file, config_err):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_err, "high")
     with pytest.raises(spack.config.ConfigError):
         spack.config.get("config")
 
-def test_read_config_exmerge_list(mock_low_high_config, write_config_file):
+def test_read_config_promerge_list(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
-    write_config_file("config", config_exmerge_list, "high")
+    write_config_file("config", config_promerge_list, "high")
     assert spack.config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": ["pathb", "pathc", "path1", "path2", "path3"],
     }
 
-def test_read_config_exmerge_tolist(mock_low_high_config, write_config_file):
+def test_read_config_promerge_tolist(mock_low_high_config, write_config_file):
     write_config_file("config", config_low2, "low")
-    write_config_file("config", config_exmerge_tolist, "high")
+    write_config_file("config", config_promerge_tolist, "high")
     assert spack.config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": ["pathd", "path4"],
     }
 
-def test_read_config_exmerge_dict(mock_low_high_config, write_config_file):
+def test_read_config_promerge_dict(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
-    write_config_file("config", config_exmerge_dict, "high")
+    write_config_file("config", config_promerge_dict, "high")
     assert spack.config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": ["path1", "path2", "path3"],
@@ -1237,7 +1237,7 @@ def test_bad_path_double_override(config):
             pass
 
 def test_bad_path_merge_after_override(config):
-    with pytest.raises(syaml.SpackYAMLError, match="Meaningless explicit merge"):
+    with pytest.raises(syaml.SpackYAMLError, match="Meaningless promoting merge"):
         with spack.config.override("bad::merge:after:override+:directive", ""):
             pass
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -600,12 +600,14 @@ def test_read_config_override_list(mock_low_high_config, write_config_file):
         "build_stage": config_override_list["config"]["build_stage:"],
     }
 
+
 @pytest.mark.parametrize("config_err", config_promerge_errs)
 def test_read_config_promerge_errors(mock_low_high_config, write_config_file, config_err):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_err, "high")
     with pytest.raises(spack.config.ConfigError):
         spack.config.get("config")
+
 
 def test_read_config_promerge_list(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
@@ -615,6 +617,7 @@ def test_read_config_promerge_list(mock_low_high_config, write_config_file):
         "build_stage": ["pathb", "pathc", "path1", "path2", "path3"],
     }
 
+
 def test_read_config_promerge_tolist(mock_low_high_config, write_config_file):
     write_config_file("config", config_low2, "low")
     write_config_file("config", config_promerge_tolist, "high")
@@ -622,6 +625,7 @@ def test_read_config_promerge_tolist(mock_low_high_config, write_config_file):
         "install_tree": {"root": "install_tree_path"},
         "build_stage": ["pathd", "path4"],
     }
+
 
 def test_read_config_promerge_dict(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
@@ -1235,6 +1239,7 @@ def test_bad_path_double_override(config):
     with pytest.raises(syaml.SpackYAMLError, match="Meaningless second override"):
         with spack.config.override("bad::double:override::directive", ""):
             pass
+
 
 def test_bad_path_merge_after_override(config):
     with pytest.raises(syaml.SpackYAMLError, match="Meaningless promoting merge"):

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -133,10 +133,10 @@ class OrderedLineLoader(RoundTripLoader):
         if value and value.endswith(":") and "@" not in value:
             value = syaml_str(value[:-1])
             value.override = True
-        # Same logic for Spack config explicit merge keys (end with '+')
+        # Same logic for Spack config promoting merge keys (end with '+')
         elif value and value.endswith("+") and "@" not in value:
             value = syaml_str(value[:-1])
-            value.explicit_merge = True
+            value.promoting_merge = True
         else:
             value = syaml_str(value)
         mark(value, node)
@@ -190,7 +190,7 @@ class OrderedLineDumper(RoundTripDumper):
     def represent_str(self, data):
         if hasattr(data, "override") and data.override:
             data = data + ":"
-        elif hasattr(data, "explicit_merge") and data.explicit_merge:
+        elif hasattr(data, "promoting_merge") and data.promoting_merge:
             data = data + "+"
         return super(OrderedLineDumper, self).represent_str(data)
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -105,7 +105,7 @@ class OrderedLineLoader(RoundTripLoader):
     """YAML loader specifically intended for reading Spack configuration
     files. It preserves order and line numbers. It also has special-purpose
     logic for handling dictionary keys that indicate a Spack config
-    override: namely any key that contains an "extra" ':' character.
+    override: namely any key that contains an "extra" ':' or '+' character.
 
     Mappings read in by this loader behave like an ordered dict.
     Sequences, mappings, and strings also have new attributes,
@@ -133,6 +133,10 @@ class OrderedLineLoader(RoundTripLoader):
         if value and value.endswith(":") and "@" not in value:
             value = syaml_str(value[:-1])
             value.override = True
+        # Same logic for Spack config explicit merge keys (end with '+')
+        elif value and value.endswith("+") and "@" not in value:
+            value = syaml_str(value[:-1])
+            value.explicit_merge = True
         else:
             value = syaml_str(value)
         mark(value, node)
@@ -186,6 +190,8 @@ class OrderedLineDumper(RoundTripDumper):
     def represent_str(self, data):
         if hasattr(data, "override") and data.override:
             data = data + ":"
+        elif hasattr(data, "explicit_merge") and data.explicit_merge:
+            data = data + "+"
         return super(OrderedLineDumper, self).represent_str(data)
 
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -241,42 +241,21 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/aws-ahug-aarch64" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "aarch64" ]
           variables:
             CI_JOB_SIZE: huge
             KUBERNETES_CPU_REQUEST: 11000m
             KUBERNETES_MEMORY_REQUEST: 42G
-
 
       - match:
         - ascent
@@ -305,7 +284,7 @@ spack:
         - vtk-h
         - vtk-m
         - warpx
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "aarch64" ]
           variables:
             CI_JOB_SIZE: large
@@ -313,30 +292,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "aarch64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "aarch64"]
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "aarch64"]
 
-  cdash:
-    build-group: AHUG ARM HPC User Group
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: AHUG ARM HPC User Group
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -238,42 +238,21 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/aws-ahug" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
             KUBERNETES_CPU_REQUEST: 11000m
             KUBERNETES_MEMORY_REQUEST: 42G
-
 
       - match:
         - ascent
@@ -302,7 +281,7 @@ spack:
         - vtk-h
         - vtk-m
         - warpx
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
@@ -310,30 +289,50 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64_v4"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: AHUG ARM HPC User Group
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: AHUG ARM HPC User Group
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -148,42 +148,21 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/aws-isc-aarch64" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "aarch64" ]
           variables:
             CI_JOB_SIZE: huge
             KUBERNETES_CPU_REQUEST: 15000m
             KUBERNETES_MEMORY_REQUEST: 62G
-
 
       - match:
         - ascent
@@ -221,7 +200,7 @@ spack:
         - warpx
         - wrf
         - wxwidgets
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "aarch64" ]
           variables:
             CI_JOB_SIZE: large
@@ -229,30 +208,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "aarch64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "aarch64"]
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "aarch64"]
 
-  cdash:
-    build-group: AWS Packages
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: AWS Packages
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -159,43 +159,22 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/aws-isc" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - pango
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
             KUBERNETES_CPU_REQUEST: 11000m
             KUBERNETES_MEMORY_REQUEST: 42G
-
 
       - match:
         - ascent
@@ -233,7 +212,7 @@ spack:
         - warpx
         - wrf
         - wxwidgets
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
@@ -241,30 +220,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64_v4"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-  cdash:
-    build-group: AWS Packages
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: AWS Packages
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -33,35 +33,14 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/build_systems" }
 
-  gitlab-ci:
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild
-    after_script:
-      - cat /proc/loadavg || true
-
-    image:
-      name: "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18"
-      entrypoint: [ "" ]
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - cmake
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64"]
           variables:
             CI_JOB_SIZE: large
@@ -74,7 +53,7 @@ spack:
           - mpich
           - openjpeg
           - sqlite
-        runner-attributes:
+        build-job:
           tags: [ "spack", "medium", "x86_64" ]
           variables:
             CI_JOB_SIZE: "medium"
@@ -98,7 +77,7 @@ spack:
           - util-macros
           - xz
           - zlib
-        runner-attributes:
+        build-job:
           tags: [ "spack", "medium", "x86_64" ]
           variables:
             CI_JOB_SIZE: "small"
@@ -107,30 +86,52 @@ spack:
 
       - match:
           - 'os=ubuntu18.04'
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64"]
+        image:
+          name: "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18"
+          entrypoint: [ "" ]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64"]
 
-  cdash:
-    build-group: Build tests for different build systems
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: Build tests for different build systems
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -72,35 +72,17 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/data-vis-sdk" }
 
-  gitlab-ci:
-    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild
-    after_script:
-     - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - qt
         - paraview
         - visit
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64" ]
           variables:
             CI_JOB_SIZE: huge
@@ -112,7 +94,7 @@ spack:
         - mesa
         - openblas
         - vtk-m
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64" ]
           variables:
             CI_JOB_SIZE: large
@@ -138,7 +120,7 @@ spack:
         - py-cinemasci
         - raja
         - vtk-h
-        runner-attributes:
+        build-job:
           tags: [ "spack", "medium", "x86_64" ]
           variables:
             CI_JOB_SIZE: "medium"
@@ -172,7 +154,7 @@ spack:
         - sqlite
         - tar
         - util-linux-uuid
-        runner-attributes:
+        build-job:
           tags: [ "spack", "small", "x86_64" ]
           variables:
             CI_JOB_SIZE: "small"
@@ -180,30 +162,49 @@ spack:
             KUBERNETES_MEMORY_REQUEST: "500M"
 
       - match: ['@:']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild
+        after_script::
+         - cat /proc/loadavg || true
 
-    service-job-attributes:
-      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      tags: ["spack", "public", "medium", "x86_64"]
+      reindex-job:
+        image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        tags: ["spack", "public", "medium", "x86_64"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: Data and Vis SDK
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: Data and Vis SDK
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -39,39 +39,39 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s-mac" }
 
-  gitlab-ci:
-
-    script:
-      - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match: ['os=monterey']
         runner-attributes:
           tags:
           - lambda
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
 
-    service-job-attributes:
-      before_script:
-      - export SPACK_USER_CACHE_PATH=$(pwd)/.spack-user-cache
-      - export SPACK_USER_CONFIG_PATH=$(pwd)/.spack-user-config
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      tags:
-      - lambda
+      reindex-job:
+        before_script::
+        - export SPACK_USER_CACHE_PATH=$(pwd)/.spack-user-cache
+        - export SPACK_USER_CONFIG_PATH=$(pwd)/.spack-user-config
+        - . "./share/spack/setup-env.sh"
+        - spack --version
+        tags:
+        - lambda
 
-  cdash:
-    build-group: E4S Mac
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: E4S Mac
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -211,27 +211,11 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/e4s" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.powerpc64le-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf '8096d202fe0a0c400b8c0573c4b9e009f2f10d2fa850a3f495340f16e9c42454 gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - spack --color=always --backtrace ci rebuild
-    after_script:
-      - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - cuda
         - dyninst
@@ -247,23 +231,39 @@ spack:
         - vtk-h
         - vtk-m
         - warpx
-        runner-attributes:
+        build-job:
           image: { "name": "ghcr.io/spack/e4s-ubuntu-20.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "ppc64le"]
       - match: ['os=ubuntu20.04']
-        runner-attributes:
+        build-job:
           image: { "name": "ghcr.io/spack/e4s-ubuntu-20.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "large", "ppc64le"]
-    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-ubuntu-20.04:v2021-10-18", "entrypoint": [""] }
-      tags: ["spack", "public", "medium", "ppc64le"]
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.powerpc64le-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf '8096d202fe0a0c400b8c0573c4b9e009f2f10d2fa850a3f495340f16e9c42454 gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - spack --color=always --backtrace ci rebuild
+        after_script::
+          - cat /proc/loadavg || true
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-ubuntu-20.04:v2021-10-18", "entrypoint": [""] }
+        tags: ["spack", "public", "medium", "ppc64le"]
 
-  cdash:
-    build-group: New PR testing workflow
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: New PR testing workflow
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -264,42 +264,17 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s-oneapi" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - export PATH=/bootstrap/runner/view/bin:${PATH}
-      - . /bootstrap/runner/install/linux-ubuntu20.04-x86_64/gcc-9.4.0/lmod-8.7.2-ri26z7qy6ixtgpsqinswx3w6tuggluv5/lmod/8.7.2/init/bash
-      - module use /opt/intel/oneapi/modulefiles
-      - module load compiler
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2022-07-01
-    
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - hipblas
           - llvm
           - llvm-amdgpu
           - rocblas
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64" ]
           variables:
             CI_JOB_SIZE: huge
@@ -324,7 +299,7 @@ spack:
           - trilinos
           - vtk-m
           - warpx
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64" ]
           variables:
             CI_JOB_SIZE: large
@@ -392,7 +367,7 @@ spack:
           - upcxx
           - vtk-h
           - zfp
-        runner-attributes:
+        build-job:
           tags: [ "spack", "medium", "x86_64" ]
           variables:
             CI_JOB_SIZE: "medium"
@@ -453,7 +428,7 @@ spack:
           - yaml-cpp
           - zlib
           - zstd
-        runner-attributes:
+        build-job:
           tags: [ "spack", "small", "x86_64" ]
           variables:
             CI_JOB_SIZE: "small"
@@ -461,30 +436,55 @@ spack:
             KUBERNETES_MEMORY_REQUEST: "500M"
 
       - match: ['os=ubuntu20.04']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - export PATH=/bootstrap/runner/view/bin:${PATH}
+          - . /bootstrap/runner/install/linux-ubuntu20.04-x86_64/gcc-9.4.0/lmod-8.7.2-ri26z7qy6ixtgpsqinswx3w6tuggluv5/lmod/8.7.2/init/bash
+          - module use /opt/intel/oneapi/modulefiles
+          - module load compiler
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2022-07-01
-      tags: ["spack", "public", "x86_64"]
+        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2022-07-01
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2022-07-01
+        tags: ["spack", "public", "x86_64"]
 
-  cdash:
-    build-group: E4S OneAPI
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: E4S OneAPI
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -240,35 +240,14 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
-
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
     broken-tests-packages:
       - gptune
 
-    match_behavior: first
-    mappings:
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - hipblas
           - llvm
@@ -276,7 +255,7 @@ spack:
           - rocblas
           - paraview
           - py-torch
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64" ]
           variables:
             CI_JOB_SIZE: huge
@@ -302,7 +281,7 @@ spack:
           - trilinos
           - vtk-m
           - warpx
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64" ]
           variables:
             CI_JOB_SIZE: large
@@ -370,7 +349,7 @@ spack:
           - upcxx
           - vtk-h
           - zfp
-        runner-attributes:
+        build-job:
           tags: [ "spack", "medium", "x86_64" ]
           variables:
             CI_JOB_SIZE: "medium"
@@ -431,7 +410,7 @@ spack:
           - yaml-cpp
           - zlib
           - zstd
-        runner-attributes:
+        build-job:
           tags: [ "spack", "small", "x86_64" ]
           variables:
             CI_JOB_SIZE: "small"
@@ -439,30 +418,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: "500M"
 
       - match: ['os=ubuntu20.04']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
-      tags: ["spack", "public", "x86_64"]
+        image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+        tags: ["spack", "public", "x86_64"]
 
-  cdash:
-    build-group: E4S
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+      reindex-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+
+    cdash:
+      build-group: E4S
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cpu/spack.yaml
@@ -88,33 +88,15 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/ml-cpu" }
 
-  gitlab-ci:
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - llvm
           - py-torch
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
@@ -122,34 +104,53 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 42G
       - match:
           - "@:"
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
             KUBERNETES_CPU_REQUEST: 8000m
             KUBERNETES_MEMORY_REQUEST: 12G
 
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: Machine Learning
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: Machine Learning
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-cuda/spack.yaml
@@ -91,33 +91,15 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/ml-cuda" }
 
-  gitlab-ci:
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - llvm
           - py-torch
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
@@ -125,34 +107,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 42G
       - match:
           - "@:"
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
             KUBERNETES_CPU_REQUEST: 8000m
             KUBERNETES_MEMORY_REQUEST: 12G
+    - build-job:
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
-
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
-
-  cdash:
-    build-group: Machine Learning
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: Machine Learning
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -94,33 +94,16 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/ml-rocm" }
 
-  gitlab-ci:
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - llvm
           - py-torch
         runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
@@ -128,34 +111,51 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 42G
       - match:
           - "@:"
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
             KUBERNETES_CPU_REQUEST: 8000m
             KUBERNETES_MEMORY_REQUEST: 12G
+    - build-job:
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
 
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
-
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
-
-  cdash:
-    build-group: Machine Learning
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: Machine Learning
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -54,37 +54,17 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/radiuss-aws-aarch64" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - pango
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "aarch64" ]
           variables:
             CI_JOB_SIZE: huge
@@ -128,7 +108,7 @@ spack:
         - warpx
         - wrf
         - wxwidgets
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "aarch64" ]
           variables:
             CI_JOB_SIZE: large
@@ -136,30 +116,50 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "aarch64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf '2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "aarch64"]
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "aarch64"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: RADIUSS AWS Packages
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: RADIUSS AWS Packages
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -59,43 +59,22 @@ spack:
 
   mirrors: { "mirror": "s3://spack-binaries/develop/radiuss-aws" }
 
-  gitlab-ci:
-
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
         - llvm
         - llvm-amdgpu
         - pango
         - paraview
-        runner-attributes:
+        build-job:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: huge
             KUBERNETES_CPU_REQUEST: 11000m
             KUBERNETES_MEMORY_REQUEST: 42G
-
 
       - match:
         - ascent
@@ -133,7 +112,7 @@ spack:
         - warpx
         - wrf
         - wxwidgets
-        runner-attributes:
+        build-job:
           tags: [ "spack", "large", "x86_64_v4" ]
           variables:
             CI_JOB_SIZE: large
@@ -141,30 +120,50 @@ spack:
             KUBERNETES_MEMORY_REQUEST: 12G
 
       - match: ['os=amzn2']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64_v4"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        after_script::
+          - cat /proc/loadavg || true
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64_v4"]
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64_v4"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: RADIUSS AWS Packages
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: RADIUSS AWS Packages
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -62,34 +62,16 @@ spack:
     - [$radiuss]
     - [$compilers]
 
-  gitlab-ci:
-    image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild
-    after_script:
-      - cat /proc/loadavg || true
-
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - lbann
           - openblas
           - rust
-        runner-attributes:
+        build-job:
           tags: ["spack", "large", "x86_64"]
           variables:
             CI_JOB_SIZE: large
@@ -109,7 +91,7 @@ spack:
           - samrai
           - vtk-h
           - vtk-m
-        runner-attributes:
+        build-job:
           tags: ["spack", "medium", "x86_64"]
           variables:
             CI_JOB_SIZE: "medium"
@@ -163,7 +145,7 @@ spack:
           - util-macros
           - zfp
           - zlib
-        runner-attributes:
+        build-job:
           tags: ["spack", "small", "x86_64"]
           variables:
             CI_JOB_SIZE: "small"
@@ -171,30 +153,49 @@ spack:
             KUBERNETES_MEMORY_REQUEST: "500M"
 
       - match: ['os=ubuntu18.04']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild
+        after_script::
+          - cat /proc/loadavg || true
 
-    service-job-attributes:
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
-      tags: ["spack", "public", "x86_64"]
+      reindex-job:
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+        tags: ["spack", "public", "x86_64"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: RADIUSS
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: RADIUSS
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -64,30 +64,11 @@ spack:
   mirrors:
     mirror: 's3://spack-binaries/develop/tutorial'
 
-  gitlab-ci:
-    script:
-      - uname -a || true
-      - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-      - nproc
-      - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
-      - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
-      - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - spack compiler find
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
-      - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild
-    after_script:
-      - cat /proc/loadavg || true
-
-    image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
-    match_behavior: first
-    mappings:
+  ci:
+    broken-specs-url: "s3://spack-binaries/broken-specs"
+    job-configuration:
+    - match_behavior: first
+      submapping:
       - match:
           - cmake
           - dyninst
@@ -95,7 +76,7 @@ spack:
           - mpich
           - netlib-lapack
           - trilinos
-        runner-attributes:
+        build-job:
           tags: ["spack", "large", "x86_64"]
           variables:
             CI_JOB_SIZE: large
@@ -113,7 +94,7 @@ spack:
             - py-beniget
             - py-scipy
             - slurm
-        runner-attributes:
+        build-job:
           tags: ["spack", "medium", "x86_64"]
           variables:
             CI_JOB_SIZE: "medium"
@@ -143,7 +124,7 @@ spack:
             - superlu
             - tar
             - util-linux-uuid
-        runner-attributes:
+        build-job:
           tags: ["spack", "small", "x86_64"]
           variables:
             CI_JOB_SIZE: "small"
@@ -151,30 +132,50 @@ spack:
             KUBERNETES_MEMORY_REQUEST: "500M"
 
       - match: ['@:']
-        runner-attributes:
+        build-job:
           tags: ["spack", "x86_64"]
           variables:
             CI_JOB_SIZE: default
 
-    broken-specs-url: "s3://spack-binaries/broken-specs"
+    - build-job:
+        script::
+          - uname -a || true
+          - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
+          - nproc
+          - curl -Lfs 'https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz' -o gmake.tar.gz
+          - printf 'fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz' | sha256sum --check --strict --quiet
+          - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+          - spack arch
+          - spack compiler find
+          - cd ${SPACK_CONCRETE_ENV_DIR}
+          - spack env activate --without-view .
+          - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+          - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
+          - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
+          - spack --color=always --backtrace ci rebuild
+        after_script::
+          - cat /proc/loadavg || true
+        image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
 
-    service-job-attributes:
-      image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
-      before_script:
-        - . "./share/spack/setup-env.sh"
-        - spack --version
-      tags: ["spack", "public", "x86_64"]
+      reindex-job:
+        image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
+        before_script::
+          - . "./share/spack/setup-env.sh"
+          - spack --version
+        tags: ["spack", "public", "x86_64"]
 
-    signing-job-attributes:
-      image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
-      tags: ["spack", "aws"]
-      script:
-        - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
-        - /sign.sh
-        - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
+      signing-job:
+        image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }
+        tags: ["spack", "aws"]
+        script::
+          - aws s3 sync --exclude "*" --include "*spec.json*" ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache /tmp
+          - /sign.sh
+          - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
 
-  cdash:
-    build-group: Spack Tutorial
-    url: https://cdash.spack.io
-    project: Spack Testing
-    site: Cloud Gitlab Infrastructure
+    cdash:
+      build-group: Spack Tutorial
+      url: https://cdash.spack.io
+      project: Spack Testing
+      site: Cloud Gitlab Infrastructure


### PR DESCRIPTION
Reboot of https://github.com/spack/spack/pull/32300 implementing the new CI configuration format myself, @kwryankrattiger  and @scottwittenburg are converging towards. Prematurely implemented (with a few of my own details) to ease discussion of the new format, allow experimentation with real-world scenarios and (hopefully) accelerate convergence on this front.

Others from prior discussions: @scheibelp @zackgalbreath

### New CI configuration format

This PR lifts the entire CI configuration (`gitlab-ci:`) into it's own `ci` configuration section. This makes it possible to "stack" configurations on top of each other [as @kwryankrattiger is doing (#34272)](https://github.com/spack/spack/pull/34272). The section is in a new format designed to make this case tractable and understandable, although this PR does not exploit any of the newly available features.

Configurations for individual jobs are now specified in a list under `ci:job-configuration`. This list consists of *clauses* which specify a configuration for the job (generic Spack config format), with qualifiers that limit when the configuration applies. Clauses can be in any of the following (very familiar) forms:
```yaml
job-configuration:
- # CONFIG applies to all jobs without distinction
  any-job: CONFIG

- # CONFIG only applies to jobs of the type indicated in the key
  build-job: CONFIG
  reindex-job: CONFIG
  noop-job: CONFIG
  cleanup-job: CONFIG
  signing-job: CONFIG

- # CONFIG applies to jobs matching the type in the key and for specs
  # satisfying any of the listed SPECs. If listed, TAGs are removed just before
  # the CONFIG is applied.
  # If match_behavior:first, only the topmost match in submapping: is applied,
  # otherwise all matching elements apply (ordered from highest to lowest precedence).
  match_behavior: first
  submapping:
  - match: [SPEC, ...]
    build-job-remove: {tags: [TAG, ...]}
    build-job: CONFIG
```
Clauses in `ci:job-configuration` (and `submapping`) are listed from highest to lowest precedence, with the very lowest precedence being the generated job itself. Note that if `match_behavior` is `merge`, `submapping:` will act *backwards* from the previous `mappings:`. This order was switched to preserve the highest to lowest precedence ordering across the entire configuration.

Configuration for the top-level pipeline is also available via the `ci:pipeline-attributes` key. This `CONFIG` applies to the pipeline as a whole, with the lowest precedence being the entire generated pipeline itself. Note that this key is merged between configurations before being merged with the generated pipeline, so there may be minor surprises if configurations specify different types for values. It is recommended to use promoting-merge keys (below) and/or a single/override `ci:pipeline-attributes` to reduce surprises.

All out-of-date specs now have build-jobs generated for them. If filtering is required, the `ci:build-if-matches` key can be used to limit this to only the listed specs. The default value `null` can be specified to remove the limit (effectively equivalent to `['@:']`).

Finally, all `CONFIGs` from the various keys specified above are all unspecified dicts, any key may be listed and will appear in the final pipeline. This grants access to the entirety of the GitLab CI job schema (i.e. the original intention of https://github.com/spack/spack/pull/32300).

### Configuration extensions

All Spack configurations including the above now support a "promoting merge" `+:` suffix on keys. Promoting merge will "promote" the previous value into the new value's type (error if not possible), and then merge the two (never override). This is similar to the default merge but has a couple differences marked below:
```yaml
--- # low.yaml
key_s: a
key_l: [a]
key_d: {a: 1}

--- # high.yaml
key_s: [b]  # --> key_s: [b]
key_s+: [b]  # --> key_s: [a, b]  <-----

key_l: [b]  # --> key_l: [a, b]
key_l+: [b]  # --> key_l: [a, b]

key_d: {b: 3}  # --> key_d: {a: 1, b: 3}
key_d+: {b: 3}  # --> key_d: {a: 1, b: 3}

key_d: [{b: 3}]  # --> key_d: [{b: 3}]
key_d+: [{b: 3}]  # --> key_d: [{a: 1}, {b: 3}]  <-----
```
Promoting merge will also error if the promotion is simply not possible due to the given types:
```yaml
--- # errors.yaml
key_s+: b  # ConfigError: unable to merge with str
key_s+: {b: 3}  # ConfigError: unable to merge str and dict
key_l+: {b: 3}  # ConfigError: unable to merge list and dict
```
***

TODO:
  - Documentation
  - Backwards compatibility with the `gitlab-ci:` configuration format