### PR TITLE
e4s ci: use 2023-01-01 runner image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -275,11 +275,11 @@ protected-publish:
 
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
 e4s-protected-generate:
   extends: [ ".e4s", ".protected-generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -255,7 +255,7 @@ spack:
     after_script:
       - cat /proc/loadavg || true
 
-    image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+    image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
 
     broken-tests-packages:
       - gptune
@@ -454,7 +454,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-      image: ecpe4s/ubuntu20.04-runner-x86_64:2022-12-01
+      image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
       tags: ["spack", "public", "x86_64"]
 
     signing-job-attributes:


### PR DESCRIPTION
E4S CI: Use updated runner image: `ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01`