### PR TITLE
wrf: Fix patching of config file when using GCC for v3.9.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -290,9 +290,13 @@ class Wrf(Package):
             # Compiling with OpenMPI requires using `-DMPI2SUPPORT`.
             other_flags = " -DMPI2SUPPORT" if self.spec.satisfies("^openmpi") else ""
             config.filter(
-                "^DM_FC.*mpif90 -f90=\$\(SFC\)", "DM_FC = {0}".format(self.spec["mpi"].mpifc) + other_flags
+                "^DM_FC.*mpif90 -f90=\$\(SFC\)",
+                "DM_FC = {0}".format(self.spec["mpi"].mpifc) + other_flags,
             )
-            config.filter("^DM_CC.*mpicc -cc=\$\(SCC\)", "DM_CC = {0}".format(self.spec["mpi"].mpicc) + other_flags)
+            config.filter(
+                "^DM_CC.*mpicc -cc=\$\(SCC\)",
+                "DM_CC = {0}".format(self.spec["mpi"].mpicc) + other_flags,
+            )
 
         if self.spec.satisfies("%aocc"):
             config.filter(

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -287,10 +287,12 @@ class Wrf(Package):
             config = FileFilter(join_path("arch", "configure.defaults"))
 
         if self.spec.satisfies("@3.9.1.1 %gcc"):
+            # Compiling with OpenMPI requires using `-DMPI2SUPPORT`.
+            other_flags = " -DMPI2SUPPORT" if self.spec.satisfies("^openmpi") else ""
             config.filter(
-                "^DM_FC.*mpif90 -f90=$(SFC)", "DM_FC = {0}".format(self.spec["mpi"].mpifc)
+                "^DM_FC.*mpif90 -f90=\$\(SFC\)", "DM_FC = {0}".format(self.spec["mpi"].mpifc) + other_flags
             )
-            config.filter("^DM_CC.*mpicc -cc=$(SCC)", "DM_CC = {0}".format(self.spec["mpi"].mpicc))
+            config.filter("^DM_CC.*mpicc -cc=\$\(SCC\)", "DM_CC = {0}".format(self.spec["mpi"].mpicc) + other_flags)
 
         if self.spec.satisfies("%aocc"):
             config.filter(

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -290,11 +290,11 @@ class Wrf(Package):
             # Compiling with OpenMPI requires using `-DMPI2SUPPORT`.
             other_flags = " -DMPI2SUPPORT" if self.spec.satisfies("^openmpi") else ""
             config.filter(
-                "^DM_FC.*mpif90 -f90=\$\(SFC\)",
+                r"^DM_FC.*mpif90 -f90=\$\(SFC\)",
                 "DM_FC = {0}".format(self.spec["mpi"].mpifc) + other_flags,
             )
             config.filter(
-                "^DM_CC.*mpicc -cc=\$\(SCC\)",
+                r"^DM_CC.*mpicc -cc=\$\(SCC\)",
                 "DM_CC = {0}".format(self.spec["mpi"].mpicc) + other_flags,
             )
 


### PR DESCRIPTION
The regex doesn't actually work because dollar signs and parentheses have to be escaped (I doubt this ever worked).  Also, compiling with OpenMPI requires defining the macro `MPI2SUPPORT`.  I found a hint about this in https://qiita.com/7of9/items/a3c692585bf6b905fff3, which quite amusingly refers to [a question on StackOverflow](https://stackoverflow.com/questions/10716528/openmpi-compiling-error-mpicxx-h-expected-identifier-before-numeric-constant) answered by @alalazo over 10 years ago :slightly_smiling_face: 

Side note: I need to do more testing, but I believe https://github.com/spack/spack/blob/a9d5db572c2c0dacd115665d12e557750e74b965/var/spack/repos/builtin/packages/wrf/package.py#L230-L233 isn't enough for passing `-fallow-argument-mismatch` through because yesterday I was still getting errors about mismatched arguments, I suspect in v3.9.1.1 `FFLAGS`/`FCFLAGS` weren't used very consistently.