### PR TITLE
environments: don't replace relative view path with absolute path on concretize/install

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -290,14 +290,12 @@ def env_create_setup_parser(subparser):
 
 
 def env_create(args):
-    if isinstance(args.with_view, str):
+    if args.with_view:
         # Expand relative paths provided on the command line to the current working directory
         # This way we interpret `spack env create --with-view ./view --dir ./env` as
         # a view in $PWD/view, not $PWD/env/view. This is different from specifying a relative
         # path in spack.yaml, which is resolved relative to the environment file.
         with_view = os.path.abspath(args.with_view)
-    elif args.with_view:
-        with_view = True
     elif args.without_view:
         with_view = False
     else:

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -290,8 +290,14 @@ def env_create_setup_parser(subparser):
 
 
 def env_create(args):
-    if args.with_view:
-        with_view = args.with_view
+    if isinstance(args.with_view, str):
+        # Expand relative paths provided on the command line to the current working directory
+        # This way we interpret `spack env create --with-view ./view --dir ./env` as
+        # a view in $PWD/view, not $PWD/env/view. This is different from specifying a relative
+        # path in spack.yaml, which is resolved relative to the environment file.
+        with_view = os.path.abspath(args.with_view)
+    elif args.with_view:
+        with_view = True
     elif args.without_view:
         with_view = False
     else:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -384,7 +384,7 @@ class ViewDescriptor(object):
         link_type="symlink",
     ):
         self.base = base_path
-        self._root = root
+        self.raw_root = root
         self.root = spack.util.path.canonicalize_path(root, default_wd=base_path)
         self.projections = projections
         self.select = select
@@ -411,7 +411,7 @@ class ViewDescriptor(object):
         )
 
     def to_dict(self):
-        ret = syaml.syaml_dict([("root", self._root)])
+        ret = syaml.syaml_dict([("root", self.raw_root)])
         if self.projections:
             # projections guaranteed to be ordered dict if true-ish
             # for python2.6, may be syaml or ruamel.yaml implementation
@@ -2128,7 +2128,7 @@ class Environment(object):
         # Construct YAML representation of view
         default_name = default_view_name
         if self.views and len(self.views) == 1 and default_name in self.views:
-            path = self.default_view._root
+            path = self.default_view.raw_root
             if self.default_view == ViewDescriptor(self.path, self.view_path_default):
                 view = True
             elif self.default_view == ViewDescriptor(self.path, path):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -384,7 +384,8 @@ class ViewDescriptor(object):
         link_type="symlink",
     ):
         self.base = base_path
-        self.root = spack.util.path.canonicalize_path(root)
+        self._root = root
+        self.root = spack.util.path.canonicalize_path(root, default_wd=base_path)
         self.projections = projections
         self.select = select
         self.exclude = exclude
@@ -410,7 +411,7 @@ class ViewDescriptor(object):
         )
 
     def to_dict(self):
-        ret = syaml.syaml_dict([("root", self.root)])
+        ret = syaml.syaml_dict([("root", self._root)])
         if self.projections:
             # projections guaranteed to be ordered dict if true-ish
             # for python2.6, may be syaml or ruamel.yaml implementation
@@ -2127,7 +2128,7 @@ class Environment(object):
         # Construct YAML representation of view
         default_name = default_view_name
         if self.views and len(self.views) == 1 and default_name in self.views:
-            path = self.default_view.root
+            path = self.default_view._root
             if self.default_view == ViewDescriptor(self.path, self.view_path_default):
                 view = True
             elif self.default_view == ViewDescriptor(self.path, path):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3181,3 +3181,10 @@ def test_env_include_packages_url(
 
         cfg = spack.config.get("packages")
         assert "openmpi" in cfg["all"]["providers"]["mpi"]
+
+
+def test_relative_view_path_on_command_line_is_made_absolute(tmpdir, config):
+    with fs.working_dir(str(tmpdir)):
+        env("create", "--with-view", "view", "--dir", "env")
+        environment = ev.Environment(os.path.join(".", "env"))
+        assert os.path.samefile("view", environment.default_view.root)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -4,9 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test environment internals without CLI"""
 import io
+import os
 import sys
 
 import pytest
+
+import llnl.util.filesystem as fs
 
 import spack.environment as ev
 import spack.spec
@@ -111,3 +114,32 @@ def test_activate_should_require_an_env():
 
     with pytest.raises(TypeError):
         ev.activate(env=None)
+
+
+def test_user_view_path_is_not_canonicalized_in_yaml(tmpdir, config):
+    # When spack.yaml files are checked into version control, we
+    # don't want view: ./relative to get canonicalized on disk.
+
+    # We create a view in <tmpdir>/env_dir
+    env_path = tmpdir.mkdir("env_dir").strpath
+
+    # And use a relative path to specify the view dir
+    view = os.path.join(".", "view")
+
+    # Which should always resolve to the following independent of cwd.
+    absolute_view = os.path.join(env_path, "view")
+
+    # Serialize environment with relative view path
+    with fs.working_dir(str(tmpdir)):
+        fst = ev.Environment(env_path, with_view=view)
+        fst.write()
+
+    # The view link should be created
+    assert os.path.isdir(absolute_view)
+
+    # Deserialize and check if the view path is still relative in yaml
+    # and also check that the getter is pointing to the right dir.
+    with fs.working_dir(str(tmpdir)):
+        snd = ev.Environment(env_path)
+        assert snd.yaml["spack"]["view"] == view
+        assert os.path.samefile(snd.default_view.root, absolute_view)


### PR DESCRIPTION
Currently if you have a `spack.yaml` that specifies a view by relative
path like this:

```yaml
spack:
  view: ./view
```

Spack expands it to an absolute path on `spack -e . install` and
persists that to disk like this:

```yaml
spack:
  view: /the/path/where/the/env/is/view
```

This is rather annoying when you share a `spack.yaml` file inside a git
repo, cause you want to use relative paths to make it relocatable, but
you constantly have to undo the changes made to `spack.yaml` by Spack
when committing something else.

So, as an alternative:

1. Treat `spack.yaml` view paths in read-only mode
2. Work with a path property that is canonicalized internally
3. Turn relative paths on the command line into absolute paths before
   storing to spack.yaml. This way you can do `spack env create --dir`
   `./env --with-view ./view` and both `./env` and `./view` are resolved
   to the current working dir, as expected (not `./env/view`). This
   corresponds to the old behavior of `spack env create`.
