### PR TITLE
axom: need to specify +rocm as part of dependency constraints

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -117,7 +117,6 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("umpire@6.0.0", when="@0.6.0")
         depends_on("umpire@5:5.0.1", when="@:0.5.0")
         depends_on("umpire +openmp", when="+openmp")
-        depends_on("umpire +cuda", when="+cuda")
 
     with when("+raja"):
         depends_on("raja@2022.03.0:", when="@0.7.0:")
@@ -125,7 +124,6 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("raja@:0.13.0", when="@:0.5.0")
         depends_on("raja~openmp", when="~openmp")
         depends_on("raja+openmp", when="+openmp")
-        depends_on("raja+cuda", when="+cuda")
 
     for val in CudaPackage.cuda_arch_values:
         depends_on("raja +cuda cuda_arch={0}".format(val), when="+raja +cuda cuda_arch={0}".format(val))

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -128,12 +128,12 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("raja+cuda", when="+cuda")
 
     for val in CudaPackage.cuda_arch_values:
-        depends_on("raja cuda_arch={0}".format(val), when="+raja cuda_arch={0}".format(val))
-        depends_on("umpire cuda_arch={0}".format(val), when="+umpire cuda_arch={0}".format(val))
+        depends_on("raja +cuda cuda_arch={0}".format(val), when="+raja +cuda cuda_arch={0}".format(val))
+        depends_on("umpire +cuda cuda_arch={0}".format(val), when="+umpire +cuda cuda_arch={0}".format(val))
 
     for val in ROCmPackage.amdgpu_targets:
-        depends_on("raja amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val))
-        depends_on("umpire amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val))
+        depends_on("raja +rocm amdgpu_target={0}".format(val), when="+rocm amdgpu_target={0}".format(val))
+        depends_on("umpire +rocm amdgpu_target={0}".format(val), when="+rocm amdgpu_target={0}".format(val))
 
     depends_on("mfem", when="+mfem")
     depends_on("mfem~mpi", when="+mfem~mpi")

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -126,12 +126,16 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("raja+openmp", when="+openmp")
 
     for val in CudaPackage.cuda_arch_values:
-        depends_on("raja +cuda cuda_arch={0}".format(val), when="+raja +cuda cuda_arch={0}".format(val))
-        depends_on("umpire +cuda cuda_arch={0}".format(val), when="+umpire +cuda cuda_arch={0}".format(val))
+        raja_cuda = "raja +cuda cuda_arch={0}".format(val)
+        umpire_cuda = "umpire +cuda cuda_arch={0}".format(val)
+        depends_on(raja_cuda, when="+{0}".format(raja_cuda))
+        depends_on(umpire_cuda, when="+{0}".format(umpire_cuda))
 
     for val in ROCmPackage.amdgpu_targets:
-        depends_on("raja +rocm amdgpu_target={0}".format(val), when="+rocm amdgpu_target={0}".format(val))
-        depends_on("umpire +rocm amdgpu_target={0}".format(val), when="+rocm amdgpu_target={0}".format(val))
+        raja_rocm = "raja +rocm amdgpu_target={0}".format(val)
+        umpire_rocm = "umpire +rocm amdgpu_target={0}".format(val)
+        depends_on(raja_rocm, when="+{0}".format(raja_rocm))
+        depends_on(umpire_rocm, when="+{0}".format(umpire_rocm))
 
     depends_on("mfem", when="+mfem")
     depends_on("mfem~mpi", when="+mfem~mpi")


### PR DESCRIPTION
Not being explicit about `+rocm` on the dependency yields an error during concretization:
* Using `spack@develop` (f593309b4e1c4590b757d7190dc14450241efd51 from `Sat Jan 21 10:17:53 2023 -0500`)
```
$> spack spec axom +rocm amdgpu_target=gfx90a
==> Error: Cannot set variant 'amdgpu_target' for package 'raja' because the variant condition cannot be satisfied for the given spec
```

Although this same error doesn't happen with `axom +cuda` I thought it might be good to be explicit there too?

@white238 @wspear