### PR TITLE
Avoid creating help.sh and test.sh in cwd

### DIFF
--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -2,9 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import itertools as it
+import itertools
 import os
+import subprocess
 import sys
 
 import pytest
@@ -14,7 +14,7 @@ import llnl.util.filesystem as fs
 import spack.ci as ci
 import spack.ci_needs_workaround as cinw
 import spack.ci_optimization as ci_opt
-import spack.config as cfg
+import spack.config
 import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
@@ -23,12 +23,16 @@ import spack.util.gpg
 import spack.util.spack_yaml as syaml
 
 
+@pytest.fixture
+def repro_dir(tmp_path):
+    result = tmp_path / "repro_dir"
+    result.mkdir()
+    with fs.working_dir(str(tmp_path)):
+        yield result
+
+
 def test_urlencode_string():
-    s = "Spack Test Project"
-
-    s_enc = ci._url_encode_string(s)
-
-    assert s_enc == "Spack+Test+Project"
+    assert ci._url_encode_string("Spack Test Project") == "Spack+Test+Project"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
@@ -54,16 +58,16 @@ def test_configure_compilers(mutable_config):
             "install_missing_compilers" in config and config["install_missing_compilers"] is True
         )
 
-    original_config = cfg.get("config")
+    original_config = spack.config.get("config")
     assert_missing(original_config)
 
     ci.configure_compilers("FIND_ANY", scope="site")
 
-    second_config = cfg.get("config")
+    second_config = spack.config.get("config")
     assert_missing(second_config)
 
     ci.configure_compilers("INSTALL_MISSING")
-    last_config = cfg.get("config")
+    last_config = spack.config.get("config")
     assert_present(last_config)
 
 
@@ -380,7 +384,7 @@ def test_ci_workarounds():
             use_artifact_buildcache=use_ab, optimize=False, use_dependencies=False
         )
 
-        for opt, deps in it.product(*(((False, True),) * 2)):
+        for opt, deps in itertools.product(*(((False, True),) * 2)):
             # neither optimizing nor converting needs->dependencies
             if not (opt or deps):
                 # therefore, nothing to test
@@ -453,33 +457,24 @@ def test_affected_specs_on_first_concretization(mutable_mock_env_path, mock_pack
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
-def test_ci_process_command(tmpdir):
-    repro_dir = tmpdir.join("repro_dir").strpath
-    os.makedirs(repro_dir)
-    result = ci.process_command("help", [], repro_dir)
-
-    assert os.path.exists(fs.join_path(repro_dir, "help.sh"))
-    assert not result
+def test_ci_process_command(repro_dir):
+    result = ci.process_command("help", commands=[], repro_dir=str(repro_dir))
+    help_sh = repro_dir / "help.sh"
+    assert help_sh.exists() and not result
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
-def test_ci_process_command_fail(tmpdir, monkeypatch):
-    import subprocess
-
-    err = "subprocess wait exception"
+def test_ci_process_command_fail(repro_dir, monkeypatch):
+    msg = "subprocess wait exception"
 
     def _fail(self, args):
-        raise RuntimeError(err)
+        raise RuntimeError(msg)
 
     monkeypatch.setattr(subprocess.Popen, "__init__", _fail)
-
-    repro_dir = tmpdir.join("repro_dir").strpath
-    os.makedirs(repro_dir)
-
-    with pytest.raises(RuntimeError, match=err):
-        ci.process_command("help", [], repro_dir)
+    with pytest.raises(RuntimeError, match=msg):
+        ci.process_command("help", [], str(repro_dir))
 
 
 def test_ci_create_buildcache(tmpdir, working_env, config, mock_packages, monkeypatch):
@@ -513,16 +508,15 @@ def test_ci_run_standalone_tests_missing_requirements(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_junit(
-    tmpdir, working_env, default_mock_concretization, mock_test_stage, capfd
+    tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):
-    log_file = tmpdir.join("junit.xml").strpath
+    log_file = tmp_path / "junit.xml"
     args = {
-        "log_file": log_file,
+        "log_file": str(log_file),
         "job_spec": default_mock_concretization("printing-package"),
-        "repro_dir": tmpdir.join("repro_dir").strpath,
+        "repro_dir": str(repro_dir),
         "fail_fast": True,
     }
-    os.makedirs(args["repro_dir"])
 
     ci.run_standalone_tests(**args)
     err = capfd.readouterr()[1]
@@ -534,16 +528,15 @@ def test_ci_run_standalone_tests_not_installed_junit(
     sys.platform == "win32", reason="Reliance on bash script not supported on Windows"
 )
 def test_ci_run_standalone_tests_not_installed_cdash(
-    tmpdir, working_env, default_mock_concretization, mock_test_stage, capfd
+    tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
 ):
     """Test run_standalone_tests with cdash and related options."""
-    log_file = tmpdir.join("junit.xml").strpath
+    log_file = tmp_path / "junit.xml"
     args = {
-        "log_file": log_file,
+        "log_file": str(log_file),
         "job_spec": default_mock_concretization("printing-package"),
-        "repro_dir": tmpdir.join("repro_dir").strpath,
+        "repro_dir": str(repro_dir),
     }
-    os.makedirs(args["repro_dir"])
 
     # Cover when CDash handler provided (with the log file as well)
     ci_cdash = {
@@ -564,9 +557,9 @@ def test_ci_run_standalone_tests_not_installed_cdash(
     assert "0 passed of 0" in out
 
     # copy test results (though none)
-    artifacts_dir = tmpdir.join("artifacts")
-    fs.mkdirp(artifacts_dir.strpath)
-    handler.copy_test_results(tmpdir.strpath, artifacts_dir.strpath)
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    handler.copy_test_results(str(tmp_path), str(artifacts_dir))
     err = capfd.readouterr()[1]
     assert "Unable to copy files" in err
     assert "No such file or directory" in err


### PR DESCRIPTION
When running unit-tests the `test/ci.py` module is leaving garbage (`help.sh` and `test.sh` files) in the current working directory. This PR changes the current working directory to a temporary path before those files are created.