### PR TITLE
HDF5 supports external find

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 import shutil
 
 import llnl.util.tty as tty
@@ -32,6 +33,7 @@ class Hdf5(CMakePackage):
     ]
 
     tags = ["e4s"]
+    executables = ["^h5cc$"]
 
     test_requires_compiler = True
 
@@ -452,6 +454,75 @@ class Hdf5(CMakePackage):
 
         return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
 
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("-showconfig", output=str, error=str)
+        match = re.search(r"HDF5 Version: (\d+\.\d+\.\d+)(\D*\S*)", output)
+        return match.group(1) if match else None
+
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        results = []
+        for exe in exes:
+            variants = []
+            output = Executable(exe)("-showconfig", output=str, error=os.devnull)
+            match = re.search(r"High-level library: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+hl")
+            else:
+                variants.append("~hl")
+
+            match = re.search(r"Parallel HDF5: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+mpi")
+            else:
+                variants.append("~mpi")
+
+            match = re.search(r"C\+\+: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+cxx")
+            else:
+                variants.append("~cxx")
+
+            match = re.search(r"Fortran: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+fortran")
+            else:
+                variants.append("~fortran")
+
+            match = re.search(r"Java: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+java")
+            else:
+                variants.append("~java")
+
+            match = re.search(r"Threadsafety: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+threadsafe")
+            else:
+                variants.append("~threadsafe")
+
+            match = re.search(r"Build HDF5 Tools: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+tools")
+            else:
+                variants.append("~tools")
+
+            match = re.search(r"I/O filters \(external\): \S*(szip\(encoder\))\S*", output)
+            if match:
+                variants.append("+szip")
+            else:
+                variants.append("~szip")
+
+            match = re.search(r"Default API mapping: (\S+)", output)
+            if match and match.group(1) in set(["v114", "v112", "v110", "v18", "v16"]):
+                variants.append("api={0}".format(match.group(1)))
+
+            results.append(" ".join(variants))
+
+        return results
+
     @when("@:1.8.21,1.10.0:1.10.5+szip")
     def setup_build_environment(self, env):
         env.set("SZIP_INSTALL", self.spec["szip"].prefix)
@@ -737,3 +808,8 @@ HDF5 version {version} {version}
 
         # Run existing install check
         self._check_install()
+
+def is_enabled(text):
+    if text in set(["t", "true", "enabled", "yes", "1"]):
+        return True
+    return False

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -460,9 +460,13 @@ class Hdf5(CMakePackage):
         match = re.search(r"HDF5 Version: (\d+\.\d+\.\d+)(\D*\S*)", output)
         return match.group(1) if match else None
 
-
     @classmethod
     def determine_variants(cls, exes, version):
+        def is_enabled(text):
+            if text in set(["t", "true", "enabled", "yes", "1"]):
+                return True
+            return False
+
         results = []
         for exe in exes:
             variants = []
@@ -808,8 +812,3 @@ HDF5 version {version} {version}
 
         # Run existing install check
         self._check_install()
-
-def is_enabled(text):
-    if text in set(["t", "true", "enabled", "yes", "1"]):
-        return True
-    return False

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -33,7 +33,7 @@ class Hdf5(CMakePackage):
     ]
 
     tags = ["e4s"]
-    executables = ["^h5cc$"]
+    executables = ["^h5cc$", "^h5pcc$"]
 
     test_requires_compiler = True
 


### PR DESCRIPTION
Added support for the HDF5 package to detect externally installed
versions.  Includes support for detecting variants.