### PR TITLE
FileCache: Delete the new cache file on exception

### DIFF
--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -33,6 +33,7 @@ def test_write_and_read_cache_file(file_cache):
         assert text == "foobar\n"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Locks not supported on Windows")
 def test_failed_write_and_read_cache_file(file_cache):
     """Test failing to write then attempting to read a cached file."""
     with pytest.raises(RuntimeError, match=r"^foobar$"):

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -5,7 +5,6 @@
 
 """Test Spack's FileCache."""
 import os
-import re
 import sys
 
 import pytest

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -43,9 +43,7 @@ def test_failed_write_and_read_cache_file(file_cache):
             raise RuntimeError("foobar")
 
     # Cache dir should have exactly one (lock) file
-    files = os.listdir(file_cache.root)
-    assert len(files) <= 1
-    assert not files or re.fullmatch(r"^\..*\.lock$", files[0])
+    assert os.listdir(file_cache.root) == [".test.yaml.lock"]
 
     # File does not exist
     assert not file_cache.init_entry("test.yaml")

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -43,8 +43,8 @@ def test_failed_write_and_read_cache_file(file_cache):
 
     # Cache dir should have exactly one (lock) file
     files = os.listdir(file_cache.root)
-    assert len(files) == 1
-    assert re.fullmatch(r"^\..*\.lock$", files[0])
+    assert len(files) <= 1
+    assert not files or re.fullmatch(r"^\..*\.lock$", files[0])
 
     # File does not exist
     assert not file_cache.init_entry("test.yaml")

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -5,6 +5,7 @@
 
 """Test Spack's FileCache."""
 import os
+import re
 import sys
 
 import pytest
@@ -30,6 +31,28 @@ def test_write_and_read_cache_file(file_cache):
     with file_cache.read_transaction("test.yaml") as stream:
         text = stream.read()
         assert text == "foobar\n"
+
+
+def test_failed_write_and_read_cache_file(file_cache):
+    """Test failing to write then attempting to read a cached file."""
+    with pytest.raises(RuntimeError, match=r"^foobar$"):
+        with file_cache.write_transaction("test.yaml") as (old, new):
+            assert old is None
+            assert new is not None
+            raise RuntimeError("foobar")
+
+    # Cache dir should have exactly one (lock) file
+    files = os.listdir(file_cache.root)
+    assert len(files) == 1
+    assert re.fullmatch(r"^\..*\.lock$", files[0])
+
+    # File does not exist
+    assert not file_cache.init_entry("test.yaml")
+
+    # Attempting to read will cause a FileNotFoundError
+    with pytest.raises(FileNotFoundError, match=r"test\.yaml"):
+        with file_cache.read_transaction("test.yaml"):
+            pass
 
 
 def test_write_and_remove_cache_file(file_cache):

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -145,7 +145,7 @@ class FileCache(object):
 
                 if value:
                     # remove tmp on exception & raise it
-                    shutil.rmtree(cm.tmp_filename, True)
+                    os.remove(cm.tmp_filename)
 
                 else:
                     rename(cm.tmp_filename, cm.orig_filename)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -144,7 +144,6 @@ class FileCache(object):
                 cm.tmp_file.close()
 
                 if value:
-                    # remove tmp on exception & raise it
                     os.remove(cm.tmp_filename)
 
                 else:


### PR DESCRIPTION
The code in `FileCache` for `write_transaction` attempts to delete the temporary file when an exception occurs under the context by calling `shutil.rmtree`. However, [`rmtree` only operates on directories](https://docs.python.org/3/library/shutil.html#shutil.rmtree) while the rest of `FileCache` uses normal files. This causes an empty file to be written to the cache key when unneeded.

Use `os.remove` instead which [operates on normal files](https://docs.python.org/3/library/os.html#os.remove).