### PR TITLE
singularity, apptainer: --without-conmon into @property config_options

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -39,15 +39,7 @@ class Apptainer(SingularityBase):
         "https://apptainer.org/docs/admin/main/admin_quickstart.html#apptainer-security",
     )
 
-    # This overrides SingularityBase (found in ../singularityce/package.py)
-    # Because Apptainer's mconfig has no option `--without-conmon`
-    # https://github.com/apptainer/apptainer/blob/v1.0.2/mconfig
-    def edit(self, spec, prefix):
-        with working_dir(self.build_directory):
-            confstring = "./mconfig --prefix=%s" % prefix
-            if "~suid" in spec:
-                confstring += " --without-suid"
-            if "~network" in spec:
-                confstring += " --without-network"
-            configure = Executable(confstring)
-            configure()
+    # Override config options from SingularityBase
+    @property
+    def config_options(self):
+        return []

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -70,12 +70,17 @@ class SingularityBase(MakefilePackage):
     def build_directory(self):
         return self.singularity_gopath_dir
 
+    # Allow overriding config options
+    @property
+    def config_options(self):
+        # Using conmon from spack
+        return ["--without-conmon"]
+
     # Hijack the edit stage to run mconfig.
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
             confstring = "./mconfig --prefix=%s" % prefix
-            # Using conmon from spack
-            confstring += " --without-conmon"
+            confstring += ' '.join(config_options)
             if "~suid" in spec:
                 confstring += " --without-suid"
             if "~network" in spec:

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -80,7 +80,7 @@ class SingularityBase(MakefilePackage):
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
             confstring = "./mconfig --prefix=%s" % prefix
-            confstring += ' '.join(config_options)
+            confstring += " ".join(config_options)
             if "~suid" in spec:
                 confstring += " --without-suid"
             if "~network" in spec:


### PR DESCRIPTION
Per https://github.com/spack/spack/issues/34192, apptainer does not support `--without-conmon`, so we introduce a base class `config_options` property that can be overridden in the `apptainer` package.