### PR TITLE
py-h5py %oneapi@2023.0.0: let warnings be warnings

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -70,6 +70,13 @@ class PyH5py(PythonPackage):
     depends_on("py-mpi4py@3.0.2:", when="@3.3.0:+mpi^python@3:3.7", type=("build", "run"))
     depends_on("py-mpi4py@3.0.3:", when="@3:+mpi^python@3.8.0:", type=("build", "run"))
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2023.0.0:"):
+                flags.append("-Wno-error=incompatible-function-pointer-types")
+                flags.append("-Wno-error=incompatible-pointer-types-discards-qualifiers")
+        return (flags, None, None)
+
     def setup_build_environment(self, env):
         env.set("HDF5_DIR", self.spec["hdf5"].prefix)
         if "+mpi" in self.spec:


### PR DESCRIPTION
For `py-h5py %oneapi@2023.0.0` set the following:
* `-Wno-error=incompatible-function-pointer-types`
* `-Wno-error=incompatible-pointer-types-discards-qualifiers`

@bryanherman @takluyver @wspear