### PR TITLE
restic: Add v0.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -14,6 +14,7 @@ class Restic(Package):
 
     maintainers = ["alecbcs"]
 
+    version("0.15.0", sha256="85a6408cfb0798dab52335bcb00ac32066376c32daaa75461d43081499bc7de8")
     version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")
     version("0.12.1", sha256="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb")
 


### PR DESCRIPTION
Add Restic v0.15.0 which includes multiple new features and bug fixes.

**Summarized Changelog:**
- Make mount return exit code 0 after receiving Ctrl-C / SIGINT.
- Fix stuck copy command when -o <backend>.connections=1.
- Correct prune statistics for partially compressed repositories.
- Make ls return exit code 1 if snapshot cannot be loaded.
- Make backup no longer hang on Solaris when seeing a FIFO file.
- Support ExFAT-formatted local backends on macOS Ventura.
- Make init ignore "Access Denied" errors when creating S3 buckets.
- Make self-update enabled by default only in release builds.

Full changelog can be found [here](https://github.com/restic/restic/releases/tag/v0.15.0).