### PR TITLE
libelf: fix build on macOS x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -30,14 +30,14 @@ class Libelf(AutotoolsPackage):
     provides("elf@0")
 
     # configure: error: neither int nor long is 32-bit
-    depends_on("automake", when="platform=darwin target=aarch64:", type="build")
-    depends_on("autoconf", when="platform=darwin target=aarch64:", type="build")
-    depends_on("libtool", when="platform=darwin target=aarch64:", type="build")
-    depends_on("m4", when="platform=darwin target=aarch64:", type="build")
+    depends_on("automake", when="platform=darwin", type="build")
+    depends_on("autoconf", when="platform=darwin", type="build")
+    depends_on("libtool", when="platform=darwin", type="build")
+    depends_on("m4", when="platform=darwin", type="build")
 
     @property
     def force_autoreconf(self):
-        return self.spec.satisfies("platform=darwin target=aarch64:")
+        return self.spec.satisfies("platform=darwin")
 
     def configure_args(self):
         args = ["--enable-shared", "--disable-debug"]


### PR DESCRIPTION
Hit the exact same error on macOS x86_64, same fix worked for me. According to https://trac.macports.org/ticket/61564 this is an Xcode 12+ thing, not an M1 thing.

Successfully builds and passes all tests on macOS 10.15.7 with Apple Clang 12.0.0.