### PR TITLE
Boost: apply 'intel-oneapi-linux-jam.patch' to all versions since 1.76

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -393,7 +393,7 @@ class Boost(Package):
     patch("pthread-stack-min-fix.patch", when="@1.69.0:1.72.0")
 
     # https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html
-    patch("intel-oneapi-linux-jam.patch", when="@1.76:1.79 %oneapi")
+    patch("intel-oneapi-linux-jam.patch", when="@1.76: %oneapi")
 
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler


### PR DESCRIPTION
Fixes #34077

This should remove the oneapi CI pipeline problem. See also #32097.

@alalazo @eugeneswalker  