### PR TITLE
Tweak more parallel build job count for spack env depfile jobserver

### DIFF
--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_environment import get_effective_jobs
 from spack.package import *
 
 
@@ -220,7 +221,10 @@ class PyHorovod(PythonPackage, CudaPackage):
         env.set("PKG_CONFIG_EXECUTABLE", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
         if "cmake" in self.spec:
             env.set("HOROVOD_CMAKE", self.spec["cmake"].command.path)
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+
+        jobs = get_effective_jobs(make_jobs, parallel=self.parallel, supports_jobserver=True)
+        if jobs is not None:
+            env.append_flags("MAKEFLAGS", "-j{0}".format(jobs))
 
         # Frameworks
         if "frameworks=tensorflow" in self.spec:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -9,6 +9,7 @@ import sys
 
 import llnl.util.tty as tty
 
+from spack.build_environment import get_effective_jobs
 from spack.operating_systems.linux_distro import kernel_version
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
@@ -310,7 +311,9 @@ class Qt(Package):
         return url
 
     def setup_build_environment(self, env):
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        jobs = get_effective_jobs(make_jobs, parallel=self.parallel, supports_jobserver=True)
+        if jobs is not None:
+            env.append_flags("MAKEFLAGS", "-j{0}".format(jobs))
         if self.version >= Version("5.11"):
             # QDoc uses LLVM as of 5.11; remove the LLVM_INSTALL_DIR to
             # disable

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+from spack.build_environment import get_effective_jobs
 from spack.package import *
 
 
@@ -215,7 +216,9 @@ class R(AutotoolsPackage):
 
         # Use the number of make_jobs set in spack. The make program will
         # determine how many jobs can actually be started.
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        jobs = get_effective_jobs(make_jobs, parallel=self.parallel, supports_jobserver=True)
+        if jobs is not None:
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
         env.set("R_HOME", join_path(self.prefix, "rlib", "R"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):


### PR DESCRIPTION
Fix `qt`, `r`, and `py-horovod` to avoid overriding parallel job count when running under a Makefile jobserver (`spack env depfile`).

The API is not pretty, but for now it still helps a lot, especially with qt.