### PR TITLE
dd4hep: depends_on root +x +opengl when +utilityapps

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -140,6 +140,7 @@ class Dd4hep(CMakePackage):
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+ddeve")
+    depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")
     depends_on("xerces-c", when="+xercesc")


### PR DESCRIPTION
UtilityApps builds teveDisplay and fails when ROOT has no ROOT::Gui and ROOT::Eve targets.

Ref: https://github.com/AIDASoft/DD4hep/blob/master/UtilityApps/CMakeLists.txt