### PR TITLE
OpenMPI: Add `--enable-orterun-prefix-by-default` configure option

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -474,6 +474,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     variant("lustre", default=False, description="Lustre filesystem library support")
     variant("romio", default=True, description="Enable ROMIO support")
     variant("rsh", default=True, description="Enable rsh (openssh) process lifecycle management")
+    variant(
+        "orterunprefix",
+        default=False,
+        description="Prefix Open MPI to PATH and LD_LIBRARY_PATH on local and remote hosts",
+    )
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #
@@ -927,6 +932,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         # Remove ssh/rsh pml
         if spec.satisfies("~rsh"):
             config_args.append("--enable-mca-no-build=plm-rsh")
+
+        # Useful for ssh-based environments
+        if spec.satisfies("@1.3:"):
+            if spec.satisfies("+orterunprefix"):
+                config_args.append("--enable-orterun-prefix-by-default")
 
         # some scientific packages ignore deprecated/remove symbols. Re-enable
         # them for now, for discussion see


### PR DESCRIPTION
Adds a `+orterunprefix` variant corresponding to the `--enable-orterun-prefix-by-default` configuration option. This option prefixes to both local and remote hosts `PATH` and `LD_LIBRARY_PATH` the `/bin` and `/lib` directories, respectively. This is useful for ssh-based clusters that do not leverage a resource manager to forward the environment to remote hosts.

<details>
  <summary>With / Without `+orterunprefix` variant</summary>
  
```
$ spack find -xlvf
-- linux-rhel8-haswell / gcc@8.3.1 ------------------------------
6nu2cwm openmpi@4.1.4%gcc ~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+orterunprefix+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none schedulers=none
hsamq6e openmpi@4.1.4%gcc ~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none schedulers=none
==> 2 installed packages

$ spack load /6nu2cwm

$ mpirun -np 2 -N 1 -host hostA:1,hostB:1 hostname
hostA
hostB

$ spack unload

$ spack load /hsamq6e

$ mpirun -np 2 -N 1 -host hostA:1,hostB:1 hostname
bash: orted: command not found
--------------------------------------------------------------------------
ORTE was unable to reliably start one or more daemons.
This usually is caused by:

* not finding the required libraries and/or binaries on
  one or more nodes. Please check your PATH and LD_LIBRARY_PATH
  settings, or configure OMPI with --enable-orterun-prefix-by-default

* lack of authority to execute on one or more specified nodes.
  Please verify your allocation and authorities.

* the inability to write startup files into /tmp (--tmpdir/orte_tmpdir_base).
  Please check with your sys admin to determine the correct location to use.

*  compilation of the orted with dynamic libraries when static are required
  (e.g., on Cray). Please check your configure cmd line and consider using
  one of the contrib/platform definitions for your system type.

* an inability to create a connection back to mpirun due to a
  lack of common network interfaces and/or no route found between
  them. Please check network connectivity (including firewalls
  and network routing requirements).
--------------------------------------------------------------------------
```

</details>


https://github.com/open-mpi/ompi/commit/8226dab86c429ce6735815a4f257393ee12e6051 suggests this should apply for `@1.3:`. Eventually I think this will get an upper limit at 5.x since PRRTE / `--enable-prte-prefix-by-default` is replacing ORTE, but that's not the case just yet.

