### PR TITLE
gitlab ci: more resources for slow builds

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -288,6 +288,7 @@ spack:
         - magma
         - mfem
         - mpich
+        - nvhpc
         - openturns
         - precice
         - raja

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -184,7 +184,6 @@ spack:
             KUBERNETES_CPU_REQUEST: 15000m
             KUBERNETES_MEMORY_REQUEST: 62G
 
-
       - match:
         - ascent
         - atk
@@ -202,9 +201,11 @@ spack:
         - magma
         - mfem
         - mpich
+        - openfoam
         - openturns
         - parallelio
         - precice
+        - qt
         - raja
         - relion
         - rocblas
@@ -215,6 +216,7 @@ spack:
         - sundials
         - trilinos
         - umpire
+        - visit
         - vtk
         - vtk-h
         - vtk-m

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -214,9 +214,11 @@ spack:
         - magma
         - mfem
         - mpich
+        - openfoam
         - openturns
         - parallelio
         - precice
+        - qt
         - raja
         - relion
         - rocblas
@@ -227,6 +229,7 @@ spack:
         - sundials
         - trilinos
         - umpire
+        - visit
         - vtk
         - vtk-h
         - vtk-m

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -111,6 +111,7 @@ spack:
         - ecp-data-vis-sdk
         - mesa
         - openblas
+        - vtk
         - vtk-m
         runner-attributes:
           tags: [ "spack", "large", "x86_64" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -291,13 +291,14 @@ spack:
       - cat /proc/loadavg || true
 
     image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2022-07-01
-    
+
     match_behavior: first
     mappings:
       - match:
           - hipblas
           - llvm
           - llvm-amdgpu
+          - paraview
           - rocblas
         runner-attributes:
           tags: [ "spack", "huge", "x86_64" ]
@@ -317,7 +318,9 @@ spack:
           - mfem
           - mpich
           - openturns
+          - plumed
           - precice
+          - qt
           - raja
           - rust
           - slate

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -285,6 +285,7 @@ spack:
 
       - match:
           - cuda
+          - dealii
           - dray
           - dyninst
           - ginkgo
@@ -294,12 +295,22 @@ spack:
           - magma
           - mfem
           - mpich
+          - nvhpc
+          - oce
           - openturns
+          - plumed
           - precice
+          - py-tensorflow
+          - qt
           - raja
+          - rocfft
+          - rocsolver
+          - rocsparse
           - rust
           - slate
           - trilinos
+          - visit
+          - vtk
           - vtk-m
           - warpx
         runner-attributes:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-rocm/spack.yaml
@@ -118,8 +118,10 @@ spack:
     match_behavior: first
     mappings:
       - match:
+          - llvm-amdgpu
           - llvm
           - py-torch
+          - rocblas
         runner-attributes:
           tags: [ "spack", "huge", "x86_64_v4" ]
           variables:

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -88,7 +88,9 @@ spack:
       - match:
           - lbann
           - openblas
+          - qt
           - rust
+          - visit
         runner-attributes:
           tags: ["spack", "large", "x86_64"]
           variables:
@@ -109,6 +111,7 @@ spack:
           - samrai
           - vtk-h
           - vtk-m
+          - vtk
         runner-attributes:
           tags: ["spack", "medium", "x86_64"]
           variables:


### PR DESCRIPTION
The goal of this change is to speed up our GitLab CI pipelines.

I arrived at this list by querying the GitLab database for packages that averaged more than 20 minutes per build since November 1. After that, I performed some subsequent queries to figure out what stacks have built these packages in the past.
