### PR TITLE
scr: require spath+mpi

### DIFF
--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -81,7 +81,7 @@ class Scr(CMakePackage):
     depends_on("rankstr@0.1.0", when="@3.0.1:")
     depends_on("redset@0.2.0", when="@3.0.1:")
     depends_on("shuffile@0.2.0", when="@3.0.1:")
-    depends_on("spath@0.2.0", when="@3.0.1:")
+    depends_on("spath@0.2.0 +mpi", when="@3.0.1:")
     depends_on("dtcmp@1.1.4", when="@3.0.1:")
 
     depends_on("axl@0.6.0", when="@3.0.0")


### PR DESCRIPTION
It includes `spath_mpi.h` explicitly, and in some concretizations
results in a build failure. (Don't ask me why the concretizer picks
`spath~mpi`).
