### PR TITLE
apptainer use the `--with-suid` configure option

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -46,3 +46,18 @@ class Apptainer(SingularityBase):
     @property
     def config_options(self):
         return []
+
+    # Hijack the edit stage to run mconfig.
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            confstring = "./mconfig --prefix=%s" % prefix
+            if "~suid" in spec:
+                confstring += " --without-suid"
+            if "+suid" in spec and spec.satisfies("@1.1.0:"):
+                confstring += " --with-suid"            
+            if "~network" in spec:
+                confstring += " --without-network"
+            configure = Executable(confstring)
+            configure()
+
+    


### PR DESCRIPTION
https://github.com/apptainer/apptainer/commit/c56641e670e62b1386da86aaa1e7ba1486af4cfd this commit added `--with-suid`

I ran a spack install with `+suid` and this is what happened:
```
 checking: unprivileged user namespaces... enabled. Implying --without-suid
```