### PR TITLE
Add pika 0.12.0 and pika-algorithms 0.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -15,6 +15,7 @@ class PikaAlgorithms(CMakePackage):
     git = "https://github.com/pika-org/pika-algorithms.git"
     maintainers("msimberg", "albestro", "teonnik", "aurianer")
 
+    version("0.1.1", sha256="4aae88ac19864fd278bbdb49ae56348014c3d0d4b49a46ab3b9ba8a180f745f6")
     version("0.1.0", sha256="64da008897dfa7373155595c46d2ce6b97a8a3cb5bea33ae7f2d1ff359f0d9b6")
     version("main", branch="main")
 
@@ -41,6 +42,7 @@ class PikaAlgorithms(CMakePackage):
     depends_on("boost@1.71:")
     depends_on("fmt@9:")
     depends_on("pika@0.11:")
+    depends_on("pika@0.11", when="@0.1.0")
 
     for cxxstd in cxxstds:
         depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -17,6 +17,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pika-org/pika.git"
     maintainers("msimberg", "albestro", "teonnik", "aurianer")
 
+    version("0.12.0", sha256="daa1422eb73d6a897ce7b8ff8022e09e7b0fec83d92728ed941a92e57dec5da3")
     version("0.11.0", sha256="3c3d94ca1a3960884bad7272bb9434d61723f4047ebdb097fcf522c6301c3fda")
     version("0.10.0", sha256="3b443b8f0f75b9a558accbaef0334a113a71b0205770e6c7ff02ea2d7c6aca5b")
     version("0.9.0", sha256="c349b2a96476d6974d2421288ca4d2e14ef9e5897d44cd7d5343165faa2d1299")

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -44,7 +44,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     variant(
         "malloc",
-        default="tcmalloc",
+        default="mimalloc",
         description="Define which allocator will be linked in",
         values=("system", "jemalloc", "mimalloc", "tbbmalloc", "tcmalloc"),
     )


### PR DESCRIPTION
This adds new versions for pika and pika-algorithms. pika-algorithms 0.1.0 is not compatible with pika 0.12.0 so adding a constraint for that. pika algorithms 0.1.1 is compatible with pika 0.11.0 and 0.12.0.

I'm also changing the default value of the `malloc` variant in pika to `mimalloc` (this reflects a change already made in pika a few versions ago). As far as I can tell this is a perfectly safe change to do, but is there a corner case I'm not taking into account by changing the default? Existing builds should be fine, new builds may end up using a different allocator than it was using before, but otherwise I can't see any problems with changing the default.