### PR TITLE
wrf: Fix compilation with GCC 10+

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -246,7 +246,7 @@ class Wrf(Package):
         # Same flags as FCFLAGS/FFLAGS above, but forced through the compiler
         # wrapper when compiling v3.9.1.1.
         if self.spec.satisfies("@3.9.1.1 %gcc@10:") and name == "fflags":
-            flags.append("-w -O2 -fallow-argument-mismatch -fallow-invalid-boz")
+            flags.extend(["-w", "-O2", "-fallow-argument-mismatch", "-fallow-invalid-boz"])
         return (flags, None, None)
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -229,7 +229,10 @@ class Wrf(Package):
         env.set("JASPERINC", self.spec["jasper"].prefix.include)
         env.set("JASPERLIB", self.spec["jasper"].prefix.lib)
 
-        if self.spec.satisfies("%gcc@10:"):
+        # These flags should be used also in v3, but FCFLAGS/FFLAGS aren't used
+        # consistently in that version of WRF, so we have to force them through
+        # `flag_handler` below.
+        if self.spec.satisfies("@4.0: %gcc@10:"):
             args = "-w -O2 -fallow-argument-mismatch -fallow-invalid-boz"
             env.set("FCFLAGS", args)
             env.set("FFLAGS", args)
@@ -238,6 +241,13 @@ class Wrf(Package):
             env.set("WRFIO_NCD_LARGE_FILE_SUPPORT", 1)
             env.set("HDF5", self.spec["hdf5"].prefix)
             env.prepend_path("PATH", ancestor(self.compiler.cc))
+
+    def flag_handler(self, name, flags):
+        # Same flags as FCFLAGS/FFLAGS above, but forced through the compiler
+        # wrapper when compiling v3.9.1.1.
+        if self.spec.satisfies("@3.9.1.1 %gcc@10:") and name == "fflags":
+            flags.append("-w -O2 -fallow-argument-mismatch -fallow-invalid-boz")
+        return (flags, None, None)
 
     def patch(self):
         # Let's not assume csh is intalled in bin


### PR DESCRIPTION
With #35140 now merged I was able to confirm what I anticipated in https://github.com/spack/spack/pull/35140#issue-1555452424: setting `FFLAGS`/`FCFLAGS` environment variables https://github.com/spack/spack/blob/a9d5db572c2c0dacd115665d12e557750e74b965/var/spack/repos/builtin/packages/wrf/package.py#L230-L233 doesn't really have any effect in older versions of WRF (I only tried v3.9.1.1, I don't know the others), we need to force the flags in the compiler wrappers.