### PR TITLE
Solver: allow constraints on reuse parameter

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -14,7 +14,9 @@ properties = {
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "reuse": {"type": "boolean"},
+            "reuse": {
+                "oneOf": [{"type": "boolean"}, {"type": "array", "items": {"type": "string"}}]
+            },
             "enable_node_namespace": {"type": "boolean"},
             "targets": {
                 "type": "object",

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2499,6 +2499,12 @@ class Solver(object):
                 # TODO: update mirror configuration so it can indicate that the
                 # TODO: source cache (or any mirror really) doesn't have binaries.
                 pass
+
+            if self.reuse is not True:  # alternative is a list
+                reusable_specs = [
+                    s for s in reusable_specs if any(s.satisfies(r) for r in self.reuse)
+                ]
+
         return reusable_specs
 
     def solve(


### PR DESCRIPTION
With this PR, users can specify constraints for Spack reuse.

E.g.
```
concretizer:
  reuse: ['%gcc']
```
This would allow Spack to reuse only packages that were built with gcc.

These constraints are combined by a logical "or" operator, so
```
concretizer:
  reuse: ['%gcc', '%clang']
  ```
  would allow Spack to reuse any package built with gcc or clang.

Note: A package with a non-reusable dependency is not reusable either.

TODO:
- [ ] docs