### PR TITLE
performance: avoid quadratic expansion of targets in the solver

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1800,8 +1800,9 @@ class SpackSolverSetup(object):
         for target in candidate_targets:
             self.gen.fact(fn.target(target.name))
             self.gen.fact(fn.target_family(target.name, target.family.name))
-            for parent in sorted(target.parents):
-                self.gen.fact(fn.target_parent(target.name, parent.name))
+            self.gen.fact(fn.target_compatible(target.name, target.name))
+            for ancestor in sorted(target.ancestors):
+                self.gen.fact(fn.target_compatible(target.name, ancestor.name))
 
             # prefer best possible targets; weight others poorly so
             # they're not used unless set explicitly

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -816,18 +816,11 @@ node_target_compatible(Package, Target)
  :- attr("node_target", Package, MyTarget),
     target_compatible(Target, MyTarget).
 
-% target_compatible(T1, T2) means code for T2 can run on T1
+% NOTE: target_compatible(T1, T2) means code for T2 can run on T1
 % This order is dependent -> dependency in the node DAG, which
 % is contravariant with the target DAG.
-target_compatible(Target, Target) :- target(Target).
-target_compatible(Child, Parent) :- target_parent(Child, Parent).
-target_compatible(Descendent, Ancestor)
-  :- target_parent(Target, Ancestor),
-     target_compatible(Descendent, Target),
-     target(Target).
 
 #defined target_satisfies/2.
-#defined target_parent/2.
 
 % can't use targets on node if the compiler for the node doesn't support them
 error(2, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Target, Compiler, Version)


### PR DESCRIPTION
We *think* this PR should improve performance when many potential compilers are in play, especially on x86_64 architectures.

Draft PR to test performance more rigorously.