### PR TITLE
py-python-lsp-server: Add v1.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -14,6 +14,7 @@ class PyPythonLspServer(PythonPackage):
 
     maintainers = ["alecbcs"]
 
+    version("1.7.0", sha256="401ce78ea2e98cadd02d94962eb32c92879caabc8055b9a2f36d7ef44acc5435")
     version("1.6.0", sha256="d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b")
 
     depends_on("python@3.7:", type=("build", "run"))


### PR DESCRIPTION
Add py-python-lsp-server v1.7.0 which includes multiple bug fixes.

**Changelog:**
- Add a new plugin to provide autoimport functionality (disabled by default).
- Add progress reporting.
- Make jedi_definition plugin follow definitions to pyi files.
- Add support for flake8 version 6.
- Add support for Yapf ignore patterns.
- Add mccabe setting to flake8 plugin.