### PR TITLE
py-pycocotools: add v2.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-pycocotools/package.py
+++ b/var/spack/repos/builtin/packages/py-pycocotools/package.py
@@ -12,10 +12,13 @@ class PyPycocotools(PythonPackage):
     homepage = "https://github.com/cocodataset/cocoapi"
     pypi = "pycocotools/pycocotools-2.0.2.tar.gz"
 
+    version("2.0.6", sha256="7fe089b05cc18e806dcf3bd764708d86dab922a100f3734eb77fb77a70a1d18c")
     version("2.0.2", sha256="24717a12799b4471c2e54aa210d642e6cd4028826a1d49fcc2b0e3497e041f1a")
 
     depends_on("python", type=("build", "link", "run"))
-    depends_on("py-setuptools@18.0:", type="build")
-    depends_on("py-cython@0.27.3:", type="build")
-    depends_on("py-numpy", type=("build", "link", "run"))
+    depends_on("py-cython@0.27.3:", when="@2.0.4:", type="build")
+    depends_on("py-cython@0.27.3:", when="@:2.0.3", type=("build", "run"))
+    depends_on("py-setuptools@43:", when="@2.0.4:", type="build")
+    depends_on("py-setuptools@18.0:", when="@:2.0.3", type=("build", "run"))
     depends_on("py-matplotlib@2.1.0:", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "link", "run"))


### PR DESCRIPTION
Older versions mistakenly required cython/setuptools at run-time. Discovered with `pip check`.