### PR TITLE
bugfix: compiler bootstrapping tests

### DIFF
--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -488,7 +488,7 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
 
 
 def test_bootstrapping_compilers_with_different_names_from_spec(
-    install_mockery, mutable_config, mock_fetch, archspec_host_is_spack_test_host
+    install_mockery, mutable_config, mock_fetch
 ):
     with spack.config.override("config:install_missing_compilers", True):
         with spack.concretize.disable_compiler_existence_check():


### PR DESCRIPTION
This compiler bootstrapping test breaks on (my?) M1 mac beacuse it can't find the bootstrap compiler after it's added to configuration. Removing the archspec host fixture seems to fix it.

@becker33 not sure if this is the right fix. Can you take a look?