### PR TITLE
py-poetry-core GIT_DIR fix

### DIFF
--- a/var/spack/repos/builtin/packages/py-poetry-core/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-core/package.py
@@ -24,7 +24,7 @@ class PyPoetryCore(PythonPackage):
 
     # https://github.com/python-poetry/poetry/issues/5547
     def setup_build_environment(self, env):
-        env.set("GIT_DIR", self.stage.source_path)
+        env.set("GIT_DIR", join_path(self.stage.source_path, ".git"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set("GIT_DIR", dependent_spec.package.stage.source_path)
+        env.set("GIT_DIR", join_path(dependent_spec.package.stage.source_path, ".git"))


### PR DESCRIPTION
Fixing py-poetry-core package bug introduced here: https://github.com/spack/spack/pull/33181

The spack py-poetry-core package sets GIT_DIR, disabling git's internal search for the .git file. In #33181, GIT_DIR is set incorrectly, meaning that the poetry-core installation succeeds, but any git commands run after the spack poetry wrapper will fail with the following error: 
```
fatal: not a git repository: '${SPACK STAGING ROOT}/spack-src'
```
The problem is that GIT_DIR must be set to the full path of the .git file, including the .git suffix (omitted in #33181). This behavior can be reproduced in any git repo:

```console
$ GIT_DIR=~/spack git status
fatal: not a git repository: '.../spack'
$ GIT_DIR=~/spack/.git git status
On branch develop
Your branch is up to date with 'origin/develop'.
nothing to commit, working tree clean
```

I tested this fix manually on a test package dependent on py-poetry-core. 