### PR TITLE
also absolutify resolved sonames in rpaths inside local prefix

### DIFF
--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from collections import namedtuple
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
@@ -12,24 +13,45 @@ from llnl.util.lang import elide_list
 import spack.bootstrap
 import spack.config
 import spack.relocate
-from spack.util.elf import ElfParsingError, parse_elf
+from spack.util.elf import ElfFile, ElfParsingError, parse_elf
 from spack.util.executable import Executable
 
+ModifyElfAction = namedtuple("ModifyElfAction", "path set_soname replace_needed")
 
-def is_shared_library_elf(filepath):
-    """Return true if filepath is most a shared library.
-    Our definition of a shared library for ELF requires:
-    1. a dynamic section,
-    2. a soname OR lack of interpreter.
-    The problem is that PIE objects (default on Ubuntu) are
-    ET_DYN too, and not all shared libraries have a soname...
-    no interpreter is typically the best indicator then."""
+
+def get_elf(filepath):
     try:
         with open(filepath, "rb") as f:
-            elf = parse_elf(f, interpreter=True, dynamic_section=True)
-            return elf.has_pt_dynamic and (elf.has_soname or not elf.has_pt_interp)
+            return parse_elf(f, interpreter=True, dynamic_section=True)
     except (IOError, OSError, ElfParsingError):
-        return False
+        return None
+
+
+def library_is_compatible(parent: ElfFile, child: ElfFile):
+    """Check whether the library has the same architecture as the parent
+    that may use it. This check avoids picking up e.g. 32 bit libs when
+    the parent is a 64 bit elf file."""
+    return (
+        parent.is_64_bit == child.is_64_bit
+        and parent.is_little_endian == child.is_little_endian
+        and parent.elf_hdr.e_machine == child.elf_hdr.e_machine
+    )
+
+
+def resolve_lib(parent: ElfFile, rpaths, lib):
+    # If there's a / in
+    if "/" in lib:
+        return None
+    for rpath in rpaths:
+        library_path = os.path.join(rpath, lib)
+        try:
+            with open(library_path, "rb") as f:
+                child = parse_elf(f, interpreter=False, dynamic_section=False)
+                if library_is_compatible(parent, child):
+                    return library_path
+        except (OSError, ElfParsingError):
+            continue
+    return None
 
 
 class SharedLibrariesVisitor(BaseDirectoryVisitor):
@@ -41,9 +63,10 @@ class SharedLibrariesVisitor(BaseDirectoryVisitor):
         # List of file and directory names to be excluded
         self.exclude_list = frozenset(exclude_list)
 
-        # Map from (ino, dev) -> path. We need 1 path per file, if there are hardlinks,
-        # we don't need to store the path multiple times.
-        self.libraries = dict()
+        # Map from (ino, dev) -> [path, new_soname, ]. We need 1 path per file,
+        # if there are hardlinks, we don't need to store the path multiple
+        # times.
+        self._actions = dict()
 
         # Set of (ino, dev) pairs (excluded by symlinks).
         self.excluded_through_symlink = set()
@@ -59,12 +82,48 @@ class SharedLibrariesVisitor(BaseDirectoryVisitor):
         identifier = (s.st_ino, s.st_dev)
 
         # We're hitting a hardlink or symlink of an excluded lib, no need to parse.
-        if identifier in self.libraries or identifier in self.excluded_through_symlink:
+        if identifier in self._actions or identifier in self.excluded_through_symlink:
             return
 
         # Register the file if it's a shared lib that needs to be patched.
-        if is_shared_library_elf(filepath):
-            self.libraries[identifier] = rel_path
+        elf = get_elf(filepath)
+        if elf is None:
+            return
+
+        # Our definition of a shared library for ELF requires:
+        # 1. a dynamic section,
+        # 2. a soname OR lack of interpreter.
+        # The problem is that PIE objects (default on Ubuntu) are
+        # ET_DYN too, and not all shared libraries have a soname...
+        # no interpreter is typically the best indicator then.
+        is_library = elf.has_pt_dynamic and (elf.has_soname or not elf.has_pt_interp)
+
+        # Resolve rpaths inside the spec's own prefix, and replace by absolute paths.
+        replace_needed = []
+        if elf.has_rpath and elf.has_needed:
+            try:
+                needed_libs = [s.decode("utf-8") for s in elf.dt_needed_strs]
+                rpaths_in_spec_prefix = list(
+                    filter(
+                        lambda p: os.path.normpath(p).startswith(root),
+                        elf.dt_rpath_str.decode("utf-8").split(":"),
+                    )
+                )
+
+                for needed in needed_libs:
+                    resolved = resolve_lib(elf, rpaths_in_spec_prefix, needed)
+                    if resolved:
+                        replace_needed.append((needed, resolved))
+            except UnicodeDecodeError:
+                # We simply skip if we can't decode rpath & needed as UTF-8,
+                # even though in principle it would be better to stick to
+                # binary mode, since paths and filenames are just a sequence
+                # of bytes without encoding.
+                pass
+
+        self._actions[identifier] = ModifyElfAction(
+            path=rel_path, set_soname=is_library, replace_needed=replace_needed
+        )
 
     def visit_symlinked_file(self, root, rel_path, depth):
         # We don't need to follow the symlink and parse the file, since we will hit
@@ -95,41 +154,54 @@ class SharedLibrariesVisitor(BaseDirectoryVisitor):
         # everywhere.
         return False
 
-    def get_shared_libraries_relative_paths(self):
-        """Get the libraries that should be patched, with the excluded libraries
-        removed."""
+    @property
+    def actions(self):
+        """Get the actions."""
         for identifier in self.excluded_through_symlink:
-            self.libraries.pop(identifier, None)
+            self._actions.pop(identifier, None)
 
-        return [rel_path for rel_path in self.libraries.values()]
+        return list(self._actions.values())
 
 
-def patch_sonames(patchelf, root, rel_paths):
-    """Set the soname to the file's own path for a list of
-    given shared libraries."""
-    fixed = []
-    for rel_path in rel_paths:
+def apply_actions(patchelf, root, actions):
+    """Run the actions (set soname, replace needed)
+    for the executables and libraries we have detected
+    in a prefix."""
+    modified = []
+    for rel_path, set_soname, replace_needed in actions:
+        args = []
         filepath = os.path.join(root, rel_path)
-        normalized = os.path.normpath(filepath)
-        args = ["--set-soname", normalized, normalized]
+
+        if set_soname:
+            args.extend(["--set-soname", os.path.normpath(filepath)])
+
+        for old_needed, new_needed in replace_needed:
+            args.extend(["--replace-needed", old_needed, new_needed])
+
+        # Nothing to do.
+        if not args:
+            continue
+
+        # Positional arg: file we're modifying.
+        args.append(filepath)
+
         output = patchelf(*args, output=str, error=str, fail_on_error=False)
         if patchelf.returncode == 0:
-            fixed.append(rel_path)
+            modified.append(rel_path)
         else:
             # Note: treat as warning to avoid (long) builds to fail post-install.
-            tty.warn("patchelf: failed to set soname of {}: {}".format(normalized, output.strip()))
-    return fixed
+            tty.warn("patchelf: failed to modify {}: {}".format(filepath, output.strip()))
+    return modified
 
 
-def find_and_patch_sonames(prefix, exclude_list, patchelf):
+def absolutify_sonames(prefix, exclude_list, patchelf):
     # Locate all shared libraries in the prefix dir of the spec, excluding
     # the ones set in the non_bindable_shared_objects property.
     visitor = SharedLibrariesVisitor(exclude_list)
     visit_directory_tree(prefix, visitor)
 
     # Patch all sonames.
-    relative_paths = visitor.get_shared_libraries_relative_paths()
-    return patch_sonames(patchelf, prefix, relative_paths)
+    return apply_actions(patchelf, prefix, visitor.actions)
 
 
 def post_install(spec):
@@ -155,17 +227,17 @@ def post_install(spec):
         return
     patchelf = Executable(patchelf_path)
 
-    fixes = find_and_patch_sonames(spec.prefix, spec.package.non_bindable_shared_objects, patchelf)
+    modified = absolutify_sonames(spec.prefix, spec.package.non_bindable_shared_objects, patchelf)
 
-    if not fixes:
+    if not modified:
         return
 
     # Unfortunately this does not end up in the build logs.
     tty.info(
         "{}: Patched {} {}: {}".format(
             spec.name,
-            len(fixes),
-            "soname" if len(fixes) == 1 else "sonames",
-            ", ".join(elide_list(fixes, max_num=5)),
+            len(modified),
+            "binary" if len(modified) == 1 else "binaries",
+            ", ".join(elide_list(modified, max_num=5)),
         )
     )

--- a/lib/spack/spack/test/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/test/hooks/absolutify_elf_sonames.py
@@ -12,8 +12,9 @@ import llnl.util.filesystem as fs
 
 import spack.platforms
 from spack.hooks.absolutify_elf_sonames import (
+    ModifyElfAction,
     SharedLibrariesVisitor,
-    find_and_patch_sonames,
+    absolutify_sonames,
 )
 from spack.util.executable import Executable
 
@@ -55,8 +56,17 @@ def test_shared_libraries_visitor(tmpdir):
             f.write("int main(){return 0;}")
         gcc("hello.c", "-o", "no-soname.so", "--shared")
         gcc("hello.c", "-o", "soname.so", "--shared", "-Wl,-soname,example.so")
-        gcc("hello.c", "-pie", "-o", "executable.so")
-        gcc("hello.c", "-o", "libskipme.so", "-Wl,-soname,libskipme.so")
+        os.symlink("soname.so", "example.so")
+        gcc("hello.c", "-o", "libskipme.so", "--shared", "-Wl,-soname,libskipme.so")
+        gcc(
+            "hello.c",
+            "-pie",
+            "-o",
+            "executable.so",
+            f"-Wl,--no-as-needed,-rpath,{tmpdir}",
+            "-L.",
+            "-l:soname.so",
+        )
         os.mkdir("my_dir")
         os.symlink("..", os.path.join("my_dir", "parent_dir"))
         os.symlink(os.path.join("..", "libskipme.so"), os.path.join("my_dir", "skip_symlink"))
@@ -64,18 +74,28 @@ def test_shared_libraries_visitor(tmpdir):
     # Visit the whole prefix, but exclude `skip_symlink`
     visitor = SharedLibrariesVisitor(exclude_list=["skip_symlink"])
     fs.visit_directory_tree(str(tmpdir), visitor)
-    relative_paths = visitor.get_shared_libraries_relative_paths()
+    actions = visitor.actions
 
-    assert "no-soname.so" in relative_paths
-    assert "soname.so" in relative_paths
-    assert "executable.so" not in relative_paths
-    assert "libskipme.so" not in relative_paths
+    # These libraries should receive sonames, whether they had sonames or not.
+    assert ModifyElfAction("no-soname.so", set_soname=True, replace_needed=[]) in actions
+    assert ModifyElfAction("soname.so", set_soname=True, replace_needed=[]) in actions
+
+    # The executable should not get a soname, but it's needed lib should be
+    # replaced since it's within the prefix
+    resolved = os.path.join(str(tmpdir), "example.so")
+    replace = [("example.so", resolved)]
+    assert ModifyElfAction("executable.so", set_soname=False, replace_needed=replace) in actions
+
+    # That's all we have to do, in particular libskipme.so shouldn't be modified.
+    assert len(actions) == 3
 
     # Run the full hook of finding libs and setting sonames.
     patchelf = ExecutableIntercept()
-    find_and_patch_sonames(str(tmpdir), ["skip_symlink"], patchelf)
-    assert len(patchelf.calls) == 2
+    absolutify_sonames(str(tmpdir), ["skip_symlink"], patchelf)
+    assert len(patchelf.calls) == 3
     elf_1 = tmpdir.join("no-soname.so")
     elf_2 = tmpdir.join("soname.so")
+    elf_3 = tmpdir.join("executable.so")
     assert ("--set-soname", elf_1, elf_1) in patchelf.calls
     assert ("--set-soname", elf_2, elf_2) in patchelf.calls
+    assert ("--replace-needed", "example.so", resolved, elf_3) in patchelf.calls

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -128,6 +128,10 @@ class ElfFile(object):
         "dt_soname_str",
     ]
 
+    is_64_bit: bool
+    is_little_endian: bool
+    elf_hdr: ElfHeader
+
     def __init__(self):
         self.dt_needed_strtab_offsets = []
         self.has_soname = False


### PR DESCRIPTION
When using `config:shared_linking:true`, Spack modifies ELF sonames
post-install, so that dependents linking to it automatically won't search at
runtime.

However, executables and libraries that link to libraries within their own
prefix (for example `<prefix>/bin/app` linking to `<prefix>/lib/libapp.so`),
would not benefit from this, since they're linked at build time, before the
post-install hook would change sonames.

This commit fixes that by resolving needed libraries within rpaths inside the
spec's own prefix.*

(*Slightly more correct would be to resolve it in all rpaths preceding those)