### PR TITLE
[WIP] Allow module projections to be formattable

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -551,7 +551,7 @@ class BaseConfiguration(object):
     @property
     def literals_to_load(self):
         """List of literal modules to be loaded."""
-        return self.conf.get("load", [])
+        return [self.spec.format(s) for s in self.conf.get("load", [])]
 
     @property
     def specs_to_prereq(self):


### PR DESCRIPTION
This PR enables Spack to generate module names and module loads based on the spec. For instance, 
```modules:
  default:
    lmod:
      'hpctoolkit +cuda':
        load: ['cuda/{^cuda.version}']
```
will automatically insert the following line in the module:
```
depends_on("cuda/11.5.2")
```
where `11.5.2` is the CUDA version that `hpctoolkit` was built against.

Tested on my workstation with the following `spack.yaml` environment file.

```yaml
spack:
  view: false
  concretizer:
    unify: when_possible
  'compilers:':
  - compiler:
      spec: gcc@10.3.0
      paths:
        cc: /usr/bin/gcc-10
        cxx: /usr/bin/g++-10
        f77: /usr/bin/gfortran-10
        fc: /usr/bin/gfortran-10
      flags: {}                                                                                                                     
      operating_system: ubuntu20.04
      target: x86_64
      modules: [gcc/10.3.0]
      environment: {}                                                                                                               
      extra_rpaths: []
  packages:
    cuda:
      buildable: false
      externals:
      - spec: cuda@11.8.0
        prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/22.11/cuda/11.8
        modules: [cuda/11.8-nvhpc]
      - spec: cuda@12.0.0
        prefix: /usr/local/cuda-12.0
        modules: [cuda/12.0]
  specs:
  - matrix:
    - [hwloc +cuda]
    - [^cuda@11.8.0, ^cuda@12.0.0]
  specs:
  - matrix:
    - [hwloc +cuda]
    - [^cuda@11.8.0, ^cuda@12.0.0]
  modules:
    default:
      enable: [lmod]
      arch_folder: false
      lmod:
        projections:
          ^cuda: '{name}/{version}-cuda{^cuda.version}'
        '^cuda':
          load: ['cuda/{^cuda.version}']
```