### PR TITLE
[flexiblas] Add 4 new version and their hashes

### DIFF
--- a/var/spack/repos/builtin/packages/flexiblas/package.py
+++ b/var/spack/repos/builtin/packages/flexiblas/package.py
@@ -12,6 +12,10 @@ class Flexiblas(CMakePackage):
     homepage = "https://www.mpi-magdeburg.mpg.de/projects/flexiblas"
     url = "https://csc.mpi-magdeburg.mpg.de/mpcsc/software/flexiblas/flexiblas-3.0.3.tar.gz"
 
+    version("3.3.0", sha256="2696cd63d69b9a007f40f1f4a1ed83ad2fc46f6a930a22753bd221758c503ea2")
+    version("3.2.1", sha256="5be7e508e2dbb751b3bf372639d8e82a11f79e9ef6cbf243b64981c24a5703cf")
+    version("3.2.0", sha256="a3f4d66a30b6fa6473e492de86d34abc5f9d4e69d4d91ba23618388e8df05904")
+    version("3.1.3", sha256="aac6175660e8475ce478b88673eee330671f8aecc0cb852a25833e23e29a0620")
     version("3.0.4", sha256="50a88f2e88994dda91b2a2621850afd9654b3b84820e737e335687a46751be5c")
     version("3.0.3", sha256="926ab31cf56f0618aec34da85314f3b48b6deb661b4e9d6e6a99dc37872b5341")
 


### PR DESCRIPTION
Add 4 new versions of flexiblas and their hashes:
- 3.3.0 (latest)
- 3.2.1
- 3.2.0
- 3.1.3

They have all been tested to compile via https://github.com/iamashwin99/flexiblas-in-spack/actions