### PR TITLE
Workaround for config error - hdf with cray

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -171,6 +171,10 @@ class Hdf(AutotoolsPackage):
             # configure script.
             config_args.append("LIBS=%s" % self.spec["rpc"].libs.link_flags)
 
+            # crayftn doesn't respect LIBRARY_PATH, so configure fails without this
+            if self.spec.compiler.name == "cce":
+                config_args.append("LDFLAGS=%s" % self.spec["rpc"].libs.search_flags)
+
         # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
         if self.spec.satisfies("%gcc@10:"):
             config_args.extend(


### PR DESCRIPTION
This PR resolves a build failure when compiling HDF4 using the Cray compilers. The configure script will do a version check, but if you use a non-system RPC library, the LIBS variable is set to something (e.g., `-ltirpc`) and this gets appended to the conf test compile. Since the Spack wrapper is running in `vcheck` mode, no library paths are added.

This command works for other compilers, presumably because they respect LIBRARY_PATH which *is* set, but Cray's Fortran compiler does not do anything with LIBRARY_PATH and so you get an error that `-ltirpc` cannot be found.

This PR sets LDFLAGS to include the search paths for RPC packages when `+external-xdr` is set and the Cray compiler is being used.