### PR TITLE
concretize with configurable # processes

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1399,7 +1399,9 @@ class Environment(object):
 
         # Solve the environment in parallel on Linux
         start = time.time()
-        max_processes = min(len(arguments), 16)  # Number of specs  # Cap on 16 cores
+
+        # Number of processes, capped to config:build_jobs & # specs.
+        max_processes = min(len(arguments), spack.config.get("config:build_jobs", 16))
 
         # TODO: revisit this print as soon as darwin is parallel too
         msg = "Starting concretization"

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -40,7 +40,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
-    - spack config add config:build_jobs:12 # concretize <= 12 processes
+    - spack config add "config:build_jobs:${SPACK_CONCRETIZATION_PROCS}"
     - spack ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
@@ -52,8 +52,11 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags: ["spack", "aws", "public", "medium", "x86_64"]
   variables:
-    KUBERNETES_CPU_REQUEST: 12000m
-    KUBERNETES_MEMORY_REQUEST: 12G
+    # This should be overridden for environments with unify:false
+    # Observed peak RSS is ~1GB / process.
+    KUBERNETES_CPU_REQUEST: 1000m
+    KUBERNETES_MEMORY_REQUEST: 1G
+    SPACK_CONCRETIZATION_PROCS: 1
   interruptible: true
   retry:
     max: 2
@@ -277,10 +280,18 @@ protected-publish:
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+  variables:
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
+    SPACK_CONCRETIZATION_PROCS: 12
 
 e4s-protected-generate:
   extends: [ ".e4s", ".protected-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+  variables:
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
+    SPACK_CONCRETIZATION_PROCS: 12
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]
@@ -541,10 +552,18 @@ radiuss-aws-aarch64-protected-build:
 data-vis-sdk-pr-generate:
   extends: [ ".data-vis-sdk", ".pr-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+  variables:
+    KUBERNETES_CPU_REQUEST: 6000m # only 6 root specs
+    KUBERNETES_MEMORY_REQUEST: 6G
+    SPACK_CONCRETIZATION_PROCS: 6
 
 data-vis-sdk-protected-generate:
   extends: [ ".data-vis-sdk", ".protected-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2022-10-01
+  variables:
+    KUBERNETES_CPU_REQUEST: 6000m # only 6 root specs
+    KUBERNETES_MEMORY_REQUEST: 6G
+    SPACK_CONCRETIZATION_PROCS: 6
 
 data-vis-sdk-pr-build:
   extends: [ ".data-vis-sdk", ".pr-build" ]
@@ -772,12 +791,16 @@ tutorial-protected-build:
   extends: .ml-linux-x86_64-cpu
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
   tags: ["spack", "aws", "public", "medium", "x86_64_v4"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
+    SPACK_CONCRETIZATION_PROCS: 12
 
 ml-linux-x86_64-cpu-pr-generate:
-  extends: [ ".ml-linux-x86_64-cpu-generate", ".pr-generate"]
+  extends: [ ".pr-generate", ".ml-linux-x86_64-cpu-generate"]
 
 ml-linux-x86_64-cpu-protected-generate:
-  extends: [ ".ml-linux-x86_64-cpu-generate", ".protected-generate"]
+  extends: [ ".protected-generate", ".ml-linux-x86_64-cpu-generate"]
 
 ml-linux-x86_64-cpu-pr-build:
   extends: [ ".ml-linux-x86_64-cpu", ".pr-build" ]
@@ -812,12 +835,16 @@ ml-linux-x86_64-cpu-protected-build:
   extends: .ml-linux-x86_64-cuda
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
   tags: ["spack", "aws", "public", "medium", "x86_64_v4"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
+    SPACK_CONCRETIZATION_PROCS: 12
 
 ml-linux-x86_64-cuda-pr-generate:
-  extends: [ ".ml-linux-x86_64-cuda-generate", ".pr-generate"]
+  extends: [ ".pr-generate", ".ml-linux-x86_64-cuda-generate"]
 
 ml-linux-x86_64-cuda-protected-generate:
-  extends: [ ".ml-linux-x86_64-cuda-generate", ".protected-generate"]
+  extends: [ ".protected-generate", ".ml-linux-x86_64-cuda-generate"]
 
 ml-linux-x86_64-cuda-pr-build:
   extends: [ ".ml-linux-x86_64-cuda", ".pr-build" ]
@@ -852,12 +879,16 @@ ml-linux-x86_64-cuda-protected-build:
   extends: .ml-linux-x86_64-rocm
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
   tags: ["spack", "aws", "public", "medium", "x86_64_v4"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
+    SPACK_CONCRETIZATION_PROCS: 12
 
 ml-linux-x86_64-rocm-pr-generate:
-  extends: [ ".ml-linux-x86_64-rocm-generate", ".pr-generate"]
+  extends: [ ".pr-generate", ".ml-linux-x86_64-rocm-generate"]
 
 ml-linux-x86_64-rocm-protected-generate:
-  extends: [ ".ml-linux-x86_64-rocm-generate", ".protected-generate"]
+  extends: [ ".protected-generate", ".ml-linux-x86_64-rocm-generate"]
 
 ml-linux-x86_64-rocm-pr-build:
   extends: [ ".ml-linux-x86_64-rocm", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -40,7 +40,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
-    - spack config add config:build_jobs:8 # concretize with 8 processes (+/- 1GB peak per process)
+    - spack config add config:build_jobs:16 # concretize <= 16 processes
     - spack ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
@@ -52,8 +52,8 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags: ["spack", "aws", "public", "medium", "x86_64"]
   variables:
-    KUBERNETES_CPU_REQUEST: 8000m
-    KUBERNETES_MEMORY_REQUEST: 8G
+    KUBERNETES_CPU_REQUEST: 16000m
+    KUBERNETES_MEMORY_REQUEST: 16G
   interruptible: true
   retry:
     max: 2

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -40,6 +40,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
+    - spack config add config:build_jobs:8 # concretize with 8 processes (+/- 1GB peak per process)
     - spack ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
@@ -51,7 +52,7 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags: ["spack", "aws", "public", "medium", "x86_64"]
   variables:
-    KUBERNETES_CPU_REQUEST: 4000m
+    KUBERNETES_CPU_REQUEST: 8000m
     KUBERNETES_MEMORY_REQUEST: 8G
   interruptible: true
   retry:

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -36,6 +36,7 @@ default:
     - uname -a || true
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
     - nproc || true
+    - grep -E '(Mem|Swap)(Total|Free)' /proc/meminfo 2>/dev/null || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -56,7 +56,7 @@ default:
     # This should be overridden for environments with unify:false
     # Observed peak RSS is ~1GB / process.
     KUBERNETES_CPU_REQUEST: 1000m
-    KUBERNETES_MEMORY_REQUEST: 1G
+    KUBERNETES_MEMORY_REQUEST: 2G
     SPACK_CONCRETIZATION_PROCS: 1
   interruptible: true
   retry:

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -40,7 +40,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
-    - spack config add config:build_jobs:16 # concretize <= 16 processes
+    - spack config add config:build_jobs:12 # concretize <= 12 processes
     - spack ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
@@ -52,8 +52,8 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags: ["spack", "aws", "public", "medium", "x86_64"]
   variables:
-    KUBERNETES_CPU_REQUEST: 16000m
-    KUBERNETES_MEMORY_REQUEST: 16G
+    KUBERNETES_CPU_REQUEST: 12000m
+    KUBERNETES_MEMORY_REQUEST: 12G
   interruptible: true
   retry:
     max: 2


### PR DESCRIPTION
Peak memory [can be 1.2GB](https://gist.github.com/haampie/6893cb08538aa3f94db5b63355c233a0) for some specs in the e4s stack, so either we have to bump the memory request, or reduce the number of processes.

They were rather arbitrary anyways, and not realistic (we were using 16 processes, so ~16GB peak, the request was 4 cpus and 8GB memory)