### PR TITLE
append cflags, cxxflags and fflags instead of prepend

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -626,39 +626,10 @@ elif [ "$SPACK_ADD_DEBUG_FLAGS" = "custom" ]; then
     extend flags_list SPACK_DEBUG_FLAGS
 fi
 
-# Fortran flags come before CPPFLAGS
-case "$mode" in
-    cc|ccld)
-        case $lang_flags in
-            F)
-                extend flags_list SPACK_FFLAGS
-                ;;
-        esac
-        ;;
-esac
-
-# C preprocessor flags come before any C/CXX flags
+# C preprocessor flags
 case "$mode" in
     cpp|as|cc|ccld)
         extend flags_list SPACK_CPPFLAGS
-        ;;
-esac
-
-
-# Add C and C++ flags
-case "$mode" in
-    cc|ccld)
-        case $lang_flags in
-            C)
-                extend flags_list SPACK_CFLAGS
-                ;;
-            CXX)
-                extend flags_list SPACK_CXXFLAGS
-                ;;
-        esac
-
-        # prepend target args
-        preextend flags_list SPACK_TARGET_ARGS
         ;;
 esac
 
@@ -762,6 +733,26 @@ esac
 
 # Other arguments from the input command
 extend args_list other_args_list
+
+# *Append* Fortran, C and C++ flags
+case "$mode" in
+    cc|ccld)
+        case $lang_flags in
+            C)
+                extend args_list SPACK_CFLAGS
+                ;;
+            CXX)
+                extend args_list SPACK_CXXFLAGS
+                ;;
+            F)
+                extend args_list SPACK_FFLAGS
+                ;;
+        esac
+
+        # prepend target args
+        preextend args_list SPACK_TARGET_ARGS
+        ;;
+esac
 
 # Inject SPACK_LDLIBS, if supplied
 extend args_list libs_list "-l"

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -307,9 +307,9 @@ def test_cc_flags(wrapper_environment, wrapper_flags):
         [real_cc]
         + target_args
         + spack_cppflags
-        + spack_cflags
         + spack_ldflags
         + common_compile_args
+        + spack_cflags
         + spack_ldlibs,
     )
 
@@ -321,9 +321,9 @@ def test_cxx_flags(wrapper_environment, wrapper_flags):
         [real_cc]
         + target_args
         + spack_cppflags
-        + spack_cxxflags
         + spack_ldflags
         + common_compile_args
+        + spack_cxxflags
         + spack_ldlibs,
     )
 
@@ -334,10 +334,10 @@ def test_fc_flags(wrapper_environment, wrapper_flags):
         test_args,
         [real_cc]
         + target_args
-        + spack_fflags
         + spack_cppflags
         + spack_ldflags
         + common_compile_args
+        + spack_fflags
         + spack_ldlibs,
     )
 


### PR DESCRIPTION
cflags/cxxflags/fflags are pretty much useless in Spack, with all
options of (1) setting the relevant env variable, (2) putting the
variable on the make command invocation, (3) injecting through the
compiler wrapper, because:

1. Env variables may be ignored by the build system (e.g. `CFLAGS = ...`
   not `CFLAGS ?= ...` in Makefiles).
2. Putting them on the command line is not composable, and may in fact
   override required defaults for badly written Makefiles; it's not
   uncommon to see Makefiles like these:
   ```Makefile
   CFLAGS = -std=c99 -D_FILE_OFFSET_BITS=64
   ```
3. The compiler wrapper *prepends* flags, which typically means they
   have no effect:
   ```
   # Our -O3 -g0 flags are overridden by -O2 -g
   gcc -O3 -g0 ... -O2 -g
   ```

The latter looks like a bug to me, so this PR ensures we *append* the
compiler flags.

It does *not* touch CPPFLAGS / LDFLAGS, since they may contain -I and
-L flags which should take precedence, so should be prepended. Maybe
Spack should just do a pass over CPPFLAGS/LDFLAGS in Python and move
-I and -L into other variables so that we can also append the other
preprocessor/linker flags... cause it'd be nice to ensure that ldflags
of the form `-fuse-ld=...` come last too.
