### PR TITLE
py-fiona: add v1.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiona/package.py
+++ b/var/spack/repos/builtin/packages/py-fiona/package.py
@@ -16,6 +16,7 @@ class PyFiona(PythonPackage):
     maintainers = ["adamjstewart"]
 
     version("master", branch="master")
+    version("1.9.0", sha256="6e487cbfba5a849fbdf06e45169fd7e1f1662f44f3d717ab4b946046b2457eae")
     version("1.8.22", sha256="a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3")
     version("1.8.21", sha256="3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc")
     version("1.8.20", sha256="a70502d2857b82f749c09cb0dea3726787747933a2a1599b5ab787d74e3c143b")
@@ -23,18 +24,23 @@ class PyFiona(PythonPackage):
     version("1.8.6", sha256="fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e")
     version("1.7.12", sha256="8b54eb8422d7c502bb7776b184018186bede1a489cf438a7a47f992ade6a0e51")
 
-    depends_on("python@3.6:", type=("build", "link", "run"), when="@1.9:")
-    depends_on("python@2.6:", type=("build", "link", "run"), when="@1.8.21:1.8")
-    depends_on("python@2.6:3.9", type=("build", "link", "run"), when="@:1.8.20")
-    depends_on("gdal@1.11:", type=("build", "link", "run"), when="@1.9:")
-    depends_on("gdal@1.8:", type=("build", "link", "run"))
-
-    depends_on("py-cython@0.29.29:", type="build", when="@master")
+    # pyproject.toml
+    depends_on("py-cython@0.29.29:0.29", when="@1.9:", type="build")
+    depends_on("py-setuptools@61:", when="@1.9:", type="build")
+    depends_on("py-attrs@19.2:", when="@1.9:", type=("build", "run"))
     depends_on("py-attrs@17:", type=("build", "run"))
-    depends_on("py-certifi", type=("build", "run"), when="@1.8.18:")
+    depends_on("py-certifi", when="@1.8.18:", type=("build", "run"))
+    depends_on("py-click@8", when="@1.9:", type=("build", "run"))
     depends_on("py-click@4:", type=("build", "run"))
-    depends_on("py-cligj@0.5:", type=("build", "run"))
     depends_on("py-click-plugins@1:", type=("build", "run"))
-    depends_on("py-six@1.7:", type=("build", "run"))
+    depends_on("py-cligj@0.5:", type=("build", "run"))
+    depends_on("py-munch@2.3.2:", when="@1.9:", type=("build", "run"))
     depends_on("py-munch", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
+
+    # setup.py or release notes
+    depends_on("gdal@3.1:", when="@1.9:", type=("build", "link", "run"))
+    depends_on("gdal@1.8:", type=("build", "link", "run"))
+
+    # Historical dependencies
+    depends_on("py-six@1.7:", when="@:1.8", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-munch/package.py
+++ b/var/spack/repos/builtin/packages/py-munch/package.py
@@ -11,9 +11,12 @@ class PyMunch(PythonPackage):
     access (a la JavaScript objects)."""
 
     homepage = "https://github.com/Infinidat/munch"
-    url = "https://github.com/Infinidat/munch/archive/2.2.0.tar.gz"
+    pypi = "munch/munch-2.5.0.tar.gz"
 
-    version("2.2.0", sha256="f354ea638e5e582c52d3e47eb54199d3eade94ee3552d64453ddfcbe953973f0")
+    version("2.5.0", sha256="2d735f6f24d4dba3417fa448cae40c6e896ec1fdab6cdb5e6510999758a4dbd2")
+    version("2.2.0", sha256="62fb4fb318e965a464b088e6af52a63e0905a50500b770596a939d3855e7aa15")
 
+    depends_on("py-pbr@3:", when="@2.5:", type="build")
+    depends_on("py-setuptools@17.1:", when="@2.5:", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-six", type=("build", "run"))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.10.8 and Apple Clang 12.0.0.

https://github.com/Toblerity/Fiona/releases/tag/1.9.0