### PR TITLE
Bring docs copyright up-to-date: 2021->2023

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -163,7 +163,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Spack"
-copyright = "2013-2021, Lawrence Livermore National Laboratory."
+copyright = "2013-2023, Lawrence Livermore National Laboratory."
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Looks like the ending year in Spack readthedocs is behind.  Updating from 2021 to 2023.