### PR TITLE
Update py-fastfold w/ py-numpy upper bound

### DIFF
--- a/var/spack/repos/builtin/packages/py-fastfold/package.py
+++ b/var/spack/repos/builtin/packages/py-fastfold/package.py
@@ -38,3 +38,5 @@ class PyFastfold(PythonPackage):
     depends_on("py-setproctitle", type=("build", "run"))
     depends_on("py-pdbfixer", type=("build", "run"))
     depends_on("py-pytorch-lightning", type=("build", "run"))
+    # py-fastfold uses np.int, which was removed in py-numpy@1.24.0
+    depends_on("py-numpy@:1.23", when="@0.2.0", type=("build", "run"))


### PR DESCRIPTION
`py-fastfold@0.2.0` uses `np.int`, which was removed in [`py-numpy@1.24.0`](https://github.com/numpy/numpy/blob/v1.24.0/numpy/__init__.py#L164-L173).