### PR TITLE
Pin black to 22.12.0 to avoid spurious style changes

### DIFF
--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -44,7 +44,7 @@ jobs:
         cache: 'pip'
     - name: Install Python packages
       run: |
-        python3 -m pip install --upgrade pip six setuptools types-six black mypy isort clingo flake8
+        python3 -m pip install --upgrade pip six setuptools types-six black==22.12.0 mypy isort clingo flake8
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -171,7 +171,7 @@ def mypy_root_spec():
 
 def black_root_spec():
     """Return the root spec used to bootstrap black"""
-    return _root_spec("py-black")
+    return _root_spec("py-black@:22.12.0")
 
 
 def flake8_root_spec():


### PR DESCRIPTION
We need to sync changes on major versions with spackbot, to avoid the bot saying everything is alright and have CI failing nonetheless.