### PR TITLE
Add type hints to DependencySpec

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -233,7 +233,7 @@ def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
     dep.concretize()
     # mark compiler as depended-on by the packages that use it
     for pkg in pkgs:
-        dep._dependents.add(spack.spec.DependencySpec(pkg.spec, dep, ("build",)))
+        dep._dependents.add(spack.spec.DependencySpec(pkg.spec, dep, deptypes=("build",)))
     packages = [(s.package, False) for s in dep.traverse(order="post", root=False)]
 
     packages.append((dep.package, True))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -56,6 +56,7 @@ import os
 import re
 import sys
 import warnings
+from typing import Tuple
 
 import ruamel.yaml as yaml
 
@@ -653,7 +654,7 @@ class CompilerSpec(object):
 
 
 @lang.lazy_lexicographic_ordering
-class DependencySpec(object):
+class DependencySpec:
     """DependencySpecs connect two nodes in the DAG, and contain deptypes.
 
     Dependencies can be one (or more) of several types:
@@ -670,12 +671,12 @@ class DependencySpec(object):
 
     __slots__ = "parent", "spec", "deptypes"
 
-    def __init__(self, parent, spec, deptypes):
+    def __init__(self, parent: "Spec", spec: "Spec", deptypes: dp.DependencyArgument):
         self.parent = parent
         self.spec = spec
         self.deptypes = dp.canonical_deptype(deptypes)
 
-    def update_deptypes(self, deptypes):
+    def update_deptypes(self, deptypes: dp.DependencyArgument) -> bool:
         deptypes = set(deptypes)
         deptypes.update(self.deptypes)
         deptypes = tuple(sorted(deptypes))
@@ -684,10 +685,10 @@ class DependencySpec(object):
         self.deptypes = deptypes
         return changed
 
-    def copy(self):
+    def copy(self) -> "DependencySpec":
         return DependencySpec(self.parent, self.spec, self.deptypes)
 
-    def add_type(self, type):
+    def add_type(self, type: dp.DependencyArgument):
         self.deptypes = dp.canonical_deptype(self.deptypes + dp.canonical_deptype(type))
 
     def _cmp_iter(self):
@@ -695,17 +696,17 @@ class DependencySpec(object):
         yield self.spec.name if self.spec else None
         yield self.deptypes
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s %s--> %s" % (
             self.parent.name if self.parent else None,
             self.deptypes,
             self.spec.name if self.spec else None,
         )
 
-    def canonical(self):
+    def canonical(self) -> Tuple[str, str, Tuple[str, ...]]:
         return self.parent.dag_hash(), self.spec.dag_hash(), self.deptypes
 
-    def flip(self):
+    def flip(self) -> "DependencySpec":
         return DependencySpec(parent=self.spec, spec=self.parent, deptypes=self.deptypes)
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -655,7 +655,8 @@ class CompilerSpec(object):
 
 @lang.lazy_lexicographic_ordering
 class DependencySpec:
-    """DependencySpecs connect two nodes in the DAG, and contain deptypes.
+    """DependencySpecs represent an edge in the DAG, and contain dependency types
+    and information on the virtuals being provided.
 
     Dependencies can be one (or more) of several types:
 
@@ -663,15 +664,15 @@ class DependencySpec:
     - link: is linked to and added to compiler flags.
     - run: needs to be in the PATH for the package to run.
 
-    Fields:
-    - spec: Spec depended on by parent.
-    - parent: Spec that depends on `spec`.
-    - deptypes: list of strings, representing dependency relationships.
+    Args:
+        parent: starting node of the edge
+        spec: ending node of the edge.
+        deptypes: list of strings, representing dependency relationships.
     """
 
     __slots__ = "parent", "spec", "deptypes"
 
-    def __init__(self, parent: "Spec", spec: "Spec", deptypes: dp.DependencyArgument):
+    def __init__(self, parent: "Spec", spec: "Spec", *, deptypes: dp.DependencyArgument):
         self.parent = parent
         self.spec = spec
         self.deptypes = dp.canonical_deptype(deptypes)
@@ -686,7 +687,7 @@ class DependencySpec:
         return changed
 
     def copy(self) -> "DependencySpec":
-        return DependencySpec(self.parent, self.spec, self.deptypes)
+        return DependencySpec(self.parent, self.spec, deptypes=self.deptypes)
 
     def add_type(self, type: dp.DependencyArgument):
         self.deptypes = dp.canonical_deptype(self.deptypes + dp.canonical_deptype(type))
@@ -1576,7 +1577,7 @@ class Spec(object):
                 edge.add_type(deptype)
                 return
 
-        edge = DependencySpec(self, dependency_spec, deptype)
+        edge = DependencySpec(self, dependency_spec, deptypes=deptype)
         self._dependencies.add(edge)
         dependency_spec._dependents.add(edge)
 


### PR DESCRIPTION
Extracted from #34821

Modifications:
- [x] Add type-hints to `DependencySpec`
- [x] Make `deptypes=` argument keyword only