### PR TITLE
MSVC compiler: add platform toolset versioning

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -113,8 +113,9 @@ class Msvc(Compiler):
     def platform_toolset_ver(self):
         """
         This is the platform toolset version of current MSVC compiler
-        of form v<toolset-ver>, i.e. v142. This is different from the VC
-        toolset version as established by `short_msvc_version`
+        i.e. 142.
+        This is different from the VC toolset version as established
+        by `short_msvc_version`
         """
         return self.msvc_version[:2].joined.string[:3]
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -103,10 +103,20 @@ class Msvc(Compiler):
         """
         This is the shorthand VCToolset version of form
         MSVC<short-ver> *NOT* the full version, for that see
-        Msvc.msvc_version
+        Msvc.msvc_version or MSVC.platform_toolset_ver for the
+        raw platform toolset version
         """
-        ver = self.msvc_version[:2].joined.string[:3]
+        ver = self.platform_toolset_ver
         return "MSVC" + ver
+
+    @property
+    def platform_toolset_ver(self):
+        """
+        This is the platform toolset version of current MSVC compiler
+        of form v<toolset-ver>, i.e. v142. This is different from the VC
+        toolset version as established by `short_msvc_version`
+        """
+        return self.msvc_version[:2].joined.string[:3]
 
     @property
     def cl_version(self):


### PR DESCRIPTION
Add the platform toolset version associated with active MSVC compiler as a property of the MSVC compiler class.

This is necessary to support #34938 in general and supports features in #35095 and #35099 directly. This should be merged prior to the aforementioned PRs as they both rely on behavior from this PR. All changes from these PRs were originally made in #34936 as one unit. 