### PR TITLE
binutils: faster/smaller and new versions

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -20,6 +20,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
     executables = ["^nm$", "^readelf$"]
 
+    version("2.40", sha256="f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a")
+    version("2.39", sha256="da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148")
     version("2.38", sha256="070ec71cf077a6a58e0b959f05a09a35015378c2d8a51e90f3aeabfe30590ef8")
     version("2.37", sha256="67fc1a4030d08ee877a4867d3dcab35828148f87e1fd05da6db585ed5a166bd4")
     version("2.36.1", sha256="5b4bd2e79e30ce8db0abd76dd2c2eae14a94ce212cfc59d3c37d23e24bc6d7a3")
@@ -30,6 +32,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     version("2.33.1", sha256="0cb4843da15a65a953907c96bad658283f3c4419d6bcc56bf2789db16306adb2")
     version("2.32", sha256="de38b15c902eb2725eac6af21183a5f34ea4634cb0bcef19612b50e5ed31072d")
     version("2.31.1", sha256="ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0")
+    version("2.30", sha256="efeade848067e9a03f1918b1da0d37aaffa0b0127a06b5e9236229851d9d0c09")
     version("2.29.1", sha256="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc")
     version("2.28", sha256="6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72")
     version("2.27", sha256="369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88")
@@ -45,9 +48,15 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     # --disable-ld flag
     variant("gold", default=False, when="+ld", description="build the gold linker")
     variant("libiberty", default=False, description="Also install libiberty.")
-    variant("nls", default=True, description="Enable Native Language Support")
+    variant("nls", default=False, description="Enable Native Language Support")
     variant("headers", default=False, description="Install extra headers (e.g. ELF)")
     variant("lto", default=False, description="Enable lto.")
+    variant(
+        "pgo",
+        default=False,
+        description="Build with profile-guided optimization (slow)",
+        when="@2.37:",
+    )
     variant("ld", default=False, description="Enable ld.")
     # When you build binutils with ~ld and +gas and load it in your PATH, you
     # may end up with incompatibilities between a potentially older system ld
@@ -57,6 +66,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     # when compiling with debug symbols on gcc.
     variant("gas", default=False, when="+ld", description="Enable as assembler.")
     variant("interwork", default=False, description="Enable interwork.")
+    variant("gprofng", default=False, description="Enable gprofng.", when="@2.39:")
     variant(
         "libs",
         default="shared,static",
@@ -76,16 +86,26 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     depends_on("diffutils", type="build")
     depends_on("gettext", when="+nls")
 
+    # PGO runs tests, which requires `runtest` from dejagnu
+    depends_on("dejagnu", when="+pgo", type="build")
+
     # Prior to 2.30, gold did not distribute the generated files and
     # thus needs bison, even for a one-time build.
     depends_on("m4", type="build", when="@:2.29 +gold")
     depends_on("bison", type="build", when="@:2.29 +gold")
 
-    # 2.34:2.38 needs makeinfo due to a bug, see:
+    # 2.34:2.40 needs makeinfo due to a bug, see:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=25491
-    depends_on("texinfo", type="build", when="@2.34:2.38")
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=28909
+    depends_on("texinfo", type="build", when="@2.34:2.40")
+
+    # gprofng requires bison
+    depends_on("bison@3.0.4:", type="build", when="+gprofng")
 
     conflicts("+gold", when="platform=darwin", msg="Binutils cannot build linkers on macOS")
+    conflicts(
+        "~lto", when="+pgo", msg="Profile-guided optimization enables link-time optimization"
+    )
 
     @classmethod
     def determine_version(cls, exe):
@@ -95,6 +115,13 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
     def flag_handler(self, name, flags):
         spec = self.spec
+
+        # Set -O3 -g0 by default when using gcc or clang, since it improves performance
+        # a bit and significantly reduces install size
+        if name in ("cflags", "cxxflags") and self.compiler.name in ("gcc", "clang"):
+            flags.insert(0, "-g0")
+            flags.insert(0, "-O3")
+
         # Use a separate variable for injecting flags. This way, installing
         # `binutils cflags='-O2'` will still work as expected.
         iflags = []
@@ -105,10 +132,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
         ):
             iflags.append("-Wno-narrowing")
         elif name == "cflags":
-            if spec.satisfies("@:2.34 %gcc@10:"):
+            if spec.satisfies("@:2.34 %gcc@10:") or spec.satisfies("%cce"):
                 iflags.append("-fcommon")
-            if spec.satisfies("%cce") or spec.satisfies("@2.38 %gcc"):
-                iflags.extend([self.compiler.cc_pic_flag, "-fcommon"])
         elif name == "ldflags":
             if spec.satisfies("%cce") or spec.satisfies("@2.38 %gcc"):
                 iflags.append("-Wl,-z,notext")
@@ -143,28 +168,45 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
+        known_targets = {
+            "x86_64": "x86_64",
+            "aarch64": "aarch64",
+            "ppc64le": "powerpc",
+        }
+        known_platforms = {"linux": "linux-gnu", "cray": "linux-gnu", "darwin": "apple-darwin"}
+
+        family = str(self.spec.target.family)
+        platform = self.spec.platform
+
+        if family in known_targets and platform in known_platforms:
+            targets = "{}-{}".format(known_targets[family], known_platforms[platform])
+        else:
+            targets = "all"
+
         args = [
             "--disable-dependency-tracking",
             "--disable-werror",
-            "--enable-multilib",
             "--enable-64-bit-bfd",
-            "--enable-targets=all",
-            "--with-system-zlib",
+            "--enable-multilib",
+            "--enable-pic",
+            "--enable-targets={}".format(targets),
             "--with-sysroot=/",
+            "--with-system-zlib",
         ]
+        args += self.enable_or_disable("gas")
+        args += self.enable_or_disable("gold")
+        args += self.enable_or_disable("gprofng")
+        args += self.enable_or_disable("install-libiberty", variant="libiberty")
+        args += self.enable_or_disable("interwork")
+        args += self.enable_or_disable("ld")
         args += self.enable_or_disable("libs")
         args += self.enable_or_disable("lto")
-        args += self.enable_or_disable("ld")
-        args += self.enable_or_disable("gas")
-        args += self.enable_or_disable("interwork")
-        args += self.enable_or_disable("gold")
         args += self.enable_or_disable("nls")
         args += self.enable_or_disable("plugins")
-
-        if "+libiberty" in self.spec:
-            args.append("--enable-install-libiberty")
+        if "+pgo" in self.spec:
+            args.append("--enable-pgo-build=lto")
         else:
-            args.append("--disable-install-libiberty")
+            args.append("--disable-pgo-build")
 
         # To avoid namespace collisions with Darwin/BSD system tools,
         # prefix executables with "g", e.g., gar, gnm; see Homebrew

--- a/var/spack/repos/builtin/packages/dejagnu/package.py
+++ b/var/spack/repos/builtin/packages/dejagnu/package.py
@@ -13,11 +13,11 @@ class Dejagnu(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/dejagnu/"
     gnu_mirror_path = "dejagnu/dejagnu-1.6.tar.gz"
 
+    version("1.6.3", sha256="87daefacd7958b4a69f88c6856dbd1634261963c414079d0c371f589cd66a2e3")
     version("1.6", sha256="00b64a618e2b6b581b16eb9131ee80f721baa2669fa0cdee93c500d1a652d763")
     version("1.4.4", sha256="d0fbedef20fb0843318d60551023631176b27ceb1e11de7468a971770d0e048d")
 
-    depends_on("expect")
-    depends_on("tcl@8.5:")
+    depends_on("expect", type=("run", "link", "build"))
 
     # DejaGnu 1.4.4 cannot be built in parallel
     # `make check` also fails but this can be ignored


### PR DESCRIPTION
- binutils new versions: v2.30, 2.39, 2.40
- toggle for gprofng 
- binutils: make PGO builds possible
- Restrict the targets to get a faster `ld` and reduce size on disk
- disable nls by default to avoid another shared lib
- deal with pic in configure flags instead of flag handler

---

With all these changes, `binutils +ld +pgo` runs significantly faster. For example

```
Summary
  '/home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.40-ogs423e7vxrxpzqwikgjrzcxwxfwfdbr/bin/ld -plugin /usr/lib/gcc/x86_64-linux-gnu/12/liblto_plugin.so -plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper -plugin-opt=-fresolution=/tmp/cc72VVl0.res -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lc -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s --build-id --eh-frame-hdr -m elf_x86_64 --hash-style=gnu --as-needed -dynamic-linker /lib64/ld-linux-x86-64.so.2 -pie -z now -z relro /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/12/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/12/../../.. -v hello.o -lgcc --push-state --as-needed -lgcc_s --pop-state -lc -lgcc --push-state --as-needed -lgcc_s --pop-state /usr/lib/gcc/x86_64-linux-gnu/12/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crtn.o' ran
    1.15 ± 0.03 times faster than '/usr/bin/ld -plugin /usr/lib/gcc/x86_64-linux-gnu/12/liblto_plugin.so -plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper -plugin-opt=-fresolution=/tmp/cc72VVl0.res -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lc -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s --build-id --eh-frame-hdr -m elf_x86_64 --hash-style=gnu --as-needed -dynamic-linker /lib64/ld-linux-x86-64.so.2 -pie -z now -z relro /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/12/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/12/../../.. -v hello.o -lgcc --push-state --as-needed -lgcc_s --pop-state -lc -lgcc --push-state --as-needed -lgcc_s --pop-state /usr/lib/gcc/x86_64-linux-gnu/12/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crtn.o'
    1.58 ± 0.03 times faster than '/home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.38-7qr6y6mwxyrgkunwhmnggleeem6dpsig/bin/ld -plugin /usr/lib/gcc/x86_64-linux-gnu/12/liblto_plugin.so -plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper -plugin-opt=-fresolution=/tmp/cc72VVl0.res -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lc -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s --build-id --eh-frame-hdr -m elf_x86_64 --hash-style=gnu --as-needed -dynamic-linker /lib64/ld-linux-x86-64.so.2 -pie -z now -z relro /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/12/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/12/../../.. -v hello.o -lgcc --push-state --as-needed -lgcc_s --pop-state -lc -lgcc --push-state --as-needed -lgcc_s --pop-state /usr/lib/gcc/x86_64-linux-gnu/12/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/crtn.o'
```

so `1.15x` faster than system `ld` and `1.58x` faster than binutils currently on Spack `develop`.

Size on disk is 95% smaller (ok, it only has static libs in the second case, but that means the executables are larger too):

```
$ du -sh /home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.38-7qr6y6mwxyrgkunwhmnggleeem6dpsig
808M	/home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.38-7qr6y6mwxyrgkunwhmnggleeem6dpsig

$ du -sh /home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.40-ogs423e7vxrxpzqwikgjrzcxwxfwfdbr
41M	/home/harmen/spack/opt/spack/linux-ubuntu22.10-zen2/gcc-12.2.0/binutils-2.40-ogs423e7vxrxpzqwikgjrzcxwxfwfdbr
```