### PR TITLE
libpng static

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -26,6 +26,8 @@ class Libpng(AutotoolsPackage):
 
     depends_on("zlib@1.0.4:")  # 1.2.5 or later recommended
 
+    variant("shared", default=True)
+
     def configure_args(self):
         args = [
             # not honored, see
@@ -34,6 +36,8 @@ class Libpng(AutotoolsPackage):
             f"CPPFLAGS={self.spec['zlib'].headers.include_flags}",
             f"LDFLAGS={self.spec['zlib'].libs.search_flags}",
         ]
+        if "~shared" in self.spec:
+            args += ["--enable-static", "--disable-shared"]
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -28,7 +28,13 @@ class Libpng(AutotoolsPackage):
 
     depends_on("zlib@1.0.4:")  # 1.2.5 or later recommended
 
-    variant("shared", default=True)
+    variant(
+        "libs",
+        default="shared,static",
+        values=("shared", "static"),
+        multi=True,
+        description="Build shared libs, static libs or both",
+    )
 
     def configure_args(self):
         args = [
@@ -38,8 +44,16 @@ class Libpng(AutotoolsPackage):
             f"CPPFLAGS={self.spec['zlib'].headers.include_flags}",
             f"LDFLAGS={self.spec['zlib'].libs.search_flags}",
         ]
-        if "~shared" in self.spec:
-            args += ["--enable-static", "--disable-shared"]
+
+        if self.spec.satisfies("libs=shared"):
+            args += ["--enable-shared"]
+        else:
+            args += ["--disable-shared"]
+        if self.spec.satisfies("libs=static"):
+            args += ["--enable-static"]
+        else:
+            args += ["--disable-static"]
+
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -45,15 +45,7 @@ class Libpng(AutotoolsPackage):
             f"LDFLAGS={self.spec['zlib'].libs.search_flags}",
         ]
 
-        if self.spec.satisfies("libs=shared"):
-            args += ["--enable-shared"]
-        else:
-            args += ["--disable-shared"]
-        if self.spec.satisfies("libs=static"):
-            args += ["--enable-static"]
-        else:
-            args += ["--disable-static"]
-
+        args += self.enable_or_disable("libs")
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -13,6 +13,8 @@ class Libpng(AutotoolsPackage):
     url = "https://prdownloads.sourceforge.net/libpng/libpng-1.6.37.tar.xz"
     git = "https://github.com/glennrp/libpng.git"
 
+    maintainers = ["AlexanderRichert-NOAA"]
+
     version("1.6.37", sha256="505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca")
     # From http://www.libpng.org/pub/png/libpng.html (2019-04-15)
     #     libpng versions 1.6.36 and earlier have a use-after-free bug in the


### PR DESCRIPTION
This PR enables static-only build of libpng. The package does not currently have a maintainer, so I have added myself. This PR is needed to support NOAA/NWS R&D and operational needs.