### PR TITLE
Update perl build for usernames ending in man1

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -178,6 +178,14 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # https://github.com/Perl/perl5/issues/15544 long PATH(>1000 chars) fails a test
         os.chmod("lib/perlbug.t", 0o644)
         filter_file("!/$B/", "! (/(?:$B|PATH)/)", "lib/perlbug.t")
+        # man1/man3 replacement fails for usernames ending in man1
+        os.chmod("Configure", 0o755)
+        filter_file(
+            r"$sed -e 's/man1/man3/g' -e 's/man\.1/man\.3/g'`",
+            r"$sed -e 's|/man1|/man3|g' -e 's|/man\.1|/man\.3|g'`",
+            "Configure",
+            string=True,
+        )
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
`spack install perl` was failing for usernames ending in `man1`. (I tested for `herriman1` and `goldman1`.) A buggy regex expression in `Configure` broke paths in `config.sh` by replacing all instances of `man1` with `man3`. @becker33 provided a fix to perl's `package.py`, which I've confirmed works.