### PR TITLE
trilinos@develop: conflict w/ cxxstd=11,14

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -331,6 +331,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts("+adios2", when="@:12.14.1")
     conflicts("cxxstd=11", when="@13.2:")
+    conflicts("cxxstd=14", when="@14:")
     conflicts("cxxstd=17", when="@:12")
     conflicts("cxxstd=11", when="+wrapper ^cuda@6.5.14")
     conflicts("cxxstd=14", when="+wrapper ^cuda@6.5.14:8.0.61")


### PR DESCRIPTION
It looks like `trilinos@develop` will no longer work with `cxxstd=11` or `cxxstd=14`

```
  >> 4    CMake Error at CMakeLists.txt:130 (MESSAGE):
     5      CMAKE_CXX_STANDARD=14 is not in the allowed set (17|20|23)
     6    
     7    
     8    -- Configuring incomplete, errors occurred!
```

@jwillenbring @keitat @kuberry @psakievich @sethrj @wspear