### PR TITLE
py-minkowskiengine: new package (sparse tensor autodiff by Nvidia)

### DIFF
--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMinkowskiengine(PythonPackage, CudaPackage):
+    """The MinkowskiEngine is an auto-differentiation
+    library for sparse tensors."""
+
+    homepage = "https://nvidia.github.io/MinkowskiEngine/"
+    pypi = "MinkowskiEngine/MinkowskiEngine-0.5.4.tar.gz"
+
+    maintainers = ["wdconinc"]
+
+    version("0.5.4", sha256="b1879c00d0b0b1d30ba622cce239886a7e3c78ee9da1064cdfe2f64c2ab15f94")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-torch", type=("build", "run"))
+    depends_on("py-pybind11", type=("build", "run"))
+
+    def patch(self):
+        filter_file(r"CC_FLAGS \+= ARGS",
+                    "CC_FLAGS += ARGS + ['-I{}']".format(self.spec["py-pybind11"].prefix.include),
+                    "setup.py")
+
+    def install_options(self, spec, prefix):
+        options = []
+        if spec.satisfies("+cuda"):
+            options.append("--force_cuda")
+        else:
+            options.append("--cpu_only")
+        return options

--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -19,7 +19,7 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", type="link")
-    
+
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-torch", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -18,16 +18,10 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
     version("0.5.4", sha256="b1879c00d0b0b1d30ba622cce239886a7e3c78ee9da1064cdfe2f64c2ab15f94")
 
     depends_on("py-setuptools", type="build")
-
+    depends_on("py-pybind11", type="link")
+    
+    depends_on("py-numpy", type=("build", "run"))
     depends_on("py-torch", type=("build", "run"))
-    depends_on("py-pybind11", type=("build", "run"))
-
-    def patch(self):
-        filter_file(
-            r"CC_FLAGS \+= ARGS",
-            "CC_FLAGS += ARGS + ['-I{}']".format(self.spec["py-pybind11"].prefix.include),
-            "setup.py",
-        )
 
     def install_options(self, spec, prefix):
         options = []

--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -23,9 +23,11 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
     depends_on("py-pybind11", type=("build", "run"))
 
     def patch(self):
-        filter_file(r"CC_FLAGS \+= ARGS",
-                    "CC_FLAGS += ARGS + ['-I{}']".format(self.spec["py-pybind11"].prefix.include),
-                    "setup.py")
+        filter_file(
+            r"CC_FLAGS \+= ARGS",
+            "CC_FLAGS += ARGS + ['-I{}']".format(self.spec["py-pybind11"].prefix.include),
+            "setup.py",
+        )
 
     def install_options(self, spec, prefix):
         options = []


### PR DESCRIPTION
This python package (with cuda support) provides torch support for sparse tensors. The `pybind11` headers are not found without the patch to `setup.py`.