### PR TITLE
Update survey version to 1.0.7 and tag release version 1.0.6.

### DIFF
--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -33,7 +33,8 @@ class Survey(CMakePackage):
     maintainers = ["jgalarowicz"]
 
     version("master", branch="master")
-    version("1.0.6", branch="1.0.6")
+    version("1.0.7", branch="1.0.7")
+    version("1.0.6", tag="1.0.6")
     version("1.0.5", tag="1.0.5")
     version("1.0.4", tag="1.0.4")
     version("1.0.3", tag="1.0.3")


### PR DESCRIPTION
Update survey version to 1.0.7 and tag release version 1.0.6.   Changing one line to make 1.0.6 a tag and adding the 1.0.7 branch to the package.py file.