### PR TITLE
mfem: support pumi w/zoltan and parmetis

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -818,8 +818,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 "PUMI_LIB=%s %s %s"
                 % (
                     ld_flags_from_dirs([spec["pumi"].prefix.lib], pumi_libs),
-                    pumi_dep_parmetis,
                     pumi_dep_zoltan,
+                    pumi_dep_parmetis,
                 ),
             ]
 

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -805,18 +805,22 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 "apf_zoltan",
                 "spr",
             ]
-            pumi_dep_zoltan=[""]
-            pumi_dep_parmetis=[""]
+            pumi_dep_zoltan = [""]
+            pumi_dep_parmetis = [""]
             if "+zoltan" in spec["pumi"]:
                 pumi_dep_zoltan = ld_flags_from_dirs([spec["zoltan"].prefix.lib], ["zoltan"])
                 if "+parmetis" in spec["zoltan"]:
-                    pumi_dep_parmetis = ld_flags_from_dirs([spec["parmetis"].prefix.lib], ["parmetis"])
+                    pumi_dep_parmetis = ld_flags_from_dirs(
+                        [spec["parmetis"].prefix.lib], ["parmetis"]
+                    )
             options += [
                 "PUMI_OPT=-I%s" % spec["pumi"].prefix.include,
-                "PUMI_LIB=%s %s %s" % (
-                  ld_flags_from_dirs([spec["pumi"].prefix.lib], pumi_libs),
-                  pumi_dep_parmetis,
-                  pumi_dep_zoltan),
+                "PUMI_LIB=%s %s %s"
+                % (
+                    ld_flags_from_dirs([spec["pumi"].prefix.lib], pumi_libs),
+                    pumi_dep_parmetis,
+                    pumi_dep_zoltan,
+                ),
             ]
 
         if "+gslib" in spec:

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -805,9 +805,18 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 "apf_zoltan",
                 "spr",
             ]
+            pumi_dep_zoltan=[""]
+            pumi_dep_parmetis=[""]
+            if "+zoltan" in spec["pumi"]:
+                pumi_dep_zoltan = ld_flags_from_dirs([spec["zoltan"].prefix.lib], ["zoltan"])
+                if "+parmetis" in spec["zoltan"]:
+                    pumi_dep_parmetis = ld_flags_from_dirs([spec["parmetis"].prefix.lib], ["parmetis"])
             options += [
                 "PUMI_OPT=-I%s" % spec["pumi"].prefix.include,
-                "PUMI_LIB=%s" % ld_flags_from_dirs([spec["pumi"].prefix.lib], pumi_libs),
+                "PUMI_LIB=%s %s %s" % (
+                  ld_flags_from_dirs([spec["pumi"].prefix.lib], pumi_libs),
+                  pumi_dep_parmetis,
+                  pumi_dep_zoltan),
             ]
 
         if "+gslib" in spec:

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -805,8 +805,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                 "apf_zoltan",
                 "spr",
             ]
-            pumi_dep_zoltan = [""]
-            pumi_dep_parmetis = [""]
+            pumi_dep_zoltan = ""
+            pumi_dep_parmetis = ""
             if "+zoltan" in spec["pumi"]:
                 pumi_dep_zoltan = ld_flags_from_dirs([spec["zoltan"].prefix.lib], ["zoltan"])
                 if "+parmetis" in spec["zoltan"]:


### PR DESCRIPTION
This PR adds support for building MFEM against PUMI when it has Zoltan/ParMETIS as dependencies.