### PR TITLE
Bugfix: Resolve circular dependency of CMake on itself

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -35,7 +35,9 @@ class Ninja(Package):
     version("1.7.2", sha256="2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9")
     version("1.6.0", sha256="b43e88fb068fe4d92a3dfd9eb4d19755dae5c33415db2e9b7b61b4659009cde7")
 
-    variant("re2c", default=not sys.platform == "win32", description="Enable buidling Ninja with re2c")
+    variant(
+        "re2c", default=not sys.platform == "win32", description="Enable buidling Ninja with re2c"
+    )
 
     depends_on("python", type="build")
     depends_on("re2c@0.11.3:", type="build", when="+re2c")

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -35,8 +35,10 @@ class Ninja(Package):
     version("1.7.2", sha256="2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9")
     version("1.6.0", sha256="b43e88fb068fe4d92a3dfd9eb4d19755dae5c33415db2e9b7b61b4659009cde7")
 
+    variant("re2c", default=not sys.platform == "win32", description="Enable buidling Ninja with re2c")
+
     depends_on("python", type="build")
-    depends_on("re2c@0.11.3:", type="build")
+    depends_on("re2c@0.11.3:", type="build", when="+re2c")
 
     phases = ["configure", "install"]
 


### PR DESCRIPTION
#33128 Introduces a dependency on `re2c` into the `Ninja` build recipe. This is problematic on Windows as we use `CMake` to build `re2c`, and `Ninja` to drive the `CMake` build. This PR resolves this issue by adding a variant to toggle the use of `re2c` with `ninja`.