### PR TITLE
reframe sanity checks outdated

### DIFF
--- a/var/spack/repos/builtin/packages/reframe/package.py
+++ b/var/spack/repos/builtin/packages/reframe/package.py
@@ -113,7 +113,6 @@ class Reframe(Package):
         "reframe",
         "tutorials",
         "unittests",
-        "cscs-checks",
     ]
 
     # check if we can run reframe


### PR DESCRIPTION
Since version 3.11.0 there is no directory `cscs-checks`. I removed it from the sanity checks. A more complete solution could be to have the sanity check still available for all version <3.11.0, but the value of it is probably very limited, besides polluting `package.py`.