### PR TITLE
malt: new package (versions : 1.2.1)

### DIFF
--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -40,13 +40,3 @@ class Malt(CMakePackage):
     depends_on("libunwind")
     depends_on("binutils", type="run")
     depends_on("qt", when="+qt")
-
-    # Gen urls
-    def url_for_version(self, version):
-        url_fmt = "https://github.com/memtt/malt/archive/v{0}.tar.gz"
-        return url_fmt.format(version)
-
-    # Generate build command
-    def cmake_args(self):
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -35,11 +35,11 @@ class Malt(CMakePackage):
     )
 
     # Dependencies
-    depends_on("node-js", when="+nodejs")
+    depends_on("node-js@18:", type=("build", "run"), when="+nodejs")
     depends_on("libelf")
     depends_on("libunwind")
-    depends_on("binutils")
-    depends_on("qt", "+qt")
+    depends_on("binutils", type="run")
+    depends_on("qt", when="+qt")
 
     # Gen urls
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -16,7 +16,7 @@ class Malt(CMakePackage):
     # Project infos
     homepage = "https://memtt.github.io/malt"
     url = "https://github.com/memtt/malt/archive/v1.2.1.tar.gz"
-    maintainers = ["svalat"]
+    maintainers("svalat")
 
     # Versions
     version("1.2.1", sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a")

--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -31,7 +31,7 @@ class Malt(CMakePackage):
         "qt",
         default=False,
         when="+nodejs",
-        description="Build the viewer nodejs + QT web toolkit (requires NodeJs too)",
+        description="Build the viewer based on NodeJS + QT web toolkit (requires NodeJS too)",
     )
 
     # Dependencies

--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Malt(CMakePackage):
+    """
+    MALT is a memory profile tool to track mallocs in a C/C++ application and report
+    allocation information (lifetime, sizes...) in a friendly web graphical interface
+    by annotating the source code and proving charts.
+    """
+
+    # Project infos
+    homepage = "https://memtt.github.io/malt"
+    url = "https://github.com/memtt/malt/archive/v1.2.1.tar.gz"
+    maintainers = ["svalat"]
+
+    # Versions
+    version("1.2.1", sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a")
+
+    # Variants
+    variant(
+        "nodejs",
+        default=True,
+        description="Enable the installation of the Web GUI based on NodeJS",
+    )
+    variant(
+        "qt",
+        default=False,
+        when="+nodejs",
+        description="Build the viewer nodejs + QT web toolkit (requires NodeJs too)",
+    )
+
+    # Dependencies
+    depends_on("node-js", when="+nodejs")
+    depends_on("libelf")
+    depends_on("libunwind")
+    depends_on("binutils")
+    depends_on("qt", "+qt")
+
+    # Gen urls
+    def url_for_version(self, version):
+        url_fmt = "https://github.com/memtt/malt/archive/v{0}.tar.gz"
+        return url_fmt.format(version)
+
+    # Generate build command
+    def cmake_args(self):
+        args = []
+        return args


### PR DESCRIPTION
Add support for the MALT memory profiling tool :
 - https://memtt.github.io/malt
 - https://github.com/memtt/malt

**Variants**
 - MALT provide an optional support of a webapp via qt instead of using a distinct webserver + browser. This is enabled with `+qt`.
 - MALT is delivers as an instrumentation backend which is a .so file and the webview based on nodejs which is enabled by default. It can be disabled with variants not to fetch nodejs by using `-nodejs`.

**Version**
The previous versions had issues which prevent from use so I added only the last one : 1.2.1. 
I Don't know what is the policy you prefer to follow : 
 - list all
 - keep only stables.

**Notice**: 
I'm the creator and maintainer of this open source software.


