### PR TITLE
py-pyvista: add v0.37.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyvista/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvista/package.py
@@ -12,6 +12,8 @@ class PyPyvista(PythonPackage):
     homepage = "https://github.com/pyvista/pyvista"
     pypi = "pyvista/pyvista-0.32.1.tar.gz"
 
+    maintainers = ["banesullivan"]
+
     version("0.37.0", sha256="d36a2c6d5f53f473ab6a9241669693acee7a5179394dc97595da14cc1de23141")
     version("0.32.1", sha256="585ac79524e351924730aff9b7207d6c5ac4175dbb5d33f7a9a2de22ae53dbf9")
 

--- a/var/spack/repos/builtin/packages/py-pyvista/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvista/package.py
@@ -12,15 +12,18 @@ class PyPyvista(PythonPackage):
     homepage = "https://github.com/pyvista/pyvista"
     pypi = "pyvista/pyvista-0.32.1.tar.gz"
 
+    version("0.37.0", sha256="d36a2c6d5f53f473ab6a9241669693acee7a5179394dc97595da14cc1de23141")
     version("0.32.1", sha256="585ac79524e351924730aff9b7207d6c5ac4175dbb5d33f7a9a2de22ae53dbf9")
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-imageio", type=("build", "run"))
     depends_on("pil", type=("build", "run"))
-    depends_on("py-appdirs", type=("build", "run"))
+    depends_on("py-pooch", when="@0.37:", type=("build", "run"))
     depends_on("py-scooby@0.5.1:", type=("build", "run"))
-    depends_on("py-meshio@4.0.3:4", type=("build", "run"))
     depends_on("vtk+python", type=("build", "run"))
-    depends_on("py-typing-extensions", type=("build", "run"))
+    depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-appdirs", when="@:0.36", type=("build", "run"))
+    depends_on("py-meshio@4.0.3:4", when="@:0.32", type=("build", "run"))


### PR DESCRIPTION
Successfully installs on macOS 12.6.1 with Python 3.9.15 and Apple Clang 14.0.0.

@banesullivan any interest in helping to maintain this build recipe? You don't need to know anything about Spack, it just gives us someone to ping for build issues and to review PRs like this one.

P.S. Thanks for your help with porting TorchGeo from Open3D to PyVista!