### PR TITLE
depfile: `--make-target-prefix` -> `--make-prefix`

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1039,7 +1039,7 @@ gets installed and is available for use in the ``env`` target.
    	$(SPACK) -e . concretize -f
 
    env.mk: spack.lock
-   	$(SPACK) -e . env depfile -o $@ --make-target-prefix spack
+   	$(SPACK) -e . env depfile -o $@ --make-prefix spack
 
    env: spack/env
    	$(info Environment installed!)
@@ -1062,9 +1062,9 @@ the include is conditional.
 .. note::
 
    When including generated ``Makefile``\s, it is important to use
-   the ``--make-target-prefix`` flag and use the non-phony target
-   ``<target-prefix>/env`` as prerequisite, instead of the phony target
-   ``<target-prefix>/all``.
+   the ``--make-prefix`` flag and use the non-phony target
+   ``<prefix>/env`` as prerequisite, instead of the phony target
+   ``<prefix>/all``.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Building a subset of the environment
@@ -1105,7 +1105,7 @@ associated ``Makefile`` with a prefix ``example``:
 
 .. code:: console
 
-   $ spack env depfile -o env.mk --make-target-prefix example
+   $ spack env depfile -o env.mk --make-prefix example
 
 And we now include it in a different ``Makefile``, in which we create a target
 ``example/push/%`` with ``%`` referring to a package identifier. This target

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3115,7 +3115,7 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
             "-o",
             makefile,
             "--make-disable-jobserver",
-            "--make-target-prefix=prefix",
+            "--make-prefix=prefix",
             *depfile_flags,
         )
 
@@ -3164,7 +3164,7 @@ def test_spack_package_ids_variable(tmpdir, mock_packages):
             "-G",
             "make",
             "--make-disable-jobserver",
-            "--make-target-prefix=example",
+            "--make-prefix=example",
             "-o",
             include_path,
         )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1004,7 +1004,7 @@ _spack_env_revert() {
 _spack_env_depfile() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --make-target-prefix --make-disable-jobserver --use-buildcache -o --output -G --generator"
+        SPACK_COMPREPLY="-h --help --make-prefix --make-target-prefix --make-disable-jobserver --use-buildcache -o --output -G --generator"
     else
         _all_packages
     fi


### PR DESCRIPTION
Since `SPACK_PACKAGE_IDS` is now also "namespaced" with `<prefix>`, it makes
more sense to call the flag `--make-prefix` and alias the old flag
`--make-target-prefix` to it.
