### PR TITLE
add_padding: fix boundary case and text encoding

### DIFF
--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -119,7 +119,6 @@ def parse_install_tree(config_dict):
             msg = "Cannot pad %s to %s characters." % (root, padded_length)
             msg += " It is already %s characters long" % len(root)
             tty.warn(msg)
-        root = root.rstrip(os.path.sep)
     else:
         root = unpadded_root
 


### PR DESCRIPTION
There is a number of issues with how we use padding in Store paths:

1. We should guarantee that trailing characters aren't dir separators.
   This would avoid issues where `os.path.join(padded_path, subdir)` does
   not add an extra dir separator, so that we effectively have a shorter
   prefix than set in config.
2. Special case of (1) is when the input string with trailing dir
   separator dropped is of size padded length - 1. In that case we
   currently do nothing, but that breaks the guarantee that
   `config:install_tree:padded_length` gives you *at least* padded_length
   padding. So, instead we should just create a 1 character subdir.
3. We use `len(string)`, which counts code points instead of code units.
   Since we care about the bytes representation here when relocating,
   it's more correct when`padded_length` counts code units, so that
   relocation works from paths consisting of just single-byte characters
   to paths that contain multibyte characters.
4. We should probably still support UTF-16, since Python is not
   guaranteed to always deal with paths as UTF-8 on Windows, even after
   PEP 529. So, that means dealing with code units instead of bytes
   makes most sense.

This PR fixes those edge case, but is unfortunately also breaking in
three ways.

Breaking change 1: if we previously had a prefix like this with
`padded_length` set to `30`:

```
123456789012345678901234567890|1
/x/__spack_path_placeholder__/|/
                             ^
                             padded length
```

then effectively we would really pad to `29` characters. In this PR, we
*do* pad to `30` characters:

```
123456789012345678901234567890|1
/x/__spack_path_placeholder___|/
                             ^
                             padded length
```

Breaking change 2: similar to 1, if we previously had a prefix like this
with `padded_length` set to 3:

```
123|4
/x |
  ^
  padded length
```

we would stick to a 2-char prefix `/x`, with this PR we use at least 3
by taking `/x/_` instead:

```
123|4
/x/|_
  ^
  padded length
```

Breaking change 3: when a path contains multi-byte characters like
emojis, we previously counted characters, but now we count code units,
so the prefix we use gets shorter. For example, if we previously had
`padded_length` set to 14, we would get:

```
/😬/__spack_pat
```

but now we get 3 characters fewer, since the emoji is 4 units

```
/😬/__spack_
```
