### PR TITLE
vtk-m: update to latest release

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,6 +29,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
+    version("2.0.0-rc1", sha256="4dc018961eeeb3c6bd4e5443d72e79b9d5fb86901e38fb757f74a7a45dbbc0d8")
     version(
         "1.9.0",
         sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4",


### PR DESCRIPTION
Finally! In a preview for a major milestone in the VTK-m project VTK-m v2.0.0-rc1 is finally out :tada: :tada: :tada:

This bring exiting new features, and bugfixes. Find the tentative release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/2.0/release-notes.md

Let me know if we need to change anything else in the package

ViB