### PR TITLE
spack list: add `--count` option

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -56,13 +56,6 @@ def setup_parser(subparser):
         help="format to be used to print the output [default: name_only]",
     )
     subparser.add_argument(
-        "--update",
-        metavar="FILE",
-        default=None,
-        action="store",
-        help="write output to the specified file, if any package is newer",
-    )
-    subparser.add_argument(
         "-v",
         "--virtuals",
         action="store_true",
@@ -70,6 +63,22 @@ def setup_parser(subparser):
         help="include virtual packages in list",
     )
     arguments.add_common_arguments(subparser, ["tags"])
+
+    # Doesn't really make sense to update in count mode.
+    count_or_update = subparser.add_mutually_exclusive_group()
+    count_or_update.add_argument(
+        "--count",
+        action="store_true",
+        default=False,
+        help="display the number of packages that would be listed",
+    )
+    count_or_update.add_argument(
+        "--update",
+        metavar="FILE",
+        default=None,
+        action="store",
+        help="write output to the specified file, if any package is newer",
+    )
 
 
 def filter_by_name(pkgs, args):
@@ -320,6 +329,9 @@ def list(parser, args):
         with open(args.update, "w") as f:
             formatter(sorted_packages, f)
 
+    elif args.count:
+        # just print the number of packages in the result
+        print(len(sorted_packages))
     else:
-        # Print to stdout
+        # print formatted package list
         formatter(sorted_packages, sys.stdout)

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -6,6 +6,7 @@
 import sys
 from textwrap import dedent
 
+import spack.repo
 from spack.main import SpackCommand
 
 list = SpackCommand("list")
@@ -123,3 +124,13 @@ def test_list_tags(mock_packages):
     output = list("--tag", "tag3")
     assert "mpich\n" not in output
     assert "mpich2" in output
+
+
+def test_list_count(mock_packages):
+    output = list("--count")
+    assert int(output.strip()) == len(spack.repo.all_package_names())
+
+    output = list("--count", "py-")
+    assert int(output.strip()) == len(
+        [name for name in spack.repo.all_package_names() if "py-" in name]
+    )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1197,7 +1197,7 @@ _spack_license_update_copyright_year() {
 _spack_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --search-description --format --update -v --virtuals -t --tag"
+        SPACK_COMPREPLY="-h --help -d --search-description --format -v --virtuals -t --tag --count --update"
     else
         _all_packages
     fi


### PR DESCRIPTION
Sometimes I just want to know how many packages of a certain type there are.

- [x] add `--count` option to `spack list` that output the number of packages that *would* be listed.

Some examples:

```console
> spack list --count
6864
> spack list --count py-
2040
> spack list --count r-
1162
```