### PR TITLE
python: remove `CPATH` from `setup_run_environment`

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1049,9 +1049,6 @@ print(json.dumps(config))
             return path.replace(prefix, "")
         return os.path.join("include", "python{}".format(self.version.up_to(2)))
 
-    def setup_run_environment(self, env):
-        env.prepend_path("CPATH", os.pathsep.join(self.spec["python"].headers.directories))
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.


### PR DESCRIPTION
Currently, the `python` package tries to set `CPATH` in `setup_run_environment()`.

We no longer set `CPATH` and other destructive environment variables (like `LD_LIBRARY_PATH` in #28354) in modules, so we shouldn't do something special for Python.

Also, the way `python` sets `CPATH` causes issues. Because it does a header search to find directories containing headers, if you bootstrap `mypy` or other style tools on a fresh Ubuntu image with *no* python devel headers installed, you'll get an error like this when trying to load the thing you just installed:

```console
[root@980de539843d /]# spack -b load py-mypy
==> Error: Unable to locate python headers in any of these locations:
/usr/include/python3.6m
/usr/include/3.6
/usr/Headers
```

The headers and includes aren't needed to get `mypy` in the path or for `mypy` to work, so we're failing unnecessarily here.

This addresses part (but not all) of #32693.

Fixes #34977

- [x] remove `setup_run_environment()` from `python/package.py`