### PR TITLE
bugfix rmda-core external find library

### DIFF
--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -65,10 +65,10 @@ class RdmaCore(CMakePackage):
     @classmethod
     def determine_version(cls, lib):
         match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d+(?:\.\d+)?)", lib)
-        if match and match.group(1) == '0':
+        if match and match.group(1) == "0":
             # On some systems there is a truncated shared library name that does not
             # sufficient version information, return a clear indicator of that
-            return 'unknown_ver'
+            return "unknown_ver"
 
         return match.group(1) if match else None
 

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -64,7 +64,12 @@ class RdmaCore(CMakePackage):
 
     @classmethod
     def determine_version(cls, lib):
-        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d+\.\d+)", lib)
+        match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d+(?:\.\d+)?)", lib)
+        if match and match.group(1) == '0':
+            # On some systems there is a truncated shared library name that does not
+            # sufficient version information, return a clear indicator of that
+            return 'unknown_ver'
+
         return match.group(1) if match else None
 
     # NOTE: specify CMAKE_INSTALL_RUNDIR explicitly to prevent rdma-core from


### PR DESCRIPTION
Added a more robust check for an external version of the library.
Included a guard to identify when the library gives no discernible version information and then to substitute with "unknown_ver" identifier.