### PR TITLE
cabana: version ranges

### DIFF
--- a/var/spack/repos/builtin/packages/cabana/package.py
+++ b/var/spack/repos/builtin/packages/cabana/package.py
@@ -44,7 +44,7 @@ class Cabana(CMakePackage):
     depends_on("cmake@3.9:", type="build", when="@:0.4.0")
     depends_on("cmake@3.16:", type="build", when="@0.5.0:")
     depends_on("googletest", type="build", when="testing")
-    _versions = {":0.2.0": "-legacy", "0.3.0": "@3.1:", "0.4.0": "@3.2:", "0.5.0": "@3.2:"}
+    _versions = {":0.2": "-legacy", "0.3:": "@3.1:", "0.4:": "@3.2:"}
     for _version in _versions:
         _kk_version = _versions[_version]
         for _backend in _kokkos_backends:

--- a/var/spack/repos/builtin/packages/cabana/package.py
+++ b/var/spack/repos/builtin/packages/cabana/package.py
@@ -44,7 +44,7 @@ class Cabana(CMakePackage):
     depends_on("cmake@3.9:", type="build", when="@:0.4.0")
     depends_on("cmake@3.16:", type="build", when="@0.5.0:")
     depends_on("googletest", type="build", when="testing")
-    _versions = {":0.2": "-legacy", "0.3:": "@3.1:", "0.4:": "@3.2:"}
+    _versions = {":0.2": "-legacy", "0.3:": "@3.1:", "0.4:": "@3.2:", "master": "@3.4:"}
     for _version in _versions:
         _kk_version = _versions[_version]
         for _backend in _kokkos_backends:


### PR DESCRIPTION
use version ranges for kokkos deps

It would be great if packages were declarative instead of imperative :weary: 