### PR TITLE
mash: patched newer GCC versions

### DIFF
--- a/var/spack/repos/builtin/packages/mash/gcc-11.patch
+++ b/var/spack/repos/builtin/packages/mash/gcc-11.patch
@@ -1,0 +1,14 @@
+# patch method from debian repo
+# https://salsa.debian.org/med-team/mash/-/blob/master/debian/patches/gcc-11.patch
+diff -Naur spack-src/src/mash/robin_hood.h spack-src.patched/src/mash/robin_hood.h 
+--- spack-src/src/mash/robin_hood.h	2021-02-26 17:13:33.000000000 -0600
++++ spack-src.patched/src/mash/robin_hood.h	2023-01-27 09:37:40.418855844 -0600
+@@ -45,6 +45,7 @@
+ #include <memory> // only to support hash of smart pointers
+ #include <stdexcept>
+ #include <string>
++#include <limits>
+ #include <type_traits>
+ #include <utility>
+ #if __cplusplus >= 201703L
+

--- a/var/spack/repos/builtin/packages/mash/package.py
+++ b/var/spack/repos/builtin/packages/mash/package.py
@@ -18,7 +18,7 @@ class Mash(AutotoolsPackage):
 
     version("2.3", sha256="f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1")
 
-    conflicts("%gcc@11:", msg="mash cannot be build with gcc >= 11")
+    patch("gcc-11.patch", when="%gcc@11:")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
fixed conflict with gcc >=11 with a simple patch. Confirmed builds and runs on gcc 12.2.1