### PR TITLE
[py-numpy, py-scipy] Enable MKL & ARMpl

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1101,6 +1101,7 @@ class IntelPackage(Package):
                 "CMAKE_PREFIX_PATH": self.normalize_path("mkl"),
                 "CMAKE_LIBRARY_PATH": self.component_lib_dir("mkl"),
                 "CMAKE_INCLUDE_PATH": self.component_include_dir("mkl"),
+                "PKG_CONFIG_PATH": os.path.join(self.normalize_path("mkl"), "bin", "pkgconfig"),
             }
 
             env.set("MKLROOT", env_mods["MKLROOT"])
@@ -1108,6 +1109,7 @@ class IntelPackage(Package):
             env.append_path("CMAKE_PREFIX_PATH", env_mods["CMAKE_PREFIX_PATH"])
             env.append_path("CMAKE_LIBRARY_PATH", env_mods["CMAKE_LIBRARY_PATH"])
             env.append_path("CMAKE_INCLUDE_PATH", env_mods["CMAKE_INCLUDE_PATH"])
+            env.append_path("PKG_CONFIG_PATH", env_mods["PKG_CONFIG_PATH"])
 
             debug_print("adding/modifying build env:", env_mods)
 

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -150,9 +150,9 @@ class PyNumpy(PythonPackage):
     # NVHPC support added in https://github.com/numpy/numpy/pull/17344
     conflicts("%nvhpc", when="@:1.19")
 
-    # Newer versions will not build with Intel https://github.com/numpy/numpy/issues/22011
-    conflicts("%intel", when="@1.23.0:")
-    conflicts("%oneapi", when="@1.23.0:")
+    # See https://github.com/numpy/numpy/issues/22011
+    conflicts("%intel", when="@1.23.0:1.23.3")
+    conflicts("%oneapi", when="@1.23.0:1.23.3")
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/n/numpy/numpy-{}.{}"
@@ -313,6 +313,12 @@ class PyNumpy(PythonPackage):
                     write_library_dirs(f, lapack_lib_dirs)
                     f.write("include_dirs = {0}\n".format(lapack_header_dirs))
                     f.write("extra_link_args = {0}\n".format(self.spec["lapack"].libs.ld_flags))
+
+            if "^armpl-gcc" in spec:
+                f.write("[blas]\n")
+                f.write("libraries = {0}\n".format(lapackblas_lib_names))
+                write_library_dirs(f, lapackblas_lib_dirs)
+                f.write("include_dirs = {0}\n".format(lapackblas_header_dirs))
 
     def setup_build_environment(self, env):
         # Tell numpy which BLAS/LAPACK libraries we want to use.

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -130,11 +130,6 @@ class PyScipy(PythonPackage):
     # Meson adds this flag for all Python extensions which include Fortran code.
     conflicts("%oneapi", when="@1.9:")
 
-    # FIXME: mysterious build issues with MKL
-    conflicts("^intel-mkl", when="@1.9:")
-    conflicts("^intel-oneapi-mkl", when="@1.9:")
-    conflicts("^intel-parallel-studio", when="@1.9:")
-
     # https://github.com/scipy/scipy/issues/12860
     patch(
         "https://git.sagemath.org/sage.git/plain/build/pkgs/scipy/patches/extern_decls.patch?id=711fe05025795e44b84233e065d240859ccae5bd",
@@ -200,14 +195,16 @@ class PyScipy(PythonPackage):
     def install(self, spec, prefix):
         blas = spec["blas"].libs.names[0]
         lapack = spec["lapack"].libs.names[0]
-        # FIXME: MKL support doesn't work, why?
         if spec["blas"].name in ["intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"]:
             blas = "mkl-dynamic-lp64-seq"
         if spec["lapack"].name in ["intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"]:
             lapack = "mkl-dynamic-lp64-seq"
-
         if spec["blas"].name in ["blis", "amdblis"]:
             blas = "blis"
+        if blas == "armpl":
+            blas += "-dynamic-lp64-seq"
+        if lapack == "armpl":
+            lapack += "-dynamic-lp64-seq"
 
         args = [
             "setup",


### PR DESCRIPTION
- Issue  https://github.com/numpy/numpy/issues/22011 has been resolved and backported for 1.23.4
- ARMpl and MKL when added to `site.cfg` in numpy and via pkg-config (in meson build) to scipy work. Tested on x86_64 (icc) and aarch64 (gcc).

Depends on https://github.com/spack/spack/pull/34978