### PR TITLE
Identify Windows support with tags

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1700,29 +1700,15 @@ If in the previous step, you did not have CMake or Ninja installed, running the 
 Windows Compatible Packages
 """""""""""""""""""""""""""
 
-Many Spack packages are not currently compatible with Windows, due to Unix
-dependencies or incompatible build tools like autoconf. Here are several
-packages known to work on Windows:
-
-* abseil-cpp
-* bzip2
-* clingo
-* cpuinfo
-* cmake
-* hdf5
-* glm
-* nasm
-* netlib-lapack (requires Intel Fortran)
-* ninja
-* openssl
-* perl
-* python
-* ruby
-* wrf
-* zlib
+Not all spack packages currently have Windows support. Some are inherently incompatible with the
+platform, and others simply have yet to be ported. To view the current set of packages with Windows
+support, the list command should be used via `spack list -t windows`. If there's a package you'd like
+to install on Windows but is not in that list, feel free to reach out to request the port or contribute
+the port yourself.
 
 .. note::
-   This is by no means a comprehensive list
+   This is by no means a comprehensive list, some packages may have ports that were not tagged
+   while others may just work out of the box on Windows and have not been tagged as such.
 
 ^^^^^^^^^^^^^^
 For developers
@@ -1734,3 +1720,4 @@ Instructions for creating the installer are at
 https://github.com/spack/spack/blob/develop/lib/spack/spack/cmd/installer/README.md
 
 Alternatively a pre-built copy of the Windows installer is available as an artifact of Spack's Windows CI
+available at each run of the CI on develop or any PR.

--- a/var/spack/repos/builtin.mock/packages/zlib/package.py
+++ b/var/spack/repos/builtin.mock/packages/zlib/package.py
@@ -17,6 +17,7 @@ class Zlib(Package):
     homepage = "http://zlib.net"
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://zlib.net/fossils/zlib-1.2.11.tar.gz"
+    tags = ["windows"]
 
     version("1.2.11", sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
     # Due to the bug fixes, any installations of 1.2.9 or 1.2.10 should be

--- a/var/spack/repos/builtin/packages/7zip/package.py
+++ b/var/spack/repos/builtin/packages/7zip/package.py
@@ -17,6 +17,7 @@ class _7zip(SourceforgePackage, Package):
 
     homepage = "https://sourceforge.net/projects/sevenzip"
     sourceforge_mirror_path = "sevenzip/files/7z2107-src.tar.xz"
+    tags = ["windows"]
 
     executables = ["7z"]
 

--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -13,6 +13,7 @@ class AbseilCpp(CMakePackage):
     url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"
 
     maintainers = ["jcftang"]
+    tags = ["windows"]
 
     version(
         "20220623.0", sha256="4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602"

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -20,6 +20,7 @@ class Bzip2(Package, SourcewarePackage):
     sourceware_mirror_path = "bzip2/bzip2-1.0.8.tar.gz"
 
     executables = [r"^bzip2$"]
+    tags = ["windows"]
 
     version("1.0.8", sha256="ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269")
     version("1.0.7", sha256="e768a87c5b1a79511499beb41500bcc4caf203726fff46a6f5f9ad27fe08ab2b")

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -22,7 +22,7 @@ class Clingo(CMakePackage):
     homepage = "https://potassco.org/clingo/"
     url = "https://github.com/potassco/clingo/archive/v5.2.2.tar.gz"
     git = "https://github.com/potassco/clingo.git"
-
+    tags = ["windows"]
     maintainers = ["tgamblin", "alalazo"]
 
     version("master", branch="master", submodules=True)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -23,7 +23,7 @@ class Cmake(Package):
     git = "https://gitlab.kitware.com/cmake/cmake.git"
     maintainers = ["chuckatkins"]
 
-    tags = ["build-tools"]
+    tags = ["build-tools", "windows"]
 
     executables = ["^cmake$"]
 

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -12,6 +12,7 @@ class Cpuinfo(CMakePackage):
 
     homepage = "https://github.com/pytorch/cpuinfo"
     git = "https://github.com/pytorch/cpuinfo.git"
+    tags = ["windows"]
 
     version("main", branch="main")
     version("2022-08-19", commit="8ec7bd91ad0470e61cf38f618cc1f270dede599c")  # py-torch@1.13

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -22,7 +22,7 @@ class Curl(NMakePackage, AutotoolsPackage):
     url = "http://curl.haxx.se/download/curl-7.78.0.tar.bz2"
 
     executables = ["^curl$"]
-    tags = ["build-tools"]
+    tags = ["build-tools", "windows"]
 
     version("7.85.0", sha256="21a7e83628ee96164ac2b36ff6bf99d467c7b0b621c1f7e317d8f0d96011539c")
     version("7.84.0", sha256="702fb26e73190a3bd77071aa146f507b9817cc4dfce218d2ab87f00cd3bc059d")

--- a/var/spack/repos/builtin/packages/glm/package.py
+++ b/var/spack/repos/builtin/packages/glm/package.py
@@ -14,6 +14,7 @@ class Glm(CMakePackage):
     homepage = "https://github.com/g-truc/glm"
     url = "https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz"
     git = "https://github.com/g-truc/glm.git"
+    tags = ["windows"]
 
     version("develop", branch="master")
     version("0.9.9.8", sha256="7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -32,7 +32,7 @@ class Hdf5(CMakePackage):
         "lkurz",
     ]
 
-    tags = ["e4s"]
+    tags = ["e4s", "windows"]
     executables = ["^h5cc$", "^h5pcc$"]
 
     test_requires_compiler = True

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -14,6 +14,7 @@ class Jsoncpp(CMakePackage):
 
     homepage = "https://github.com/open-source-parsers/jsoncpp"
     url = "https://github.com/open-source-parsers/jsoncpp/archive/1.7.3.tar.gz"
+    tags = ["windows"]
 
     version("1.9.4", sha256="e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999")
     version("1.9.3", sha256="8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d")

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -18,6 +18,7 @@ class Msmpi(Package):
     homepage = "https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi"
     url = "https://github.com/microsoft/Microsoft-MPI/archive/refs/tags/v10.1.1.tar.gz"
     git = "https://github.com/microsoft/Microsoft-MPI.git"
+    tags = ["windows"]
 
     executable = ["mpiexec"]
 

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -16,6 +16,7 @@ class Nasm(AutotoolsPackage):
     url = "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz"
     list_url = "https://www.nasm.us/pub/nasm/releasebuilds"
     list_depth = 1
+    tags = ["windows"]
 
     build_system("autotools", conditional("generic", when="platform=windows"), default="autotools")
 

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -17,6 +17,7 @@ class NetlibLapack(CMakePackage):
 
     homepage = "https://www.netlib.org/lapack/"
     url = "https://www.netlib.org/lapack/lapack-3.5.0.tgz"
+    tags = ["windows"]
 
     version(
         "3.10.1",

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -19,7 +19,7 @@ class Ninja(Package):
     url = "https://github.com/ninja-build/ninja/archive/v1.7.2.tar.gz"
     git = "https://github.com/ninja-build/ninja.git"
 
-    tags = ["build-tools", "e4s"]
+    tags = ["build-tools", "e4s", "windows"]
 
     executables = ["^ninja$"]
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -24,7 +24,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 
-    tags = ["core-packages"]
+    tags = ["core-packages", "windows"]
 
     executables = ["openssl"]
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -33,6 +33,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     homepage = "https://www.perl.org"
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://www.cpan.org/src/5.0/perl-5.34.0.tar.gz"
+    tags = ["windows"]
 
     executables = [r"^perl(-?\d+.*)?$"]
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -35,6 +35,7 @@ class Python(Package):
     url = "https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz"
     list_url = "https://www.python.org/ftp/python/"
     list_depth = 1
+    tags = ["windows"]
 
     maintainers = ["adamjstewart", "skosukhin", "scheibelp", "pradyunsg"]
 

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -15,6 +15,7 @@ class Re2c(Package):
 
     homepage = "https://re2c.org/index.html"
     url = "https://github.com/skvadrik/re2c/releases/download/1.2.1/re2c-1.2.1.tar.xz"
+    tags = ["windows"]
 
     version("2.2", sha256="0fc45e4130a8a555d68e230d1795de0216dfe99096b61b28e67c86dfd7d86bda")
     version("2.1.1", sha256="036ee264fafd5423141ebd628890775aa9447a4c4068a6307385d7366fe711f8")

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -20,6 +20,7 @@ class Ruby(AutotoolsPackage, NMakePackage):
     url = "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz"
     list_url = "https://cache.ruby-lang.org/pub/ruby/"
     list_depth = 1
+    tags = ["windows"]
 
     version("3.1.0", sha256="50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854")
     version("3.0.2", sha256="5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1")

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -15,7 +15,7 @@ class Scons(PythonPackage):
     homepage = "https://scons.org"
     pypi = "SCons/SCons-4.3.0.tar.gz"
 
-    tags = ["build-tools"]
+    tags = ["build-tools", "windows"]
 
     version("4.3.0", sha256="d47081587e3675cc168f1f54f0d74a69b328a2fc90ec4feb85f728677419b879")
     version("4.2.0", sha256="691893b63f38ad14295f5104661d55cb738ec6514421c6261323351c25432b0a")

--- a/var/spack/repos/builtin/packages/wgl/package.py
+++ b/var/spack/repos/builtin/packages/wgl/package.py
@@ -14,7 +14,7 @@ class Wgl(Package):
 
     homepage = "https://learn.microsoft.com/en-us/windows/win32/opengl/wgl-and-windows-reference"
     has_code = False
-
+    tags = ["windows"]
     # hard code the extension as shared lib
     libraries = ["OpenGL32.Lib"]
 

--- a/var/spack/repos/builtin/packages/win-sdk/package.py
+++ b/var/spack/repos/builtin/packages/win-sdk/package.py
@@ -19,6 +19,7 @@ class WinSdk(Package):
 
     homepage = "https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/"
     has_code = False
+    tags = ["windows"]
 
     # The sdk has many libraries and executables. Record one for detection purposes
     libraries = ["rcdll.dll"]

--- a/var/spack/repos/builtin/packages/win-wdk/package.py
+++ b/var/spack/repos/builtin/packages/win-wdk/package.py
@@ -18,6 +18,7 @@ class WinWdk(Package):
     """
 
     homepage = "https://learn.microsoft.com/en-us/windows-hardware/drivers/"
+    tags = ["windows"]
 
     # The wdk has many libraries and executables. Record one for detection purposes
     libraries = ["mmos.lib"]

--- a/var/spack/repos/builtin/packages/winbison/package.py
+++ b/var/spack/repos/builtin/packages/winbison/package.py
@@ -16,6 +16,7 @@ class Winbison(CMakePackage):
 
     homepage = "https://github.com/lexxmark/winflexbison#readme"
     url = "https://github.com/lexxmark/winflexbison/archive/v2.5.25.tar.gz"
+    tags = ["windows"]
 
     executables = [r"^bison(.*)?$"]
 

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -69,6 +69,7 @@ class Wrf(Package):
     homepage = "https://www.mmm.ucar.edu/weather-research-and-forecasting-model"
     url = "https://github.com/wrf-model/WRF/archive/v4.2.tar.gz"
     maintainers = ["MichaelLaufer", "ptooley"]
+    tags = ["windows"]
 
     version(
         "4.4",


### PR DESCRIPTION
Document which packages are supported on Windows via package 'tags' rather than a constantly out of date list in the docs.

I've tried to tag as many packages as I can recall that @jpopelar and myself have ported, however I likely missed a few so if anyone has more packages that should be tagged with `"windows"` feel free to commit to this branch or request the tag.