### PR TITLE
hpctoolkit: replace filter_file with upstream patch

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -159,27 +159,19 @@ class Hpctoolkit(AutotoolsPackage):
         when="@2019.08.01:2021.03 %gcc@11.0:",
     )
 
+    # Update configure for rocm 5.3.0
+    patch(
+        "https://gitlab.com/hpctoolkit/hpctoolkit/-/commit/411d62544717873432c49ef45c7cb99cc5de2fb8.patch",
+        sha256="484045891a665cdba3b0f141540c89f0d691ed32c5912ef62a93670d44c2786c",
+        when="@2022.04:2022.10 +rocm ^hip@5.3.0:",
+    )
+
     # Change python to python3 for some old revs that use a script
     # with /usr/bin/env python.
     depends_on("python@3.4:", type="build", when="@2020.03:2020.08")
     patch("python3.patch", when="@2020.03:2020.08")
 
     flag_handler = AutotoolsPackage.build_system_flags
-
-    def patch(self):
-        if self.spec.satisfies("^hip@5.3.0:"):
-            filter_file(
-                'ROCM_HSA_IFLAGS="-I$ROCM_HSA/include/hsa"',
-                'ROCM_HSA_IFLAGS="-I$ROCM_HSA/include"',
-                "configure",
-                string=True,
-            )
-            filter_file(
-                "#include <hsa.h>",
-                "#include <hsa/hsa.h>",
-                "src/tool/hpcrun/gpu/amd/roctracer-api.c",
-                string=True,
-            )
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Replace the filter_file for older configure with rocm 5.3 with an upstream patch.  Further, the patch is no longer needed for develop or later releases.