### PR TITLE
`spack solve`: use consistent units for time

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -890,8 +890,8 @@ def load_module_from_file(module_name, module_path):
 
     # This recipe is adapted from https://stackoverflow.com/a/67692/771663
 
-    spec = importlib.util.spec_from_file_location(module_name, module_path)  # novm
-    module = importlib.util.module_from_spec(spec)  # novm
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
     # The module object needs to exist in sys.modules before the
     # loader executes the module code.
     #
@@ -990,10 +990,9 @@ def enum(**kwargs):
 
 
 def stable_partition(
-    input_iterable,  # type: Iterable
-    predicate_fn,  # type: Callable[[Any], bool]
-):
-    # type: (...) -> Tuple[List[Any], List[Any]]
+    input_iterable: Iterable,
+    predicate_fn: Callable[[Any], bool],
+) -> Tuple[List[Any], List[Any]]:
     """Partition the input iterable according to a custom predicate.
 
     Args:
@@ -1065,23 +1064,20 @@ class GroupedExceptionHandler(object):
     """A generic mechanism to coalesce multiple exceptions and preserve tracebacks."""
 
     def __init__(self):
-        self.exceptions = []  # type: List[Tuple[str, Exception, List[str]]]
+        self.exceptions: List[Tuple[str, Exception, List[str]]] = []
 
     def __bool__(self):
         """Whether any exceptions were handled."""
         return bool(self.exceptions)
 
-    def forward(self, context):
-        # type: (str) -> GroupedExceptionForwarder
+    def forward(self, context: str) -> "GroupedExceptionForwarder":
         """Return a contextmanager which extracts tracebacks and prefixes a message."""
         return GroupedExceptionForwarder(context, self)
 
-    def _receive_forwarded(self, context, exc, tb):
-        # type: (str, Exception, List[str]) -> None
+    def _receive_forwarded(self, context: str, exc: Exception, tb: List[str]):
         self.exceptions.append((context, exc, tb))
 
-    def grouped_message(self, with_tracebacks=True):
-        # type: (bool) -> str
+    def grouped_message(self, with_tracebacks: bool = True) -> str:
         """Print out an error message coalescing all the forwarded errors."""
         each_exception_message = [
             "{0} raised {1}: {2}{3}".format(
@@ -1099,8 +1095,7 @@ class GroupedExceptionForwarder(object):
     """A contextmanager to capture exceptions and forward them to a
     GroupedExceptionHandler."""
 
-    def __init__(self, context, handler):
-        # type: (str, GroupedExceptionHandler) -> None
+    def __init__(self, context: str, handler: GroupedExceptionHandler):
         self._context = context
         self._handler = handler
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -741,6 +741,18 @@ def pretty_string_to_date(date_str, now=None):
     raise ValueError(msg)
 
 
+def pretty_seconds_formatter(seconds):
+    if seconds >= 1:
+        multiplier, unit = 1, "s"
+    elif seconds >= 1e-3:
+        multiplier, unit = 1e3, "ms"
+    elif seconds >= 1e-6:
+        multiplier, unit = 1e6, "us"
+    else:
+        multiplier, unit = 1e9, "ns"
+    return lambda s: "%.3f%s" % (multiplier * s, unit)
+
+
 def pretty_seconds(seconds):
     """Seconds to string with appropriate units
 
@@ -750,15 +762,7 @@ def pretty_seconds(seconds):
     Returns:
         str: Time string with units
     """
-    if seconds >= 1:
-        value, unit = seconds, "s"
-    elif seconds >= 1e-3:
-        value, unit = seconds * 1e3, "ms"
-    elif seconds >= 1e-6:
-        value, unit = seconds * 1e6, "us"
-    else:
-        value, unit = seconds * 1e9, "ns"
-    return "%.3f%s" % (value, unit)
+    return pretty_seconds_formatter(seconds)(seconds)
 
 
 class RequiredAttributeError(ValueError):

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -21,12 +21,12 @@ import threading
 import traceback
 from contextlib import contextmanager
 from threading import Thread
-from types import ModuleType  # novm
-from typing import Optional  # novm
+from types import ModuleType
+from typing import Optional
 
 import llnl.util.tty as tty
 
-termios = None  # type: Optional[ModuleType]
+termios: Optional[ModuleType] = None
 try:
     import termios as term_mod
 

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -120,9 +120,9 @@ def test_timer_write():
 
     output = text_buffer.getvalue().splitlines()
     assert "timer" in output[0]
-    assert "1.0000s" in output[0]
+    assert "1.000s" in output[0]
     assert "total" in output[1]
-    assert "3.0000s" in output[1]
+    assert "3.000s" in output[1]
 
     deserialized = json.loads(json_buffer.getvalue())
     assert deserialized == {

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -120,9 +120,9 @@ def test_timer_write():
 
     output = text_buffer.getvalue().splitlines()
     assert "timer" in output[0]
-    assert "1.000s" in output[0]
+    assert "1.0000s" in output[0]
     assert "total" in output[1]
-    assert "3.000s" in output[1]
+    assert "3.0000s" in output[1]
 
     deserialized = json.loads(json_buffer.getvalue())
     assert deserialized == {

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -14,7 +14,7 @@ import time
 from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
 
-from llnl.util.lang import pretty_seconds
+from llnl.util.lang import pretty_seconds_formatter
 
 import spack.util.spack_json as sjson
 
@@ -139,12 +139,16 @@ class Timer(object):
 
     def write_tty(self, out=sys.stdout):
         """Write a human-readable summary of timings"""
-        # Individual timers ordered by registration
-        formatted = [(p, f"{self.duration(p):.4f}s") for p in self.phases]
 
-        # Total time
-        formatted.append(("total", f"{self.duration():.4f}s"))
+        times = [self.duration(p) for p in self.phases]
+
+        # Get a consistent unit for the time
+        pretty_seconds = pretty_seconds_formatter(max(times))
+
+        # Tuples of (phase, time) including total.
+        formatted = list(zip(self.phases, times))
+        formatted.append(("total", self.duration()))
 
         # Write to out
         for name, duration in formatted:
-            out.write(f"    {name:10s} {duration:>10s}\n")
+            out.write(f"    {name:10s} {pretty_seconds(duration):>10s}\n")

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -140,11 +140,11 @@ class Timer(object):
     def write_tty(self, out=sys.stdout):
         """Write a human-readable summary of timings"""
         # Individual timers ordered by registration
-        formatted = [(p, pretty_seconds(self.duration(p))) for p in self.phases]
+        formatted = [(p, f"{self.duration(p):.4f}s") for p in self.phases]
 
         # Total time
-        formatted.append(("total", pretty_seconds(self.duration())))
+        formatted.append(("total", f"{self.duration():.4f}s"))
 
         # Write to out
         for name, duration in formatted:
-            out.write("    {:10s} {:>10s}\n".format(name, duration))
+            out.write(f"    {name:10s} {duration:>10s}\n")


### PR DESCRIPTION
`spack solve` is supposed to show you times you can compare. setup, ground, solve, etc. all in a list. You're also supposed to be able to compare easily across runs. With `pretty_seconds()` (introduced in #33900), it's easy to miss the units, e.g., spot the bottleneck here:

```console
> spack solve --timers tcl
    setup        22.125ms
    load         16.083ms
    ground        8.298ms
    solve       848.055us
    total        58.615ms
```

It's easier to see what matters if these are all in the same units, e.g.:

```console
> spack solve --timers tcl
    setup         0.0147s
    load          0.0130s
    ground        0.0078s
    solve         0.0008s
    total         0.0463s
```

And the units won't fluctuate from run to run as you make changes.

- [x] make `spack solve` timings consistent like before
- [x] update tests