### PR TITLE
py-xxhash: fix xxhash dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-xxhash/package.py
+++ b/var/spack/repos/builtin/packages/py-xxhash/package.py
@@ -17,7 +17,7 @@ class PyXxhash(PythonPackage):
 
     depends_on("python@2.6:2,3.3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("xxhash@0.8.0")
+    depends_on("xxhash@0.8.0:")
 
     def setup_build_environment(self, env):
         env.set("XXHASH_LINK_SO", "1")

--- a/var/spack/repos/builtin/packages/py-xxhash/package.py
+++ b/var/spack/repos/builtin/packages/py-xxhash/package.py
@@ -13,11 +13,14 @@ class PyXxhash(PythonPackage):
     homepage = "https://github.com/ifduyue/python-xxhash"
     pypi = "xxhash/xxhash-2.0.2.tar.gz"
 
+    version("3.2.0", sha256="1afd47af8955c5db730f630ad53ae798cf7fae0acb64cebb3cf94d35c47dd088")
     version("2.0.2", sha256="b7bead8cf6210eadf9cecf356e17af794f57c0939a3d420a00d87ea652f87b49")
 
     depends_on("python@2.6:2,3.3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("xxhash@0.8.0:")
+    depends_on("py-setuptools@45:", type="build", when="@3.2.0:")
+    depends_on("py-setuptools-scm@6.2:", type="build", when="@3.2.0:")
+    depends_on("xxhash@0.8:")
 
     def setup_build_environment(self, env):
         env.set("XXHASH_LINK_SO", "1")


### PR DESCRIPTION
The dependency should be xxhash@0.8.0:.