### PR TITLE
gmake: Fix too many levels of symbolic links error

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -47,6 +47,9 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
         when="@:4.2.1",
     )
 
+    # Avoid symlinking GNUMakefile to GNUMakefile
+    build_directory = 'spack-build'
+
     # See https://savannah.gnu.org/bugs/?57962
     patch("findprog-in-ignore-directories.patch", when="@4.3")
 

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -48,7 +48,7 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
     )
 
     # Avoid symlinking GNUMakefile to GNUMakefile
-    build_directory = 'spack-build'
+    build_directory = "spack-build"
 
     # See https://savannah.gnu.org/bugs/?57962
     patch("findprog-in-ignore-directories.patch", when="@4.3")


### PR DESCRIPTION
Fix build error "too many levels of symbolic links" that started after a recent update to the way we build gmake.