### PR TITLE
neovim: version 0.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -17,6 +17,7 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable")
+    version("0.8.2", sha256="c516c8db73e1b12917a6b2e991b344d0914c057cef8266bce61a2100a28ffcc9")
     version("0.8.0", sha256="505e3dfb71e2f73495c737c034a416911c260c0ba9fd2092c6be296655be4d18")
     version("0.7.2", sha256="ccab8ca02a0c292de9ea14b39f84f90b635a69282de38a6b4ccc8565bc65d096")
     version("0.7.0", sha256="792a9c55d5d5f4a5148d475847267df309d65fb20f05523f21c1319ea8a6c7df")

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -137,6 +137,11 @@ class Neovim(CMakePackage):
     with when("@0.8:"):
         depends_on("libvterm@0.3:", type="link")
 
+    # Support for `libvterm@0.2:` has been added in neovim@0.8.0
+    # term: Add support for libvterm >= 0.2 (https://github.com/neovim/neovim/releases/tag/v0.8.0)
+    # https://github.com/neovim/neovim/issues/16217#issuecomment-958590493
+    conflicts("libvterm@0.2:", when="@:0.7")
+
     @when("^lua")
     def cmake_args(self):
         return [self.define("PREFER_LUA", True)]


### PR DESCRIPTION
Add new release + add conflict for older releases with new `libvterm` dependency API.