### PR TITLE
Automated deployment to update package flux-core 2022-12-12

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -20,6 +20,8 @@ class FluxCore(AutotoolsPackage):
     maintainers = ["grondo"]
 
     version("master", branch="master")
+    version("0.46.1", sha256="a7873fd49889c11f12e62d59eb992d4a089ddfde8566789f79eca1dfae1a5ffa")
+    version("0.46.0", sha256="8e51ca3e6e6525e9014ce0c135f529df7770cc12fa94c1ee03e8c5b45b48468e")
     version("0.45.0", sha256="6550fe682c1686745e1d9c201daf18f9c57691468124565c9252d27823d2fe46")
     version("0.44.0", sha256="6786b258657675ed573907a2a6012f68f2dd5053d7d09eb76b4e7f9943d6d466")
     version("0.43.0", sha256="4b9816d04e8b5b248a8d5e3dac3f9822f8f89831e340f36745e01512d768597b")

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -21,7 +21,6 @@ class FluxCore(AutotoolsPackage):
 
     version("master", branch="master")
     version("0.46.1", sha256="a7873fd49889c11f12e62d59eb992d4a089ddfde8566789f79eca1dfae1a5ffa")
-    version("0.46.0", sha256="8e51ca3e6e6525e9014ce0c135f529df7770cc12fa94c1ee03e8c5b45b48468e")
     version("0.45.0", sha256="6550fe682c1686745e1d9c201daf18f9c57691468124565c9252d27823d2fe46")
     version("0.44.0", sha256="6786b258657675ed573907a2a6012f68f2dd5053d7d09eb76b4e7f9943d6d466")
     version("0.43.0", sha256="4b9816d04e8b5b248a8d5e3dac3f9822f8f89831e340f36745e01512d768597b")


### PR DESCRIPTION
This is a release (one day after!) version 0.46.0 for 0.46.1 for Flux Core, and this PR includes both. @grondo  - I'll leave it up to you how you want to review and merge. if you choose this one, it's two birds one stone, and we can close the other one. If you want to do them separately, I can update this one. If you want to skip 0.46.0 entirely, we can close https://github.com/spack/spack/pull/34450 and I'll update here.
