### PR TITLE
py-gevent%oneapi@2023.0.0: -Wno-error=incompatible-function-pointer-t…

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -38,3 +38,10 @@ class PyGevent(PythonPackage):
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="%intel")
+
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2023.0.0:"):
+                iflags.append("-Wno-error=incompatible-function-pointer-types")
+        return (iflags, None, None)

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -40,8 +40,7 @@ class PyGevent(PythonPackage):
     patch("icc.patch", when="%intel")
 
     def flag_handler(self, name, flags):
-        iflags = []
         if name == "cflags":
-            if self.spec.satisfies("%oneapi@2023.0.0:"):
-                iflags.append("-Wno-error=incompatible-function-pointer-types")
-        return (iflags, None, None)
+            if self.spec.satisfies("%oneapi@2023:"):
+                flags.append("-Wno-error=incompatible-function-pointer-types")
+        return (flags, None, None)


### PR DESCRIPTION
Needed to resolve issue building with `%oneapi@2023.0.0`
```
==> py-gevent: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 1:
    '/spack/opt/spack/linux-ubuntu20.04-x86_64/oneapi-2023.0.0/python-3.10.8-gcexi3jv2xvnawtinwqlovztglqzxo4q/bin/python3.10' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/spack/opt/spack/linux-ubuntu20.04-x86_64/oneapi-2023.0.0/py-gevent-1.5.0-omi2h6435arovyvenjmnbm5wd7cyxmyy' '.'

1 error found in build log:
     3383      /tmp/root/spack-stage/spack-stage-py-gevent-1.5.0-omi2h6435arovyvenjmnbm5wd7cyxmyy/spack-src/deps/libev/ev.h:179:16: note: expanded from macro 'EV_A'
     3384      # define EV_A  loop                               /* a loop as sole argument to a function call */
     3385                     ^~~~
     3386      /tmp/root/spack-stage/spack-stage-py-gevent-1.5.0-omi2h6435arovyvenjmnbm5wd7cyxmyy/spack-src/deps/libev/ev.h:700:70: note: expanded from macro 'ev_io_set'
     3387      #define ev_io_set(ev,fd_,events_)            do { (ev)->fd = (fd_); (ev)->events = (events_) | EV__IOFDSET; } while (0)
     3388                                                                           ^~
  >> 3389    build/temp.linux-x86_64-cpython-310/gevent.libev._corecffi.c:647:22: error: incompatible function pointer types passing 'void *(void *, size_t)' (aka 'void *(void *, unsigned 
             long)') to parameter of type 'void *(*)(void *, long)' [-Wincompatible-function-pointer-types]
     3390          ev_set_allocator(gevent_realloc);
     3391                           ^~~~~~~~~~~~~~
     3392      /tmp/root/spack-stage/spack-stage-py-gevent-1.5.0-omi2h6435arovyvenjmnbm5wd7cyxmyy/spack-src/deps/libev/ev.c:1915:27: note: passing argument to parameter 'cb' here
     3393      ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT
     3394                                ^
     3395      30 warnings and 1 error generated.
```

CC @adamjstewart @pradyunsg