### PR TITLE
Windows: port theora & ogg

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -124,12 +124,15 @@ class Msvc(Compiler):
         """Cl toolset version"""
         return Version(
             re.search(
-                Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")
+                Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, version_arg=None)
             ).group(1)
         )
 
     @property
     def vs_root(self):
+        # The MSVC install root is located at a fix level above the compiler
+        # and is referenceable idiomatically via the pattern below
+        # this should be consistent accross versions
         return os.path.abspath(os.path.join(self.cc, "../../../../../../../.."))
 
     def setup_custom_environment(self, pkg, env):

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -124,7 +124,8 @@ class Msvc(Compiler):
         """Cl toolset version"""
         return Version(
             re.search(
-                Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, version_arg=None)
+                Msvc.version_regex,
+                spack.compiler.get_compiler_version_output(self.cc, version_arg=None),
             ).group(1)
         )
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -122,7 +122,11 @@ class Msvc(Compiler):
     @property
     def cl_version(self):
         """Cl toolset version"""
-        return Version(re.search(Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")).group(1))
+        return Version(
+            re.search(
+                Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")
+            ).group(1)
+        )
 
     @property
     def vs_root(self):

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -122,7 +122,11 @@ class Msvc(Compiler):
     @property
     def cl_version(self):
         """Cl toolset version"""
-        return spack.compiler.get_compiler_version_output(self.cc)
+        return Version(re.search(Msvc.version_regex, spack.compiler.get_compiler_version_output(self.cc, "")).group(1))
+
+    @property
+    def vs_root(self):
+        return os.path.abspath(os.path.join(self.cc, "../../../../../../../.."))
 
     def setup_custom_environment(self, pkg, env):
         """Set environment variables for MSVC using the

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import platform
 
 from spack.build_systems.generic import GenericBuilder
 from spack.package import *

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -40,7 +40,7 @@ class GenericBuilder(GenericBuilder):
     phases = ["build", "install"]
 
     def is_64bit(self):
-        return platform.machine().endswith("64")
+        return "64" in self.pkg.spec.target.family
 
     def build(self, spec, prefix):
         if spec.satisfies("%msvc"):

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import platform
+
+from spack.build_systems.generic import GenericBuilder
 from spack.package import *
 
 
-class Libogg(AutotoolsPackage):
+class Libogg(CMakePackage, AutotoolsPackage, Package):
     """Ogg is a multimedia container format, and the native file and stream
     format for the Xiph.org multimedia codecs."""
 
@@ -24,3 +28,35 @@ class Libogg(AutotoolsPackage):
         sha256="0f4d289aecb3d5f7329d51f1a72ab10c04c336b25481a40d6d841120721be485",
         when="@1.3.4 platform=darwin",
     )
+    build_system(
+        conditional("cmake", when="@1.3.4:"),
+        conditional("generic", when="@1.3.2 platform=windows"),
+        "autotools",
+        default="autotools",
+    )
+
+
+class GenericBuilder(GenericBuilder):
+    phases = ["build", "install"]
+
+    def is_64bit(self):
+        return platform.machine().endswith("64")
+
+    def build(self, spec, prefix):
+        if spec.satisfies("%msvc"):
+            plat_tools = self.pkg.compiler.msvc_version
+        else:
+            raise RuntimeError("Package does not support non MSVC compilers on Windows")
+        ms_build_args = ["libogg_static.vcxproj", "/p:PlatformToolset=v%s" % plat_tools]
+        msbuild(*ms_build_args)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.include.ogg)
+        mkdirp(prefix.lib)
+        mkdirp(prefix.share)
+        install(
+            os.path.join(self.pkg.stage.source_path, "include", "ogg", "*.h"), prefix.include.ogg
+        )
+        plat_prefix = "x64" if self.is_64bit() else "x86"
+        install(os.path.join(plat_prefix, "Debug", "*.lib"), prefix.lib)
+        install_tree(os.path.join(self.pkg.stage.source_path, "doc"), prefix.share)

--- a/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
+++ b/var/spack/repos/builtin/packages/libtheora/libtheora-inc-external-ogg.patch
@@ -1,0 +1,35 @@
+diff --git a/win32/VS2008/libogg.vsprops b/win32/VS2008/libogg.vsprops
+index 1355b50..8b3c5b8 100644
+--- a/win32/VS2008/libogg.vsprops
++++ b/win32/VS2008/libogg.vsprops
+@@ -6,11 +6,11 @@
+ 	>
+ 	<Tool
+ 		Name="VCCLCompilerTool"
+-		AdditionalIncludeDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
++		AdditionalIncludeDirectories="$(SPACK_OGG_PREFIX)\include;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\include&quot;;..\..\..\..\ogg\include;..\..\..\..\..\..\..\core\ogg\libogg\include"
+ 	/>
+ 	<Tool
+ 		Name="VCLinkerTool"
+-		AdditionalLibraryDirectories="&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
++		AdditionalLibraryDirectories="$(SPACK_OGG_PREFIX)\lib;&quot;..\..\..\..\libogg-$(LIBOGG_VERSION)\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\ogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;;&quot;..\..\..\..\..\..\..\core\ogg\libogg\win32\VS2008\$(PlatformName)\$(ConfigurationName)&quot;"
+ 	/>
+ 	<UserMacro
+ 		Name="LIBOGG_VERSION"
+diff --git a/win32/VS2008/libtheora_static.sln b/win32/VS2008/libtheora_static.sln
+index 2b39635..fa40518 100644
+--- a/win32/VS2008/libtheora_static.sln
++++ b/win32/VS2008/libtheora_static.sln
+@@ -1,12 +1,8 @@
+
+ Microsoft Visual Studio Solution File, Format Version 10.00
+ # Visual Studio 2008
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dump_video_static", "dump_video\dump_video_static.vcproj", "{1A8CA99D-B6C7-48CB-B263-6CECDADF5FBF}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libtheora_static", "libtheora\libtheora_static.vcproj", "{653F3841-3F26-49B9-AFCF-091DB4B67031}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "encoder_example_static", "encoder_example\encoder_example_static.vcproj", "{AD710263-EBFA-4388-BAA9-AD73C32AFF26}"
+-EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Win32 = Debug|Win32

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -59,7 +59,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args += self.enable_or_disable("doc")
         return args
 
-    def autoreconf(self, spec, prefix):
+    def autoreconf(self, pkg, spec, prefix):
         sh = which("sh")
         if self.spec.satisfies("target=aarch64:"):
             sh("./autogen.sh", "prefix={0}".format(prefix), "--build=arm-linux")


### PR DESCRIPTION
Ports for libtheora and libogg (and related changes to the MSVC compiler class to support that end) to the multi build system and their own Windows supported builders. 

This PR supports #34938 and depends on #35098 before it can go in.

Note: libtheora depends on libogg and changes to libtheora require an installable libogg on Windows to test so these package changes should be grouped together and this PR should not be closed on those grounds.