### PR TITLE
libpsl: new versions through 0.21.2

### DIFF
--- a/var/spack/repos/builtin/packages/libpsl/package.py
+++ b/var/spack/repos/builtin/packages/libpsl/package.py
@@ -11,9 +11,14 @@ class Libpsl(AutotoolsPackage):
 
     homepage = "https://github.com/rockdaboot/libpsl"
     url = (
-        "https://github.com/rockdaboot/libpsl/releases/download/libpsl-0.17.0/libpsl-0.17.0.tar.gz"
+        "https://github.com/rockdaboot/libpsl/releases/download/0.21.2/libpsl-0.21.2.tar.gz"
     )
+    list_url = "https://github.com/rockdaboot/libpsl/tags"
 
+    version("0.21.2", sha256="e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f")
+    version("0.20.2", sha256="7aa949fd3fdba61b0dc7b3f4c2520263b942c189746e157f48436386eca3398e")
+    version("0.19.1", sha256="9b47387a087bcac2af31ea0c94f644bfa32e0be6d079bfa430452b7521ad8c57")
+    version("0.18.0", sha256="f79c6b257dd39e8f37c7e18d293bbfa35f38676f5d6b6e918687d1cd08216439")
     version("0.17.0", sha256="025729d6a26ffd53cb54b4d86196f62c01d1813a4360c627546c6eb60ce3dd4b")
 
     depends_on("icu4c")
@@ -23,6 +28,12 @@ class Libpsl(AutotoolsPackage):
     depends_on("python@2.7:", type="build")
 
     depends_on("valgrind~mpi~boost", type="test")
+
+    def url_for_version(self, version):
+        if version >= Version("0.21.1"):
+            return super(Libpsl, self).url_for_version(version)
+        url_fmt = "https://github.com/rockdaboot/libpsl/releases/download/libpsl-{0}/libpsl-{0}.tar.gz"
+        return url_fmt.format(version)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/libpsl/package.py
+++ b/var/spack/repos/builtin/packages/libpsl/package.py
@@ -10,9 +10,7 @@ class Libpsl(AutotoolsPackage):
     """libpsl - C library to handle the Public Suffix List."""
 
     homepage = "https://github.com/rockdaboot/libpsl"
-    url = (
-        "https://github.com/rockdaboot/libpsl/releases/download/0.21.2/libpsl-0.21.2.tar.gz"
-    )
+    url = "https://github.com/rockdaboot/libpsl/releases/download/0.21.2/libpsl-0.21.2.tar.gz"
     list_url = "https://github.com/rockdaboot/libpsl/tags"
 
     version("0.21.2", sha256="e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f")
@@ -32,7 +30,9 @@ class Libpsl(AutotoolsPackage):
     def url_for_version(self, version):
         if version >= Version("0.21.1"):
             return super(Libpsl, self).url_for_version(version)
-        url_fmt = "https://github.com/rockdaboot/libpsl/releases/download/libpsl-{0}/libpsl-{0}.tar.gz"
+        url_fmt = (
+            "https://github.com/rockdaboot/libpsl/releases/download/libpsl-{0}/libpsl-{0}.tar.gz"
+        )
         return url_fmt.format(version)
 
     def configure_args(self):


### PR DESCRIPTION
This adds the final bugfix versions through the 0.21.2 just released.

With 0.21.1 the tag name pattern was changed, hence url_for_version.

No major changes to build system (meson is also supported upstream as of 0.21.0, but keeping it out of the spack package for now).