### PR TITLE
numaprof: New package (version : 1.1.4)

### DIFF
--- a/var/spack/repos/builtin/packages/numaprof/numaprof-1.1.4-pin-layout.patch
+++ b/var/spack/repos/builtin/packages/numaprof/numaprof-1.1.4-pin-layout.patch
@@ -1,0 +1,15 @@
+diff --git a/src/integration/pintool/Makefile.pin.in b/src/integration/pintool/Makefile.pin.in
+index ec95b7b..1b84423 100644
+--- a/src/integration/pintool/Makefile.pin.in
++++ b/src/integration/pintool/Makefile.pin.in
+@@ -4,7 +4,8 @@
+ #
+ ##############################################################
+ 
+-PIN_ROOT=$(shell dirname @PINTOOL_PIN@)
++PIN_ROOT_BIN=$(shell dirname @PINTOOL_PIN@)
++PIN_ROOT=$(shell dirname $(PIN_ROOT_BIN))
+ MAKE+=-f Makefile.pin
+ SRCDIR=@CMAKE_CURRENT_SOURCE_DIR@
+ CST_DEBUG_FLAGS=@PINTOOL_CFLAGS@
+

--- a/var/spack/repos/builtin/packages/numaprof/package.py
+++ b/var/spack/repos/builtin/packages/numaprof/package.py
@@ -17,7 +17,7 @@ class Numaprof(CMakePackage):
     # Infos
     homepage = "https://memtt.github.io/numaprof"
     url = "https://github.com/memtt/numaprof/releases/download/v1.1.4/numaprof-1.1.4.tar.bz2"
-    maintainers = ["svalat"]
+    maintainers("svalat")
 
     # Versions
     version("1.1.4", sha256="96cc5e153895f43d8be58e052433c9e7c9842071cc6bf915b3b1b346908cbbff")
@@ -39,11 +39,6 @@ class Numaprof(CMakePackage):
         when="@1.1.4:",
         sha256="a2e3242f72b502285da2ad41dd896382e99a8987bda9ff38e081a048776ee7b3",
     )
-
-    # Generate the urls
-    def url_for_version(self, version):
-        url_fmt = "https://github.com/memtt/numaprof/releases/download/v{0}/numaprof-{0}.tar.bz2"
-        return url_fmt.format(version)
 
     # Generate build command
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/numaprof/package.py
+++ b/var/spack/repos/builtin/packages/numaprof/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Numaprof(CMakePackage):
+    """
+    NumaProf is a NUMA memory access profiling tool. It is based on Intel-PIN to intercept
+    all the memory access and report them on NUMA counters so we can tell by annotating the
+    source code where you make local, remote, unpinned memory accessed. It also provide
+    some charts to better understand the NUMA behavior of the application.
+    """
+
+    # Infos
+    homepage = "https://memtt.github.io/numaprof"
+    url = "https://github.com/memtt/numaprof/releases/download/v1.1.4/numaprof-1.1.4.tar.bz2"
+    maintainers = ["svalat"]
+
+    # Versions
+    version("1.1.4", sha256="96cc5e153895f43d8be58e052433c9e7c9842071cc6bf915b3b1b346908cbbff")
+
+    # Variants
+    variant(
+        "qt", default=False, description="Build the QT embeded webview with Pyton + QT web toolkit"
+    )
+
+    # Dependencies
+    depends_on("python")
+    depends_on("intel-pin")
+    depends_on("numactl")
+    depends_on("py-pyqt5", "+qt")
+
+    # Patches
+    patch(
+        "numaprof-1.1.4-pin-layout.patch",
+        when="@1.1.4:",
+        sha256="a2e3242f72b502285da2ad41dd896382e99a8987bda9ff38e081a048776ee7b3",
+    )
+
+    # Generate the urls
+    def url_for_version(self, version):
+        url_fmt = "https://github.com/memtt/numaprof/releases/download/v{0}/numaprof-{0}.tar.bz2"
+        return url_fmt.format(version)
+
+    # Generate build command
+    def cmake_args(self):
+        spec = self.spec
+        args = ["-DPINTOOL_PREFIX=" + spec["intel-pin"].prefix]
+        return args

--- a/var/spack/repos/builtin/packages/numaprof/package.py
+++ b/var/spack/repos/builtin/packages/numaprof/package.py
@@ -28,10 +28,10 @@ class Numaprof(CMakePackage):
     )
 
     # Dependencies
-    depends_on("python")
-    depends_on("intel-pin")
+    depends_on("python", type=("build", "run"))
+    depends_on("intel-pin", type=("build", "link", "run"))
     depends_on("numactl")
-    depends_on("py-pyqt5", "+qt")
+    depends_on("py-pyqt5", "+qt", type=("build", "run"))
 
     # Patches
     patch(


### PR DESCRIPTION
Add support for the Numaprof profiling tool :
 - https://memtt.github.io/numaprof
 - https://github.com/memtt/numaprof

**Patch**
It requires a patch to handle the fact that Spack re-organize the Pintool files in unix prefix semantic.

**Variants**
Numaprof provide an optional support of a webapp via py-qt instead of using a distinct webserver + browser. This is enabled with `+qt`.

**Version**
The previous versions had issues which prevent from use so I added only the last one : 1.1.4. 
I Don't know what is the policy you prefer to follow : 
 - list all
 - keep only stables.

**Notice**: 
I'm the creator and maintainer of this open source software.


