### PR TITLE
py-macs2: add version 2.2.7.1 and support python@3.10:

### DIFF
--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -17,34 +17,25 @@ class PyMacs2(PythonPackage):
 
     version("2.2.7.1", sha256="ad2ca69bdd02a8942a68aae23133289b5c16ba382bcbe20c39fabf3948929de5")
     version("2.2.4", sha256="b131aadc8f5fd94bec35308b821e1f7585def788d2e7c756fc8cac402ffee25b")
-    version("2.1.4", sha256="e4966d001914320829ab859c7bc8e92c6410aa7bdbddfd00b7625e9a0fb15c97")
-    version("2.1.3.3", sha256="00959e523f45ed92b8429f55944eca6984623ac008d7cdb488c3ffe59c21984a")
-    version(
-        "2.1.1.20160309", sha256="2008ba838f83f34f8e0fddefe2a3a0159f4a740707c68058f815b31ddad53d26"
-    )
 
     # patch to correctly identify python-3.10 as greater than required version
     patch(
         "https://github.com/macs3-project/MACS/pull/497.patch?full_index=1",
         sha256="eaff891b9b3c6a910bd5d454dcc6e21288c8d1ad4d6d6f77e370bc8f90921cbd",
-        when="^python@3.10:",
+        when="@2.2.7.1^python@3.10:",
     )
 
     depends_on("python@3.6:", when="@2.2.7.1:", type=("build", "run"))
-    depends_on("python@3.5:", when="@2.2:", type=("build", "run"))
-    depends_on("python@2.7:2.8", when="@:2.1", type=("build", "run"))
+    # version 2.2.4 does not build with python-3.10
+    depends_on("python@3.5:3.9", when="@2.2.4", type=("build", "run"))
     depends_on("py-cython", type="build")
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-macs2 requires py-setuptools during runtime as well.
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-setuptools@41.2:", when="@2.2.4:", type=("build", "run"))
-    depends_on("py-numpy@1.17:", when="@2.2:", type=("build", "run"))
-    depends_on("py-numpy@1.16:", when="@2.1.4", type=("build", "run"))
-    depends_on("py-numpy@1.15:", when="@2.1.3.3", type=("build", "run"))
-    depends_on("py-numpy@1.6:", when="@2.1.1.20160309", type=("build", "run"))
-    depends_on("py-cython@0.29:", when="@2.1.4:", type="build")
-    depends_on("py-cython@0.25:", when="@2.1.3.3", type="build")
+    depends_on("py-numpy@1.17:", when="@2.2.4:", type=("build", "run"))
+    depends_on("py-cython@0.29:", when="@2.2.4:", type="build")
 
     def patch(self):
         # regenerate C files from pyx files with cython

--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import glob
+
 from spack.package import *
 
 
@@ -13,13 +15,38 @@ class PyMacs2(PythonPackage):
     homepage = "https://github.com/taoliu/MACS"
     pypi = "MACS2/MACS2-2.2.4.tar.gz"
 
+    version("2.2.7.1", sha256="ad2ca69bdd02a8942a68aae23133289b5c16ba382bcbe20c39fabf3948929de5")
     version("2.2.4", sha256="b131aadc8f5fd94bec35308b821e1f7585def788d2e7c756fc8cac402ffee25b")
+    version("2.1.4", sha256="e4966d001914320829ab859c7bc8e92c6410aa7bdbddfd00b7625e9a0fb15c97")
+    version("2.1.3.3", sha256="00959e523f45ed92b8429f55944eca6984623ac008d7cdb488c3ffe59c21984a")
+    version(
+        "2.1.1.20160309", sha256="2008ba838f83f34f8e0fddefe2a3a0159f4a740707c68058f815b31ddad53d26"
+    )
 
-    depends_on("python@3.5:", type=("build", "run"))
+    # patch to correctly identify python-3.10 as greater than required version
+    patch(
+        "https://github.com/macs3-project/MACS/pull/497.patch?full_index=1",
+        sha256="eaff891b9b3c6a910bd5d454dcc6e21288c8d1ad4d6d6f77e370bc8f90921cbd",
+        when="^python@3.10:",
+    )
+
+    depends_on("python@3.6:", when="@2.2.7.1:", type=("build", "run"))
+    depends_on("python@3.5:", when="@2.2:", type=("build", "run"))
+    depends_on("python@2.7:2.8", when="@:2.1", type=("build", "run"))
     depends_on("py-cython", type="build")
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-macs2 requires py-setuptools during runtime as well.
     depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-numpy@1.17:", type=("build", "run"))
-    depends_on("py-numpy@1.16:", type=("build", "run"))
+    depends_on("py-setuptools@41.2:", when="@2.2.4:", type=("build", "run"))
+    depends_on("py-numpy@1.17:", when="@2.2:", type=("build", "run"))
+    depends_on("py-numpy@1.16:", when="@2.1.4", type=("build", "run"))
+    depends_on("py-numpy@1.15:", when="@2.1.3.3", type=("build", "run"))
+    depends_on("py-numpy@1.6:", when="@2.1.1.20160309", type=("build", "run"))
+    depends_on("py-cython@0.29:", when="@2.1.4:", type="build")
+    depends_on("py-cython@0.25:", when="@2.1.3.3", type="build")
+
+    def patch(self):
+        # regenerate C files from pyx files with cython
+        files = glob.glob("MACS2/**/[!c]*.c", recursive=True)
+        force_remove(*files)


### PR DESCRIPTION
The tarball from PyPi includes the Cythonized C files. The tarball from github does not. Remove the Cythonized C files from the source so that they are rebuilt with the Spack Python/Cython combination. This is necessary for python-3.10 but make sense for other combinations as well.