### PR TITLE
Remove **kwargs from function signatures in llnl.util.filesystem

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -224,7 +224,7 @@ def filter_file(
     ignore_absent: bool = False,
     start_at: Optional[str] = None,
     stop_at: Optional[str] = None,
-):
+) -> None:
     r"""Like sed, but uses python regular expressions.
 
     Filters every line of each file through regex and replaces the file
@@ -344,8 +344,26 @@ class FileFilter(object):
     def __init__(self, *filenames):
         self.filenames = filenames
 
-    def filter(self, regex, repl, **kwargs):
-        return filter_file(regex, repl, *self.filenames, **kwargs)
+    def filter(
+        self,
+        regex: str,
+        repl: Union[str, Callable[[re.Match], str]],
+        string: bool = False,
+        backup: bool = False,
+        ignore_absent: bool = False,
+        start_at: Optional[str] = None,
+        stop_at: Optional[str] = None,
+    ) -> None:
+        return filter_file(
+            regex,
+            repl,
+            *self.filenames,
+            string=string,
+            backup=backup,
+            ignore_absent=ignore_absent,
+            start_at=start_at,
+            stop_at=stop_at,
+        )
 
 
 def change_sed_delimiter(old_delim, new_delim, *filenames):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -671,7 +671,13 @@ def resolve_link_target_relative_to_the_link(link):
 
 
 @system_path_filter
-def copy_tree(src, dest, symlinks=True, ignore=None, _permissions=False):
+def copy_tree(
+    src: str,
+    dest: str,
+    symlinks: bool = True,
+    ignore: Optional[Callable[[str], bool]] = None,
+    _permissions: bool = False,
+):
     """Recursively copy an entire directory tree rooted at *src*.
 
     If the destination directory *dest* does not already exist, it will
@@ -2617,13 +2623,15 @@ def keep_modification_time(*filenames):
 
 
 @contextmanager
-def temporary_dir(*args, **kwargs):
+def temporary_dir(
+    suffix: Optional[str] = None, prefix: Optional[str] = None, dir: Optional[str] = None
+):
     """Create a temporary directory and cd's into it. Delete the directory
     on exit.
 
     Takes the same arguments as tempfile.mkdtemp()
     """
-    tmp_dir = tempfile.mkdtemp(*args, **kwargs)
+    tmp_dir = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
     try:
         with working_dir(tmp_dir):
             yield tmp_dir

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from sys import platform as _platform
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Match, Optional, Tuple, Union
 
 from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
@@ -217,7 +217,7 @@ def same_path(path1, path2):
 
 def filter_file(
     regex: str,
-    repl: Union[str, Callable[[re.Match], str]],
+    repl: Union[str, Callable[[Match], str]],
     *filenames: str,
     string: bool = False,
     backup: bool = False,
@@ -258,7 +258,7 @@ def filter_file(
     if not callable(repl):
         unescaped = repl.replace(r"\\", "\\")
 
-        def replace_groups_with_groupid(m: re.Match) -> str:
+        def replace_groups_with_groupid(m: Match) -> str:
             def groupid_to_group(x):
                 return m.group(int(x.group(1)))
 
@@ -347,7 +347,7 @@ class FileFilter(object):
     def filter(
         self,
         regex: str,
-        repl: Union[str, Callable[[re.Match], str]],
+        repl: Union[str, Callable[[Match], str]],
         string: bool = False,
         backup: bool = False,
         ignore_absent: bool = False,

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -847,16 +847,14 @@ def mkdirp(
 
     Arguments:
         paths: paths to create with mkdirp
-        mode (permission bits or None): optional permissions to set
-            on the created directory -- use OS default if not provided
-        group (group name or None): optional group for permissions of
-            final created directory -- use OS default if not provided. Only
-            used if world write permissions are not set
-        default_perms (str or None): one of 'parents' or 'args'. The default permissions
-            that are set for directories that are not themselves an argument
-            for mkdirp. 'parents' means intermediate directories get the
-            permissions of their direct parent directory, 'args' means
-            intermediate get the same permissions specified in the arguments to
+        mode: optional permissions to set on the created directory -- use OS default
+            if not provided
+        group: optional group for permissions of final created directory -- use OS
+            default if not provided. Only used if world write permissions are not set
+        default_perms: one of 'parents' or 'args'. The default permissions that are set for
+            directories that are not themselves an argument for mkdirp. 'parents' means
+            intermediate directories get the permissions of their direct parent directory,
+            'args' means intermediate get the same permissions specified in the arguments to
             mkdirp -- default value is 'args'
     """
     default_perms = default_perms or "args"

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -920,7 +920,7 @@ def longest_existing_parent(path: str) -> Tuple[str, List[str]]:
     last_parent = ""
     intermediate_path = os.path.dirname(path)
     while intermediate_path:
-        if os.path.exists(intermediate_path):
+        if os.path.lexists(intermediate_path):
             last_parent = intermediate_path
             break
 


### PR DESCRIPTION
Since we dropped support for Python 2.7, we can embrace using keyword only arguments for many functions in Spack that use `**kwargs` in the function signature. Here I changed all the functions of that kind in `llnl.util.filesystem` to have an explicit list of arguments. 

There were a couple of bugs lurking in the code related to typo-like errors when retrieving from kwargs. Those have been fixed as well.

Modifications:
- [x] Modified functions in `llnl.util.filesystem` using `**kwargs` in function signatures to have explicit parameters
- [x] Added type hints to those functions
- [x] Fixed typo-like bugs found during the refactoring