### PR TITLE
spack.dependency: add type hints

### DIFF
--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -569,7 +569,7 @@ def static_graph_dot(
 def graph_dot(
     specs: List[spack.spec.Spec],
     builder: Optional[DotGraphBuilder] = None,
-    deptype: Optional[Union[str, Tuple[str, ...]]] = "all",
+    deptype: spack.dependency.DependencyArgument = "all",
     out: Optional[TextIO] = None,
 ):
     """DOT graph of the concrete specs passed as input.


### PR DESCRIPTION
Extracted from a larger branch that modifies edges in DAGs to keep track of virtual dependencies. This helps avoiding type-matching issues while we refactor the code.

Modifications:
- [x] Add type hints to code in `spack.dependency`