### PR TITLE
Fix libvterm and libtermkey packages

### DIFF
--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Libtermkey(Package):
+class Libtermkey(MakefilePackage):
     """Easy keyboard entry processing for terminal programs"""
 
     homepage = "http://www.leonerd.org.uk/code/libtermkey/"
@@ -20,9 +20,10 @@ class Libtermkey(Package):
     version("0.14", sha256="3d114d4509499b80a583ea39cd35f18268aacf4a7bbf56c142cd032632005c79")
 
     depends_on("libtool", type="build")
+
     depends_on("unibilium")
     depends_on("pkgconfig")
 
-    def install(self, spec, prefix):
-        make()
-        make("install", "PREFIX=" + prefix)
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("PREFIX=.*", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -24,6 +24,9 @@ class Libtermkey(MakefilePackage):
     depends_on("unibilium")
     depends_on("pkgconfig")
 
+    def setup_build_environment(self, env):
+        env.set("LIBTOOL", self.spec["libtool"].prefix.bin.join("libtool"))
+
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX=.*", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -27,6 +27,8 @@ class Libtermkey(MakefilePackage):
     def setup_build_environment(self, env):
         env.set("LIBTOOL", self.spec["libtool"].prefix.bin.join("libtool"))
 
-    def edit(self, spec, prefix):
-        makefile = FileFilter("Makefile")
-        makefile.filter("PREFIX=.*", "PREFIX=" + prefix)
+    def build(self, spec, prefix):
+        make("PREFIX=" + prefix)
+
+    def install(self, spec, prefix):
+        make("install", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -28,6 +28,8 @@ class Libvterm(MakefilePackage):
     def setup_build_environment(self, env):
         env.set("LIBTOOL", self.spec["libtool"].prefix.bin.join("libtool"))
 
-    def edit(self, spec, prefix):
-        makefile = FileFilter("Makefile")
-        makefile.filter("PREFIX=.*", "PREFIX=" + prefix)
+    def build(self, spec, prefix):
+        make("PREFIX=" + prefix)
+
+    def install(self, spec, prefix):
+        make("install", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -25,6 +25,9 @@ class Libvterm(MakefilePackage):
 
     depends_on("libtool", type="build")
 
+    def setup_build_environment(self, env):
+        env.set("LIBTOOL", self.spec["libtool"].prefix.bin.join("libtool"))
+
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("PREFIX=.*", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -7,7 +7,7 @@
 from spack.package import *
 
 
-class Libvterm(Package):
+class Libvterm(MakefilePackage):
     """An abstract library implementation of a terminal emulator"""
 
     homepage = "http://www.leonerd.org.uk/code/libvterm/"
@@ -25,6 +25,6 @@ class Libvterm(Package):
 
     depends_on("libtool", type="build")
 
-    def install(self, spec, prefix):
-        make()
-        make("install", "PREFIX=" + prefix)
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("PREFIX=.*", "PREFIX=" + prefix)


### PR DESCRIPTION
Close #34693 

`PREFIX` was not set at build time but just during install phase, which was too late since everything was already built with the default `/usr/local` prefix.

This fixes the problem reported in #34693 about library install names, and it also fixes the installation of these packages, since they were polluting `/usr/local` (e.g. `bin` and `include`).

Instead of a quick fix, I opted for making the `MakefilePackages` instead of basic ones, so they can exploit all facilities of Makefile packages.

Moreover, there is a minor fix, which sets `LIBTOOL` to the binary provided by dependency, instead of using the one available in the PATH.

@dpzmick can you give it a try?