### PR TITLE
Implements `--best-arch` option for spack load

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -262,9 +262,7 @@ def disambiguate_spec(spec, env, local=False, installed=True, best=False):
     return disambiguate_spec_from_hashes(spec, hashes, local, installed, best)
 
 
-def disambiguate_spec_from_hashes(
-    spec, hashes, local=False, installed=True, best=False
-):
+def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, best=False):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -262,7 +262,7 @@ def disambiguate_spec(spec, env, local=False, installed=True, first=False, best_
 
 
 def disambiguate_spec_from_hashes(
-        spec, hashes, local=False, installed=True, first=False, best_arch=False
+    spec, hashes, local=False, installed=True, first=False, best_arch=False
 ):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -11,6 +11,8 @@ import sys
 from textwrap import dedent
 from typing import List, Match, Tuple
 
+import archspec.cpu
+
 import llnl.string
 import llnl.util.tty as tty
 from llnl.util.filesystem import join_path
@@ -22,6 +24,7 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.extensions
+import spack.package_prefs
 import spack.parser
 import spack.paths
 import spack.spec
@@ -245,7 +248,7 @@ def matching_spec_from_env(spec):
         return spec.concretized()
 
 
-def disambiguate_spec(spec, env, local=False, installed=True, first=False):
+def disambiguate_spec(spec, env, local=False, installed=True, best=False):
     """Given a spec, figure out which installed package it refers to.
 
     Arguments:
@@ -256,13 +259,13 @@ def disambiguate_spec(spec, env, local=False, installed=True, first=False):
         installed (bool or spack.database.InstallStatus or typing.Iterable):
             install status argument passed to database query.
             See ``spack.database.Database._query`` for details.
-        first (bool): load the best matching spec for the current architecture
+        best (bool): choose the best matching spec based on arch and package prefs
     """
     hashes = env.all_hashes() if env else None
-    return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
+    return disambiguate_spec_from_hashes(spec, hashes, local, installed, best)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False):
+def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, best=False):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:
@@ -272,7 +275,7 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
         installed (bool or spack.database.InstallStatus or typing.Iterable):
             install status argument passed to database query.
             See ``spack.database.Database._query`` for details.
-        first (bool): load the best matching spec for the current architecture
+        best (bool): choose the best matching spec based on arch and package prefs
     """
     if local:
         matching_specs = spack.store.STORE.db.query_local(spec, hashes=hashes, installed=installed)
@@ -281,22 +284,27 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 
-    elif first:
-        import archspec.cpu
+    elif best:
+        host_arch = archspec.cpu.host()
 
-        # Figure out the arch then select spec by best arch matching spec
-        platform = spack.platforms.host()
-        uarch = archspec.cpu.TARGETS.get(platform.default)
-        candidate_targets = [uarch] + uarch.ancestors
-        # Return the first spec matching the platform's architecture
-        for spec in matching_specs:
-            for target in candidate_targets:
-                name = spec.architecture.target.name
-                spec_target = archspec.cpu.TARGETS.get(
-                    name, archspec.cpu.generic_microarchitecture(name)
-                )
-                if spec_target <= target:
-                    return spec
+        # filter out specs that won't run on this machine
+        matching_specs = [spec for spec in matching_specs if host_arch >= spec.target]
+
+        # comparators for picking best spec according to current prefs
+        ver = spack.package_prefs.PackagePrefs(spec.name, "version")
+        target = spack.package_prefs.PackagePrefs(spec.name, "target")
+        compiler = spack.package_prefs.PackagePrefs(spec.name, "compiler")
+
+        # these are harder but can be done w/package prefs:
+        # TODO: pick version with most preferred variants
+        # TODO: pick version with most preferred virtual provider (e.g. MPI)
+
+        # sort key that orders specs by prefs above
+        def sort_key(spec):
+            return (ver(spec.version), target(spec.target), compiler(spec.compiler), spec)
+
+        matching_specs.sort(key=sort_key)
+        return matching_specs[0]
 
     ensure_single_spec_or_die(spec, matching_specs)
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -261,7 +261,9 @@ def disambiguate_spec(spec, env, local=False, installed=True, first=False, best_
     return disambiguate_spec_from_hashes(spec, hashes, local, installed, first, best_arch)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False, best_arch=False):
+def disambiguate_spec_from_hashes(
+        spec, hashes, local=False, installed=True, first=False, best_arch=False
+):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:
@@ -284,6 +286,7 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
 
     if best_arch:
         import archspec.cpu
+
         # Figure out the arch then select spec by best arch matching spec
         platform = spack.platforms.host()
         uarch = archspec.cpu.TARGETS.get(platform.default)
@@ -293,7 +296,9 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, fir
         for spec in matching_specs:
             for target in candidate_targets:
                 name = spec.architecture.target.name
-                spec_target = archspec.cpu.TARGETS.get(name, archspec.cpu.generic_microarchitecture(name))
+                spec_target = archspec.cpu.TARGETS.get(
+                    name, archspec.cpu.generic_microarchitecture(name)
+                )
                 if spec_target <= target:
                     supported_specs.append(spec)
         return supported_specs[0]

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -245,7 +245,7 @@ def matching_spec_from_env(spec):
         return spec.concretized()
 
 
-def disambiguate_spec(spec, env, local=False, installed=True, best=False):
+def disambiguate_spec(spec, env, local=False, installed=True, first=False):
     """Given a spec, figure out which installed package it refers to.
 
     Arguments:
@@ -256,13 +256,13 @@ def disambiguate_spec(spec, env, local=False, installed=True, best=False):
         installed (bool or spack.database.InstallStatus or typing.Iterable):
             install status argument passed to database query.
             See ``spack.database.Database._query`` for details.
-        best (bool): load the best matching spec for the current architecture
+        first (bool): load the best matching spec for the current architecture
     """
     hashes = env.all_hashes() if env else None
-    return disambiguate_spec_from_hashes(spec, hashes, local, installed, best)
+    return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, best=False):
+def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False):
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:
@@ -272,7 +272,7 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, bes
         installed (bool or spack.database.InstallStatus or typing.Iterable):
             install status argument passed to database query.
             See ``spack.database.Database._query`` for details.
-        best (bool): load the best matching spec for the current architecture
+        first (bool): load the best matching spec for the current architecture
     """
     if local:
         matching_specs = spack.store.STORE.db.query_local(spec, hashes=hashes, installed=installed)
@@ -281,7 +281,7 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, bes
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 
-    elif best:
+    elif first:
         import archspec.cpu
 
         # Figure out the arch then select spec by best arch matching spec

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -171,6 +171,18 @@ class CreateReporter(argparse.Action):
 
 
 @arg
+def best():
+    return Args(
+        "--best",
+        "--first",
+        action="store_true",
+        default=False,
+        dest="best",
+        help="choose 'best' of multiple matches by arch, version, etc.",
+    )
+
+
+@arg
 def log_format():
     return Args(
         "--log-format",

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -32,18 +32,12 @@ def setup_parser(subparser):
         help="dump json output instead of pretty printing",
     )
     subparser.add_argument(
-        "--first",
-        action="store_true",
-        default=False,
-        dest="load_first",
-        help="load the first match if multiple packages match the spec",
-    )
-    subparser.add_argument(
         "-a",
         "--attribute",
         action="append",
         help="select the attributes to show (defaults to all)",
     )
+    arguments.add_common_arguments(subparser, ["best"])
 
 
 def shift(asp_function):
@@ -203,7 +197,7 @@ def diff(parser, args):
         if spec.concrete:
             specs.append(spec)
         else:
-            specs.append(spack.cmd.disambiguate_spec(spec, env, first=args.load_first))
+            specs.append(spack.cmd.disambiguate_spec(spec, env, best=args.best))
 
     # Calculate the comparison (c)
     color = False if args.dump_json else get_color_when()

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -107,7 +107,7 @@ def load(parser, args):
         return
 
     specs = [
-        spack.cmd.disambiguate_spec(spec, env, best=args.load_best)
+        spack.cmd.disambiguate_spec(spec, env, first=args.load_best)
         for spec in spack.cmd.parse_specs(args.constraint)
     ]
 

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -66,12 +66,12 @@ def setup_parser(subparser):
         "--first",
         action="store_true",
         default=False,
-        dest="load_first",
+        dest="load_best",
         help="load the first match if multiple packages match the spec",
     )
 
     subparser.add_argument(
-        "--best-arch",
+        "--best",
         action="store_true",
         default=False,
         dest="load_best",
@@ -107,7 +107,7 @@ def load(parser, args):
         return
 
     specs = [
-        spack.cmd.disambiguate_spec(spec, env, first=args.load_first, best_arch=args.load_best)
+        spack.cmd.disambiguate_spec(spec, env, best=args.load_best)
         for spec in spack.cmd.parse_specs(args.constraint)
     ]
 

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -71,6 +71,14 @@ def setup_parser(subparser):
     )
 
     subparser.add_argument(
+        "--best-arch",
+        action="store_true",
+        default=False,
+        dest="load_best",
+        help="load the best match for the architecture if multiple packages match the spec",
+    )
+
+    subparser.add_argument(
         "--only",
         default="package,dependencies",
         dest="things_to_load",
@@ -99,7 +107,7 @@ def load(parser, args):
         return
 
     specs = [
-        spack.cmd.disambiguate_spec(spec, env, first=args.load_first)
+        spack.cmd.disambiguate_spec(spec, env, first=args.load_first, best_arch=args.load_best)
         for spec in spack.cmd.parse_specs(args.constraint)
     ]
 

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -63,12 +63,12 @@ def setup_parser(subparser):
     )
 
     subparser.add_argument(
-        "--best", "--first"
+        "--best",
+        "--first",
         action="store_true",
         default=False,
-        dest="load_best",
-        help="""load the best match for the architecture if multiple 
-packages match the spec, otherwise load the first found""",
+        dest="best",
+        help="choose 'best' of multiple matches by arch, version, etc.",
     )
 
     subparser.add_argument(
@@ -100,7 +100,7 @@ def load(parser, args):
         return
 
     specs = [
-        spack.cmd.disambiguate_spec(spec, env, first=args.load_best)
+        spack.cmd.disambiguate_spec(spec, env, best=args.best)
         for spec in spack.cmd.parse_specs(args.constraint)
     ]
 

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -63,19 +63,12 @@ def setup_parser(subparser):
     )
 
     subparser.add_argument(
-        "--first",
+        "--best", "--first"
         action="store_true",
         default=False,
         dest="load_best",
-        help="load the first match if multiple packages match the spec",
-    )
-
-    subparser.add_argument(
-        "--best",
-        action="store_true",
-        default=False,
-        dest="load_best",
-        help="load the best match for the architecture if multiple packages match the spec",
+        help="""load the best match for the architecture if multiple 
+packages match the spec, otherwise load the first found""",
     )
 
     subparser.add_argument(

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -74,15 +74,7 @@ def setup_parser(subparser):
         help="location of the named or current environment",
     )
 
-    subparser.add_argument(
-        "--first",
-        action="store_true",
-        default=False,
-        dest="find_first",
-        help="use the first match if multiple packages match the spec",
-    )
-
-    arguments.add_common_arguments(subparser, ["spec"])
+    arguments.add_common_arguments(subparser, ["spec", "best"])
 
 
 def location(parser, args):
@@ -127,7 +119,7 @@ def location(parser, args):
     # install_dir command matches against installed specs.
     if args.install_dir:
         env = ev.active_environment()
-        spec = spack.cmd.disambiguate_spec(specs[0], env, first=args.find_first)
+        spec = spack.cmd.disambiguate_spec(specs[0], env, best=args.best)
         print(spec.prefix)
         return
 

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -114,8 +114,8 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     load("--sh", "--first", "libelf")
 
 
-def test_load_best_arch(install_mockery, mock_fetch, mock_archive, mock_packages):
-    """Test with and without the --best-arch option"""
+def test_load_best(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test with and without the --best option"""
     install("libelf@0.8.12 arch=x86_64")
     install("libelf@0.8.12")
 
@@ -125,7 +125,7 @@ def test_load_best_arch(install_mockery, mock_fetch, mock_archive, mock_packages
     assert "Use a more specific spec" in out
 
     # Using --best-arch should avoid the error condition
-    load("--sh", "--best-arch", "libelf")
+    load("--sh", "--best", "libelf")
 
 
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive, mock_packages):

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -114,6 +114,20 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     load("--sh", "--first", "libelf")
 
 
+def test_load_best_arch(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test with and without the --best-arch option"""
+    install("libelf@0.8.12 arch=x86_64")
+    install("libelf@0.8.12")
+
+    # Now there are two versions of libelf installed for different archs, which should cause an error
+    out = load("--sh", "libelf", fail_on_error=False)
+    assert "matches multiple packages" in out
+    assert "Use a more specific spec" in out
+
+    # Using --best-arch should avoid the error condition
+    load("--sh", "--best-arch", "libelf")
+
+
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that spack load prints an error message without a shell."""
     install("mpileaks")

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -119,7 +119,7 @@ def test_load_best_arch(install_mockery, mock_fetch, mock_archive, mock_packages
     install("libelf@0.8.12 arch=x86_64")
     install("libelf@0.8.12")
 
-    # Now there are two versions of libelf installed for different archs, which should cause an error
+    # Now there are 2 versions of libelf installed for different archs, which should cause an error
     out = load("--sh", "libelf", fail_on_error=False)
     assert "matches multiple packages" in out
     assert "Use a more specific spec" in out

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1315,7 +1315,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --best-arch --only --list"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1315,7 +1315,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --best-arch --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --best --only --list"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -663,7 +663,7 @@ _spack_buildcache_rebuild_index() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --best --first"
     else
         _all_packages
     fi
@@ -985,7 +985,7 @@ _spack_develop() {
 _spack_diff() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --json --first -a --attribute"
+        SPACK_COMPREPLY="-h --help --json -a --attribute --best --first"
     else
         _all_packages
     fi
@@ -1315,7 +1315,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --best --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --best --first --only --list"
     else
         _installed_packages
     fi
@@ -1324,7 +1324,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --best --first"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -867,7 +867,7 @@ complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k 
 complete -c spack -n '__fish_spack_using_command buildcache rebuild-index' -s k -l keys -d 'if provided, key index will be updated as well as package index'
 
 # spack cd
-set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages source-dir b/build-dir e/env= best
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 cd' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -d 'show this help message and exit'
@@ -891,8 +891,8 @@ complete -c spack -n '__fish_spack_using_command cd' -s b -l build-dir -f -a bui
 complete -c spack -n '__fish_spack_using_command cd' -s b -l build-dir -d 'build directory for a spec (requires it to be staged first)'
 complete -c spack -n '__fish_spack_using_command cd' -s e -l env -r -f -a location_env
 complete -c spack -n '__fish_spack_using_command cd' -s e -l env -r -d 'location of the named or current environment'
-complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
-complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
+complete -c spack -n '__fish_spack_using_command cd' -l best -l first -f -a best
+complete -c spack -n '__fish_spack_using_command cd' -l best -l first -d 'choose \'best\' of multiple matches by arch, version, etc.'
 
 # spack change
 set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all
@@ -1387,16 +1387,16 @@ complete -c spack -n '__fish_spack_using_command develop' -s f -l force -r -f -a
 complete -c spack -n '__fish_spack_using_command develop' -s f -l force -r -d 'remove any files or directories that block cloning source code'
 
 # spack diff
-set -g __fish_spack_optspecs_spack_diff h/help json first a/attribute=
+set -g __fish_spack_optspecs_spack_diff h/help json a/attribute= best
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 diff' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command diff' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command diff' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command diff' -l json -f -a dump_json
 complete -c spack -n '__fish_spack_using_command diff' -l json -d 'dump json output instead of pretty printing'
-complete -c spack -n '__fish_spack_using_command diff' -l first -f -a load_first
-complete -c spack -n '__fish_spack_using_command diff' -l first -d 'load the first match if multiple packages match the spec'
 complete -c spack -n '__fish_spack_using_command diff' -s a -l attribute -r -f -a attribute
 complete -c spack -n '__fish_spack_using_command diff' -s a -l attribute -r -d 'select the attributes to show (defaults to all)'
+complete -c spack -n '__fish_spack_using_command diff' -l best -l first -f -a best
+complete -c spack -n '__fish_spack_using_command diff' -l best -l first -d 'choose \'best\' of multiple matches by arch, version, etc.'
 
 # spack docs
 set -g __fish_spack_optspecs_spack_docs h/help
@@ -2003,7 +2003,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first best only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh best only= list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -2017,17 +2017,15 @@ complete -c spack -n '__fish_spack_using_command load' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l bat -d 'print bat commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -d 'print pwsh commands to load the package'
-complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_best
-complete -c spack -n '__fish_spack_using_command load' -l first -d 'load the first match if multiple packages match the spec'
-complete -c spack -n '__fish_spack_using_command load' -l best -f -a load_best
-complete -c spack -n '__fish_spack_using_command load' -l best -d 'load the best match for the architecture if multiple packages match the spec'
+complete -c spack -n '__fish_spack_using_command load' -l best -l first -f -a best
+complete -c spack -n '__fish_spack_using_command load' -l best -l first -d 'choose \'best\' of multiple matches by arch, version, etc.'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -d 'select whether to load the package and its dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l list -f -a list
 complete -c spack -n '__fish_spack_using_command load' -l list -d 'show loaded packages: same as `spack find --loaded`'
 
 # spack location
-set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir P/packages s/stage-dir S/stages source-dir b/build-dir e/env= best
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 location' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -d 'show this help message and exit'
@@ -2051,8 +2049,8 @@ complete -c spack -n '__fish_spack_using_command location' -s b -l build-dir -f 
 complete -c spack -n '__fish_spack_using_command location' -s b -l build-dir -d 'build directory for a spec (requires it to be staged first)'
 complete -c spack -n '__fish_spack_using_command location' -s e -l env -r -f -a location_env
 complete -c spack -n '__fish_spack_using_command location' -s e -l env -r -d 'location of the named or current environment'
-complete -c spack -n '__fish_spack_using_command location' -l first -f -a find_first
-complete -c spack -n '__fish_spack_using_command location' -l first -d 'use the first match if multiple packages match the spec'
+complete -c spack -n '__fish_spack_using_command location' -l best -l first -f -a best
+complete -c spack -n '__fish_spack_using_command location' -l best -l first -d 'choose \'best\' of multiple matches by arch, version, etc.'
 
 # spack log-parse
 set -g __fish_spack_optspecs_spack_log_parse h/help show= c/context= p/profile w/width= j/jobs=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2003,7 +2003,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first best-arch only= list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -2019,6 +2019,8 @@ complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -d 'print pwsh commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_first
 complete -c spack -n '__fish_spack_using_command load' -l first -d 'load the first match if multiple packages match the spec'
+complete -c spack -n '__fish_spack_using_command load' -l best-arch -f -a load_best
+complete -c spack -n '__fish_spack_using_command load' -l best-arch -d 'load the best match for the architecture if multiple packages match the spec'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -d 'select whether to load the package and its dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l list -f -a list

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2003,7 +2003,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first best-arch only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first best only= list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -2017,10 +2017,10 @@ complete -c spack -n '__fish_spack_using_command load' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l bat -d 'print bat commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -d 'print pwsh commands to load the package'
-complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_first
+complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_best
 complete -c spack -n '__fish_spack_using_command load' -l first -d 'load the first match if multiple packages match the spec'
-complete -c spack -n '__fish_spack_using_command load' -l best-arch -f -a load_best
-complete -c spack -n '__fish_spack_using_command load' -l best-arch -d 'load the best match for the architecture if multiple packages match the spec'
+complete -c spack -n '__fish_spack_using_command load' -l best -f -a load_best
+complete -c spack -n '__fish_spack_using_command load' -l best -d 'load the best match for the architecture if multiple packages match the spec'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -d 'select whether to load the package and its dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l list -f -a list


### PR DESCRIPTION
Implements an option to load a spack spec that best matches the current platform's architecture.

When a package has been installed for more than a single architecture, a simple `spack load ...` will fail.
```
$ spack load libelf
==> Error: libelf matches multiple packages.
  Matching packages:
    bcuy2dh libelf@0.8.13%gcc@12.2.0 arch=linux-amzn2-skylake_avx512
    lkukxhw libelf@0.8.13%gcc@12.2.0 arch=linux-amzn2-zen2
  Use a more specific spec (e.g., prepend '/' to the hash).
```

Using the `--best-arch` parameter will instead select the spec that best matches the platform's architecture, in a way that is also compatible in situations where the output of $(spack arch) is not available in the specs installed on the site. This may happen if Spack base compiler is not as recent as the architecture on the platform.

E.g:

```
$ spack load libelf
==> Error: libelf matches multiple packages.
  Matching packages:
    lea4cp6 libelf@0.8.13%gcc@7.3.1 arch=linux-amzn2-skylake_avx512
    v5covop libelf@0.8.13%gcc@7.3.1 arch=linux-amzn2-zen
  Use a more specific spec (e.g., prepend '/' to the hash).
$ spack load libelf arch=$(spack arch)
==> Error: Spec 'libelf arch=linux-amzn2-zen2' matches no installed packages.
```

When using `--best-arch` the `arch=linux-amzn2-zen` is correctly selected

```
$ spack load --best-arch libelf
```