### PR TITLE
Consolidate how Spack uses `git`

### DIFF
--- a/.github/workflows/setup_git.ps1
+++ b/.github/workflows/setup_git.ps1
@@ -4,10 +4,6 @@ git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 git config --global core.longpaths true
 
-# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE-2022-39253)
-# This is needed to let some fixture in our unit-test suite run
-git config --global protocol.file.allow always
-
 if ($(git branch --show-current) -ne "develop")
 {
     git branch develop origin/develop

--- a/.github/workflows/setup_git.sh
+++ b/.github/workflows/setup_git.sh
@@ -2,10 +2,6 @@
 git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
 
-# See https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE-2022-39253)
-# This is needed to let some fixture in our unit-test suite run
-git config --global protocol.file.allow always
-
 # create a local pr base branch
 if [[ -n $GITHUB_BASE_REF ]]; then
     git fetch origin "${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -209,7 +209,6 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.VersionBase"),
     ("py:class", "spack.spec.DependencySpec"),
-    ("py:class", "spack.util.executable.CommandNotFoundError"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -209,6 +209,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.VersionBase"),
     ("py:class", "spack.spec.DependencySpec"),
+    ("py:class", "spack.util.executable.CommandNotFoundError"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -33,7 +33,7 @@ import spack.main
 import spack.mirror
 import spack.paths
 import spack.repo
-import spack.util.executable as exe
+import spack.util.git
 import spack.util.gpg as gpg_util
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -486,7 +486,7 @@ def get_stack_changed(env_path, rev1="HEAD^", rev2="HEAD"):
     whether or not the stack was changed.  Returns True if the environment
     manifest changed between the provided revisions (or additionally if the
     `.gitlab-ci.yml` file itself changed).  Returns False otherwise."""
-    git = exe.which("git")
+    git = spack.util.git.get_git()
     if git:
         with fs.working_dir(spack.paths.prefix):
             git_log = git(
@@ -1655,7 +1655,7 @@ def get_spack_info():
     entry, otherwise, return a string containing the spack version."""
     git_path = os.path.join(spack.paths.prefix, ".git")
     if os.path.exists(git_path):
-        git = exe.which("git")
+        git = spack.util.git.get_git()
         if git:
             with fs.working_dir(spack.paths.prefix):
                 git_log = git("log", "-1", output=str, error=os.devnull, fail_on_error=False)
@@ -1695,7 +1695,7 @@ def setup_spack_repro_version(repro_dir, checkout_commit, merge_commit=None):
 
     spack_git_path = spack.paths.prefix
 
-    git = exe.which("git")
+    git = spack.util.git.get_git()
     if not git:
         tty.error("reproduction of pipeline job requires git")
         return False

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -486,7 +486,7 @@ def get_stack_changed(env_path, rev1="HEAD^", rev2="HEAD"):
     whether or not the stack was changed.  Returns True if the environment
     manifest changed between the provided revisions (or additionally if the
     `.gitlab-ci.yml` file itself changed).  Returns False otherwise."""
-    git = spack.util.git.get_git()
+    git = spack.util.git.git()
     if git:
         with fs.working_dir(spack.paths.prefix):
             git_log = git(
@@ -1655,7 +1655,7 @@ def get_spack_info():
     entry, otherwise, return a string containing the spack version."""
     git_path = os.path.join(spack.paths.prefix, ".git")
     if os.path.exists(git_path):
-        git = spack.util.git.get_git()
+        git = spack.util.git.git()
         if git:
             with fs.working_dir(spack.paths.prefix):
                 git_log = git("log", "-1", output=str, error=os.devnull, fail_on_error=False)
@@ -1695,7 +1695,7 @@ def setup_spack_repro_version(repro_dir, checkout_commit, merge_commit=None):
 
     spack_git_path = spack.paths.prefix
 
-    git = spack.util.git.get_git()
+    git = spack.util.git.git()
     if not git:
         tty.error("reproduction of pipeline job requires git")
         return False

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -14,9 +14,9 @@ from llnl.util.tty.colify import colify_table
 
 import spack.paths
 import spack.repo
+import spack.util.git
 import spack.util.spack_json as sjson
 from spack.cmd import spack_is_git_repo
-from spack.util.executable import which
 
 description = "show contributors to packages"
 section = "developer"
@@ -116,7 +116,7 @@ def blame(parser, args):
     # make sure this is a git repo
     if not spack_is_git_repo():
         tty.die("This spack is not a git clone. Can't use 'spack blame'")
-    git = which("git", required=True)
+    git = spack.util.git.git(required=True)
 
     # Get name of file to blame
     blame_file = None

--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -9,7 +9,8 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.paths
-from spack.util.executable import ProcessError, which
+import spack.util.git
+from spack.util.executable import ProcessError
 
 _SPACK_UPSTREAM = "https://github.com/spack/spack"
 
@@ -32,7 +33,7 @@ def setup_parser(subparser):
 
 def get_origin_info(remote):
     git_dir = os.path.join(spack.paths.prefix, ".git")
-    git = which("git", required=True)
+    git = spack.util.git.git(required=True)
     try:
         branch = git("symbolic-ref", "--short", "HEAD", output=str)
     except ProcessError:
@@ -69,13 +70,13 @@ def clone(parser, args):
     if files_in_the_way:
         tty.die(
             "There are already files there! " "Delete these files before boostrapping spack.",
-            *files_in_the_way
+            *files_in_the_way,
         )
 
     tty.msg("Installing:", "%s/bin/spack" % prefix, "%s/lib/spack/..." % prefix)
 
     with working_dir(prefix):
-        git = which("git", required=True)
+        git = spack.util.git.git(required=True)
         git("init", "--shared", "-q")
         git("remote", "add", "origin", origin_url)
         git("fetch", "origin", "%s:refs/remotes/origin/%s" % (branch, branch), "-n", "-q")

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -17,6 +17,7 @@ from llnl.util.filesystem import working_dir
 import spack.config
 import spack.paths
 import spack.platforms
+import spack.util.git
 from spack.main import get_version
 from spack.util.executable import which
 
@@ -35,7 +36,7 @@ def _debug_tarball_suffix():
     now = datetime.now()
     suffix = now.strftime("%Y-%m-%d-%H%M%S")
 
-    git = which("git")
+    git = spack.util.git.git()
     if not git:
         return "nobranch-nogit-%s" % suffix
 

--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -13,14 +13,10 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.paths
-from spack.util.executable import which
 
 description = "list and check license headers on files in spack"
 section = "developer"
 level = "long"
-
-#: need the git command to check new files
-git = which("git")
 
 #: SPDX license id must appear in the first <license_lines> lines of a file
 license_lines = 7
@@ -238,9 +234,6 @@ def setup_parser(subparser):
 
 
 def license(parser, args):
-    if not git:
-        tty.die("spack license requires git in your environment")
-
     licensed_files[:] = [re.compile(regex) for regex in licensed_files]
 
     commands = {

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -13,6 +13,7 @@ import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 
 import spack.paths
+import spack.util.git
 from spack.util.executable import which
 
 description = "runs source code style checks on spack"
@@ -81,7 +82,7 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None):
     if root is None:
         root = spack.paths.prefix
 
-    git = which("git", required=True)
+    git = spack.util.git.git(required=True)
 
     # ensure base is in the repo
     base_sha = git(

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -15,8 +15,8 @@ import spack
 import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.paths
+import spack.util.git
 import spack.util.gpg
-from spack.util.executable import which
 from spack.util.spack_yaml import syaml_dict
 
 description = "set up spack for our tutorial (WARNING: modifies config!)"
@@ -84,7 +84,7 @@ def tutorial(parser, args):
     # If you don't put this last, you'll get import errors for the code
     # that follows (exacerbated by the various lazy singletons we use)
     tty.msg("Ensuring we're on the releases/v{0}.{1} branch".format(*spack.spack_version_info[:2]))
-    git = which("git", required=True)
+    git = spack.util.git.git(required=True)
     with working_dir(spack.paths.prefix):
         git("checkout", tutorial_branch)
     # NO CODE BEYOND HERE

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -10,7 +10,7 @@ import sys
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
-import spack.util.executable as executable
+import spack.util.git
 
 #: Global variable used to cache in memory the content of images.json
 _data = None
@@ -97,7 +97,7 @@ def _verify_ref(url, ref, enforce_sha):
     # Do a checkout in a temporary directory
     msg = 'Cloning "{0}" to verify ref "{1}"'.format(url, ref)
     tty.info(msg, stream=sys.stderr)
-    git = executable.which("git", required=True)
+    git = spack.util.git.git(required=True)
     with fs.temporary_dir():
         git("clone", "-q", url, ".")
         sha = git(

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -48,6 +48,7 @@ import spack.config
 import spack.error
 import spack.url
 import spack.util.crypto as crypto
+import spack.util.git
 import spack.util.pattern as pattern
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -765,7 +766,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     @property
     def git(self):
         if not self._git:
-            self._git = which("git", required=True)
+            self._git = spack.util.git.get_git()
 
             # Disable advice for a quieter fetch
             # https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.2.txt

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -766,7 +766,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     @property
     def git(self):
         if not self._git:
-            self._git = spack.util.git.get_git()
+            self._git = spack.util.git.git()
 
             # Disable advice for a quieter fetch
             # https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.2.txt

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -45,7 +45,7 @@ import spack.spec
 import spack.store
 import spack.util.debug
 import spack.util.environment
-import spack.util.executable as exe
+import spack.util.git
 import spack.util.path
 from spack.error import SpackError
 
@@ -136,7 +136,7 @@ def get_version():
     version = spack.spack_version
     git_path = os.path.join(spack.paths.prefix, ".git")
     if os.path.exists(git_path):
-        git = exe.which("git")
+        git = spack.util.git.git()
         if not git:
             return version
         rev = git(

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -41,9 +41,9 @@ import spack.provider_index
 import spack.spec
 import spack.tag
 import spack.util.file_cache
+import spack.util.git
 import spack.util.naming as nm
 import spack.util.path
-from spack.util.executable import which
 
 #: Package modules are imported as spack.pkg.<repo-namespace>.<pkg-name>
 ROOT_PYTHON_NAMESPACE = "spack.pkg"
@@ -198,27 +198,16 @@ class GitExe:
     #
     # Not using -C as that is not supported for git < 1.8.5.
     def __init__(self):
-        self._git_cmd = which("git", required=True)
+        self._git_cmd = spack.util.git.git(required=True)
 
     def __call__(self, *args, **kwargs):
         with working_dir(packages_path()):
             return self._git_cmd(*args, **kwargs)
 
 
-_git = None
-
-
-def get_git():
-    """Get a git executable that runs *within* the packages path."""
-    global _git
-    if _git is None:
-        _git = GitExe()
-    return _git
-
-
 def list_packages(rev):
     """List all packages associated with the given revision"""
-    git = get_git()
+    git = GitExe()
 
     # git ls-tree does not support ... merge-base syntax, so do it manually
     if rev.endswith("..."):
@@ -270,7 +259,7 @@ def get_all_package_diffs(type, rev1="HEAD^1", rev2="HEAD"):
 
     removed, added = diff_packages(rev1, rev2)
 
-    git = get_git()
+    git = GitExe()
     out = git("diff", "--relative", "--name-only", rev1, rev2, output=str).strip()
 
     lines = [] if not out else re.split(r"\s+", out)
@@ -293,7 +282,7 @@ def get_all_package_diffs(type, rev1="HEAD^1", rev2="HEAD"):
 
 def add_package_to_git_stage(packages):
     """add a package to the git stage with `git add`"""
-    git = get_git()
+    git = GitExe()
 
     for pkg_name in packages:
         filename = spack.repo.path.filename_for_package_name(pkg_name)

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -22,11 +22,11 @@ import spack.build_environment
 import spack.fetch_strategy
 import spack.package_base
 import spack.platforms
+import spack.util.git
 from spack.error import SpackError
 from spack.reporter import Reporter
 from spack.reporters.extract import extract_test_parts
 from spack.util.crypto import checksum
-from spack.util.executable import which
 from spack.util.log_parse import parse_log_events
 
 __all__ = ["CDash"]
@@ -108,7 +108,7 @@ class CDash(Reporter):
         )
         self.buildIds = collections.OrderedDict()
         self.revision = ""
-        git = which("git")
+        git = spack.util.git.git()
         with working_dir(spack.paths.spack_root):
             self.revision = git("rev-parse", "HEAD", output=str).strip()
         self.generator = "spack-{0}".format(spack.main.get_version())

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -187,7 +187,7 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
     assert "Unable to find the path" in err
 
     monkeypatch.setattr(spack.paths, "prefix", prefix_save)
-    monkeypatch.setattr(spack.util.git, "get_git", lambda: None)
+    monkeypatch.setattr(spack.util.git, "git", lambda: None)
 
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
     out, err = capfd.readouterr()
@@ -208,7 +208,7 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
 
     git_cmd = mock_git_cmd()
 
-    monkeypatch.setattr(spack.util.git, "get_git", lambda: git_cmd)
+    monkeypatch.setattr(spack.util.git, "git", lambda: git_cmd)
 
     git_cmd.check = lambda *a, **k: 1 if len(a) > 2 and a[2] == c2 else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -18,6 +18,7 @@ import spack.config as cfg
 import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
+import spack.util.git
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 
@@ -180,14 +181,13 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
     monkeypatch.setattr(spack.paths, "prefix", "/garbage")
 
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Unable to find the path" in err
 
     monkeypatch.setattr(spack.paths, "prefix", prefix_save)
-
-    monkeypatch.setattr(spack.util.executable, "which", lambda cmd: None)
+    monkeypatch.setattr(spack.util.git, "get_git", lambda: None)
 
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
     out, err = capfd.readouterr()
@@ -208,39 +208,39 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
 
     git_cmd = mock_git_cmd()
 
-    monkeypatch.setattr(spack.util.executable, "which", lambda cmd: git_cmd)
+    monkeypatch.setattr(spack.util.git, "get_git", lambda: git_cmd)
 
     git_cmd.check = lambda *a, **k: 1 if len(a) > 2 and a[2] == c2 else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Missing commit: {0}".format(c2) in err
 
     git_cmd.check = lambda *a, **k: 1 if len(a) > 2 and a[2] == c1 else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Missing commit: {0}".format(c1) in err
 
     git_cmd.check = lambda *a, **k: 1 if a[0] == "clone" else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Unable to clone" in err
 
     git_cmd.check = lambda *a, **k: 1 if a[0] == "checkout" else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Unable to checkout" in err
 
     git_cmd.check = lambda *a, **k: 1 if "merge" in a else 0
     ret = ci.setup_spack_repro_version(repro_dir, c2, c1)
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
 
     assert not ret
     assert "Unable to merge {0}".format(c1) in err

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -13,11 +13,8 @@ import spack.cmd
 import spack.paths
 import spack.util.spack_json as sjson
 from spack.main import SpackCommand
-from spack.util.executable import which
 
-pytestmark = pytest.mark.skipif(
-    not which("git") or not spack.cmd.spack_is_git_repo(), reason="needs git"
-)
+pytestmark = pytest.mark.usefixtures("git")
 
 blame = SpackCommand("blame")
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -31,7 +31,6 @@ from spack.schema.buildcache_spec import schema as specfile_schema
 from spack.schema.database_index import schema as db_idx_schema
 from spack.schema.gitlab_ci import schema as gitlab_ci_schema
 from spack.spec import CompilerSpec, Spec
-from spack.util.executable import which
 from spack.util.pattern import Bunch
 
 ci_cmd = spack.main.SpackCommand("ci")
@@ -54,14 +53,13 @@ def ci_base_environment(working_env, tmpdir):
 
 
 @pytest.fixture(scope="function")
-def mock_git_repo(tmpdir):
+def mock_git_repo(git, tmpdir):
     """Create a mock git repo with two commits, the last one creating
     a .gitlab-ci.yml"""
 
     repo_path = tmpdir.join("mockspackrepo").strpath
     mkdirp(repo_path)
 
-    git = which("git", required=True)
     with working_dir(repo_path):
         git("init")
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -68,9 +68,11 @@ def ensure_configuration_fixture_run_before(request):
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.skipif(not spack.util.git.git(), reason="requires git to be installed")
 def git():
     """Fixture for tests that use git."""
+    if not spack.util.git.git():
+        pytest.skip("requires git to be installed")
+
     return spack.util.git.git(required=True)
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -68,10 +68,10 @@ def ensure_configuration_fixture_run_before(request):
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.skipif(not spack.util.git.get_git(), reason="requires git to be installed")
+@pytest.mark.skipif(not spack.util.git.git(), reason="requires git to be installed")
 def git():
     """Fixture for tests that use git."""
-    return spack.util.git.get_git(required=True)
+    return spack.util.git.git(required=True)
 
 
 #

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -213,7 +213,7 @@ def test_debug_fetch(
             assert os.path.isdir(s.package.stage.source_path)
 
 
-def test_git_extra_fetch(tmpdir):
+def test_git_extra_fetch(git, tmpdir):
     """Ensure a fetch after 'expanding' is effectively a no-op."""
     testpath = str(tmpdir)
 
@@ -224,7 +224,7 @@ def test_git_extra_fetch(tmpdir):
         shutil.rmtree(stage.source_path)
 
 
-def test_needs_stage():
+def test_needs_stage(git):
     """Trigger a NoStageError when attempt a fetch without a stage."""
     with pytest.raises(
         spack.fetch_strategy.NoStageError, match=r"set_stage.*before calling fetch"

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -16,17 +16,13 @@ import spack.repo
 from spack.fetch_strategy import GitFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 from spack.version import ver
-
-pytestmark = pytest.mark.skipif(not which("git"), reason="requires git to be installed")
-
 
 _mock_transport_error = "Mock HTTP transport error"
 
 
 @pytest.fixture(params=[None, "1.8.5.2", "1.8.5.1", "1.7.10", "1.7.1", "1.7.0"])
-def git_version(request, monkeypatch):
+def git_version(git, request, monkeypatch):
     """Tests GitFetchStrategy behavior for different git versions.
 
     GitFetchStrategy tries to optimize using features of newer git
@@ -34,7 +30,6 @@ def git_version(request, monkeypatch):
     paths for old versions still work, we fake it out here and make it
     use the backward-compatibility code paths with newer git versions.
     """
-    git = which("git", required=True)
     real_git_version = spack.fetch_strategy.GitFetchStrategy.version_from_git(git)
 
     if request.param is None:
@@ -83,6 +78,7 @@ def test_bad_git(tmpdir, mock_bad_git):
 @pytest.mark.parametrize("type_of_test", ["default", "branch", "tag", "commit"])
 @pytest.mark.parametrize("secure", [True, False])
 def test_fetch(
+    git,
     type_of_test,
     secure,
     mock_git_repository,

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import sys
 
 import pytest
@@ -11,6 +10,8 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.paths
+import spack.util.executable as exe
+import spack.util.git
 from spack.main import get_version, main
 
 pytestmark = pytest.mark.skipif(
@@ -18,7 +19,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_version_git_nonsense_output(tmpdir, working_env):
+def test_version_git_nonsense_output(tmpdir, working_env, monkeypatch):
     git = str(tmpdir.join("git"))
     with open(git, "w") as f:
         f.write(
@@ -28,11 +29,11 @@ echo --|not a hash|----
         )
     fs.set_executable(git)
 
-    os.environ["PATH"] = str(tmpdir)
+    monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(git))
     assert spack.spack_version == get_version()
 
 
-def test_version_git_fails(tmpdir, working_env):
+def test_version_git_fails(tmpdir, working_env, monkeypatch):
     git = str(tmpdir.join("git"))
     with open(git, "w") as f:
         f.write(
@@ -43,11 +44,11 @@ exit 1
         )
     fs.set_executable(git)
 
-    os.environ["PATH"] = str(tmpdir)
+    monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(git))
     assert spack.spack_version == get_version()
 
 
-def test_git_sha_output(tmpdir, working_env):
+def test_git_sha_output(tmpdir, working_env, monkeypatch):
     git = str(tmpdir.join("git"))
     sha = "26552533be04e83e66be2c28e0eb5011cb54e8fa"
     with open(git, "w") as f:
@@ -60,7 +61,7 @@ echo {0}
         )
     fs.set_executable(git)
 
-    os.environ["PATH"] = str(tmpdir)
+    monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(git))
     expected = "{0} ({1})".format(spack.spack_version, sha)
     assert expected == get_version()
 
@@ -70,18 +71,22 @@ def test_get_version_no_repo(tmpdir, monkeypatch):
     assert spack.spack_version == get_version()
 
 
-def test_get_version_no_git(tmpdir, working_env):
-    os.environ["PATH"] = str(tmpdir)
+def test_get_version_no_git(tmpdir, working_env, monkeypatch):
+    monkeypatch.setattr(spack.util.git, "git", lambda: None)
     assert spack.spack_version == get_version()
 
 
-def test_main_calls_get_version(tmpdir, capsys, working_env):
-    os.environ["PATH"] = str(tmpdir)
+def test_main_calls_get_version(tmpdir, capsys, working_env, monkeypatch):
+    # act like git is not found in the PATH
+    monkeypatch.setattr(spack.util.git, "git", lambda: None)
+
+    # make sure we get a bare version (without commit) when this happens
     main(["-V"])
-    assert spack.spack_version == capsys.readouterr()[0].strip()
+    out, err = capsys.readouterr()
+    assert spack.spack_version == out.strip()
 
 
-def test_get_version_bad_git(tmpdir, working_env):
+def test_get_version_bad_git(tmpdir, working_env, monkeypatch):
     bad_git = str(tmpdir.join("git"))
     with open(bad_git, "w") as f:
         f.write(
@@ -91,5 +96,5 @@ exit 1
         )
     fs.set_executable(bad_git)
 
-    os.environ["PATH"] = str(tmpdir)
+    monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(bad_git))
     assert spack.spack_version == get_version()

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -104,33 +104,24 @@ def test_url_mirror(mock_archive):
     repos.clear()
 
 
-@pytest.mark.skipif(not which("git"), reason="requires git to be installed")
-def test_git_mirror(mock_git_repository):
+def test_git_mirror(git, mock_git_repository):
     set_up_package("git-test", mock_git_repository, "git")
     check_mirror()
     repos.clear()
 
 
-@pytest.mark.skipif(
-    not which("svn") or not which("svnadmin"), reason="requires subversion to be installed"
-)
 def test_svn_mirror(mock_svn_repository):
     set_up_package("svn-test", mock_svn_repository, "svn")
     check_mirror()
     repos.clear()
 
 
-@pytest.mark.skipif(not which("hg"), reason="requires mercurial to be installed")
 def test_hg_mirror(mock_hg_repository):
     set_up_package("hg-test", mock_hg_repository, "hg")
     check_mirror()
     repos.clear()
 
 
-@pytest.mark.skipif(
-    not all([which("svn"), which("hg"), which("git")]),
-    reason="requires subversion, git, and mercurial to be installed",
-)
 def test_all_mirror(mock_git_repository, mock_svn_repository, mock_hg_repository, mock_archive):
 
     set_up_package("git-test", mock_git_repository, "git")

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -16,7 +16,6 @@ from llnl.util.filesystem import working_dir
 
 import spack.package_base
 import spack.spec
-from spack.util.executable import which
 from spack.version import (
     GitVersion,
     Version,
@@ -593,7 +592,7 @@ def test_invalid_versions(version_str):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
-def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
+def test_versions_from_git(git, mock_git_version_info, monkeypatch, mock_packages):
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
         spack.package_base.PackageBase, "git", "file://%s" % repo_path, raising=False
@@ -607,7 +606,7 @@ def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
         ]
 
         with working_dir(repo_path):
-            which("git")("checkout", commit)
+            git("checkout", commit)
         with open(os.path.join(repo_path, filename), "r") as f:
             expected = f.read()
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Single util module where Spack should get a git executable."""
+
+import sys
+
+import llnl.util.lang
+
+import spack.util.executable
+
+
+@llnl.util.lang.memoized
+def get_git(required=False):
+    """Get a git executable.
+
+    Arguments:
+        required: if ``True``, fail if ``git`` is not found. By default return ``None``.
+    """
+    git = spack.util.executable.which("git", required=required)
+
+    # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
+    # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
+    if "pytest" in sys.modules:
+        git.add_default_arg("-c")
+        git.add_default_arg("protocol.file.allow=always")
+
+    return git

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -5,14 +5,15 @@
 """Single util module where Spack should get a git executable."""
 
 import sys
+from typing import Optional
 
 import llnl.util.lang
 
-import spack.util.executable
+import spack.util.executable as exe
 
 
 @llnl.util.lang.memoized
-def git(required=False):
+def git(required: bool = False):
     """Get a git executable.
 
     Arguments:
@@ -21,11 +22,11 @@ def git(required=False):
     Raises:
         CommandNotFoundError: if required is ``True`` and ``git`` is not present.
     """
-    git = spack.util.executable.which("git", required=required)
+    git: Optional[exe.Executable] = exe.which("git", required=required)
 
     # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
-    if "pytest" in sys.modules:
+    if git and "pytest" in sys.modules:
         git.add_default_arg("-c")
         git.add_default_arg("protocol.file.allow=always")
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -17,6 +17,9 @@ def git(required=False):
 
     Arguments:
         required: if ``True``, fail if ``git`` is not found. By default return ``None``.
+
+    Raises:
+        CommandNotFoundError: if required is ``True`` and ``git`` is not present.
     """
     git = spack.util.executable.which("git", required=required)
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -12,7 +12,7 @@ import spack.util.executable
 
 
 @llnl.util.lang.memoized
-def get_git(required=False):
+def git(required=False):
     """Get a git executable.
 
     Arguments:

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -18,9 +18,6 @@ def git(required: bool = False):
 
     Arguments:
         required: if ``True``, fail if ``git`` is not found. By default return ``None``.
-
-    Raises:
-        CommandNotFoundError: if required is ``True`` and ``git`` is not present.
     """
     git: Optional[exe.Executable] = exe.which("git", required=required)
 


### PR DESCRIPTION
Local `git` tests will fail with `fatal: transport 'file' not allowed` when using git 2.38.1 or higher, due to a fix for `CVE-2022-39253`.

This was fixed in CI in #33429, but that doesn't help the issue for anyone's local environment. Instead of fixing this with git config in CI, we should ensure that the tests run anywhere.

- [x] Introduce `spack.util.git`.
- [x] Use `spack.util.git.get_git()` to get a git executable, instead of `which("git")` everywhere.
- [x] Make all `git` tests use a `git` fixture that goes through `spack.util.git.get_git()`.
- [x] Add `-c protocol.file.allow=always` to all `git` invocations under `pytest`.
- [x] Revert changes from #33429, which are no longer needed.