### PR TITLE
py-tensorboard-data-server: build needs rust+rustfmt

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
@@ -18,7 +18,7 @@ class PyTensorboardDataServer(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("rust", type="build")
+    depends_on("rust+rustfmt", type="build")
 
     # https://github.com/tensorflow/tensorboard/issues/5713
     patch(


### PR DESCRIPTION
Fix issue found here: https://github.com/spack/spack/pull/34437#pullrequestreview-1213109895

Confirming build on aarch64-linux with external rust (building rust from source takes a long time)

When building using external rust (found by `spack external find rust`), when rustfmt is not installed, build fails with:

```py
==> Error: ProcessError: Command exited with status 101:
    '/usr/bin/cargo' 'build' '--release'

1 error found in build log:
     304       Compiling tower v0.4.6
     305       Compiling hyper v0.14.2
     306       Compiling tonic-build v0.4.2
     307       Compiling tonic-reflection v0.1.0
     308       Compiling hyper-rustls v0.22.1
     309       Compiling tonic v0.4.2
  >> 310    error: failed to run custom build command for `tonic-reflection v0.1.0`
     311    
     312    Caused by:
     313      process didn't exit successfully: `spack-stage-py-tensorboard-data-server-0.6.1-jjhgcll5nroku5pzrcfbwsnvlhrsyy3y/spack-src/tensorboard
            /data/server/target/release/build/tonic-reflection-f629cb57ce97759a/build-script-build` (exit status: 1)
     314      --- stderr
     315      error running rustfmt: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
The same error would happen if `rustfmt` is not installed on the system and the spack-internal `rust` used during the build was built using `rust~rustfmt`. Request `rust+rustfmt` as dependency to fix this.