### PR TITLE
Documentation: Add installation policy to packaging guide

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -34,6 +34,15 @@ ubiquitous in the scientific software community. Second, it's a modern
 language and has many powerful features to help make package writing
 easy.
 
+.. warning::
+
+   As a general rule, packages should install the software *from source*.
+   The only exception is for proprietary software (e.g., vendor compilers).
+
+   If a special build system needs to be added in order to support building
+   a package from source, then the associated code and recipe need to be added
+   first.
+
 
 .. _installation_procedure:
 


### PR DESCRIPTION
This PR adds a warning to the packaging guide introduction stating that the general rule is for recipes to install software from source.  It notes that the exception is proprietary software and that if a new build system is needed, then that code must be added.