### PR TITLE
Add --exclude option to 'spack external find'

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -39,6 +39,11 @@ def setup_parser(subparser):
         help="packages with detected externals won't be built with Spack",
     )
     find_parser.add_argument(
+        "--exclude",
+        action="append",
+        help="packages to exclude from search",
+    )
+    find_parser.add_argument(
         "-p",
         "--path",
         default=None,
@@ -150,6 +155,10 @@ def external_find(args):
     # If the list of packages is empty, search for every possible package
     if not args.tags and not pkg_cls_to_check:
         pkg_cls_to_check = list(spack.repo.path.all_package_classes())
+
+    # If the user specified any packages to exclude from external find, add them here
+    if args.exclude:
+        pkg_cls_to_check = [pkg for pkg in pkg_cls_to_check if pkg.name not in args.exclude]
 
     detected_packages = spack.detection.by_executable(pkg_cls_to_check, path_hints=args.path)
     detected_packages.update(spack.detection.by_library(pkg_cls_to_check, path_hints=args.path))

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -162,6 +162,21 @@ def test_find_external_cmd_full_repo(
     assert {"spec": "find-externals1@1.foo", "prefix": prefix} in pkg_externals
 
 
+def test_find_external_cmd_exclude(
+    mutable_config, working_env, mock_executable, mutable_mock_repo, _platform_executables
+):
+    """Test invoking 'spack external find --all --exclude', to ensure arbitary
+    external packages can be ignored.
+    """
+    exe_path1 = mock_executable("find-externals1-exe", output="echo find-externals1 version 1.foo")
+    os.environ["PATH"] = os.pathsep.join([os.path.dirname(exe_path1)])
+    external("find", "--all", "--exclude=find-externals1")
+
+    pkgs_cfg = spack.config.get("packages")
+
+    assert "find-externals1" not in pkgs_cfg.keys()
+
+
 def test_find_external_no_manifest(
     mutable_config,
     working_env,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1031,7 +1031,7 @@ _spack_external() {
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --not-buildable -p --path --scope --all -t --tag --exclude"
+        SPACK_COMPREPLY="-h --help --not-buildable --exclude -p --path --scope --all -t --tag"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1031,7 +1031,7 @@ _spack_external() {
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --not-buildable -p --path --scope --all -t --tag"
+        SPACK_COMPREPLY="-h --help --not-buildable -p --path --scope --all -t --tag --exclude"
     else
         _all_packages
     fi


### PR DESCRIPTION
This PR adds an --exclude option to `spack external find` that allows users to ignore specific external packages by name. Thanks to @tgamblin for the main logic.