### PR TITLE
Forward lookup of "test_log_file" and "test_failures"

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -128,7 +128,11 @@ def _create(pkg):
             new_cls = type(
                 new_cls_name,
                 bases,
-                {"run_tests": property(lambda x: x.wrapped_package_object.run_tests)},
+                {
+                    "run_tests": property(lambda x: x.wrapped_package_object.run_tests),
+                    "test_log_file": property(lambda x: x.wrapped_package_object.test_log_file),
+                    "test_failures": property(lambda x: x.wrapped_package_object.test_failures),
+                },
             )
             new_cls.__module__ = package_cls.__module__
             self.__class__ = new_cls

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -132,6 +132,7 @@ def _create(pkg):
                     "run_tests": property(lambda x: x.wrapped_package_object.run_tests),
                     "test_log_file": property(lambda x: x.wrapped_package_object.test_log_file),
                     "test_failures": property(lambda x: x.wrapped_package_object.test_failures),
+                    "test_suite": property(lambda x: x.wrapped_package_object.test_suite),
                 },
             )
             new_cls.__module__ = package_cls.__module__

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -651,9 +651,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: List of test failures encountered during a smoke/install test run.
     test_failures = None
 
-    #: TestSuite instance used to manage smoke/install tests for one or more
-    #: specs.
+    #: TestSuite instance used to manage smoke/install tests for one or more specs.
     test_suite = None
+
+    #: Path to the log file used for tests
+    test_log_file = None
 
     def __init__(self, spec):
         # this determines how the package should be built.

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -154,3 +154,17 @@ def test_monkey_patching_wrapped_pkg():
     s.package.run_tests = True
     assert builder.pkg.run_tests is True
     assert builder.pkg_with_dispatcher.run_tests is True
+
+
+@pytest.mark.regression("34440")
+@pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
+def test_monkey_patching_test_log_file():
+    s = spack.spec.Spec("old-style-autotools").concretized()
+    builder = spack.builder.create(s.package)
+    assert s.package.test_log_file is None
+    assert builder.pkg.test_log_file is None
+    assert builder.pkg_with_dispatcher.test_log_file is None
+
+    s.package.test_log_file = "/some/file"
+    assert builder.pkg.test_log_file == "/some/file"
+    assert builder.pkg_with_dispatcher.test_log_file == "/some/file"

--- a/var/spack/repos/builtin/packages/py-libensemble/package.py
+++ b/var/spack/repos/builtin/packages/py-libensemble/package.py
@@ -72,12 +72,11 @@ class PyLibensemble(PythonPackage):
     def run_tutorial_tests(self, exe):
         """Run example stand alone test"""
 
-        test_dir = join_path(
-            self.test_suite.current_test_cache_dir,
-            "examples",
-            "calling_scripts",
-            "regression_tests",
-        )
+        root_test_dir = self.install_test_root
+        if self.test_suite is not None:
+            root_test_dir = self.test_suite.current_test_cache_dir
+
+        test_dir = join_path(root_test_dir, "examples", "calling_scripts", "regression_tests")
 
         if not os.path.isfile(join_path(test_dir, exe)):
             print("Skipping {0} test".format(exe))
@@ -91,4 +90,5 @@ class PyLibensemble(PythonPackage):
         )
 
     def test(self):
-        self.run_tutorial_tests("test_uniform_sampling.py")
+        super().test()
+        self.run_tutorial_tests("test_1d_sampling.py")

--- a/var/spack/repos/builtin/packages/py-libensemble/package.py
+++ b/var/spack/repos/builtin/packages/py-libensemble/package.py
@@ -72,14 +72,15 @@ class PyLibensemble(PythonPackage):
     def run_tutorial_tests(self, exe):
         """Run example stand alone test"""
 
-        root_test_dir = self.install_test_root
-        if self.test_suite is not None:
-            root_test_dir = self.test_suite.current_test_cache_dir
-
-        test_dir = join_path(root_test_dir, "examples", "calling_scripts", "regression_tests")
+        test_dir = join_path(
+            self.test_suite.current_test_cache_dir,
+            "examples",
+            "calling_scripts",
+            "regression_tests",
+        )
 
         if not os.path.isfile(join_path(test_dir, exe)):
-            print("Skipping {0} test".format(exe))
+            print("SKIPPED: {0} test does not exist".format(exe))
             return
 
         self.run_test(
@@ -90,5 +91,6 @@ class PyLibensemble(PythonPackage):
         )
 
     def test(self):
-        super().test()
-        self.run_tutorial_tests("test_1d_sampling.py")
+        super(__class__, self).test()
+        for tutorial in ["test_uniform_sampling.py", "test_1d_sampling.py"]:
+            self.run_tutorial_tests(tutorial)


### PR DESCRIPTION
refers #34531
closes #34487
fixes #34440

The two attributes are created when tests are executed, and they are part of the package class. A better long-term solution would be to extract behavior from the `PackageBase` class into other classes, but that can happen later.