### PR TITLE
updated samtools to 1.16.1 and htslib to 1.16

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -16,6 +16,7 @@ class Bcftools(AutotoolsPackage):
     homepage = "https://samtools.github.io/bcftools/"
     url = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
 
+    version("1.16", sha256="293010736b076cf684d2873928924fcc3d2c231a091084c2ac23a8045c7df982")
     version("1.15.1", sha256="f21f9564873eb27ccf22d13b91a64acb8fbbfe4f9e4c37933a54b9a95857f2d7")
     version("1.14", sha256="b7ef88ae89fcb55658c5bea2e8cb8e756b055e13860036d6be13756782aa19cb")
     version("1.13", sha256="13bfa1da2a5edda8fa51196a47a0b4afb3fef17516451e4f0e78477f3dd30b90")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -12,6 +12,7 @@ class Htslib(AutotoolsPackage):
     homepage = "https://github.com/samtools/htslib"
     url = "https://github.com/samtools/htslib/releases/download/1.13/htslib-1.13.tar.bz2"
 
+    version("1.16", sha256="606b7c7aff73734cf033ecd156f40529fa5792f54524952a28938ca0890d7924")
     version("1.15.1", sha256="8d7f8bf9658226942eeab70af2a22aca618577eaa8fe2ed9416ee306d5351aa1")
     version("1.15", sha256="1a9f49911503a22f56817cc82ea9b87fb7e7467b5ff989ca5aa61c12e7d532d9")
     version("1.14", sha256="ed221b8f52f4812f810eebe0cc56cd8355a5c9d21c62d142ac05ad0da147935f")

--- a/var/spack/repos/builtin/packages/psrchive/package.py
+++ b/var/spack/repos/builtin/packages/psrchive/package.py
@@ -44,7 +44,7 @@ class Psrchive(AutotoolsPackage):
     depends_on("tempo")
     depends_on("fftw@3:")
     depends_on("python")
-    depends_on("pgplot")
+    depends_on("pgplot+X")
 
     depends_on("mpi", when="+mpi")
     depends_on("mkl", when="+mkl")

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -41,6 +41,7 @@ class Samtools(Package):
     depends_on("python", type="run")
 
     # htslib became standalone @1.3.1, must use corresponding version
+    depends_on("htslib@1.16", when="@1.16.1")
     depends_on("htslib@1.15.1", when="@1.15.1")
     depends_on("htslib@1.15", when="@1.15")
     depends_on("htslib@1.14", when="@1.14")

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -13,7 +13,7 @@ class Samtools(Package):
 
     homepage = "https://www.htslib.org"
     url = "https://github.com/samtools/samtools/releases/download/1.13/samtools-1.13.tar.bz2"
-
+    version("1.16.1", sha256="2fa0a25f78594cf23d07c9d32d5060a14f1c5ee14d7b0af7a8a71abc9fdf1d07")
     version("1.15.1", sha256="708c525ac76b0532b25f14aadea34a4d11df667bc19bf0a74dae617d80526c6e")
     version("1.15", sha256="35d945a5eee9817a764490870474f24e538400b0397b28f94247a5b91447215d")
     version("1.14", sha256="9341dabaa98b0ea7d60fd47e42af25df43a7d3d64d8e654cdf852974546b7d74")

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -13,7 +13,7 @@ class Samtools(Package):
 
     homepage = "https://www.htslib.org"
     url = "https://github.com/samtools/samtools/releases/download/1.13/samtools-1.13.tar.bz2"
-    version("1.16.1", sha256="2fa0a25f78594cf23d07c9d32d5060a14f1c5ee14d7b0af7a8a71abc9fdf1d07")
+
     version("1.15.1", sha256="708c525ac76b0532b25f14aadea34a4d11df667bc19bf0a74dae617d80526c6e")
     version("1.15", sha256="35d945a5eee9817a764490870474f24e538400b0397b28f94247a5b91447215d")
     version("1.14", sha256="9341dabaa98b0ea7d60fd47e42af25df43a7d3d64d8e654cdf852974546b7d74")


### PR DESCRIPTION
Updated the versions of these two packages.
N.B. There is no version 1.16.1 of htslib (as of 2023-01-17).