### PR TITLE
Add package file for xtb and py-xtb

### DIFF
--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -44,8 +44,16 @@ class Dftd4(MesonPackage):
             lapack = "auto"
 
         return [
-            "--wrap-mode=nodownload",
             "-Dlapack={0}".format(lapack),
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
             "-Dpython={0}".format(str("+python" in self.spec).lower()),
         ]
+
+    def setup_run_environment(self, env):
+        if "+python" in self.spec:
+            pydir = join_path(
+                self.prefix.lib,
+                "python" + str(self.spec["python"].version.up_to(2)),
+                "site-packages",
+            )
+            env.prepend_path("PYTHONPATH", pydir)

--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -10,12 +10,13 @@ class Dftd4(MesonPackage):
     """Generally Applicable Atomic-Charge Dependent London Dispersion Correction"""
 
     homepage = "https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dftd4"
-    url = "https://github.com/dftd4/dftd4/releases/download/v3.3.0/dftd4-3.3.0-source.tar.xz"
+    url = "https://github.com/dftd4/dftd4/releases/download/v3.5.0/dftd4-3.5.0-source.tar.xz"
     git = "https://github.com/dftd4/dftd4.git"
 
     maintainers = ["awvwgk"]
 
     version("main", branch="main")
+    version("3.5.0", "d2bab992b5ef999fd13fec8eb1da9e9e8d94b8727a2e624d176086197a00a46f")
     version("3.4.0", "24fcb225cdd5c292ac26f7d3204ee3c4024174adb5272eeda9ae7bc57113ec8d")
     version("3.3.0", "408720b8545532d5240dd743c05d57b140af983192dad6d965b0d79393d0a9ef")
     version("3.2.0", "cef505e091469aa9b8f008ee1756545bb87b02760bb2c7ca54854e20ba8c590a")
@@ -26,13 +27,14 @@ class Dftd4(MesonPackage):
     variant("python", default=False, description="Build Python extension module")
 
     depends_on("blas")
-    depends_on("cmake", type="build")
     depends_on("lapack")
     depends_on("mctc-lib")
     depends_on("meson@0.57.1:", type="build")  # mesonbuild/meson#8377
     depends_on("pkgconfig", type="build")
     depends_on("py-cffi", when="+python")
     depends_on("python@3.6:", when="+python")
+
+    extends("python", when="+python")
 
     def meson_args(self):
         lapack = self.spec["lapack"].libs.names[0]
@@ -48,12 +50,3 @@ class Dftd4(MesonPackage):
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
             "-Dpython={0}".format(str("+python" in self.spec).lower()),
         ]
-
-    def setup_run_environment(self, env):
-        if "+python" in self.spec:
-            pydir = join_path(
-                self.prefix.lib,
-                "python" + str(self.spec["python"].version.up_to(2)),
-                "site-packages",
-            )
-            env.prepend_path("PYTHONPATH", pydir)

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -27,6 +27,5 @@ class MctcLib(MesonPackage):
 
     def meson_args(self):
         return [
-            "--wrap-mode=nodownload",
             "-Djson={0}".format("enabled" if "+json" in self.spec else "disabled"),
         ]

--- a/var/spack/repos/builtin/packages/py-xtb/package.py
+++ b/var/spack/repos/builtin/packages/py-xtb/package.py
@@ -10,18 +10,19 @@ class PyXtb(PythonPackage):
     """Python API for the extended tight binding program package"""
 
     homepage = "https://xtb-python.readthedocs.org"
-    url = "https://github.com/grimme-lab/xtb-python/releases/download/v22.1/xtb-22.1.tar.gz"
+    pypi = "xtb/xtb-22.1.tar.gz"
+    git = "https://github.com/grimme-lab/xtb-python.git"
 
     maintainers = [
         *PythonPackage.maintainers,
         "awvwgk",
     ]
 
-    version("22.1", sha256="7a59e7b783fc6e8b7328f55211de681e535a83991b07c4bab73494063f5e9018")
+    version("22.1", "7a59e7b783fc6e8b7328f55211de681e535a83991b07c4bab73494063f5e9018")
 
     depends_on("pkgconfig", type="build")
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-cffi", type=("build", "run"))
-    depends_on("py-meson-python@0.11.0:", type="build")
-    depends_on("py-numpy", type="run")
+    depends_on("py-meson-python", type="build")
+    depends_on("py-numpy", type=("build", "run"))
     depends_on("xtb", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-xtb/package.py
+++ b/var/spack/repos/builtin/packages/py-xtb/package.py
@@ -12,7 +12,10 @@ class PyXtb(PythonPackage):
     homepage = "https://xtb-python.readthedocs.org"
     url = "https://github.com/grimme-lab/xtb-python/releases/download/v22.1/xtb-22.1.tar.gz"
 
-    maintainers = ["awvwgk"]
+    maintainers = [
+        *PythonPackage.maintainers,
+        "awvwgk",
+    ]
 
     version("22.1", sha256="7a59e7b783fc6e8b7328f55211de681e535a83991b07c4bab73494063f5e9018")
 

--- a/var/spack/repos/builtin/packages/py-xtb/package.py
+++ b/var/spack/repos/builtin/packages/py-xtb/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyXtb(PythonPackage):
+    """Python API for the extended tight binding program package"""
+
+    homepage = "https://xtb-python.readthedocs.org"
+    url = "https://github.com/grimme-lab/xtb-python/releases/download/v22.1/xtb-22.1.tar.gz"
+
+    maintainers = ["awvwgk"]
+
+    version("22.1", sha256="7a59e7b783fc6e8b7328f55211de681e535a83991b07c4bab73494063f5e9018")
+
+    depends_on("pkgconfig", type="build")
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-cffi", type=("build", "run"))
+    depends_on("py-meson-python@0.11.0:", type="build")
+    depends_on("py-numpy", type="run")
+    depends_on("xtb", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/simple-dftd3/package.py
+++ b/var/spack/repos/builtin/packages/simple-dftd3/package.py
@@ -34,7 +34,15 @@ class SimpleDftd3(MesonPackage):
     def meson_args(self):
 
         return [
-            "--wrap-mode=nodownload",
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
             "-Dpython={0}".format(str("+python" in self.spec).lower()),
         ]
+
+    def setup_run_environment(self, env):
+        if "+python" in self.spec:
+            pydir = join_path(
+                self.prefix.lib,
+                "python" + str(self.spec["python"].version.up_to(2)),
+                "site-packages",
+            )
+            env.prepend_path("PYTHONPATH", pydir)

--- a/var/spack/repos/builtin/packages/simple-dftd3/package.py
+++ b/var/spack/repos/builtin/packages/simple-dftd3/package.py
@@ -12,7 +12,7 @@ class SimpleDftd3(MesonPackage):
     """
 
     homepage = "https://dftd3.readthedocs.io"
-    url = "https://github.com/dftd3/simple-dftd3/releases/download/v0.7.0/s-dftd3-0.7.0.tar.xz"
+    url = "https://github.com/dftd3/simple-dftd3/releases/download/v0.7.0/s-dftd3-0.7.0-source.tar.xz"
     git = "https://github.com/dftd3/simple-dftd3.git"
 
     maintainers = ["awvwgk"]
@@ -21,14 +21,6 @@ class SimpleDftd3(MesonPackage):
     version("0.7.0", "5390b20102474a3c37240f38226f3a54a809b34bcb910317bdd109b8c2865f4e")
     version("0.6.0", "c057361565f570cb128489c70131487f71b6891a40e5292dfe37041596810dfe")
     version("0.5.1", "0411fdaebe438f652a970cb232ae3199c4cc840366ed05fda4c38e634632040d")
-
-    def url_for_version(self, version):
-        return (
-            "https://github.com/dftd3/simple-dftd3/releases/download/v{version}/"
-            + "s-dftd3-{version}-source.tar.xz"
-            if version < Version("0.7")
-            else "s-dftd3-{version}.tar.xz"
-        ).format(version=str(version))
 
     variant("openmp", default=True, description="Use OpenMP parallelisation")
     variant("python", default=False, description="Build Python extension module")

--- a/var/spack/repos/builtin/packages/simple-dftd3/package.py
+++ b/var/spack/repos/builtin/packages/simple-dftd3/package.py
@@ -12,14 +12,23 @@ class SimpleDftd3(MesonPackage):
     """
 
     homepage = "https://dftd3.readthedocs.io"
-    url = "https://github.com/dftd3/simple-dftd3/releases/download/v0.6.0/s-dftd3-0.6.0-source.tar.xz"
+    url = "https://github.com/dftd3/simple-dftd3/releases/download/v0.7.0/s-dftd3-0.7.0.tar.xz"
     git = "https://github.com/dftd3/simple-dftd3.git"
 
     maintainers = ["awvwgk"]
 
     version("main", branch="main")
+    version("0.7.0", "5390b20102474a3c37240f38226f3a54a809b34bcb910317bdd109b8c2865f4e")
     version("0.6.0", "c057361565f570cb128489c70131487f71b6891a40e5292dfe37041596810dfe")
     version("0.5.1", "0411fdaebe438f652a970cb232ae3199c4cc840366ed05fda4c38e634632040d")
+
+    def url_for_version(self, version):
+        return (
+            "https://github.com/dftd3/simple-dftd3/releases/download/v{version}/"
+            + "s-dftd3-{version}-source.tar.xz"
+            if version < Version("0.7")
+            else "s-dftd3-{version}.tar.xz"
+        ).format(version=str(version))
 
     variant("openmp", default=True, description="Use OpenMP parallelisation")
     variant("python", default=False, description="Build Python extension module")
@@ -31,18 +40,11 @@ class SimpleDftd3(MesonPackage):
     depends_on("py-cffi", when="+python")
     depends_on("python@3.6:", when="+python")
 
+    extends("python", when="+python")
+
     def meson_args(self):
 
         return [
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
             "-Dpython={0}".format(str("+python" in self.spec).lower()),
         ]
-
-    def setup_run_environment(self, env):
-        if "+python" in self.spec:
-            pydir = join_path(
-                self.prefix.lib,
-                "python" + str(self.spec["python"].version.up_to(2)),
-                "site-packages",
-            )
-            env.prepend_path("PYTHONPATH", pydir)

--- a/var/spack/repos/builtin/packages/toml-f/package.py
+++ b/var/spack/repos/builtin/packages/toml-f/package.py
@@ -24,8 +24,3 @@ class TomlF(MesonPackage):
     version("0.2.3", "2dca7ff6d3e35415cd92454c31560d2b656c014af8236be09c54c13452e4539c")
 
     depends_on("meson@0.57.2:", type="build")
-
-    def meson_args(self):
-        return [
-            "--wrap-mode=nodownload",
-        ]

--- a/var/spack/repos/builtin/packages/xtb/package.py
+++ b/var/spack/repos/builtin/packages/xtb/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Xtb(MesonPackage):
+    """Semiempirical extended tight binding program package"""
+
+    homepage = "https://xtb-docs.readthedocs.org"
+    url = "https://github.com/grimme-lab/xtb/releases/download/v6.5.1/xtb-6.5.1-source.tar.xz"
+
+    maintainers = ["awvwgk"]
+
+    version("6.5.1", sha256="0922205cc224fe79e28f3d75be4e10c03efa8f3f666aedec8346fed82b272cad")
+    version("6.5.0", sha256="5f780656bf7b440a8e1f753a9a877401a7d497fb3160762f48bdefc8a9914976")
+
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("meson@0.57.2:", type="build")
+    depends_on("mctc-lib")
+    depends_on("pkgconfig", type="build")
+
+    variant("openmp", default=True, description="Use OpenMP parallelisation")
+
+    def meson_args(self):
+        lapack = self.spec["lapack"].libs.names[0]
+        if lapack.startswith("mkl"):
+            lapack = "mkl"
+        elif lapack != "openblas":
+            lapack = "netlib"
+
+        return [
+            "-Dla_backend={0}".format(lapack),
+            "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
+        ]


### PR DESCRIPTION
Add packages for xtb and py-xtb, also fixes simple-dftd3, dftd4 and mctc-lib packages to account for latest MesonPackage update.