### PR TITLE
WarpX 22.11, 22.12 & PICMI-Standard

### DIFF
--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -16,6 +16,7 @@ class PyPicmistandard(PythonPackage):
     maintainers = ["ax3l", "dpgrote", "RemiLehe"]
 
     version("develop", branch="master")
+    version("0.0.22", sha256="e234a431274254b22cd70be64d6555b383d98426b2763ea0c174cf77bf4d0890")
     version("0.0.21", sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b")
     version("0.0.20", sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905")
     version("0.0.19", sha256="4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a")

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -27,6 +27,8 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version("develop", branch="development")
+    version("22.12", sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062")
+    version("22.11", sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e")
     version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
     version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
     version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")
@@ -50,6 +52,8 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
+        "22.12",
+        "22.11",
         "22.10",
         "22.09",
         "22.08",
@@ -82,7 +86,8 @@ class PyWarpx(PythonPackage):
     depends_on("py-picmistandard@0.0.16", type=("build", "run"), when="@21.12")
     depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
     depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
-    depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:")
+    depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")
+    depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:")
     depends_on("py-setuptools@42:", type="build")
     # Since we use PYWARPX_LIB_DIR to pull binaries out of the
     # 'warpx' spack package, we don't need py-cmake as declared

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.10.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.12.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ["ax3l", "dpgrote", "MaxThevenet", "RemiLehe"]
@@ -25,6 +25,8 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
+    version("22.12", sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062")
+    version("22.11", sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e")
     version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
     version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
     version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")


### PR DESCRIPTION
Update `warpx` & `py-warpx` to the latest release, `22.12`. Update `py-picmistandard` accordingly.