### PR TITLE
netcdf-cxx: add patch to fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx/macos.patch
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/macos.patch
@@ -1,0 +1,11 @@
+--- a/configure	2011-09-30 09:34:31.000000000 -0500
++++ b/configure	2022-12-16 22:16:06.250866499 -0600
+@@ -2329,7 +2329,7 @@
+ 
+ # Create the VERSION file, which contains the package version from
+ # AC_INIT.
+-echo -n 4.2>VERSION
++echo -n 4.2>VERSION.txt
+ 
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: netCDF-cxx 4.2" >&5

--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -21,6 +21,9 @@ class NetcdfCxx(AutotoolsPackage):
 
     variant("netcdf4", default=True, description="Compile with netCDF4 support")
 
+    # https://github.com/Unidata/netcdf-cxx4/pull/112
+    patch("macos.patch")
+
     @property
     def libs(self):
         shared = True


### PR DESCRIPTION
Successfully builds on macOS 12.6.1 with Apple Clang 14.0.0.

Stole this patch from netcdf-cxx4, the modern version. Unfortunately VTK still depends on this deprecated version for some reason.