### PR TITLE
Add variants for overriding ESMF_OS and ESMF_COMM for ESMF package

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -90,6 +90,8 @@ class Esmf(MakefilePackage):
     )
     variant("debug", default=False, description="Make a debuggable version of the library")
     variant("shared", default=True, description="Build shared library")
+    variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
+    variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
 
     # Required dependencies
     depends_on("zlib")
@@ -251,6 +253,11 @@ class Esmf(MakefilePackage):
         if self.compiler.name == "cce" or "^cray-mpich" in self.spec:
             os.environ["ESMF_OS"] = "Unicos"
 
+        # Allow override of ESMF_OS:
+        os_variant = spec.variants["esmf_os"].value
+        if os_variant != "auto":
+            os.environ["ESMF_OS"] = os_variant
+
         #######
         # MPI #
         #######
@@ -283,6 +290,11 @@ class Esmf(MakefilePackage):
         else:
             # Force use of the single-processor MPI-bypass library.
             os.environ["ESMF_COMM"] = "mpiuni"
+
+        # Allow override of ESMF_COMM:
+        comm_variant = spec.variants["esmf_comm"].value
+        if comm_variant != "auto":
+            os.environ["ESMF_COMM"] = comm_variant
 
         ##########
         # LAPACK #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -90,6 +90,9 @@ class Esmf(MakefilePackage):
     )
     variant("debug", default=False, description="Make a debuggable version of the library")
     variant("shared", default=True, description="Build shared library")
+    # 'esmf_comm' and 'esmf_os' variants allow override values for their corresponding
+    # build environment variables. Documentation, including valid values, can be found at
+    # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
     variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
     variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
 


### PR DESCRIPTION
This PR adds two new variants for the ESMF package. They allow the user to override the ESMF_OS and ESMF_COMM settings. The default value for both is "auto," in which case the current logic for determining those variables in package.py is used. I have not attempted to check or restrict values. Thankfully, the ESMF build system fails fast if these settings are invalid.

Fixes https://github.com/spack/spack/issues/34720