### PR TITLE
stringtie: add version 2.2.1 and fix build

### DIFF
--- a/var/spack/repos/builtin/packages/stringtie/package.py
+++ b/var/spack/repos/builtin/packages/stringtie/package.py
@@ -13,11 +13,15 @@ class Stringtie(MakefilePackage):
     homepage = "https://ccb.jhu.edu/software/stringtie"
     url = "https://github.com/gpertea/stringtie/archive/v1.3.3b.tar.gz"
 
+    version("2.2.1", sha256="19592aa37e293f4dcd684a4c6e0a1439ee34876d9f22944fb4edceba8c09631b")
     version("1.3.4d", sha256="0134c0adc264efd31a1df4301b33bfcf3b3fe96bd3990ce3df90819bad9af968")
     version("1.3.4a", sha256="6164a5fa9bf8807ef68ec89f47e3a61fe57fa07fe858f52fb6627f705bf71add")
     version("1.3.3b", sha256="30e8a3a29b474f0abeef1540d9b4624a827d8b29d7347226d86a38afea28bc0f")
 
-    depends_on("samtools")
+    depends_on("zlib")
+
+    def build(self, spec, prefix):
+        make("release")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
- stringtie uses internal samtools so remove dependency on samtools
- add dependency for zlib
- use make release target to get correct flags