### PR TITLE
Remove dep on jupyter meta-package

### DIFF
--- a/var/spack/repos/builtin/packages/r-irkernel/package.py
+++ b/var/spack/repos/builtin/packages/r-irkernel/package.py
@@ -35,7 +35,7 @@ class RIrkernel(RPackage):
     depends_on("r-jsonlite@0.9.6:", type=("build", "run"))
     depends_on("r-uuid", type=("build", "run"))
     depends_on("r-digest", type=("build", "run"))
-    depends_on("py-jupyter", type="run")
+    depends_on("py-jupyter-client", type="run")
 
     depends_on("r-evaluate@0.5.4:", type=("build", "run"), when="@0.7")
     depends_on("r-devtools", type=("build", "run"), when="@0.7")


### PR DESCRIPTION
Right now r-irkernel requires py-jupyter, which is a metapackage for everything in the jupyter ecosystem.  That includes (among other things) the desktop client, qtconsole, which depends on qt. Besides being a huge (and unnecessary) dependency on its own, qt by default transitively pulls in llvm (qt->glx->mesa->llvm), which adds a lot of time to a fresh install. 

I'm pretty sure all that's really needed here at runtime is the jupyter client. 