### PR TITLE
`thrift`: add v0.17.0

### DIFF
--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -22,6 +22,7 @@ class Thrift(Package):
     list_url = "http://archive.apache.org/dist/thrift/"
     list_depth = 1
 
+    version("0.17.0", sha256="b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f")
     version("0.16.0", sha256="f460b5c1ca30d8918ff95ea3eb6291b3951cf518553566088f3f2be8981f6209")
     version("0.13.0", sha256="7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179")
     version("0.12.0", sha256="c336099532b765a6815173f62df0ed897528a9d551837d627c1f87fadad90428")
@@ -89,6 +90,8 @@ class Thrift(Package):
         options.append("--with-go=%s" % ("yes" if "+go" in spec else "no"))
         options.append("--with-lua=%s" % ("yes" if "+lua" in spec else "no"))
         options.append("--with-php=%s" % ("yes" if "+php" in spec else "no"))
+        options.append("--with-kotlin=%s" % ("yes" if "+kotlin" in spec else "no"))
+        options.append("--with-ruby=%s" % ("yes" if "+ruby" in spec else "no"))
         options.append("--with-qt4=%s" % ("yes" if "+qt4" in spec else "no"))
 
         configure(*options)

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -31,12 +31,12 @@ class Thrift(Package):
     version("0.9.3", sha256="b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e")
 
     # Currently only support for c-family and python
-    variant("c", default=True, description="Build support for C-family languages")
     variant("pic", default=True, description="Build position independent code")
+    variant("c", default=True, description="Build support for C-family languages")
     variant("python", default=True, description="Build support for python")
+    variant("java", default=False, description="Build support for java")
 
     depends_on("pkgconfig", type="build")
-    depends_on("java")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
@@ -51,6 +51,9 @@ class Thrift(Package):
     depends_on("openssl")
 
     # Variant dependencies
+    depends_on("zlib", when="+c")
+    depends_on("libevent", when="+c")
+
     extends("python", when="+python")
     depends_on("py-setuptools", type=("build", "run"), when="+python")
     depends_on("py-six@1.7.2:", type=("build", "run"), when="@0.10.0:+python")
@@ -60,8 +63,7 @@ class Thrift(Package):
     depends_on("py-pure-sasl", type=("build", "run"), when="+python")
     depends_on("scons", type=("build", "run"), when="+python")
 
-    depends_on("zlib", when="+c")
-    depends_on("libevent", when="+c")
+    depends_on("java", when="+java")
 
     patch(
         "https://github.com/apache/thrift/pull/2511.patch?full_index=1",
@@ -87,12 +89,12 @@ class Thrift(Package):
         options.append("--with-c=%s" % ("yes" if "+c" in spec else "no"))
         options.append("--with-python=%s" % ("yes" if "+python" in spec else "no"))
         options.append("--with-java=%s" % ("yes" if "+java" in spec else "no"))
-        options.append("--with-go=%s" % ("yes" if "+go" in spec else "no"))
-        options.append("--with-lua=%s" % ("yes" if "+lua" in spec else "no"))
-        options.append("--with-php=%s" % ("yes" if "+php" in spec else "no"))
-        options.append("--with-kotlin=%s" % ("yes" if "+kotlin" in spec else "no"))
-        options.append("--with-ruby=%s" % ("yes" if "+ruby" in spec else "no"))
-        options.append("--with-qt4=%s" % ("yes" if "+qt4" in spec else "no"))
+        options.append("--with-go=no")
+        options.append("--with-lua=no")
+        options.append("--with-php=no")
+        options.append("--with-kotlin=no")
+        options.append("--with-ruby=no")
+        options.append("--with-qt4=no")
 
         configure(*options)
 

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -22,6 +22,8 @@ class Thrift(Package):
     list_url = "http://archive.apache.org/dist/thrift/"
     list_depth = 1
 
+    maintainers = ["thomas-bouvier"]
+
     version("0.17.0", sha256="b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f")
     version("0.16.0", sha256="f460b5c1ca30d8918ff95ea3eb6291b3951cf518553566088f3f2be8981f6209")
     version("0.13.0", sha256="7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179")
@@ -30,11 +32,10 @@ class Thrift(Package):
     version("0.10.0", sha256="2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b")
     version("0.9.3", sha256="b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e")
 
-    # Currently only support for c-family and python
     variant("pic", default=True, description="Build position independent code")
     variant("c", default=True, description="Build support for C-family languages")
-    variant("python", default=True, description="Build support for python")
     variant("java", default=False, description="Build support for java")
+    variant("python", default=True, description="Build support for python")
 
     depends_on("pkgconfig", type="build")
     depends_on("autoconf", type="build")
@@ -54,6 +55,9 @@ class Thrift(Package):
     depends_on("zlib", when="+c")
     depends_on("libevent", when="+c")
 
+    depends_on("java@7:", when="+java")
+    depends_on("ant", when="+java")
+
     extends("python", when="+python")
     depends_on("py-setuptools", type=("build", "run"), when="+python")
     depends_on("py-six@1.7.2:", type=("build", "run"), when="@0.10.0:+python")
@@ -62,8 +66,6 @@ class Thrift(Package):
     depends_on("py-zope-interface", type=("build", "run"), when="+python")
     depends_on("py-pure-sasl", type=("build", "run"), when="+python")
     depends_on("scons", type=("build", "run"), when="+python")
-
-    depends_on("java", when="+java")
 
     patch(
         "https://github.com/apache/thrift/pull/2511.patch?full_index=1",


### PR DESCRIPTION
Also, don't build kotlin and ruby libs if not explicitly enabled. My build was failing because of missing dependencies, even though I don't care about these languages (and didn't ask for their support).