### PR TITLE
py-shapely: add v2.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -93,7 +93,9 @@ class PyNumpy(PythonPackage):
     depends_on("python@3.6:3.10", type=("build", "link", "run"), when="@1.19")
     depends_on("python@3.7:3.10", type=("build", "link", "run"), when="@1.20:1.21")
     depends_on("python@3.8:", type=("build", "link", "run"), when="@1.22:")
-    depends_on("py-setuptools@:59", type=("build", "run"))
+    # https://github.com/spack/spack/pull/32078
+    depends_on("py-setuptools@:63", type=("build", "run"))
+    depends_on("py-setuptools@:59", when="@:1.22.1", type=("build", "run"))
     # Check pyproject.toml for updates to the required cython version
     depends_on("py-cython@0.29.13:2", when="@1.18.0:", type="build")
     depends_on("py-cython@0.29.14:2", when="@1.18.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -12,14 +12,14 @@ from spack.package import *
 class PyShapely(PythonPackage):
     """Manipulation and analysis of geometric objects in the Cartesian plane."""
 
-    homepage = "https://github.com/Toblerity/Shapely"
-    pypi = "Shapely/Shapely-1.7.1.tar.gz"
-    git = "https://github.com/Toblerity/Shapely.git"
+    homepage = "https://github.com/shapely/shapely"
+    pypi = "shapely/shapely-1.7.1.tar.gz"
+    git = "https://github.com/shapely/shapely.git"
 
     maintainers = ["adamjstewart"]
 
     version("main", branch="main")
-    version("master", branch="main", deprecated=True)
+    version("2.0.0", sha256="11f1b1231a6c04213fb1226c6968d1b1b3b369ec42d1e9655066af87631860ea")
     version("1.8.5", sha256="e82b6d60ecfb124120c88fe106a478596bbeab142116d7e7f64a364dac902a92")
     version("1.8.4", sha256="a195e51caafa218291f2cbaa3fef69fd3353c93ec4b65b2a4722c4cf40c3198c")
     version("1.8.3", sha256="1ce9da186d48efc50130af96d62ffb4d2e175235143d804ef395aad156d45bb3")
@@ -33,20 +33,31 @@ class PyShapely(PythonPackage):
     depends_on("python@3.6:", when="@1.8:", type=("build", "link", "run"))
     depends_on("python@2.7:2.8,3.4:", when="@1.7", type=("build", "link", "run"))
     depends_on("python@2.6:", when="@:1.6", type=("build", "link", "run"))
-    depends_on("py-setuptools@:63", type="build")
-    depends_on("py-cython@0.29.24:2", type="build")
+    depends_on("py-setuptools@61:", when="@2:", type="build")
+    depends_on("py-setuptools@:63", when="@:1", type="build")
+    depends_on("py-cython@0.29:0", when="@2:", type="build")
+    depends_on("py-cython@0.29.24:2", when="@:1", type="build")
+    depends_on("py-numpy@1.14:", when="@2:", type=("build", "link", "run"))
     depends_on("py-numpy", type=("build", "link", "run"))
-    depends_on("geos@3.3:3.10", when="@:1.7")
-    depends_on("geos@3.6:3.10", when="@1.8:")
+    depends_on("geos@3.5:", when="@2:")
+    depends_on("geos@3.3:", when="@:1")
     depends_on("py-pytest", type="test")
     depends_on("py-pytest-cov", type="test")
 
-    # https://github.com/Toblerity/Shapely/pull/891
+    # https://github.com/shapely/shapely/pull/891
     patch(
-        "https://github.com/Toblerity/Shapely/commit/98f6b36710bbe05b4ab59231cb0e08b06fe8b69c.patch?full_index=1",
+        "https://github.com/shapely/shapely/commit/98f6b36710bbe05b4ab59231cb0e08b06fe8b69c.patch?full_index=1",
         sha256="8583cdc97648277fa4faea8bd88d49e43390e87f697b966bd2b4290fba945ba0",
         when="@:1.7.0",
     )
+
+    def url_for_version(self, version):
+        if version >= Version("2"):
+            letter = "s"
+        else:
+            letter = "S"
+        url = "https://files.pythonhosted.org/packages/source/{0}/{0}hapely/{0}hapely-{1}.tar.gz"
+        return url.format(letter, version)
 
     @when("^python@3.7:")
     def patch(self):
@@ -62,7 +73,7 @@ class PyShapely(PythonPackage):
 
         # Shapely uses ctypes.util.find_library, which searches LD_LIBRARY_PATH
         # Our RPATH logic works fine, but the unit tests fail without this
-        # https://github.com/Toblerity/Shapely/issues/909
+        # https://github.com/shapely/shapely/issues/909
         libs = ":".join(self.spec["geos"].libs.directories)
         if sys.platform == "darwin":
             env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", libs)
@@ -78,4 +89,9 @@ class PyShapely(PythonPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def test_install(self):
-        python("-m", "pytest")
+        # https://shapely.readthedocs.io/en/latest/installation.html#testing-shapely
+        if self.version >= Version("2"):
+            with working_dir("spack-test", create=True):
+                python("-m", "pytest", "--pyargs", "shapely.tests")
+        else:
+            python("-m", "pytest")

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -52,11 +52,11 @@ class PyShapely(PythonPackage):
     )
 
     def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/{0}/{0}hapely/{0}hapely-{1}.tar.gz"
         if version >= Version("2"):
             letter = "s"
         else:
             letter = "S"
-        url = "https://files.pythonhosted.org/packages/source/{0}/{0}hapely/{0}hapely-{1}.tar.gz"
         return url.format(letter, version)
 
     @when("^python@3.7:")


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 with Python 3.10.8 and Apple Clang 14.0.0.