### PR TITLE
New bootstrap container for Rocky Linux

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -42,6 +42,7 @@ jobs:
         dockerfile: [[amazon-linux, 'linux/amd64,linux/arm64', 'amazonlinux:2'],
                      [centos7, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:7'],
                      [centos-stream, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:stream'],
+                     [rockylinux8, 'linux/amd64,linux/arm64', 'rockylinux:8'],
                      [leap15, 'linux/amd64,linux/arm64,linux/ppc64le', 'opensuse/leap:15'],
                      [ubuntu-bionic, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:18.04'],
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -26,6 +26,16 @@
         "develop": "latest"
       }
     },
+    "rockylinux:8": {
+      "bootstrap": {
+        "template": "container/rockylinux_8.dockerfile"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/rockylinux",
+      "build_tags": {
+        "develop": "latest"
+      }
+    },
     "centos:7": {
       "bootstrap": {
         "template": "container/centos_7.dockerfile"

--- a/share/spack/templates/container/rockylinux_8.dockerfile
+++ b/share/spack/templates/container/rockylinux_8.dockerfile
@@ -1,0 +1,29 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ # See https://fedoraproject.org/wiki/EPEL#Quickstart for powertools
+ && yum install -y dnf-plugins-core \
+ && dnf config-manager --set-enabled powertools \
+ && yum install -y epel-release \
+ && yum update -y \
+ && yum --enablerepo epel groupinstall -y "Development Tools" \
+ && yum --enablerepo epel install -y \
+        curl \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python38 \
+        python38-pip \
+        python38-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}


### PR DESCRIPTION
Adds support for Rocky Linux for `spack containerize`.

I think this is all that's needed, but I haven't tested the resultant image yet; marking draft until then.

I'd also like to get this working on Rocky Linux 9; but it wasn't quite as drop-in as 8, so I'm starting with this to make sure the process is at least correct, and to answer any questions that might come up. Let me know if there's anything I've missed.

# to do

* Confirm that the resultant rockylinux8 image is working
* Update documentation