### PR TITLE
remove warning in download_tarball

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1576,10 +1576,6 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
             )
         )
 
-    tty.warn(
-        "download_tarball() was unable to download "
-        + "{0} from any configured mirrors".format(spec)
-    )
     return None
 
 


### PR DESCRIPTION
`download_tarball` is called during `spack install` now for direct fetches, and
issues a lot of warnings about missing remote binaries. That should not happen.


![Screenshot from 2022-12-15 13-10-40](https://user-images.githubusercontent.com/194764/207855998-d3f75fe5-840d-4f40-8cc2-6e8a5fe45dbd.png)
