### PR TITLE
elfutils: support external gettext with libintl from glibc

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -124,7 +124,9 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
         if "+nls" in spec:
             # configure doesn't use LIBS correctly
-            args.append("LDFLAGS=-Wl,--no-as-needed -L%s -lintl" % spec["gettext"].prefix.lib)
+            # Add -lintl if provided by gettext, otherwise libintl is provided by system's glibc:
+            if any("libintl." in filename.split("/")[-1] for filename in spec["gettext"].libs):
+                args.append("LDFLAGS=-Wl,--no-as-needed -L%s -lintl" % spec["gettext"].prefix.lib)
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -339,7 +339,7 @@ class Glib(Package):
         # the gettext library directory. The patch below explitly adds the
         # appropriate -L path.
         spec = self.spec
-        if spec.satisfies("@2.0:2"):
+        if spec.satisfies("@2.0:2") and spec["gettext"].libs.directories:
             pattern = "Libs:"
             repl = "Libs: -L{0} -Wl,-rpath={0} ".format(spec["gettext"].libs.directories[0])
             myfile = join_path(self.spec["glib"].libs.directories[0], "pkgconfig", "glib-2.0.pc")


### PR DESCRIPTION
@sethrj Thank you very much for reviewing my gettext/libintl check for `bcache` in #34114 and #34383!
---
This adds the same check to `elfutils` to support `spack external find gettext` on glibc systems for building elfutils:
---
glibc's libc.so itself provides an integrated libintl, which is why on glibc systems, the gettext packages provide no libintl.so library.

To support `spack external find gettext` on glibc systems, the recipe should check if the gettext spec says that libintl is provided before adding -lintl.

The fix to add this check has been successfully reviewed and merged in the bcache recipe, so use it for adding -lintl in elfutils likewise.

### See #34114 and #34383 for the details on arriving on this already used check.