### PR TITLE
netlib-scalpack: add fixing prb with netlib-scalpack linking

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/fortran_mpi_link.patch
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/fortran_mpi_link.patch
@@ -1,0 +1,22 @@
+diff -ruN CMakeLists.txt spack-src/CMakeLists.txt
+--- CMakeLists.txt	2022-12-14 01:36:59.000000000 +0000
++++ spack-src/CMakeLists.txt	2022-12-14 01:37:41.000000000 +0000
+@@ -238,14 +238,14 @@
+ 
+ if (UNIX)
+    add_library(scalapack ${blacs} ${tools} ${tools-C} ${extra_lapack} ${pblas} ${pblas-F} ${ptzblas} ${ptools} ${pbblas} ${redist} ${src} ${src-C})
+-   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
++   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+    scalapack_install_library(scalapack)
+ else (UNIX) # Need to separate Fortran and C Code
+    OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON )
+-   add_library(scalapack ${blacs} ${tools-C} ${pblas} ${ptools} ${redist} ${src-C})
+-   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
++   add_library(scalapack ${blacs} ${tools-C} ${pblas} ${ptools} ${redist} ${src-C} )
++   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+    add_library(scalapack-F ${pblas-F} ${pbblas} ${ptzblas} ${tools} ${src} ${extra_lapack} )
+-   target_link_libraries( scalapack-F ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
++   target_link_libraries( scalapack-F ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+    scalapack_install_library(scalapack)
+    scalapack_install_library(scalapack-F)
+ endif (UNIX)

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -44,6 +44,7 @@ class ScalapackBase(CMakePackage):
         sha256="072b006e485f0ca4cba56096912a986e4d3da73aae51c2205928aa5eb842cefd",
         when="@2.2.0",
     )
+    patch("fortran_mpi_link.patch", when="@2.2.0")
 
     def flag_handler(self, name, flags):
         iflags = []


### PR DESCRIPTION
Fix Fortran MPI linking. The patch is straightforward and adds ${MPI_Fortran_LIBRARIES} to target_link_libraries.

I tested in aarch64, Monterey. However, the error fix should be working for other systems.