### PR TITLE
CP2K: Fix cp2k/package.py URL for v2022.1

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -23,7 +23,7 @@ class Cp2k(MakefilePackage, CudaPackage):
 
     maintainers = ["dev-zero"]
 
-    version("2022.1", sha256="2c34f1a7972973c62d471cd35856f444f11ab22f2ff930f6ead20f3454fd228b")
+    version("2022.1", sha256="2c34f1a7972973c62d471cd35856f444f11ab22f2ff930f6ead20f3454fd228b", url="https://github.com/cp2k/cp2k/releases/download/v2022.1/cp2k-2022.1.tar.bz2")
     version("9.1", sha256="fedb4c684a98ad857cd49b69a3ae51a73f85a9c36e9cb63e3b02320c74454ce6")
     version("8.2", sha256="2e24768720efed1a5a4a58e83e2aca502cd8b95544c21695eb0de71ed652f20a")
     version("8.1", sha256="7f37aead120730234a60b2989d0547ae5e5498d93b1e9b5eb548c041ee8e7772")


### PR DESCRIPTION
Searched a false URL for the CP2K v2022.1 archive, manually inserted correct URL.
Wrong URL: "https://github.com/cp2k/cp2k/releases/download/v2022.1.0/cp2k-2022.1.tar.bz2"
Correct URL (without ".0" in version directory): "https://github.com/cp2k/cp2k/releases/download/v2022.1/cp2k-2022.1.tar.bz2"