### PR TITLE
Change regex in bacio patch to avoid python re bug

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -43,3 +43,4 @@ class Bacio(CMakePackage):
     def patch(self):
         if self.spec.satisfies("@2.4.1"):
             filter_file(".+", "2.4.1", "VERSION")
+

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -42,4 +42,4 @@ class Bacio(CMakePackage):
 
     def patch(self):
         if self.spec.satisfies("@2.4.1"):
-            filter_file(".*", "2.4.1", "VERSION")
+            filter_file(".+", "2.4.1", "VERSION")

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -43,4 +43,3 @@ class Bacio(CMakePackage):
     def patch(self):
         if self.spec.satisfies("@2.4.1"):
             filter_file(".+", "2.4.1", "VERSION")
-


### PR DESCRIPTION
Apparently in sufficiently recent versions of Python (I've found it in 3.8 and 3.10), there's what I can only assume is a bug where for the re module, ".*" matches twice for a given string. So `re.sub(".*","replacement","pattern")` yields "replacementreplacement". For the bacio patch, this causes the contents of VERSION to be set to "2.4.12.4.1". This can be avoided by using ".+" instead.