### PR TITLE
VTK: fix 9.1–9.2 builds

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -23,11 +23,7 @@ class Vtk(CMakePackage):
 
     version("9.2.2", sha256="1c5b0a2be71fac96ff4831af69e350f7a0ea3168981f790c000709dcf9121075")
     version("9.1.0", sha256="8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96")
-    version(
-        "9.0.3",
-        sha256="bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a",
-        preferred=True,
-    )
+    version("9.0.3", sha256="bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a")
     version("9.0.1", sha256="1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7")
     version("9.0.0", sha256="15def4e6f84d72f82386617fe595ec124dda3cbd13ea19a0dcd91583197d8715")
     version("8.2.0", sha256="34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb")
@@ -149,7 +145,6 @@ class Vtk(CMakePackage):
     depends_on("seacas@2021-05-12:+mpi", when="@9.1: +mpi")
     depends_on("seacas@2021-05-12:~mpi", when="@9.1: ~mpi")
     depends_on("nlohmann-json", when="@9.2:")
-    # depends_on("verdict", when="@9.2:")
 
     # For finding Fujitsu-MPI wrapper commands
     patch("find_fujitsu_mpi.patch", when="@:8.2.0%fj")
@@ -228,6 +223,8 @@ class Vtk(CMakePackage):
                         "-DVTK_MODULE_USE_EXTERNAL_VTK_fmt:BOOL=OFF",
                     ]
                 )
+            if spec.satisfies("@9.2:"):
+                cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
 
         # Some variable names have changed
         if spec.satisfies("@8.2.0"):

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -129,7 +129,7 @@ class Vtk(CMakePackage):
     depends_on("lz4")
     depends_on("netcdf-c~mpi", when="~mpi")
     depends_on("netcdf-c+mpi", when="+mpi")
-    depends_on("netcdf-cxx")
+    depends_on("netcdf-cxx4")
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("zlib")
@@ -148,6 +148,8 @@ class Vtk(CMakePackage):
     depends_on("cgns@4.1.1:~mpi", when="@9.1: ~mpi")
     depends_on("seacas@2021-05-12:+mpi", when="@9.1: +mpi")
     depends_on("seacas@2021-05-12:~mpi", when="@9.1: ~mpi")
+    depends_on("nlohmann-json", when="@9.2:")
+    # depends_on("verdict", when="@9.2:")
 
     # For finding Fujitsu-MPI wrapper commands
     patch("find_fujitsu_mpi.patch", when="@:8.2.0%fj")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -157,6 +157,12 @@ class Vtk(CMakePackage):
         when="@:9.0.1 ^freetype@2.10.3:",
     )
 
+    patch(
+        "https://gitlab.kitware.com/vtk/vtk/-/commit/5a1c96e12e9b4a660d326be3bed115a2ceadb573.patch",
+        sha256="65175731c080961f85d779d613ac1f6bce89783745e54e864edec7637b03b18a",
+        when="@9.1",
+    )
+
     def url_for_version(self, version):
         url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"
         return url.format(version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -125,7 +125,7 @@ class Vtk(CMakePackage):
     depends_on("lz4")
     depends_on("netcdf-c~mpi", when="~mpi")
     depends_on("netcdf-c+mpi", when="+mpi")
-    depends_on("netcdf-cxx4")
+    depends_on("netcdf-cxx")
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("zlib")
@@ -239,7 +239,7 @@ class Vtk(CMakePackage):
             cmake_args.extend(
                 [
                     "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
-                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx4"].prefix),
+                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
                 ]
             )
 
@@ -388,10 +388,10 @@ class Vtk(CMakePackage):
             # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
             # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
             # used instead to detect these bindings
-            netcdf_cxx_lib = spec["netcdf-cxx4"].libs.joined()
+            netcdf_cxx_lib = spec["netcdf-cxx"].libs.joined()
             cmake_args.extend(
                 [
-                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx4"].prefix.include),
+                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx"].prefix.include),
                     "-DNETCDF_CXX_LIBRARY={0}".format(netcdf_cxx_lib),
                 ]
             )

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -239,7 +239,7 @@ class Vtk(CMakePackage):
             cmake_args.extend(
                 [
                     "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
-                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
+                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx4"].prefix),
                 ]
             )
 
@@ -388,10 +388,10 @@ class Vtk(CMakePackage):
             # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
             # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
             # used instead to detect these bindings
-            netcdf_cxx_lib = spec["netcdf-cxx"].libs.joined()
+            netcdf_cxx_lib = spec["netcdf-cxx4"].libs.joined()
             cmake_args.extend(
                 [
-                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx"].prefix.include),
+                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx4"].prefix.include),
                     "-DNETCDF_CXX_LIBRARY={0}".format(netcdf_cxx_lib),
                 ]
             )

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -15,9 +15,9 @@ class Vtk(CMakePackage):
     available software system for 3D computer graphics, image
     processing and visualization."""
 
-    homepage = "http://www.vtk.org"
+    homepage = "https://www.vtk.org"
     url = "https://www.vtk.org/files/release/9.0/VTK-9.0.0.tar.gz"
-    list_url = "http://www.vtk.org/download/"
+    list_url = "https://www.vtk.org/download/"
 
     maintainers = ["chuckatkins", "danlipsa"]
 


### PR DESCRIPTION
This PR includes the following changes:

- [x] Add missing nlohmann-json dependency
- [x] Fix missing verdict dependency, use internal copy since no spack package
- [x] Change default version to latest version (supports default Python version)
- [x] Fix cmake configuration error in 9.1.0

Unfortunately, it still doesn't build. Here is 9.2.2:
```
Undefined symbols for architecture arm64:
  "Ioss::Init::Initializer::Initializer()", referenced from:
      vtkIOSSReader::vtkInternals::vtkInternals(vtkIOSSReader*) in vtkIOSSReader.cxx.o
      vtkIOSSWriter::vtkIOSSWriter() in vtkIOSSWriter.cxx.o
  "Ioss::Init::Initializer::~Initializer()", referenced from:
      vtkIOSSReader::vtkInternals::vtkInternals(vtkIOSSReader*) in vtkIOSSReader.cxx.o
      vtkIOSSReader::vtkInternals::~vtkInternals() in vtkIOSSReader.cxx.o
      std::__1::unique_ptr<vtkIOSSWriter::vtkInternals, std::__1::default_delete<vtkIOSSWriter::vtkInternals> >::~unique_ptr() in vtkIOSSWriter.cxx.o
      vtkIOSSWriter::~vtkIOSSWriter() in vtkIOSSWriter.cxx.o
      vtkIOSSWriter::vtkIOSSWriter() (.cold.1) in vtkIOSSWriter.cxx.o
  "Iotr::Factory::create(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      vtkIOSSUtilities::GetConnectivity(Ioss::GroupingEntity*, int&, vtkIOSSUtilities::Cache*) in vtkIOSSUtilities.cxx.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libvtkIOIOSS-9.2.9.2.2.dylib] Error 1
make[1]: *** [IO/IOSS/CMakeFiles/IOIOSS.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
9.1.0 also has problems (note that I'm building `~mpi`):
```
/var/folders/j1/68dlgpr91vlgs26vty2c8xk80000gn/T/ajstewart/spack-stage/spack-stage-vtk-9.1.0-t2rhk4gjtvvw7em3dvbpfhb2qnmrwevh/spack-src/IO/IOSS/vtkIOSSReader.cxx:1304:38: error: use of undeclared identifier 'MPI_COMM_WORLD'
      dbasename, Ioss::READ_RESTART, MPI_COMM_WORLD, properties));
                                     ^
```
Any suggestions would be useful.