### PR TITLE
binutils: Fix support for using the libintl of glibc

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -186,8 +186,11 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         install(join_path(self.build_directory, "bfd", "*.h"), extradir)
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("%cce"):
+        spec = self.spec
+        if spec.satisfies("%cce"):
             env.append_flags("LDFLAGS", "-Wl,-z,muldefs")
 
-        if "+nls" in self.spec:
-            env.append_flags("LDFLAGS", "-lintl")
+        if "+nls" in spec:
+            # Add -lintl if provided by gettext. Otherwise, libintl is provided by system's glibc:
+            if any("libintl." in filename.split("/")[-1] for filename in spec["gettext"].libs):
+                env.append_flags("LDFLAGS", "-lintl")


### PR DESCRIPTION
This reuses same check to support `spack external find gettext` on glibc systems like in #34114 

gettext may be installed by spack or when `spack external find gettext` was used from the host OS.

Glibc-based Linux distributions don't deliver a libintl at all because glibc's libc already provides the API provided by libintl.

Whe using external gettext, but the libs property will not find a libintl library on glibc systems therefore.

Thus, recipes which want to add -lintl to the linker flags should do so only after checking if a separate libintl has been found by gettext's libs property.

The added check has already be reviewed and improved in #34114, and spec = self.spec is used as a simple helper and to no exceed 99 chars on one line.