### PR TITLE
style: fix spurious `mypy` errors from `numpy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,11 +141,14 @@ ignore_missing_imports = true
   ignore_errors = true
   ignore_missing_imports = true
 
-  # jinja has syntax in it that requires python3 and causes a parse error
-  # skip importing it
+  # pytest (which we depend on) optionally imports numpy, which requires Python 3.8 in
+  # recent versions. mypy still imports its .pyi file, which has positional-only
+  # arguments, which don't work in 3.7, which causes mypy to bail out early if you have
+  # numpy installed.
   [[tool.mypy.overrides]]
-  module = 'jinja2'
+  module = 'numpy'
   follow_imports = 'skip'
+  follow_imports_for_stubs = true
 
 [tool.pyright]
 useLibraryCodeForTypes = true


### PR DESCRIPTION
Spack imports `pytest`, which *can* import `numpy`. Recent versions of `numpy` require Python 3.8 or higher, and they use 3.8 type annotations in their type stubs (`.pyi` files). At the same time, we tell `mypy` to target Python 3.7, as we still support older versions of Python.

What all this means is that if you run `mypy` on `spack`, `mypy` will follow all the static import statements, and it ends up giving you this error when it finds numpy stuff that is newer than the target Python version:

```
==> Running mypy checks
src/spack/var/spack/environments/default/.spack-env/._view/4g7jd4ibkg4gopv4rosq3kn2vsxrxm2f/lib/python3.11/site-packages/numpy/__ini\
t__.pyi:638: error: Positional-only parameters are only supported in Python 3.8 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
  mypy found errors
```

We can fix this by telling `mypy` to skip all imports of `numpy` in `pyproject.toml`:

```toml
   [[tool.mypy.overrides]]
   module = 'numpy'
   follow_imports = 'skip'
   follow_imports_for_stubs = true
```

- [x] don't follow imports from `numpy` in `mypy`
- [x] get rid of old rule not to follow `jinja2` imports, as we now require Python 3