### PR TITLE
More Windows Paraview support ports

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -112,7 +112,8 @@ class Msvc(Compiler):
     def platform_toolset_ver(self):
         """
         This is the platform toolset version of current MSVC compiler
-        of form v<toolset-ver>, i.e. v142. This is different from the VC
+        of form <toolset-ver>, i.e. 142, and is typically consumed and prepended
+        with a 'v'. This is different from the VC
         toolset version as established by `short_msvc_version`
         """
         return self.msvc_version[:2].joined.string[:3]
@@ -120,7 +121,11 @@ class Msvc(Compiler):
     @property
     def cl_version(self):
         """Cl toolset version"""
-        return spack.compiler.get_compiler_version_output(self.cc)
+        return Version(re.search(Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")).group(1))
+
+    @property
+    def vs_root(self):
+        return os.path.abspath(os.path.join(self.cc, "../../../../../../../.."))
 
     def setup_custom_environment(self, pkg, env):
         """Set environment variables for MSVC using the

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -109,6 +109,15 @@ class Msvc(Compiler):
         return "MSVC" + ver
 
     @property
+    def platform_toolset_ver(self):
+        """
+        This is the platform toolset version of current MSVC compiler
+        of form v<toolset-ver>, i.e. v142. This is different from the VC
+        toolset version as established by `short_msvc_version`
+        """
+        return self.msvc_version[:2].joined.string[:3]
+
+    @property
     def cl_version(self):
         """Cl toolset version"""
         return spack.compiler.get_compiler_version_output(self.cc)

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import platform
+
+from spack.build_systems.generic import GenericBuilder
 from spack.package import *
 
 
-class Libogg(AutotoolsPackage):
+class Libogg(CMakePackage, AutotoolsPackage, Package):
     """Ogg is a multimedia container format, and the native file and stream
     format for the Xiph.org multimedia codecs."""
 
@@ -24,3 +28,35 @@ class Libogg(AutotoolsPackage):
         sha256="0f4d289aecb3d5f7329d51f1a72ab10c04c336b25481a40d6d841120721be485",
         when="@1.3.4 platform=darwin",
     )
+    build_system(
+        conditional("cmake", when="@1.3.4:"),
+        conditional("generic", when="@1.3.2 platform=windows"),
+        "autotools",
+        default="autotools",
+    )
+
+
+class GenericBuilder(GenericBuilder):
+    phases = ["build", "install"]
+
+    def is_64bit(self):
+        return platform.machine().endswith("64")
+
+    def build(self, spec, prefix):
+        if spec.satisfies("%msvc"):
+            plat_tools = self.pkg.compiler.msvc_version
+        else:
+            raise RuntimeError("Package does not support non MSVC compilers on Windows")
+        ms_build_args = ["libogg_static.vcxproj", "/p:PlatformToolset=v%s" % plat_tools]
+        msbuild(*ms_build_args)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.include.ogg)
+        mkdirp(prefix.lib)
+        mkdirp(prefix.share)
+        install(
+            os.path.join(self.pkg.stage.source_path, "include", "ogg", "*.h"), prefix.include.ogg
+        )
+        plat_prefix = "x64" if self.is_64bit() else "x86"
+        install(os.path.join(plat_prefix, "Debug", "*.lib"), prefix.lib)
+        install_tree(os.path.join(self.pkg.stage.source_path, "doc"), prefix.share)

--- a/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
+++ b/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
@@ -1,0 +1,35 @@
+diff --git a/win32/VS2008/libogg.vsprops b/win32/VS2008/libogg.vsprops
+index 1355b50..8b3c5b8 100644
+--- a/win32/VS2008/libogg.vsprops
++++ b/win32/VS2008/libogg.vsprops
+@@ -6,11 +6,11 @@
+ 	>
+ 	<Tool
+ 		Name="VCCLCompilerTool"
+-		AdditionalIncludeDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
++		AdditionalIncludeDirectories="$(SPACK_OGG_PREFIX)\include;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
+ 	/>
+ 	<Tool
+ 		Name="VCLinkerTool"
+-		AdditionalLibraryDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
++		AdditionalLibraryDirectories="$(SPACK_OGG_PREFIX)\lib;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
+ 	/>
+ 	<UserMacro
+ 		Name="LIBOGG_VERSION"
+diff --git a/win32/VS2008/libtheora_static.sln b/win32/VS2008/libtheora_static.sln
+index 2b39635..fa40518 100644
+--- a/win32/VS2008/libtheora_static.sln
++++ b/win32/VS2008/libtheora_static.sln
+@@ -1,12 +1,8 @@
+
+ Microsoft Visual Studio Solution File, Format Version 10.00
+ # Visual Studio 2008
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dump_video_static", "dump_video\dump_video_static.vcproj", "{1A8CA99D-B6C7-48CB-B263-6CECDADF5FBF}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libtheora_static", "libtheora\libtheora_static.vcproj", "{653F3841-3F26-49B9-AFCF-091DB4B67031}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "encoder_example_static", "encoder_example\encoder_example_static.vcproj", "{AD710263-EBFA-4388-BAA9-AD73C32AFF26}"
+-EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Win32 = Debug|Win32

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -3,12 +3,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
 import re
+import sys
 
+from spack.build_systems.autotools import AutotoolsBuilder
+from spack.build_systems.msbuild import MSBuildBuilder
 from spack.package import *
 
 
-class Xz(AutotoolsPackage, SourceforgePackage):
+class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     """XZ Utils is free general-purpose data compression software with
     high compression ratio. XZ Utils were written for POSIX-like systems,
     but also work on some not-so-POSIX systems. XZ Utils are the successor
@@ -42,9 +47,11 @@ class Xz(AutotoolsPackage, SourceforgePackage):
     # xz-5.2.7/src/liblzma/common/common.h:56 uses attribute __symver__ instead of
     # __asm__(.symver) for newer GCC releases.
     conflicts("%intel", when="@5.2.7", msg="icc does not support attribute __symver__")
+    conflicts("platform=windows", when="+pic")  # no pic on Windows
+    # prior to 5.2.3, build system is for MinGW only, not currently supported by Spack
+    conflicts("platform=windows", when="@:5.2.3")
 
-    def configure_args(self):
-        return self.enable_or_disable("libs")
+    build_system(conditional("msbuild", when="platform=windows"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):
         if name == "cflags" and "+pic" in self.spec:
@@ -61,7 +68,59 @@ class Xz(AutotoolsPackage, SourceforgePackage):
         match = re.search(r"xz \(XZ Utils\) (\S+)", output)
         return match.group(1) if match else None
 
+
+class RunAfter(object):
     @run_after("install")
     def darwin_fix(self):
         if self.spec.satisfies("platform=darwin"):
             fix_darwin_install_name(self.prefix.lib)
+
+
+class AutotoolsBuilder(AutotoolsBuilder):
+    def configure_args(self):
+        return self.enable_or_disable("libs")
+
+
+class MSBuildBuilder(MSBuildBuilder):
+    @property
+    def build_directory(self):
+        def get_file_string_number(f):
+            s = re.findall(r"\d+$", f)
+            return (int(s[0]) if s else -1, f)
+        win_dir = os.path.join(super().build_directory, "windows")
+        compiler_dirs = []
+        with working_dir(win_dir):
+            for obj in os.scandir():
+                if obj.is_dir():
+                    compiler_dirs.append(obj.name)
+        newest_compiler = max(compiler_dirs, key=get_file_string_number)
+        return os.path.join(win_dir, newest_compiler)
+
+    @property
+    def toolchain_version(self):
+        return "v" + self.pkg.compiler.platform_toolset_ver
+
+    def msbuild_args(self):
+        if self.pkg.spec.satisfies("libs=shared,static"):
+            f =  "xz_win.sln"
+        elif self.pkg.spec.satisfies("libs=shared"):
+            f =  "liblzma_dll.vcxproj"
+        else:
+            f = "liblzma.vcxproj"
+        return [self.define("Configuration", "Release"), f]
+
+    def install(self, pkg, spec, prefix):
+        with working_dir(self.build_directory):
+            libs_to_find = []
+        if self.pkg.spec.satisfies("libs=shared,static"):
+            libs_to_find.extend(["*.dll", "*.lib"])
+        elif self.pkg.spec.satisfies("libs=shared"):
+            libs_to_find.append("*.dll")
+        else:
+            libs_to_find.append("*.lib")
+        for lib in libs_to_find:
+            libs_to_install = glob.glob(os.path.join(self.build_directory, "**", lib))
+            for l in libs_to_install:
+                install(l, prefix.lib)
+        with working_dir(pkg.stage.source_path):
+            install_tree(os.path.join("src", "liblzma", "api"), prefix.include)


### PR DESCRIPTION
More ports supporting Paraview on Windows
Ports include packages:
- xz
- libtheora
- libogg

Changes to msvc compiler class supporting these ports.