### PR TITLE
use `update-index --mirror-url <url>` instead of `-d <url>`

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1264,7 +1264,7 @@ def generate_gitlab_ci_yaml(
 
             final_job["stage"] = "stage-rebuild-index"
             final_job["script"] = [
-                "spack buildcache update-index --keys -d {0}".format(index_target_mirror)
+                "spack buildcache update-index --keys --mirror-url {0}".format(index_target_mirror)
             ]
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -322,7 +322,7 @@ def test_ci_workarounds():
 
         result = {
             "stage": "stage-rebuild-index",
-            "script": "spack buildcache update-index -d s3://mirror",
+            "script": "spack buildcache update-index --mirror-url s3://mirror",
             "tags": ["tag-0", "tag-1"],
             "image": {"name": "spack/centos7", "entrypoint": [""]},
             "after_script": ['rm -rf "./spack"'],

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -231,7 +231,7 @@ spack:
 
             assert "rebuild-index" in yaml_contents
             rebuild_job = yaml_contents["rebuild-index"]
-            expected = "spack buildcache update-index --keys -d {0}".format(mirror_url)
+            expected = "spack buildcache update-index --keys --mirror-url {0}".format(mirror_url)
             assert rebuild_job["script"][0] == expected
 
             assert "variables" in yaml_contents


### PR DESCRIPTION
In #34452 `update-index` got the same three flags (`--mirror-url`, `--mirror-name`, `-d,--directory`) as the other commands, replacing the inconsistent or incorrect `-d` == `--mirror-url` flag.

But in CI `-d <mirror url>` was actually used. This fixes that