### PR TITLE
Update gftl, gftl-shared, fargparse, pfunit, yafyaml, pflogger

### DIFF
--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -19,6 +19,8 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    # Generate checksum with spack checksum fargparse@x.y.z
+    version("1.4.2", sha256="2cd3f14845235407c6a4171ab4602499dade045e3f9b7dc75190f4a315ac8b44")
     version("1.4.1", sha256="8f9b92a80f05b0a8ab2dd5cd309ad165041c7fcdd589b96bf75c7dd889b9b584")
     version("1.3.1", sha256="65d168696762b53f9a34fac8a82527fb602372f47be05018ebb382ec27b52c6c")
     version("1.3.0", sha256="08fde5fb1b739b69203ac336fe7b39915cfc7f52e068e564b9b6d905d79fc93d")

--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -19,7 +19,6 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
-    # Generate checksum with spack checksum fargparse@x.y.z
     version("1.4.2", sha256="2cd3f14845235407c6a4171ab4602499dade045e3f9b7dc75190f4a315ac8b44")
     version("1.4.1", sha256="8f9b92a80f05b0a8ab2dd5cd309ad165041c7fcdd589b96bf75c7dd889b9b584")
     version("1.3.1", sha256="65d168696762b53f9a34fac8a82527fb602372f47be05018ebb382ec27b52c6c")
@@ -29,6 +28,7 @@ class Fargparse(CMakePackage):
 
     depends_on("gftl-shared")
     depends_on("gftl")
+    depends_on("cmake@3.12:", type="build")
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -22,7 +22,6 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
-    # Generate checksum with spack checksum gftl-shared@x.y.z
     version("1.5.1", sha256="353d07cc22678d1a79b19dbf53d8ba54b889e424a15e315cc4f035b72eedb83a")
     version("1.5.0", sha256="c19b8197cc6956d4a51a16f98b38b63c7bc9f784f1fd38f8e3949be3ea792356")
     version("1.4.1", sha256="bb403f72e80aaac49ed5107f7c755ce5273c2e650bd5438a746228798eeced6c")
@@ -36,7 +35,7 @@ class GftlShared(CMakePackage):
     version("1.3.0", sha256="979b00c4d531e701bf4346f662e3e4cc865124a97ca958637a53201d66d4ee43")
 
     depends_on("m4", type=("build", "run"))
-    depends_on("cmake", type="build")
+    depends_on("cmake@3.12:", type="build")
     depends_on("gftl")
 
     variant(

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -22,6 +22,8 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    # Generate checksum with spack checksum gftl-shared@x.y.z
+    version("1.5.1", sha256="353d07cc22678d1a79b19dbf53d8ba54b889e424a15e315cc4f035b72eedb83a")
     version("1.5.0", sha256="c19b8197cc6956d4a51a16f98b38b63c7bc9f784f1fd38f8e3949be3ea792356")
     version("1.4.1", sha256="bb403f72e80aaac49ed5107f7c755ce5273c2e650bd5438a746228798eeced6c")
     version("1.4.0", sha256="83a2474ae943d81d797460b18106874de14c39093efd4e35abb3f1b6ec835171")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -38,7 +38,6 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
-    # Generate checksum with spack checksum gftl@x.y.z
     version("1.8.2", sha256="7ee9a1db62f6dd09e533516d7dc53fbc9c8c81464bb12f6eb558ad5d3bfd85ef")
     version("1.8.1", sha256="b8171ea69b108325816472ee47068618d709a3f563959142bc58ff38908a7210")
     version("1.8.0", sha256="e99def0a9a1b3031ceff22c416bee75e70558cf6b91ce4be70b0ad752dda26c6")
@@ -50,7 +49,7 @@ class Gftl(CMakePackage):
     version("1.5.5", sha256="67ff8210f08e9f2ee6ba23c8c26336f948420db5db7fc054c3a662e9017f18a3")
     version("1.5.4", sha256="4c53e932ba8d82616b65500f403a33a14957b9266b5e931e2448f1f005990750")
 
-    depends_on("cmake", type="build")
+    depends_on("cmake@3.12:", type="build")
     depends_on("m4", type="build")
 
     variant(

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -38,6 +38,8 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    # Generate checksum with spack checksum gftl@x.y.z
+    version("1.8.2", sha256="7ee9a1db62f6dd09e533516d7dc53fbc9c8c81464bb12f6eb558ad5d3bfd85ef")
     version("1.8.1", sha256="b8171ea69b108325816472ee47068618d709a3f563959142bc58ff38908a7210")
     version("1.8.0", sha256="e99def0a9a1b3031ceff22c416bee75e70558cf6b91ce4be70b0ad752dda26c6")
     version("1.7.2", sha256="35a39a0dffb91969af5577b6dd7681379e1c16ca545f0cc2dae0b5192474d852")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -19,7 +19,6 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
-    # Generate checksum with spack checksum pflogger@x.y.z
     version("1.9.2", sha256="783879eb1326a911f6e22c016e8530644ed0d315660405f2b43df42ba8670acc")
     version("1.9.1", sha256="918965f5a748a3a62e54751578f5935a820407b988b8455f7f25c266b5b7fe3c")
     version("1.9.0", sha256="aacd9b7e188bee3a54a4e681adde32e3bd95bb556cbbbd2c725c81aca5008003")
@@ -49,6 +48,8 @@ class Pflogger(CMakePackage):
     depends_on("yafyaml@1.0.4:", when="@1.9:")
 
     depends_on("mpi", when="+mpi")
+
+    depends_on("cmake@3.12:", type="build")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -19,6 +19,8 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    # Generate checksum with spack checksum pflogger@x.y.z
+    version("1.9.2", sha256="783879eb1326a911f6e22c016e8530644ed0d315660405f2b43df42ba8670acc")
     version("1.9.1", sha256="918965f5a748a3a62e54751578f5935a820407b988b8455f7f25c266b5b7fe3c")
     version("1.9.0", sha256="aacd9b7e188bee3a54a4e681adde32e3bd95bb556cbbbd2c725c81aca5008003")
     version("1.8.0", sha256="28ce9ac8af374253b6dfd8f53f8fd271c787d432645ec9bc6a5a01601dc56e19")

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -20,6 +20,8 @@ class Pfunit(CMakePackage):
 
     maintainers = ["mathomp4", "tclune"]
 
+    # Generate checksum with spack checksum pfunit@x.y.z
+    version("4.6.2", sha256="fd302a1f7a131b38e18bc31ede69a216e580c640152e5e313f5a1e084669a950")
     version("4.6.1", sha256="19de22ff0542ca900aaf2957407f24d7dadaccd993ea210beaf22032d3095add")
     version("4.6.0", sha256="7c768ea3a2d16d8ef6229b25bd7756721c24a18db779c7422afde0e3e2248d72")
     version("4.5.0", sha256="ae0ed4541f2f4ec7b1d06eed532a49cb4c666394ab92b233911f92ce50f76743")

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -20,7 +20,6 @@ class Pfunit(CMakePackage):
 
     maintainers = ["mathomp4", "tclune"]
 
-    # Generate checksum with spack checksum pfunit@x.y.z
     version("4.6.2", sha256="fd302a1f7a131b38e18bc31ede69a216e580c640152e5e313f5a1e084669a950")
     version("4.6.1", sha256="19de22ff0542ca900aaf2957407f24d7dadaccd993ea210beaf22032d3095add")
     version("4.6.0", sha256="7c768ea3a2d16d8ef6229b25bd7756721c24a18db779c7422afde0e3e2248d72")
@@ -78,6 +77,15 @@ class Pfunit(CMakePackage):
     depends_on("esmf", when="+esmf")
     depends_on("m4", when="@4.1.5:", type="build")
     depends_on("fargparse", when="@4:")
+    depends_on("cmake@3.12:", type="build")
+
+    # CMake 3.25.0 has an issue with pFUnit
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/24203
+    conflicts(
+        "^cmake@3.25.0",
+        when="@4.0.0:",
+        msg="CMake 3.25.0 has a bug with pFUnit. Please use an older or newer version.",
+    )
 
     conflicts(
         "%gcc@:8.3.9",

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -25,6 +25,8 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    # Generate checksum with spack checksum yafyaml@x.y.z
+    version("1.0.5", sha256="84abad01cdcfe387240844c35e5fb36d5099f657b57a50d5d5909cc567e72200")
     version("1.0.4", sha256="93ba67c87cf96be7ebe479907ca5343251aa48072b2671b8630bd244540096d3")
     version("1.0.3", sha256="cfbc6b6db660c5688e37da56f9f0091e5cafeeaec395c2a038469066c83b0c65")
     version("1.0.2", sha256="1d08d093d0f4331e4019306a3b6cb0b230aed18998692b57931555d6805f3d94")

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -25,7 +25,6 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
-    # Generate checksum with spack checksum yafyaml@x.y.z
     version("1.0.5", sha256="84abad01cdcfe387240844c35e5fb36d5099f657b57a50d5d5909cc567e72200")
     version("1.0.4", sha256="93ba67c87cf96be7ebe479907ca5343251aa48072b2671b8630bd244540096d3")
     version("1.0.3", sha256="cfbc6b6db660c5688e37da56f9f0091e5cafeeaec395c2a038469066c83b0c65")
@@ -42,6 +41,7 @@ class Yafyaml(CMakePackage):
 
     depends_on("gftl-shared")
     depends_on("gftl")
+    depends_on("cmake@3.12:", type="build")
 
     variant(
         "build_type",


### PR DESCRIPTION
Closes #35055

This PR updates the GFE packages:

* gftl
* gftl-shared
* fargparse
* pfunit
* yafyaml
* pflogger

The updates in version are to fix issues when using GFE packages with GNU Make instead of CMake.