### PR TITLE
googletest: set PIC flag for static build

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -50,6 +50,7 @@ class Googletest(CMakePackage):
             # New style (contains both Google Mock and Google Test)
             args.append(self.define("BUILD_GTEST", True))
             args.append(self.define_from_variant("BUILD_GMOCK", "gmock"))
+            args.append(self.define("CMAKE_POSITION_INDEPENDENT_CODE", True))
 
         return args
 

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -114,5 +114,7 @@ class Hipfft(CMakePackage):
         elif self.spec.satisfies("@5.2.0:"):
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))
+        if self.spec.satisfies("@5.3.0:"):
+            args.append(self.define("CMAKE_INSTALL_LIBDIR", "lib"))
 
         return args

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -114,7 +114,5 @@ class Hipfft(CMakePackage):
         elif self.spec.satisfies("@5.2.0:"):
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))
-        if self.spec.satisfies("@5.3.0:"):
-            args.append(self.define("CMAKE_INSTALL_LIBDIR", "lib"))
 
         return args


### PR DESCRIPTION
Rocm-validation-suite failing on Centos because CMAKE_POSITION_INDEPENDENT_CODE was not added in google test.
Adding the argument CMAKE_POSITION_INDEPENDENT_CODE in google test.
