### PR TITLE
python allow builds with zlib-ng

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -139,6 +139,7 @@ class Python(Package):
     variant("dbm", default=True, description="Build dbm module")
     variant("nis", default=False, description="Build nis module")
     variant("zlib", default=True, description="Build zlib module")
+    variant("zlib_ng", default=False, when="+zlib", description="Use zlib-ng instead of zlib")
     variant("bz2", default=True, description="Build bz2 module")
     variant("lzma", default=True, description="Build lzma module")
     variant("pyexpat", default=True, description="Build pyexpat module")
@@ -169,7 +170,8 @@ class Python(Package):
         depends_on("sqlite@3.7.15:", when="@3.10:+sqlite3")
         depends_on("gdbm", when="+dbm")  # alternatively ndbm or berkeley-db
         depends_on("libnsl", when="+nis")
-        depends_on("zlib@1.1.3:", when="+zlib")
+        depends_on("zlib@1.1.3:", when="+zlib ~zlib_ng")
+        depends_on("zlib-ng +compat", when="+zlib_ng")
         depends_on("bzip2", when="+bz2")
         depends_on("xz", when="+lzma")
         depends_on("expat", when="+pyexpat")

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -12,6 +12,7 @@ class ZlibNg(CMakePackage):
     homepage = "https://github.com/zlib-ng/zlib-ng"
     url = "https://github.com/zlib-ng/zlib-ng/archive/2.0.0.tar.gz"
 
+    version("2.0.6", sha256="8258b75a72303b661a238047cb348203d88d9dddf85d480ed885f375916fcab6")
     version("2.0.0", sha256="86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8")
 
     variant("compat", default=False, description="Enable compatibility API")
@@ -19,10 +20,16 @@ class ZlibNg(CMakePackage):
 
     depends_on("cmake@3.5.1:", type="build")
 
+    @property
+    def libs(self):
+        name = "libz" if "+compat" in self.spec else "libz-ng"
+        return find_libraries([name], root=self.prefix, recursive=True)
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ZLIB_COMPAT", "compat"),
             self.define_from_variant("WITH_OPTIM", "opt"),
+            self.define("ZLIB_ENABLE_TESTS", False),
         ]
 
         return args


### PR DESCRIPTION
This would help a lot in our own docker images.

Python with `zlib` takes about `4m10s` to create a tarball of cuda + deps, with `zlib-ng` this is only `2m1s`, this is still single-threaded.