### PR TITLE
[adios2] Older versions of ifx (oneapi) fail compilation

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -91,6 +91,9 @@ class Adios2(CMakePackage, CudaPackage):
     conflicts("%intel@:15")
     conflicts("%pgi@:14")
 
+    # ifx does not support submodules in separate files
+    conflicts("%oneapi@:2022.1.0", when="+fortran")
+
     depends_on("cmake@3.12.0:", type="build")
     depends_on("pkgconfig", type="build")
 


### PR DESCRIPTION
See https://community.intel.com/t5/Intel-Fortran-Compiler/version-node-not-found-for-symbol/m-p/1443784/thread-id/164290

Fixes https://github.com/spack/spack/issues/31817