### PR TITLE
py-horovod: patch no longer applies

### DIFF
--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -159,7 +159,7 @@ class PyHorovod(PythonPackage, CudaPackage):
     # Patch vendored copy of eigen to fix build on aarch64
     # https://github.com/horovod/horovod/issues/3605
     # https://gitlab.com/libeigen/eigen/-/commit/fd1dcb6b45a2c797ad4c4d6cc7678ee70763b4ed
-    patch("eigen.patch", when="@0.21: target=aarch64:")
+    patch("eigen.patch", when="@0.21:0.25 target=aarch64:")
 
     @property
     def import_modules(self):


### PR DESCRIPTION
The submodule was updated so the patch is no longer needed. Discovered in #34300