### PR TITLE
nwchem: restricting current versions to python@3.9 at latest

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -42,7 +42,7 @@ class Nwchem(Package):
     depends_on("mpi")
     depends_on("scalapack")
     depends_on("fftw-api")
-    depends_on("python@3:", type=("build", "link", "run"))
+    depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")
 
     def install(self, spec, prefix):
         scalapack = spec["scalapack"].libs


### PR DESCRIPTION
Python 3.10 removed the old parser, this looks for headers that are part of that. It looks like this will be fixed in the next release.