### PR TITLE
`arrow`: don't use `when` as a keyword argument to filter_file()

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -105,12 +105,14 @@ class Arrow(CMakePackage, CudaPackage):
             filter_file(
                 r'set\(ARROW_LLVM_VERSIONS "10" "9" "8" "7"\)',
                 'set(ARROW_LLVM_VERSIONS "11" "10" "9" "8" "7")',
-                "cpp/CMakeLists.txt"
+                "cpp/CMakeLists.txt",
             )
             filter_file(
                 r"#include <llvm/Support/DynamicLibrary\.h>",
-                r"#include <llvm/Support/DynamicLibrary.h>" + "\n" + r"#include <llvm/Support/Host.h>",
-                "cpp/src/gandiva/engine.cc"
+                r"#include <llvm/Support/DynamicLibrary.h>"
+                + "\n"
+                + r"#include <llvm/Support/Host.h>",
+                "cpp/src/gandiva/engine.cc",
             )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -101,19 +101,17 @@ class Arrow(CMakePackage, CudaPackage):
             r"(include_directories\()SYSTEM ", r"\1", "cpp/cmake_modules/ThirdpartyToolchain.cmake"
         )
 
-        filter_file(
-            r'set\(ARROW_LLVM_VERSIONS "10" "9" "8" "7"\)',
-            'set(ARROW_LLVM_VERSIONS "11" "10" "9" "8" "7")',
-            "cpp/CMakeLists.txt",
-            when="@:2.0.0",
-        )
-
-        filter_file(
-            r"#include <llvm/Support/DynamicLibrary\.h>",
-            r"#include <llvm/Support/DynamicLibrary.h>" + "\n" + r"#include <llvm/Support/Host.h>",
-            "cpp/src/gandiva/engine.cc",
-            when="@2.0.0",
-        )
+        if self.spec.satisfies("@:2.0.0"):
+            filter_file(
+                r'set\(ARROW_LLVM_VERSIONS "10" "9" "8" "7"\)',
+                'set(ARROW_LLVM_VERSIONS "11" "10" "9" "8" "7")',
+                "cpp/CMakeLists.txt"
+            )
+            filter_file(
+                r"#include <llvm/Support/DynamicLibrary\.h>",
+                r"#include <llvm/Support/DynamicLibrary.h>" + "\n" + r"#include <llvm/Support/Host.h>",
+                "cpp/src/gandiva/engine.cc"
+            )
 
     def cmake_args(self):
         args = ["-DARROW_DEPENDENCY_SOURCE=SYSTEM", "-DARROW_NO_DEPRECATED_API=ON"]


### PR DESCRIPTION
Building arrow is broken because of changes introduced in https://github.com/spack/spack/commit/9d00e7d15d5da43cd098f695f15d0ee4d1aeaedc