### PR TITLE
bacio version fix

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -41,4 +41,5 @@ class Bacio(CMakePackage):
         return args
 
     def patch(self):
-        filter_file(".*", "2.4.1", "VERSION", when="bacio@2.4.1")
+        if self.spec.satisifes("@2.4.1"):
+            filter_file(".*", "2.4.1", "VERSION")

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -39,3 +39,6 @@ class Bacio(CMakePackage):
         args = [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 
         return args
+
+    def patch(self):
+        filter_file(".*", "2.4.1", "VERSION", when="bacio@2.4.1")


### PR DESCRIPTION
This PR patches an incorrect version in bacio's VERSION file for bacio@2.4.1. For that release, VERSION contains 2.4.**0**, which gets propagated into the cmake config files.