### PR TITLE
e4s: ecp-data-vis-sdk +rocm: remove redundant amdgpu_target specify

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -199,7 +199,7 @@ spack:
   - cabana +rocm
   - caliper +rocm
   - chai ~benchmarks +rocm
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a 
+  - ecp-data-vis-sdk +paraview +vtkm +rocm
   - gasnet +rocm
   - ginkgo +rocm
   - heffte +rocm


### PR DESCRIPTION
E4S: remove redundant `amdgpu_target` specification (this is already captured at `packages:` level)

@wspear