### PR TITLE
py-getorganelle: rename to getorganelle and add version 1.7.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/getorganelle/package.py
+++ b/var/spack/repos/builtin/packages/getorganelle/package.py
@@ -6,14 +6,15 @@
 from spack.package import *
 
 
-class PyGetorganelle(PythonPackage):
+class Getorganelle(PythonPackage):
     """Organelle Genome Assembly Toolkit (Chloroplast/Mitocondrial/ITS)"""
 
     homepage = "https://github.com/Kinggerm/GetOrganelle"
     url = "https://github.com/Kinggerm/GetOrganelle/archive/refs/tags/1.7.5.0.tar.gz"
 
-    maintainers = ["dorton21"]
+    maintainers = ["snehring"]
 
+    version("1.7.7.0", sha256="dd351b5cd33688adfcd8bff9794ae0cc0ce01a572dac2bcf6c9d7db77b3e4883")
     version("1.7.5.0", sha256="c498196737726cb4c0158f23037bf301a069f5028ece729bb4d09c7d915df93d")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-getorganelle/package.py
+++ b/var/spack/repos/builtin/packages/py-getorganelle/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGetorganelle(PythonPackage):
+    """Organelle Genome Assembly Toolkit (Chloroplast/Mitocondrial/ITS)"""
+
+    homepage = "https://github.com/Kinggerm/GetOrganelle"
+    url = "https://github.com/Kinggerm/GetOrganelle/archive/refs/tags/1.7.5.0.tar.gz"
+
+    maintainers = ["dorton21"]
+
+    # renamed to getorganelle
+    version(
+        "1.7.5.0",
+        sha256="c498196737726cb4c0158f23037bf301a069f5028ece729bb4d09c7d915df93d",
+        deprecated=True,
+    )
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy@1.16.4:", type=("build", "run"))
+    depends_on("py-scipy@1.3.0:", type=("build", "run"))
+    depends_on("py-sympy@1.4:", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"))
+
+    depends_on("bowtie2", type="run")
+    depends_on("spades", type="run")
+    depends_on("blast-plus", type="run")
+
+    # Allow access to relevant runtime scripts
+    # I.e. get_organelle_config.py, get_organelle_from_reads.py, etc.
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", prefix)
+        env.prepend_path("PATH", prefix.Utilities)


### PR DESCRIPTION
Seeing as this is more a standalone package than a python library I felt it appropriate to rename. Also adding a new version.