### PR TITLE
cp2k: explicitly use C99 standard

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -810,3 +810,10 @@ class Cp2k(MakefilePackage, CudaPackage):
         with spack.util.environment.set_env(CP2K_DATA_DIR=data_dir, PWD=self.build_directory):
             with working_dir(self.build_directory):
                 make("test", *self.build_targets)
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            # CP2K Makefile doesn't set C standard, but the source code uses
+            # C99-style for-loops with inline definition of iterating variable.
+            flags.append(self.compiler.c99_flag)
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -334,6 +334,10 @@ class Cp2k(MakefilePackage, CudaPackage):
         libs = []
         gpuver = ""
 
+        # CP2K Makefile doesn't set C standard, but the source code uses
+        # C99-style for-loops with inline definition of iterating variable.
+        cflags.append(self.compiler.c99_flag)
+
         if "%intel" in spec:
             cflags.append("-fp-model precise")
             cxxflags.append("-fp-model precise")
@@ -810,10 +814,3 @@ class Cp2k(MakefilePackage, CudaPackage):
         with spack.util.environment.set_env(CP2K_DATA_DIR=data_dir, PWD=self.build_directory):
             with working_dir(self.build_directory):
                 make("test", *self.build_targets)
-
-    def flag_handler(self, name, flags):
-        if name == "cflags":
-            # CP2K Makefile doesn't set C standard, but the source code uses
-            # C99-style for-loops with inline definition of iterating variable.
-            flags.append(self.compiler.c99_flag)
-        return (flags, None, None)


### PR DESCRIPTION
The Makefile wouldn't do it, so we have to do it ourselves.