### PR TITLE
Fix typo in bacio patch

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -41,5 +41,5 @@ class Bacio(CMakePackage):
         return args
 
     def patch(self):
-        if self.spec.satisifes("@2.4.1"):
+        if self.spec.satisfies("@2.4.1"):
             filter_file(".*", "2.4.1", "VERSION")


### PR DESCRIPTION
Changing "satisifes"->"satisfies" for patch in bacio package.py. **This typo currently breaks the package.**