### PR TITLE
Backport #34490 to v0.19.1

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1244,8 +1244,8 @@ For example, for the ``stackstart`` variant:
 
 .. code-block:: sh
 
-    mpileaks stackstart=4    # variant will be propagated to dependencies
-    mpileaks stackstart==4   # only mpileaks will have this variant value
+    mpileaks stackstart==4   # variant will be propagated to dependencies
+    mpileaks stackstart=4    # only mpileaks will have this variant value
 
 ^^^^^^^^^^^^^^
 Compiler Flags

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -3525,7 +3525,7 @@ will likely contain some overriding of default builder methods:
        def cmake_args(self):
            pass
 
-   class Autotoolsbuilder(spack.build_systems.autotools.AutotoolsBuilder):
+   class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
        def configure_args(self):
            pass
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -6,6 +6,7 @@
 import codecs
 import collections
 import hashlib
+import io
 import json
 import multiprocessing.pool
 import os
@@ -887,6 +888,42 @@ def sign_specfile(key, force, specfile_path):
     spack.util.gpg.sign(key, specfile_path, signed_specfile_path, clearsign=True)
 
 
+def _load_clearsigned_json(stream):
+    # Skip the PGP header
+    stream.readline()
+    stream.readline()
+    json = stream.read()
+    footer_index = json.rfind("-----BEGIN PGP SIGNATURE-----")
+    if footer_index == -1 or not json[footer_index - 1].isspace():
+        raise ValueError("Could not find PGP signature in clearsigned json file.")
+    return sjson.load(json[:footer_index])
+
+
+def _load_possibly_clearsigned_json(stream):
+    if _is_clearsigned_stream(stream):
+        return _load_clearsigned_json(stream)
+    return sjson.load(stream)
+
+
+def _is_clearsigned_stream(stream):
+    curr = stream.tell()
+    header = stream.read(34)
+    stream.seek(curr)
+    return header == "-----BEGIN PGP SIGNED MESSAGE-----"
+
+
+def is_clearsigned_file(path):
+    with open(path, "r") as f:
+        return _is_clearsigned_stream(f)
+
+
+def load_possibly_clearsigned_json(s):
+    """Deserialize JSON from a string or stream s, removing any clearsign
+    header/footer."""
+    s = io.StringIO(s) if isinstance(s, str) else s
+    return _load_possibly_clearsigned_json(s)
+
+
 def _read_specs_and_push_index(file_list, read_method, cache_prefix, db, temp_dir, concurrency):
     """Read all the specs listed in the provided list, using thread given thread parallelism,
         generate the index, and push it to the mirror.
@@ -909,13 +946,10 @@ def _read_specs_and_push_index(file_list, read_method, cache_prefix, db, temp_di
 
         if spec_file_contents:
             # Need full spec.json name or this gets confused with index.json.
-            if spec_url.endswith(".json.sig"):
-                specfile_json = Spec.extract_json_from_clearsig(spec_file_contents)
-                return Spec.from_dict(specfile_json)
-            if spec_url.endswith(".json"):
-                return Spec.from_json(spec_file_contents)
             if spec_url.endswith(".yaml"):
                 return Spec.from_yaml(spec_file_contents)
+            else:
+                return Spec.from_dict(load_possibly_clearsigned_json(spec_file_contents))
 
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:
@@ -1534,68 +1568,49 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
             }
         )
 
-    tried_to_verify_sigs = []
-
-    # Assumes we care more about finding a spec file by preferred ext
-    # than by mirrory priority.  This can be made less complicated as
-    # we remove support for deprecated spec formats and buildcache layouts.
+    # Only look for json.sig files as a last resort, since we don't generate them
+    # anymore.
+    verification_failure = False
     for ext in ["json.sig", "json", "yaml"]:
-        for mirror_to_try in mirrors_to_try:
-            specfile_url = "{0}.{1}".format(mirror_to_try["specfile"], ext)
-            spackfile_url = mirror_to_try["spackfile"]
-            local_specfile_stage = try_fetch(specfile_url)
-            if local_specfile_stage:
-                local_specfile_path = local_specfile_stage.save_filename
-                signature_verified = False
+        for mirror in mirrors_to_try:
+            # Try to download the specfile. For any legacy version of Spack's buildcache
+            # we definitely require this file.
+            specfile_url = "{0}.{1}".format(mirror["specfile"], ext)
+            specfile_stage = try_fetch(specfile_url)
+            if not specfile_stage:
+                continue
 
-                if ext.endswith(".sig") and not unsigned:
-                    # If we found a signed specfile at the root, try to verify
-                    # the signature immediately.  We will not download the
-                    # tarball if we could not verify the signature.
-                    tried_to_verify_sigs.append(specfile_url)
-                    signature_verified = try_verify(local_specfile_path)
-                    if not signature_verified:
-                        tty.warn("Failed to verify: {0}".format(specfile_url))
+            specfile_path = specfile_stage.save_filename
 
-                if unsigned or signature_verified or not ext.endswith(".sig"):
-                    # We will download the tarball in one of three cases:
-                    #     1. user asked for --no-check-signature
-                    #     2. user didn't ask for --no-check-signature, but we
-                    #     found a spec.json.sig and verified the signature already
-                    #     3. neither of the first two cases are true, but this file
-                    #     is *not* a signed json (not a spec.json.sig file).  That
-                    #     means we already looked at all the mirrors and either didn't
-                    #     find any .sig files or couldn't verify any of them.  But it
-                    #     is still possible to find an old style binary package where
-                    #     the signature is a detached .asc file in the outer archive
-                    #     of the tarball, and in that case, the only way to know is to
-                    #     download the tarball.  This is a deprecated use case, so if
-                    #     something goes wrong during the extraction process (can't
-                    #     verify signature, checksum doesn't match) we will fail at
-                    #     that point instead of trying to download more tarballs from
-                    #     the remaining mirrors, looking for one we can use.
-                    tarball_stage = try_fetch(spackfile_url)
-                    if tarball_stage:
-                        if ext == "yaml":
-                            msg = (
-                                "Reading {} from mirror.\n\n\tThe YAML format for buildcaches is "
-                                "deprecated and will be removed in v0.20\n"
-                            ).format(spackfile_url)
-                            warnings.warn(msg)
+            # If it is a clearsign file, we must verify it (unless disabled)
+            should_verify = (
+                not unsigned and not ext == "yaml" and is_clearsigned_file(specfile_path)
+            )
+            if should_verify and not try_verify(specfile_path):
+                verification_failure = True
+                tty.warn("Failed to verify: {0}".format(specfile_url))
+                specfile_stage.destroy()
+                continue
 
-                        return {
-                            "tarball_stage": tarball_stage,
-                            "specfile_stage": local_specfile_stage,
-                            "signature_verified": signature_verified,
-                        }
-
-                local_specfile_stage.destroy()
+            # In case the spec.json is not clearsigned, it means it's a legacy
+            # format, where either the signature is in the tarball with binaries, or
+            # the package is unsigned. Verification
+            # is then postponed.
+            spackfile_url = mirror["spackfile"]
+            tarball_stage = try_fetch(spackfile_url)
+            if tarball_stage:
+                return {
+                    "tarball_stage": tarball_stage,
+                    "specfile_stage": specfile_stage,
+                    "signature_verified": should_verify,  # should_verify implies it was verified
+                }
+            specfile_stage.destroy()
 
     # Falling through the nested loops meeans we exhaustively searched
     # for all known kinds of spec files on all mirrors and did not find
     # an acceptable one for which we could download a tarball.
 
-    if tried_to_verify_sigs:
+    if verification_failure:
         raise NoVerifyException(
             (
                 "Spack found new style signed binary packages, "
@@ -1884,13 +1899,10 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
     specfile_path = download_result["specfile_stage"].save_filename
 
     with open(specfile_path, "r") as inputfile:
-        content = inputfile.read()
-        if specfile_path.endswith(".json.sig"):
-            spec_dict = Spec.extract_json_from_clearsig(content)
-        elif specfile_path.endswith(".json"):
-            spec_dict = sjson.load(content)
+        if specfile_path.endswith(".yaml"):
+            spec_dict = syaml.load(inputfile)
         else:
-            spec_dict = syaml.load(content)
+            spec_dict = load_possibly_clearsigned_json(inputfile)
 
     bchecksum = spec_dict["binary_cache_checksum"]
     filename = download_result["tarball_stage"].save_filename
@@ -2056,69 +2068,38 @@ def try_direct_fetch(spec, mirrors=None):
     deprecated_specfile_name = tarball_name(spec, ".spec.yaml")
     specfile_name = tarball_name(spec, ".spec.json")
     signed_specfile_name = tarball_name(spec, ".spec.json.sig")
-    specfile_is_signed = False
-    specfile_is_json = True
     found_specs = []
 
     for mirror in spack.mirror.MirrorCollection(mirrors=mirrors).values():
-        buildcache_fetch_url_yaml = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path, deprecated_specfile_name
-        )
-        buildcache_fetch_url_json = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path, specfile_name
-        )
-        buildcache_fetch_url_signed_json = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path, signed_specfile_name
-        )
-        try:
-            _, _, fs = web_util.read_from_url(buildcache_fetch_url_signed_json)
-            specfile_is_signed = True
-        except (URLError, web_util.SpackWebError, HTTPError) as url_err:
+        for file in (specfile_name, signed_specfile_name, deprecated_specfile_name):
+            url = url_util.join(mirror.fetch_url, _build_cache_relative_path, file)
             try:
-                _, _, fs = web_util.read_from_url(buildcache_fetch_url_json)
-            except (URLError, web_util.SpackWebError, HTTPError) as url_err_x:
-                try:
-                    _, _, fs = web_util.read_from_url(buildcache_fetch_url_yaml)
-                    specfile_is_json = False
-                except (URLError, web_util.SpackWebError, HTTPError) as url_err_y:
-                    tty.debug(
-                        "Did not find {0} on {1}".format(
-                            specfile_name, buildcache_fetch_url_signed_json
-                        ),
-                        url_err,
-                        level=2,
-                    )
-                    tty.debug(
-                        "Did not find {0} on {1}".format(specfile_name, buildcache_fetch_url_json),
-                        url_err_x,
-                        level=2,
-                    )
-                    tty.debug(
-                        "Did not find {0} on {1}".format(specfile_name, buildcache_fetch_url_yaml),
-                        url_err_y,
-                        level=2,
-                    )
-                    continue
-        specfile_contents = codecs.getreader("utf-8")(fs).read()
+                _, _, fs = web_util.read_from_url(url)
+            except (URLError, web_util.SpackWebError, HTTPError) as url_err:
+                tty.debug(
+                    "Did not find {0} on {1}".format(specfile_name, url),
+                    url_err,
+                    level=2,
+                )
+                continue
 
-        # read the spec from the build cache file. All specs in build caches
-        # are concrete (as they are built) so we need to mark this spec
-        # concrete on read-in.
-        if specfile_is_signed:
-            specfile_json = Spec.extract_json_from_clearsig(specfile_contents)
-            fetched_spec = Spec.from_dict(specfile_json)
-        elif specfile_is_json:
-            fetched_spec = Spec.from_json(specfile_contents)
-        else:
-            fetched_spec = Spec.from_yaml(specfile_contents)
-        fetched_spec._mark_concrete()
+            # read the spec from the build cache file. All specs in build caches
+            # are concrete (as they are built) so we need to mark this spec
+            # concrete on read-in.
+            stream = codecs.getreader("utf-8")(fs)
+            if file.endswith(".yaml"):
+                fetched_spec = Spec.from_yaml(stream)
+            else:
+                fetched_spec = Spec.from_dict(load_possibly_clearsigned_json(stream))
+            fetched_spec._mark_concrete()
 
-        found_specs.append(
-            {
-                "mirror_url": mirror.fetch_url,
-                "spec": fetched_spec,
-            }
-        )
+            found_specs.append(
+                {
+                    "mirror_url": mirror.fetch_url,
+                    "spec": fetched_spec,
+                }
+            )
+            break
 
     return found_specs
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1769,9 +1769,9 @@ def reproduce_ci_job(url, work_dir):
     download_and_extract_artifacts(url, work_dir)
 
     lock_file = fs.find(work_dir, "spack.lock")[0]
-    concrete_env_dir = os.path.dirname(lock_file)
+    repro_lock_dir = os.path.dirname(lock_file)
 
-    tty.debug("Concrete environment directory: {0}".format(concrete_env_dir))
+    tty.debug("Found lock file in: {0}".format(repro_lock_dir))
 
     yaml_files = fs.find(work_dir, ["*.yaml", "*.yml"])
 
@@ -1793,6 +1793,20 @@ def reproduce_ci_job(url, work_dir):
 
     if pipeline_yaml:
         tty.debug("\n{0} is likely your pipeline file".format(yf))
+
+    relative_concrete_env_dir = pipeline_yaml["variables"]["SPACK_CONCRETE_ENV_DIR"]
+    tty.debug("Relative environment path used by cloud job: {0}".format(relative_concrete_env_dir))
+
+    # Using the relative concrete environment path found in the generated
+    # pipeline variable above, copy the spack environment files so they'll
+    # be found in the same location as when the job ran in the cloud.
+    concrete_env_dir = os.path.join(work_dir, relative_concrete_env_dir)
+    os.makedirs(concrete_env_dir, exist_ok=True)
+    copy_lock_path = os.path.join(concrete_env_dir, "spack.lock")
+    orig_yaml_path = os.path.join(repro_lock_dir, "spack.yaml")
+    copy_yaml_path = os.path.join(concrete_env_dir, "spack.yaml")
+    shutil.copyfile(lock_file, copy_lock_path)
+    shutil.copyfile(orig_yaml_path, copy_yaml_path)
 
     # Find the install script in the unzipped artifacts and make it executable
     install_script = fs.find(work_dir, "install.sh")[0]
@@ -1849,6 +1863,7 @@ def reproduce_ci_job(url, work_dir):
         if repro_details:
             mount_as_dir = repro_details["ci_project_dir"]
             mounted_repro_dir = os.path.join(mount_as_dir, rel_repro_dir)
+            mounted_env_dir = os.path.join(mount_as_dir, relative_concrete_env_dir)
 
         # We will also try to clone spack from your local checkout and
         # reproduce the state present during the CI build, and put that into
@@ -1932,7 +1947,7 @@ def reproduce_ci_job(url, work_dir):
     inst_list.append("        $ source {0}/share/spack/setup-env.sh\n".format(spack_root))
     inst_list.append(
         "        $ spack env activate --without-view {0}\n\n".format(
-            mounted_repro_dir if job_image else repro_dir
+            mounted_env_dir if job_image else repro_dir
         )
     )
     inst_list.append("    - Run the install script\n\n")

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -17,6 +17,7 @@ import spack.error
 import spack.package_base
 import spack.repo
 import spack.store
+import spack.traverse as traverse
 from spack.database import InstallStatuses
 
 description = "remove installed packages"
@@ -144,11 +145,7 @@ def installed_dependents(specs, env):
         active environment, and one from specs to dependent installs outside of
         the active environment.
 
-        Any of the input specs may appear in both mappings (if there are
-        dependents both inside and outside the current environment).
-
-        If a dependent spec is used both by the active environment and by
-        an inactive environment, it will only appear in the first mapping.
+        Every installed dependent spec is listed once.
 
         If there is not current active environment, the first mapping will be
         empty.
@@ -158,19 +155,27 @@ def installed_dependents(specs, env):
 
     env_hashes = set(env.all_hashes()) if env else set()
 
-    all_specs_in_db = spack.store.db.query()
+    # Ensure we stop traversal at input specs.
+    visited = set(s.dag_hash() for s in specs)
 
     for spec in specs:
-        installed = [x for x in all_specs_in_db if spec in x]
-
-        # separate installed dependents into dpts in this environment and
-        # dpts that are outside this environment
-        for dpt in installed:
-            if dpt not in specs:
-                if dpt.dag_hash() in env_hashes:
-                    active_dpts.setdefault(spec, set()).add(dpt)
-                else:
-                    outside_dpts.setdefault(spec, set()).add(dpt)
+        for dpt in traverse.traverse_nodes(
+            spec.dependents(deptype="all"),
+            direction="parents",
+            visited=visited,
+            deptype="all",
+            root=True,
+            key=lambda s: s.dag_hash(),
+        ):
+            hash = dpt.dag_hash()
+            # Ensure that all the specs we get are installed
+            record = spack.store.db.query_local_by_spec_hash(hash)
+            if record is None or not record.installed:
+                continue
+            if hash in env_hashes:
+                active_dpts.setdefault(spec, set()).add(dpt)
+            else:
+                outside_dpts.setdefault(spec, set()).add(dpt)
 
     return active_dpts, outside_dpts
 
@@ -250,7 +255,7 @@ def do_uninstall(env, specs, force):
         if force:
             return True
 
-        _, record = spack.store.db.query_by_spec_hash(dag_hash)
+        record = spack.store.db.query_local_by_spec_hash(dag_hash)
         if not record.ref_count:
             return True
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -725,6 +725,15 @@ class Database(object):
                 return True, db._data[hash_key]
         return False, None
 
+    def query_local_by_spec_hash(self, hash_key):
+        """Get a spec by hash in the local database
+
+        Return:
+            (InstallRecord or None): InstallRecord when installed
+                locally, otherwise None."""
+        with self.read_transaction():
+            return self._data.get(hash_key, None)
+
     def _assign_dependencies(self, hash_key, installs, data):
         # Add dependencies from other records in the install DB to
         # form a full spec.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -56,9 +56,9 @@ import spack.repo
 import spack.store
 import spack.util.executable
 import spack.util.path
+import spack.util.timer as timer
 from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.executable import which
-from spack.util.timer import Timer
 
 #: Counter to support unique spec sequencing that is used to ensure packages
 #: with the same priority are (initially) processed in the order in which they
@@ -304,9 +304,9 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False):
         bool: ``True`` if the package was extract from binary cache,
             ``False`` otherwise
     """
-    timer = Timer()
+    t = timer.Timer()
     installed_from_cache = _try_install_from_binary_cache(
-        pkg, explicit, unsigned=unsigned, timer=timer
+        pkg, explicit, unsigned=unsigned, timer=t
     )
     pkg_id = package_id(pkg)
     if not installed_from_cache:
@@ -316,14 +316,14 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False):
 
         tty.msg("{0}: installing from source".format(pre))
         return False
-    timer.stop()
+    t.stop()
     tty.debug("Successfully extracted {0} from binary cache".format(pkg_id))
     _print_timer(
         pre=_log_prefix(pkg.name),
         pkg_id=pkg_id,
-        fetch=timer.phases.get("search", 0) + timer.phases.get("fetch", 0),
-        build=timer.phases.get("install", 0),
-        total=timer.total,
+        fetch=t.duration("search") + t.duration("fetch"),
+        build=t.duration("install"),
+        total=t.duration(),
     )
     _print_installed_pkg(pkg.spec.prefix)
     spack.hooks.post_install(pkg.spec)
@@ -372,7 +372,7 @@ def _process_external_package(pkg, explicit):
 
 
 def _process_binary_cache_tarball(
-    pkg, binary_spec, explicit, unsigned, mirrors_for_spec=None, timer=None
+    pkg, binary_spec, explicit, unsigned, mirrors_for_spec=None, timer=timer.NULL_TIMER
 ):
     """
     Process the binary cache tarball.
@@ -391,11 +391,11 @@ def _process_binary_cache_tarball(
         bool: ``True`` if the package was extracted from binary cache,
             else ``False``
     """
+    timer.start("fetch")
     download_result = binary_distribution.download_tarball(
         binary_spec, unsigned, mirrors_for_spec=mirrors_for_spec
     )
-    if timer:
-        timer.phase("fetch")
+    timer.stop("fetch")
     # see #10063 : install from source if tarball doesn't exist
     if download_result is None:
         tty.msg("{0} exists in binary cache but with different hash".format(pkg.name))
@@ -405,6 +405,7 @@ def _process_binary_cache_tarball(
     tty.msg("Extracting {0} from binary cache".format(pkg_id))
 
     # don't print long padded paths while extracting/relocating binaries
+    timer.start("install")
     with spack.util.path.filter_padding():
         binary_distribution.extract_tarball(
             binary_spec, download_result, allow_root=False, unsigned=unsigned, force=False
@@ -412,12 +413,11 @@ def _process_binary_cache_tarball(
 
     pkg.installed_from_binary_cache = True
     spack.store.db.add(pkg.spec, spack.store.layout, explicit=explicit)
-    if timer:
-        timer.phase("install")
+    timer.stop("install")
     return True
 
 
-def _try_install_from_binary_cache(pkg, explicit, unsigned=False, timer=None):
+def _try_install_from_binary_cache(pkg, explicit, unsigned=False, timer=timer.NULL_TIMER):
     """
     Try to extract the package from binary cache.
 
@@ -430,10 +430,10 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False, timer=None):
     """
     pkg_id = package_id(pkg)
     tty.debug("Searching for binary cache of {0}".format(pkg_id))
-    matches = binary_distribution.get_mirrors_for_spec(pkg.spec)
 
-    if timer:
-        timer.phase("search")
+    timer.start("search")
+    matches = binary_distribution.get_mirrors_for_spec(pkg.spec)
+    timer.stop("search")
 
     if not matches:
         return False
@@ -1906,7 +1906,7 @@ class BuildProcessInstaller(object):
         self.env_mods = install_args.get("env_modifications", EnvironmentModifications())
 
         # timer for build phases
-        self.timer = Timer()
+        self.timer = timer.Timer()
 
         # If we are using a padded path, filter the output to compress padded paths
         # The real log still has full-length paths.
@@ -1961,8 +1961,8 @@ class BuildProcessInstaller(object):
             pre=self.pre,
             pkg_id=self.pkg_id,
             fetch=self.pkg._fetch_time,
-            build=self.timer.total - self.pkg._fetch_time,
-            total=self.timer.total,
+            build=self.timer.duration() - self.pkg._fetch_time,
+            total=self.timer.duration(),
         )
         _print_installed_pkg(self.pkg.prefix)
 
@@ -2035,6 +2035,7 @@ class BuildProcessInstaller(object):
                     )
 
                     with log_contextmanager as logger:
+                        # Redirect stdout and stderr to daemon pipe
                         with logger.force_echo():
                             inner_debug_level = tty.debug_level()
                             tty.set_debug(debug_level)
@@ -2042,12 +2043,12 @@ class BuildProcessInstaller(object):
                             tty.msg(msg.format(self.pre, phase_fn.name))
                             tty.set_debug(inner_debug_level)
 
-                        # Redirect stdout and stderr to daemon pipe
-                        self.timer.phase(phase_fn.name)
-
                         # Catch any errors to report to logging
                         phase_fn.execute()
+
+                        self.timer.start(phase_fn.name)
                         spack.hooks.on_phase_success(pkg, phase_fn.name, log_file)
+                        self.timer.stop(phase_fn.name)
 
                 except BaseException:
                     combine_phase_logs(pkg.phase_log_files, pkg.log_path)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2044,9 +2044,8 @@ class BuildProcessInstaller(object):
                             tty.set_debug(inner_debug_level)
 
                         # Catch any errors to report to logging
-                        phase_fn.execute()
-
                         self.timer.start(phase_fn.name)
+                        phase_fn.execute()
                         spack.hooks.on_phase_success(pkg, phase_fn.name, log_file)
                         self.timer.stop(phase_fn.name)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -623,11 +623,13 @@ class PyclingoDriver(object):
         self.control = control or default_clingo_control()
         # set up the problem -- this generates facts and rules
         self.assumptions = []
+        timer.start("setup")
         with self.control.backend() as backend:
             self.backend = backend
             setup.setup(self, specs, reuse=reuse, namespace=namespace)
-        timer.phase("setup")
+        timer.stop("setup")
 
+        timer.start("load")
         # read in the main ASP program and display logic -- these are
         # handwritten, not generated, so we load them as resources
         parent_dir = os.path.dirname(__file__)
@@ -657,12 +659,13 @@ class PyclingoDriver(object):
         self.control.load(os.path.join(parent_dir, "concretize.lp"))
         self.control.load(os.path.join(parent_dir, "os_compatibility.lp"))
         self.control.load(os.path.join(parent_dir, "display.lp"))
-        timer.phase("load")
+        timer.stop("load")
 
         # Grounding is the first step in the solve -- it turns our facts
         # and first-order logic rules into propositional logic.
+        timer.start("ground")
         self.control.ground([("base", [])])
-        timer.phase("ground")
+        timer.stop("ground")
 
         # With a grounded program, we can run the solve.
         result = Result(specs)
@@ -680,8 +683,10 @@ class PyclingoDriver(object):
 
         if clingo_cffi:
             solve_kwargs["on_unsat"] = cores.append
+
+        timer.start("solve")
         solve_result = self.control.solve(**solve_kwargs)
-        timer.phase("solve")
+        timer.stop("solve")
 
         # once done, construct the solve result
         result.satisfiable = solve_result.satisfiable

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -190,16 +190,6 @@ default_format = "{name}{@version}"
 default_format += "{%compiler.name}{@compiler.version}{compiler_flags}"
 default_format += "{variants}{arch=architecture}"
 
-#: Regular expression to pull spec contents out of clearsigned signature
-#: file.
-CLEARSIGN_FILE_REGEX = re.compile(
-    (
-        r"^-----BEGIN PGP SIGNED MESSAGE-----"
-        r"\s+Hash:\s+[^\s]+\s+(.+)-----BEGIN PGP SIGNATURE-----"
-    ),
-    re.MULTILINE | re.DOTALL,
-)
-
 #: specfile format version. Must increase monotonically
 specfile_format_version = 3
 
@@ -2443,27 +2433,6 @@ class Spec(object):
                 sjson.SpackJSONError("error parsing JSON spec:", str(e)),
                 e,
             )
-
-    @staticmethod
-    def extract_json_from_clearsig(data):
-        m = CLEARSIGN_FILE_REGEX.search(data)
-        if m:
-            return sjson.load(m.group(1))
-        return sjson.load(data)
-
-    @staticmethod
-    def from_signed_json(stream):
-        """Construct a spec from clearsigned json spec file.
-
-        Args:
-            stream: string or file object to read from.
-        """
-        data = stream
-        if hasattr(stream, "read"):
-            data = stream.read()
-
-        extracted_json = Spec.extract_json_from_clearsig(data)
-        return Spec.from_dict(extracted_json)
 
     @staticmethod
     def from_detection(spec_str, extra_attributes=None):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1324,7 +1324,9 @@ spack:
                 if file_name.endswith(".spec.json.sig"):
                     spec_json_path = os.path.join(buildcache_path, file_name)
                     with open(spec_json_path) as json_fd:
-                        json_object = Spec.extract_json_from_clearsig(json_fd.read())
+                        json_object = spack.binary_distribution.load_possibly_clearsigned_json(
+                            json_fd
+                        )
                         validate(json_object, specfile_schema)
 
             logs_dir = working_dir.join("logs_dir")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -3,12 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import sys
 
 import pytest
 
 import llnl.util.tty as tty
 
+import spack.cmd.uninstall
 import spack.environment
 import spack.store
 from spack.main import SpackCommand, SpackCommandError
@@ -38,6 +40,39 @@ def test_installed_dependents(mutable_database):
     """Test can't uninstall when there are installed dependents."""
     with pytest.raises(SpackCommandError):
         uninstall("-y", "libelf")
+
+
+@pytest.mark.db
+def test_correct_installed_dependents(mutable_database):
+    # Test whether we return the right dependents.
+
+    # Take callpath from the database
+    callpath = spack.store.db.query_local("callpath")[0]
+
+    # Ensure it still has dependents and dependencies
+    dependents = callpath.dependents(deptype="all")
+    dependencies = callpath.dependencies(deptype="all")
+    assert dependents and dependencies
+
+    # Uninstall it, so it's missing.
+    callpath.package.do_uninstall(force=True)
+
+    # Retrieve all dependent hashes
+    inside_dpts, outside_dpts = spack.cmd.uninstall.installed_dependents(dependencies, None)
+    dependent_hashes = [s.dag_hash() for s in itertools.chain(*outside_dpts.values())]
+    set_dependent_hashes = set(dependent_hashes)
+
+    # We dont have an env, so this should be empty.
+    assert not inside_dpts
+
+    # Assert uniqueness
+    assert len(dependent_hashes) == len(set_dependent_hashes)
+
+    # Ensure parents of callpath are listed
+    assert all(s.dag_hash() in set_dependent_hashes for s in dependents)
+
+    # Ensure callpath itself is not, since it was missing.
+    assert callpath.dag_hash() not in set_dependent_hashes
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -28,7 +28,7 @@ def test_set_install_hash_length(hash_length, mutable_config, tmpdir):
         assert len(hash_str) == hash_length
 
 
-@pytest.mark.use_fixtures("mock_packages")
+@pytest.mark.usefixtures("mock_packages")
 def test_set_install_hash_length_upper_case(mutable_config, tmpdir):
     mutable_config.set("config:install_hash_length", 5)
     mutable_config.set(

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -252,12 +252,8 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
 
     # The order should be maintained
     phases = [x["name"] for x in times["phases"]]
-    total = sum([x["seconds"] for x in times["phases"]])
-    for name in ["one", "two", "three", "install"]:
-        assert name in phases
-
-    # Give a generous difference threshold
-    assert abs(total - times["total"]["seconds"]) < 5
+    assert phases == ["one", "two", "three", "install"]
+    assert all(isinstance(x["seconds"], float) for x in times["phases"])
 
 
 def test_flatten_deps(install_mockery, mock_fetch, mutable_mock_repo):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -48,27 +48,6 @@ def test_simple_spec():
     check_json_round_trip(spec)
 
 
-def test_read_spec_from_signed_json():
-    spec_dir = os.path.join(spack.paths.test_path, "data", "mirrors", "signed_json")
-    file_name = (
-        "linux-ubuntu18.04-haswell-gcc-8.4.0-"
-        "zlib-1.2.12-g7otk5dra3hifqxej36m5qzm7uyghqgb.spec.json.sig"
-    )
-    spec_path = os.path.join(spec_dir, file_name)
-
-    def check_spec(spec_to_check):
-        assert spec_to_check.name == "zlib"
-        assert spec_to_check._hash == "g7otk5dra3hifqxej36m5qzm7uyghqgb"
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd)
-        check_spec(s)
-
-    with open(spec_path) as fd:
-        s = Spec.from_signed_json(fd.read())
-        check_spec(s)
-
-
 def test_normal_spec(mock_packages):
     spec = Spec("mpileaks+debug~opt")
     spec.normalize()

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -1,0 +1,150 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import json
+
+from six import StringIO
+
+import spack.util.timer as timer
+
+
+class Tick(object):
+    """Timer that increments the seconds passed by 1
+    everytime tick is called."""
+
+    def __init__(self):
+        self.time = 0.0
+
+    def tick(self):
+        self.time += 1
+        return self.time
+
+
+def test_timer():
+    # 0
+    t = timer.Timer(now=Tick().tick)
+
+    # 1 (restart)
+    t.start()
+
+    # 2
+    t.start("wrapped")
+
+    # 3
+    t.start("first")
+
+    # 4
+    t.stop("first")
+    assert t.duration("first") == 1.0
+
+    # 5
+    t.start("second")
+
+    # 6
+    t.stop("second")
+    assert t.duration("second") == 1.0
+
+    # 7-8
+    with t.measure("third"):
+        pass
+    assert t.duration("third") == 1.0
+
+    # 9
+    t.stop("wrapped")
+    assert t.duration("wrapped") == 7.0
+
+    # tick 10-13
+    t.start("not-stopped")
+    assert t.duration("not-stopped") == 1.0
+    assert t.duration("not-stopped") == 2.0
+    assert t.duration("not-stopped") == 3.0
+
+    # 14
+    assert t.duration() == 13.0
+
+    # 15
+    t.stop()
+    assert t.duration() == 14.0
+
+
+def test_timer_stop_stops_all():
+    # Ensure that timer.stop() effectively stops all timers.
+
+    # 0
+    t = timer.Timer(now=Tick().tick)
+
+    # 1
+    t.start("first")
+
+    # 2
+    t.start("second")
+
+    # 3
+    t.start("third")
+
+    # 4
+    t.stop()
+
+    assert t.duration("first") == 3.0
+    assert t.duration("second") == 2.0
+    assert t.duration("third") == 1.0
+    assert t.duration() == 4.0
+
+
+def test_stopping_unstarted_timer_is_no_error():
+    t = timer.Timer(now=Tick().tick)
+    assert t.duration("hello") == 0.0
+    t.stop("hello")
+    assert t.duration("hello") == 0.0
+
+
+def test_timer_write():
+    text_buffer = StringIO()
+    json_buffer = StringIO()
+
+    # 0
+    t = timer.Timer(now=Tick().tick)
+
+    # 1
+    t.start("timer")
+
+    # 2
+    t.stop("timer")
+
+    # 3
+    t.stop()
+
+    t.write_tty(text_buffer)
+    t.write_json(json_buffer)
+
+    output = text_buffer.getvalue().splitlines()
+    assert "timer" in output[0]
+    assert "1.000s" in output[0]
+    assert "total" in output[1]
+    assert "3.000s" in output[1]
+
+    deserialized = json.loads(json_buffer.getvalue())
+    assert deserialized == {
+        "phases": [{"name": "timer", "seconds": 1.0}],
+        "total": {"seconds": 3.0},
+    }
+
+
+def test_null_timer():
+    # Just ensure that the interface of the noop-timer doesn't break at some point
+    buffer = StringIO()
+    t = timer.NullTimer()
+    t.start()
+    t.start("first")
+    t.stop("first")
+    with t.measure("second"):
+        pass
+    t.stop()
+    assert t.duration("first") == 0.0
+    assert t.duration() == 0.0
+    assert not t.phases
+    t.write_json(buffer)
+    t.write_tty(buffer)
+    assert not buffer.getvalue()

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -11,51 +11,140 @@ a stack trace and drops the user into an interpreter.
 """
 import sys
 import time
+from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
+
+from llnl.util.lang import pretty_seconds
 
 import spack.util.spack_json as sjson
 
+Interval = namedtuple("Interval", ("begin", "end"))
 
-class Timer(object):
-    """
-    Simple timer for timing phases of a solve or install
-    """
+#: name for the global timer (used in start(), stop(), duration() without arguments)
+global_timer_name = "_global"
 
-    def __init__(self):
-        self.start = time.time()
-        self.last = self.start
-        self.phases = {}
-        self.end = None
 
-    def phase(self, name):
-        last = self.last
-        now = time.time()
-        self.phases[name] = now - last
-        self.last = now
+class NullTimer(object):
+    """Timer interface that does nothing, useful in for "tell
+    don't ask" style code when timers are optional."""
+
+    def start(self, name=global_timer_name):
+        pass
+
+    def stop(self, name=global_timer_name):
+        pass
+
+    def duration(self, name=global_timer_name):
+        return 0.0
+
+    @contextmanager
+    def measure(self, name):
+        yield
 
     @property
-    def total(self):
-        """Return the total time"""
-        if self.end:
-            return self.end - self.start
-        return time.time() - self.start
-
-    def stop(self):
-        """
-        Stop the timer to record a total time, if desired.
-        """
-        self.end = time.time()
+    def phases(self):
+        return []
 
     def write_json(self, out=sys.stdout):
+        pass
+
+    def write_tty(self, out=sys.stdout):
+        pass
+
+
+#: instance of a do-nothing timer
+NULL_TIMER = NullTimer()
+
+
+class Timer(object):
+    """Simple interval timer"""
+
+    def __init__(self, now=time.time):
         """
-        Write a json object with times to file
+        Arguments:
+            now: function that gives the seconds since e.g. epoch
         """
-        phases = [{"name": p, "seconds": s} for p, s in self.phases.items()]
-        times = {"phases": phases, "total": {"seconds": self.total}}
+        self._now = now
+        self._timers = OrderedDict()  # type: OrderedDict[str,Interval]
+
+        # _global is the overal timer since the instance was created
+        self._timers[global_timer_name] = Interval(self._now(), end=None)
+
+    def start(self, name=global_timer_name):
+        """
+        Start or restart a named timer, or the global timer when no name is given.
+
+        Arguments:
+            name (str): Optional name of the timer. When no name is passed, the
+                global timer is started.
+        """
+        self._timers[name] = Interval(self._now(), None)
+
+    def stop(self, name=global_timer_name):
+        """
+        Stop a named timer, or all timers when no name is given. Stopping a
+        timer that has not started has no effect.
+
+        Arguments:
+            name (str): Optional name of the timer. When no name is passed, all
+                timers are stopped.
+        """
+        interval = self._timers.get(name, None)
+        if not interval:
+            return
+        self._timers[name] = Interval(interval.begin, self._now())
+
+    def duration(self, name=global_timer_name):
+        """
+        Get the time in seconds of a named timer, or the total time if no
+        name is passed. The duration is always 0 for timers that have not been
+        started, no error is raised.
+
+        Arguments:
+            name (str): (Optional) name of the timer
+
+        Returns:
+            float: duration of timer.
+        """
+        try:
+            interval = self._timers[name]
+        except KeyError:
+            return 0.0
+        # Take either the interval end, the global timer, or now.
+        end = interval.end or self._timers[global_timer_name].end or self._now()
+        return end - interval.begin
+
+    @contextmanager
+    def measure(self, name):
+        """
+        Context manager that allows you to time a block of code.
+
+        Arguments:
+            name (str): Name of the timer
+        """
+        begin = self._now()
+        yield
+        self._timers[name] = Interval(begin, self._now())
+
+    @property
+    def phases(self):
+        """Get all named timers (excluding the global/total timer)"""
+        return [k for k in self._timers.keys() if k != global_timer_name]
+
+    def write_json(self, out=sys.stdout):
+        """Write a json object with times to file"""
+        phases = [{"name": p, "seconds": self.duration(p)} for p in self.phases]
+        times = {"phases": phases, "total": {"seconds": self.duration()}}
         out.write(sjson.dump(times))
 
     def write_tty(self, out=sys.stdout):
-        now = time.time()
-        out.write("Time:\n")
-        for phase, t in self.phases.items():
-            out.write("    %-15s%.4f\n" % (phase + ":", t))
-        out.write("Total: %.4f\n" % (now - self.start))
+        """Write a human-readable summary of timings"""
+        # Individual timers ordered by registration
+        formatted = [(p, pretty_seconds(self.duration(p))) for p in self.phases]
+
+        # Total time
+        formatted.append(("total", pretty_seconds(self.duration())))
+
+        # Write to out
+        for name, duration in formatted:
+            out.write("    {:10s} {:>10s}\n".format(name, duration))

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from time import sleep
-
 from spack.package import *
 
 
@@ -17,15 +15,12 @@ class DevBuildTestInstallPhases(Package):
     phases = ["one", "two", "three", "install"]
 
     def one(self, spec, prefix):
-        sleep(1)
         print("One locomoco")
 
     def two(self, spec, prefix):
-        sleep(2)
         print("Two locomoco")
 
     def three(self, spec, prefix):
-        sleep(3)
         print("Three locomoco")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Currently we have separate `spec.json` and `spec.json.sig` files. The
former is a pure spec, the latter is clearsigned spec. This is a bit
unfortunate, cause a lookup for a spec file now requires two remote
requests (with or without cache).

This PR allows clearsigned `spec.json` files too, and changes otherwise
nothing.

The idea is to backport this to 0.19.1, since for 0.19.1 it is not a
behavioral change, but rather a bugfix for improved 0.20 / 0.21 forward
compatibility.

Next steps after this PR:

- Start uploading spec.json.sig files both as spec.json.sig and
  spec.json. This ensure they work with any Spack version.
- Deprecate spec.json.sig in 0.20.
- After Spack 0.20 branches off, stop uploading *.sig, and stop checking
  the remote for *.sig files.
- Potentially we can also add a config option to disable checking for
  *.sig files on develop earlier.
