### PR TITLE
Simpler package API for jobserver support

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -9,6 +9,7 @@ import sys
 
 import spack.build_environment
 from spack.package import *
+from spack.util.environment import env_flag
 
 is_windows = sys.platform == "win32"
 
@@ -327,12 +328,9 @@ class Cmake(Package):
         if not sys.platform == "win32":
             args.append("--prefix={0}".format(self.prefix))
 
-            jobs = spack.build_environment.get_effective_jobs(
-                make_jobs,
-                parallel=self.parallel,
-                supports_jobserver=self.generator.supports_jobserver,
-            )
-            if jobs is not None:
+            jobs = 1 if env_flag(spack.build_environment.SPACK_NO_PARALLEL_MAKE) else make_jobs
+            jobserver = jobs > 1 and should_support_jobserver and self.generator.supports_jobserver
+            if not jobserver:
                 args.append("--parallel={0}".format(jobs))
 
             if "+ownlibs" in spec:

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -220,7 +220,9 @@ class PyHorovod(PythonPackage, CudaPackage):
         env.set("PKG_CONFIG_EXECUTABLE", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
         if "cmake" in self.spec:
             env.set("HOROVOD_CMAKE", self.spec["cmake"].command.path)
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
 
         # Frameworks
         if "frameworks=tensorflow" in self.spec:

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -222,7 +222,7 @@ class PyHorovod(PythonPackage, CudaPackage):
             env.set("HOROVOD_CMAKE", self.spec["cmake"].command.path)
 
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
 
         # Frameworks
         if "frameworks=tensorflow" in self.spec:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -312,7 +312,7 @@ class Qt(Package):
 
     def setup_build_environment(self, env):
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
         if self.version >= Version("5.11"):
             # QDoc uses LLVM as of 5.11; remove the LLVM_INSTALL_DIR to
             # disable

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -311,7 +311,8 @@ class Qt(Package):
         return url
 
     def setup_build_environment(self, env):
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
         if self.version >= Version("5.11"):
             # QDoc uses LLVM as of 5.11; remove the LLVM_INSTALL_DIR to
             # disable

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -216,7 +216,7 @@ class R(AutotoolsPackage):
         # Use the number of make_jobs set in spack. The make program will
         # determine how many jobs can actually be started.
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
         env.set("R_HOME", join_path(self.prefix, "rlib", "R"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -215,7 +215,8 @@ class R(AutotoolsPackage):
 
         # Use the number of make_jobs set in spack. The make program will
         # determine how many jobs can actually be started.
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
         env.set("R_HOME", join_path(self.prefix, "rlib", "R"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):


### PR DESCRIPTION
Replace the `get_effective_jobs()` mechanism by something a bit simpler: a `should_support_jobserver` variable in package modules.

Also fix `qt`, `r`, and `py-horovod` to support jobserver.

Supersedes #35183 if accepted.

Compared to a more "factorized" API (say a `make_j_arg` or something for example), I think `should_support_jobserver` is more "intentional" and more flexible for future yet unknown tools with jobserver support.

Quick summary:

Package that use `make()` or `ninja()` are OK as-is. Others should mind jobserver support: e.g. don't add a `-j` to make or ninja if `should_support_jobserver` is `True`.

