### PR TITLE
add dummy perl+open variant, use it in external find, require it in libxcrypt

### DIFF
--- a/var/spack/repos/builtin/packages/libxcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libxcrypt/package.py
@@ -32,6 +32,15 @@ class Libxcrypt(AutotoolsPackage):
 
     patch("truncating-conversion.patch", when="@4.4.30")
 
+    with when("@:4.4.17"):
+        depends_on("autoconf", type="build")
+        depends_on("automake@1.14:", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+
+    # Some distros have incomplete perl installs, +open catches that.
+    depends_on("perl@5.14.0: +open", type="build", when="@4.4.18:")
+
     def configure_args(self):
         args = [
             # Disable test dependency on Python (Python itself depends on libxcrypt).
@@ -45,9 +54,3 @@ class Libxcrypt(AutotoolsPackage):
     @property
     def libs(self):
         return find_libraries("libcrypt", root=self.prefix, recursive=True)
-
-    with when("@:4.4.17"):
-        depends_on("autoconf", type="build")
-        depends_on("automake@1.14:", type="build")
-        depends_on("libtool", type="build")
-        depends_on("m4", type="build")

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -159,10 +159,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # having it in core increases the "energy of activation" for doing
     # things cleanly.
     variant("cpanm", default=True, description="Optionally install cpanm with the core packages.")
-
     variant("shared", default=True, description="Build a shared libperl.so library")
-
     variant("threads", default=True, description="Build perl with threads support")
+    variant("open", default=True, description="Support open.pm")
 
     resource(
         name="cpanm",
@@ -211,6 +210,16 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 variants += "+cpanm"
             else:
                 variants += "~cpanm"
+            # this is just to detect incomplete installs
+            # normally perl installs open.pm
+            perl(
+                "-e",
+                "use open OUT => qw(:raw)",
+                output=os.devnull,
+                error=os.devnull,
+                fail_on_error=False,
+            )
+            variants += "+open" if perl.returncode == 0 else "~open"
             return variants
 
     # On a lustre filesystem, patch may fail when files


### PR DESCRIPTION
So, this is PR #inf in the series of attempts to fix libxcrypt depends on perl.

The problem previously was that if you do `yum install autoconf` or so on
rhel8, you get a partial perl install, lacking `open.pm`, and if you relied on
`spack external find perl` the build of libxcrypt would fail, which is required
for pretty much anything.

This is now solved by adding a dummy `perl +open` variant, which defaults to
`True`, and can be detected in external find, and is required by `libxcrypt`.

