### PR TITLE
pixman: new versions 0.42.0, 0.42.2

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -16,6 +16,8 @@ class Pixman(AutotoolsPackage):
     homepage = "http://www.pixman.org"
     url = "https://cairographics.org/releases/pixman-0.32.6.tar.gz"
 
+    version("0.42.2", sha256="ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e")
+    version("0.42.0", sha256="07f74c8d95e4a43eb2b08578b37f40b7937e6c5b48597b3a0bb2c13a53f46c13")
     version("0.40.0", sha256="6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc")
     version("0.38.4", sha256="da66d6fd6e40aee70f7bd02e4f8f76fc3f006ec879d346bae6a723025cfbdde7")
     version("0.38.0", sha256="a7592bef0156d7c27545487a52245669b00cf7e70054505381cff2136d890ca8")


### PR DESCRIPTION
This fixes, [among other things](https://lists.freedesktop.org/archives/pixman/2022-October/004993.html), a [bug](https://issuetracker.google.com/issues/249834910) in 0.40.0 that prevents building with oneapi.