### PR TITLE
Revert "Fix for padding relocation (issue 28170)"

### DIFF
--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -119,7 +119,6 @@ def parse_install_tree(config_dict):
             msg = "Cannot pad %s to %s characters." % (root, padded_length)
             msg += " It is already %s characters long" % len(root)
             tty.warn(msg)
-        root = root.rstrip(os.path.sep)
     else:
         root = unpadded_root
 


### PR DESCRIPTION
Reverts spack/spack#33122

The linked PR was not properly reviewed. The result is that the effective prefix is one byte shorter than required by the config setting, so that relocation may fail when moving to a location of exactly `padded_length` bytes.

The latter is a very typical use-case, for example when `config:install_tree:padded_length` is globally configured to say `128`, but the `config:install_tree:root` has variable length in different environments.