### PR TITLE
Further constrain version for mimalloc patch in HPX package

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -188,7 +188,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Patches APEX
     patch("git_external.patch", when="@1.3.0 instrumentation=apex")
-    patch("mimalloc_no_version_requirement.patch", when="@:1.8 malloc=mimalloc")
+    patch("mimalloc_no_version_requirement.patch", when="@:1.8.0 malloc=mimalloc")
 
     def instrumentation_args(self):
         args = []


### PR DESCRIPTION
The patch was added in 1.8.1, so constraining the version when it's applied to `:1.8.0`.