### PR TITLE
[armpl-gcc] Make pkg-config files available

### DIFF
--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -264,10 +264,10 @@ class ArmplGcc(Package):
 
     @run_after("install")
     def make_pkgconfig_files(self):
-        # ARMpl pkcfonfig files do not have .pc extension and are thus not found by pkg-config
+        # ArmPL pkgconfig files do not have .pc extension and are thus not found by pkg-config
         armpl_dir = get_armpl_prefix(self.spec)
         for f in find(join_path(armpl_dir, "pkgconfig"), "*"):
-            copy(f, f + ".pc")
+            symlink(f, f + ".pc")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         # pkgconfig directory is not in standard ("lib", "lib64", "share") location

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -262,3 +262,15 @@ class ArmplGcc(Package):
         make("-C", armpl_example_dir, "ARMPL_DIR=" + armpl_dir)
         # clean up
         make("-C", armpl_example_dir, "ARMPL_DIR=" + armpl_dir, "clean")
+
+    @run_after("install")
+    def make_pkgconfig_files(self):
+        # ARMpl pkcfonfig files do not have .pc extension and are thus not found by pkg-config
+        armpl_dir = get_armpl_prefix(self.spec)
+        for f in find(join_path(armpl_dir, "pkgconfig"), '*'):
+            copy(f, f + '.pc')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # pkgconfig directory is not in standard ("lib", "lib64", "share") location
+        armpl_dir = get_armpl_prefix(self.spec)
+        env.append_path("PKG_CONFIG_PATH",  join_path(armpl_dir, "pkgconfig"))

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -273,4 +273,4 @@ class ArmplGcc(Package):
     def setup_dependent_build_environment(self, env, dependent_spec):
         # pkgconfig directory is not in standard ("lib", "lib64", "share") location
         armpl_dir = get_armpl_prefix(self.spec)
-        env.append_path("PKG_CONFIG_PATH",  join_path(armpl_dir, "pkgconfig"))
+        env.append_path("PKG_CONFIG_PATH", join_path(armpl_dir, "pkgconfig"))

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -17,7 +17,6 @@ _os_map = {
     "amzn2": "RHEL-7",
 }
 
-
 _versions = {
     "22.1_gcc-11.2": {
         "RHEL-7": ("9ce7858525109cca8f4e1d533113b6410d55f10cc4db16c4742562da87a32f2b"),
@@ -267,8 +266,8 @@ class ArmplGcc(Package):
     def make_pkgconfig_files(self):
         # ARMpl pkcfonfig files do not have .pc extension and are thus not found by pkg-config
         armpl_dir = get_armpl_prefix(self.spec)
-        for f in find(join_path(armpl_dir, "pkgconfig"), '*'):
-            copy(f, f + '.pc')
+        for f in find(join_path(armpl_dir, "pkgconfig"), "*"):
+            copy(f, f + ".pc")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         # pkgconfig directory is not in standard ("lib", "lib64", "share") location


### PR DESCRIPTION
ARMpl pkgconfig files are located in a non-default location and do not have the .pc extension. Changing those both helps pkgconfig pick them up correctly, e.g. in the meson build of `py-scipy`.