### PR TITLE
HDF5: No specific MPI provider in depends on

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -197,7 +197,6 @@ class Hdf5(CMakePackage):
     depends_on("cmake@3.12:", type="build")
     depends_on("cmake@3.18:", type="build", when="@1.13:")
 
-    depends_on("msmpi", when="+mpi platform=windows")
     depends_on("mpi", when="+mpi")
     depends_on("java", type=("build", "run"), when="+java")
     depends_on("szip", when="+szip")


### PR DESCRIPTION
Remove direct statement of dependence on a specific MPI provider for Windows platform.

This is not only fundamentally incorrect w.r.t. modeling, it also precludes us from using IntelMPI on Windows with HDF5, which is obviously not ideal. Thus this PR removes that line and allows Spack's virtual dependency management to provide the MPI.

Part of #34938 