### PR TITLE
Setting lib install directory for hipfft

### DIFF
--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -114,5 +114,7 @@ class Hipfft(CMakePackage):
         elif self.spec.satisfies("@5.2.0:"):
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip))
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))
+        if self.spec.satisfies("@5.3.0:"):
+            args.append(self.define("CMAKE_INSTALL_LIBDIR", "lib"))
 
         return args


### PR DESCRIPTION
Setting CMAKE_INSTALL_LIBDIR to lib since hipfft installing it to lib64 in CentOS