### PR TITLE
libxpm: support external gettext with libintl from glibc

### DIFF
--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -27,8 +27,5 @@ class Libxpm(AutotoolsPackage, XorgPackage):
     depends_on("util-macros", type="build")
 
     def setup_build_environment(self, env):
-        # If libxpm is installed as an external package, gettext won't
-        # be available in the spec. See
-        # https://github.com/spack/spack/issues/9149 for details.
-        if "gettext" in self.spec:
+        if any("libintl." in filename.split("/")[-1] for filename in self.spec["gettext"].libs):
             env.append_flags("LDFLAGS", "-L{0} -lintl".format(self.spec["gettext"].prefix.lib))


### PR DESCRIPTION
### @sethrj Thank you very much for reviewing my gettext/libintl check for bcache in https://github.com/spack/spack/pull/34114 and https://github.com/spack/spack/pull/34383!

### This adds the same check to elfutils to support spack external find gettext on glibc systems for building elfutils:

glibc's libc.so provides an integrated libintl, which is why on glibc systems, the gettext packages provide no libintl.so library.

To support `spack external find gettext` on glibc systems, the recipe must check if `spec["gettext"].libs` contains libintl if adding -lintl.

The fix to add this check has been successfully reviewed and merged in the bcache recipe, so use it for adding -lintl in elfutils likewise.

See #34114 and #34383 for the details on arriving on this already used check.

#### PS: Since #9149 is fixed by #33777, `self.spec[dependency]` can be used in any case.