### PR TITLE
`py-pyarrow`: add version v10.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -15,6 +15,7 @@ class Arrow(CMakePackage, CudaPackage):
     homepage = "https://arrow.apache.org"
     url = "https://github.com/apache/arrow/archive/apache-arrow-0.9.0.tar.gz"
 
+    version("10.0.1", sha256="28c3e0402bc1c3c1e047b6e26cedb8d1d89b2b9497d576af24b0b700eef11701")
     version("9.0.0", sha256="bb187b4b0af8dcc027fffed3700a7b891c9f76c9b63ad8925b4afb8257a2bb1b")
     version("8.0.0", sha256="19ece12de48e51ce4287d2dee00dc358fbc5ff02f41629d16076f77b8579e272")
     version("7.0.0", sha256="57e13c62f27b710e1de54fd30faed612aefa22aa41fa2c0c3bacd204dd18a8f3")

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -15,6 +15,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
     homepage = "https://arrow.apache.org"
     pypi = "pyarrow/pyarrow-0.17.1.tar.gz"
 
+    version("10.0.1", sha256="28c3e0402bc1c3c1e047b6e26cedb8d1d89b2b9497d576af24b0b700eef11701")
     version("8.0.0", sha256="4a18a211ed888f1ac0b0ebcb99e2d9a3e913a481120ee9b1fe33d3fedb945d4e")
     version("7.0.0", sha256="da656cad3c23a2ebb6a307ab01d35fce22f7850059cffafcb90d12590f8f4f38")
     version("4.0.1", sha256="11517f0b4f4acbab0c37c674b4d1aad3c3dfea0f6b1bb322e921555258101ab3")
@@ -35,6 +36,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
     depends_on("python@3.7:", type=("build", "run"), when="@7.0.0:")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@38.6.0:", type="build", when="@7.0.0:")
+    depends_on("py-setuptools@40.1.0:", type="build", when="@10.0.1:")
     depends_on("py-setuptools-scm", type="build", when="@0.15.0:")
     depends_on("py-cython", type="build")
     depends_on("py-cython@0.29:", type="build", when="@0.15.0:")
@@ -53,6 +55,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
         "@4.0.1",
         "@7.0.0",
         "@8.0.0",
+        "@10.0.1",
     )
     for v in arrow_versions:
         depends_on("arrow+python" + v, when=v)


### PR DESCRIPTION
This is still a work in progress as I get the following when building `py-pyarrow@10.0.1+parquet` (`arrow@10.0.1+parquet` builds just fine):

```
==> py-pyarrow: Executing phase: 'install'
==> [2023-01-22-14:33:46.156641] '/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/python-3.10.8-ed7xzsy7uqik7pds5gjjuxag7tawx53n/bin/python3.10' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pyarrow-10.0.1-wqx22j5unn2ntkwqfkobudfhvl77us5h' '--install-option=--with-parquet' '.'
WARNING: Disabling all use of wheels due to the use of --build-option / --global-option / --install-option.
Using pip 22.2.2 from /mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip (python 3.10)
Non-user install due to --prefix or --target option
Ignoring indexes: https://pypi.org/simple
Created temporary directory: /tmp/pip-ephem-wheel-cache-anal14jd
Created temporary directory: /tmp/pip-build-tracker-4ko2fmq1
Initialized build tracking at /tmp/pip-build-tracker-4ko2fmq1
Created build tracker: /tmp/pip-build-tracker-4ko2fmq1
Entered build tracker: /tmp/pip-build-tracker-4ko2fmq1
Created temporary directory: /tmp/pip-install-rxf8u5sk
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
Exception information:
Traceback (most recent call last):
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 167, in exc_logging_wrapper
    status = run_func(*args)
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/commands/install.py", line 335, in run
    reqs = self.get_requirements(args, options, finder, session)
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 411, in get_requirements
    req_to_add = install_req_from_line(
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/req/constructors.py", line 393, in install_req_from_line
    parts = parse_req_from_line(name, line_source)
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/req/constructors.py", line 310, in parse_req_from_line
    url = _get_url_from_path(p, name)
  File "/mnt/spack/linux-debian11-broadwell/gcc-10.2.1/py-pip-22.2.2-ev2inuoyzgbcqidixckzteoisfoxswc7/lib/python3.10/site-packages/pip/_internal/req/constructors.py", line 266, in _get_url_from_path
    raise InstallationError(
pip._internal.exceptions.InstallationError: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
Removed build tracker: '/tmp/pip-build-tracker-4ko2fmq1'
```

The pypi archive contains both `setup.py` and `pyproject.toml`. Any pointers?