### PR TITLE
Create Windows package defaults

### DIFF
--- a/etc/spack/defaults/windows/packages.yaml
+++ b/etc/spack/defaults/windows/packages.yaml
@@ -1,0 +1,21 @@
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  all:
+    compiler:
+    - msvc
+    providers:
+      mpi: [msmpi]

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -18,7 +18,7 @@ class Msmpi(Package):
     url = "https://github.com/microsoft/Microsoft-MPI/archive/refs/tags/v10.1.1.tar.gz"
     git = "https://github.com/microsoft/Microsoft-MPI.git"
 
-    executable = ["mpiexec.exe"]
+    executable = ["mpiexec"]
 
     version("10.1.1", sha256="63c7da941fc4ffb05a0f97bd54a67968c71f63389a0d162d3182eabba1beab3d")
     version("10.0.0", sha256="cfb53cf53c3cf0d4935ab58be13f013a0f7ccb1189109a5b8eea0fcfdcaef8c1")
@@ -31,9 +31,9 @@ class Msmpi(Package):
 
     @classmethod
     def determine_version(cls, exe):
-        output = Executable(exe)()
-        ver_str = re.search("[Version ([0-9.]+)]", output)
-        return Version(ver_str.group(0)) if ver_str else None
+        output = Executable(exe)(output=str, error=str)
+        ver_str = re.search(r"\[Version ([0-9.]+)\]", output)
+        return Version(ver_str.group(1)) if ver_str else None
 
 
 class GenericBuilder(GenericBuilder):

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -37,7 +37,7 @@ class Msmpi(Package):
         if sys.platform != "win32":
             return None
         output = Executable(exe)(output=str, error=str)
-        ver_str = re.search(r"\[Version ([0-9.]+)\]", output)
+        ver_str = re.search(r"Microsoft MPI Startup Program \[Version ([0-9.]+)\]", output)
         return Version(ver_str.group(1)) if ver_str else None
 
 

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -6,6 +6,7 @@
 import os
 import platform
 import re
+import sys
 
 from spack.build_systems.generic import GenericBuilder
 from spack.package import *
@@ -31,6 +32,10 @@ class Msmpi(Package):
 
     @classmethod
     def determine_version(cls, exe):
+        # MSMPI is typically MS only, don't detect on other platforms
+        # to avoid potential collisions with other mpiexec executables
+        if sys.platform != "win32":
+            return None
         output = Executable(exe)(output=str, error=str)
         ver_str = re.search(r"\[Version ([0-9.]+)\]", output)
         return Version(ver_str.group(1)) if ver_str else None


### PR DESCRIPTION
Additionally update MSMPI external detection logic as we're now defaulting to that implementation to provide MPI.