### PR TITLE
trilinos: enable mumps solver in amesos2 if variant is set

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -650,6 +650,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 ),
                 define_from_variant("Amesos2_ENABLE_Basker", "basker"),
                 define_from_variant("Amesos2_ENABLE_LAPACK", "amesos2"),
+                define_from_variant('Amesos2_ENABLE_MUMPS', 'mumps'),
             ]
         )
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -650,7 +650,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 ),
                 define_from_variant("Amesos2_ENABLE_Basker", "basker"),
                 define_from_variant("Amesos2_ENABLE_LAPACK", "amesos2"),
-                define_from_variant('Amesos2_ENABLE_MUMPS', 'mumps'),
+                define_from_variant("Amesos2_ENABLE_MUMPS", "mumps"),
             ]
         )
 


### PR DESCRIPTION
This PR enables the mumps solver for amesos2 if the variant mumps is set for the trilinos package