### PR TITLE
sed %oneapi@2023.0.0: -Wno-error=incompatible-function-pointer-types

### DIFF
--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -35,3 +35,10 @@ class Sed(AutotoolsPackage, GNUMirrorPackage):
         version_regexp = r"{:s} \(GNU sed\) (\S+)".format(exe)
         match = re.search(version_regexp, output)
         return match.group(1) if match else None
+
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2023.0.0:"):
+                iflags.append("-Wno-error=incompatible-function-pointer-types")
+        return (iflags, None, None)


### PR DESCRIPTION
Needed to fix:
```
...
==> sed: Executing phase: 'autoreconf'
==> sed: Executing phase: 'configure'
==> sed: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

4 errors found in build log:
     1515    depbase=`echo lib/regex.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
     1516    /spack/lib/spack/env/oneapi/icx -DHAVE_CONFIG_H -I. -I/tmp/root/spack-stage/spack-stage-sed-4.8-ud3u2mnklqzkszxh3he3adopaj5w7cgf/spack-src  -I/tmp/root/spack-stage/spack-stage
             -sed-4.8-ud3u2mnklqzkszxh3he3adopaj5w7cgf/spack-src -I/tmp/root/spack-stage/spack-stage-sed-4.8-ud3u2mnklqzkszxh3he3adopaj5w7cgf/spack-src/lib -I./lib -I./sed   -O2 -MT lib/re
             gex.o -MD -MP -MF $depbase.Tpo -c -o lib/regex.o /tmp/root/spack-stage/spack-stage-sed-4.8-ud3u2mnklqzkszxh3he3adopaj5w7cgf/spack-src/lib/regex.c &&\
     1517    mv -f $depbase.Tpo $depbase.Po
     1518    rm -f sed/libver.a
     1519    ar cr sed/libver.a sed/version.o
     1520    ranlib sed/libver.a
  >> 1521    /tmp/root/spack-stage/spack-stage-sed-4.8-ud3u2mnklqzkszxh3he3adopaj5w7cgf/spack-src/lib/obstack.c:351:31: error: incompatible function pointer types initializing 'void (*)(vo
             id) __attribute__((noreturn))' with an expression of type 'void (void)' [-Wincompatible-function-pointer-types]
     1522    __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
...
```