### PR TITLE
Adding rocm-opencl prefix lib path to LD_LIBRARY_PATH for run_environ…

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -235,6 +235,7 @@ class RocmOpencl(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib),
         env.set("OCL_ICD_VENDORS", self.prefix.vendors + "/")
 
     @run_after("install")


### PR DESCRIPTION
Prepend rocm-opencl prefix lib path in run environment for making OpenCL available at runtime. 