### PR TITLE
XNNPACK: fix build on macOS, update deps

### DIFF
--- a/var/spack/repos/builtin/packages/xnnpack/2797.patch
+++ b/var/spack/repos/builtin/packages/xnnpack/2797.patch
@@ -1,0 +1,22 @@
+From 142144085b85904c86d5f9985c964338b133e38d Mon Sep 17 00:00:00 2001
+From: xbwee <xiaobin.wee@gmail.com>
+Date: Mon, 28 Mar 2022 16:32:43 +0800
+Subject: [PATCH 1/2] Fix build error for src/jit (macos_x86_64 only).
+
+Because the target XNNPACK depends on ${JIT_SRCS} directly and does not add C++11 property.
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b611cdf0593fb1630ec298052e1ac58ca854966e..7612532d198a4c2915f23608e6ddd290fb8b7489 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6599,6 +6599,7 @@ ELSE()
+ ENDIF()
+ SET_TARGET_PROPERTIES(XNNPACK PROPERTIES
+   C_STANDARD 99
++  CXX_STANDARD 11
+   C_EXTENSIONS YES)
+ IF(NOT MSVC)
+   SET_PROPERTY(SOURCE ${PROD_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -fno-math-errno ")

--- a/var/spack/repos/builtin/packages/xnnpack/package.py
+++ b/var/spack/repos/builtin/packages/xnnpack/package.py
@@ -42,8 +42,8 @@ class Xnnpack(CMakePackage):
     )
     resource(
         name="fp16",
-        url="https://github.com/Maratyszcza/FP16/archive/3c54eacb74f6f5e39077300c5564156c424d77ba.zip",
-        sha256="0d56bb92f649ec294dbccb13e04865e3c82933b6f6735d1d7145de45da700156",
+        url="https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip",
+        sha256="e66e65515fa09927b348d3d584c68be4215cfe664100d01c9dbc7655a5716d70",
         destination="deps",
         placement="fp16",
     )
@@ -62,26 +62,15 @@ class Xnnpack(CMakePackage):
         placement="pthreadpool",
     )
     resource(
-        name="googletest",
-        url="https://github.com/google/googletest/archive/5a509dbd2e5a6c694116e329c5a20dc190653724.zip",
-        sha256="fcfac631041fce253eba4fc014c28fd620e33e3758f64f8ed5487cc3e1840e3d",
-        destination="deps",
-        placement="googletest",
-    )
-    resource(
-        name="googlebenchmark",
-        url="https://github.com/google/benchmark/archive/v1.4.1.zip",
-        sha256="61ae07eb5d4a0b02753419eb17a82b7d322786bb36ab62bd3df331a4d47c00a7",
-        destination="deps",
-        placement="googlebenchmark",
-    )
-    resource(
         name="psimd",
-        git="https://github.com/Maratyszcza/psimd.git",
-        branch="master",
+        url="https://github.com/Maratyszcza/psimd/archive/10b4ffc6ea9e2e11668f86969586f88bc82aaefa.tar.gz",
+        sha256="1fefd66702cb2eb3462b962f33d4fb23d59a55d5889ee6372469d286c4512df4",
         destination="deps",
         placement="psimd",
     )
+
+    # https://github.com/google/XNNPACK/pull/2797
+    patch("2797.patch", when="@:2022-03-27")
 
     def cmake_args(self):
         # TODO: XNNPACK has a XNNPACK_USE_SYSTEM_LIBS option, but it seems to be broken
@@ -96,14 +85,8 @@ class Xnnpack(CMakePackage):
             self.define(
                 "PTHREADPOOL_SOURCE_DIR", join_path(self.stage.source_path, "deps", "pthreadpool")
             ),
-            self.define(
-                "GOOGLETEST_SOURCE_DIR", join_path(self.stage.source_path, "deps", "googletest")
-            ),
-            self.define(
-                "GOOGLEBENCHMARK_SOURCE_DIR",
-                join_path(self.stage.source_path, "deps", "googlebenchmark"),
-            ),
             self.define("PSIMD_SOURCE_DIR", join_path(self.stage.source_path, "deps", "psimd")),
-            self.define("XNNPACK_BUILD_TESTS", self.run_tests),
-            self.define("XNNPACK_BUILD_BENCHMARKS", self.run_tests),
+            self.define("BUILD_SHARED_LIBS", True),
+            self.define("XNNPACK_BUILD_TESTS", False),
+            self.define("XNNPACK_BUILD_BENCHMARKS", False),
         ]


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 with Apple Clang 14.0.0.