### PR TITLE
e4s: add py-h5py ~mpi variant

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -126,7 +126,8 @@ spack:
   - plumed
   - precice
   - pumi
-  - py-h5py
+  - py-h5py +mpi
+  - py-h5py ~mpi
   - py-jupyterhub
   - py-libensemble +mpi +nlopt
   - py-petsc4py


### PR DESCRIPTION
E4S: build both `py-h5py +mpi` and `py-h5py ~mpi` per @ax3l

Follow up to:
* https://github.com/E4S-Project/e4s/issues/107#issuecomment-1387441296