### PR TITLE
Bugfix: Update Petsc Python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -205,7 +205,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("rocprim", when="+rocm")
 
     # Build dependencies
-    depends_on("python@2.6:2.8,3.4:", type="build")
+    depends_on("python@2.6:2.8,3.4:3.8", when="@:3.13", type="build")
+    depends_on("python@2.6:2.8,3.4:", when="@3.14:3.17", type="build")
     depends_on("python@3.4:", when="@3.18:", type="build")
 
     # Other dependencies

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -206,6 +206,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     # Build dependencies
     depends_on("python@2.6:2.8,3.4:", type="build")
+    depends_on("python@3.4:", when="@3.18:", type="build")
 
     # Other dependencies
     depends_on("metis@5:~int64+real64", when="@:3.7+metis~int64+double")


### PR DESCRIPTION
Was trying to build a package depending on `petsc` and `petsc` kept failing with:

```
*********************************************************************************************
*                     Python version 3.4+ is required to run ./configure                    *
*********************************************************************************************
```

Had the same issue when I tried depending on `petsc@3.18.0`.  This change fixes the issue for me.

I didn't check any versions before `3.18`.