### PR TITLE
Bump gnupg & libksba, (CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -14,6 +14,7 @@ class Gnupg(AutotoolsPackage):
 
     maintainers = ["alalazo"]
 
+    version("2.4.0", sha256="1d79158dd01d992431dd2e3facb89fdac97127f89784ea2cb610c600fb0c1483")
     version("2.3.8", sha256="540b7a40e57da261fb10ef521a282e0021532a80fd023e75fb71757e8a4969ed")
     version("2.3.7", sha256="ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669")
     version("2.2.40", sha256="1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28")

--- a/var/spack/repos/builtin/packages/libksba/package.py
+++ b/var/spack/repos/builtin/packages/libksba/package.py
@@ -17,12 +17,39 @@ class Libksba(AutotoolsPackage):
 
     maintainers = ["alalazo"]
 
-    version("1.6.2", sha256="fce01ccac59812bddadffacff017dac2e4762bdb6ebc6ffe06f6ed4f6192c971")
-    version("1.6.0", sha256="dad683e6f2d915d880aa4bed5cea9a115690b8935b78a1bbe01669189307a48b")
-    version("1.5.1", sha256="b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921")
-    version("1.5.0", sha256="ae4af129216b2d7fdea0b5bf2a788cd458a79c983bb09a43f4d525cc87aba0ba")
-    version("1.4.0", sha256="bfe6a8e91ff0f54d8a329514db406667000cb207238eded49b599761bfca41b6")
-    version("1.3.5", sha256="41444fd7a6ff73a79ad9728f985e71c9ba8cd3e5e53358e70d5f066d35c1a340")
+    version("1.6.3", sha256="3f72c68db30971ebbf14367527719423f0a4d5f8103fc9f4a1c01a9fa440de5c")
+
+    # Deprecated over CVE-2022-3515 (https://gnupg.org/blog/20221017-pepe-left-the-ksba.html)
+    version(
+        "1.6.2",
+        sha256="fce01ccac59812bddadffacff017dac2e4762bdb6ebc6ffe06f6ed4f6192c971",
+        deprecated=True,
+    )
+    version(
+        "1.6.0",
+        sha256="dad683e6f2d915d880aa4bed5cea9a115690b8935b78a1bbe01669189307a48b",
+        deprecated=True,
+    )
+    version(
+        "1.5.1",
+        sha256="b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921",
+        deprecated=True,
+    )
+    version(
+        "1.5.0",
+        sha256="ae4af129216b2d7fdea0b5bf2a788cd458a79c983bb09a43f4d525cc87aba0ba",
+        deprecated=True,
+    )
+    version(
+        "1.4.0",
+        sha256="bfe6a8e91ff0f54d8a329514db406667000cb207238eded49b599761bfca41b6",
+        deprecated=True,
+    )
+    version(
+        "1.3.5",
+        sha256="41444fd7a6ff73a79ad9728f985e71c9ba8cd3e5e53358e70d5f066d35c1a340",
+        deprecated=True,
+    )
 
     depends_on("libgpg-error@1.8:")
 


### PR DESCRIPTION
- gnupg: 2.4.0
- libksba: 1.6.3 (CVE-2022-47629)
