### PR TITLE
Forward lookup of the "run_tests" attribute

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -124,7 +124,12 @@ def _create(pkg):
             wrapper_cls = type(self)
             bases = (package_cls, wrapper_cls)
             new_cls_name = package_cls.__name__ + "Wrapper"
-            new_cls = type(new_cls_name, bases, {})
+            # Forward attributes that might be monkey patched later
+            new_cls = type(
+                new_cls_name,
+                bases,
+                {"run_tests": property(lambda x: x.wrapped_package_object.run_tests)},
+            )
             new_cls.__module__ = package_cls.__module__
             self.__class__ = new_cls
             self.__dict__.update(wrapped_pkg_object.__dict__)

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -140,3 +140,17 @@ def test_build_time_tests_are_executed_from_default_builder():
 
     assert os.environ.get("CHECK_CALLED") == "1", "Build time tests not executed"
     assert os.environ.get("INSTALLCHECK_CALLED") == "1", "Install time tests not executed"
+
+
+@pytest.mark.regression("34518")
+@pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
+def test_monkey_patching_wrapped_pkg():
+    s = spack.spec.Spec("old-style-autotools").concretized()
+    builder = spack.builder.create(s.package)
+    assert s.package.run_tests is False
+    assert builder.pkg.run_tests is False
+    assert builder.pkg_with_dispatcher.run_tests is False
+
+    s.package.run_tests = True
+    assert builder.pkg.run_tests is True
+    assert builder.pkg_with_dispatcher.run_tests is True


### PR DESCRIPTION
fixes #34518

Fix an issue due to the MRO chain of the package wrapper during build. Before this PR we were always returning False when the builder object was created before the run_tests method was monkey patched.