### PR TITLE
Fix markdown links

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2402,7 +2402,7 @@ the ``package.py`` recipes). ``test`` dependencies do not affect the package
 hash, as they are only used to construct a test environment *after* building and
 installing a given package installation. Older versions of Spack did not include
 build dependencies in the hash, but this has been 
-`fixed <https://github.com/spack/spack/pull/28504>`_ as of |Spack v0.18|_
+`fixed <https://github.com/spack/spack/pull/28504>`_ as of |Spack v0.18|_.
 
 .. |Spack v0.18| replace:: Spack ``v0.18``
 .. _Spack v0.18: https://github.com/spack/spack/releases/tag/v0.18.0

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2397,13 +2397,15 @@ this because uninstalling the dependency would break the package.
 
 ``build``, ``link``, and ``run`` dependencies all affect the hash of Spack
 packages (along with ``sha256`` sums of patches and archives used to build the
-package, and a [canonical hash](https://github.com/spack/spack/pull/28156) of
+package, and a `canonical hash <https://github.com/spack/spack/pull/28156>`_ of
 the ``package.py`` recipes). ``test`` dependencies do not affect the package
 hash, as they are only used to construct a test environment *after* building and
 installing a given package installation. Older versions of Spack did not include
-build dependencies in the hash, but this has been
-[fixed](https://github.com/spack/spack/pull/28504) as of [Spack
-``v0.18``](https://github.com/spack/spack/releases/tag/v0.18.0)
+build dependencies in the hash, but this has been 
+`fixed <https://github.com/spack/spack/pull/28504>`_ as of |Spack v0.18|_
+
+.. |Spack v0.18| replace:: Spack ``v0.18``
+.. _Spack v0.18: https://github.com/spack/spack/releases/tag/v0.18.0
 
 If the dependency type is not specified, Spack uses a default of
 ``('build', 'link')``. This is the common case for compiler languages.


### PR DESCRIPTION
Fix markdown links added in https://github.com/spack/spack/pull/31860

Closes #34485

Note I have replicated exactly the formatting of the following link
```
[Spack ``v0.18``](https://github.com/spack/spack/releases/tag/v0.18.0)
```
which renders as:

[Spack ``v0.18``](https://github.com/spack/spack/releases/tag/v0.18.0)

in markdown, but in RST with RTD style looks like this:

![Screen Shot 2022-12-13 at 5 40 50 pm](https://user-images.githubusercontent.com/6063709/207245089-b524c073-fab1-4237-96c7-a0c209c5c272.png)

It is all a link, but the red styling makes it less obvious.

It appears that the current doc build system does not complain about markdown style links. I hacked up a little python script to check for any other markdown links:
```python
import re
import sys

md_links = re.compile('(\[[^\[]+?\])(\(.*?\))', flags=re.DOTALL)

for f in sys.argv[1:]:

    with open(f, 'r') as docfile:
        contents = docfile.read()
        matches = re.findall(md_links, contents)
        if len(matches) > 0:
            print(f)
            for m in matches:
                print(m[0]+m[1])
```

Output before fix (from `spack/lib/spack/docs`):
```bash
$ python check_md.py $(find . -name "*.rst")
./packaging_guide.rst
[canonical hash](https://github.com/spack/spack/pull/28156)
[fixed](https://github.com/spack/spack/pull/28504)
[Spack
``v0.18``](https://github.com/spack/spack/releases/tag/v0.18.0)
```

It could be adapted and added to your tests if you think this is worthwhile. Happy to do this, but not sure if it would be welcome, or where to put it, as I couldn't find any `pytest` tests running on the `docs` directory.

Edit: Added more information on output from check script