### PR TITLE
GenericBuilder: facilitate post-install phase test callbacks

### DIFF
--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -8,7 +8,7 @@ import spack.builder
 import spack.directives
 import spack.package_base
 
-from ._checks import BaseBuilder, apply_macos_rpath_fixups
+from ._checks import BaseBuilder, apply_macos_rpath_fixups, execute_install_time_tests
 
 
 class Package(spack.package_base.PackageBase):
@@ -38,7 +38,16 @@ class GenericBuilder(BaseBuilder):
     legacy_methods: Tuple[str, ...] = ()
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes: Tuple[str, ...] = ("archive_files",)
+    legacy_attributes: Tuple[str, ...] = (
+        "archive_files",
+        "install_time_test_callbacks",
+    )
+
+    #: Callback names for post-install phase tests
+    install_time_test_callbacks = []
 
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
     spack.builder.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
+
+    # unconditionally perform any post-install phase tests
+    spack.builder.run_after("install")(execute_install_time_tests)

--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -39,6 +39,13 @@ class Oommf(Package):
     # default URL for versions
     url = "https://github.com/fangohr/oommf/archive/refs/tags/20a1_20180930_ext.tar.gz"
 
+    #: post-install phase methods used to check the installation
+    install_time_test_callbacks = [
+        "check_install_version",
+        "check_install_platform",
+        "check_install_stdprob3",
+    ]
+
     maintainers("fangohr")
 
     version(
@@ -220,15 +227,12 @@ class Oommf(Package):
 
         print("output received from oommf is %s" % output)
 
-    @run_after("install")
     def check_install_version(self):
         self._check_install_oommf_command(["+version"])
 
-    @run_after("install")
     def check_install_platform(self):
         self._check_install_oommf_command(["+platform"])
 
-    @run_after("install")
     def check_install_stdprob3(self):
         oommf_examples = join_path(self.spec.prefix.usr.bin, "oommf/app/oxs/examples")
         task = join_path(oommf_examples, "stdprob3.mif")


### PR DESCRIPTION
This PR adds the ability for those packages relying on the `GenericBuilder` to add names of methods to the package's `install_time_test_callbacks` list for those methods that are to always be called after the `spack install` `install` phase to check that the installation was successful.

The `GenericBuilder` supports the `install` phase by default.  So this PR allows package developers to use `install_time_test_callbacks` in a manner similar to the way other build systems use them to support post-`install` checks.  (See the table at https://spack.readthedocs.io/en/latest/packaging_guide.html#id24.)

Adding this support can simplify and tighten the package code.  The benefit isn't as obvious in the `oommf` package included here but it will be clearer with the new stand-alone testing approach in #34236 (where a converted version of the existing `test` method can be split into the three corresponding `test_*` methods and re-used).