### PR TITLE
CPMD: Update for open-source release

### DIFF
--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -11,16 +11,12 @@ from spack.package import *
 class Cpmd(MakefilePackage):
     """The CPMD code is a parallelized plane wave / pseudopotential
     implementation of Density Functional Theory, particularly
-    designed for ab-initio molecular dynamics.
-    Move to new directory, download CPMD main archive and patch.to.XXXXs
-    manually, and run Spack"""
+    designed for ab-initio molecular dynamics."""
 
     homepage = "https://www.cpmd.org/wordpress/"
-    basedir = os.getcwd()
-    url = "file://{0}/cpmd-v4.3.tar.gz".format(basedir)
-    manual_download = True
+    url = "https://github.com/CPMD-code/CPMD/archive/refs/tags/4.3.tar.gz"
 
-    version("4.3", sha256="4f31ddf045f1ae5d6f25559d85ddbdab4d7a6200362849df833632976d095df4")
+    version("4.3", sha256="e0290f9da0d255f90a612e60662b14a97ca53003f89073c6af84fa7bc8739f65")
 
     variant("omp", description="Enables the use of OMP instructions", default=False)
     variant("mpi", description="Build with MPI support", default=False)
@@ -30,37 +26,6 @@ class Cpmd(MakefilePackage):
 
     conflicts("^openblas threads=none", when="+omp")
     conflicts("^openblas threads=pthreads", when="+omp")
-
-    patch(
-        "file://{0}/patch.to.4612".format(basedir),
-        sha256="3b7d91e04c40418ad958069234ec7253fbf6c4be361a1d5cfd804774eeb44915",
-        level=0,
-        when="@4.3",
-    )
-    patch(
-        "file://{0}/patch.to.4615".format(basedir),
-        sha256="5ec5790fb6ca64632bcc1b0f5b8f3423c54455766a0979ff4136624bbe8d49eb",
-        level=0,
-        when="@4.3",
-    )
-    patch(
-        "file://{0}/patch.to.4616".format(basedir),
-        sha256="ac0bc215c4259f55da4dc59803fe636f797e241f8a01974e05730c9778ad44c4",
-        level=0,
-        when="@4.3",
-    )
-    patch(
-        "file://{0}/patch.to.4621".format(basedir),
-        sha256="2d2bc7e37246032fc354f51da7dbdb5a219dd228867399931b0e94da1265d5ca",
-        level=0,
-        when="@4.3",
-    )
-    patch(
-        "file://{0}/patch.to.4624".format(basedir),
-        sha256="0a19687528264bf91c9f50ffdc0b920a8511eecf5259b667c8c29350f9dabc53",
-        level=0,
-        when="@4.3",
-    )
 
     def edit(self, spec, prefix):
         # patch configure file


### PR DESCRIPTION
CPMD has been open-sourced on GitHub so manual download is no longer needed. The patches have been included in the new 4.3 release.