### PR TITLE
bacio: Patch VERSION file for v2.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -42,4 +42,4 @@ class Bacio(CMakePackage):
 
     # Correct VERSION file for v2.4.1.
     def patch(self):
-        filter_file('2\.4\.0',str(self.spec.version),"VERSION",when="bacio@2.4.1")
+        filter_file('2\.4\.0', str(self.spec.version), "VERSION", when="bacio@2.4.1")

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -39,3 +39,7 @@ class Bacio(CMakePackage):
         args = [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 
         return args
+
+    # Correct VERSION file for v2.4.1.
+    def patch(self):
+        filter_file('2\.4\.0',str(self.spec.version),"VERSION",when="bacio@2.4.1")

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -42,4 +42,4 @@ class Bacio(CMakePackage):
 
     # Correct VERSION file for v2.4.1.
     def patch(self):
-        filter_file('2\.4\.0', str(self.spec.version), "VERSION", when="bacio@2.4.1")
+        filter_file(r"2\.4\.0", str(self.spec.version), "VERSION", when="bacio@2.4.1")

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Bacio(CMakePackage):
-    """The bacio ibrary performs binary I/O for the NCEP models, processing
+    """The bacio library performs binary I/O for the NCEP models, processing
     unformatted byte-addressable data records, and transforming the little
     endian files and big endian files."""
 


### PR DESCRIPTION
## Description
In version 2.4.1, bacio's VERSION file, which is used to generate the cmake configuration files, contains 2.4.0. This can cause bacio to not be findable through cmake.

## Summary of changes
This PR adds a patch using filter_file to update the version when installing bacio@2.4.1. There do not seem to be similar issues for other bacio releases.