### PR TITLE
view: fix issue with non-contributing specs

### DIFF
--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -75,7 +75,7 @@ class SourceMergeVisitor(BaseDirectoryVisitor):
         # so that we have a fast lookup and can run mkdir in order.
         self.directories = OrderedDict()
 
-        # Files to link. Maps dst_rel to (src_rel, src_root)
+        # Files to link. Maps dst_rel to (src_root, src_rel)
         self.files = OrderedDict()
 
     def before_visit_dir(self, root, rel_path, depth):

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import sys
 
 import pytest
 
 from spack.directory_layout import DirectoryLayout
-from spack.filesystem_view import YamlFilesystemView
+from spack.filesystem_view import SimpleFilesystemView, YamlFilesystemView
 from spack.spec import Spec
 
 
@@ -23,3 +24,45 @@ def test_remove_extensions_ordered(install_mockery, mock_fetch, tmpdir):
 
     e1 = e2["extension1"]
     view.remove_specs(e1, e2)
+
+
+@pytest.mark.regression("32456")
+def test_view_with_spec_not_contributing_files(mock_packages, tmpdir):
+    view_dir = os.path.join(str(tmpdir), "view")
+    os.mkdir(view_dir)
+
+    layout = DirectoryLayout(view_dir)
+    view = SimpleFilesystemView(view_dir, layout)
+
+    a = Spec("a")
+    b = Spec("b")
+    a.prefix = os.path.join(tmpdir, "a")
+    b.prefix = os.path.join(tmpdir, "b")
+    a._mark_concrete()
+    b._mark_concrete()
+
+    # Create directory structure for a and b, and view
+    os.makedirs(a.prefix.subdir)
+    os.makedirs(b.prefix.subdir)
+    os.makedirs(os.path.join(a.prefix, ".spack"))
+    os.makedirs(os.path.join(b.prefix, ".spack"))
+
+    # Add files to b's prefix, but not to a's
+    with open(b.prefix.file, "w") as f:
+        f.write("file 1")
+
+    with open(b.prefix.subdir.file, "w") as f:
+        f.write("file 2")
+
+    # In previous versions of Spack we incorrectly called add_files_to_view
+    # with b's merge map. It shouldn't be called at all, since a has no
+    # files to add to the view.
+    def pkg_a_add_files_to_view(view, merge_map, skip_if_exists=True):
+        assert False, "There shouldn't be files to add"
+
+    a.package.add_files_to_view = pkg_a_add_files_to_view
+
+    # Create view and see if files are linked.
+    view.add_specs(a, b)
+    assert os.path.lexists(os.path.join(view_dir, "file"))
+    assert os.path.lexists(os.path.join(view_dir, "subdir", "file"))


### PR DESCRIPTION
Closes #32456
Closes #35475

Specs that did not contribute any files to an env view caused a problem
where zip(specs, files grouped by prefix) got "out of sync", causing the
wrong merge map to be passed to a package's `add_files_to_view`, which
specifically caused an issue where *sometimes* bin/python ended up as a
symlink instead of a copy.

One such example is kokkos + kokkos-nvcc-wrapper, as the latter package
only provides the file bin/nvcc_wrapper, which is also added to view by
kokkos, causing kokkos-nvcc-wrapper to contribute 0 files.

The test feels a bit contrived, but it captures the problem... pkg a is
added first and has 0 files to contribute, pkg b adds a single file, and
we check if pkg b receives a merge map (and a does not).
