### PR TITLE
node_flag_source is not particularly constrained

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1011,6 +1011,7 @@ error(2, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source
 attr("node_flag_source", Package, FlagType, Package) :- attr("node_flag_set", Package, FlagType, _).
 attr("node_flag_source", Dependency, FlagType, Q)
  :- attr("node_flag_source", Package, FlagType, Q), node_flag_inherited(Dependency, FlagType, _),
+    depends_on(Package, Dependency),
     attr("node_flag_propagate", Package, FlagType).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches


### PR DESCRIPTION
If you do

```
spack env activate --temp
spack add python cflags==-x
spack add curl cflags==-y
```

It gives you _both_ `python` and `curl` as the "sources" of the inherited flags `-x` and
`-y`, since the relation between Package and Dependency is not specified. Just
creating this PR to see if what I say makes sense.

It doesn't solve #34370 (yet).

Edit: this is not enough in general. Can't we just store pairs (parent, child) and then
reconstruct the path post-hoc?