### PR TITLE
depfile: variable with all identifiers

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1090,3 +1090,51 @@ output (``spack install --verbose``) while its dependencies are installed silent
 
    # Install the root spec with verbose output.
    $ make -j16 install/python-3.11.0-<hash> SPACK_INSTALL_FLAGS=--verbose
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding post-install hooks
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Another advanced use-case of generated ``Makefile``\s is running a post-install
+command for each package. These "hooks" could be anything from printing a
+post-install message, running tests, or pushing just-built binaries to a buildcache.
+
+This can be accomplished through the generated ``[<prefix>/]SPACK_PACKAGE_IDS``
+variable. Assuming we have an active and concrete environment, we generate the
+associated ``Makefile`` with a prefix ``example``:
+
+.. code:: console
+
+   $ spack env depfile -o env.mk --make-target-prefix example
+
+And we now include it in a different ``Makefile``, in which we create a target
+``example/push/%`` with ``%`` referring to a package identifier. This target
+depends on the particular package installation. In this target we automatically
+have the target-specific ``HASH`` and ``SPEC`` variables at our disposal. They
+are respectively the spec hash (excluding leading ``/``), and a human-readable spec.
+Finally, we have an entrypoint target ``push`` that will update the buildcache
+index once every package is pushed. Note how this target uses the generated
+``example/SPACK_PACKAGE_IDS`` variable to define its prerequisites.
+
+.. code:: Makefile
+
+   SPACK ?= spack
+   BUILDCACHE_DIR = $(CURDIR)/tarballs
+   
+   .PHONY: all
+   
+   all: push
+   
+   include env.mk
+   
+   example/push/%: example/install/%
+   	@mkdir -p $(dir $@)
+   	$(info About to push $(SPEC) to a buildcache)
+   	$(SPACK) -e . buildcache create --allow-root --only=package --directory $(BUILDCACHE_DIR) /$(HASH)
+   	@touch $@
+   
+   push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))
+   	$(info Updating the buildcache index)
+   	$(SPACK) -e . buildcache update-index --directory $(BUILDCACHE_DIR)
+   	$(info Done!)
+   	@touch $@

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -737,6 +737,16 @@ def env_depfile(args):
 
     all_pkg_identifiers = []
 
+    # The SPACK_PACKAGE_IDS variable is "exported", which can be used when including
+    # generated makefiles to add post-install hooks, like pushing to a buildcache,
+    # running tests, etc.
+    # NOTE: GNU Make allows directory separators in variable names, so for consistency
+    # we can namespace this variable with the same prefix as targets.
+    if args.make_target_prefix is None:
+        pkg_identifier_variable = "SPACK_PACKAGE_IDS"
+    else:
+        pkg_identifier_variable = os.path.join(target_prefix, "SPACK_PACKAGE_IDS")
+
     # All install and install-deps targets
     all_install_related_targets = []
 
@@ -773,6 +783,7 @@ def env_depfile(args):
             "adjacency_list": make_targets.adjacency_list,
             "phony_convenience_targets": " ".join(phony_convenience_targets),
             "target_prefix": target_prefix,
+            "pkg_ids_variable": pkg_identifier_variable,
             "pkg_ids": " ".join(all_pkg_identifiers),
         }
     )

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -735,6 +735,8 @@ def env_depfile(args):
     # Root specs without deps are the prereqs for the environment target
     root_install_targets = [get_install_target(h.format("{name}-{version}-{hash}")) for h in roots]
 
+    all_pkg_identifiers = []
+
     # All install and install-deps targets
     all_install_related_targets = []
 
@@ -744,6 +746,7 @@ def env_depfile(args):
     phony_convenience_targets = []
 
     for tgt, _, _, _, _ in make_targets.adjacency_list:
+        all_pkg_identifiers.append(tgt)
         all_install_related_targets.append(get_install_target(tgt))
         all_install_related_targets.append(get_install_deps_target(tgt))
         if args.make_target_prefix is None:
@@ -770,6 +773,7 @@ def env_depfile(args):
             "adjacency_list": make_targets.adjacency_list,
             "phony_convenience_targets": " ".join(phony_convenience_targets),
             "target_prefix": target_prefix,
+            "pkg_ids": " ".join(all_pkg_identifiers),
         }
     )
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3178,7 +3178,7 @@ all: post-install
 include include.mk
 
 example/post-install/%: example/install/%
-	$(info post-install: $(HASH))
+	$(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
 """

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -2,7 +2,7 @@ SPACK ?= spack
 SPACK_INSTALL_FLAGS ?=
 
 # This variable can be used to add post install hooks
-SPACK_PACKAGE_IDS := {{ pkg_ids }}
+{{ pkg_ids_variable }} := {{ pkg_ids }}
 
 .PHONY: {{ all_target }} {{ clean_target }}
 

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -1,6 +1,9 @@
 SPACK ?= spack
 SPACK_INSTALL_FLAGS ?=
 
+# This variable can be used to add post install hooks
+SPACK_PACKAGE_IDS := {{ pkg_ids }}
+
 .PHONY: {{ all_target }} {{ clean_target }}
 
 {{ all_target }}: {{ env_target }}


### PR DESCRIPTION
ping @finkandreas / @bcumming

With the new variable `[prefix/]SPACK_PACKAGE_IDS` you can conveniently execute
things after each successful install.

For example, push each just-built package to a buildcache (while other packages
are still building).

```Makefile
SPACK ?= spack
export SPACK_COLOR = always
MAKEFLAGS += -Orecurse
MY_BUILDCACHE := $(CURDIR)/cache

.PHONY: all clean

all: push

ifeq (,$(filter clean,$(MAKECMDGOALS)))
include env.mk
endif

# the relevant part: push has *all* example/push/<pkg identifier> as prereqs
push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))
	$(SPACK) -e . buildcache update-index --directory $(MY_BUILDCACHE)
	$(info Pushed everything, yay!)

# and each example/push/<pkg identifier> has the install target as prereq,
# and the body can use target local $(HASH) and $(SPEC) variables to do
# things, such as pushing to a build cache
example/push/%: example/install/%
	@mkdir -p $(dir $@)
	$(SPACK) -e . buildcache create --allow-root --only=package --unsigned --directory $(MY_BUILDCACHE) /$(HASH) # push $(SPEC)
	@touch $@

spack.lock: spack.yaml
	$(SPACK) -e . concretize -f

env.mk: spack.lock
	$(SPACK) -e . env depfile -o $@ --make-target-prefix example

clean:
	rm -rf spack.lock env.mk example/
```

```console
$ make push -j16

spack -e . concretize -f
==> Concretized python
[+]  dpw4nbp  python@3.11.0%gcc@12.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis+optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,f2fd060 arch=linux-ubuntu22.10-zen2
[+]  dswoyul      ^bzip2@1.0.8%gcc@12.2.0~debug~pic+shared build_system=generic arch=linux-ubuntu22.10-zen2
...

spack -e . env depfile -o env.mk --make-target-prefix example
spack -e '/tmp/tmp.uLxVzmcIr9' install   --only-concrete --only=package --no-add /62p6a5kjo4iwiqdw6xdbcuypcvvza7oo # libmd@1.0.4%gcc@12.2.0 build_system=autotools arch=linux-ubuntu22.10-zen2
[+] /home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/libmd-1.0.4-62p6a5kjo4iwiqdw6xdbcuypcvvza7oo
spack -e '/tmp/tmp.uLxVzmcIr9' install   --only-concrete --only=package --no-add /ialqdvwetyvgpb4zrorogl3vvf3hvobi # libiconv@1.16%gcc@12.2.0 build_system=autotools libs=shared,static arch=linux-ubuntu22.10-zen2
[+] /home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/libiconv-1.16-ialqdvwetyvgpb4zrorogl3vvf3hvobi
...
spack -e . buildcache create --allow-root --only=package --unsigned --directory /tmp/tmp.uLxVzmcIr9/cache /ta4pw75cgzygpyqh3ppgqy2jspb73vp2 # push libxcrypt@4.4.33%gcc@12.2.0~obsolete_api build_system=autotools arch=linux-ubuntu22.10-zen2
==> Pushing binary packages to file:///tmp/tmp.uLxVzmcIr9/cache/build_cache
spack -e . buildcache create --allow-root --only=package --unsigned --directory /tmp/tmp.uLxVzmcIr9/cache /mec6k7yoobnz6yz76sddrb7afbhh5s6w # push pkgconf@1.8.0%gcc@12.2.0 build_system=autotools arch=linux-ubuntu22.10-zen2
==> Pushing binary packages to file:///tmp/tmp.uLxVzmcIr9/cache/build_cache
...
spack -e '/tmp/tmp.uLxVzmcIr9' install   --only-concrete --only=package --no-add /lu5yc7ug6xcrznkrkfmvly2nzzzgdryi # util-linux-uuid@2.38.1%gcc@12.2.0 build_system=autotools arch=linux-ubuntu22.10-zen2
[+] /home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/util-linux-uuid-2.38.1-lu5yc7ug6xcrznkrkfmvly2nzzzgdryi
```
