### PR TITLE
faiss: fixed error when importing faiss python package

### DIFF
--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -75,7 +75,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
     def setup_run_environment(self, env):
         if "+python" in self.spec:
             env.prepend_path("PYTHONPATH", python_platlib)
-            env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss/"))
+            env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss"))
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -22,7 +22,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
     homepage = "https://github.com/facebookresearch/faiss"
     url = "https://github.com/facebookresearch/faiss/archive/v1.6.3.tar.gz"
 
-    maintainers = ["bhatiaharsh", "rblake-llnl"]
+    maintainers = ["bhatiaharsh", "rblake-llnl", "lpottier"]
 
     build_system(
         conditional("cmake", when="@1.7:"), conditional("autotools", when="@:1.6"), default="cmake"
@@ -75,7 +75,12 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
     def setup_run_environment(self, env):
         if "+python" in self.spec:
             env.prepend_path("PYTHONPATH", python_platlib)
-            env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss"))
+            if self.spec.satisfies("platform=darwin"):
+                env.append_path(
+                    "DYLD_FALLBACK_LIBRARY_PATH", os.path.join(python_platlib, "faiss")
+                )
+            else:
+                env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss"))
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -75,6 +75,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
     def setup_run_environment(self, env):
         if "+python" in self.spec:
             env.prepend_path("PYTHONPATH", python_platlib)
+            env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss/"))
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):


### PR DESCRIPTION
Missing directory in `LD_LIBRARY_PATH` resulting into the following error when doing `import faiss`:
```python
ImportError: libfaiss_python_callbacks.so: cannot open shared object file: No such file or directory
```

Signed-off-by: Loïc Pottier <48072795+lpottier@users.noreply.github.com>