### PR TITLE
environments: `develop` paths were not getting expanded

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -379,8 +379,8 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir):
         if not dev_specs:
             return
         for name, entry in dev_specs.items():
-            dev_path = spack.util.path.canonicalize_path(entry["path"])
-            expanded_path = os.path.normpath(os.path.join(init_file_dir, dev_path))
+            dev_path = substitute_path_variables(entry["path"])
+            expanded_path = spack.util.path.canonicalize_path(dev_path, default_wd=init_file_dir)
 
             # Skip if the expanded path is the same (e.g. when absolute)
             if dev_path == expanded_path:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -379,8 +379,8 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir):
         if not dev_specs:
             return
         for name, entry in dev_specs.items():
-            dev_path = entry["path"]
-            expanded_path = os.path.normpath(os.path.join(init_file_dir, entry["path"]))
+            dev_path = spack.util.path.canonicalize_path(entry["path"])
+            expanded_path = os.path.normpath(os.path.join(init_file_dir, dev_path))
 
             # Skip if the expanded path is the same (e.g. when absolute)
             if dev_path == expanded_path:

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -234,7 +234,7 @@ def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path,
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                f"""\
+                """\
 spack:
   specs:
   - dev-build-test-install@0.0.0

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -225,9 +225,8 @@ def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path,
     # store the build path in an environment variable that will be used in the environment
     monkeypatch.setenv("CUSTOM_BUILD_PATH", build_dir)
 
-    with build_dir.as_cwd():
-        with open(spec.package.filename, "w") as f:
-            f.write(spec.package.original_string)
+    with build_dir.as_cwd(), open(spec.package.filename, "w") as f:
+        f.write(spec.package.original_string)
 
     # setup environment
     envdir = tmpdir.mkdir("env")

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -215,6 +215,45 @@ spack:
         assert f.read() == spec.package.replacement_string
 
 
+def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path, monkeypatch):
+    """Test Spack does dev builds for packages in develop section of env (path with variables)."""
+    # setup dev-build-test-install package for dev build
+    build_dir = tmpdir.mkdir("build")
+    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % build_dir)
+    spec.concretize()
+
+    # store the build path in an environment variable that will be used in the environment
+    monkeypatch.setenv("CUSTOM_BUILD_PATH", build_dir)
+
+    with build_dir.as_cwd():
+        with open(spec.package.filename, "w") as f:
+            f.write(spec.package.original_string)
+
+    # setup environment
+    envdir = tmpdir.mkdir("env")
+    with envdir.as_cwd():
+        with open("spack.yaml", "w") as f:
+            f.write(
+                f"""\
+spack:
+  specs:
+  - dev-build-test-install@0.0.0
+
+  develop:
+    dev-build-test-install:
+      spec: dev-build-test-install@0.0.0
+      path: $CUSTOM_BUILD_PATH
+"""
+            )
+        env("create", "test", "./spack.yaml")
+        with ev.read("test"):
+            install()
+
+    assert spec.package.filename in os.listdir(spec.prefix)
+    with open(os.path.join(spec.prefix, spec.package.filename), "r") as f:
+        assert f.read() == spec.package.replacement_string
+
+
 def test_dev_build_env_version_mismatch(tmpdir, install_mockery, mutable_mock_env_path):
     """Test Spack constraints concretization by develop specs."""
     # setup dev-build-test-install package for dev build

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -219,7 +219,7 @@ def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path,
     """Test Spack does dev builds for packages in develop section of env (path with variables)."""
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir("build")
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % build_dir)
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={build_dir}")
     spec.concretize()
 
     # store the build path in an environment variable that will be used in the environment


### PR DESCRIPTION
This PR aims at fixing wrong expansion of develop paths in environment configuration.

I opted for `substitute_path_variables` instead of `canonicalize_path`, because I just want to expand variables/users without making any decision in case the given path is relative, leaving up to the environment logic what has to be done in that case.

### The problem

Given an environment

```
# /path-to-original-env/spack.yaml
spack:
  specs: [dla-future]
  develop:
    dla-future:
      spec: dla-future@develop
      path: ~/path-to-my-pkg
```

when cloning it

```bash
$ spack env create new_env original_env/spack.yaml
```

the `new_env` develop path resulted int

```
spack:
  specs: [dla-future]
  develop:
    dla-future:
      spec: dla-future@develop
      path: /path-to-original-env/~/workspace/repos/dla-future.master
```