### PR TITLE
qt-base: ~network by default

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -35,7 +35,7 @@ class QtBase(CMakePackage):
     variant("gui", default=True, description="Build the Qt GUI module and dependencies.")
     variant("shared", default=True, description="Build shared libraries.")
     variant("sql", default=True, description="Build with SQL support.")
-    variant("network", default=True, description="Build with SSL support.")
+    variant("network", default=False, description="Build with SSL support.")
 
     # GUI-only dependencies
     variant(


### PR DESCRIPTION
`qt-base+network` doesn't build reliably: #34037. Until it does, we should disable it by default.

Extracted out of #32696 to make that PR easier to review.