### PR TITLE
sqlite: basic support (export & import)

### DIFF
--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1059,3 +1059,24 @@ def test_query_installed_when_package_unknown(database, tmpdir):
             assert not s.installed_upstream
             with pytest.raises(spack.repo.UnknownNamespaceError):
                 s.package
+
+
+def test_sqlite_roundtrip(database: spack.database.Database, tmpdir):
+    # Test that export to sqlite and importing back gives the same database.
+    assert len(database.query_local()) > 0
+    export = str(tmpdir.join("dump.sqlite"))
+    database.to_sqlite(export)
+    new_db = spack.database.Database(str(tmpdir))
+    new_db.from_sqlite(export)
+    assert new_db.query_local() == database.query_local()
+
+
+def test_sqlite_export_failure(database: spack.database.Database, tmpdir):
+    export = str(tmpdir.join("dump.sqlite"))
+    # works
+    database.to_sqlite(export)
+
+    with pytest.raises(ValueError):
+        database.to_sqlite(export)
+
+    database.to_sqlite(export, force=True)


### PR DESCRIPTION
This would be a useful default format to replace index.json in buildcaches, cause it allows for fast lookups without the string -> dict -> Spec overhead.

As a datapoint (from the develop e4s buildcache):

```
$ du -sh index.*
96M	index.json
70M	index.sqlite
```

So file size is better, even with an index both on hash & package name.

Compressed size is slightly worse, but not much:

```
$ gzip --keep index.json index.sqlite
$ du -sh *.gz
9.4M	index.json.gz
12M	index.sqlite.gz

$ zstd index.json index.sqlite
$ du -sh *.zst
5.2M	index.json.zst
7.2M	index.sqlite.zst
```

Querying for existence is fast and O(1):

```
$ python3 script.py index.sqlite 4grp7qzjdszhtwikbn4jrjtxzzacgizy
Exists (190µs)

$ python3 script.py index.sqlite 4grp7qzjdszhtwikbn4jrjtxzzacgizz
Does not exist (200µs)
```

The best possible implementation of a JSON-equivalent is:

```python
import json
sys.argv[2] in json.load(open(sys.argv[1]))["database"]["installs"]
```

which has worst-case runtime of:

```
$ python3 script2.py index.json 4grp7qzjdszhtwikbn4jrjtxzzacgizy
Exists (1.434s)

$ python3 script2.py index.json 4grp7qzjdszhtwikbn4jrjtxzzacgizz
Does not exist (1.417s)
```

That is 7000x slower.

And the worst overhead is not even measured, namely going from dict -> Spec.
Actually in our code paths where we _just_ do existence checks, we even do
the horribly slow instantiation of a Database, which is another O(v + e) pass
over the full graph in Python

For buildcache I don't think we really need more than this format, since we
only ever need to (a) find possible dependencies, which could be done in
a single query of `select hash, data from specs where name in (x, y, z)`, 
and (b) check for existence to prefer a particular mirror during spack install, 
which is one query `select hash from specs where hash in (x, y, z)` none of 
this requires access to dependents