### PR TITLE
s3: adaptor for Request objects and ClientError

### DIFF
--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -42,15 +42,50 @@ class WrapStream(BufferedReader):
         return getattr(self.raw, key)
 
 
-def _s3_open(url, method="GET"):
-    parsed = urllib.parse.urlparse(url)
-    s3 = s3_util.get_s3_session(url, method="fetch")
+def client_error_to_http_error(url, e):
+    """Adaptor to transform S3 ClientError errors into HTTPError.
+    This makes error handling easier, since the call-site can deal
+    uniformly with status codes. In particular it's easier to
+    deal specifically with 404 Not Found or 304 Not Modified
+    errors without having to worry about the protocol."""
+    metadata = e.response.get("ResponseMetadata", None)
 
-    bucket = parsed.netloc
-    key = parsed.path
+    if not metadata:
+        return urllib.error.URLError(e)
 
-    if key.startswith("/"):
-        key = key[1:]
+    code = metadata.get("HTTPStatusCode", None)
+
+    if code:
+        error = e.response.get("Error", {})
+        return urllib.error.HTTPError(
+            url=url,
+            code=code,
+            msg=error.get("Message", ""),
+            hdrs=metadata.get("HTTPHeaders", {}),
+            fp=None,
+        )
+
+    return urllib.error.URLError(e)
+
+
+def request_to_s3_client_kwargs(req: urllib.request.Request):
+    """Adaptor for Request -> s3 get_*(...) kwargs.
+    This allows us to translate HTTP headers like If-None-Match: <tag>
+    to the approriate key."""
+    url = urllib.parse.urlparse(req.get_full_url())
+    kwargs = {"Bucket": url.netloc, "Key": url.path.lstrip("/")}
+
+    # Maybe this can be more efficient as header keys are
+    # case-normalized. Right now we only handle If-None-Match.
+    for name, value in req.header_items():
+        if name.lower() == "if-none-match":
+            # HTTP rfc's require quotes, s3 does not.
+            kwargs["IfNoneMatch"] = value.replace('"', "")
+    return kwargs
+
+
+def _s3_open(url, method="GET", **kwargs):
+    client = s3_util.get_s3_session(url, method="fetch")
 
     if method not in ("GET", "HEAD"):
         raise urllib.error.URLError(
@@ -59,14 +94,14 @@ def _s3_open(url, method="GET"):
 
     try:
         if method == "GET":
-            obj = s3.get_object(Bucket=bucket, Key=key)
+            obj = client.get_object(**kwargs)
             # NOTE(opadron): Apply workaround here (see above)
             stream = WrapStream(obj["Body"])
         elif method == "HEAD":
-            obj = s3.head_object(Bucket=bucket, Key=key)
+            obj = client.head_object(**kwargs)
             stream = BytesIO()
-    except s3.ClientError as e:
-        raise urllib.error.URLError(e) from e
+    except client.ClientError as e:
+        raise client_error_to_http_error(url, e) from e
 
     headers = obj["ResponseMetadata"]["HTTPHeaders"]
 
@@ -76,5 +111,7 @@ def _s3_open(url, method="GET"):
 class UrllibS3Handler(urllib.request.BaseHandler):
     def s3_open(self, req):
         orig_url = req.get_full_url()
-        url, headers, stream = _s3_open(orig_url, method=req.get_method())
+        url, headers, stream = _s3_open(
+            url=orig_url, method=req.get_method(), **request_to_s3_client_kwargs(req)
+        )
         return urllib.response.addinfourl(stream, headers, url)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -356,7 +356,7 @@ def test_s3_request_to_s3_client_kwargs():
 def test_client_error_to_http_error_adaptor():
     err = spack.s3_handler.client_error_to_http_error("s3://my-bucket/x/y", MockClientError())
     assert isinstance(err, urllib.error.HTTPError)
-    assert err.status == 404
+    assert err.getcode() == 404
 
     err = spack.s3_handler.client_error_to_http_error(
         "s3://my-bucket/x/y", MockClientError(response={})


### PR DESCRIPTION
This makes `urlopen(Request("s3://..."))` more HTTP-like, so that the
call site can provide certain http(s) headers such as If-None-Match for
etags, without having to care about the protocol.

Also, this maps s3 client errors to HTTPError, so that the call site can
do error handling uniformly (in particular, distinguish between fatal
and non-fatal errors: 404 and 304 repsonses may require different error
handling in certain cases).

This makes it all a bit easier to implement caching with etags.

It's sure is a bit awkward, but the thing is that s3 is an optional
dependency, so it would great if the call site didn't have to worry
about s3 at all.
