### PR TITLE
libicd: macOS now supported

### DIFF
--- a/var/spack/repos/builtin/packages/libicd/package.py
+++ b/var/spack/repos/builtin/packages/libicd/package.py
@@ -18,6 +18,3 @@ class Libicd(CMakePackage):
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("lerc")
-
-    # https://github.com/lucianpls/libicd/issues/3
-    conflicts("platform=darwin")


### PR DESCRIPTION
Successfully installs on macOS 12.6.1 with Apple Clang 14.0.0.

https://github.com/lucianpls/libicd/issues/3