### PR TITLE
s3_open: return peekable stream

### DIFF
--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import urllib.parse
 import urllib.response
+from io import BufferedReader
 from urllib.error import URLError
 from urllib.request import BaseHandler
 
@@ -17,7 +18,7 @@ def gcs_open(req, *args, **kwargs):
 
     if not gcsblob.exists():
         raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
-    stream = gcsblob.get_blob_byte_stream()
+    stream = BufferedReader(gcsblob.get_blob_byte_stream())
     headers = gcsblob.get_blob_headers()
 
     return urllib.response.addinfourl(stream, headers, url)

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -26,6 +26,8 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         description="Build shared libs, static libs or both",
     )
 
+    variant("rebuild_me", default=True, description="remove me")
+
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch("gets.patch", when="@1.14")

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -26,8 +26,6 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         description="Build shared libs, static libs or both",
     )
 
-    variant("rebuild_me", default=True, description="remove me")
-
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch("gets.patch", when="@1.14")

--- a/var/spack/repos/builtin/packages/spack/package.py
+++ b/var/spack/repos/builtin/packages/spack/package.py
@@ -78,6 +78,7 @@ class Spack(Package):
     depends_on("patchelf", type="run", when="platform=linux")
     depends_on("patchelf", type="run", when="platform=cray")
     depends_on("py-boto3", type="run")
+    depends_on("py-boto3@1.9: ^py-urllib3@1.25:", type="run", when="@0.20:")
 
     # See https://github.com/spack/spack/pull/24686
     # and #25595, #25726, #25853, #25923, #25924 upstream in python/cpython


### PR DESCRIPTION
botocore has been using a wrapper around `urllib3.request.HTTPResponse`
since 2014 (https://github.com/boto/botocore/commit/969f0c22cb2727123bc62832ceac93dc4a23005c)
which does two things: allow setting a timeout on the socket (which we
don't use) and erroring when content-length: ... does not match the
actual content length.

The downside is that this wrapper class doesn't derive from any of the
Python IO classes, so we used to create yet another wrapper to make it
more compatible with the type of stream urlopen returns for its builtin
responses for http/https etc... And this wrapper was incomplete as it
did not implement `peek()`. So instead the proposal here is to replace
the two awkward wrappers with BufferedReader, which ensures the stream
object is peekable and derives from BufferedIOBase.

BUT, there's yet another caveat, namely that the underlying stream
is urllib3.request.HTTPResponse instead of http.client.HTTPResponse,
and urllib3 has this weird property of returns closed() == True upon
reading the EOF, which is non-standard. They fixed that weirdness
trying to be backward compatible in [urllib3 v1.25.4](https://github.com/urllib3/urllib3/commit/f0d9ebc41e51c4c4c9990b1eed02d297fd1b20d8). The first
botocore to support that is `botocore v1.12.154` and the
first botocore to *require* it is v1.19. That means that
1. `py-boto3@1.9` and above support `urllib3@v1.25.4`
2. `py-boto3@1.16` and above _require_ `urllib3@1.25.4:`

In our CI we use `py-boto3` version 1.20.35 or higher.

Ubuntu 18.04 provides (shock) an apt package `python3-boto3`
which uses urllib3 version 1.22 :(. Alternatively through `python3-pip3`
you can install boto3 1.23 and urllib 1.26. Ubuntu 20.04's system boto3
is more up-to-date (urllib3 1.25.8).

Notice that `http.client.HTTPResponse` (what urllib returns for e.g.
http/https) does implement `peek` separately from deriving from
BufferedIOBase. I also checked `ftp`, it gives a BufferedReader
object too.