### PR TITLE
intersect "all" and "pkg" variant prefs

### DIFF
--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -158,8 +158,9 @@ class PackagePrefs(object):
             formatted_all = all.format("{variants}")
             formatted_pkg = pkg.format("{variants}")
             error_message = (
-                "Ambiguous config for package {}: the package specific variant preferences {} conflict "
-                "with the general preferences {}. Consider promoting the conflicting variant value to a requirement, for example: "
+                "Ambiguous config for package {}: the package specific variant "
+                "preferences {} conflict with the general preferences {}. Consider "
+                "promoting the conflicting variant value to a requirement, for example: "
                 "`packages:{}:require:{}`."
             ).format(pkg_name, formatted_pkg, formatted_all, pkg_name, formatted_pkg)
             raise spack.config.ConfigError(error_message) from e

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -160,7 +160,7 @@ class PackagePrefs(object):
             error_message = (
                 "Ambiguous config for package {}: the package specific variant "
                 "preferences {} conflict with the general preferences {}. Consider "
-                "promoting the conflicting variant value to a requirement, for example: "
+                "promoting the conflicting variant preference to a requirement, for example: "
                 "`packages:{}:require:{}`."
             ).format(pkg_name, formatted_pkg, formatted_all, pkg_name, formatted_pkg)
             raise spack.config.ConfigError(error_message) from e


### PR DESCRIPTION
The following

```yaml
packages:
  all:
    variants: +x +y
  pkg:
    variants: +y +z
```

should really mean `+x +y +z` as a preference for `pkg`. Currently it means `+y +z`, which is confusing.

This PR takes the intersection `all.constrain(pkg)` for variant preferences.

The case of

```yaml
packages:
  all:
    variants: +x
  pkg:
    variants: ~x
```

errors about ambiguity and informs the user through an error message that

```yaml
packages:
  all:
    variants: +x
  pkg:
    require: ~x
```

resolves that ambiguity.
