### PR TITLE
Windows: Fix spack.bat handling of env commands

### DIFF
--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -96,20 +96,23 @@ set str_subcommand=%_sp_subcommand:"='%
 set str_flags=%_sp_flags:"='%
 set str_args=%_sp_args:"='%
 if "%str_subcommand%"=="ECHO is off." (set "_sp_subcommand=")
+if "%str_subcommand%"=="ECHO is on." (set "_sp_subcommand=")
 if "%str_flags%"=="ECHO is off." (set "_sp_flags=")
+if "%str_flags%"=="ECHO is on." (set "_sp_flags=")
 if "%str_args%"=="ECHO is off." (set "_sp_args=")
+if "%str_args%"=="ECHO is on." (set "_sp_args=")
 del subcmd
 del flags
 del args
 
 :: Filter out some commands. For any others, just run the command.
-if "%_sp_subcommand%" == "cd" (
+if %_sp_subcommand% == "cd" (
     goto :case_cd
-) else if "%_sp_subcommand%" == "env" (
+) else if %_sp_subcommand% == "env" (
     goto :case_env
-) else if "%_sp_subcommand%" == "load" (
+) else if %_sp_subcommand% == "load" (
     goto :case_load
-) else if "%_sp_subcommand%" == "unload" (
+) else if %_sp_subcommand% == "unload" (
     goto :case_load
 ) else (
     goto :default_case
@@ -141,21 +144,22 @@ goto :end_switch
 
 :case_env
 :: If no args or args contain --bat or -h/--help: just execute.
+set args_no_quote=%_sp_args:"=%
 if NOT defined _sp_args (
     goto :default_case
-)else if NOT "%_sp_args%"=="%_sp_args:--help=%" (
+)else if NOT "%args_no_quote%"=="%args_no_quote:--help=%" (
     goto :default_case
-) else if NOT "%_sp_args%"=="%_sp_args: -h=%" (
+) else if NOT "%args_no_quote%"=="%args_no_quote: -h=%" (
     goto :default_case
-) else if NOT "%_sp_args%"=="%_sp_args:--bat=%" (
+) else if NOT "%args_no_quote%"=="%args_no_quote:--bat=%" (
     goto :default_case
-) else if NOT "%_sp_args%"=="%_sp_args:deactivate=%" (
+) else if NOT "%args_no_quote%"=="%args_no_quote:deactivate=%" (
     for /f "tokens=* USEBACKQ" %%I in (
-        `call python "%spack%" %_sp_flags% env deactivate --bat %_sp_args:deactivate=%`
+        `call python %spack% %_sp_flags% env deactivate --bat %args_no_quote:deactivate=%`
     ) do %%I
-) else if NOT "%_sp_args%"=="%_sp_args:activate=%" (
+) else if NOT "%args_no_quote%"=="%args_no_quote:activate=%" (
     for /f "tokens=* USEBACKQ" %%I in (
-        `call python "%spack%" %_sp_flags% env activate --bat %_sp_args:activate=%`
+        `python %spack% %_sp_flags% env activate --bat %args_no_quote:activate=%`
     ) do %%I
 ) else (
     goto :default_case

--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -83,6 +83,16 @@ if defined _sp_flags (
         exit /B 0
     )
 )
+if not defined _sp_subcommand (
+   if not defined _sp_args (
+      if not defined _sp_flags (
+         python "%spack%" --help
+         exit /B 0
+      )
+   )
+)
+
+
 :: pass parsed variables outside of local scope. Need to do
 :: this because delayedexpansion can only be set by setlocal
 echo %_sp_flags%>flags
@@ -144,10 +154,11 @@ goto :end_switch
 
 :case_env
 :: If no args or args contain --bat or -h/--help: just execute.
-set args_no_quote=%_sp_args:"=%
 if NOT defined _sp_args (
     goto :default_case
-)else if NOT "%args_no_quote%"=="%args_no_quote:--help=%" (
+)
+set args_no_quote=%_sp_args:"=%
+if NOT "%args_no_quote%"=="%args_no_quote:--help=%" (
     goto :default_case
 ) else if NOT "%args_no_quote%"=="%args_no_quote: -h=%" (
     goto :default_case

--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -102,15 +102,12 @@ endlocal
 set /p _sp_subcommand=<subcmd
 set /p _sp_flags=<flags
 set /p _sp_args=<args
-set str_subcommand=%_sp_subcommand:"='%
-set str_flags=%_sp_flags:"='%
-set str_args=%_sp_args:"='%
-if "%str_subcommand%"=="ECHO is off." (set "_sp_subcommand=")
-if "%str_subcommand%"=="ECHO is on." (set "_sp_subcommand=")
-if "%str_flags%"=="ECHO is off." (set "_sp_flags=")
-if "%str_flags%"=="ECHO is on." (set "_sp_flags=")
-if "%str_args%"=="ECHO is off." (set "_sp_args=")
-if "%str_args%"=="ECHO is on." (set "_sp_args=")
+if "%_sp_subcommand%"=="ECHO is off." (set "_sp_subcommand=")
+if "%_sp_subcommand%"=="ECHO is on." (set "_sp_subcommand=")
+if "%_sp_flags%"=="ECHO is off." (set "_sp_flags=")
+if "%_sp_flags%"=="ECHO is on." (set "_sp_flags=")
+if "%_sp_args%"=="ECHO is off." (set "_sp_args=")
+if "%_sp_args%"=="ECHO is on." (set "_sp_args=")
 del subcmd
 del flags
 del args

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -22,7 +22,7 @@ from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
 from llnl.util.symlink import islink, symlink
 
-from spack.util.executable import CommandNotFoundError, Executable, which
+from spack.util.executable import Executable, which
 from spack.util.path import path_to_os_path, system_path_filter
 
 is_windows = _platform == "win32"

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -116,13 +116,7 @@ def path_contains_subdirectory(path, root):
 @memoized
 def file_command(*args):
     """Creates entry point to `file` system command with provided arguments"""
-    try:
-        file_cmd = which("file", required=True)
-    except CommandNotFoundError as e:
-        if is_windows:
-            raise CommandNotFoundError("`file` utility is not available on Windows")
-        else:
-            raise e
+    file_cmd = which("file", required=True)
     for arg in args:
         file_cmd.add_default_arg(arg)
     return file_cmd
@@ -133,7 +127,11 @@ def _get_mime_type():
     """Generate method to call `file` system command to aquire mime type
     for a specified path
     """
-    return file_command("-b", "-h", "--mime-type")
+    if is_windows:
+        # -h option (no-dereference) does not exist in Windows
+        return file_command("-b", "--mime-type")
+    else:
+        return file_command("-b", "-h", "--mime-type")
 
 
 @memoized


### PR DESCRIPTION
This PR enables the successful execution of the spack binary cache tutorial on Windows.
It assumes gnupg and file are available ( I installed them with choco).
It fixes additional double quote issues in spack.cmd 