### PR TITLE
gmp: Add `cxx` variant, and require it in `libint` package

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -35,6 +35,7 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
         multi=True,
         description="Build shared libs, static libs or both",
     )
+    variant("cxx", default=True, description="Enable C++ support")
 
     # gmp's configure script seems to be broken; it sometimes misdetects
     # shared library support. Regenerating it fixes the issue.
@@ -51,7 +52,7 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
         return (flags, None, None)
 
     def configure_args(self):
-        args = ["--enable-cxx"]
+        args = self.enable_or_disable("cxx")
         args += self.enable_or_disable("libs")
         if "libs=static" in self.spec:
             args.append("--with-pic")

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -66,7 +66,7 @@ class Libint(AutotoolsPackage):
     # Libint 2 dependencies
     # Fixme: Can maintainers please confirm that this is a required dependency
     depends_on(Boost.with_default_variants, when="@2:")
-    depends_on("gmp", when="@2:")
+    depends_on("gmp+cxx", when="@2:")
 
     for tvariant in TUNE_VARIANTS[1:]:
         conflicts(


### PR DESCRIPTION
While trying to build `libint` in an environment where I have `gmp`  as external package, it occurred to me that `gmp` doesn't have a `cxx` variant.  In GMP build system, enabling C++ is off by default (while Spack switches it on by default), so it's more likely to have an external non-C++ GMP than not.