### PR TITLE
py-archspec fails to build

### DIFF
--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -30,7 +30,7 @@ class PyArchspec(PythonPackage):
 
     def patch(self):
         # See https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
-        with working_dir(self.build_directory):
+        with working_dir(self.stage.source_path):
             if self.spec.satisfies("@:0.1.3"):
                 filter_file("poetry>=0.12", "poetry_core>=1.0.0", "pyproject.toml")
                 filter_file("poetry.masonry.api", "poetry.core.masonry.api", "pyproject.toml")


### PR DESCRIPTION
Commit https://github.com/spack/spack/commit/30c9ff50dd048573e3cd7a63a8ab9c05c0bee339 broke the package `py-archspec` because `PythonPackage.build_directory` was removed.
Potentially this commit broke also other packages, but at this point only `py-archspec` failed to build in my environment.

Maybe the fix is not in line with development guidelines, so please review and adapt to correct guidelines.