### PR TITLE
metabat: adding missing build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/metabat/package.py
+++ b/var/spack/repos/builtin/packages/metabat/package.py
@@ -28,6 +28,7 @@ class Metabat(CMakePackage):
         deprecated=True,
     )
 
+    depends_on("autoconf", type="build")
     depends_on("cmake", type="build", when="@2.13:")
     depends_on("boost@1.55.0:", type=("build", "run"))
 


### PR DESCRIPTION
Calls autoheader and autoconf during the build phase for its included htslib, which builds regardless of whether htslib is present.