### PR TITLE
loki%oneapi@2023.0.0: -Wno-error=dynamic-exception-spec

### DIFF
--- a/var/spack/repos/builtin/packages/loki/package.py
+++ b/var/spack/repos/builtin/packages/loki/package.py
@@ -18,6 +18,13 @@ class Loki(MakefilePackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2023.0.0:"):
+                iflags.append("-Wno-error=dynamic-exception-spec")
+        return (iflags, None, None)
+
     def build(self, spec, prefix):
         if "+shared" in spec:
             make("-C", "src", "build-shared")


### PR DESCRIPTION
Needed to resolve:

```
...
==> loki: Executing phase: 'edit'
==> loki: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' '-C' 'src' 'build-shared'

6 errors found in build log:
     184    # define _GLIBCXX11_DEPRECATED_SUGGEST(ALT) _GLIBCXX_DEPRECATED_SUGGEST(ALT)
     185                                                ^
     186    /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/c++config.h:94:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
     187      __attribute__ ((__deprecated__ ("use '" ALT "' instead")))
     188                      ^
     189    In file included from SmallObj.cpp:19:
  >> 190    ../include/loki/SmallObj.h:462:57: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
     191            static void * operator new ( std::size_t size ) throw ( std::bad_alloc )
     192                                                            ^~~~~~~~~~~~~~~~~~~~~~~~
     193    ../include/loki/SmallObj.h:462:57: note: use 'noexcept(false)' instead
     194            static void * operator new ( std::size_t size ) throw ( std::bad_alloc )
     195                                                            ^~~~~~~~~~~~~~~~~~~~~~~~
     196                                                            noexcept(false)
...
```