### PR TITLE
Make docbook-xml work across all entity versions

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -28,11 +28,12 @@ class Dbus(Package):
     version("1.8.2", sha256="5689f7411165adc953f37974e276a3028db94447c76e8dd92efe910c6d3bae08")
 
     depends_on("pkgconfig", type="build")
-    depends_on("docbook-xml@4.4", type="build")
+    depends_on("docbook-xml", type="build")
     depends_on("docbook-xsl", type="build")
     depends_on("expat")
     depends_on("glib")
     depends_on("libsm")
+    depends_on("xmlto")
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix, "--disable-systemd", "--disable-launchd")

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -341,6 +341,9 @@ class DocbookXml(Package):
 
         # map all versions to current version
         dtversions = [
+            "4.1",
+            "4.1.1",
+            "4.1.2",
             "4.2",
             "4.3",
             "4.4",

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -339,6 +339,55 @@ class DocbookXml(Package):
             catalog,
         )
 
+        # map all versions to current version
+        dtversions = [
+            "4.2",
+            "4.3",
+            "4.4",
+            "4.5",
+        ]
+        for dtversion in dtversions:
+            xmlcatalog(
+                "--noout",
+                "--add",
+                "public",
+                "-//OASIS//DTD DocBook XML V{0}//EN".format(dtversion),
+                "http://www.oasis-open.org/docbook/xml/{0}/docbookx.dtd".format(dtversion),
+                docbook,
+            )
+            xmlcatalog(
+                "--noout",
+                "--add",
+                "rewriteSystem",
+                "http://www.oasis-open.org/docbook/xml/{0}".format(dtversion),
+                "file://{0}".format(prefix),
+                docbook,
+            )
+            xmlcatalog(
+                "--noout",
+                "--add",
+                "rewriteURI",
+                "http://www.oasis-open.org/docbook/xml/{0}".format(dtversion),
+                "file://{0}".format(prefix),
+                docbook,
+            )
+            xmlcatalog(
+                "--noout",
+                "--add",
+                "delegateSystem",
+                "http://www.oasis-open.org/docbook/xml/{0}".format(dtversion),
+                "file://{0}".format(docbook),
+                catalog,
+            )
+            xmlcatalog(
+                "--noout",
+                "--add",
+                "delegateURI",
+                "http://www.oasis-open.org/docbook/xml/{0}".format(dtversion),
+                "file://{0}".format(docbook),
+                catalog,
+            )
+
     def setup_run_environment(self, env):
         catalog = self.catalog
         env.prepend_path("XML_CATALOG_FILES", catalog, separator=" ")

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -62,7 +62,7 @@ class DocbookXsl(Package):
                         "--add",
                         docbook_rewrite,
                         "http://{0}/release/xsl/{1}".format(docbook_url, docbook_version),
-                        prefix,
+                        "file://{0}".format(prefix),
                         catalog,
                     )
 

--- a/var/spack/repos/builtin/packages/gtk-doc/package.py
+++ b/var/spack/repos/builtin/packages/gtk-doc/package.py
@@ -38,8 +38,8 @@ class GtkDoc(AutotoolsPackage):
     depends_on("py-six", type=("test"))
     depends_on("libxslt")
     depends_on("libxml2@2.3.6:")
-    depends_on("docbook-xsl@1.78.1")
-    depends_on("docbook-xml@4.3")
+    depends_on("docbook-xsl")
+    depends_on("docbook-xml")
     # depends_on('dblatex', when='+pdf')
 
     patch("build.patch")


### PR DESCRIPTION
Packages that use docbook-xml may specify a specific entity version. When this is specified as a version constraint in the package recipe it will cause problems when using `unify = True` in a Spack environment, as there could be multiple versions of docbook-xml in the spec. In practice, any entity version should work with any other version and everything should work with the latest version. This PR maps all Spack docbook-xml entity versions to the docbook-xml version in the spec. Ideally, the version in the spec would be the latest version. With this PR, even if a package specifies an older entity version, it will map to the entity version (latest) in the spec. This means that there can be one docbook-xml version in a Spack environment spec and packages requesting older entity versions will still work.

To help facilitate this, docbook-xml version constraints for packages that have them have been removed. Those packages are dbus and gtk-doc.