### PR TITLE
Package libxcrypt: Added dependency on perl

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -33,7 +33,7 @@ class Libxcrypt(AutotoolsPackage):
     patch("truncating-conversion.patch", when="@4.4.30")
 
     depends_on("perl@5.15:", type="build")
-    
+
     def configure_args(self):
         args = [
             # Disable test dependency on Python (Python itself depends on libxcrypt).

--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -32,6 +32,8 @@ class Libxcrypt(AutotoolsPackage):
 
     patch("truncating-conversion.patch", when="@4.4.30")
 
+    depends_on("perl@5.15:", type="build")
+    
     def configure_args(self):
         args = [
             # Disable test dependency on Python (Python itself depends on libxcrypt).


### PR DESCRIPTION
libxcrypt needs to run a perl script at build time which requires a perl pragma "use open".  If this is not provided by the OS, then libxcrypt fails to install.  This causes more important things to fail such as python which directly depends on libxcrypt.  This failure occurs in OSes like RHEL9 which do not by default install the "perl-open" package.