### PR TITLE
mirrors: auto-update paths to urls

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -43,6 +43,8 @@ BINARY_METADATA = {
         "The sha256 checksum of binaries is checked before installation."
     ),
     "info": {
+        # This is a mis-nomer since it's not a URL; but file urls cannot
+        # represent relative paths, so we have to live with it for now.
         "url": os.path.join("..", "..", LOCAL_MIRROR_DIR),
         "homepage": "https://github.com/spack/spack-bootstrap-mirrors",
         "releases": "https://github.com/spack/spack-bootstrap-mirrors/releases",
@@ -58,7 +60,11 @@ PATCHELF_JSON = "$spack/share/spack/bootstrap/github-actions-v0.4/patchelf.json"
 SOURCE_METADATA = {
     "type": "install",
     "description": "Mirror with software needed to bootstrap Spack",
-    "info": {"url": os.path.join("..", "..", LOCAL_MIRROR_DIR)},
+    "info": {
+        # This is a mis-nomer since it's not a URL; but file urls cannot
+        # represent relative paths, so we have to live with it for now.
+        "url": os.path.join("..", "..", LOCAL_MIRROR_DIR)
+    },
 }
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -144,7 +144,7 @@ def setup_parser(subparser):
 
 
 def promote_deprecated_path_to_url(path_or_url):
-    # Spack tutorial still mention spac mirror add <name> <path>
+    # Spack tutorial still mentions spack mirror add <name> <path>
     # but the commands really expect URLs.
     if not url_util.is_path_instead_of_url(path_or_url):
         return path_or_url

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -143,9 +143,22 @@ def setup_parser(subparser):
     )
 
 
+def promote_deprecated_path_to_url(path_or_url):
+    # Spack tutorial still mention spac mirror add <name> <path>
+    # but the commands really expect URLs.
+    if not url_util.is_path_instead_of_url(path_or_url):
+        return path_or_url
+
+    url = url_util.path_to_file_url(path_or_url)
+
+    tty.warn("Converted path to URL: {}.".format(url))
+
+    return path_or_url
+
+
 def mirror_add(args):
     """Add a mirror to Spack."""
-    url = url_util.format(args.url)
+    url = url_util.format(promote_deprecated_path_to_url(args.url))
     spack.mirror.add(args.name, url, args.scope, args)
 
 
@@ -156,7 +169,7 @@ def mirror_remove(args):
 
 def mirror_set_url(args):
     """Change the URL of a mirror."""
-    url = url_util.format(args.url)
+    url = url_util.format(promote_deprecated_path_to_url(args.url))
     mirrors = spack.config.get("mirrors", scope=args.scope)
     if not mirrors:
         mirrors = syaml_dict()

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -37,6 +37,15 @@ import spack.util.url as url_util
 from spack.util.spack_yaml import syaml_dict
 from spack.version import VersionList
 
+#: What schemes do we support
+supported_url_schemes = ("file", "http", "https", "ftp", "s3", "gs")
+
+
+def ensure_valid_url(url: str):
+    scheme = urllib.parse.urlparse(url).scheme
+    if scheme not in supported_url_schemes:
+        raise ValueError("Unsupported URL scheme `{}` for mirror url {}".format(scheme, url))
+
 
 def _is_string(url):
     return isinstance(url, str)
@@ -529,6 +538,8 @@ def add(name, url, scope, args={}):
 
     if name in mirrors:
         tty.die("Mirror with name %s already exists." % name)
+
+    ensure_valid_url(url)
 
     items = [(n, u) for n, u in mirrors.items()]
     mirror_data = url

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -50,7 +50,8 @@ def update(data):
     # Look for filesystem paths that should be replaced by URLs
     changed = False
 
-    for mirror, info in data.items():
+    for mirror in data:
+        info = data[mirror]
         if isinstance(info, str):
             if not url_util.is_path_instead_of_url(info):
                 continue

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -60,7 +60,7 @@ def mirror_dir(tmpdir_factory):
 
 
 @pytest.fixture(scope="function")
-def test_mirror(mirror_dir):
+def test_mirror(mirror_dir, mutable_config):
     mirror_url = url_util.path_to_file_url(mirror_dir)
     mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
     yield mirror_dir

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -60,7 +60,7 @@ def mirror_dir(tmpdir_factory):
 
 
 @pytest.fixture(scope="function")
-def test_mirror(mirror_dir, mutable_config):
+def test_mirror(mirror_dir):
     mirror_url = url_util.path_to_file_url(mirror_dir)
     mirror_cmd("add", "--scope", "site", "test-mirror-func", mirror_url)
     yield mirror_dir

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -22,22 +22,6 @@ import spack.util.gpg
 import spack.util.spack_yaml as syaml
 
 
-@pytest.fixture
-def tmp_scope():
-    """Creates a temporary configuration scope"""
-    base_name = "internal-testing-scope"
-    current_overrides = set(x.name for x in cfg.config.matching_scopes(r"^{0}".format(base_name)))
-
-    num_overrides = 0
-    scope_name = base_name
-    while scope_name in current_overrides:
-        scope_name = "{0}{1}".format(base_name, num_overrides)
-        num_overrides += 1
-
-    with cfg.override(cfg.InternalConfigScope(scope_name)):
-        yield scope_name
-
-
 def test_urlencode_string():
     s = "Spack Test Project"
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -246,15 +246,17 @@ def test_config_with_c_argument(mutable_empty_config):
 
 
 def test_config_add_ordered_dict(mutable_empty_config):
-    config("add", "mirrors:first:/path/to/first")
-    config("add", "mirrors:second:/path/to/second")
-    output = config("get", "mirrors")
+    config("add", "upstreams:first:install_tree:/path/to/first")
+    config("add", "upstreams:second:install_tree:/path/to/second")
+    output = config("get", "upstreams")
 
     assert (
         output
-        == """mirrors:
-  first: /path/to/first
-  second: /path/to/second
+        == """upstreams:
+  first:
+    install_tree: /path/to/first
+  second:
+    install_tree: /path/to/second
 """
     )
 

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -25,25 +25,6 @@ mirror = SpackCommand("mirror")
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
-@pytest.fixture
-def tmp_scope():
-    """Creates a temporary configuration scope"""
-
-    base_name = "internal-testing-scope"
-    current_overrides = set(
-        x.name for x in spack.config.config.matching_scopes(r"^{0}".format(base_name))
-    )
-
-    num_overrides = 0
-    scope_name = base_name
-    while scope_name in current_overrides:
-        scope_name = "{0}{1}".format(base_name, num_overrides)
-        num_overrides += 1
-
-    with spack.config.override(spack.config.InternalConfigScope(scope_name)):
-        yield scope_name
-
-
 # test gpg command detection
 @pytest.mark.parametrize(
     "cmd_name,version",
@@ -81,7 +62,7 @@ def test_no_gpg_in_path(tmpdir, mock_gnupghome, monkeypatch, mutable_config):
 
 
 @pytest.mark.maybeslow
-def test_gpg(tmpdir, tmp_scope, mock_gnupghome):
+def test_gpg(tmpdir, mutable_config, mock_gnupghome):
     # Verify a file with an empty keyring.
     with pytest.raises(ProcessError):
         gpg("verify", os.path.join(mock_gpg_data_path, "content.txt"))
@@ -211,6 +192,6 @@ def test_gpg(tmpdir, tmp_scope, mock_gnupghome):
     test_path = tmpdir.join("named_cache")
     os.makedirs("%s" % test_path)
     mirror_url = "file://%s" % test_path
-    mirror("add", "--scope", tmp_scope, "gpg", mirror_url)
+    mirror("add", "gpg", mirror_url)
     gpg("publish", "--rebuild-index", "-m", "gpg")
     assert os.path.exists("%s/build_cache/_pgp/index.json" % test_path)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -20,6 +20,7 @@ from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which
 from spack.util.spack_yaml import SpackYAMLError
+import spack.schema.mirrors
 
 pytestmark = [
     pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),
@@ -312,3 +313,21 @@ def test_get_all_versions(specs, expected_specs):
     output_list = [str(x) for x in output_list]
     # Compare sets since order is not important
     assert set(output_list) == set(expected_specs)
+
+
+def test_mirror_update_path_to_url():
+    path = os.getcwd()
+    url = url_util.path_to_file_url(path)
+    old_config = {
+        "mirror_1": path,
+        "mirror_2": {
+            "push": {"url": path},
+            "fetch": {"url": path},
+        },
+    }
+    updated = spack.schema.mirrors.update(old_config)
+
+    assert updated
+    assert old_config["mirror_1"] == url
+    assert old_config["mirror_2"]["push"]["url"] == url
+    assert old_config["mirror_2"]["fetch"]["url"] == url

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -13,6 +13,7 @@ from llnl.util.filesystem import resolve_link_target_relative_to_the_link
 
 import spack.mirror
 import spack.repo
+import spack.schema.mirrors
 import spack.util.executable
 import spack.util.spack_json as sjson
 import spack.util.url as url_util
@@ -20,7 +21,6 @@ from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which
 from spack.util.spack_yaml import SpackYAMLError
-import spack.schema.mirrors
 
 pytestmark = [
     pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows"),

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -63,6 +63,20 @@ def file_url_string_to_path(url):
     return urllib.request.url2pathname(urllib.parse.urlparse(url).path)
 
 
+def is_path_instead_of_url(path_or_url):
+    """Historically some config files and spack commands used paths
+    where urls should be used. This utility can be used to validate
+    and promote paths to urls."""
+    scheme = urllib.parse.urlparse(path_or_url).scheme
+
+    # On non-Windows, no scheme means it's likely a path
+    if not sys.platform == "win32":
+        return not scheme
+
+    # On Windows, we may have drive letters.
+    return "A" <= scheme <= "Z"
+
+
 def format(parsed_url):
     """Format a URL string
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1282,7 +1282,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url"
+        SPACK_COMPREPLY="-h --help --directory --url --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url"
     else
         _mirrors
     fi


### PR DESCRIPTION
Fixes #34532

- Fix an issue where paths were used in urls in bootstrap mirrors
- Fix an issue where file paths in `mirrors.yaml` config instead of urls made Spack open it as a URL
- Add `spack config update` to auto-update file paths to urls in mirrors.yaml
- Add flags `spack mirror add (--directory x | --url x) name` while remaining backwards compatible with now deprecated `spack mirror add <name> <url>`.

The reason to split up --directory / --url in the input is that we can throw reasonable errors in case people do:

```
spack mirror add --url example.com example # missing scheme, error!
spack mirror add example example.com # would be interpreted as a directory without error :|
```
and it helps disambiguate Windows:
```
spack mirror add --directory 'c:\\x\y\z' example # just a path, fine! 
spack mirror add example 'c:\\x\y\z' # directory or url with scheme `c`?
```