### PR TITLE
arpack-ng: Add variant for ICB option

### DIFF
--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -57,7 +57,7 @@ class ArpackNg(CMakePackage, AutotoolsPackage):
 
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant("mpi", default=True, description="Activates MPI support")
-    variant("icb", default=False, description="Activates iso_c_binding support")
+    variant("icb", default=False, when="@3.6:", description="Activates iso_c_binding support")
 
     # The function pdlamch10 does not set the return variable.
     # This is fixed upstream
@@ -85,8 +85,6 @@ class ArpackNg(CMakePackage, AutotoolsPackage):
         depends_on("autoconf", type="build")
         depends_on("libtool@2.4.2:", type="build")
         depends_on("pkgconfig", type="build")
-
-    conflicts("+icb", when="@:3.5.0")
 
     def flag_handler(self, name, flags):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -57,6 +57,7 @@ class ArpackNg(CMakePackage, AutotoolsPackage):
 
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant("mpi", default=True, description="Activates MPI support")
+    variant("icb", default=False, description="Activates iso_c_binding support")
 
     # The function pdlamch10 does not set the return variable.
     # This is fixed upstream
@@ -84,6 +85,8 @@ class ArpackNg(CMakePackage, AutotoolsPackage):
         depends_on("autoconf", type="build")
         depends_on("libtool@2.4.2:", type="build")
         depends_on("pkgconfig", type="build")
+
+    conflicts("+icb", when="@:3.5.0")
 
     def flag_handler(self, name, flags):
         spec = self.spec
@@ -126,6 +129,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define("BLAS_INCLUDE_DIRS", spec["blas"].prefix.include),
             self.define("BLAS_LIBRARIES", blas_libs),
             self.define_from_variant("MPI", "mpi"),
+            self.define_from_variant("ICB", "icb"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("CMAKE_POSITION_INDEPENDENT_CODE", True),
         ]


### PR DESCRIPTION
This has been in ARPACK-NG since v3.6.0.