### PR TITLE
numactl: remove bash

### DIFF
--- a/var/spack/repos/builtin/packages/numactl/package.py
+++ b/var/spack/repos/builtin/packages/numactl/package.py
@@ -37,8 +37,7 @@ class Numactl(AutotoolsPackage):
     conflicts("platform=darwin")
 
     def autoreconf(self, spec, prefix):
-        bash = which("bash")
-        bash("./autogen.sh")
+        Executable("./autogen.sh")()
 
     @when("%nvhpc")
     def patch(self):


### PR DESCRIPTION
It doesn't require bash on any registered version, and the file is
executable and has a /bin/sh shebang.
