### PR TITLE
Allow spec.json files to be clearsigned, use transparent compression for *.json

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -6,6 +6,7 @@
 import codecs
 import collections
 import hashlib
+import io
 import json
 import multiprocessing.pool
 import os
@@ -845,6 +846,42 @@ def sign_specfile(key, force, specfile_path):
     spack.util.gpg.sign(key, specfile_path, signed_specfile_path, clearsign=True)
 
 
+def _load_clearsigned_json(stream):
+    # Skip the PGP header
+    stream.readline()
+    stream.readline()
+    json = stream.read()
+    footer_index = json.rfind("-----BEGIN PGP SIGNATURE-----")
+    if footer_index == -1 or not json[footer_index - 1].isspace():
+        raise ValueError("Could not find PGP signature in clearsigned json file.")
+    return sjson.load(json[:footer_index])
+
+
+def _load_possibly_clearsigned_json(stream):
+    if _is_clearsigned_stream(stream):
+        return _load_clearsigned_json(stream)
+    return sjson.load(stream)
+
+
+def _is_clearsigned_stream(stream):
+    curr = stream.tell()
+    header = stream.read(34)
+    stream.seek(curr)
+    return header == "-----BEGIN PGP SIGNED MESSAGE-----"
+
+
+def is_clearsigned_file(path):
+    with open(path, "r") as f:
+        return _is_clearsigned_stream(f)
+
+
+def load_possibly_clearsigned_json(s):
+    """Deserialize JSON from a string or stream s, removing any clearsign
+    header/footer."""
+    s = io.StringIO(s) if isinstance(s, str) else s
+    return _load_possibly_clearsigned_json(s)
+
+
 def _read_specs_and_push_index(file_list, read_method, cache_prefix, db, temp_dir, concurrency):
     """Read all the specs listed in the provided list, using thread given thread parallelism,
         generate the index, and push it to the mirror.
@@ -867,11 +904,7 @@ def _read_specs_and_push_index(file_list, read_method, cache_prefix, db, temp_di
 
         if spec_file_contents:
             # Need full spec.json name or this gets confused with index.json.
-            if spec_url.endswith(".json.sig"):
-                specfile_json = Spec.extract_json_from_clearsig(spec_file_contents)
-                return Spec.from_dict(specfile_json)
-            if spec_url.endswith(".json"):
-                return Spec.from_json(spec_file_contents)
+            return Spec.from_dict(load_possibly_clearsigned_json(spec_file_contents))
 
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:
@@ -1467,61 +1500,45 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
             }
         )
 
-    tried_to_verify_sigs = []
-
-    # Assumes we care more about finding a spec file by preferred ext
-    # than by mirrory priority.  This can be made less complicated as
-    # we remove support for deprecated spec formats and buildcache layouts.
+    verification_failure = False
     for ext in ["json.sig", "json"]:
-        for mirror_to_try in mirrors_to_try:
-            specfile_url = "{0}.{1}".format(mirror_to_try["specfile"], ext)
-            spackfile_url = mirror_to_try["spackfile"]
-            local_specfile_stage = try_fetch(specfile_url)
-            if local_specfile_stage:
-                local_specfile_path = local_specfile_stage.save_filename
-                signature_verified = False
+        for mirror in mirrors_to_try:
+            # Try to download the specfile. For any legacy version of Spack's buildcache
+            # we definitely require this file.
+            specfile_url = "{0}.{1}".format(mirror["specfile"], ext)
+            specfile_stage = try_fetch(specfile_url)
+            if not specfile_stage:
+                continue
 
-                if ext.endswith(".sig") and not unsigned:
-                    # If we found a signed specfile at the root, try to verify
-                    # the signature immediately.  We will not download the
-                    # tarball if we could not verify the signature.
-                    tried_to_verify_sigs.append(specfile_url)
-                    signature_verified = try_verify(local_specfile_path)
-                    if not signature_verified:
-                        tty.warn("Failed to verify: {0}".format(specfile_url))
+            specfile_path = specfile_stage.save_filename
 
-                if unsigned or signature_verified or not ext.endswith(".sig"):
-                    # We will download the tarball in one of three cases:
-                    #     1. user asked for --no-check-signature
-                    #     2. user didn't ask for --no-check-signature, but we
-                    #     found a spec.json.sig and verified the signature already
-                    #     3. neither of the first two cases are true, but this file
-                    #     is *not* a signed json (not a spec.json.sig file).  That
-                    #     means we already looked at all the mirrors and either didn't
-                    #     find any .sig files or couldn't verify any of them.  But it
-                    #     is still possible to find an old style binary package where
-                    #     the signature is a detached .asc file in the outer archive
-                    #     of the tarball, and in that case, the only way to know is to
-                    #     download the tarball.  This is a deprecated use case, so if
-                    #     something goes wrong during the extraction process (can't
-                    #     verify signature, checksum doesn't match) we will fail at
-                    #     that point instead of trying to download more tarballs from
-                    #     the remaining mirrors, looking for one we can use.
-                    tarball_stage = try_fetch(spackfile_url)
-                    if tarball_stage:
-                        return {
-                            "tarball_stage": tarball_stage,
-                            "specfile_stage": local_specfile_stage,
-                            "signature_verified": signature_verified,
-                        }
+            # If it is a clearsign file, we must verify it (unless disabled)
+            should_verify = not unsigned and is_clearsigned_file(specfile_path)
+            if should_verify and not try_verify(specfile_path):
+                verification_failure = True
+                tty.warn("Failed to verify: {0}".format(specfile_url))
+                specfile_stage.destroy()
+                continue
 
-                local_specfile_stage.destroy()
+            # In case the spec.json is not clearsigned, it means it's a legacy
+            # format, where either the signature is in the tarball with binaries, or
+            # the package is unsigned. Verification
+            # is then postponed.
+            spackfile_url = mirror["spackfile"]
+            tarball_stage = try_fetch(spackfile_url)
+            if tarball_stage:
+                return {
+                    "tarball_stage": tarball_stage,
+                    "specfile_stage": specfile_stage,
+                    "signature_verified": should_verify,  # should_verify implies it was verified
+                }
+            specfile_stage.destroy()
 
     # Falling through the nested loops meeans we exhaustively searched
     # for all known kinds of spec files on all mirrors and did not find
     # an acceptable one for which we could download a tarball.
 
-    if tried_to_verify_sigs:
+    if verification_failure:
         raise NoVerifyException(
             (
                 "Spack found new style signed binary packages, "
@@ -1802,11 +1819,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
     specfile_path = download_result["specfile_stage"].save_filename
 
     with open(specfile_path, "r") as inputfile:
-        content = inputfile.read()
-        if specfile_path.endswith(".json.sig"):
-            spec_dict = Spec.extract_json_from_clearsig(content)
-        else:
-            spec_dict = sjson.load(content)
+        spec_dict = load_possibly_clearsigned_json(inputfile)
 
     bchecksum = spec_dict["binary_cache_checksum"]
     filename = download_result["tarball_stage"].save_filename
@@ -1971,54 +1984,35 @@ def try_direct_fetch(spec, mirrors=None):
     """
     specfile_name = tarball_name(spec, ".spec.json")
     signed_specfile_name = tarball_name(spec, ".spec.json.sig")
-    specfile_is_signed = False
     found_specs = []
 
     for mirror in spack.mirror.MirrorCollection(mirrors=mirrors).values():
-        buildcache_fetch_url_json = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path, specfile_name
-        )
-        buildcache_fetch_url_signed_json = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path, signed_specfile_name
-        )
-        try:
-            _, _, fs = web_util.read_from_url(buildcache_fetch_url_signed_json)
-            specfile_is_signed = True
-        except (URLError, web_util.SpackWebError, HTTPError) as url_err:
+        for file in (specfile_name, signed_specfile_name):
+            url = url_util.join(mirror.fetch_url, _build_cache_relative_path, file)
             try:
-                _, _, fs = web_util.read_from_url(buildcache_fetch_url_json)
-            except (URLError, web_util.SpackWebError, HTTPError) as url_err_x:
+                _, _, fs = web_util.read_from_url(url)
+            except (URLError, web_util.SpackWebError, HTTPError) as url_err:
                 tty.debug(
-                    "Did not find {0} on {1}".format(
-                        specfile_name, buildcache_fetch_url_signed_json
-                    ),
+                    "Did not find {0} on {1}".format(specfile_name, url),
                     url_err,
                     level=2,
                 )
-                tty.debug(
-                    "Did not find {0} on {1}".format(specfile_name, buildcache_fetch_url_json),
-                    url_err_x,
-                    level=2,
-                )
                 continue
-        specfile_contents = codecs.getreader("utf-8")(fs).read()
 
-        # read the spec from the build cache file. All specs in build caches
-        # are concrete (as they are built) so we need to mark this spec
-        # concrete on read-in.
-        if specfile_is_signed:
-            specfile_json = Spec.extract_json_from_clearsig(specfile_contents)
-            fetched_spec = Spec.from_dict(specfile_json)
-        else:
-            fetched_spec = Spec.from_json(specfile_contents)
-        fetched_spec._mark_concrete()
+            # read the spec from the build cache file. All specs in build caches
+            # are concrete (as they are built) so we need to mark this spec
+            # concrete on read-in.
+            stream = codecs.getreader("utf-8")(fs)
+            fetched_spec = Spec.from_dict(load_possibly_clearsigned_json(stream))
+            fetched_spec._mark_concrete()
 
-        found_specs.append(
-            {
-                "mirror_url": mirror.fetch_url,
-                "spec": fetched_spec,
-            }
-        )
+            found_specs.append(
+                {
+                    "mirror_url": mirror.fetch_url,
+                    "spec": fetched_spec,
+                }
+            )
+            break
 
     return found_specs
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -156,16 +156,6 @@ default_format = "{name}{@version}"
 default_format += "{%compiler.name}{@compiler.version}{compiler_flags}"
 default_format += "{variants}{arch=architecture}"
 
-#: Regular expression to pull spec contents out of clearsigned signature
-#: file.
-CLEARSIGN_FILE_REGEX = re.compile(
-    (
-        r"^-----BEGIN PGP SIGNED MESSAGE-----"
-        r"\s+Hash:\s+[^\s]+\s+(.+)-----BEGIN PGP SIGNATURE-----"
-    ),
-    re.MULTILINE | re.DOTALL,
-)
-
 #: specfile format version. Must increase monotonically
 specfile_format_version = 3
 
@@ -2452,27 +2442,6 @@ class Spec(object):
             return Spec.from_dict(data)
         except Exception as e:
             raise sjson.SpackJSONError("error parsing JSON spec:", str(e)) from e
-
-    @staticmethod
-    def extract_json_from_clearsig(data):
-        m = CLEARSIGN_FILE_REGEX.search(data)
-        if m:
-            return sjson.load(m.group(1))
-        return sjson.load(data)
-
-    @staticmethod
-    def from_signed_json(stream):
-        """Construct a spec from clearsigned json spec file.
-
-        Args:
-            stream: string or file object to read from.
-        """
-        data = stream
-        if hasattr(stream, "read"):
-            data = stream.read()
-
-        extracted_json = Spec.extract_json_from_clearsig(data)
-        return Spec.from_dict(extracted_json)
 
     @staticmethod
     def from_detection(spec_str, extra_attributes=None):

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import glob
 import io
+import json
 import os
 import platform
 import sys
@@ -889,3 +890,96 @@ def test_default_index_json_404():
 
     with pytest.raises(bindist.FetchIndexError, match="Could not fetch index"):
         fetcher.conditional_fetch()
+
+
+def test_read_spec_from_signed_json():
+    spec_dir = os.path.join(test_path, "data", "mirrors", "signed_json")
+    file_name = (
+        "linux-ubuntu18.04-haswell-gcc-8.4.0-"
+        "zlib-1.2.12-g7otk5dra3hifqxej36m5qzm7uyghqgb.spec.json.sig"
+    )
+    spec_path = os.path.join(spec_dir, file_name)
+
+    def check_spec(spec_to_check):
+        assert spec_to_check.name == "zlib"
+        assert spec_to_check._hash == "g7otk5dra3hifqxej36m5qzm7uyghqgb"
+
+    with open(spec_path) as fd:
+        s = Spec.from_dict(bindist.load_possibly_clearsigned_json(fd))
+        check_spec(s)
+
+
+def test_load_clearsigned_json():
+    obj = {"hello": "world"}
+    clearsigned = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+xyz
+-----END PGP SIGNATURE-----""".format(
+        json.dumps(obj)
+    )
+
+    # Should accept strings and streams
+    assert bindist.load_possibly_clearsigned_json(clearsigned) == obj
+    assert bindist.load_possibly_clearsigned_json(io.StringIO(clearsigned)) == obj
+
+
+def test_load_without_clearsigned_json():
+    obj = {"hello": "world"}
+    not_clearsigned = json.dumps(obj)
+
+    # Should accept strings and streams
+    assert bindist.load_possibly_clearsigned_json(not_clearsigned) == obj
+    assert bindist.load_possibly_clearsigned_json(io.StringIO(not_clearsigned)) == obj
+
+
+def test_json_containing_clearsigned_message_is_json():
+    # Test that we don't interpret json with a PGP signed message as a string somewhere
+    # as a clearsigned message. It should just deserialize the json contents.
+    val = """\
+"-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+signature
+-----END PGP SIGNATURE-----
+"""
+    input = json.dumps({"key": val})
+    assert bindist.load_possibly_clearsigned_json(input)["key"] == val
+
+
+def test_clearsign_signature_part_of_json_string():
+    # Check if we can deal with a string in json containing the string that is used
+    # at the start of a PGP signature.
+    obj = {"-----BEGIN PGP SIGNATURE-----": "-----BEGIN PGP SIGNATURE-----"}
+    input = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+-----BEGIN PGP SIGNATURE-----
+signature
+-----END PGP SIGNATURE-----
+""".format(
+        json.dumps(obj)
+    )
+    assert bindist.load_possibly_clearsigned_json(input) == obj
+
+
+def test_broken_clearsign_signature():
+    # In this test there is no PGP signature.
+    obj = {"-----BEGIN PGP SIGNATURE-----": "-----BEGIN PGP SIGNATURE-----"}
+    input = """\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{}
+""".format(
+        json.dumps(obj)
+    )
+    with pytest.raises(ValueError, match="Could not find PGP signature"):
+        bindist.load_possibly_clearsigned_json(input)

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import glob
+import gzip
 import io
 import json
 import os
@@ -983,3 +984,13 @@ Hash: SHA512
     )
     with pytest.raises(ValueError, match="Could not find PGP signature"):
         bindist.load_possibly_clearsigned_json(input)
+
+
+def test_transparent_decompression():
+    """Test a roundtrip of string -> gzip -> string."""
+    text = "this is utf8 that should be compressed"
+    gzipped = io.BytesIO()
+    with gzip.GzipFile(fileobj=gzipped, mode="w", compresslevel=1, mtime=0) as f:
+        f.write(text.encode("utf-8"))
+    gzipped.seek(0)
+    assert bindist.transparently_decompress_bytes_to_string(gzipped).read() == text

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1324,7 +1324,9 @@ spack:
                 if file_name.endswith(".spec.json.sig"):
                     spec_json_path = os.path.join(buildcache_path, file_name)
                     with open(spec_json_path) as json_fd:
-                        json_object = Spec.extract_json_from_clearsig(json_fd.read())
+                        json_object = spack.binary_distribution.load_possibly_clearsigned_json(
+                            json_fd
+                        )
                         jsonschema.validate(json_object, specfile_schema)
 
             logs_dir = working_dir.join("logs_dir")

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -47,27 +47,6 @@ def test_simple_spec():
     check_json_round_trip(spec)
 
 
-def test_read_spec_from_signed_json():
-    spec_dir = os.path.join(spack.paths.test_path, "data", "mirrors", "signed_json")
-    file_name = (
-        "linux-ubuntu18.04-haswell-gcc-8.4.0-"
-        "zlib-1.2.12-g7otk5dra3hifqxej36m5qzm7uyghqgb.spec.json.sig"
-    )
-    spec_path = os.path.join(spec_dir, file_name)
-
-    def check_spec(spec_to_check):
-        assert spec_to_check.name == "zlib"
-        assert spec_to_check._hash == "g7otk5dra3hifqxej36m5qzm7uyghqgb"
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd)
-        check_spec(s)
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd.read())
-        check_spec(s)
-
-
 def test_normal_spec(mock_packages):
     spec = Spec("mpileaks+debug~opt")
     spec.normalize()


### PR DESCRIPTION
This PR does two things:

1. Reduce the number of requests to a mirror for metadata
2. Make Spack accept gzipped metadata (i.e. transmit fewer bytes)

It does *not* make any changes to how we create binary caches.
The idea is to allow this PR to be backported. 

---

Currently we have separate `spec.json` and `spec.json.sig` files. The
former is a pure spec, the latter is clearsigned spec. This is unfortunate,
cause metadata lookups now requires at most two requests per remote.

Further, update-index logic fetches all spec.json files, which can take
quite some bandwidth. We can drop ~85% of the size by compressing
those files. To avoid yet another lookup (spec.json.sig.gz etc) we can
use transparent decompression. So a file is decompressed when the
magic bytes signal it's gzip, otherwise it's treated as text.

This PR allows `spec.json` (and `index.json`) files to be any combination
of the cartesian product `[gzip compressed, uncompressed]` x 
`[clearsigned, unsigned]`.

The idea is to backport this to 0.19.1, since for 0.19.1 it is not a
behavioral change, but rather a bugfix for improved Spack 0.21 forward
compatibility.

Next steps after this PR:

- Backport to 0.19.1
- Start uploading spec.json.sig files both as spec.json.sig and
  spec.json. This ensure they work with any Spack version.
- Compress before pushing (if the filesize is reduced)
- Deprecate spec.json.sig in 0.20.
- After Spack 0.20 branches off, stop uploading *.sig, and stop checking
  the remote for *.sig files.
- Potentially we can also add a config option to disable checking for
  *.sig files on develop earlier.