### PR TITLE
freeimage: fails to compile with c++17, use c++14

### DIFF
--- a/var/spack/repos/builtin/packages/freeimage/install_fixes.patch
+++ b/var/spack/repos/builtin/packages/freeimage/install_fixes.patch
@@ -4,10 +4,10 @@
 
  # General configuration variables:
  DESTDIR ?= /
--INCDIR ?= $(DESTDIR)/include
--INSTALLDIR ?= $(DESTDIR)/lib
-+INCDIR ?= $(DESTDIR)/usr/include
-+INSTALLDIR ?= $(DESTDIR)/usr/lib
+-INCDIR ?= $(DESTDIR)/usr/include
+-INSTALLDIR ?= $(DESTDIR)/usr/lib
++INCDIR ?= $(DESTDIR)/include
++INSTALLDIR ?= $(DESTDIR)/lib
 
  # Converts cr/lf to just lf
  DOS2UNIX = dos2unix

--- a/var/spack/repos/builtin/packages/freeimage/install_fixes.patch
+++ b/var/spack/repos/builtin/packages/freeimage/install_fixes.patch
@@ -1,5 +1,16 @@
 --- a/Makefile.gnu	2015-03-10 09:04:00.000000000 +0100
-+++ b/Makefile.gnu	2019-03-15 13:20:12.480698778 +0100
++++ b/Makefile.gnu      2023-01-21 15:53:35.782911926 -0600
+@@ -5,8 +5,8 @@
+
+ # General configuration variables:
+ DESTDIR ?= /
+-INCDIR ?= $(DESTDIR)/include
+-INSTALLDIR ?= $(DESTDIR)/lib
++INCDIR ?= $(DESTDIR)/usr/include
++INSTALLDIR ?= $(DESTDIR)/usr/lib
+
+ # Converts cr/lf to just lf
+ DOS2UNIX = dos2unix
 @@ -71,9 +71,9 @@
  
  install:

--- a/var/spack/repos/builtin/packages/freeimage/package.py
+++ b/var/spack/repos/builtin/packages/freeimage/package.py
@@ -19,6 +19,7 @@ class Freeimage(MakefilePackage):
 
     def edit(self, spec, prefix):
         env["DESTDIR"] = prefix
+        env["CXXFLAGS"] = "-std=c++14"
 
     def url_for_version(self, version):
         url = "https://downloads.sourceforge.net/project/freeimage/Source%20Distribution/{0}/FreeImage{1}.zip"


### PR DESCRIPTION
Only `opencascade` when a (non-default) variant depends on `freeimage`, which seems to have gone unmaintained. There are c++17 standard violations [[1]]( https://en.cppreference.com/w/cpp/language/except_spec) in the code, so we can at most expect c++14. Since some compilers default to c++17 (gcc-12) we need to be explicit.