### PR TITLE
glib: glib@2.74: needs pcre2@10.34:

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -126,6 +126,7 @@ class Glib(Package):
     depends_on("perl", type=("build", "run"))
     depends_on("python", type=("build", "run"), when="@2.53.4:")
     depends_on("pcre2", when="@2.73.2:")
+    depends_on("pcre2@10.34:", when="@2.74:")
     depends_on("pcre+utf", when="@2.48:2.73.1")
     depends_on("uuid", when="+libmount")
     depends_on("util-linux", when="+libmount")


### PR DESCRIPTION
Add minimum pcre2 10.34 requirement for glib 2.74.

This constraint is useful to me when using external pcre/pcre2 so the concretization can choose a compatible glib.

Tested on ubuntu 22.04, spack 0.19:
  
```console
$ spack install glib@2.74.0 ^pcre2@10.34
# OK
$ spack install glib@2.74.0 ^pcre2@10.33
#...
  >> 451    FAILED: glib/libglib-2.0.so.0.7400.0.p/gregex.c.o
     452    /spack/lib/spack/env/gcc/gcc -Iglib/libglib-2.0.so.0.7400.0.p -Iglib -I../glib -I. -I.. -I/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-11.2.0/pcre2-10.33-kgcjmrxomsu2tdm276qtq4qb5zgnkb2b/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wext
            ra -Wpedantic -std=gnu99 -O3 -D_GNU_SOURCE -fno-strict-aliasing -DG_DISABLE_CAST_CHECKS -Wduplicated-branches -Wimplicit-fallthrough -Wmisleading-indentation -Wunused -Wno-unused-parameter -Wno-cast-function-type -Wno-pedantic -Wno-format-zero-length -Wno-variadic-macros -Werror=format=2 -Werror=init-self -Werror=missing-include-dirs -Werror=pointer-
            arith -Werror=unused-result -Wstrict-prototypes -Wno-bad-function-cast -Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=pointer-sign -fPIC -pthread '-DG_LOG_DOMAIN="GLib"' -DGLIB_COMPILATION -fvisibility=hidden -MD -MQ glib/libglib-2.0.so.0.7400.0.p/gregex.c.o -MF glib/libglib-2.0.so.0.7400.
            0.p/gregex.c.o.d -o glib/libglib-2.0.so.0.7400.0.p/gregex.c.o -c ../glib/gregex.c
     453    ../glib/gregex.c: In function 'get_pcre2_compile_options':
  >> 454    ../glib/gregex.c:165:37: error: 'PCRE2_MATCH_INVALID_UTF' undeclared (first use in this function); did you mean 'PCRE2_JIT_INVALID_UTF'?
     455      165 |                                     PCRE2_MATCH_INVALID_UTF    | \
     456          |                                     ^~~~~~~~~~~~~~~~~~~~~~~
     457    ../glib/gregex.c:310:24: note: in expansion of macro 'G_REGEX_PCRE2_COMPILE_MASK'
     458      310 |   return pcre2_flags & G_REGEX_PCRE2_COMPILE_MASK;
     459          |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
     460    ../glib/gregex.c:165:37: note: each undeclared identifier is reported only once for each function it appears in
     461      165 |                                     PCRE2_MATCH_INVALID_UTF    | \
     462          |                                     ^~~~~~~~~~~~~~~~~~~~~~~
     463    ../glib/gregex.c:310:24: note: in expansion of macro 'G_REGEX_PCRE2_COMPILE_MASK'
     464      310 |   return pcre2_flags & G_REGEX_PCRE2_COMPILE_MASK;
     465          |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
     466    ../glib/gregex.c: In function 'get_pcre2_inline_compile_options':
  >> 467    ../glib/gregex.c:165:37: error: 'PCRE2_MATCH_INVALID_UTF' undeclared (first use in this function); did you mean 'PCRE2_JIT_INVALID_UTF'?
     468      165 |                                     PCRE2_MATCH_INVALID_UTF    | \
     469          |                                     ^~~~~~~~~~~~~~~~~~~~~~~
     470    ../glib/gregex.c:1837:44: note: in expansion of macro 'G_REGEX_PCRE2_COMPILE_MASK'
     471     1837 |   compile_options = pcre_compile_options & G_REGEX_PCRE2_COMPILE_MASK;
     472          |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
     473    ../glib/gregex.c: In function 'get_pcre2_compile_options':

See build log for details:
  /.../build_stage/spack-stage-glib-2.74.0-w4ksn74qitddjv6qmg4x3ngoi7rtazhz/spack-build-out.txt

```

`PCRE2_MATCH_INVALID_UTF` indeed seemed to be introduced in pcre 2.34: https://github.com/PCRE2Project/pcre2/commit/16c046ce50f292d09fe12670370f1a1d227d8184

