### PR TITLE
Simplify creation of test and install reports

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2364,6 +2364,7 @@ class CDashHandler(object):
             site=self.site,
             buildstamp=self.build_stamp,
             track=None,
+            ctest_parsing=False,
         )
         reporter = CDash(configuration=configuration)
         reporter.test_skipped_report(directory_name, spec, reason)

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -39,7 +39,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.error import SpackError
-from spack.reporters.cdash import CDash
+from spack.reporters import CDash
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 from spack.util.pattern import Bunch
 
@@ -2363,5 +2363,6 @@ class CDashHandler(object):
         it = iter(cli_args)
         kv = {x.replace("--", "").replace("-", "_"): next(it) for x in it}
 
+        kv.setdefault("cdash_track", None)
         reporter = CDash(Bunch(**kv))
         reporter.test_skipped_report(directory_name, spec, reason)

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -39,9 +39,8 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.error import SpackError
-from spack.reporters import CDash
+from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
-from spack.util.pattern import Bunch
 
 JOB_RETRY_CONDITIONS = [
     "always",
@@ -2358,11 +2357,13 @@ class CDashHandler(object):
             tty.warn(msg)
 
     def report_skipped(self, spec, directory_name, reason):
-        cli_args = self.args()
-        cli_args.extend(["package", [spec.name]])
-        it = iter(cli_args)
-        kv = {x.replace("--", "").replace("-", "_"): next(it) for x in it}
-
-        kv.setdefault("cdash_track", None)
-        reporter = CDash(Bunch(**kv))
+        configuration = CDashConfiguration(
+            upload_url=self.upload_url,
+            packages=[spec.name],
+            build=self.build_name,
+            site=self.site,
+            buildstamp=self.build_stamp,
+            track=None,
+        )
+        reporter = CDash(configuration=configuration)
         reporter.test_skipped_report(directory_name, spec, reason)

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -153,6 +153,7 @@ def _cdash_reporter(namespace):
             site=namespace.cdash_site,
             buildstamp=namespace.cdash_buildstamp,
             track=namespace.cdash_track,
+            ctest_parsing=getattr(namespace, "ctest_parsing", False),
         )
         return spack.reporters.CDash(configuration=configuration)
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -13,6 +13,7 @@ import spack.config
 import spack.dependency as dep
 import spack.environment as ev
 import spack.modules
+import spack.reporters
 import spack.spec
 import spack.store
 from spack.util.pattern import Args
@@ -121,6 +122,63 @@ class DeptypeAction(argparse.Action):
             deptype = dep.canonical_deptype(deptype)
 
         setattr(namespace, self.dest, deptype)
+
+
+def _cdash_reporter(namespace):
+    """Helper function to create a CDash reporter. This function gets an early reference to the
+    argparse namespace under construction, so it can later use it to create the object.
+    """
+
+    def _factory():
+        def installed_specs(args):
+            if getattr(args, "spec", ""):
+                packages = args.spec
+            elif getattr(args, "specs", ""):
+                packages = args.specs
+            elif getattr(args, "package", ""):
+                # Ensure CI 'spack test run' can output CDash results
+                packages = args.package
+            else:
+                packages = []
+                for file in args.specfiles:
+                    with open(file, "r") as f:
+                        s = spack.spec.Spec.from_yaml(f)
+                        packages.append(s.format())
+            return packages
+
+        configuration = spack.reporters.CDashConfiguration(
+            upload_url=namespace.cdash_upload_url,
+            packages=installed_specs(namespace),
+            build=namespace.cdash_build,
+            site=namespace.cdash_site,
+            buildstamp=namespace.cdash_buildstamp,
+            track=namespace.cdash_track,
+        )
+        return spack.reporters.CDash(configuration=configuration)
+
+    return _factory
+
+
+class CreateReporter(argparse.Action):
+    """Create the correct object to generate reports for installation and testing."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        if values == "junit":
+            setattr(namespace, "reporter", spack.reporters.JUnit)
+        elif values == "cdash":
+            setattr(namespace, "reporter", _cdash_reporter(namespace))
+
+
+@arg
+def log_format():
+    return Args(
+        "--log-format",
+        default=None,
+        action=CreateReporter,
+        choices=("junit", "cdash"),
+        help="format to be used for log files",
+    )
 
 
 # TODO: merge constraint and installed_specs

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -356,24 +356,6 @@ SPACK_CDASH_AUTH_TOKEN
     parser.print_help()
 
 
-def _create_log_reporter(args):
-    def _factory(specs):
-        if args.log_format is None:
-            return None
-
-        filename = args.log_file or args.cdash_upload_url or default_log_file(specs[0])
-        context_manager = spack.report.collect_info(
-            spack.package_base.PackageInstaller,
-            "_install_task",
-            reporter=args.reporter(),
-            filename=filename,
-            specs=specs,
-        )
-        return context_manager
-
-    return _factory
-
-
 def install_all_specs_from_active_environment(
     install_kwargs, only_concrete, cli_test_arg, reporter_factory
 ):
@@ -516,7 +498,20 @@ def install(parser, args):
     if args.deprecated:
         spack.config.set("config:deprecated", True, scope="command_line")
 
-    reporter_factory = _create_log_reporter(args)
+    def reporter_factory(specs):
+        if args.log_format is None:
+            return None
+
+        filename = args.log_file or args.cdash_upload_url or default_log_file(specs[0])
+        context_manager = spack.report.collect_info(
+            spack.package_base.PackageInstaller,
+            "_install_task",
+            reporter=args.reporter(),
+            filename=filename,
+            specs=specs,
+        )
+        return context_manager
+
     install_kwargs = install_kwargs_from_args(args)
 
     if not args.spec and not args.specfiles:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -235,7 +235,7 @@ packages. If neither are chosen, don't run tests for any packages.""",
     subparser.add_argument(
         "--log-format",
         default=None,
-        choices=spack.report.valid_formats,
+        choices=spack.report.VALID_FORMATS,
         help="format to be used for log files",
     )
     subparser.add_argument(

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -509,6 +509,7 @@ def install(parser, args):
             reporter=args.reporter(),
             filename=filename,
             specs=specs,
+            raw_logs_directory=os.getcwd(),
         )
         return context_manager
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -362,13 +362,11 @@ def _create_log_reporter(args):
             return None
 
         filename = args.log_file or args.cdash_upload_url or default_log_file(specs[0])
-        ctest_parsing = getattr(args, "ctest_parsing", False)
         context_manager = spack.report.collect_info(
             spack.package_base.PackageInstaller,
             "_install_task",
             reporter=args.reporter(),
             filename=filename,
-            ctest_parsing=ctest_parsing,
         )
         context_manager.specs = specs
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -373,18 +373,25 @@ def _create_log_reporter(args):
         if args.log_format is None:
             return None
 
-        reporter = spack.report.collect_info(
-            spack.package_base.PackageInstaller, "_install_task", fmt=report_format, args=args
+        reporter = spack.report.create_reporter(report_format, args)
+        filename = args.cdash_upload_url
+        ctest_parsing = getattr(args, "ctest_parsing", False)
+        context_manager = spack.report.collect_info(
+            spack.package_base.PackageInstaller,
+            "_install_task",
+            reporter=reporter,
+            filename=filename,
+            ctest_parsing=ctest_parsing,
         )
         if args.log_file:
-            reporter.filename = args.log_file
+            context_manager.filename = args.log_file
 
-        if not reporter.filename:
-            reporter.filename = default_log_file(specs[0])
+        if not context_manager.filename:
+            context_manager.filename = default_log_file(specs[0])
 
-        reporter.specs = specs
+        context_manager.specs = specs
 
-        return reporter
+        return context_manager
 
     return _factory
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -364,8 +364,15 @@ SPACK_CDASH_AUTH_TOKEN
 def _create_log_reporter(args):
     # TODO: remove args injection to spack.report.collect_info, since a class in core
     # TODO: shouldn't know what are the command line arguments a command use.
+    if args.log_format is None:
+        report_format = spack.report.ReportFormat.NULL
+    elif args.log_format == "junit":
+        report_format = spack.report.ReportFormat.JUnit
+    elif args.log_format == "cdash":
+        report_format = spack.report.ReportFormat.CDash
+
     reporter = spack.report.collect_info(
-        spack.package_base.PackageInstaller, "_install_task", args.log_format, args
+        spack.package_base.PackageInstaller, "_install_task", fmt=report_format, args=args
     )
     if args.log_file:
         reporter.filename = args.log_file

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -367,9 +367,8 @@ def _create_log_reporter(args):
             "_install_task",
             reporter=args.reporter(),
             filename=filename,
+            specs=specs,
         )
-        context_manager.specs = specs
-
         return context_manager
 
     return _factory

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -513,7 +513,6 @@ def install(parser, args):
             reporter=args.reporter(),
             filename=report_filename(args, specs=specs),
             specs=specs,
-            raw_logs_dir=os.getcwd(),
         )
         return context_manager
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -232,12 +232,7 @@ installation for top-level packages (but skip tests for dependencies).
 if 'all' is chosen, run package tests during installation for all
 packages. If neither are chosen, don't run tests for any packages.""",
     )
-    subparser.add_argument(
-        "--log-format",
-        default=None,
-        choices=spack.report.VALID_FORMATS,
-        help="format to be used for log files",
-    )
+    arguments.add_common_arguments(subparser, ["log_format"])
     subparser.add_argument(
         "--log-file",
         default=None,
@@ -362,24 +357,16 @@ SPACK_CDASH_AUTH_TOKEN
 
 
 def _create_log_reporter(args):
-    # TODO: remove args injection to spack.report.collect_info, since a class in core
-    # TODO: shouldn't know what are the command line arguments a command use.
-    if args.log_format == "junit":
-        report_format = spack.report.ReportFormat.JUnit
-    elif args.log_format == "cdash":
-        report_format = spack.report.ReportFormat.CDash
-
     def _factory(specs):
         if args.log_format is None:
             return None
 
-        reporter = spack.report.create_reporter(report_format, args)
         filename = args.cdash_upload_url
         ctest_parsing = getattr(args, "ctest_parsing", False)
         context_manager = spack.report.collect_info(
             spack.package_base.PackageInstaller,
             "_install_task",
-            reporter=reporter,
+            reporter=args.reporter(),
             filename=filename,
             ctest_parsing=ctest_parsing,
         )

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -361,7 +361,7 @@ def _create_log_reporter(args):
         if args.log_format is None:
             return None
 
-        filename = args.cdash_upload_url
+        filename = args.log_file or args.cdash_upload_url or default_log_file(specs[0])
         ctest_parsing = getattr(args, "ctest_parsing", False)
         context_manager = spack.report.collect_info(
             spack.package_base.PackageInstaller,
@@ -370,12 +370,6 @@ def _create_log_reporter(args):
             filename=filename,
             ctest_parsing=ctest_parsing,
         )
-        if args.log_file:
-            context_manager.filename = args.log_file
-
-        if not context_manager.filename:
-            context_manager.filename = default_log_file(specs[0])
-
         context_manager.specs = specs
 
         return context_manager

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -253,14 +253,14 @@ def create_reporter(args, specs_to_test, test_suite):
             log_file = os.path.join(os.getcwd(), "test-%s" % test_suite.name)
         filename = log_file
 
-    reporter = spack.report.collect_info(
+    context_manager = spack.report.collect_info(
         spack.package_base.PackageBase,
         "do_test",
         reporter=args.reporter(),
         filename=filename,
+        specs=specs_to_test,
     )
-    reporter.specs = specs_to_test
-    return reporter
+    return context_manager
 
 
 def test_list(args):

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -63,12 +63,7 @@ def setup_parser(subparser):
     run_parser.add_argument(
         "--keep-stage", action="store_true", help="Keep testing directory for debugging"
     )
-    run_parser.add_argument(
-        "--log-format",
-        default=None,
-        choices=spack.report.VALID_FORMATS,
-        help="format to be used for log files",
-    )
+    arguments.add_common_arguments(run_parser, ["log_format"])
     run_parser.add_argument(
         "--log-file",
         default=None,
@@ -246,19 +241,12 @@ def create_reporter(args, specs_to_test, test_suite):
     if args.log_format is None:
         return None
 
-    report_format = None
-    if args.log_format == "junit":
-        report_format = spack.report.ReportFormat.JUnit
-    elif args.log_format == "cdash":
-        report_format = spack.report.ReportFormat.CDash
-
-    reporter = spack.report.create_reporter(report_format, args)
     filename = args.cdash_upload_url
     ctest_parsing = getattr(args, "ctest_parsing", False)
     reporter = spack.report.collect_info(
         spack.package_base.PackageBase,
         "do_test",
-        reporter=reporter,
+        reporter=args.reporter(),
         filename=filename,
         ctest_parsing=ctest_parsing,
     )

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -231,8 +231,15 @@ environment variables:
 
     # Set up reporter
     setattr(args, "package", [s.format() for s in test_suite.specs])
+    if args.log_format is None:
+        report_format = spack.report.ReportFormat.NULL
+    elif args.log_format == "junit":
+        report_format = spack.report.ReportFormat.JUnit
+    elif args.log_format == "cdash":
+        report_format = spack.report.ReportFormat.CDash
+
     reporter = spack.report.collect_info(
-        spack.package_base.PackageBase, "do_test", args.log_format, args
+        spack.package_base.PackageBase, "do_test", fmt=report_format, args=args
     )
     if not reporter.filename:
         if args.log_file:

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -252,8 +252,15 @@ def create_reporter(args, specs_to_test, test_suite):
     elif args.log_format == "cdash":
         report_format = spack.report.ReportFormat.CDash
 
+    reporter = spack.report.create_reporter(report_format, args)
+    filename = args.cdash_upload_url
+    ctest_parsing = getattr(args, "ctest_parsing", False)
     reporter = spack.report.collect_info(
-        spack.package_base.PackageBase, "do_test", fmt=report_format, args=args
+        spack.package_base.PackageBase,
+        "do_test",
+        reporter=reporter,
+        filename=filename,
+        ctest_parsing=ctest_parsing,
     )
     if not reporter.filename:
         if args.log_file:

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -253,13 +253,11 @@ def create_reporter(args, specs_to_test, test_suite):
             log_file = os.path.join(os.getcwd(), "test-%s" % test_suite.name)
         filename = log_file
 
-    ctest_parsing = getattr(args, "ctest_parsing", False)
     reporter = spack.report.collect_info(
         spack.package_base.PackageBase,
         "do_test",
         reporter=args.reporter(),
         filename=filename,
-        ctest_parsing=ctest_parsing,
     )
     reporter.specs = specs_to_test
     return reporter

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -226,9 +226,9 @@ environment variables:
 
     # Set up reporter
     setattr(args, "package", [s.format() for s in test_suite.specs])
-    reporter = create_reporter(args, specs_to_test, test_suite) or lang.nullcontext
+    reporter = create_reporter(args, specs_to_test, test_suite) or lang.nullcontext()
 
-    with reporter("test"):
+    with reporter:
         test_suite(
             remove_directory=not args.keep_stage,
             dirty=args.dirty,
@@ -253,13 +253,11 @@ def create_reporter(args, specs_to_test, test_suite):
             log_file = os.path.join(os.getcwd(), "test-%s" % test_suite.name)
         filename = log_file
 
-    context_manager = spack.report.collect_info(
-        spack.package_base.PackageBase,
-        "do_test",
+    context_manager = spack.report.test_context_manager(
         reporter=args.reporter(),
         filename=filename,
         specs=specs_to_test,
-        raw_logs_directory=test_suite.stage,
+        raw_logs_dir=test_suite.stage,
     )
     return context_manager
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -228,7 +228,7 @@ environment variables:
     setattr(args, "package", [s.format() for s in test_suite.specs])
     reporter = create_reporter(args, specs_to_test, test_suite) or lang.nullcontext
 
-    with reporter("test", test_suite.stage):
+    with reporter("test"):
         test_suite(
             remove_directory=not args.keep_stage,
             dirty=args.dirty,
@@ -259,6 +259,7 @@ def create_reporter(args, specs_to_test, test_suite):
         reporter=args.reporter(),
         filename=filename,
         specs=specs_to_test,
+        raw_logs_directory=test_suite.stage,
     )
     return context_manager
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -242,15 +242,7 @@ def create_reporter(args, specs_to_test, test_suite):
         return None
 
     filename = args.cdash_upload_url
-    ctest_parsing = getattr(args, "ctest_parsing", False)
-    reporter = spack.report.collect_info(
-        spack.package_base.PackageBase,
-        "do_test",
-        reporter=args.reporter(),
-        filename=filename,
-        ctest_parsing=ctest_parsing,
-    )
-    if not reporter.filename:
+    if not filename:
         if args.log_file:
             if os.path.isabs(args.log_file):
                 log_file = args.log_file
@@ -259,7 +251,16 @@ def create_reporter(args, specs_to_test, test_suite):
                 log_file = os.path.join(log_dir, args.log_file)
         else:
             log_file = os.path.join(os.getcwd(), "test-%s" % test_suite.name)
-        reporter.filename = log_file
+        filename = log_file
+
+    ctest_parsing = getattr(args, "ctest_parsing", False)
+    reporter = spack.report.collect_info(
+        spack.package_base.PackageBase,
+        "do_test",
+        reporter=args.reporter(),
+        filename=filename,
+        ctest_parsing=ctest_parsing,
+    )
     reporter.specs = specs_to_test
     return reporter
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -66,7 +66,7 @@ def setup_parser(subparser):
     run_parser.add_argument(
         "--log-format",
         default=None,
-        choices=spack.report.valid_formats,
+        choices=spack.report.VALID_FORMATS,
         help="format to be used for log files",
     )
     run_parser.add_argument(

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -11,7 +11,7 @@ import functools
 import os
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable, Dict, List, Type, Optional
 
 import llnl.util.lang
 
@@ -19,7 +19,7 @@ import spack.build_environment
 import spack.fetch_strategy
 import spack.package_base
 from spack.install_test import TestSuite
-from spack.reporters import CDash, CDashConfiguration, JUnit
+from spack.reporters import CDash, CDashConfiguration, JUnit, Reporter
 
 
 class ReportFormat(enum.Enum):
@@ -280,15 +280,20 @@ class collect_info(object):
         ValueError: when ``format_name`` is not in ``valid_formats``
     """
 
-    def __init__(self, cls, function, fmt: ReportFormat, args):
+    def __init__(
+        self,
+        cls,
+        function,
+        *,
+        reporter: Reporter,
+        filename: Optional[str] = None,
+        ctest_parsing: bool = False,
+    ):
         self.cls = cls
         self.function = function
-        self.filename = None
-        self.ctest_parsing = getattr(args, "ctest_parsing", False)
-        if args.cdash_upload_url:
-            self.filename = "cdash_report"
-
-        self.report_writer = create_reporter(fmt, args)
+        self.filename = filename
+        self.ctest_parsing = ctest_parsing
+        self.report_writer = reporter
 
     def __call__(self, type, dir=None):
         self.type = type

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -28,13 +28,6 @@ class ReportFormat(enum.Enum):
     CDash = enum.auto()
 
 
-REPORT_WRITERS = {
-    ReportFormat.NULL: NullReporter,
-    ReportFormat.JUnit: JUnit,
-    ReportFormat.CDash: CDash,
-}
-
-#: Allowed report formats
 VALID_FORMATS = [None, "junit", "cdash"]
 
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -231,20 +231,11 @@ class collect_info:
         ValueError: when ``format_name`` is not in ``valid_formats``
     """
 
-    def __init__(
-        self,
-        cls,
-        function,
-        *,
-        reporter: spack.reporters.Reporter,
-        filename: str,
-        ctest_parsing: bool = False,
-    ):
+    def __init__(self, cls, function, *, reporter: spack.reporters.Reporter, filename: str):
         self.cls = cls
         self.function = function
         self.filename = filename
-        self.ctest_parsing = ctest_parsing
-        self.report_writer = reporter
+        self.reporter = reporter
 
     def __call__(self, type, dir=None):
         self.type = type
@@ -252,7 +243,7 @@ class collect_info:
         return self
 
     def concretization_report(self, msg: str):
-        self.report_writer.concretization_report(self.filename, msg)
+        self.reporter.concretization_report(self.filename, msg)
 
     def __enter__(self):
         self.collector = InfoCollector(self.cls, self.function, self.specs, self.dir)
@@ -261,6 +252,6 @@ class collect_info:
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Close the collector and restore the original function
         self.collector.__exit__(exc_type, exc_val, exc_tb)
-        report_data = {"specs": self.collector.specs, "ctest-parsing": self.ctest_parsing}
-        report_fn = getattr(self.report_writer, "%s_report" % self.type)
+        report_data = {"specs": self.collector.specs}
+        report_fn = getattr(self.reporter, "%s_report" % self.type)
         report_fn(self.filename, report_data)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -223,9 +223,10 @@ class collect_info:
 
     Args:
         cls: class on which to wrap a function
-        function function to wrap
+        function: function to wrap
         reporter: object that generates the report
         filename: optional filename for the report
+        specs: specs that need reporting
 
     Raises:
         ValueError: when ``format_name`` is not in ``valid_formats``

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -19,6 +19,7 @@ import spack.install_test
 import spack.installer
 import spack.package_base
 import spack.reporters
+import spack.spec
 
 
 class InfoCollector:
@@ -35,7 +36,7 @@ class InfoCollector:
     input_specs: List["spack.spec.Spec"]
     specs: List[Dict[str, Any]]
 
-    def __init__(self, wrap_class, do_fn, specs):
+    def __init__(self, wrap_class, do_fn, specs: List[spack.spec.Spec]):
         #: Class for which to wrap a function
         self.wrap_class = wrap_class
         #: Action to be reported on
@@ -165,7 +166,7 @@ class BuildInfoCollector(InfoCollector):
     """Collect information for the PackageInstaller._install_task method.
 
     Args:
-        specs (list of Spec): specs whose install information will be recorded
+        specs (list of spack.spec.Spec): specs whose install information will be recorded
     """
 
     def __init__(self, specs):
@@ -201,7 +202,7 @@ class TestInfoCollector(InfoCollector):
     """Collect information for the PackageBase.do_test method.
 
     Args:
-        specs (list of Spec): specs whose install information will be recorded
+        specs (list of spack.spec.Spec): specs whose install information will be recorded
         record_directory (str): record directory for test log paths
     """
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -38,6 +38,16 @@ REPORT_WRITERS = {
 VALID_FORMATS = [None, "junit", "cdash"]
 
 
+def create_reporter(fmt: ReportFormat, args):
+    if fmt == ReportFormat.NULL:
+        return NullReporter()
+    if fmt == ReportFormat.JUnit:
+        return JUnit()
+    if fmt == ReportFormat.CDash:
+        return CDash(args)
+    return None
+
+
 def fetch_log(pkg, do_fn, dir):
     log_files = {
         "_install_task": pkg.build_log_path,
@@ -266,8 +276,7 @@ class collect_info(object):
         else:
             self.format_name = fmt
 
-        # Check that the format is valid.
-        self.report_writer = REPORT_WRITERS[self.format_name](args)
+        self.report_writer = create_reporter(fmt, args)
 
     def __call__(self, type, dir=None):
         self.type = type

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -20,12 +20,10 @@ import spack.package_base
 from spack.install_test import TestSuite
 from spack.reporters import CDash, JUnit, Reporter
 
-report_writers = {None: Reporter, "junit": JUnit, "cdash": CDash}
+REPORT_WRITERS = {None: Reporter, "junit": JUnit, "cdash": CDash}
 
 #: Allowed report formats
-valid_formats = list(report_writers.keys())
-
-__all__ = ["valid_formats", "collect_info"]
+VALID_FORMATS = list(REPORT_WRITERS.keys())
 
 
 def fetch_log(pkg, do_fn, dir):
@@ -255,10 +253,12 @@ class collect_info(object):
             self.filename = "cdash_report"
         else:
             self.format_name = format_name
+
         # Check that the format is valid.
-        if self.format_name not in valid_formats:
+        if self.format_name not in VALID_FORMATS:
             raise ValueError("invalid report type: {0}".format(self.format_name))
-        self.report_writer = report_writers[self.format_name](args)
+
+        self.report_writer = REPORT_WRITERS[self.format_name](args)
 
     def __call__(self, type, dir=None):
         self.type = type

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -286,10 +286,7 @@ class collect_info(object):
         self.filename = None
         self.ctest_parsing = getattr(args, "ctest_parsing", False)
         if args.cdash_upload_url:
-            self.format_name = ReportFormat.CDash
             self.filename = "cdash_report"
-        else:
-            self.format_name = fmt
 
         self.report_writer = create_reporter(fmt, args)
 
@@ -302,17 +299,13 @@ class collect_info(object):
         self.report_writer.concretization_report(self.filename, msg)
 
     def __enter__(self):
-        if self.format_name:
-            # Start the collector and patch self.function on appropriate class
-            self.collector = InfoCollector(self.cls, self.function, self.specs, self.dir)
-            self.collector.__enter__()
+        self.collector = InfoCollector(self.cls, self.function, self.specs, self.dir)
+        self.collector.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.format_name:
-            # Close the collector and restore the original function
-            self.collector.__exit__(exc_type, exc_val, exc_tb)
+        # Close the collector and restore the original function
+        self.collector.__exit__(exc_type, exc_val, exc_tb)
 
-            report_data = {"specs": self.collector.specs}
-            report_data["ctest-parsing"] = self.ctest_parsing
-            report_fn = getattr(self.report_writer, "%s_report" % self.type)
-            report_fn(self.filename, report_data)
+        report_data = {"specs": self.collector.specs, "ctest-parsing": self.ctest_parsing}
+        report_fn = getattr(self.report_writer, "%s_report" % self.type)
+        report_fn(self.filename, report_data)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -18,9 +18,7 @@ import spack.build_environment
 import spack.fetch_strategy
 import spack.package_base
 from spack.install_test import TestSuite
-from spack.reporter import Reporter
-from spack.reporters.cdash import CDash
-from spack.reporters.junit import JUnit
+from spack.reporters import CDash, JUnit, Reporter
 
 report_writers = {None: Reporter, "junit": JUnit, "cdash": CDash}
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -30,24 +30,23 @@ class ReportFormat(enum.Enum):
 VALID_FORMATS = ["junit", "cdash"]
 
 
-def installed_specs(args):
-    if getattr(args, "spec", ""):
-        packages = args.spec
-    elif getattr(args, "specs", ""):
-        packages = args.specs
-    elif getattr(args, "package", ""):
-        # Ensure CI 'spack test run' can output CDash results
-        packages = args.package
-    else:
-        packages = []
-        for file in args.specfiles:
-            with open(file, "r") as f:
-                s = spack.spec.Spec.from_yaml(f)
-                packages.append(s.format())
-    return packages
-
-
 def create_reporter(fmt: ReportFormat, args):
+    def installed_specs(args):
+        if getattr(args, "spec", ""):
+            packages = args.spec
+        elif getattr(args, "specs", ""):
+            packages = args.specs
+        elif getattr(args, "package", ""):
+            # Ensure CI 'spack test run' can output CDash results
+            packages = args.package
+        else:
+            packages = []
+            for file in args.specfiles:
+                with open(file, "r") as f:
+                    s = spack.spec.Spec.from_yaml(f)
+                    packages.append(s.format())
+        return packages
+
     if fmt == ReportFormat.JUnit:
         return JUnit()
     if fmt == ReportFormat.CDash:

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -16,43 +16,26 @@ import llnl.util.lang
 import spack.build_environment
 import spack.fetch_strategy
 import spack.install_test
+import spack.installer
 import spack.package_base
 import spack.reporters
 
 
-def fetch_log(pkg, do_fn, dir):
-    log_files = {
-        "_install_task": pkg.build_log_path,
-        "do_test": os.path.join(dir, spack.install_test.TestSuite.test_log_name(pkg.spec)),
-    }
-    try:
-        with open(log_files[do_fn.__name__], "r", encoding="utf-8") as f:
-            return "".join(f.readlines())
-    except Exception:
-        return "Cannot open log for {0}".format(pkg.spec.cshort_spec)
-
-
 class InfoCollector:
-    """Decorates PackageInstaller._install_task, which is called via
-    PackageBase.do_install for individual specs, to collect information
-    on the installation of certain specs.
+    """Base class for context manager objects that collect information during the execution of
+    certain package functions.
 
-    When exiting the context this change will be rolled-back.
-
-    The data collected is available through the ``specs``
-    attribute once exited, and it's organized as a list where
-    each item represents the installation of one of the spec.
+    The data collected is available through the ``specs`` attribute once exited, and it's
+    organized as a list where each item represents the installation of one spec.
 
     """
-
     wrap_class: Type
     do_fn: str
     _backup_do_fn: Callable
     input_specs: List["spack.spec.Spec"]
     specs: List[Dict[str, Any]]
-    dir: str
 
-    def __init__(self, wrap_class: Type, do_fn: str, specs: List["spack.spec.Spec"], dir: str):
+    def __init__(self, wrap_class, do_fn, specs):
         #: Class for which to wrap a function
         self.wrap_class = wrap_class
         #: Action to be reported on
@@ -61,19 +44,28 @@ class InfoCollector:
         self._backup_do_fn = getattr(self.wrap_class, do_fn)
         #: Specs that will be acted on
         self.input_specs = specs
-        #: This is where we record the data that will be included
-        #: in our report.
+        #: This is where we record the data that will be included in our report
         self.specs = []
-        #: Record directory for test log paths
-        self.dir = dir
+
+    def fetch_log(self, pkg: spack.package_base.PackageBase) -> str:
+        """Return the stdout log associated with the function being monitored
+
+        Args:
+            pkg (spack.package_base.PackageBase): package under consideration
+        """
+        raise NotImplementedError("must be implemented by derived classes")
+
+    def extract_package_from_signature(self, instance, *args, **kwargs):
+        """Return the package instance, given the signature of the wrapped function."""
+        raise NotImplementedError("must be implemented by derived classes")
 
     def __enter__(self):
         # Initialize the spec report with the data that is available upfront.
+        Property = collections.namedtuple("Property", ["name", "value"])
         for input_spec in self.input_specs:
             name_fmt = "{0}_{1}"
             name = name_fmt.format(input_spec.name, input_spec.dag_hash(length=7))
-
-            spec = {
+            spec_record = {
                 "name": name,
                 "nerrors": None,
                 "nfailures": None,
@@ -83,45 +75,17 @@ class InfoCollector:
                 "properties": [],
                 "packages": [],
             }
+            spec_record["properties"].append(Property("architecture", input_spec.architecture))
+            spec_record["properties"].append(Property("compiler", input_spec.compiler))
+            self.init_spec_record(input_spec, spec_record)
+            self.specs.append(spec_record)
 
-            self.specs.append(spec)
+        def gather_info(wrapped_fn):
+            """Decorates a function to gather useful information for a CI report."""
 
-            Property = collections.namedtuple("Property", ["name", "value"])
-            spec["properties"].append(Property("architecture", input_spec.architecture))
-            spec["properties"].append(Property("compiler", input_spec.compiler))
-
-            # Check which specs are already installed and mark them as skipped
-            # only for install_task
-            if self.do_fn == "_install_task":
-                for dep in filter(lambda x: x.installed, input_spec.traverse()):
-                    package = {
-                        "name": dep.name,
-                        "id": dep.dag_hash(),
-                        "elapsed_time": "0.0",
-                        "result": "skipped",
-                        "message": "Spec already installed",
-                    }
-                    spec["packages"].append(package)
-
-        def gather_info(do_fn):
-            """Decorates do_fn to gather useful information for
-            a CI report.
-
-            It's defined here to capture the environment and build
-            this context as the installations proceed.
-            """
-
-            @functools.wraps(do_fn)
+            @functools.wraps(wrapped_fn)
             def wrapper(instance, *args, **kwargs):
-                if isinstance(instance, spack.package_base.PackageBase):
-                    pkg = instance
-                elif hasattr(args[0], "pkg"):
-                    pkg = args[0].pkg
-                else:
-                    raise Exception
-
-                # We accounted before for what is already installed
-                installed_already = pkg.spec.installed
+                pkg = self.extract_package_from_signature(instance, *args, **kwargs)
 
                 package = {
                     "name": pkg.name,
@@ -146,27 +110,20 @@ class InfoCollector:
                         pass
 
                 start_time = time.time()
-                value = None
                 try:
-                    value = do_fn(instance, *args, **kwargs)
 
-                    externals = kwargs.get("externals", False)
-                    skip_externals = pkg.spec.external and not externals
-                    if do_fn.__name__ == "do_test" and skip_externals:
-                        package["result"] = "skipped"
-                    else:
-                        package["result"] = "success"
-                    package["stdout"] = fetch_log(pkg, do_fn, self.dir)
+                    value = wrapped_fn(instance, *args, **kwargs)
+                    package["stdout"] = self.fetch_log(pkg)
                     package["installed_from_binary_cache"] = pkg.installed_from_binary_cache
-                    if do_fn.__name__ == "_install_task" and installed_already:
-                        return
+                    self.on_success(pkg, kwargs, package)
+                    return value
 
                 except spack.build_environment.InstallError as e:
                     # An InstallError is considered a failure (the recipe
                     # didn't work correctly)
                     package["result"] = "failure"
                     package["message"] = e.message or "Installation failure"
-                    package["stdout"] = fetch_log(pkg, do_fn, self.dir)
+                    package["stdout"] = self.fetch_log(pkg)
                     package["stdout"] += package["message"]
                     package["exception"] = e.traceback
                     raise
@@ -175,7 +132,7 @@ class InfoCollector:
                     # Everything else is an error (the installation
                     # failed outside of the child process)
                     package["result"] = "error"
-                    package["stdout"] = fetch_log(pkg, do_fn, self.dir)
+                    package["stdout"] = self.fetch_log(pkg)
                     package["message"] = str(e) or "Unknown error"
                     package["exception"] = traceback.format_exc()
                     raise
@@ -183,17 +140,21 @@ class InfoCollector:
                 finally:
                     package["elapsed_time"] = time.time() - start_time
 
-                return value
-
             return wrapper
 
         setattr(self.wrap_class, self.do_fn, gather_info(getattr(self.wrap_class, self.do_fn)))
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def on_success(self, pkg, kwargs, package_record):
+        """Add additional properties on function call success."""
+        raise NotImplementedError("must be implemented by derived classes")
 
+    def init_spec_record(self, input_spec, record):
+        """Add additional entries to a spec record when entering the collection context."""
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
         # Restore the original method in PackageBase
         setattr(self.wrap_class, self.do_fn, self._backup_do_fn)
-
         for spec in self.specs:
             spec["npackages"] = len(spec["packages"])
             spec["nfailures"] = len([x for x in spec["packages"] if x["result"] == "failure"])
@@ -201,25 +162,75 @@ class InfoCollector:
             spec["time"] = sum([float(x["elapsed_time"]) for x in spec["packages"]])
 
 
+class BuildInfoCollector(InfoCollector):
+    def __init__(self, specs):
+        super().__init__(spack.installer.PackageInstaller, "_install_task", specs)
+
+    def init_spec_record(self, input_spec, record):
+        # Check which specs are already installed and mark them as skipped
+        for dep in filter(lambda x: x.installed, input_spec.traverse()):
+            package = {
+                "name": dep.name,
+                "id": dep.dag_hash(),
+                "elapsed_time": "0.0",
+                "result": "skipped",
+                "message": "Spec already installed",
+            }
+            record["packages"].append(package)
+
+    def on_success(self, pkg, kwargs, package_record):
+        package_record["result"] = "success"
+
+    def fetch_log(self, pkg):
+        try:
+            with open(pkg.build_log_path, "r", encoding="utf-8") as f:
+                return "".join(f.readlines())
+        except Exception:
+            return f"Cannot open log for {pkg.spec.cshort_spec}"
+
+    def extract_package_from_signature(self, instance, *args, **kwargs):
+        return args[0].pkg
+
+
+class TestInfoCollector(InfoCollector):
+    def __init__(self, specs, dir):
+        super().__init__(spack.package_base.PackageBase, "do_test", specs)
+        #: Record directory for test log paths
+        self.dir = dir
+
+    def on_success(self, pkg, kwargs, package_record):
+        externals = kwargs.get("externals", False)
+        skip_externals = pkg.spec.external and not externals
+        if skip_externals:
+            package_record["result"] = "skipped"
+        package_record["result"] = "success"
+
+    def fetch_log(self, pkg):
+        log_file = os.path.join(self.dir, spack.install_test.TestSuite.test_log_name(pkg.spec))
+        try:
+            with open(log_file, "r", encoding="utf-8") as f:
+                return "".join(f.readlines())
+        except Exception:
+            return f"Cannot open log for {pkg.spec.cshort_spec}"
+
+    def extract_package_from_signature(self, instance, *args, **kwargs):
+        return instance
+
+
 @contextlib.contextmanager
 def build_context_manager(
     reporter: spack.reporters.Reporter,
     filename: str,
     specs: List[spack.spec.Spec],
-    raw_logs_dir: str,
 ):
-    """Decorate ``PackageInstaller._install_task`` so that an installation report is emitted in
-    the end.
+    """Decorate a package to generate a report after the installation function is executed.
 
     Args:
         reporter (spack.reporters.Reporter): object that generates the report
         filename (str):  filename for the report
         specs (list of spack.spec.Spec): specs that need reporting
-        raw_logs_dir (str): TODO
     """
-    collector = InfoCollector(
-        spack.package_base.PackageInstaller, "_install_task", specs, raw_logs_dir
-    )
+    collector = BuildInfoCollector(specs)
     try:
         with collector:
             yield
@@ -234,15 +245,15 @@ def test_context_manager(
     specs: List[spack.spec.Spec],
     raw_logs_dir: str,
 ):
-    """Decorate ``PackageBase.do_test`` so that a test report is emitted in the end.
+    """Decorate a package to generate a report after the test function is executed.
 
     Args:
         reporter (spack.reporters.Reporter): object that generates the report
         filename (str):  filename for the report
         specs (list of spack.spec.Spec): specs that need reporting
-        raw_logs_dir (str): TODO
+        raw_logs_dir (str): record directory for test log paths
     """
-    collector = InfoCollector(spack.package_base.PackageBase, "do_test", specs, raw_logs_dir)
+    collector = TestInfoCollector(specs, raw_logs_dir)
     try:
         with collector:
             yield

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -32,7 +32,7 @@ def fetch_log(pkg, do_fn, dir):
         return "Cannot open log for {0}".format(pkg.spec.cshort_spec)
 
 
-class InfoCollector(object):
+class InfoCollector:
     """Decorates PackageInstaller._install_task, which is called via
     PackageBase.do_install for individual specs, to collect information
     on the installation of certain specs.
@@ -201,7 +201,7 @@ class InfoCollector(object):
             spec["time"] = sum([float(x["elapsed_time"]) for x in spec["packages"]])
 
 
-class collect_info(object):
+class collect_info:
     """Collects information to build a report while installing and dumps it on exit.
 
     Within the context, only the specs that are passed to it on initialization will be recorded
@@ -237,7 +237,7 @@ class collect_info(object):
         function,
         *,
         reporter: spack.reporters.Reporter,
-        filename: Optional[str] = None,
+        filename: str,
         ctest_parsing: bool = False,
     ):
         self.cls = cls
@@ -251,7 +251,7 @@ class collect_info(object):
         self.dir = dir or os.getcwd()
         return self
 
-    def concretization_report(self, msg):
+    def concretization_report(self, msg: str):
         self.report_writer.concretization_report(self.filename, msg)
 
     def __enter__(self):

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -9,7 +9,7 @@ import functools
 import os
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Type, Optional
+from typing import Any, Callable, Dict, List, Type
 
 import llnl.util.lang
 
@@ -231,14 +231,23 @@ class collect_info:
         ValueError: when ``format_name`` is not in ``valid_formats``
     """
 
-    def __init__(self, cls, function, *, reporter: spack.reporters.Reporter, filename: str):
+    def __init__(
+        self,
+        cls,
+        function,
+        *,
+        reporter: spack.reporters.Reporter,
+        filename: str,
+        specs: List[spack.spec.Spec],
+    ):
         self.cls = cls
         self.function = function
         self.filename = filename
         self.reporter = reporter
+        self.specs = specs
 
-    def __call__(self, type, dir=None):
-        self.type = type
+    def __call__(self, report_tag: str, dir=None):
+        self.report_tag = report_tag
         self.dir = dir or os.getcwd()
         return self
 
@@ -252,6 +261,5 @@ class collect_info:
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Close the collector and restore the original function
         self.collector.__exit__(exc_type, exc_val, exc_tb)
-        report_data = {"specs": self.collector.specs}
-        report_fn = getattr(self.reporter, "%s_report" % self.type)
-        report_fn(self.filename, report_data)
+        report_fn = getattr(self.reporter, f"{self.report_tag}_report")
+        report_fn(self.filename, self.collector.specs)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -46,7 +46,7 @@ class InfoCollector:
         #: Specs that will be acted on
         self.input_specs = specs
         #: This is where we record the data that will be included in our report
-        self.specs = []
+        self.specs: List[Dict[str, Any]] = []
 
     def fetch_log(self, pkg: spack.package_base.PackageBase) -> str:
         """Return the stdout log associated with the function being monitored

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -6,7 +6,6 @@
 import argparse
 import codecs
 import collections
-import enum
 import functools
 import os
 import time
@@ -19,47 +18,7 @@ import spack.build_environment
 import spack.fetch_strategy
 import spack.package_base
 from spack.install_test import TestSuite
-from spack.reporters import CDash, CDashConfiguration, JUnit, Reporter
-
-
-class ReportFormat(enum.Enum):
-    JUnit = enum.auto()
-    CDash = enum.auto()
-
-
-VALID_FORMATS = ["junit", "cdash"]
-
-
-def create_reporter(fmt: ReportFormat, args):
-    def installed_specs(args):
-        if getattr(args, "spec", ""):
-            packages = args.spec
-        elif getattr(args, "specs", ""):
-            packages = args.specs
-        elif getattr(args, "package", ""):
-            # Ensure CI 'spack test run' can output CDash results
-            packages = args.package
-        else:
-            packages = []
-            for file in args.specfiles:
-                with open(file, "r") as f:
-                    s = spack.spec.Spec.from_yaml(f)
-                    packages.append(s.format())
-        return packages
-
-    if fmt == ReportFormat.JUnit:
-        return JUnit()
-    if fmt == ReportFormat.CDash:
-        configuration = CDashConfiguration(
-            upload_url=args.cdash_upload_url,
-            packages=installed_specs(args),
-            build=args.cdash_build,
-            site=args.cdash_site,
-            buildstamp=args.cdash_buildstamp,
-            track=args.cdash_track,
-        )
-        return CDash(configuration=configuration)
-    return None
+from spack.reporters import Reporter
 
 
 def fetch_log(pkg, do_fn, dir):

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -19,16 +19,15 @@ import spack.build_environment
 import spack.fetch_strategy
 import spack.package_base
 from spack.install_test import TestSuite
-from spack.reporters import CDash, CDashConfiguration, JUnit, NullReporter
+from spack.reporters import CDash, CDashConfiguration, JUnit
 
 
 class ReportFormat(enum.Enum):
-    NULL = enum.auto()
     JUnit = enum.auto()
     CDash = enum.auto()
 
 
-VALID_FORMATS = [None, "junit", "cdash"]
+VALID_FORMATS = ["junit", "cdash"]
 
 
 def installed_specs(args):
@@ -49,8 +48,6 @@ def installed_specs(args):
 
 
 def create_reporter(fmt: ReportFormat, args):
-    if fmt == ReportFormat.NULL:
-        return NullReporter()
     if fmt == ReportFormat.JUnit:
         return JUnit()
     if fmt == ReportFormat.CDash:

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tools to produce reports of spec installations"""
-import codecs
 import collections
 import functools
 import os
@@ -26,7 +25,7 @@ def fetch_log(pkg, do_fn, dir):
         "do_test": os.path.join(dir, spack.install_test.TestSuite.test_log_name(pkg.spec)),
     }
     try:
-        with codecs.open(log_files[do_fn.__name__], "r", "utf-8") as f:
+        with open(log_files[do_fn.__name__], "r", encoding="utf-8") as f:
             return "".join(f.readlines())
     except Exception:
         return "Cannot open log for {0}".format(pkg.spec.cshort_spec)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -30,13 +30,14 @@ class InfoCollector:
     organized as a list where each item represents the installation of one spec.
 
     """
+
     wrap_class: Type
     do_fn: str
     _backup_do_fn: Callable
-    input_specs: List["spack.spec.Spec"]
+    input_specs: List[spack.spec.Spec]
     specs: List[Dict[str, Any]]
 
-    def __init__(self, wrap_class, do_fn, specs: List[spack.spec.Spec]):
+    def __init__(self, wrap_class: Type, do_fn: str, specs: List[spack.spec.Spec]):
         #: Class for which to wrap a function
         self.wrap_class = wrap_class
         #: Action to be reported on
@@ -52,7 +53,7 @@ class InfoCollector:
         """Return the stdout log associated with the function being monitored
 
         Args:
-            pkg (spack.package_base.PackageBase): package under consideration
+            pkg: package under consideration
         """
         raise NotImplementedError("must be implemented by derived classes")
 
@@ -166,10 +167,10 @@ class BuildInfoCollector(InfoCollector):
     """Collect information for the PackageInstaller._install_task method.
 
     Args:
-        specs (list of spack.spec.Spec): specs whose install information will be recorded
+        specs: specs whose install information will be recorded
     """
 
-    def __init__(self, specs):
+    def __init__(self, specs: List[spack.spec.Spec]):
         super().__init__(spack.installer.PackageInstaller, "_install_task", specs)
 
     def init_spec_record(self, input_spec, record):
@@ -202,11 +203,13 @@ class TestInfoCollector(InfoCollector):
     """Collect information for the PackageBase.do_test method.
 
     Args:
-        specs (list of spack.spec.Spec): specs whose install information will be recorded
-        record_directory (str): record directory for test log paths
+        specs: specs whose install information will be recorded
+        record_directory: record directory for test log paths
     """
 
-    def __init__(self, specs, record_directory):
+    dir: str
+
+    def __init__(self, specs: List[spack.spec.Spec], record_directory: str):
         super().__init__(spack.package_base.PackageBase, "do_test", specs)
         self.dir = record_directory
 
@@ -217,7 +220,7 @@ class TestInfoCollector(InfoCollector):
             package_record["result"] = "skipped"
         package_record["result"] = "success"
 
-    def fetch_log(self, pkg):
+    def fetch_log(self, pkg: spack.package_base.PackageBase):
         log_file = os.path.join(self.dir, spack.install_test.TestSuite.test_log_name(pkg.spec))
         try:
             with open(log_file, "r", encoding="utf-8") as stream:
@@ -238,9 +241,9 @@ def build_context_manager(
     """Decorate a package to generate a report after the installation function is executed.
 
     Args:
-        reporter (spack.reporters.Reporter): object that generates the report
-        filename (str):  filename for the report
-        specs (list of spack.spec.Spec): specs that need reporting
+        reporter: object that generates the report
+        filename:  filename for the report
+        specs: specs that need reporting
     """
     collector = BuildInfoCollector(specs)
     try:
@@ -260,10 +263,10 @@ def test_context_manager(
     """Decorate a package to generate a report after the test function is executed.
 
     Args:
-        reporter (spack.reporters.Reporter): object that generates the report
-        filename (str):  filename for the report
-        specs (list of spack.spec.Spec): specs that need reporting
-        raw_logs_dir (str): record directory for test log paths
+        reporter: object that generates the report
+        filename:  filename for the report
+        specs: specs that need reporting
+        raw_logs_dir: record directory for test log paths
     """
     collector = TestInfoCollector(specs, raw_logs_dir)
     try:

--- a/lib/spack/spack/reporters/__init__.py
+++ b/lib/spack/spack/reporters/__init__.py
@@ -2,3 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from .base import Reporter
+from .cdash import CDash
+from .junit import JUnit
+
+__all__ = ["Reporter", "JUnit", "CDash"]

--- a/lib/spack/spack/reporters/__init__.py
+++ b/lib/spack/spack/reporters/__init__.py
@@ -2,8 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .base import Reporter
+from .base import NullReporter
 from .cdash import CDash
 from .junit import JUnit
 
-__all__ = ["Reporter", "JUnit", "CDash"]
+__all__ = ["NullReporter", "JUnit", "CDash"]

--- a/lib/spack/spack/reporters/__init__.py
+++ b/lib/spack/spack/reporters/__init__.py
@@ -2,8 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .base import NullReporter
 from .cdash import CDash, CDashConfiguration
 from .junit import JUnit
 
-__all__ = ["NullReporter", "JUnit", "CDash", "CDashConfiguration"]
+__all__ = ["JUnit", "CDash", "CDashConfiguration"]

--- a/lib/spack/spack/reporters/__init__.py
+++ b/lib/spack/spack/reporters/__init__.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from .base import NullReporter
-from .cdash import CDash
+from .cdash import CDash, CDashConfiguration
 from .junit import JUnit
 
-__all__ = ["NullReporter", "JUnit", "CDash"]
+__all__ = ["NullReporter", "JUnit", "CDash", "CDashConfiguration"]

--- a/lib/spack/spack/reporters/__init__.py
+++ b/lib/spack/spack/reporters/__init__.py
@@ -2,7 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from .base import Reporter
 from .cdash import CDash, CDashConfiguration
 from .junit import JUnit
 
-__all__ = ["JUnit", "CDash", "CDashConfiguration"]
+__all__ = ["JUnit", "CDash", "CDashConfiguration", "Reporter"]

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -7,9 +7,6 @@
 class Reporter:
     """Base class for report writers."""
 
-    def __init__(self, args):
-        self.args = args
-
     def build_report(self, filename, report_data):
         raise NotImplementedError("must be implemented by derived classes")
 

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -2,18 +2,16 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from typing import List
-
-import spack.spec
+from typing import Any, Dict, List
 
 
 class Reporter:
     """Base class for report writers."""
 
-    def build_report(self, filename: str, specs: List[spack.spec.Spec]):
+    def build_report(self, filename: str, specs: List[Dict[str, Any]]):
         raise NotImplementedError("must be implemented by derived classes")
 
-    def test_report(self, filename: str, specs: List[spack.spec.Spec]):
+    def test_report(self, filename: str, specs: List[Dict[str, Any]]):
         raise NotImplementedError("must be implemented by derived classes")
 
     def concretization_report(self, filename: str, msg: str):

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -4,10 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-__all__ = ["Reporter"]
-
-
-class Reporter(object):
+class Reporter:
     """Base class for report writers."""
 
     def __init__(self, args):

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -2,15 +2,18 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import List
+
+import spack.spec
 
 
 class Reporter:
     """Base class for report writers."""
 
-    def build_report(self, filename: str, report_data: str):
+    def build_report(self, filename: str, specs: List[spack.spec.Spec]):
         raise NotImplementedError("must be implemented by derived classes")
 
-    def test_report(self, filename: str, report_data: str):
+    def test_report(self, filename: str, specs: List[spack.spec.Spec]):
         raise NotImplementedError("must be implemented by derived classes")
 
     def concretization_report(self, filename: str, msg: str):

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -7,11 +7,11 @@
 class Reporter:
     """Base class for report writers."""
 
-    def build_report(self, filename, report_data):
+    def build_report(self, filename: str, report_data: str):
         raise NotImplementedError("must be implemented by derived classes")
 
-    def test_report(self, filename, report_data):
+    def test_report(self, filename: str, report_data: str):
         raise NotImplementedError("must be implemented by derived classes")
 
-    def concretization_report(self, filename, msg):
+    def concretization_report(self, filename: str, msg: str):
         raise NotImplementedError("must be implemented by derived classes")

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -15,16 +15,3 @@ class Reporter:
 
     def concretization_report(self, filename, msg):
         raise NotImplementedError("must be implemented by derived classes")
-
-
-class NullReporter(Reporter):
-    """A reporter that does nothing"""
-
-    def concretization_report(self, filename, msg):
-        pass
-
-    def test_report(self, filename, report_data):
-        pass
-
-    def build_report(self, filename, report_data):
-        pass

--- a/lib/spack/spack/reporters/base.py
+++ b/lib/spack/spack/reporters/base.py
@@ -11,10 +11,23 @@ class Reporter:
         self.args = args
 
     def build_report(self, filename, report_data):
+        raise NotImplementedError("must be implemented by derived classes")
+
+    def test_report(self, filename, report_data):
+        raise NotImplementedError("must be implemented by derived classes")
+
+    def concretization_report(self, filename, msg):
+        raise NotImplementedError("must be implemented by derived classes")
+
+
+class NullReporter(Reporter):
+    """A reporter that does nothing"""
+
+    def concretization_report(self, filename, msg):
         pass
 
     def test_report(self, filename, report_data):
         pass
 
-    def concretization_report(self, filename, msg):
+    def build_report(self, filename, report_data):
         pass

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -47,7 +47,8 @@ CDASH_PHASES.add("update")
 
 
 CDashConfiguration = collections.namedtuple(
-    "CDashConfiguration", ["upload_url", "packages", "build", "site", "buildstamp", "track"]
+    "CDashConfiguration",
+    ["upload_url", "packages", "build", "site", "buildstamp", "track", "ctest_parsing"],
 )
 
 
@@ -105,6 +106,7 @@ class CDash(Reporter):
             self.revision = git("rev-parse", "HEAD", output=str).strip()
         self.generator = "spack-{0}".format(spack.main.get_version())
         self.multiple_packages = False
+        self.ctest_parsing = configuration.ctest_parsing
 
     def report_build_name(self, pkg_name):
         return (
@@ -396,7 +398,7 @@ class CDash(Reporter):
                     directory_name,
                     package,
                     duration,
-                    input_data["ctest-parsing"],
+                    self.ctest_parsing,
                 )
 
         self.finalize_report()

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -233,13 +233,13 @@ class CDash(Reporter):
                 f.write(t.render(report_data))
             self.upload(phase_report)
 
-    def build_report(self, directory_name, input_data):
+    def build_report(self, directory_name, specs):
         # Do an initial scan to determine if we are generating reports for more
         # than one package. When we're only reporting on a single package we
         # do not explicitly include the package's name in the CDash build name.
         self.multipe_packages = False
         num_packages = 0
-        for spec in input_data["specs"]:
+        for spec in specs:
             # Do not generate reports for packages that were installed
             # from the binary cache.
             spec["packages"] = [
@@ -257,7 +257,7 @@ class CDash(Reporter):
                 break
 
         # Generate reports for each package in each spec.
-        for spec in input_data["specs"]:
+        for spec in specs:
             duration = 0
             if "time" in spec:
                 duration = int(spec["time"])
@@ -386,10 +386,10 @@ class CDash(Reporter):
 
         self.report_test_data(directory_name, package, phases, report_data)
 
-    def test_report(self, directory_name, input_data):
+    def test_report(self, directory_name, specs):
         """Generate reports for each package in each spec."""
         tty.debug("Processing test report")
-        for spec in input_data["specs"]:
+        for spec in specs:
             duration = 0
             if "time" in spec:
                 duration = int(spec["time"])

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -24,10 +24,11 @@ import spack.package_base
 import spack.platforms
 import spack.util.git
 from spack.error import SpackError
-from spack.reporter import Reporter
-from spack.reporters.extract import extract_test_parts
 from spack.util.crypto import checksum
 from spack.util.log_parse import parse_log_events
+
+from .base import Reporter
+from .extract import extract_test_parts
 
 __all__ = ["CDash"]
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -66,7 +66,7 @@ class CDash(Reporter):
     """
 
     def __init__(self, args):
-        Reporter.__init__(self, args)
+        super().__init__(args)
         self.success = True
         # Posixpath is used here to support the underlying template enginge
         # Jinja2, which expects `/` path separators

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -86,8 +86,6 @@ class CDash(Reporter):
     """
 
     def __init__(self, args):
-        super().__init__(args)
-
         configuration = CDashConfiguration(
             upload_url=args.cdash_upload_url,
             packages=installed_specs(args),

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -237,7 +237,7 @@ class CDash(Reporter):
         # Do an initial scan to determine if we are generating reports for more
         # than one package. When we're only reporting on a single package we
         # do not explicitly include the package's name in the CDash build name.
-        self.multipe_packages = False
+        self.multiple_packages = False
         num_packages = 0
         for spec in specs:
             # Do not generate reports for packages that were installed

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -30,10 +30,8 @@ from spack.util.log_parse import parse_log_events
 from .base import Reporter
 from .extract import extract_test_parts
 
-__all__ = ["CDash"]
-
 # Mapping Spack phases to the corresponding CTest/CDash phase.
-map_phases_to_cdash = {
+MAP_PHASES_TO_CDASH = {
     "autoreconf": "configure",
     "cmake": "configure",
     "configure": "configure",
@@ -43,8 +41,8 @@ map_phases_to_cdash = {
 }
 
 # Initialize data structures common to each phase's report.
-cdash_phases = set(map_phases_to_cdash.values())
-cdash_phases.add("update")
+CDASH_PHASES = set(MAP_PHASES_TO_CDASH.values())
+CDASH_PHASES.add("update")
 
 
 def build_stamp(track, timestamp):
@@ -67,7 +65,9 @@ class CDash(Reporter):
 
     def __init__(self, args):
         super().__init__(args)
+        #: Set to False if any error occurs when building the CDash report
         self.success = True
+
         # Posixpath is used here to support the underlying template enginge
         # Jinja2, which expects `/` path separators
         self.template_dir = posixpath.join("reports", "cdash")
@@ -130,7 +130,7 @@ class CDash(Reporter):
         self.current_package_name = package["name"]
         self.buildname = self.report_build_name(self.current_package_name)
         report_data = self.initialize_report(directory_name)
-        for phase in cdash_phases:
+        for phase in CDASH_PHASES:
             report_data[phase] = {}
             report_data[phase]["loglines"] = []
             report_data[phase]["status"] = 0
@@ -150,10 +150,10 @@ class CDash(Reporter):
                 match = self.phase_regexp.search(line)
             if match:
                 current_phase = match.group(1)
-                if current_phase not in map_phases_to_cdash:
+                if current_phase not in MAP_PHASES_TO_CDASH:
                     current_phase = ""
                     continue
-                cdash_phase = map_phases_to_cdash[current_phase]
+                cdash_phase = MAP_PHASES_TO_CDASH[current_phase]
                 if cdash_phase not in phases_encountered:
                     phases_encountered.append(cdash_phase)
                 report_data[cdash_phase]["loglines"].append(

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -14,6 +14,9 @@ from .base import Reporter
 class JUnit(Reporter):
     """Generate reports of spec installations for JUnit."""
 
+    def concretization_report(self, filename, msg):
+        pass
+
     def __init__(self, args):
         super().__init__(args)
         # Posixpath is used here to support the underlying template engine

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -15,7 +15,7 @@ class JUnit(Reporter):
     """Generate reports of spec installations for JUnit."""
 
     def __init__(self, args):
-        Reporter.__init__(self, args)
+        super().__init__(args)
         # Posixpath is used here to support the underlying template enginge
         # Jinja2, which expects `/` path separators
         self.template_file = posixpath.join("reports", "junit.xml")

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -16,7 +16,7 @@ class JUnit(Reporter):
 
     def __init__(self, args):
         super().__init__(args)
-        # Posixpath is used here to support the underlying template enginge
+        # Posixpath is used here to support the underlying template engine
         # Jinja2, which expects `/` path separators
         self.template_file = posixpath.join("reports", "junit.xml")
 

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -17,17 +17,17 @@ class JUnit(Reporter):
     def concretization_report(self, filename, msg):
         pass
 
-    def build_report(self, filename, report_data):
+    def build_report(self, filename, specs):
         if not (os.path.splitext(filename))[1]:
             # Ensure the report name will end with the proper extension;
             # otherwise, it currently defaults to the "directory" name.
             filename = filename + ".xml"
 
-        # Write the report
+        report_data = {"specs": specs}
         with open(filename, "w") as f:
             env = spack.tengine.make_environment()
             t = env.get_template(self._jinja_template)
             f.write(t.render(report_data))
 
-    def test_report(self, filename, report_data):
-        self.build_report(filename, report_data)
+    def test_report(self, filename, specs):
+        self.build_report(filename, specs)

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -17,8 +17,7 @@ class JUnit(Reporter):
     def concretization_report(self, filename, msg):
         pass
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self):
         # Posixpath is used here to support the underlying template engine
         # Jinja2, which expects `/` path separators
         self.template_file = posixpath.join("reports", "junit.xml")

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -12,12 +12,10 @@ from .base import Reporter
 class JUnit(Reporter):
     """Generate reports of spec installations for JUnit."""
 
+    _jinja_template = "reports/junit.xml"
+
     def concretization_report(self, filename, msg):
         pass
-
-    def __init__(self):
-        # Jinja2 expects `/` path separators
-        self.template_file = "reports/junit.xml"
 
     def build_report(self, filename, report_data):
         if not (os.path.splitext(filename))[1]:
@@ -28,7 +26,7 @@ class JUnit(Reporter):
         # Write the report
         with open(filename, "w") as f:
             env = spack.tengine.make_environment()
-            t = env.get_template(self.template_file)
+            t = env.get_template(self._jinja_template)
             f.write(t.render(report_data))
 
     def test_report(self, filename, report_data):

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -2,9 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os.path
-import posixpath
 
 import spack.tengine
 

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -18,9 +18,8 @@ class JUnit(Reporter):
         pass
 
     def __init__(self):
-        # Posixpath is used here to support the underlying template engine
-        # Jinja2, which expects `/` path separators
-        self.template_file = posixpath.join("reports", "junit.xml")
+        # Jinja2 expects `/` path separators
+        self.template_file = "reports/junit.xml"
 
     def build_report(self, filename, report_data):
         if not (os.path.splitext(filename))[1]:

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
-from typing import List
 
 import spack.tengine
 
@@ -18,7 +17,7 @@ class JUnit(Reporter):
     def concretization_report(self, filename, msg):
         pass
 
-    def build_report(self, filename: str, specs: List[spack.spec.Spec]):
+    def build_report(self, filename, specs):
         if not (os.path.splitext(filename))[1]:
             # Ensure the report name will end with the proper extension;
             # otherwise, it currently defaults to the "directory" name.

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
+from typing import List
 
 import spack.tengine
 
@@ -17,7 +18,7 @@ class JUnit(Reporter):
     def concretization_report(self, filename, msg):
         pass
 
-    def build_report(self, filename, specs):
+    def build_report(self, filename: str, specs: List[spack.spec.Spec]):
         if not (os.path.splitext(filename))[1]:
             # Ensure the report name will end with the proper extension;
             # otherwise, it currently defaults to the "directory" name.

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -7,9 +7,8 @@ import os.path
 import posixpath
 
 import spack.tengine
-from spack.reporter import Reporter
 
-__all__ = ["JUnit"]
+from .base import Reporter
 
 
 class JUnit(Reporter):

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -7,10 +7,9 @@ import pytest
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
-import spack.reporters.cdash
 import spack.reporters.extract
 import spack.spec
-from spack.util.pattern import Bunch
+from spack.reporters import CDash, CDashConfiguration
 
 # Use a path variable to appease Spack style line length checks
 fake_install_prefix = fs.join_path(
@@ -152,22 +151,22 @@ Results for test suite abcdefghijklmn
 
 
 def test_reporters_report_for_package_no_stdout(tmpdir, monkeypatch, capfd):
-    class MockCDash(spack.reporters.cdash.CDash):
+    class MockCDash(CDash):
         def upload(*args, **kwargs):
             # Just return (Do NOT try to upload the report to the fake site)
             return
 
-    args = Bunch(
-        cdash_upload_url="https://fake-upload",
-        package="fake-package",
-        cdash_build="fake-cdash-build",
-        cdash_site="fake-site",
-        cdash_buildstamp=None,
-        cdash_track="fake-track",
+    configuration = CDashConfiguration(
+        upload_url="https://fake-upload",
+        packages="fake-package",
+        build="fake-cdash-build",
+        site="fake-site",
+        buildstamp=None,
+        track="fake-track",
     )
     monkeypatch.setattr(tty, "_debug", 1)
 
-    reporter = MockCDash(args)
+    reporter = MockCDash(configuration=configuration)
     pkg_data = {"name": "fake-package"}
     reporter.test_report_for_package(tmpdir.strpath, pkg_data, 0, False)
     err = capfd.readouterr()[1]

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -163,6 +163,7 @@ def test_reporters_report_for_package_no_stdout(tmpdir, monkeypatch, capfd):
         site="fake-site",
         buildstamp=None,
         track="fake-track",
+        ctest_parsing=False,
     )
     monkeypatch.setattr(tty, "_debug", 1)
 


### PR DESCRIPTION
The code in Spack to generate install and test reports currently suffers from unneeded complexity. For instance, we have classes in Spack core packages, like `spack.reporters.CDash`, that need an `argparse.Namespace` to be initialized and have "hard-coded" string literals on which they branch to change their behavior:
```python
if do_fn.__name__ == "do_test" and skip_externals:
    package["result"] = "skipped"
else:
    package["result"] = "success"
package["stdout"] = fetch_log(pkg, do_fn, self.dir)
package["installed_from_binary_cache"] = pkg.installed_from_binary_cache
if do_fn.__name__ == "_install_task" and installed_already:
    return
```
This PR attempt to polish the major issues encountered in both `spack.report` and `spack.reporters`. In details:

- [x] `spack.reporters` is now a package that contains both the base class `Reporter` and all the derived classes (`JUnit` and `CDash`)
- [x] Classes derived from `spack.reporters.Reporter` don't take an `argparse.Namespace` anymore as argument to `__init__`. The rationale is that code for commands should be built upon Spack core classes, not vice-versa.
- [x] An `argparse.Action` has been coded to create the correct `Reporter` object based on command line arguments
- [x] The context managers to generate reports from either `spack install` or from `spack test` have been greatly simplified, and have been made less "dynamic" in nature. In particular, the `collect_info` class has been deleted in favor of two more specific context managers.
- [x] The `InfoCollector` class has been turned into a simple hierarchy, so to avoid conditional statements within methods that assume a knowledge of the context in which the method is called.