### PR TITLE
Update parallelio from NOAA-EMC fork

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -33,7 +33,7 @@ class Parallelio(CMakePackage):
     )
     variant("mpi", default=True, description="Use mpi to build, otherwise use mpi-serial")
 
-    patch('remove_redefinition_of_mpi_offset.patch', when='@:2.5.6')
+    patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
 
     depends_on("cmake@3.7:")
     depends_on("mpi", when="+mpi")
@@ -43,13 +43,7 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
-    resource(name="genf90",
-             git="https://github.com/PARALLELIO/genf90.git",
-             tag="genf90_200608")
-
-    def url_for_version(self, version):
-        url = 'https://github.com/NCAR/ParallelIO/archive/refs/tags/pio{}.tar.gz'
-        return url.format(version.underscored)
+    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
 
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="@:2.5.8 +fortran %gcc@10:")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -35,7 +35,7 @@ class Parallelio(CMakePackage):
 
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
 
-    depends_on("cmake@3.7:")
+    depends_on("cmake@3.7:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("mpi-serial", when="~mpi")
     depends_on("netcdf-c +mpi", type="link", when="+mpi")

--- a/var/spack/repos/builtin/packages/parallelio/remove_redefinition_of_mpi_offset.patch
+++ b/var/spack/repos/builtin/packages/parallelio/remove_redefinition_of_mpi_offset.patch
@@ -1,0 +1,35 @@
+--- a/src/clib/pio_internal.h
++++ b/src/clib/pio_internal.h
+@@ -30,12 +30,12 @@
+ #include <mpe.h>
+ #endif /* USE_MPE */
+ 
+-#ifndef MPI_OFFSET
++//#ifndef MPI_OFFSET
+ /** MPI_OFFSET is an integer type of size sufficient to represent the
+  * size (in bytes) of the largest file supported by MPI. In some MPI
+  * implementations MPI_OFFSET is not properly defined.  */
+-#define MPI_OFFSET  MPI_LONG_LONG
+-#endif
++//#define MPI_OFFSET  MPI_LONG_LONG
++//#endif
+ 
+ /* These are the sizes of types in netCDF files. Do not replace these
+  * constants with sizeof() calls for C types. They are not the
+@@ -57,10 +57,10 @@
+ #define MPI_OFFSET OMPI_OFFSET_DATATYPE
+ #endif
+ #endif
+-#ifndef MPI_Offset
++//#ifndef MPI_Offset
+ /** This is the type used for PIO_Offset. */
+-#define MPI_Offset long long
+-#endif
++//#define MPI_Offset long long
++//#endif
+ 
+ /** Some MPI implementations do not allow passing MPI_DATATYPE_NULL to
+  * comm functions even though the send or recv length is 0, in these
+-- 
+2.34.1
+


### PR DESCRIPTION
This PR provides significant updates to the parallelio package. Improvements include:
- Change underscores to periods in version numbers
- Add a 'shared' variant to allow static-only builds
- Add an MPI-related patch for versions up 2.5.6
- Add/update several build-related variables

This PR is intended to support operations and R&D for NOAA/NWS.