### PR TITLE
feature: make several packages detectable

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -5,6 +5,7 @@
 
 import glob
 import os.path
+import re
 
 from spack.package import *
 
@@ -21,6 +22,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     sourceware_mirror_path = "elfutils/0.179/elfutils-0.179.tar.bz2"
     list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 1
+    executables = ["^eu-objdump$"]
 
     maintainers = ["mwkrentel"]
 
@@ -148,3 +150,9 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     @property
     def libs(self):
         return find_libraries("libelf", self.prefix, recursive=True)
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"eu-objdump \(elfutils\) (\S+)", output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -12,6 +14,8 @@ class Libbsd(AutotoolsPackage):
     to port projects with strong BSD origins, without needing to embed the
     same code over and over again on each project.
     """
+
+    libraries = ["libbsd.so"]
 
     homepage = "https://libbsd.freedesktop.org/wiki/"
     urls = [
@@ -42,3 +46,9 @@ class Libbsd(AutotoolsPackage):
     conflicts("@0.11.4: %nvhpc")
 
     depends_on("libmd", when="@0.11:")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -2,6 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
@@ -16,6 +19,7 @@ class Libxml2(AutotoolsPackage):
     homepage = "http://xmlsoft.org"
     url = "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz"
     list_url = "https://gitlab.gnome.org/GNOME/libxml2/-/releases"
+    libraries = ["libxml2.so"]
 
     def url_for_version(self, version):
         if version >= Version("2.9.13"):
@@ -162,3 +166,9 @@ class Libxml2(AutotoolsPackage):
 
         # Perform some cleanup
         fs.force_remove(test_filename)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -12,6 +14,7 @@ class Pigz(MakefilePackage):
 
     homepage = "https://zlib.net/pigz/"
     url = "https://github.com/madler/pigz/archive/v2.3.4.tar.gz"
+    executables = ["^pigz$"]
 
     version("2.7", sha256="d2045087dae5e9482158f1f1c0f21c7d3de6f7cdc7cc5848bdabda544e69aa58")
     version("2.6", sha256="577673676cd5c7219f94b236075451220bae3e1ca451cf849947a2998fbf5820")
@@ -30,3 +33,9 @@ class Pigz(MakefilePackage):
         mkdirp(prefix.man.man1)
         install("pigz", "%s/pigz" % prefix.bin)
         install("pigz.1", "%s/pigz.1" % prefix.man.man1)
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"pigz (\S+)", output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 import sys
 
 from spack.package import *
@@ -16,6 +17,7 @@ class Re2c(Package):
     homepage = "https://re2c.org/index.html"
     url = "https://github.com/skvadrik/re2c/releases/download/1.2.1/re2c-1.2.1.tar.xz"
     tags = ["windows"]
+    executables = ["^re2c$"]
 
     version("2.2", sha256="0fc45e4130a8a555d68e230d1795de0216dfe99096b61b28e67c86dfd7d86bda")
     version("2.1.1", sha256="036ee264fafd5423141ebd628890775aa9447a4c4068a6307385d7366fe711f8")
@@ -66,3 +68,9 @@ class Re2c(Package):
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):
             self.make_tool("install")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"re2c \S+", output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -17,6 +19,7 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://tiswww.case.edu/php/chet/readline/rltop.html"
     # URL must remain http:// so Spack can bootstrap curl
     gnu_mirror_path = "readline/readline-8.0.tar.gz"
+    libraries = ["libreadline.so"]
 
     version("8.2", sha256="3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35")
     version("8.1", sha256="f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02")
@@ -69,3 +72,9 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies("%nvhpc"):
             filter_file("${GCC+-Wno-parentheses}", "", "configure", string=True)
             filter_file("${GCC+-Wno-format-security}", "", "configure", string=True)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 
 from spack.package import *
 
@@ -15,6 +16,7 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/src-highlite/"
     gnu_mirror_path = "src-highlite/source-highlight-3.1.8.tar.gz"
     git = "https://git.savannah.gnu.org/git/src-highlite.git"
+    executables = ["^source-highlight$"]
 
     version("master", branch="master")
     version("3.1.9", sha256="3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91")
@@ -39,3 +41,9 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         args = ["--with-boost={0}".format(self.spec["boost"].prefix)]
         return args
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"GNU Source-highlight (\S+)", output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -8,6 +8,7 @@
 # The AutotoolsPackage causes zlib to fail to build with PGI
 import glob
 import os
+import re
 
 import spack.build_systems.generic
 import spack.build_systems.makefile
@@ -22,6 +23,7 @@ class Zlib(MakefilePackage, Package):
     homepage = "https://zlib.net"
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://zlib.net/fossils/zlib-1.2.11.tar.gz"
+    libraries = ["libz.so"]
 
     version("1.2.13", sha256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30")
     version(
@@ -55,6 +57,12 @@ class Zlib(MakefilePackage, Package):
 
     patch("w_patch.patch", when="@1.2.11%cce")
     patch("configure-cc.patch", when="@1.2.12")
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+
+        return match.group(1) if match else None
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -14,6 +16,7 @@ class Zstd(MakefilePackage):
     homepage = "https://facebook.github.io/zstd/"
     url = "https://github.com/facebook/zstd/archive/v1.4.3.tar.gz"
     git = "https://github.com/facebook/zstd.git"
+    libraries = ["libzstd.so"]
 
     maintainers = ["haampie"]
 
@@ -88,3 +91,9 @@ class Zstd(MakefilePackage):
                 programs_args.append("HAVE_LZ4=0")
             programs_args.append("install")
             make(*programs_args)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+
+        return match.group(1) if match else None


### PR DESCRIPTION
This makes a handful of common packages detectable by adding their libraries/executable names. I checked with `apt` that the naming scheme of the DSOs matches the version numbers, as I had to exclude a few other libraries (libffi, libpciaccess, ...) for a differing ABI versioning scheme. For those, I guess one would have to parse the config headers.