### PR TITLE
fms: add 32bit variant, add protections

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -46,7 +46,12 @@ class Fms(CMakePackage):
     version(
         "2019.01.03", sha256="60a5181e883e141f2fdd4a30c535a788d609bcbbbca4af7e1ec73f66f4e58dc0"
     )
-
+    
+    variant(
+        "32bit",
+        default=True,
+        description="Build a version of the library with default 32 bit reals",
+    )
     variant(
         "64bit",
         default=True,
@@ -80,6 +85,7 @@ class Fms(CMakePackage):
 
     def cmake_args(self):
         args = [
+            self.define_from_variant("32BIT"),
             self.define_from_variant("64BIT"),
             self.define_from_variant("GFS_PHYS"),
             self.define_from_variant("OPENMP"),

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -54,7 +54,7 @@ class Fms(CMakePackage):
     )
     variant(
         "64bit",
-        default=True,
+        default=False,
         description="Build a version of the library with default 64 bit reals",
     )
     variant("gfs_phys", default=True, description="Use GFS Physics")
@@ -84,6 +84,19 @@ class Fms(CMakePackage):
     depends_on("libyaml", when="+yaml")
 
     def cmake_args(self):
+        # If we are older than 2022.04, we allow only one of 32bit or 64bit
+        if self.spec.satisfies("@:2022.03"):
+            if "+32bit" in self.spec and "+64bit" in self.spec:
+                raise InstallError(
+                    "FMS 2022.03 and older can only build as either 32bit or 64bit, not both.  Please choose one."
+                )
+
+        # No matter the version, a user must choose at least one of 32bit or 64bit
+        if "+32bit" not in self.spec and "+64bit" not in self.spec:
+            raise InstallError(
+                "FMS requires at least one variant of 32bit or 64bit"
+            )
+
         args = [
             self.define_from_variant("32BIT"),
             self.define_from_variant("64BIT"),

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -88,7 +88,8 @@ class Fms(CMakePackage):
         if self.spec.satisfies("@:2022.03"):
             if "+32bit" in self.spec and "+64bit" in self.spec:
                 raise InstallError(
-                    "FMS 2022.03 and older can only build as either 32bit or 64bit, not both.  Please choose one."
+                    "FMS 2022.03 and older can only build as "
+                    "either 32bit or 64bit, not both. Please choose one."
                 )
 
         # No matter the version, a user must choose at least one of 32bit or 64bit

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -46,13 +46,13 @@ class Fms(CMakePackage):
 
     variant(
         "precision",
-        values=('32', '64'),
+        values=("32", "64"),
         description="Build a version of the library with default 32 or 64 bit reals or both",
-        default='64',
+        default="64",
         multi=True,
     )
     conflicts(
-        "precision=32,64", 
+        "precision=32,64",
         when="@:2022.03",
         msg="FMS versions prior to 2022.04 do not support both 32 and 64 bit precision",
     )

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -91,8 +91,8 @@ class Fms(CMakePackage):
             self.define_from_variant("WITH_YAML", "yaml"),
             self.define_from_variant("CONSTANTS"),
             self.define_from_variant("FPIC"),
-            "-D32BIT:BOOL={}".format("ON" if "precision=32" in self.spec else "OFF"),
-            "-D64BIT:BOOL={}".format("ON" if "precision=64" in self.spec else "OFF"),
+            self.define("32BIT", "precision=32" in self.spec),
+            self.define("64BIT", "precision=64" in self.spec),
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -93,9 +93,7 @@ class Fms(CMakePackage):
 
         # No matter the version, a user must choose at least one of 32bit or 64bit
         if "+32bit" not in self.spec and "+64bit" not in self.spec:
-            raise InstallError(
-                "FMS requires at least one variant of 32bit or 64bit"
-            )
+            raise InstallError("FMS requires at least one variant of 32bit or 64bit")
 
         args = [
             self.define_from_variant("32BIT"),

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -43,9 +43,6 @@ class Fms(CMakePackage):
     version(
         "2020.04.01", sha256="2c409242de7dea0cf29f8dbf7495698b6bcac1eeb5c4599a728bdea172ffe37c"
     )
-    version(
-        "2019.01.03", sha256="60a5181e883e141f2fdd4a30c535a788d609bcbbbca4af7e1ec73f66f4e58dc0"
-    )
 
     variant(
         "precision",

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -49,7 +49,7 @@ class Fms(CMakePackage):
 
     variant(
         "32bit",
-        default=False,
+        default=True,
         description="Build a version of the library with default 32 bit reals",
     )
     variant(

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -46,7 +46,7 @@ class Fms(CMakePackage):
     version(
         "2019.01.03", sha256="60a5181e883e141f2fdd4a30c535a788d609bcbbbca4af7e1ec73f66f4e58dc0"
     )
-    
+
     variant(
         "32bit",
         default=False,

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -48,7 +48,7 @@ class Fms(CMakePackage):
         "precision",
         values=("32", "64"),
         description="Build a version of the library with default 32 or 64 bit reals or both",
-        default="64",
+        default="32",
         multi=True,
     )
     conflicts(

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -49,7 +49,7 @@ class Fms(CMakePackage):
     
     variant(
         "32bit",
-        default=True,
+        default=False,
         description="Build a version of the library with default 32 bit reals",
     )
     variant(


### PR DESCRIPTION
The GEOS Earth System Model currently requires the 32-bit variant of FMS. This PR adds that variant so we can pursue moving to use Spack.