### PR TITLE
Convert libpng to build with CMake

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 from spack.build_systems.cmake import CMakeBuilder
+from spack.package import *
+
 
 class Libpng(CMakePackage):
     """libpng is the official PNG reference library."""
@@ -43,5 +44,5 @@ class CMakeBuilder(CMakeBuilder):
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
             self.define("PNG_SHARED", "shared" in self.pkg.variants["libs"]),
-            self.define("PNG_STATIC", "static" in self.pkg.variants["libs"])
+            self.define("PNG_STATIC", "static" in self.pkg.variants["libs"]),
         ]

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -43,6 +43,6 @@ class CMakeBuilder(CMakeBuilder):
         return [
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
-            self.define("PNG_SHARED", "shared" in self.pkg.variants["libs"]),
-            self.define("PNG_STATIC", "static" in self.pkg.variants["libs"]),
+            self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
+            self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
         ]

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -36,21 +36,12 @@ class Libpng(CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
-    def configure_args(self):
-        args = [
-            # not honored, see
-            #   https://sourceforge.net/p/libpng/bugs/210/#33f1
-            # '--with-zlib=' + self.spec['zlib'].prefix,
-            f"CPPFLAGS={self.spec['zlib'].headers.include_flags}",
-            f"LDFLAGS={self.spec['zlib'].libs.search_flags}",
-        ]
-
-        args += self.enable_or_disable("libs")
-        return args
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         return [
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
+            self.define("PNG_SHARED", "shared" in self.pkg.variants["libs"]),
+            self.define("PNG_STATIC", "static" in self.pkg.variants["libs"])
         ]

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.build_systems.cmake import CMakeBuilder
 
-
-class Libpng(AutotoolsPackage):
+class Libpng(CMakePackage):
     """libpng is the official PNG reference library."""
 
     homepage = "http://www.libpng.org/pub/png/libpng.html"
@@ -48,7 +48,9 @@ class Libpng(AutotoolsPackage):
         args += self.enable_or_disable("libs")
         return args
 
-    def check(self):
-        # Libpng has both 'check' and 'test' targets that are aliases.
-        # Only need to run the tests once.
-        make("check")
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        return [
+            self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
+            self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
+        ]


### PR DESCRIPTION
Refactor libpng to be built with CMake instead of autotools and in doing so, support Windows.

Part of #34938 