### PR TITLE
nmap: update to depend on python2 for ndiff and zenmap; add 7.93

### DIFF
--- a/var/spack/repos/builtin/packages/ruby-gist/package.py
+++ b/var/spack/repos/builtin/packages/ruby-gist/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RubyGist(RubyPackage):
+    """The gist gem provides a gist command that you can use from your terminal to upload content to https://gist.github.com/."""
+
+    homepage = "https://github.com/defunkt/gist"
+    url = "https://rubygems.org/downloads/gist-6.0.0.gem"
+
+    version(
+        "6.0.0",
+        sha256="0d0a3616b1a4eec837ce4e5b5477bc809d58597ee350b2c34104acd3b00ccd62",
+        expand=False,
+    )
+
+    depends_on("ruby@1.8:2", type=("build", "run"))


### PR DESCRIPTION
This fixes the build on my linux machine. I'm still having an issue with macOS though; that's still under investigation