### PR TITLE
spack env view enable --link all/run/roots

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -424,6 +424,12 @@ def env_view_setup_parser(subparser):
     subparser.add_argument(
         "view_path", nargs="?", help="when enabling a view, optionally set the path manually"
     )
+    subparser.add_argument(
+        "--link",
+        choices=("all", "run", "roots"),
+        default="all",
+        help="when enabling a view, optionally specify the link type",
+    )
 
 
 def env_view(args):
@@ -437,7 +443,7 @@ def env_view(args):
                 view_path = args.view_path
             else:
                 view_path = env.view_path_default
-            env.update_default_view(view_path)
+            env.update_default_view(view_path, args.link)
             env.write()
         elif args.action == ViewAction.disable:
             env.update_default_view(None)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1494,7 +1494,7 @@ class Environment(object):
 
         return self.views[default_view_name]
 
-    def update_default_view(self, viewpath):
+    def update_default_view(self, viewpath, link):
         name = default_view_name
         if name in self.views and self.default_view.root != viewpath:
             shutil.rmtree(self.default_view.root)
@@ -1502,8 +1502,9 @@ class Environment(object):
         if viewpath:
             if name in self.views:
                 self.default_view.root = viewpath
+                self.default_view.link = link
             else:
-                self.views[name] = ViewDescriptor(self.path, viewpath)
+                self.views[name] = ViewDescriptor(self.path, root=viewpath, link=link)
         else:
             self.views.pop(name, None)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -977,7 +977,7 @@ _spack_env_loads() {
 _spack_env_view() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --link"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
views are expensive on the filesystem, so let's make it convenient to
link a subset.

Not added tests cause I expect people don't appreciate the interface, but...
the interface is generally awkward in how we dispatch on the action; it should
be another subcommand really

