### PR TITLE
binary_distribution: show extract / relocate time separately

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -40,6 +40,7 @@ import spack.util.file_cache as file_cache
 import spack.util.gpg
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+import spack.util.timer as timer
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.caches import misc_cache_location
@@ -1833,10 +1834,13 @@ def _extract_inner_tarball(spec, filename, extract_to, unsigned, remote_checksum
     return tarfile_path
 
 
-def extract_tarball(spec, download_result, allow_root=False, unsigned=False, force=False):
+def extract_tarball(
+    spec, download_result, allow_root=False, unsigned=False, force=False, timer=timer.NULL_TIMER
+):
     """
     extract binary tarball for given package into install area
     """
+    timer.start("extract")
     if os.path.exists(spec.prefix):
         if force:
             shutil.rmtree(spec.prefix)
@@ -1925,7 +1929,9 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         raise e
     os.remove(tarfile_path)
     os.remove(specfile_path)
+    timer.stop("extract")
 
+    timer.start("relocate")
     try:
         relocate_package(spec, allow_root)
     except Exception as e:
@@ -1944,6 +1950,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         if os.path.exists(filename):
             os.remove(filename)
         _delete_staged_downloads(download_result)
+    timer.stop("relocate")
 
 
 def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1452,7 +1452,7 @@ def _delete_staged_downloads(download_result):
     download_result["specfile_stage"].destroy()
 
 
-def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
+def download_tarball(spec, unsigned=False, mirrors_for_spec=None, timer=timer.NULL_TIMER):
     """
     Download binary tarball for given package into stage area, returning
     path to downloaded tarball if successful, None otherwise.
@@ -1521,7 +1521,9 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
         for mirror_to_try in mirrors_to_try:
             specfile_url = "{0}.{1}".format(mirror_to_try["specfile"], ext)
             spackfile_url = mirror_to_try["spackfile"]
+            timer.start("fetch {}".format(specfile_url))
             local_specfile_stage = try_fetch(specfile_url)
+            timer.stop("fetch {}".format(specfile_url))
             if local_specfile_stage:
                 local_specfile_path = local_specfile_stage.save_filename
                 signature_verified = False
@@ -1552,7 +1554,9 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                     #     verify signature, checksum doesn't match) we will fail at
                     #     that point instead of trying to download more tarballs from
                     #     the remaining mirrors, looking for one we can use.
+                    timer.start("fetch {}".format(spackfile_url))
                     tarball_stage = try_fetch(spackfile_url)
+                    timer.stop("fetch {}".format(spackfile_url))
                     if tarball_stage:
                         return {
                             "tarball_stage": tarball_stage,

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -581,7 +581,6 @@ def ci_rebuild(args):
             "GNUMAKEFLAGS=--output-sync=recurse",
         ],
         [
-            "time",
             MAKE_COMMAND,
             "SPACK={}".format(args_to_string(spack_cmd)),
             "SPACK_COLOR=always",

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -581,6 +581,7 @@ def ci_rebuild(args):
             "GNUMAKEFLAGS=--output-sync=recurse",
         ],
         [
+            "time",
             MAKE_COMMAND,
             "SPACK={}".format(args_to_string(spack_cmd)),
             "SPACK_COLOR=always",

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -407,8 +407,10 @@ def _process_binary_cache_tarball(
             timer=timer,
         )
 
+    timer.start("database")
     pkg.installed_from_binary_cache = True
     spack.store.db.add(pkg.spec, spack.store.layout, explicit=explicit)
+    timer.stop("database")
     return True
 
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -397,15 +397,18 @@ def _process_binary_cache_tarball(
     tty.msg("Extracting {0} from binary cache".format(pkg_id))
 
     # don't print long padded paths while extracting/relocating binaries
-    timer.start("install")
     with spack.util.path.filter_padding():
         binary_distribution.extract_tarball(
-            binary_spec, download_result, allow_root=False, unsigned=unsigned, force=False
+            binary_spec,
+            download_result,
+            allow_root=False,
+            unsigned=unsigned,
+            force=False,
+            timer=timer,
         )
 
     pkg.installed_from_binary_cache = True
     spack.store.db.add(pkg.spec, spack.store.layout, explicit=explicit)
-    timer.stop("install")
     return True
 
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -383,11 +383,9 @@ def _process_binary_cache_tarball(
         bool: ``True`` if the package was extracted from binary cache,
             else ``False``
     """
-    timer.start("fetch")
     download_result = binary_distribution.download_tarball(
-        binary_spec, unsigned, mirrors_for_spec=mirrors_for_spec
+        binary_spec, unsigned, mirrors_for_spec=mirrors_for_spec, timer=timer
     )
-    timer.stop("fetch")
     # see #10063 : install from source if tarball doesn't exist
     if download_result is None:
         tty.msg("{0} exists in binary cache but with different hash".format(pkg.name))

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -70,7 +70,10 @@ spack:
       - [$sdk_base_spec]
       - [$^visit_specs]
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/data-vis-sdk" }
+  mirrors:
+    mirror:
+      fetch: https://binaries.spack.io/develop/data-vis-sdk
+      push: s3://spack-binaries/develop/data-vis-sdk
 
   gitlab-ci:
     image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,7 +92,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     variant("vtkm", default=False, description="Enable VTK-m")
     variant("zfp", default=False, description="Enable ZFP")
 
-    variant("rebuildme", default=True, description="Change hash please")
+    variant("rebuildme", default=False, description="Change hash please")
 
     # Language Options
     variant("fortran", default=True, sticky=True, description="Enable fortran language features.")

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,7 +92,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     variant("vtkm", default=False, description="Enable VTK-m")
     variant("zfp", default=False, description="Enable ZFP")
 
-    variant("rebuild-me", default=False, description="Change hash please")
+    variant("rebuild-me", default=True, description="Change hash please")
 
     # Language Options
     variant("fortran", default=True, sticky=True, description="Enable fortran language features.")

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,6 +92,8 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     variant("vtkm", default=False, description="Enable VTK-m")
     variant("zfp", default=False, description="Enable ZFP")
 
+    variant("rebuildme", default=True, description="Change hash please")
+
     # Language Options
     variant("fortran", default=True, sticky=True, description="Enable fortran language features.")
 

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,7 +92,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     variant("vtkm", default=False, description="Enable VTK-m")
     variant("zfp", default=False, description="Enable ZFP")
 
-    variant("rebuildme", default=False, description="Change hash please")
+    variant("rebuild-me", default=False, description="Change hash please")
 
     # Language Options
     variant("fortran", default=True, sticky=True, description="Enable fortran language features.")


### PR DESCRIPTION
Replace `Install: 34s` with `Extract: 30s.  Relocate 1s.  Database: 3s.` so that we know where
we ~waste~ spend time

Result from https://gitlab.spack.io/spack/spack/-/jobs/4994086, the totals in seconds:

| Search | Fetch  | Extract | Relocate | Database | Total  |
|--------|--------|---------|----------|----------|--------|
| 0.0    | 324.55 | 265.49  | 49.32    | 210.73   | 851.86 |

![x](https://user-images.githubusercontent.com/194764/207922863-ca6009e2-d051-405a-a431-3c64be63a4af.png)


Notice that this is CPU time, not wall time