### PR TITLE
e4s ci: py-libensemble: activate variants

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -124,7 +124,7 @@ spack:
   - precice
   - pumi
   - py-jupyterhub
-  - py-libensemble
+  - py-libensemble +mpi +nlopt
   - py-petsc4py
   - py-warpx ^warpx dims=2
   - py-warpx ^warpx dims=3

--- a/var/spack/repos/builtin/packages/py-libensemble/package.py
+++ b/var/spack/repos/builtin/packages/py-libensemble/package.py
@@ -37,7 +37,7 @@ class PyLibensemble(PythonPackage):
     version("0.2.0", sha256="ecac7275d4d0f4a5e497e5c9ef2cd998da82b2c020a0fb87546eeea262f495ff")
     version("0.1.0", sha256="0b27c59ae80f7af8b1bee92fcf2eb6c9a8fd3494bf2eb6b3ea17a7c03d3726bb")
 
-    variant("mpi", default=False, description="Install with MPI")
+    variant("mpi", default=True, description="Install with MPI")
     variant("scipy", default=False, description="Install with scipy")
     variant("petsc4py", default=False, description="Install with petsc4py")
     variant("nlopt", default=False, description="Install with nlopt")


### PR DESCRIPTION
E4S CI: explicitly turn on `py-libensemble` variants

@jlnav @shuds13