### PR TITLE
CompilerSpec: add type hints

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -184,7 +184,7 @@ class LmodConfiguration(BaseConfiguration):
         elif self.spec.name in spack.compilers.package_name_to_compiler_name:
             # If it is the package for a supported compiler, but of a different name
             cname = spack.compilers.package_name_to_compiler_name[self.spec.name]
-            provides["compiler"] = spack.spec.CompilerSpec("%s@%s" % (cname, self.spec.version))
+            provides["compiler"] = spack.spec.CompilerSpec(cname, self.spec.version)
 
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1473,20 +1473,6 @@ class Spec(object):
             result[key] = list(group)
         return result
 
-    #
-    # Private routines here are called by the parser when building a spec.
-    #
-    def _add_versions(self, version_list):
-        """Called by the parser to add an allowable version."""
-        # If it already has a non-trivial version list, this is an error
-        if self.versions and self.versions != vn.VersionList(":"):
-            raise MultipleVersionError(
-                "A spec cannot contain multiple version signifiers." " Use a version list instead."
-            )
-        self.versions = vn.VersionList()
-        for version in version_list:
-            self.versions.add(version)
-
     def _add_flag(self, name, value, propagate):
         """Called by the parser to add a known flag.
         Known flags currently include "arch"
@@ -1554,14 +1540,6 @@ class Spec(object):
                     )
                 else:
                     setattr(self.architecture, new_attr, new_value)
-
-    def _set_compiler(self, compiler):
-        """Called by the parser to set the compiler."""
-        if self.compiler:
-            raise DuplicateCompilerSpecError(
-                "Spec for '%s' cannot have two compilers." % self.name
-            )
-        self.compiler = compiler
 
     def _add_dependency(self, spec: "Spec", *, deptypes: dp.DependencyArgument):
         """Called by the parser to add another spec as a dependency."""


### PR DESCRIPTION
Pulled out from #34873 , since we decided to revert the change in `CompilerSpec` constructor.

Modifications:
- [x] Added type hints to `CompilerSpec` methods
- [x] Removed `CompilerSpec._add_versions`, `Spec._add_versions` and `Spec._set_compiler` (dead code)