### PR TITLE
nmap: update to depend on python2 for ndiff and zenmap; add 7.93

### DIFF
--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -44,6 +44,25 @@ class Nmap(AutotoolsPackage):
     depends_on("openssl@1.1:", when="@7.50:7.92")
     depends_on("openssl@:1.0.9", when="@:7.49")
 
+    # nmap includes vendors a few libraries, but we should build against spack's
+    # versions where appropriate. see their build guide at
+    # https://nmap.org/book/inst-source.html#inst-configure. Also see:
+    # https://github.com/nmap/nmap/issues/1602
+    #
+    # Any that are included "for convinience" we should provide.
+    #
+    # The recursive builds to build the vendored dependencies is also broken on
+    # darwin (something races); using our own deps works around that issue.
+    #
+    # Specifically, something is touching libpcre/configure during the build,
+    # which causes the recursive `make`'s configure.status --recheck pass to
+    # attempt to rerun configure. Rerunning configure fails due and asks to run
+    # `make distclean`.
+
+    depends_on("libssh2@1.10")
+    depends_on("pcre@8")
+    depends_on("zlib@1.2")
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -36,7 +36,12 @@ class Nmap(AutotoolsPackage):
     variant("nping", default=True, description="Enable nping")
     variant("nmap-update", default=False, description="Enable nmap-update")
 
-    depends_on("openssl@1.1:", when="@7.50:")
+    # Release notes for 7.3: "Ensure Nmap builds with OpenSSL 3.0 using no
+    # deprecated API functions."
+    depends_on("openssl@3.0.7:", when="@7.93:")
+
+    # previous verisons use a few deprecated openssl apis
+    depends_on("openssl@1.1:", when="@7.50:7.92")
     depends_on("openssl@:1.0.9", when="@:7.49")
 
     def configure_args(self):
@@ -45,7 +50,7 @@ class Nmap(AutotoolsPackage):
         # https://github.com/nmap/nmap/issues/2144
         args.append("--disable-rdma")
 
-        # ndiff and zenmap both require python2, which is deprecated.
+        # ndiff and zenmap both require python2, which is deprecated in spack.
         # The next nmap release will fix this, so, disable these features
         # completely for now. We will add feature flags for these features again
         # when they can be supported without a dependency on python2

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -15,7 +15,7 @@ class Nmap(AutotoolsPackage):
     url = "https://nmap.org/dist/nmap-7.70.tar.bz2"
     list_url = "https://nmap.org/dist-old/"
 
-    version("7.93", sha256="a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1")
+    version("7.93", sha256="55bcfe4793e25acc96ba4274d8c4228db550b8e8efd72004b38ec55a2dd16651")
     version("7.92", sha256="a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1")
     version("7.91", sha256="18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300")
     version("7.90", sha256="5557c3458275e8c43e1d0cfa5dad4e71dd39e091e2029a293891ad54098a40e8")
@@ -33,19 +33,11 @@ class Nmap(AutotoolsPackage):
 
     variant("liblua", default=True, description="Enable lua (required by all of NSE)")
     variant("ncat", default=True, description="Enable ncat")
-    variant("ndiff", default=False, description="Enable ndiff")
     variant("nping", default=True, description="Enable nping")
-    variant("zenmap", default=False, description="Enable zenmap")
     variant("nmap-update", default=False, description="Enable nmap-update")
 
     depends_on("openssl@1.1:", when="@7.50:")
     depends_on("openssl@:1.0.9", when="@:7.49")
-
-    # python2 is not packaged with spack so these features are disabled unless a
-    # user has an external python2 package configured.
-    # this will be fixed in the next release of nmap
-    depends_on("python@:2", when="+ndiff")
-    depends_on("python@:2", when="+zenmap")
 
     def configure_args(self):
         args = []
@@ -53,11 +45,16 @@ class Nmap(AutotoolsPackage):
         # https://github.com/nmap/nmap/issues/2144
         args.append("--disable-rdma")
 
+        # ndiff and zenmap both require python2, which is deprecated.
+        # The next nmap release will fix this, so, disable these features
+        # completely for now. We will add feature flags for these features again
+        # when they can be supported without a dependency on python2
+        args.append("--disable-ndiff")
+        args.append("--disable-zenmap")
+
         args += self.with_or_without("liblua")
         args += self.with_or_without("ncat")
-        args += self.with_or_without("ndiff")
         args += self.with_or_without("nping")
-        args += self.with_or_without("zenmap")
         args += self.with_or_without("nmap-update")
 
         return args

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -44,19 +44,19 @@ class Nmap(AutotoolsPackage):
     depends_on("openssl@1.1:", when="@7.50:7.92")
     depends_on("openssl@:1.0.9", when="@:7.49")
 
-    # nmap includes vendors a few libraries, but we should build against spack's
-    # versions where appropriate. see their build guide at
+    # nmap vendors a few libraries, but we should build against spack's
+    # versions where appropriate. See their build guide at
     # https://nmap.org/book/inst-source.html#inst-configure. Also see:
     # https://github.com/nmap/nmap/issues/1602
     #
-    # Any that are included "for convinience" we should provide.
+    # Any that are included "for convenience" we should provide.
     #
     # The recursive builds to build the vendored dependencies is also broken on
     # darwin (something races); using our own deps works around that issue.
     #
     # Specifically, something is touching libpcre/configure during the build,
     # which causes the recursive `make`'s configure.status --recheck pass to
-    # attempt to rerun configure. Rerunning configure fails due and asks to run
+    # attempt to rerun configure. Rerunning configure fails and asks you to run
     # `make distclean`.
 
     depends_on("libssh2@1.10")
@@ -71,7 +71,7 @@ class Nmap(AutotoolsPackage):
 
         # ndiff and zenmap both require python2, which is deprecated in spack.
         # The next nmap release will fix this, so, disable these features
-        # completely for now. We will add feature flags for these features again
+        # completely for now. We will add flags for these features again
         # when they can be supported without a dependency on python2
         args.append("--disable-ndiff")
         args.append("--disable-zenmap")

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -15,6 +15,7 @@ class Nmap(AutotoolsPackage):
     url = "https://nmap.org/dist/nmap-7.70.tar.bz2"
     list_url = "https://nmap.org/dist-old/"
 
+    version("7.93", sha256="a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1")
     version("7.92", sha256="a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1")
     version("7.91", sha256="18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300")
     version("7.90", sha256="5557c3458275e8c43e1d0cfa5dad4e71dd39e091e2029a293891ad54098a40e8")
@@ -32,13 +33,19 @@ class Nmap(AutotoolsPackage):
 
     variant("liblua", default=True, description="Enable lua (required by all of NSE)")
     variant("ncat", default=True, description="Enable ncat")
-    variant("ndiff", default=True, description="Enable ndiff")
+    variant("ndiff", default=False, description="Enable ndiff")
     variant("nping", default=True, description="Enable nping")
-    variant("zenmap", default=True, description="Enable zenmap")
+    variant("zenmap", default=False, description="Enable zenmap")
     variant("nmap-update", default=False, description="Enable nmap-update")
 
     depends_on("openssl@1.1:", when="@7.50:")
     depends_on("openssl@:1.0.9", when="@:7.49")
+
+    # python2 is not packaged with spack so these features are disabled unless a
+    # user has an external python2 package configured.
+    # this will be fixed in the next release of nmap
+    depends_on("python@:2", when="+ndiff")
+    depends_on("python@:2", when="+zenmap")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -51,7 +51,7 @@ class Nmap(AutotoolsPackage):
     #
     # Any that are included "for convenience" we should provide.
     #
-    # The recursive builds to build the vendored dependencies is also broken on
+    # The recursive builds for vendored dependencies is also broken on
     # darwin (something races); using our own deps works around that issue.
     #
     # Specifically, something is touching libpcre/configure during the build,


### PR DESCRIPTION
I'm not sure how to do this exactly. It's failing CI due to a missing python2

this is also still getting issues on m1 darwin for me (but not my linux machines)