### PR TITLE
libzmq: make location of libsodium explicit

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -100,7 +100,7 @@ class Libzmq(AutotoolsPackage):
         config_args.extend(self.enable_or_disable("libunwind"))
 
         if "+libsodium" in self.spec:
-            config_args.append("--with-libsodium")
+            config_args.append("--with-libsodium=" + self.spec["libsodium"].prefix)
         if "~docs" in self.spec:
             config_args.append("--without-docs")
         if "clang" in self.compiler.cc:


### PR DESCRIPTION
`--with-sodium` previously specified for `configure` without explicit location being given.

This has been causing failure of`e4s-mac-pr-build` in the ci pipeline.