### PR TITLE
index.json.hash, no fatal error if key cannot be fetched

### DIFF
--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -854,8 +854,7 @@ def test_default_index_invalid_hash_file(index_json):
         url="https://www.example.com", local_hash=index_json_hash, urlopen=urlopen
     )
 
-    with pytest.raises(bindist.FetchIndexError, match="Invalid hash format"):
-        fetcher.conditional_fetch()
+    assert fetcher.get_remote_hash() is None
 
 
 def test_default_index_json_404():


### PR DESCRIPTION
Not being able to fetch `index.json.hash` shouldn't prevent fetching `index.json`.

Also set the Spack `User-Agent`