### PR TITLE
hypre: add option for sycl variant

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -276,6 +276,12 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if "+sycl" in spec:
             configure_args.append("--with-scyl")
+            sycl_compatible_compilers = ["dpcpp", "icpx"]
+            if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
+                raise InstallError(
+                    "Hypre's SYCL GPU Backend requires DPC++ (dpcpp)"
+                    + " or the oneAPI CXX (icpx) compiler."
+                )
 
         if "+unified-memory" in spec:
             configure_args.append("--enable-unified-memory")

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -75,6 +75,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("fortran", default=True, description="Enables fortran bindings")
     variant("gptune", default=False, description="Add the GPTune hookup code")
     variant("umpire", default=False, description="Enable Umpire support")
+    variant("sycl", default=False, description="Enable SYCL support")
 
     # Patch to add gptune hookup codes
     patch("ij_gptune.patch", when="+gptune@2.19.0")
@@ -269,6 +270,9 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
                     "--disable-rocsparse",
                 ]
             )
+
+        if "+sycl" in spec:
+            configure_args.append("--with-scyl")
 
         if "+unified-memory" in spec:
             configure_args.append("--enable-unified-memory")

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -140,6 +140,9 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     # Option added in v2.21.0
     conflicts("+umpire", when="@:2.20")
 
+    # Option added in v2.24.0
+    conflicts("+sycl", when="@:2.23")
+
     configure_directory = "src"
 
     def url_for_version(self, version):


### PR DESCRIPTION
Starting this to add a `hypre +sycl` variant.

Question for maintainers:
* What is minimum version of `hypre` that should accept `+sycl` ?
* Should we make a conflict or error of some sort if someone tries to, say, build `hypre +sycl %gcc` ?

What do you think?

@balay @osborn9 @ulrikeyang @wspear