### PR TITLE
Add new versions of Reframe

### DIFF
--- a/var/spack/repos/builtin/packages/reframe/package.py
+++ b/var/spack/repos/builtin/packages/reframe/package.py
@@ -24,6 +24,8 @@ class Reframe(Package):
     maintainers = ["victorusu", "vkarak"]
 
     version("master", branch="master")
+    version("4.0.1", sha256="1680b8f0dd405dcf98be23473570595a424cbee830b2dbb665459e2974723f6f")
+    version("4.0.0", sha256="50fc0462747b8b1f504912cd8072c49c46c1744567f4f1884e753abbe8d7c6e1")
     version(
         "4.0.0-dev.4", sha256="35d37ee2747807b539b2c5b75073619870371d1e0fed9778f2a33a8abd37b8a1"
     )
@@ -39,11 +41,7 @@ class Reframe(Package):
     version(
         "4.0.0-dev.0", sha256="a96162a88a36ea0793836c492a39470010f6e63b8d9bd324c033614d27304fa6"
     )
-    version(
-        "3.12.0",
-        sha256="425cc546e24edd5b2dbfcdcb61dbbf723ca1a2a2977948e359e893514f5eb10f",
-        preferred=True,
-    )
+    version("3.12.0", sha256="425cc546e24edd5b2dbfcdcb61dbbf723ca1a2a2977948e359e893514f5eb10f")
     version("3.11.2", sha256="d6f36071df316d6a5ef5ce6f0477b3385d9dac5c1b82e54ae6954dc9b68f9440")
     version("3.11.1", sha256="7f591cd8f4fbb2c6255cc8ea02e3814393355a8931ac883e9f57490fde699b63")
     version("3.11.0", sha256="3ddfef5482f0c304286a6c8f1ad0b3d75c4c61d0b9f9f8429b6157c189f2bb64")


### PR DESCRIPTION
This is a very small PR that adds the now-released versions of Reframe 4.0.0 and 4.0.1. It also deselects 3.12.0 as the preferred version as there is now no pre-release version that is newer than the latest released version. 

If someone thinks 3.12.0 should still be the preferred version, I can change that back before this is merged.

