### PR TITLE
py-kornia: add v0.6.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-kornia/package.py
+++ b/var/spack/repos/builtin/packages/py-kornia/package.py
@@ -12,6 +12,7 @@ class PyKornia(PythonPackage):
     homepage = "https://www.kornia.org/"
     pypi = "kornia/kornia-0.5.10.tar.gz"
 
+    version("0.6.9", sha256="b756bba0db8d47046417fa72271b2d648c570ec6f1d61e1805e6a36911f63bb9")
     version("0.6.8", sha256="0985e02453c0ab4f030e8d22a3a7554dab312ffa8f8a54ec872190e6f0b58c56")
     version("0.6.7", sha256="7ff57c931551a1a1465aaac1fa6842a2aad650f51a0f9bf6cf0b0f7d6e5fb59c")
     version("0.6.6", sha256="e29f0f994e3bafec016b101a9a3e89c3751b4fe99ada3ac21d3febb47904faa4")
@@ -22,9 +23,9 @@ class PyKornia(PythonPackage):
     version("0.6.1", sha256="f638fb3309f88666545866c162f510b6d485fd8f7131d5570d4e6c0d295fdcd6")
     version("0.5.10", sha256="428b4b934a2ba7360cc6cba051ed8fd96c2d0f66611fdca0834e82845f14f65d")
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-pytest-runner", type="build")
-    depends_on("py-torch@1.6.0:", type=("build", "run"))
-    depends_on("py-torch@1.8.1:", when="@0.6:", type=("build", "run"))
     depends_on("py-packaging", when="@0.6:", type=("build", "run"))
+    depends_on("py-torch@1.9.1:", when="@0.6.9:", type=("build", "run"))
+    depends_on("py-torch@1.8.1:", when="@0.6:", type=("build", "run"))
+    depends_on("py-torch@1.6.0:", type=("build", "run"))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.

https://github.com/kornia/kornia/releases/tag/v0.6.9