### PR TITLE
glib: support build with external gettext with libintl from glibc

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -339,7 +339,7 @@ class Glib(Package):
         # the gettext library directory. The patch below explitly adds the
         # appropriate -L path.
         spec = self.spec
-        if spec.satisfies("@2.0:2"):
+        if spec.satisfies("@2.0:2") and spec["gettext"].libs.directories:
             pattern = "Libs:"
             repl = "Libs: -L{0} -Wl,-rpath={0} ".format(spec["gettext"].libs.directories[0])
             myfile = join_path(self.spec["glib"].libs.directories[0], "pkgconfig", "glib-2.0.pc")


### PR DESCRIPTION
#### @sethrj This is somewhat similar to the `libintl` fixes for `bcache` and `elfutils`, except here we just need to check if `spec["gettext"].libs.directories` is non-empty before using `spec["gettext"].libs.directories[0]`:

This fixes a python exception when accessing `spec["gettext"].libs.directories[0]` because `spec["gettext"].libs.directories` is empty when `spack external find gettext` provides `gettext` from a glibc system which does not have any `spec["gettext"].libs.directories` because the libintl libraries are all integrated into glibc.

### Details:

glibc's libc.so itself provides an integrated libintl, which is why on glibc systems, the gettext packages provide no libintl.so library.

A few recipes like bcache and elfutils assumed that gettext will always provides a libintl and glib also assumed this for now by assuming that spec["gettext"].libs.directories[0] is always is accessible.

### The fix is clear:

With `spack external find gettext`, `spec["gettext"].libs.directories` is **empty** because the external gettext is completely integrated in glibc and accessing spec["gettext"].libs.directories[0] with it leads to a python exception.

With internal gettext and on non-glibc systems, `spec["gettext"].libs.directories[0]` of course existing, so check if it is non-empty before using `spec["gettext"].libs.directories[0]`.


[var/spack/repos/builtin/packages/glib/package.py](https://github.com/spack/spack/pull/34542/files#diff-3bc897d3033a87a628ab1c9cc50cb35c6bdf01d2d81bdf83da9e74a6b1bb1b9c)
```diff
@@ -339,7 +339,7 @@ def gettext_libdir(self):
        # the gettext library directory. The patch below explitly adds the
        # appropriate -L path.
        spec = self.spec
-       if spec.satisfies("@2.0:2"):
+       if spec.satisfies("@2.0:2") and spec["gettext"].libs.directories:
            pattern = "Libs:"
            repl = "Libs: -L{0} -Wl,-rpath={0} ".format(spec["gettext"].libs.directories[0])
            myfile = join_path(self.spec["glib"].libs.directories[0], "pkgconfig", "glib-2.0.pc")
```