### PR TITLE
edm4hep: depends_on nlohmann-json

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -70,6 +70,7 @@ class Edm4hep(CMakePackage):
     depends_on("python", type="build")
 
     depends_on("root@6.08:")
+    depends_on("nlohmann-json@3.10:", when="@0.7.1:")
     depends_on("podio@0.15:", when="@0.6:")
     depends_on("podio@0.14.1:", when="@0.4.1:")
     depends_on("podio@0.14", when="@0.4")


### PR DESCRIPTION
This is required for the new edm4hep2json exporter. We may pick this up transitively through `root`, but it makes sense to be explicit here.