### PR TITLE
py-flatten-dict: require poetry to build.

### DIFF
--- a/var/spack/repos/builtin/packages/py-flatten-dict/package.py
+++ b/var/spack/repos/builtin/packages/py-flatten-dict/package.py
@@ -17,6 +17,6 @@ class PyFlattenDict(PythonPackage):
     version("0.3.0", sha256="0ccc43f15c7c84c5ef387ad19254f6769a32d170313a1bcbf4ce582089313d7e")
 
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-poetry", type="build")
     depends_on("py-six@1.12:1", type=("build", "run"))
     depends_on("py-pathlib2@2.3:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-flatten-dict/package.py
+++ b/var/spack/repos/builtin/packages/py-flatten-dict/package.py
@@ -16,7 +16,7 @@ class PyFlattenDict(PythonPackage):
 
     version("0.3.0", sha256="0ccc43f15c7c84c5ef387ad19254f6769a32d170313a1bcbf4ce582089313d7e")
 
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
+    depends_on("python@2.7,3.5:3", type=("build", "run"))
     depends_on("py-poetry@1:", type="build")
     depends_on("py-six@1.12:1", type=("build", "run"))
     depends_on("py-pathlib2@2.3:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-flatten-dict/package.py
+++ b/var/spack/repos/builtin/packages/py-flatten-dict/package.py
@@ -17,6 +17,6 @@ class PyFlattenDict(PythonPackage):
     version("0.3.0", sha256="0ccc43f15c7c84c5ef387ad19254f6769a32d170313a1bcbf4ce582089313d7e")
 
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
-    depends_on("py-poetry", type="build")
+    depends_on("py-poetry@1:", type="build")
     depends_on("py-six@1.12:1", type=("build", "run"))
     depends_on("py-pathlib2@2.3:2", type=("build", "run"))


### PR DESCRIPTION
The sources seem to contain a bundled, auto-generated `setup.py`.
Building with `pip` insist on using Poetry as mentioned in
`pyproject.toml`, so require it as a build dependency.
