### PR TITLE
hdf5@1.8.21 %oneapi@2023.0.0: -Wno-error=int-conversion

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -341,6 +341,8 @@ class Hdf5(CMakePackage):
                 # More recent versions set CMAKE_POSITION_INDEPENDENT_CODE to
                 # True and build with PIC flags.
                 cmake_flags.append(self.compiler.cc_pic_flag)
+            if spec.satisfies("@1.8.21 %oneapi@2023.0.0"):
+                cmake_flags.append("-Wno-error=int-conversion")
         elif name == "cxxflags":
             if spec.satisfies("@:1.8.12+cxx~shared"):
                 cmake_flags.append(self.compiler.cxx_pic_flag)


### PR DESCRIPTION
This changes resolves the following error when build `hdf5@1.8.21 %oneapi@2023.0.0`

```
==> hdf5: Executing phase: 'cmake'
==> hdf5: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

7 errors found in build log:
     546                            (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(mem_type, H5T_COPY_ALL), FALSE)) < 0)
     547                                                                          ^~~~~~~~
     548    /tmp/root/spack-stage/spack-stage-hdf5-1.8.21-cedkt3synrj5as5igwffcexszvjmrmga/spack-src/src/H5Tprivate.h:107:31: note: passing arg
            ument to parameter 'old_dt' here
     549    H5_DLL H5T_t *H5T_copy(H5T_t *old_dt, H5T_copy_t method);
     550                                  ^
     551    [  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2cache.c.o
  >> 552    /tmp/root/spack-stage/spack-stage-hdf5-1.8.21-cedkt3synrj5as5igwffcexszvjmrmga/spack-src/src/H5Aint.c:2102:21: error: incompatible 
            integer to pointer conversion assigning to 'H5A_t *' (aka 'struct H5A_t *') from 'int' [-Wint-conversion]
     553                        HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
...
```

CC @wspear @brtnfld @byrnHDF @gheber @hyoklee @lkurz @lrknox