### PR TITLE
Allow buildcache specs to be referenced by hash

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -419,7 +419,7 @@ class BinaryCacheIndex(object):
 
         self._write_local_index_cache()
 
-        if all_methods_failed:
+        if configured_mirror_urls and all_methods_failed:
             raise FetchCacheError(fetch_errors)
         if fetch_errors:
             tty.warn(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2408,6 +2408,10 @@ class BinaryCacheQuery(object):
         self.possible_specs = specs
 
     def __call__(self, spec, **kwargs):
+        """
+        Args:
+            spec (str): The spec being searched for in its string representation or hash.
+        """
         matches = []
         if spec.startswith("/"):
             # Matching a DAG hash

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1118,9 +1118,9 @@ class Environment:
             raise SpackEnvironmentError(f"No list {list_name} exists in environment {self.name}")
 
         if list_name == user_speclist_name:
-            if not spec.name:
+            if spec.anonymous:
                 raise SpackEnvironmentError("cannot add anonymous specs to an environment")
-            elif not spack.repo.path.exists(spec.name):
+            elif not spack.repo.path.exists(spec.name) and not spec.abstract_hash:
                 virtuals = spack.repo.path.provider_index.providers.keys()
                 if spec.name not in virtuals:
                     msg = "no such package: %s" % spec.name

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -519,6 +519,11 @@ def parse_one_or_raise(
             message += color.colorize(f"@*r{{{underline}}}")
         raise ValueError(message)
 
+    if result is None:
+        message = "a single spec was requested, but none was parsed:"
+        message += f"\n{text}"
+        raise ValueError(message)
+
     return result
 
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -309,7 +309,7 @@ class SpecNodeParser:
         self.has_version = False
         self.has_hash = False
 
-    def parse(self, initial_spec: Optional[spack.spec.Spec] = None) -> spack.spec.Spec:
+    def parse(self, initial_spec: Optional[spack.spec.Spec] = None) -> Optional[spack.spec.Spec]:
         """Parse a single spec node from a stream of tokens
 
         Args:

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -399,6 +399,9 @@ class SpecNodeParser:
                 if not matches:
                     matches = spack.store.db.get_by_hash(dag_hash)
                 if not matches:
+                    query = spack.binary_distribution.BinaryCacheQuery(True)
+                    matches = query(self.ctx.current_token.value)
+                if not matches:
                     raise spack.spec.NoSuchHashError(dag_hash)
 
                 if len(matches) != 1:

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -258,7 +258,7 @@ class SpecParser:
         return list(filter(lambda x: x.kind != TokenType.WS, tokenize(self.literal_str)))
 
     def next_spec(
-            self, initial_spec: Optional[spack.spec.Spec] = None
+        self, initial_spec: Optional[spack.spec.Spec] = None
     ) -> Optional[spack.spec.Spec]:
         """Return the next spec parsed from text.
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -391,14 +391,11 @@ class SpecNodeParser:
                 initial_spec._add_flag(name, value, propagate=True)
             elif not self.has_hash and self.ctx.accept(TokenType.DAG_HASH):
                 initial_spec.abstract_hash = self.ctx.current_token.value[1:]
-                print("found abstract hash: setting {}".format(self.ctx.current_token.value[1:]))
                 self.has_hash = True
             else:
                 break
         if self.has_hash:
             print("final parsed abstract hash is {}".format(initial_spec.abstract_hash))
-            print("final parsed spec is {}".format(initial_spec))
-            print("type of parsed spec is {}".format(type(initial_spec)))
 
         return initial_spec
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -389,7 +389,12 @@ class SpecNodeParser:
                 name = name.strip("'\" ")
                 value = value.strip("'\" ")
                 initial_spec._add_flag(name, value, propagate=True)
-            elif not self.has_hash and self.ctx.accept(TokenType.DAG_HASH):
+            elif self.ctx.accept(TokenType.DAG_HASH):
+                if initial_spec.abstract_hash:
+                    msg = (f"Parsed multiple hashes /{initial_spec.abstract_hash}and "
+                           "/{self.current_token}. If you were attempting to specify a file path,"
+                           " check that it was formatted properly")
+                    raise spack.spec.RedundantSpecError(msg, self.ctx.current_token.value)
                 initial_spec.abstract_hash = self.ctx.current_token.value[1:]
                 self.has_hash = True
             else:

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -275,7 +275,7 @@ class SpecParser:
                     raise spack.spec.RedundantSpecError(root_spec, self.ctx.current_token)
                 dependency = SpecNodeParser(self.ctx).parse(spack.spec.Spec())
 
-                if dependency == spack.spec.Spec():
+                if not dependency.abstract_hash and dependency == spack.spec.Spec():
                     msg = (
                         "this dependency sigil needs to be followed by a package name "
                         "or a node attribute (version, variant, etc.)"

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -392,7 +392,7 @@ class SpecNodeParser:
             elif self.ctx.accept(TokenType.DAG_HASH):
                 if initial_spec.abstract_hash:
                     msg = (
-                        f"Parsed multiple hashes /{initial_spec.abstract_hash}and "
+                        f"Parsed multiple hashes /{initial_spec.abstract_hash} and "
                         "/{self.current_token}. If you were attempting to specify a file path,"
                         " check that it was formatted properly"
                     )

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -391,9 +391,11 @@ class SpecNodeParser:
                 initial_spec._add_flag(name, value, propagate=True)
             elif self.ctx.accept(TokenType.DAG_HASH):
                 if initial_spec.abstract_hash:
-                    msg = (f"Parsed multiple hashes /{initial_spec.abstract_hash}and "
-                           "/{self.current_token}. If you were attempting to specify a file path,"
-                           " check that it was formatted properly")
+                    msg = (
+                        f"Parsed multiple hashes /{initial_spec.abstract_hash}and "
+                        "/{self.current_token}. If you were attempting to specify a file path,"
+                        " check that it was formatted properly"
+                    )
                     raise spack.spec.RedundantSpecError(msg, self.ctx.current_token.value)
                 initial_spec.abstract_hash = self.ctx.current_token.value[1:]
                 self.has_hash = True

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -279,8 +279,6 @@ class SpecParser:
         root_spec = SpecNodeParser(self.ctx).parse(initial_spec)
         while True:
             if self.ctx.accept(TokenType.DEPENDENCY):
-                if root_spec.abstract_hash:
-                    raise spack.spec.RedundantSpecError(root_spec, self.ctx.current_token)
                 dependency = SpecNodeParser(self.ctx).parse()
 
                 if dependency is None:
@@ -403,24 +401,11 @@ class SpecNodeParser:
                 name = name.strip("'\" ")
                 value = value.strip("'\" ")
                 initial_spec._add_flag(name, value, propagate=True)
-            elif self.ctx.accept(TokenType.DAG_HASH):
-                # if initial_spec.abstract_hash:
-                #     msg = (
-                #         f"Parsed multiple hashes /{initial_spec.abstract_hash} and "
-                #         "/{self.current_token}. If you were attempting to specify a file path,"
-                #         " check that it was formatted properly"
-                #     )
-                #     raise spack.spec.RedundantSpecError(msg, self.ctx.current_token.value)
+            elif self.ctx.expect(TokenType.DAG_HASH):
+                if initial_spec.abstract_hash:
+                    break
+                self.ctx.accept(TokenType.DAG_HASH)
                 initial_spec.abstract_hash = self.ctx.current_token.value[1:]
-                if self.ctx.next_token and not self.ctx.expect(
-                    TokenType.UNQUALIFIED_PACKAGE_NAME,
-                    TokenType.FULLY_QUALIFIED_PACKAGE_NAME,
-                    TokenType.DAG_HASH,
-                    TokenType.FILENAME,
-                    TokenType.DEPENDENCY,
-                ):
-                    raise spack.spec.RedundantSpecError(initial_spec, self.ctx.next_token)
-                break
             else:
                 break
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -394,8 +394,6 @@ class SpecNodeParser:
                 self.has_hash = True
             else:
                 break
-        if self.has_hash:
-            print("final parsed abstract hash is {}".format(initial_spec.abstract_hash))
 
         return initial_spec
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -269,6 +269,9 @@ class SpecParser:
         Return
             The spec that was parsed
         """
+        if not self.ctx.next_token:
+            return None
+
         initial_spec = initial_spec or spack.spec.Spec()
         root_spec = SpecNodeParser(self.ctx).parse(initial_spec)
         while True:
@@ -296,7 +299,7 @@ class SpecParser:
 
     def all_specs(self) -> List[spack.spec.Spec]:
         """Return all the specs that remain to be parsed"""
-        return list(iter(self.next_spec, spack.spec.Spec()))
+        return list(iter(self.next_spec, None))
 
 
 class SpecNodeParser:

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -267,15 +267,16 @@ class SpecParser:
         Return
             The spec that was parsed
         """
-        initial_spec = initial_spec or spack.spec.Spec()
         root_spec = SpecNodeParser(self.ctx).parse(initial_spec)
         while True:
             if self.ctx.accept(TokenType.DEPENDENCY):
+                if root_spec is None:
+                    root_spec = spack.spec.Spec()
+
                 if root_spec.abstract_hash:
                     raise spack.spec.RedundantSpecError(root_spec, self.ctx.current_token)
-                dependency = SpecNodeParser(self.ctx).parse(spack.spec.Spec())
-
-                if not dependency.abstract_hash and dependency == spack.spec.Spec():
+                dependency = SpecNodeParser(self.ctx).parse()
+                if not dependency:
                     msg = (
                         "this dependency sigil needs to be followed by a package name "
                         "or a node attribute (version, variant, etc.)"
@@ -294,7 +295,7 @@ class SpecParser:
 
     def all_specs(self) -> List[spack.spec.Spec]:
         """Return all the specs that remain to be parsed"""
-        return list(iter(self.next_spec, spack.spec.Spec()))
+        return list(iter(self.next_spec, None))
 
 
 class SpecNodeParser:
@@ -308,7 +309,7 @@ class SpecNodeParser:
         self.has_version = False
         self.has_hash = False
 
-    def parse(self, initial_spec: spack.spec.Spec) -> spack.spec.Spec:
+    def parse(self, initial_spec: Optional[spack.spec.Spec] = None) -> spack.spec.Spec:
         """Parse a single spec node from a stream of tokens
 
         Args:
@@ -321,18 +322,27 @@ class SpecNodeParser:
         # If we start with a package name we have a named spec, we cannot
         # accept another package name afterwards in a node
         if self.ctx.accept(TokenType.UNQUALIFIED_PACKAGE_NAME):
+            if initial_spec is None:
+                initial_spec = spack.spec.Spec()
             initial_spec.name = self.ctx.current_token.value
         elif self.ctx.accept(TokenType.FULLY_QUALIFIED_PACKAGE_NAME):
+            if initial_spec is None:
+                initial_spec = spack.spec.Spec()
             parts = self.ctx.current_token.value.split(".")
             name = parts[-1]
             namespace = ".".join(parts[:-1])
             initial_spec.name = name
             initial_spec.namespace = namespace
         elif self.ctx.accept(TokenType.FILENAME):
+            if initial_spec is None:
+                initial_spec = spack.spec.Spec()
             return FileParser(self.ctx).parse(initial_spec)
 
         while True:
             if self.ctx.accept(TokenType.COMPILER):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 if self.has_compiler:
                     raise spack.spec.DuplicateCompilerSpecError(
@@ -343,6 +353,9 @@ class SpecNodeParser:
                 initial_spec.compiler = spack.spec.CompilerSpec(compiler_name.strip(), ":")
                 self.has_compiler = True
             elif self.ctx.accept(TokenType.COMPILER_AND_VERSION):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 if self.has_compiler:
                     raise spack.spec.DuplicateCompilerSpecError(
@@ -357,6 +370,9 @@ class SpecNodeParser:
             elif self.ctx.accept(TokenType.VERSION) or self.ctx.accept(
                 TokenType.VERSION_HASH_PAIR
             ):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 if self.has_version:
                     raise spack.spec.MultipleVersionError(
@@ -368,30 +384,45 @@ class SpecNodeParser:
                 initial_spec.attach_git_version_lookup()
                 self.has_version = True
             elif self.ctx.accept(TokenType.BOOL_VARIANT):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 variant_value = self.ctx.current_token.value[0] == "+"
                 initial_spec._add_flag(
                     self.ctx.current_token.value[1:].strip(), variant_value, propagate=False
                 )
             elif self.ctx.accept(TokenType.PROPAGATED_BOOL_VARIANT):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 variant_value = self.ctx.current_token.value[0:2] == "++"
                 initial_spec._add_flag(
                     self.ctx.current_token.value[2:].strip(), variant_value, propagate=True
                 )
             elif self.ctx.accept(TokenType.KEY_VALUE_PAIR):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 name, value = self.ctx.current_token.value.split("=", maxsplit=1)
                 name = name.strip("'\" ")
                 value = value.strip("'\" ")
                 initial_spec._add_flag(name, value, propagate=False)
             elif self.ctx.accept(TokenType.PROPAGATED_KEY_VALUE_PAIR):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 self.hash_not_parsed_or_raise(initial_spec, self.ctx.current_token.value)
                 name, value = self.ctx.current_token.value.split("==", maxsplit=1)
                 name = name.strip("'\" ")
                 value = value.strip("'\" ")
                 initial_spec._add_flag(name, value, propagate=True)
             elif self.ctx.accept(TokenType.DAG_HASH):
+                if initial_spec is None:
+                    initial_spec = spack.spec.Spec()
+
                 # if initial_spec.abstract_hash:
                 #     msg = (
                 #         f"Parsed multiple hashes /{initial_spec.abstract_hash} and "

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -257,7 +257,9 @@ class SpecParser:
         """
         return list(filter(lambda x: x.kind != TokenType.WS, tokenize(self.literal_str)))
 
-    def next_spec(self, initial_spec: Optional[spack.spec.Spec] = None) -> spack.spec.Spec:
+    def next_spec(
+            self, initial_spec: Optional[spack.spec.Spec] = None
+    ) -> Optional[spack.spec.Spec]:
         """Return the next spec parsed from text.
 
         Args:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1854,7 +1854,7 @@ class Spec(object):
         """Given a spec with an abstract hash, return a copy of the spec with all properties and
         dependencies by looking up the hash in the environment, store, or finally, binary caches.
         This is non-destructive."""
-        if self.concrete:
+        if self.concrete or not any(node.abstract_hash for node in self.traverse()):
             return self
 
         spec = self.copy(deps=False)
@@ -1881,7 +1881,7 @@ class Spec(object):
         # reattach nodes that were not otherwise satisfied by new dependencies
         for node in self.traverse(root=False):
             if not any(n._satisfies(node) for n in spec.traverse()):
-                spec._add_dependency(node, deptypes=())
+                spec._add_dependency(node.copy(), deptypes=())
 
         return spec
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3600,15 +3600,6 @@ class Spec(object):
         return Spec(spec_like)
 
     def intersects(self, other: "Spec", deps: bool = True) -> bool:
-
-        other = self._autospec(other)
-
-        lhs = self.lookup_hash() or self
-        rhs = other.lookup_hash() or other
-
-        return lhs._intersects(rhs, deps)
-
-    def _intersects(self, other: "Spec", deps: bool = True) -> bool:
         """Return True if there exists at least one concrete spec that matches both
         self and other, otherwise False.
 
@@ -3621,6 +3612,12 @@ class Spec(object):
         """
         other = self._autospec(other)
 
+        lhs = self.lookup_hash() or self
+        rhs = other.lookup_hash() or other
+
+        return lhs._intersects(rhs, deps)
+
+    def _intersects(self, other: "Spec", deps: bool = True) -> bool:
         if other.concrete and self.concrete:
             return self.dag_hash() == other.dag_hash()
 
@@ -3687,6 +3684,9 @@ class Spec(object):
             return True
 
     def satisfies(self, other, deps=True):
+        """
+        This checks constraints on common dependencies against each other.
+        """
         other = self._autospec(other)
 
         lhs = self.lookup_hash() or self
@@ -3695,10 +3695,6 @@ class Spec(object):
         return lhs._satisfies(rhs, deps=deps)
 
     def _intersects_dependencies(self, other):
-        """
-        This checks constraints on common dependencies against each other.
-        """
-        other = self._autospec(other)
 
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1894,7 +1894,6 @@ class Spec(object):
 
         spec_by_hash = self.lookup_hash()
 
-        # if spec_by_hash != self or not self.eq_dag(spec_by_hash):
         self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3600,6 +3600,15 @@ class Spec(object):
         return Spec(spec_like)
 
     def intersects(self, other: "Spec", deps: bool = True) -> bool:
+
+        other = self._autospec(other)
+
+        lhs = self.lookup_hash() or self
+        rhs = other.lookup_hash() or other
+
+        return lhs._intersects(rhs, deps)
+
+    def _intersects(self, other: "Spec", deps: bool = True) -> bool:
         """Return True if there exists at least one concrete spec that matches both
         self and other, otherwise False.
 
@@ -3677,13 +3686,13 @@ class Spec(object):
         else:
             return True
 
-    def satisfies(self, other, deps=True, strict=False):
+    def satisfies(self, other, deps=True):
         other = self._autospec(other)
 
         lhs = self.lookup_hash() or self
         rhs = other.lookup_hash() or other
 
-        return lhs._satisfies(rhs, deps=deps, strict=strict)
+        return lhs._satisfies(rhs, deps=deps)
 
     def _intersects_dependencies(self, other):
         """
@@ -3725,7 +3734,7 @@ class Spec(object):
 
         return True
 
-    def satisfies(self, other: "Spec", deps: bool = True) -> bool:
+    def _satisfies(self, other: "Spec", deps: bool = True) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
 
         Args:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3670,7 +3670,6 @@ class Spec(object):
             return True
 
     def satisfies(self, other, deps=True, strict=False):
-
         other = self._autospec(other)
 
         lhs = self.lookup_hash() or self

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3685,7 +3685,7 @@ class Spec(object):
 
         return lhs._satisfies(rhs, deps=deps, strict=strict)
 
-    def satisfies_dependencies(self, other, strict=False):
+    def _intersects_dependencies(self, other):
         """
         This checks constraints on common dependencies against each other.
         """

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1898,7 +1898,7 @@ class Spec(object):
         if not spec_by_hash._satisfies(self):
             raise InvalidHashError(self, spec_by_hash.abstract_hash)
 
-        if spec_by_hash != self:
+        if spec_by_hash != self or not self.eq_dag(spec_by_hash):
             self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):
@@ -2861,8 +2861,11 @@ class Spec(object):
 
         self.replace_hash()
 
-        if not self.name:
-            raise spack.error.SpecError("Spec has no name; cannot concretize an anonymous spec")
+        for node in self.traverse():
+            if not node.name:
+                raise spack.error.SpecError(
+                    f"Spec {node} has no name; cannot concretize an anonymous spec"
+                )
 
         if self._concrete:
             return

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3449,7 +3449,6 @@ class Spec(object):
                 self.abstract_hash = other.abstract_hash
             elif not self.abstract_hash.startswith(other.abstract_hash):
                 raise InvalidHashError(self, other.abstract_hash)
-        # other.lookup_hash()
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -147,7 +147,7 @@ _separators = "[\\%s]" % "\\".join(color_formats.keys())
 
 default_format = "{name}{@versions}"
 default_format += "{%compiler.name}{@compiler.versions}{compiler_flags}"
-default_format += "{variants}{arch=architecture}"
+default_format += "{variants}{arch=architecture}{/abstract_hash}"
 
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.
@@ -1617,6 +1617,10 @@ class Spec(object):
             if self.namespace
             else (self.name if self.name else "")
         )
+
+    @property
+    def anonymous(self):
+        return not self.name and not self.abstract_hash
 
     @property
     def root(self):
@@ -4250,7 +4254,7 @@ class Spec(object):
                 raise SpecFormatSigilError(sig, "versions", attribute)
             elif sig == "%" and attribute not in ("compiler", "compiler.name"):
                 raise SpecFormatSigilError(sig, "compilers", attribute)
-            elif sig == "/" and not re.match(r"hash(:\d+)?$", attribute):
+            elif sig == "/" and not re.match(r"(abstract_)?hash(:\d+)?$", attribute):
                 raise SpecFormatSigilError(sig, "DAG hashes", attribute)
             elif sig == " arch=" and attribute not in ("architecture", "arch"):
                 raise SpecFormatSigilError(sig, "the architecture", attribute)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3695,7 +3695,6 @@ class Spec(object):
         return lhs._satisfies(rhs, deps=deps)
 
     def _intersects_dependencies(self, other):
-
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other
             return True

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1860,7 +1860,7 @@ class Spec(object):
         if spec.abstract_hash:
             new = spec._lookup_hash()
             if not new._satisfies(self):
-                raise BaseException
+                raise InvalidHashError(spec, spec.abstract_hash)
             spec._dup(new)
             return spec
 
@@ -1869,7 +1869,7 @@ class Spec(object):
             if node.abstract_hash:
                 new = node._lookup_hash()  # do we need a defensive copy here?
                 if not new._satisfies(node):
-                    raise BaseException
+                    raise InvalidHashError(node, node.abstract_hash)
                 spec._add_dependency(new, deptypes=())
 
         # reattach nodes that were not otherwise satisfied by new dependencies
@@ -1897,7 +1897,7 @@ class Spec(object):
 
         spec_by_hash = self.lookup_hash()
         if not spec_by_hash._satisfies(self):
-            raise spack.spec.InvalidHashError(self, spec_by_hash.dag_hash())  # abstract?
+            raise spack.spec.InvalidHashError(self, spec_by_hash.abstract_hash)
         self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1891,8 +1891,8 @@ class Spec(object):
 
         spec_by_hash = self.lookup_hash()
 
-        if spec_by_hash != self or not self.eq_dag(spec_by_hash):
-            self._dup(spec_by_hash)
+        # if spec_by_hash != self or not self.eq_dag(spec_by_hash):
+        self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
@@ -4101,6 +4101,7 @@ class Spec(object):
         yield self.compiler
         yield self.compiler_flags
         yield self.architecture
+        yield self.abstract_hash
 
         # this is not present on older specs
         yield getattr(self, "_package_hash", None)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1898,7 +1898,8 @@ class Spec(object):
         if not spec_by_hash._satisfies(self):
             raise InvalidHashError(self, spec_by_hash.abstract_hash)
 
-        self._dup(spec_by_hash)
+        if spec_by_hash != self:
+            self._dup(spec_by_hash)
 
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
@@ -3444,8 +3445,12 @@ class Spec(object):
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
-
-        other.lookup_hash()
+        if other.abstract_hash:
+            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
+                self.abstract_hash = other.abstract_hash
+            elif not self.abstract_hash.startswith(other.abstract_hash):
+                raise InvalidHashError(self, other.abstract_hash)
+        # other.lookup_hash()
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1557,7 +1557,7 @@ class Spec(object):
 
     def _add_dependency(self, spec: "Spec", *, deptypes: dp.DependencyArgument):
         """Called by the parser to add another spec as a dependency."""
-        if spec.name not in self._dependencies:
+        if spec.name not in self._dependencies or not spec.name:
             self.add_dependency_edge(spec, deptypes=deptypes)
             return
 
@@ -4350,7 +4350,7 @@ class Spec(object):
         return self.format(*args, **kwargs)
 
     def __str__(self):
-        sorted_nodes = [self] + sorted(self.traverse(root=False), key=lambda x: x.name)
+        sorted_nodes = [self] + sorted(self.traverse(root=False), key=lambda x: x.name or x.abstract_hash)
         spec_str = " ^".join(d.format() for d in sorted_nodes)
         return spec_str.strip()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1858,16 +1858,12 @@ class Spec(object):
             return self
 
         spec = self.copy(deps=False)
-
         # root spec is replaced
         if spec.abstract_hash:
             new = spec._lookup_hash()
             if not new._satisfies(self):
                 raise InvalidHashError(spec, spec.abstract_hash)
             spec._dup(new)
-            for dep in self.traverse():
-                if not any(node._satisfies(dep) for node in spec.traverse()):
-                    raise RedundantSpecError(self, self.abstract_hash)
             return spec
 
         # Get dependencies that need to be replaced
@@ -1894,9 +1890,6 @@ class Spec(object):
             return
 
         spec_by_hash = self.lookup_hash()
-
-        if not spec_by_hash._satisfies(self):
-            raise InvalidHashError(self, spec_by_hash.abstract_hash)
 
         if spec_by_hash != self or not self.eq_dag(spec_by_hash):
             self._dup(spec_by_hash)

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -88,7 +88,7 @@ def test_spec_parse_unquoted_flags_report():
     # Verify that the generated error message is nicely formatted.
     assert str(cm.value) == dedent(
         '''\
-    No installed spec matches the hash: 'usr'
+    No spec with hash usr could be found to match gcc cflags="-Os -I" ~other-arg-that-gets-ignored~pipe/usr. Either the hash does not exist, or it does not match other spec constraints.
 
     Some compiler or linker flags were provided without quoting their arguments,
     which now causes spack to try to parse the *next* argument as a spec component

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -86,10 +86,9 @@ def test_spec_parse_unquoted_flags_report():
         # cflags, we just explain how to fix it for the immediate next arg.
         spec("gcc cflags=-Os -pipe -other-arg-that-gets-ignored cflags=-I /usr/include")
     # Verify that the generated error message is nicely formatted.
-    assert str(cm.value) == dedent(
-        '''\
-    No spec with hash usr could be found to match gcc cflags="-Os -I" ~other-arg-that-gets-ignored~pipe/usr. Either the hash does not exist, or it does not match other spec constraints.
 
+    expected_message = dedent(
+        '''\
     Some compiler or linker flags were provided without quoting their arguments,
     which now causes spack to try to parse the *next* argument as a spec component
     such as a variant instead of an additional compiler or linker flag. If the
@@ -99,6 +98,8 @@ def test_spec_parse_unquoted_flags_report():
     (1) cflags=-Os -pipe => cflags="-Os -pipe"
     (2) cflags=-I /usr/include => cflags="-I /usr/include"'''
     )
+
+    assert expected_message in str(cm.value)
 
     # Verify that the same unquoted cflags report is generated in the error message even
     # if it fails during concretization, not just during parsing.

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -242,7 +242,9 @@ class TestSpecSemantics(object):
     def test_constrain_specs_by_hash(self, default_mock_concretization, database):
         """Test that Specs specified only by their hashes can constrain eachother."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
-        assert Spec(mpich_dag_hash[:7]).constrain(Spec(mpich_dag_hash)) is False
+        spec = Spec(mpich_dag_hash[:7])
+        assert spec.constrain(Spec(mpich_dag_hash)) is False
+        assert spec.abstract_hash == mpich_dag_hash[1:]
 
     def test_mismatched_constrain_spec_by_hash(self, default_mock_concretization, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
@@ -250,6 +252,7 @@ class TestSpecSemantics(object):
         rhs = "/" + database.query_one("callpath ^mpich2").dag_hash()
         with pytest.raises(spack.spec.InvalidHashError):
             Spec(lhs).constrain(Spec(rhs))
+        with pytest.raises(spack.spec.InvalidHashError):
             Spec(lhs[:7]).constrain(Spec(rhs))
 
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -239,6 +239,19 @@ class TestSpecSemantics(object):
         assert c1 == c2
         assert c1 == expected
 
+    def test_constrain_specs_by_hash(self, default_mock_concretization, database):
+        """Test that Specs specified only by their hashes can constrain eachother."""
+        mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
+        assert Spec(mpich_dag_hash[:7]).constrain(Spec(mpich_dag_hash)) is False
+
+    def test_mismatched_constrain_spec_by_hash(self, default_mock_concretization, database):
+        """Test that Specs specified only by their incompatible hashes fail appropriately."""
+        lhs = "/" + database.query_one("callpath ^mpich").dag_hash()
+        rhs = "/" + database.query_one("callpath ^mpich2").dag_hash()
+        with pytest.raises(spack.spec.InvalidHashError):
+            Spec(lhs).constrain(Spec(rhs))
+            Spec(lhs[:7]).constrain(Spec(rhs))
+
     @pytest.mark.parametrize(
         "lhs,rhs", [("libelf", Spec()), ("libelf", "@0:1"), ("libelf", "@0:1 %gcc")]
     )

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -629,12 +629,12 @@ def test_spec_by_hash_tokens(text, tokens):
     parser = SpecParser(text)
     assert parser.tokens() == tokens
 
-
 @pytest.mark.db
-def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
+def test_spec_by_hash(database, config):
     mpileaks = database.query_one("mpileaks ^zmpi")
     a = spack.spec.Spec("a").concretized()
-    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
+    monkeypatch.setattr(spack.binary_distribution,
+                        "update_cache_and_get_specs", lambda: a)
 
     hash_str = f"/{mpileaks.dag_hash()}"
     b = SpecParser(hash_str).next_spec()
@@ -654,9 +654,8 @@ def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     a_hash = f"/{a.dag_hash()}"
     assert SpecParser(a_hash).next_spec() == a
 
-
 @pytest.mark.db
-def test_dep_spec_by_hash(database, mutable_empty_config):
+def test_dep_spec_by_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -692,7 +691,7 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database, mutable_empty_config):
+def test_multiple_specs_with_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -724,7 +723,7 @@ def test_multiple_specs_with_hash(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_empty_config):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -742,7 +741,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
 
 @pytest.mark.db
-def test_invalid_hash(database, mutable_empty_config):
+def test_invalid_hash(database, config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 
@@ -758,7 +757,7 @@ def test_invalid_hash(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database, mutable_empty_config):
+def test_nonexistent_hash(database, config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -736,7 +736,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
 
 @pytest.mark.db
-def test_invalid_hash(database, config):
+def test_invalid_hash(database, mutable_empty_config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -684,7 +684,6 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
     mpileaks_hash_fake_and_zmpi = SpecParser(
         f"mpileaks ^/{fake.dag_hash()[:4]} ^ /{zmpi.dag_hash()[:5]}"
     ).next_spec()
-    nodes = mpileaks_hash_fake_and_zmpi.traverse()
     mpileaks_hash_fake_and_zmpi.replace_hash()
     assert "zmpi" in mpileaks_hash_fake_and_zmpi
     assert mpileaks_hash_fake_and_zmpi["zmpi"] == zmpi
@@ -736,11 +735,13 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
     # ambiguity in first hash character
     with pytest.raises(spack.spec.AmbiguousHashError):
-        SpecParser("/x").next_spec()
+        b = SpecParser("/x").next_spec()
+        b.replace_hash()
 
     # ambiguity in first hash character AND spec name
     with pytest.raises(spack.spec.AmbiguousHashError):
-        SpecParser("a/x").next_spec()
+        b = SpecParser("a/x").next_spec()
+        b.replace_hash()
 
 
 @pytest.mark.db
@@ -750,13 +751,16 @@ def test_invalid_hash(database, mutable_empty_config):
 
     # name + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
+        b = SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
+        b.replace_hash()
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
+        b = SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
+        b.replace_hash()
 
     # name + dep + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
+        b = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
+        b.replace_hash()
 
 
 @pytest.mark.db
@@ -770,7 +774,8 @@ def test_nonexistent_hash(database, mutable_empty_config):
     assert no_such_hash not in [h[: len(no_such_hash)] for h in hashes]
 
     with pytest.raises(spack.spec.NoSuchHashError):
-        SpecParser(f"/{no_such_hash}").next_spec()
+        b = SpecParser(f"/{no_such_hash}").next_spec()
+        b.replace_hash()
 
 
 @pytest.mark.db
@@ -788,7 +793,8 @@ def test_redundant_spec(query_str, text_fmt, database):
     spec = database.query_one(query_str)
     text = text_fmt.format(spec, hash=spec.dag_hash())
     with pytest.raises(spack.spec.RedundantSpecError):
-        SpecParser(text).next_spec()
+        b = SpecParser(text).next_spec()
+        b.replace_hash()
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -689,7 +689,7 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
     # assert mpileaks_zmpi.compiler.satisfies(mpileaks_hash_zmpi.compiler)
 
     mpileaks_hash_fake_and_zmpi = SpecParser(
-        f"mpileaks ^ fake /{fake.dag_hash()[:4]} ^ zmpi /{zmpi.dag_hash()[:5]}"
+        f"mpileaks ^/{fake.dag_hash()[:4]} ^ /{zmpi.dag_hash()[:5]}"
     ).next_spec()
     nodes = mpileaks_hash_fake_and_zmpi.traverse()
     for node in nodes:

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -630,11 +630,10 @@ def test_spec_by_hash_tokens(text, tokens):
     assert parser.tokens() == tokens
 
 @pytest.mark.db
-def test_spec_by_hash(database, config):
+def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     mpileaks = database.query_one("mpileaks ^zmpi")
     a = spack.spec.Spec("a").concretized()
-    monkeypatch.setattr(spack.binary_distribution,
-                        "update_cache_and_get_specs", lambda: a)
+    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
 
     hash_str = f"/{mpileaks.dag_hash()}"
     b = SpecParser(hash_str).next_spec()
@@ -654,8 +653,9 @@ def test_spec_by_hash(database, config):
     a_hash = f"/{a.dag_hash()}"
     assert SpecParser(a_hash).next_spec() == a
 
+
 @pytest.mark.db
-def test_dep_spec_by_hash(database, config):
+def test_dep_spec_by_hash(database, mutable_empty_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -691,7 +691,7 @@ def test_dep_spec_by_hash(database, config):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database, config):
+def test_multiple_specs_with_hash(database, mutable_empty_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -723,7 +723,7 @@ def test_multiple_specs_with_hash(database, config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_empty_config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -757,7 +757,7 @@ def test_invalid_hash(database, config):
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database, config):
+def test_nonexistent_hash(database, mutable_empty_config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -633,8 +633,8 @@ def test_spec_by_hash_tokens(text, tokens):
 @pytest.mark.db
 def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     mpileaks = database.query_one("mpileaks ^zmpi")
-    a = spack.spec.Spec("a").concretized()
-    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
+    b = spack.spec.Spec("b").concretized()
+    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [b])
 
     hash_str = f"/{mpileaks.dag_hash()}"
     parsed_spec = SpecParser(hash_str).next_spec()
@@ -651,10 +651,10 @@ def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     parsed_spec.replace_hash()
     assert parsed_spec == mpileaks
 
-    a_hash = f"/{a.dag_hash()}"
-    parsed_spec = SpecParser(a_hash).next_spec()
+    b_hash = f"/{b.dag_hash()}"
+    parsed_spec = SpecParser(b_hash).next_spec()
     parsed_spec.replace_hash()
-    assert parsed_spec == a
+    assert parsed_spec == b
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -630,11 +630,10 @@ def test_spec_by_hash_tokens(text, tokens):
     assert parser.tokens() == tokens
 
 @pytest.mark.db
-def test_spec_by_hash(database, config):
+def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     mpileaks = database.query_one("mpileaks ^zmpi")
     a = spack.spec.Spec("a").concretized()
-    monkeypatch.setattr(spack.binary_distribution,
-                        "update_cache_and_get_specs", lambda: a)
+    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
 
     hash_str = f"/{mpileaks.dag_hash()}"
     assert str(SpecParser(hash_str).next_spec()) == str(mpileaks)
@@ -648,8 +647,9 @@ def test_spec_by_hash(database, config):
     a_hash = f"/{a.dag_hash()}"
     assert SpecParser(a_hash).next_spec() == a
 
+
 @pytest.mark.db
-def test_dep_spec_by_hash(database, config):
+def test_dep_spec_by_hash(database, mutable_empty_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -685,7 +685,7 @@ def test_dep_spec_by_hash(database, config):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database, config):
+def test_multiple_specs_with_hash(database, mutable_empty_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -717,7 +717,7 @@ def test_multiple_specs_with_hash(database, config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_empty_config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -751,7 +751,7 @@ def test_invalid_hash(database, config):
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database, config):
+def test_nonexistent_hash(database, mutable_empty_config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -629,6 +629,7 @@ def test_spec_by_hash_tokens(text, tokens):
     parser = SpecParser(text)
     assert parser.tokens() == tokens
 
+
 @pytest.mark.db
 def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     mpileaks = database.query_one("mpileaks ^zmpi")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -668,40 +668,29 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
     assert "fake" in mpileaks_zmpi
     assert "zmpi" in mpileaks_zmpi
 
-    # mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()}").next_spec()
-    # mpileaks_hash_fake.replace_hash()
-    # print('The specs are {0} and {1}'.format(mpileaks_hash_fake, fake))
-    # assert "fake" in mpileaks_hash_fake
-    # assert mpileaks_hash_fake["fake"] == fake
+    mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()}").next_spec()
+    mpileaks_hash_fake.replace_hash()
+    assert "fake" in mpileaks_hash_fake
+    assert mpileaks_hash_fake["fake"] == fake
 
-    # mpileaks_hash_zmpi = SpecParser(
-    #     f"mpileaks %{mpileaks_zmpi.compiler} ^ /{zmpi.dag_hash()}"
-    # ).next_spec()
-    # mpileaks_hash_zmpi.replace_hash()
-    # assert "zmpi" in mpileaks_hash_zmpi
-    # assert mpileaks_hash_zmpi["zmpi"] == zmpi
-
-    # notice: the round-trip str -> Spec loses specificity when
-    # since %gcc@=x gets printed as %gcc@x. So stick to satisfies
-    # here, unless/until we want to differentiate between ranges
-    # and specific versions in the future.
-    # assert mpileaks_hash_zmpi.compiler == mpileaks_zmpi.compiler
-    # assert mpileaks_zmpi.compiler.satisfies(mpileaks_hash_zmpi.compiler)
+    mpileaks_hash_zmpi = SpecParser(
+        f"mpileaks %{mpileaks_zmpi.compiler} ^ /{zmpi.dag_hash()}"
+    ).next_spec()
+    mpileaks_hash_zmpi.replace_hash()
+    assert "zmpi" in mpileaks_hash_zmpi
+    assert mpileaks_hash_zmpi["zmpi"] == zmpi
+    assert mpileaks_zmpi.compiler.satisfies(mpileaks_hash_zmpi.compiler)
 
     mpileaks_hash_fake_and_zmpi = SpecParser(
         f"mpileaks ^/{fake.dag_hash()[:4]} ^ /{zmpi.dag_hash()[:5]}"
     ).next_spec()
     nodes = mpileaks_hash_fake_and_zmpi.traverse()
-    for node in nodes:
-        print("Node name: {0}\tAbstract Hash: {1}".format(node, node.abstract_hash))
     mpileaks_hash_fake_and_zmpi.replace_hash()
-    print('The specs are {0} and {1}'.format(mpileaks_hash_fake_and_zmpi, zmpi))
     assert "zmpi" in mpileaks_hash_fake_and_zmpi
     assert mpileaks_hash_fake_and_zmpi["zmpi"] == zmpi
 
     assert "fake" in mpileaks_hash_fake_and_zmpi
     assert mpileaks_hash_fake_and_zmpi["fake"] == fake
-    assert False
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -658,7 +658,7 @@ def test_spec_by_hash(database, monkeypatch, mutable_config):
 
 
 @pytest.mark.db
-def test_dep_spec_by_hash(database, mutable_empty_config):
+def test_dep_spec_by_hash(database, mutable_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -693,7 +693,7 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database, mutable_empty_config):
+def test_multiple_specs_with_hash(database, mutable_config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -725,7 +725,7 @@ def test_multiple_specs_with_hash(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_empty_config):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -745,7 +745,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
 
 @pytest.mark.db
-def test_invalid_hash(database, mutable_empty_config):
+def test_invalid_hash(database, mutable_config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 
@@ -763,7 +763,7 @@ def test_invalid_hash(database, mutable_empty_config):
         parsed_spec.replace_hash()
 
 
-def test_invalid_hash_dep(database, mutable_empty_config):
+def test_invalid_hash_dep(database, mutable_config):
     mpich = database.query_one("mpich")
     hash = mpich.dag_hash()
     with pytest.raises(spack.spec.InvalidHashError):
@@ -771,7 +771,7 @@ def test_invalid_hash_dep(database, mutable_empty_config):
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database, mutable_empty_config):
+def test_nonexistent_hash(database, mutable_config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -666,10 +666,12 @@ def test_dep_spec_by_hash(database, mutable_empty_config):
     assert "fake" in mpileaks_zmpi
     assert "zmpi" in mpileaks_zmpi
 
-    mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()}").next_spec()
+    mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()} ^zmpi").next_spec()
     mpileaks_hash_fake.replace_hash()
     assert "fake" in mpileaks_hash_fake
     assert mpileaks_hash_fake["fake"] == fake
+    assert "zmpi" in mpileaks_hash_fake
+    assert mpileaks_hash_fake["zmpi"] == spack.spec.Spec("zmpi")
 
     mpileaks_hash_zmpi = SpecParser(
         f"mpileaks %{mpileaks_zmpi.compiler} ^ /{zmpi.dag_hash()}"
@@ -759,6 +761,12 @@ def test_invalid_hash(database, mutable_empty_config):
     with pytest.raises(spack.spec.InvalidHashError):
         parsed_spec = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
         parsed_spec.replace_hash()
+
+
+def test_invalid_hash_dep(database, mutable_empty_config):
+    mpich = database.query_one("mpich")
+    hash = mpich.dag_hash()
+    spack.spec.Spec(f"callpath ^zlib/{hash}").replace_hash()
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -742,7 +742,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
 
 @pytest.mark.db
-def test_invalid_hash(database, config):
+def test_invalid_hash(database, mutable_empty_config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -914,7 +914,7 @@ def test_error_conditions(text, exc_cls):
 )
 def test_specfile_error_conditions_windows(text, exc_cls):
     with pytest.raises(exc_cls):
-        SpecParser(text).next_spec()
+        SpecParser(text).all_specs()
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -859,13 +859,13 @@ def test_error_conditions(text, exc_cls):
     [
         # Specfile related errors
         pytest.param(
-            "/bogus/path/libdwarf.yaml", spack.spec.RedundantSpecError, marks=FAIL_ON_WINDOWS
+            "/bogus/path/libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param("../../libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS),
         pytest.param("./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS),
         pytest.param(
             "libfoo ^/bogus/path/libdwarf.yaml",
-            spack.spec.RedundantSpecError,
+            spack.spec.NoSuchSpecFileError,
             marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(
@@ -875,11 +875,13 @@ def test_error_conditions(text, exc_cls):
             "libfoo ^./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param(
-            "/bogus/path/libdwarf.yamlfoobar", spack.spec.RedundantSpecError, marks=FAIL_ON_WINDOWS
+            "/bogus/path/libdwarf.yamlfoobar",
+            spack.spec.NoSuchSpecFileError,
+            marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(
             "libdwarf^/bogus/path/libelf.yamlfoobar ^/path/to/bogus.yaml",
-            spack.spec.RedundantSpecError,
+            spack.spec.NoSuchSpecFileError,
             marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -631,7 +631,7 @@ def test_spec_by_hash_tokens(text, tokens):
 
 
 @pytest.mark.db
-def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
+def test_spec_by_hash(database, monkeypatch, mutable_config):
     mpileaks = database.query_one("mpileaks ^zmpi")
     b = spack.spec.Spec("b").concretized()
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [b])

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -637,26 +637,24 @@ def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
 
     hash_str = f"/{mpileaks.dag_hash()}"
-    b = SpecParser(hash_str).next_spec()
-    b.replace_hash()
-    assert b == mpileaks
+    parsed_spec = SpecParser(hash_str).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
 
     short_hash_str = f"/{mpileaks.dag_hash()[:5]}"
-    b = SpecParser(short_hash_str).next_spec()
-    b.replace_hash()
-    assert b == mpileaks
+    parsed_spec = SpecParser(short_hash_str).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
 
     name_version_and_hash = f"{mpileaks.name}@{mpileaks.version} /{mpileaks.dag_hash()[:5]}"
-    b = SpecParser(name_version_and_hash).next_spec()
-    print("The hashes are {0} and {1}".format(name_version_and_hash, b.abstract_hash))
-    b.replace_hash()
-    assert b == mpileaks
+    parsed_spec = SpecParser(name_version_and_hash).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == mpileaks
 
     a_hash = f"/{a.dag_hash()}"
-    b = SpecParser(a_hash).next_spec()
-    print("The hashes are {0} and {1}".format(a_hash, b.abstract_hash))
-    b.replace_hash()
-    assert b == a
+    parsed_spec = SpecParser(a_hash).next_spec()
+    parsed_spec.replace_hash()
+    assert parsed_spec == a
 
 
 @pytest.mark.db
@@ -735,13 +733,13 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_e
 
     # ambiguity in first hash character
     with pytest.raises(spack.spec.AmbiguousHashError):
-        b = SpecParser("/x").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser("/x").next_spec()
+        parsed_spec.replace_hash()
 
     # ambiguity in first hash character AND spec name
     with pytest.raises(spack.spec.AmbiguousHashError):
-        b = SpecParser("a/x").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser("a/x").next_spec()
+        parsed_spec.replace_hash()
 
 
 @pytest.mark.db
@@ -751,16 +749,16 @@ def test_invalid_hash(database, mutable_empty_config):
 
     # name + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        b = SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
     with pytest.raises(spack.spec.InvalidHashError):
-        b = SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
 
     # name + dep + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
-        b = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
+        parsed_spec.replace_hash()
 
 
 @pytest.mark.db
@@ -774,8 +772,8 @@ def test_nonexistent_hash(database, mutable_empty_config):
     assert no_such_hash not in [h[: len(no_such_hash)] for h in hashes]
 
     with pytest.raises(spack.spec.NoSuchHashError):
-        b = SpecParser(f"/{no_such_hash}").next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser(f"/{no_such_hash}").next_spec()
+        parsed_spec.replace_hash()
 
 
 @pytest.mark.db
@@ -783,7 +781,7 @@ def test_nonexistent_hash(database, mutable_empty_config):
     "query_str,text_fmt",
     [
         ("mpileaks ^zmpi", r"/{hash}%{0.compiler}"),
-        ("callpath ^zmpi", r"callpath /{hash} ^libelf"),
+        ("callpath ^zmpi", r"callpath /{hash} ^a"),
         ("dyninst", r'/{hash} cflags="-O3 -fPIC"'),
         ("mpileaks ^mpich2", r"mpileaks/{hash} @{0.version}"),
     ],
@@ -793,8 +791,8 @@ def test_redundant_spec(query_str, text_fmt, database):
     spec = database.query_one(query_str)
     text = text_fmt.format(spec, hash=spec.dag_hash())
     with pytest.raises(spack.spec.RedundantSpecError):
-        b = SpecParser(text).next_spec()
-        b.replace_hash()
+        parsed_spec = SpecParser(text).next_spec()
+        parsed_spec.replace_hash()
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -631,7 +631,7 @@ def test_spec_by_hash_tokens(text, tokens):
 
 
 @pytest.mark.db
-def test_spec_by_hash(database, monkeypatch, mutable_config):
+def test_spec_by_hash(database, monkeypatch, config):
     mpileaks = database.query_one("mpileaks ^zmpi")
     b = spack.spec.Spec("b").concretized()
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [b])
@@ -658,7 +658,7 @@ def test_spec_by_hash(database, monkeypatch, mutable_config):
 
 
 @pytest.mark.db
-def test_dep_spec_by_hash(database, mutable_config):
+def test_dep_spec_by_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     zmpi = database.query_one("zmpi")
     fake = database.query_one("fake")
@@ -693,7 +693,7 @@ def test_dep_spec_by_hash(database, mutable_config):
 
 
 @pytest.mark.db
-def test_multiple_specs_with_hash(database, mutable_config):
+def test_multiple_specs_with_hash(database, config):
     mpileaks_zmpi = database.query_one("mpileaks ^zmpi")
     callpath_mpich2 = database.query_one("callpath ^mpich2")
 
@@ -725,7 +725,7 @@ def test_multiple_specs_with_hash(database, mutable_config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_config):
+def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
     x1 = default_mock_concretization("a")
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -745,7 +745,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, mutable_c
 
 
 @pytest.mark.db
-def test_invalid_hash(database, mutable_config):
+def test_invalid_hash(database, config):
     zmpi = database.query_one("zmpi")
     mpich = database.query_one("mpich")
 
@@ -763,7 +763,7 @@ def test_invalid_hash(database, mutable_config):
         parsed_spec.replace_hash()
 
 
-def test_invalid_hash_dep(database, mutable_config):
+def test_invalid_hash_dep(database, config):
     mpich = database.query_one("mpich")
     hash = mpich.dag_hash()
     with pytest.raises(spack.spec.InvalidHashError):
@@ -771,7 +771,7 @@ def test_invalid_hash_dep(database, mutable_config):
 
 
 @pytest.mark.db
-def test_nonexistent_hash(database, mutable_config):
+def test_nonexistent_hash(database, config):
     """Ensure we get errors for non existent hashes."""
     specs = database.query()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -637,10 +637,16 @@ def test_spec_by_hash(database, monkeypatch, mutable_empty_config):
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [a])
 
     hash_str = f"/{mpileaks.dag_hash()}"
-    assert str(SpecParser(hash_str).next_spec()) == str(mpileaks)
+    b = SpecParser(hash_str).next_spec()
+    b.replace_hash()
+    # b here is NOT a Spec--it is still a query_spec!
+    # THEREFORE, it does not have an abstract_hash attribute, which would be useless anyway.
+    print("parser found {}".format(b))
+    assert b == mpileaks
 
     short_hash_str = f"/{mpileaks.dag_hash()[:5]}"
-    assert str(SpecParser(short_hash_str).next_spec()) == str(mpileaks)
+    b = SpecParser(short_hash_str).next_spec().concretize()
+    assert str(b) == str(mpileaks)
 
     name_version_and_hash = f"{mpileaks.name}@{mpileaks.version} /{mpileaks.dag_hash()[:5]}"
     assert str(SpecParser(name_version_and_hash).next_spec()) == str(mpileaks)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -859,13 +859,13 @@ def test_error_conditions(text, exc_cls):
     [
         # Specfile related errors
         pytest.param(
-            "/bogus/path/libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS
+            "/bogus/path/libdwarf.yaml", spack.spec.RedundantSpecError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param("../../libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS),
         pytest.param("./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS),
         pytest.param(
             "libfoo ^/bogus/path/libdwarf.yaml",
-            spack.spec.NoSuchSpecFileError,
+            spack.spec.RedundantSpecError,
             marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(
@@ -875,11 +875,11 @@ def test_error_conditions(text, exc_cls):
             "libfoo ^./libdwarf.yaml", spack.spec.NoSuchSpecFileError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param(
-            "/bogus/path/libdwarf.yamlfoobar", spack.spec.SpecFilenameError, marks=FAIL_ON_WINDOWS
+            "/bogus/path/libdwarf.yamlfoobar", spack.spec.RedundantSpecError, marks=FAIL_ON_WINDOWS
         ),
         pytest.param(
             "libdwarf^/bogus/path/libelf.yamlfoobar ^/path/to/bogus.yaml",
-            spack.spec.SpecFilenameError,
+            spack.spec.RedundantSpecError,
             marks=FAIL_ON_WINDOWS,
         ),
         pytest.param(

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -766,7 +766,8 @@ def test_invalid_hash(database, mutable_empty_config):
 def test_invalid_hash_dep(database, mutable_empty_config):
     mpich = database.query_one("mpich")
     hash = mpich.dag_hash()
-    spack.spec.Spec(f"callpath ^zlib/{hash}").replace_hash()
+    with pytest.raises(spack.spec.InvalidHashError):
+        spack.spec.Spec(f"callpath ^zlib/{hash}").replace_hash()
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -792,7 +792,7 @@ def test_nonexistent_hash(database, config):
         ("zlib+shared", "zlib~shared", "+shared"),
         ("hdf5+mpi^zmpi", "hdf5~mpi", "^zmpi"),
         ("hdf5+mpi^mpich+debug", "hdf5+mpi^mpich~debug", "^mpich+debug"),
-    ]
+    ],
 )
 def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monkeypatch, config):
     spec1_concrete = spack.spec.Spec(spec1).concretized()
@@ -804,7 +804,7 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
     monkeypatch.setattr(
         spack.binary_distribution,
         "update_cache_and_get_specs",
-        lambda: [spec1_concrete, spec2_concrete]
+        lambda: [spec1_concrete, spec2_concrete],
     )
 
     # Ordering is tricky -- for constraints we want after, for names we want before

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -18,7 +18,7 @@ EdgeAndDepth = namedtuple("EdgeAndDepth", ["edge", "depth"])
 
 
 def sort_edges(edges):
-    edges.sort(key=lambda edge: edge.spec.name or edge.spec.abstract_hash)
+    edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or ""))
     return edges
 
 

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -18,7 +18,7 @@ EdgeAndDepth = namedtuple("EdgeAndDepth", ["edge", "depth"])
 
 
 def sort_edges(edges):
-    edges.sort(key=lambda edge: edge.spec.name)
+    edges.sort(key=lambda edge: edge.spec.name or edge.spec.abstract_hash)
     return edges
 
 


### PR DESCRIPTION
## What this PR does

Currently, specs on buildcache mirrors must be referenced by their full description. This PR allows buildcache specs to be referenced by their hashes, rather than their full description.

## How it works

Hash resolution has been moved from `SpecParser` into `Spec`, and now includes the ability to execute a `BinaryCacheQuery` after checking the local store, but before concluding that the hash doesn't exist.

### Side-effects of Proposed Changes

Failures will take longer when nonexistent hashes are parsed, as mirrors will now be scanned.

## Other Changes

- `BinaryCacheIndex.update` has been modified to fail appropriately only when mirrors have been configured.
- Tests of hash failures have been updated to use `mutable_empty_config` so they don't needlessly search mirrors.
- Documentation has been clarified for `BinaryCacheQuery`, and more documentation has been added to the hash resolution functions added to `Spec`.
