### PR TITLE
e4s: add py-h5py

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -123,6 +123,7 @@ spack:
   - plumed
   - precice
   - pumi
+  - py-h5py
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py


### PR DESCRIPTION
`E4S`: add `py-h5py` to CI stack