### PR TITLE
eckit: skip broken test

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -152,6 +152,16 @@ class Eckit(CMakePackage):
 
     def check(self):
         ctest_args = ["-j", str(make_jobs)]
+
+        broken_tests = []
+        if self._enable_experimental:
+            # The following test quasi-randomly fails not because it reveals a bug in the library
+            # but because its implementation has a bug (static initialization order fiasco):
+            broken_tests.append("eckit_test_experimental_singleton_singleton")
+
+        if broken_tests:
+            ctest_args.extend(["-E", "|".join(broken_tests)])
+
         with working_dir(self.build_directory):
             ctest(*ctest_args)
 

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -88,7 +88,7 @@ class Eckit(CMakePackage):
     def cmake_args(self):
         args = [
             # Some features that we want to build are experimental:
-            self.define("ENABLE_EXPERIMENTAL", True),
+            self.define("ENABLE_EXPERIMENTAL", self._enable_experimental),
             self.define_from_variant("ENABLE_BUILD_TOOLS", "tools"),
             # We let ecBuild find the MPI library. We could help it by setting
             # CMAKE_C_COMPILER to mpicc but that might give CMake a wrong
@@ -154,3 +154,7 @@ class Eckit(CMakePackage):
         ctest_args = ["-j", str(make_jobs)]
         with working_dir(self.build_directory):
             ctest(*ctest_args)
+
+    @property
+    def _enable_experimental(self):
+        return "linalg=armadillo" in self.spec

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -149,3 +149,8 @@ class Eckit(CMakePackage):
             args.append(self.define("CURSES_NEED_NCURSES", True))
 
         return args
+
+    def check(self):
+        ctest_args = ["-j", str(make_jobs)]
+        with working_dir(self.build_directory):
+            ctest(*ctest_args)


### PR DESCRIPTION
We have to enable all experimental features when `linalg=armadillo`. Unfortunately, one of such features is to run `eckit_test_experimental_singleton_singleton`, which is broken: it fails quasi-randomly due to a bug in its implementation. This PR introduces a workaround: skip the test when the experimental features are enabled.