### PR TITLE
Proper scons executable on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
+
 from spack.package import *
 
-
 is_windows = sys.platform == "win32"
+
 
 class Scons(PythonPackage):
     """SCons is a software construction tool"""
@@ -60,5 +61,5 @@ class Scons(PythonPackage):
     def setup_dependent_package(self, module, dspec):
         if is_windows:
             module.scons = Executable(self.spec.prefix.Scripts.scons)
-        else:    
+        else:
             module.scons = Executable(self.spec.prefix.bin.scons)

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -2,9 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import sys
 from spack.package import *
 
+
+is_windows = sys.platform == "win32"
 
 class Scons(PythonPackage):
     """SCons is a software construction tool"""
@@ -56,4 +58,7 @@ class Scons(PythonPackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib.scons)
 
     def setup_dependent_package(self, module, dspec):
-        module.scons = Executable(self.spec.prefix.bin.scons)
+        if is_windows:
+            module.scons = Executable(self.spec.prefix.Scripts.scons)
+        else:    
+            module.scons = Executable(self.spec.prefix.bin.scons)


### PR DESCRIPTION
Scons exe is found in the scripts directory of its prefix on Windows, there is no bin dir.