### PR TITLE
Improve libtiff CMake builder

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -113,12 +113,13 @@ class Libtiff(CMakePackage, AutotoolsPackage):
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        args = [self.define_from_variant(var) for var in VARIANTS]
+        return [
+            self.define_from_variant("jpeg"),
+            self.define_from_variant("zlib"),
+            self.define_from_variant("jbig"),
+            self.define_from_variant("pixarlog")
+        ]
 
-        # Remove empty strings
-        args = [arg for arg in args if arg]
-
-        return args
 
 
 class AutotoolsBuilder(AutotoolsBuilder):

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -117,9 +117,8 @@ class CMakeBuilder(CMakeBuilder):
             self.define_from_variant("jpeg"),
             self.define_from_variant("zlib"),
             self.define_from_variant("jbig"),
-            self.define_from_variant("pixarlog")
+            self.define_from_variant("pixarlog"),
         ]
-
 
 
 class AutotoolsBuilder(AutotoolsBuilder):


### PR DESCRIPTION
update libtiff's CMake port for more robust handling w.r.t. variants.

Part of #34938 