### PR TITLE
rocsolver: expand version compatibility with fmt

### DIFF
--- a/var/spack/repos/builtin/packages/rocsolver/fmt-8.1-compatibility.patch
+++ b/var/spack/repos/builtin/packages/rocsolver/fmt-8.1-compatibility.patch
@@ -1,0 +1,143 @@
+--- a/library/src/include/rocsolver_logvalue.hpp
++++ b/library/src/include/rocsolver_logvalue.hpp
+@@ -8,6 +8,14 @@
+ 
+ #include "rocsolver_datatype2string.hpp"
+ 
++/* The format function for user-defined types cannot be const before fmt v8.0
++   but must be const in fmt v8.1 if the type is used in a tuple. */
++#if FMT_VERSION < 80000
++#define ROCSOLVER_FMT_CONST
++#else
++#define ROCSOLVER_FMT_CONST const
++#endif
++
+ /***************************************************************************
+  * Wrapper for types passed to logger, so we can more easily adjust the
+  * default way of printing built-in types without doing it globally. (e.g.
+@@ -37,7 +45,7 @@ template <typename T>
+ struct formatter<rocsolver_logvalue<T>> : formatter<T>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<T> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<T> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<T>::format(wrapper.value, ctx);
+     }
+@@ -49,7 +57,7 @@ template <>
+ struct formatter<rocsolver_logvalue<bool>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<bool> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<bool> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(wrapper.value ? '1' : '0', ctx);
+     }
+@@ -58,7 +66,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_operation>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_operation> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_operation> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_operation(wrapper.value), ctx);
+     }
+@@ -67,7 +75,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_fill>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_fill> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_fill> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_fill(wrapper.value), ctx);
+     }
+@@ -76,7 +84,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_diagonal>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_diagonal> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_diagonal> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_diagonal(wrapper.value), ctx);
+     }
+@@ -85,7 +93,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_side>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_side> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_side> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_side(wrapper.value), ctx);
+     }
+@@ -94,7 +102,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_direct>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_direct> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_direct> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_direct(wrapper.value), ctx);
+     }
+@@ -104,7 +112,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_storev>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_storev> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_storev> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_storev(wrapper.value), ctx);
+     }
+@@ -113,7 +121,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_workmode>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_workmode> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_workmode> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_workmode(wrapper.value), ctx);
+     }
+@@ -122,7 +130,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_svect>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_svect> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_svect> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_svect(wrapper.value), ctx);
+     }
+@@ -131,7 +139,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_evect>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_evect> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_evect> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_evect(wrapper.value), ctx);
+     }
+@@ -140,7 +148,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_eform>> : formatter<char>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_eform> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_eform> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<char>::format(rocblas2char_eform(wrapper.value), ctx);
+     }
+@@ -149,7 +157,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_datatype>> : formatter<string_view>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_datatype> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_datatype> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<string_view>::format(rocblas2string_datatype(wrapper.value), ctx);
+     }
+@@ -158,7 +166,7 @@ template <>
+ struct formatter<rocsolver_logvalue<rocblas_initialization>> : formatter<string_view>
+ {
+     template <typename FormatCtx>
+-    auto format(rocsolver_logvalue<rocblas_initialization> wrapper, FormatCtx& ctx)
++    auto format(rocsolver_logvalue<rocblas_initialization> wrapper, FormatCtx& ctx) ROCSOLVER_FMT_CONST
+     {
+         return formatter<string_view>::format(rocblas2string_initialization(wrapper.value), ctx);
+     }

--- a/var/spack/repos/builtin/packages/rocsolver/fmt-9-compatibility.patch
+++ b/var/spack/repos/builtin/packages/rocsolver/fmt-9-compatibility.patch
@@ -1,0 +1,13 @@
+diff --git a/clients/gtest/logging_gtest.cpp b/clients/gtest/logging_gtest.cpp
+index e4f594af..e9d70f60 100644
+--- a/clients/gtest/logging_gtest.cpp
++++ b/clients/gtest/logging_gtest.cpp
+@@ -49,7 +49,7 @@ protected:
+         {
+             if(HasFailure() && std::getenv("ROCSOLVER_TEST_DEBUG"))
+                 fmt::print(stderr, "ROCSOLVER_TEST_DEBUG is set so {} was not removed.\n",
+-                           log_filepath);
++                           log_filepath.string());
+             else
+                 EXPECT_TRUE(fs::remove(log_filepath));
+         }

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -122,12 +122,16 @@ class Rocsolver(CMakePackage):
 
     depends_on("cmake@3.8:", type="build", when="@4.1.0:")
     depends_on("cmake@3.5:", type="build")
-    depends_on("fmt@7:8.0.1", type="build", when="@4.5.0:")
+    depends_on("fmt@7:", type="build", when="@4.5.0:")
 
     depends_on("googletest@1.10.0:", type="test")
     depends_on("netlib-lapack@3.7.1:", type="test")
 
     patch("link-clients-blas.patch", when="@4.3.0:4.3.2")
+    # Backport https://github.com/ROCmSoftwarePlatform/rocSOLVER/commit/2bbfb8976f6e4d667499c77e41a6433850063e88
+    patch("fmt-8.1-compatibility.patch", when="@4.5.0:5.1.3")
+    # Maximize compatibility with other libraries that are using fmt.
+    patch("fmt-9-compatibility.patch", when="@5.2.0:")
 
     def check(self):
         exe = join_path(self.build_directory, "clients", "staging", "rocsolver-test")


### PR DESCRIPTION
This change is useful for the `pika` package, which depends on `fmt@9:`.

Fixes https://github.com/ROCmSoftwarePlatform/rocSOLVER/issues/514.