### PR TITLE
fix: python tix detection blocks reuse

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -298,11 +298,12 @@ class Python(Package):
             variants += "~pyexpat"
 
         # Some variant names do not match module names
-        try:
-            python("-c", "import tkinter.tix", error=os.devnull)
-            variants += "+tix"
-        except ProcessError:
-            variants += "~tix"
+        if "+tkinter" in variants:
+            try:
+                python("-c", "import tkinter.tix", error=os.devnull)
+                variants += "+tix"
+            except ProcessError:
+                variants += "~tix"
 
         # Some modules are platform-dependent
         if not is_windows:


### PR DESCRIPTION
Now that the `tix` variant is conditional, it should also be detected
conditionally, otherwise the spec violates the when condition and
is not considered during concretization

Reported by @giordano 