### PR TITLE
root: conflicts +ipo

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -319,6 +319,10 @@ class Root(CMakePackage):
     # ROOT <6.14 is incompatible with Python >=3.7, which is the minimum supported by spack
     conflicts("+python", when="@:6.13", msg="Spack wants python >=3.7, too new for ROOT <6.14")
 
+    # ROOT does not support LTO builds
+    # See https://github.com/root-project/root/issues/11135
+    conflicts("+ipo", msg="LTO is not a supported configuration for building ROOT")
+
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
         result = []


### PR DESCRIPTION
ROOT does not build successfully with `+ipo`, with symptoms as in https://github.com/root-project/root/issues/10777, and discussed most recently in https://github.com/root-project/root/issues/11135. As indicated there, LTO is not a supported build configuration. As of 6.26.10 there is no estimate for a fix since upstream is still broken.

@vvolkl @drbenmorgan: I don't think `+ipo` was ever supported. It may have worked in the past, but that could probably be considered accidental given the undefined behavior. It may work with other compilers, though, since the issue seems to be related to gcc specific behavior. Nevertheless, the statement in the bug report is that LTO is not supported, not that it isn't supported for gcc only, so I didn't add `%gcc` to the conflict.