### PR TITLE
feature: compiler as deps

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -46,7 +46,7 @@ jobs:
           spack bootstrap disable github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   ubuntu-clingo-sources:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
           spack bootstrap disable github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   ubuntu-clingo-binaries-and-patchelf:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
         run: |
           source share/spack/setup-env.sh
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   opensuse-clingo-sources:
     runs-on: ubuntu-latest
@@ -149,7 +149,7 @@ jobs:
           spack bootstrap disable github-actions-v0.3
           spack external find cmake bison
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   macos-clingo-sources:
     runs-on: macos-latest
@@ -167,7 +167,7 @@ jobs:
           spack bootstrap disable github-actions-v0.3
           spack external find --not-buildable cmake bison
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   macos-clingo-binaries:
     runs-on: ${{ matrix.macos-version }}
@@ -267,7 +267,7 @@ jobs:
           source share/spack/setup-env.sh
           spack bootstrap disable spack-install
           spack -d gpg list
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   ubuntu-gnupg-sources:
     runs-on: ubuntu-latest
@@ -305,7 +305,7 @@ jobs:
           spack bootstrap disable github-actions-v0.4
           spack bootstrap disable github-actions-v0.3
           spack -d gpg list
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   macos-gnupg-binaries:
     runs-on: macos-latest
@@ -322,7 +322,7 @@ jobs:
           source share/spack/setup-env.sh
           spack bootstrap disable spack-install
           spack -d gpg list
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
   macos-gnupg-sources:
     runs-on: macos-latest
@@ -341,7 +341,7 @@ jobs:
           spack bootstrap disable github-actions-v0.4
           spack bootstrap disable github-actions-v0.3
           spack -d gpg list
-          tree ~/.spack/bootstrap/store/
+          tree ~/.spack-compilers-as-deps/bootstrap/store/
 
 
 # [1] Distros that have patched git to resolve CVE-2022-24765 (e.g. Ubuntu patching v2.25.1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - releases/**
+      - features/compilers-as-deps
 
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -85,7 +85,9 @@ gpg_path = os.path.join(opt_path, "spack", "gpg")
 # setting `SPACK_USER_CACHE_PATH`. Otherwise it defaults to ~/.spack.
 #
 def _get_user_cache_path():
-    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack" % os.sep)
+    return os.path.expanduser(
+        os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack-compilers-as-deps" % os.sep
+    )
 
 
 user_cache_path = _get_user_cache_path()
@@ -120,7 +122,9 @@ default_misc_cache_path = os.path.join(user_cache_path, "cache")
 
 # User configuration and caches in $HOME/.spack
 def _get_user_config_path():
-    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
+    return os.path.expanduser(
+        os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack-compilers-as-deps" % os.sep
+    )
 
 
 # Configuration in /etc/spack on the system

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1218,7 +1218,10 @@ def test_user_config_path_is_overridable(working_env):
 
 def test_user_config_path_is_default_when_env_var_is_empty(working_env):
     os.environ["SPACK_USER_CONFIG_PATH"] = ""
-    assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_config_path()
+    assert (
+        os.path.expanduser("~%s.spack-compilers-as-deps" % os.sep)
+        == spack.paths._get_user_config_path()
+    )
 
 
 def test_default_install_tree(monkeypatch):
@@ -1259,7 +1262,10 @@ def test_user_cache_path_is_overridable(working_env):
 
 def test_user_cache_path_is_default_when_env_var_is_empty(working_env):
     os.environ["SPACK_USER_CACHE_PATH"] = ""
-    assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_cache_path()
+    assert (
+        os.path.expanduser("~%s.spack-compilers-as-deps" % os.sep)
+        == spack.paths._get_user_cache_path()
+    )
 
 
 github_url = "https://github.com/fake/fake/{0}/develop"


### PR DESCRIPTION
This currently only contains a commit that guards against mixing the `develop` database & user cache, so it's a bit more convenient.

```
$ cd spack
$ git fetch [upstream] features/compilers-as-deps
$ git worktree add ../spack-compilers-as-deps features/compilers-as-deps
```