### PR TITLE
py-hjson: fix typo in latest version

### DIFF
--- a/var/spack/repos/builtin/packages/py-hjson/package.py
+++ b/var/spack/repos/builtin/packages/py-hjson/package.py
@@ -12,7 +12,7 @@ class PyHjson(PythonPackage):
     homepage = "https://github.com/hjson/hjson-py"
     pypi = "hjson/hjson-3.0.2.tar.gz"
 
-    version("3.1.2", sha256="55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75")
+    version("3.1.0", sha256="55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75")
     version("3.0.2", sha256="2838fd7200e5839ea4516ece953f3a19892c41089f0d933ba3f68e596aacfcd5")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
I somehow managed to typo the latest py-hjson version with the correct shasum. This PR fixes that.