### PR TITLE
libxsmm: Add build dependency on binutils

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -77,6 +77,11 @@ class Libxsmm(MakefilePackage):
     )
     depends_on("python", type="build")
 
+    # A recent `as` is needed to compile libxmss until version 1.17
+    # (<https://github.com/spack/spack/issues/28404>), but not afterwards
+    # (<https://github.com/spack/spack/pull/21671#issuecomment-779882282>).
+    depends_on("binutils+ld+gas@2.33:", type="build", when="@:1.17")
+
     @property
     def libs(self):
         result = find_libraries(["libxsmm", "libxsmmf"], root=self.prefix, recursive=True)


### PR DESCRIPTION
On some systems compiling libxsmm fails because system `as` is not capable of compiling some assembly code, see #28404 and https://github.com/libxsmm/libxsmm/issues/652.  I determined binutils 2.33 as the minimum required version of binutils by trial-and-error (libxsmm [README.md](https://github.com/libxsmm/libxsmm/blob/61e9f0ad28631f1178a64d011e6aa03693400f35/README.md#outdated-binutils) generally talks about "outdated Binutils", without concrete references).  Also, I verified that compiling `libxsmm@main` doesn't require a new binutils, see https://github.com/spack/spack/pull/21671#issuecomment-779882282.

Fix #28404.