### PR TITLE
Avoid building @main/@master/@develop etc in CI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug-aarch64/spack.yaml
@@ -25,6 +25,7 @@ spack:
           - openmpi
           - mpich
       variants: +mpi
+      require: "@:99999999" # avoid @main, @develop etc.
     tbb:
       require: "intel-tbb"
     binutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-ahug/spack.yaml
@@ -25,6 +25,7 @@ spack:
           - openmpi
           - mpich
       variants: +mpi
+      require: "@:99999999" # avoid @main, @develop etc.
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
       version:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -25,6 +25,7 @@ spack:
           - openmpi
           - mpich
       variants: +mpi
+      require: "@:99999999" # avoid @main, @develop etc.
     tbb:
       require: "intel-tbb"
     binutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -25,6 +25,7 @@ spack:
           - openmpi
           - mpich
       variants: +mpi
+      require: "@:99999999" # avoid @main, @develop etc.
     tbb:
       require: "intel-tbb"
     binutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -13,6 +13,10 @@ spack:
       projections:
         all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
 
+  packages:
+    all:
+      require: "@:99999999" # avoid @main, @develop etc.
+
   definitions:
     - default_specs:
       - 'uncrustify build_system=autotools'

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -24,6 +24,7 @@ spack:
       require: ^mesa +glx
     all:
       target: [x86_64]
+      require: "@:99999999" # avoid @main, @develop etc.
 
   definitions:
   - paraview_specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -17,6 +17,7 @@ spack:
     all:
       compiler: [apple-clang@13.1.6]
       target: [m1]
+      require: "@:99999999" # avoid @main, @develop etc.
 
   definitions:
   - easy_specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -25,6 +25,7 @@ spack:
       target:
         - ppc64le
       variants: +mpi
+      require: "@:99999999" # avoid @main, @develop etc.
     binutils:
       variants: +ld +gold +headers +libiberty ~nls +plugins
       version:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -63,7 +63,9 @@ spack:
     adios2:
       require: "%gcc"
     all:
-      require: "%oneapi"
+      require:
+      - "%oneapi"
+      - "@:99999999" # avoid @main, @develop etc.
       providers:
         blas: [openblas]
         mpi: [mpich]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -63,9 +63,7 @@ spack:
     adios2:
       require: "%gcc"
     all:
-      require:
-      - "%oneapi"
-      - "@:99999999" # avoid @main, @develop etc.
+      require: "@:99999999 %oneapi" # avoid @main, @develop etc.
       providers:
         blas: [openblas]
         mpi: [mpich]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -22,6 +22,7 @@ spack:
         mpi: [mpich]
       target: [x86_64]
       variants: +mpi amdgpu_target=gfx90a cuda_arch=80
+      require: "@:99999999" # avoid @main, @develop etc.
     tbb:
       require: "intel-tbb"
     binutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -18,6 +18,7 @@ spack:
     all:
       target: [x86_64_v3]
       variants: ~cuda~rocm
+      require: "@:99999999" # avoid @main, @develop etc.
 
   definitions:
     - packages:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -18,6 +18,7 @@ spack:
     all:
       target: [x86_64_v3]
       variants: ~rocm+cuda cuda_arch=80
+      require: "@:99999999" # avoid @main, @develop etc.
     llvm:
       # https://github.com/spack/spack/issues/27999
       require: ~cuda

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -18,6 +18,7 @@ spack:
     all:
       target: [x86_64_v3]
       variants: ~cuda+rocm amdgpu_target=gfx90a
+      require: "@:99999999" # avoid @main, @develop etc.
     gl:
       require: "osmesa"
     py-torch:

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -16,6 +16,7 @@ spack:
 
   packages:
     all:
+      require: "@:99999999" # avoid @main, @develop etc.
       providers:
         blas:
           - openblas

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws/spack.yaml
@@ -16,6 +16,7 @@ spack:
 
   packages:
     all:
+      require: "@:99999999" # avoid @main, @develop etc.
       providers:
         blas:
           - openblas

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -17,6 +17,7 @@ spack:
   packages:
     all:
       target: [x86_64]
+      require: "@:99999999" # avoid @main, @develop etc.
 
       providers:
         mpi: [mvapich2]

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -19,6 +19,7 @@ spack:
   packages:
     all:
       target: [x86_64]
+      require: "@:99999999" # avoid @main, @develop etc.
     tbb:
       require: 'intel-tbb'
 

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -39,7 +39,7 @@ class Gptune(CMakePackage):
     depends_on("py-scikit-learn", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-scikit-optimize@master+gptune", type=("build", "run"))
+    depends_on("py-scikit-optimize", type=("build", "run"))
     depends_on("py-gpy", type=("build", "run"))
     depends_on("py-lhsmdu", type=("build", "run"))
     depends_on("py-hpbandster", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
@@ -24,7 +24,7 @@ class Hdf5VolAsync(CMakePackage):
     version("1.0", tag="v1.0")
 
     depends_on("mpi")
-    depends_on("argobots@main")
+    depends_on("argobots@1.1:")
     depends_on("hdf5 +mpi +threadsafe")
     depends_on("hdf5@1.13.0:1.13.2", when="@:1.3")
     depends_on("hdf5@1.13.3:", when="@1.4:")


### PR DESCRIPTION
Currently it's possible that we build a moving target in CI, which leads to reproducibility problems, security issues, etc.

We don't have better syntax than @:[many nines] for this unfortunately.