### PR TITLE
mesa: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -194,7 +194,6 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         args = [
             "-Dvulkan-drivers=",
             "-Dgallium-vdpau=disabled",
-            "-Dgallium-xvmc=disabled",
             "-Dgallium-omx=disabled",
             "-Dgallium-va=disabled",
             "-Dgallium-xa=disabled",
@@ -203,6 +202,8 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
             "-Dbuild-tests=false",
             "-Dglvnd=false",
         ]
+        if spec.satisfies("@:22.2"):
+            args.append("-Dgallium-xvmc=disabled")
         args_platforms = []
         args_gallium_drivers = ["swrast"]
         args_dri_drivers = []

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -19,11 +19,15 @@ class Mesa(MesonPackage):
     url = "https://archive.mesa3d.org/mesa-20.2.1.tar.xz"
 
     version("main", tag="main")
+    version("22.3.2", sha256="c15df758a8795f53e57f2a228eb4593c22b16dffd9b38f83901f76cd9533140b")
+    version("22.2.5", sha256="850f063146f8ebb262aec04f666c2c1e5623f2a1987dda24e4361b17b912c73b")
     version(
-        "22.1.2",
-        sha256="df4fa560dcce6680133067cd15b0505fc424ca703244ce9ab247c74d2fab6885",
+        "22.1.6",
+        sha256="22ced061eb9adab8ea35368246c1995c09723f3f71653cd5050c5cec376e671a",
         preferred=True,
     )
+    version("22.1.2", sha256="0971226b4a6a3d10cfc255736b33e4017e18c14c9db1e53863ac1f8ae0deb9ea")
+    version("22.0.5", sha256="5ee2dc06eff19e19b2867f12eb0db0905c9691c07974f6253f2f1443df4c7a35")
     version("22.0.2", sha256="df4fa560dcce6680133067cd15b0505fc424ca703244ce9ab247c74d2fab6885")
     version("21.3.8", sha256="e70d273bdc53a4e931871bb5550ba3900e6a3deab2fff64184107c33e92d9da7")
     version("21.3.7", sha256="b4fa9db7aa61bf209ef0b40bef83080999d86ad98df8b8b4fada7c128a1efc3d")


### PR DESCRIPTION
No major changes like in the transition to 22.0.

Note: I've kept the preferred version within the same 22.1 series but moved to the latest bugfix release.