### PR TITLE
Fix string append in OpenCV package

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -929,10 +929,10 @@ class Opencv(CMakePackage, CudaPackage):
         ]
 
         if self.spec.satisfies("+contrib"):
-            args += self.define(
+            args.append(self.define(
                 "OPENCV_EXTRA_MODULES_PATH",
                 join_path(self.stage.source_path, "opencv_contrib", "modules"),
-            )
+            ))
 
         # OpenCV pre-built apps
         apps_list = []

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -929,10 +929,12 @@ class Opencv(CMakePackage, CudaPackage):
         ]
 
         if self.spec.satisfies("+contrib"):
-            args.append(self.define(
-                "OPENCV_EXTRA_MODULES_PATH",
-                join_path(self.stage.source_path, "opencv_contrib", "modules"),
-            ))
+            args.append(
+                self.define(
+                    "OPENCV_EXTRA_MODULES_PATH",
+                    join_path(self.stage.source_path, "opencv_contrib", "modules"),
+                )
+            )
 
         # OpenCV pre-built apps
         apps_list = []


### PR DESCRIPTION
The latest change to the OpenCV package made it so that the argument is added as a list of characters, rather than as a string. This PR fixes it.