### PR TITLE
Allocate more memory for generate jobs in all stacks

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -54,6 +54,7 @@ default:
     KUBERNETES_CPU_REQUEST: 4000m
     KUBERNETES_MEMORY_REQUEST: 16G
   interruptible: true
+  timeout: 60 minutes
   retry:
     max: 2
     when:

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -52,7 +52,7 @@ default:
   tags: ["spack", "aws", "public", "medium", "x86_64"]
   variables:
     KUBERNETES_CPU_REQUEST: 4000m
-    KUBERNETES_MEMORY_REQUEST: 8G
+    KUBERNETES_MEMORY_REQUEST: 16G
   interruptible: true
   retry:
     max: 2
@@ -289,14 +289,10 @@ protected-publish:
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 16G
 
 e4s-protected-generate:
   extends: [ ".e4s", ".protected-generate"]
   image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 16G
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]
@@ -784,8 +780,6 @@ tutorial-protected-build:
 .ml-linux-x86_64-cpu-generate:
   extends: [ .ml-linux-x86_64-cpu, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 16G
 
 ml-linux-x86_64-cpu-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-cpu-generate" ]
@@ -825,8 +819,6 @@ ml-linux-x86_64-cpu-protected-build:
 .ml-linux-x86_64-cuda-generate:
   extends: [ .ml-linux-x86_64-cuda, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 16G
 
 ml-linux-x86_64-cuda-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-cuda-generate" ]
@@ -866,8 +858,6 @@ ml-linux-x86_64-cuda-protected-build:
 .ml-linux-x86_64-rocm-generate:
   extends: [ .ml-linux-x86_64-rocm, ".tags-x86_64_v4" ]
   image: ghcr.io/spack/e4s-amazonlinux-2:v2022-03-21
-  variables:
-    KUBERNETES_MEMORY_REQUEST: 16G
 
 ml-linux-x86_64-rocm-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-rocm-generate" ]


### PR DESCRIPTION
Our hope is that this will eliminate the "timeout after 6 hours" errors that we've seen in the generate jobs of our GitLab CI pipelines.