### PR TITLE
Revert flex%oneapi: -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -66,10 +66,6 @@ class Flex(AutotoolsPackage):
                 iflags.append("-Wno-error=implicit-function-declaration")
         return (iflags, None, None)
 
-    def setup_build_environment(self, env):
-        if self.spec.satisfies("%oneapi@2023.0.0:"):
-            env.set("CFLAGS", "-Wno-error=implicit-function-declaration")
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)


### PR DESCRIPTION
This reverts commit 62f83dfb6dbc86eace56495aa59587ac1942dc20.

PR 34900 broke flex%apple-clang@14 builds per:
* https://github.com/spack/spack/pull/34900#pullrequestreview-1271123569

@kuberry 