### PR TITLE
py-numba: fix py-numpy version dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -31,7 +31,7 @@ class PyNumba(PythonPackage):
     depends_on("python@3.6:3.8", when="@0.48:0.51", type=("build", "run"))
     depends_on("python@3.3:3.7", when="@0.40.1:0.47", type=("build", "run"))
     depends_on("py-numpy@1.18:1.23", when="@0.56.1:", type=("build", "run"))
-    depends_on("py-numpy@1.18:1.22", when="@0.55.2:", type=("build", "run"))
+    depends_on("py-numpy@1.18:1.22", when="@0.55.2:0.56.0", type=("build", "run"))
     depends_on("py-numpy@1.18:1.21", when="@0.55.0:0.55.1", type=("build", "run"))
     depends_on("py-numpy@1.17:1.20", when="@0.54", type=("build", "run"))
     # set upper bound for py-numpy the same as newer release


### PR DESCRIPTION
As per #34362 comments, to allow py-numba@0.56.4 to use py-numpy@1.23.