### PR TITLE
singularity: bugfix add space between prefix and other options

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -80,7 +80,7 @@ class SingularityBase(MakefilePackage):
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
             confstring = "./mconfig --prefix=%s" % prefix
-            confstring += " ".join(config_options)
+            confstring += " " + " ".join(self.config_options)
             if "~suid" in spec:
                 confstring += " --without-suid"
             if "~network" in spec:


### PR DESCRIPTION
This fixes two issues introduced in #34474: prefix got the next option appended, and property was not resolved without the self.

Good intention for 2023: I shall check my PRs more thoroughly...

This PR now successfully builds an environment with both apptainer and singularityce.