### PR TITLE
trilinos: extend range of Teuchos patch

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -439,7 +439,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     patch(
         "https://patch-diff.githubusercontent.com/raw/trilinos/Trilinos/pull/10545.patch?full_index=1",
         sha256="62272054f7cc644583c269e692c69f0a26af19e5a5bd262db3ea3de3447b3358",
-        when="@:13.4.0 +complex",
+        when="@:13.4 +complex",
     )
 
     # workaround an NVCC bug with c++14 (https://github.com/trilinos/Trilinos/issues/6954)


### PR DESCRIPTION
Patch was to extend up to 13.4.0, but will be needed until 13.5, so 13.4.1 isn't handled properly.