### PR TITLE
Windows: port lower level pkgs

### DIFF
--- a/etc/spack/defaults/windows/packages.yaml
+++ b/etc/spack/defaults/windows/packages.yaml
@@ -19,3 +19,4 @@ packages:
     - msvc
     providers:
       mpi: [msmpi]
+      gl: [wgl]

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -23,8 +23,10 @@ class AppleGl(Package):
     # Only supported on 'platform=darwin' and compiler=apple-clang
     conflicts("platform=linux")
     conflicts("platform=cray")
+    conflicts("platform=windows")
     conflicts("%gcc")
     conflicts("%clang")
+    conflicts("%msvc")
 
     phases = []
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -195,7 +195,6 @@ class Hdf5(CMakePackage):
     depends_on("cmake@3.12:", type="build")
     depends_on("cmake@3.18:", type="build", when="@1.13:")
 
-    depends_on("msmpi", when="+mpi platform=windows")
     depends_on("mpi", when="+mpi")
     depends_on("java", type=("build", "run"), when="+java")
     depends_on("szip", when="+szip")

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -19,7 +19,7 @@ class Msmpi(Package):
     url = "https://github.com/microsoft/Microsoft-MPI/archive/refs/tags/v10.1.1.tar.gz"
     git = "https://github.com/microsoft/Microsoft-MPI.git"
 
-    executable = ["mpiexec"]
+    executables = ["mpiexec"]
 
     version("10.1.1", sha256="63c7da941fc4ffb05a0f97bd54a67968c71f63389a0d162d3182eabba1beab3d")
     version("10.0.0", sha256="cfb53cf53c3cf0d4935ab58be13f013a0f7ccb1189109a5b8eea0fcfdcaef8c1")
@@ -41,9 +41,18 @@ class Msmpi(Package):
         return Version(ver_str.group(1)) if ver_str else None
 
 
+    def setup_dependent_package(self, module, dependent_spec):
+        spec = self.spec
+
+        spec.mpicc = spack_cc
+        spec.mpicxx = spack_cxx
+        spec.mpifc = spack_fc
+        spec.mpif77 = spack_f77
+
+
 class GenericBuilder(GenericBuilder):
     def setup_build_environment(self, env):
-        ifort_root = os.path.join(*self.compiler.fc.split(os.path.sep)[:-2])
+        ifort_root = os.path.join(*self.pkg.compiler.fc.split(os.path.sep)[:-2])
         env.set("SPACK_IFORT", ifort_root)
 
     def is_64bit(self):
@@ -51,18 +60,18 @@ class GenericBuilder(GenericBuilder):
 
     def build_command_line(self):
         args = ["-noLogo"]
-        ifort_bin = self.compiler.fc
+        ifort_bin = self.pkg.compiler.fc
         if not ifort_bin:
             raise InstallError(
                 "Cannot install MSMPI without fortran"
                 "please select a compiler with fortran support."
             )
         args.append("/p:IFORT_BIN=%s" % os.path.dirname(ifort_bin))
-        args.append("/p:VCToolsVersion=%s" % self.compiler.msvc_version)
-        args.append("/p:WindowsTargetPlatformVersion=%s" % str(self.spec["wdk"].version))
-        args.append("/p:PlatformToolset=%s" % self.compiler.cc_version)
+        args.append("/p:VCToolsVersion=%s" % self.pkg.compiler.msvc_version)
+        args.append("/p:WindowsTargetPlatformVersion=%s" % str(self.pkg.spec["wdk"].version))
+        args.append("/p:PlatformToolset=%s" % self.pkg.compiler.cc_version)
         return args
 
     def install(self, spec, prefix):
-        with working_dir(self.stage.build_directory, create=True):
+        with working_dir(self.pkg.stage.build_directory, create=True):
             msbuild(*self.build_command_line())

--- a/var/spack/repos/builtin/packages/wgl/package.py
+++ b/var/spack/repos/builtin/packages/wgl/package.py
@@ -34,6 +34,7 @@ class Wgl(Package):
     version("10.0.14393")
     version("10.0.10586")
     version("10.0.26639")
+    version("10.0.20348")
 
     # As per https://github.com/spack/spack/pull/31748 this provisory version represents
     # an arbitrary openGL version designed for maximum compatibility with calling packages
@@ -48,13 +49,15 @@ class Wgl(Package):
     # needed to use OpenGL are found in the SDK (GL/gl.h)
     # Dep is needed to consolidate sdk version to locate header files for
     # version of SDK being used
-    depends_on("win-sdk@10.0.19041", when="@10.0.19041")
-    depends_on("win-sdk@10.0.18362", when="@10.0.18362")
-    depends_on("win-sdk@10.0.17763", when="@10.0.17763")
-    depends_on("win-sdk@10.0.17134", when="@10.0.17134")
-    depends_on("win-sdk@10.0.16299", when="@10.0.16299")
-    depends_on("win-sdk@10.0.15063", when="@10.0.15063")
-    depends_on("win-sdk@10.0.14393", when="@10.0.14393")
+    # Generic depends to capture handling for external versions
+    depends_on("win-sdk", type=("build", "run"))
+    depends_on("win-sdk@10.0.19041", when="@10.0.19041", type=("build", "run"))
+    depends_on("win-sdk@10.0.18362", when="@10.0.18362", type=("build", "run"))
+    depends_on("win-sdk@10.0.17763", when="@10.0.17763", type=("build", "run"))
+    depends_on("win-sdk@10.0.17134", when="@10.0.17134", type=("build", "run"))
+    depends_on("win-sdk@10.0.16299", when="@10.0.16299", type=("build", "run"))
+    depends_on("win-sdk@10.0.15063", when="@10.0.15063", type=("build", "run"))
+    depends_on("win-sdk@10.0.14393", when="@10.0.14393", type=("build", "run"))
 
     # WGL has no meaning on other platforms, should not be able to spec
     for plat in ["linux", "darwin", "cray"]:
@@ -80,11 +83,11 @@ class Wgl(Package):
     # As noted above, the headers neccesary to include
     @property
     def headers(self):
-        return find_headers("GL/gl.h", root=self.spec["win-sdk"].prefix.includes, recursive=True)
+        return find_headers("GL", root=os.path.join(self.prefix.Include, str(self.version)+".0"), recursive=True)
 
     @property
     def libs(self):
-        return find_libraries("opengl32", shared=False, root=self.prefix, recursive=True)
+        return find_libraries("opengl32", shared=False, root=os.path.join(self.prefix.Lib, str(self.version)+".0", "um", self.spec.variants["plat"].value), recursive=True)
 
     def install(self, spec, prefix):
         raise RuntimeError(


### PR DESCRIPTION
Supporting package ports/amendments for the port of Paraview to Windows. 

Includes changes to:
- wgl
- msmpi
- hdf5
- apple-gl

Also sets wgl as default opengl provider for Windows