### PR TITLE
Output test log path (optionally contents) post-install, include post-install times

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -43,6 +43,7 @@ import types
 from typing import List, Tuple
 
 import llnl.util.tty as tty
+from llnl.util.filesystem import join_path
 from llnl.util.lang import dedupe
 from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
@@ -1346,6 +1347,15 @@ class ChildError(InstallError):
         if have_log:
             out.write("See {0} log for details:\n".format(self.log_type))
             out.write("  {0}\n".format(self.log_name))
+
+            # Also output the test log path IF it exists
+            if self.context != "test":
+                test_log = join_path(
+                    os.path.dirname(self.log_name), spack.package_base._spack_install_test_log
+                )
+                if os.path.exists(test_log):
+                    out.write("\nSee test log for details:\n")
+                    out.write("  {0}\n".format(test_log))
 
         return out.getvalue()
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -281,7 +281,7 @@ def _print_installed_pkg(message):
 
 
 def _print_install_test_log(pkg: "spack.package_base.PackageBase"):
-    """Output install test log file information.
+    """Output install test log path.
 
     Args:
         pkg: package of interest
@@ -1967,7 +1967,6 @@ class BuildProcessInstaller(object):
             with open(self.pkg.times_log_path, "w") as timelog:
                 self.timer.write_json(timelog)
 
-        _print_install_test_log(self.pkg)
         _print_timer(pre=self.pre, pkg_id=self.pkg_id, timer=self.timer)
         _print_installed_pkg(self.pkg.prefix)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -280,16 +280,15 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
-def _print_install_test_log(pkg: "spack.package_base.PackageBase", verbose: bool):
+def _print_install_test_log(pkg: "spack.package_base.PackageBase"):
     """Output install test log file information.
 
     Args:
         pkg: package of interest
-        verbose: True if the test log contents are to be printed
     """
 
-    if not pkg.run_tests:
-        # The tests were not run
+    if not pkg.run_tests or not pkg.test_failures:
+        # The tests were not run or there were no test failures
         return
 
     log = pkg.install_test_install_log_path
@@ -299,15 +298,7 @@ def _print_install_test_log(pkg: "spack.package_base.PackageBase", verbose: bool
             tty.debug("There is no test log file (staged or installed)")
             return
 
-    if verbose:
-        with open(log, "r") as f:
-            for ln in f.readlines():
-                if ln.startswith("==>"):
-                    ln = colorize("@*g{==>}") + ln[3:]
-                print(ln.strip("\n"))
-
-    if pkg.test_failures:
-        print("\nSee test results at:\n  {0}".format(log))
+    print("\nSee test results at:\n  {0}".format(log))
 
 
 def _print_timer(pre, pkg_id, timer):
@@ -1976,7 +1967,7 @@ class BuildProcessInstaller(object):
             with open(self.pkg.times_log_path, "w") as timelog:
                 self.timer.write_json(timelog)
 
-        _print_install_test_log(self.pkg, self.verbose)
+        _print_install_test_log(self.pkg)
         _print_timer(pre=self.pre, pkg_id=self.pkg_id, timer=self.timer)
         _print_installed_pkg(self.pkg.prefix)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -280,6 +280,28 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
+def _print_test_log(pkg, verbose):
+    """Output test log file information.
+
+    Args:
+        pkg (spack.package.PackageBase): package of interest
+        verbose (bool): True if the test log contents are to be printed
+    """
+    log = pkg.install_test_install_log_path
+    if not os.path.isfile(log):
+        log = pkg.test_install_log if hasattr(pkg, "test_install_log") else None
+        if not (log and os.path.isfile(log)):
+            tty.debug("There is no test log file (staged or installed)")
+            return
+
+    if verbose:
+        with open(log, "r") as f:
+            for ln in f.readlines():
+                print(ln.strip("\n"))
+
+    print("\nSee test results at:\n  {0}".format(log))
+
+
 def _print_timer(pre, pkg_id, timer):
     phases = ["{}: {}.".format(p.capitalize(), _hms(timer.duration(p))) for p in timer.phases]
     phases.append("Total: {}".format(_hms(timer.duration())))
@@ -1945,6 +1967,7 @@ class BuildProcessInstaller(object):
             spack.hooks.post_install(self.pkg.spec)
 
         _print_timer(pre=self.pre, pkg_id=self.pkg_id, timer=self.timer)
+        _print_test_log(self.pkg, self.verbose)
         _print_installed_pkg(self.pkg.prefix)
 
         # Send final status that install is successful

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -280,13 +280,17 @@ def _print_installed_pkg(message):
     print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
-def _print_test_log(pkg, verbose):
-    """Output test log file information.
+def _print_install_test_log(pkg, verbose):
+    """Output install test log file information.
 
     Args:
         pkg (spack.package.PackageBase): package of interest
         verbose (bool): True if the test log contents are to be printed
     """
+    if not pkg.run_tests:
+        # The tests were not run
+        return
+
     log = pkg.install_test_install_log_path
     if not os.path.isfile(log):
         log = pkg.test_install_log if hasattr(pkg, "test_install_log") else None
@@ -1967,7 +1971,7 @@ class BuildProcessInstaller(object):
             spack.hooks.post_install(self.pkg.spec)
 
         _print_timer(pre=self.pre, pkg_id=self.pkg_id, timer=self.timer)
-        _print_test_log(self.pkg, self.verbose)
+        _print_install_test_log(self.pkg, self.verbose)
         _print_installed_pkg(self.pkg.prefix)
 
         # Send final status that install is successful

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1888,7 +1888,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         with tty.log.log_output(self.test_log_file, verbose) as logger:
             with logger.force_echo():
-                tty.msg("Testing package {0}".format(pkg_id))
+                tty.info("Testing package {0}".format(pkg_id), format="*g")
 
             # use debug print levels for log file to record commands
             old_debug = tty.is_debug()
@@ -2446,6 +2446,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     print_test_message(logger, msg, True)
 
                     fn()
+
                 except AttributeError as e:
                     msg = "RUN-TESTS: method not implemented [{0}]".format(name)
                     print_test_message(logger, msg, True)
@@ -2453,6 +2454,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     builder.pkg.test_failures.append((e, msg))
                     if fail_fast:
                         break
+
+            if "test" in method_names:
+                print_test_message(logger, "Completed testing", True)
 
             # Raise any collected failures here
             if builder.pkg.test_failures:
@@ -2480,9 +2484,9 @@ def has_test_method(pkg):
 def print_test_message(logger, msg, verbose):
     if verbose:
         with logger.force_echo():
-            tty.msg(msg)
+            tty.info(msg, format="*g")
     else:
-        tty.msg(msg)
+        tty.info(msg, format="*g")
 
 
 def _copy_cached_test_files(pkg, spec):

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -233,6 +233,7 @@ def test_test_list_all(mock_packages):
             "printing-package",
             "py-extension1",
             "py-extension2",
+            "py-test-callback",
             "simple-standalone-test",
             "test-error",
             "test-fail",

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -252,7 +252,7 @@ def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
 
     # The order should be maintained
     phases = [x["name"] for x in times["phases"]]
-    assert phases == ["stage", "one", "two", "three", "install"]
+    assert phases == ["stage", "one", "two", "three", "install", "post-install"]
     assert all(isinstance(x["seconds"], float) for x in times["phases"])
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1344,15 +1344,8 @@ def test_single_external_implicit_install(install_mockery, explicit_args, is_exp
         (True, False, True),  # install log file, print contents
     ],
 )
-def test_print_test_log(
-    tmpdir,
-    mock_packages,
-    install_mockery,
-    capsys,
-    monkeypatch,
-    installed,
-    staged,
-    verbose,
+def test_print_install_test_log(
+    tmpdir, mock_packages, install_mockery, capsys, monkeypatch, installed, staged, verbose
 ):
     pkg = "py-test-callback"
     content = """
@@ -1389,7 +1382,8 @@ def test_print_test_log(
     s = spack.spec.Spec(pkg).concretized()
     write_outputs(s.package)
 
-    inst._print_test_log(s.package, verbose)
+    s.package.run_tests = True
+    inst._print_install_test_log(s.package, verbose)
     captured = str(capsys.readouterr())
 
     for e in expected:

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.pkg.builtin.mock.python as mp
+from spack.package import *
+
+
+class PyTestCallback(mp.Python):
+    """A package for testing stand-alone test methods as a callback."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/test-callback-1.0.tar.gz"
+
+    version("1.0", "00000000000000000000000000000110")
+    version("2.0", "00000000000000000000000000000120")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+
+    def test(self):
+        super(PyTestCallback, self).test()
+
+        print("PyTestCallback test")


### PR DESCRIPTION
(UPDATED) This PR provides more post-install test information:

1. prints the test log path IF a test failure occurs;
2. prints the contents of the test log IF `-v` option is passed to `spack install`; and
3. times and prints post-install operations (e.g., post-install tests).

For example, with `-v --test=root` for a package with a (fake) test failure:
```
$ spack install -v --test=root py-libensemble@0.9.2
...
==> Installing py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d
==> No binary for py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d found: installing from source
==> Using cached archive: $spack/var/spack/cache/_source-cache/archive/e4/e46598e5696f770cbff4cb90507b52867faad5654f1b80de35405a95228c909f.tar.gz
==> No patches needed for py-libensemble
==> py-libensemble: Executing phase: 'install'
...
Successfully built libensemble
Installing collected packages: libensemble

Successfully installed libensemble-0.9.2
...
==> Testing package py-libensemble-0.9.2-lr5qi7b
==> [2023-02-24-16:08:32.534705] Running install-time tests
==> [2023-02-24-16:08:32.536319] Installing $/spack/opt/spack/linux-rhel7-broadwell/gcc-8.3.1/py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d/.spack/test to /var/tmp/dahlgren/spack-stage/spack-stage-py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d/py-libensemble-0.9.2-lr5qi7b/cache/py-libensemble
==> [2023-02-24-16:08:32.811530] RUN-TESTS: install-time tests [test]
==> [2023-02-24-16:08:32.876125] Detected the following modules: ['libensemble', 'libensemble.alloc_funcs', 'libensemble.comms', 'libensemble.executors', 'libensemble.executors.balsam_executors', 'libensemble.gen_funcs', 'libensemble.resources', 'libensemble.sim_funcs', 'libensemble.sim_funcs.branin', 'libensemble.tests', 'libensemble.tests.regression_tests', 'libensemble.tests.unit_tests', 'libensemble.tools', 'libensemble.utils']
==> [2023-02-24-16:08:32.877048] checking import of libensemble
==> [2023-02-24-16:08:32.877751] '/usr/tce/bin/python3.7' '-c' 'import libensemble'
PASSED
...
==> [2023-02-24-16:08:45.706608] test: run test_1d_sampling.py example
==> [2023-02-24-16:08:45.707351] '/usr/tce/bin/python3.7' 'test_1d_sampling.py' '--comms' 'local' '--nworkers' '2'

libEnsemble with random sampling has generated enough points
libensemble.tools.tools: ------------------ Run completed -------------------
Saving results to file: 1d_sampling_history_length=1000_evals=502_workers=2
PASSED
==> [2023-02-24-16:08:47.117321] test: fail
==> [2023-02-24-16:08:47.118023] '/usr/tce/bin/python3.7' '-c' 'raise RuntimeError("fail")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: fail
FAILED: Command exited with status 1:
    '/usr/tce/bin/python3.7' '-c' 'raise RuntimeError("fail")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: fail
...
  File "$spack/var/spack/repos/builtin/packages/py-libensemble/package.py", line 100, in test
    purpose="test: fail",
==> [2023-02-24-16:08:47.450596] Completed testing
==> Error: TestFailure: 1 tests failed.

Command exited with status 1:
    '/usr/tce/bin/python3.7' '-c' 'raise RuntimeError("fail")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: fail

1 error found in test log:
...
See build log for details:
  $TMPDIR/spack-stage/spack-stage-py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d/spack-build-out.txt

See test log for details:
  $TMPDIR/spack-stage/spack-stage-py-libensemble-0.9.2-lr5qi7bfilbfm7ci5jvwno5kccjavc7d/install-time-test-log.txt

193.295u 23.579s 3:59.98 90.3%	0+0k 1816+6256io 1pf+0w
```

While running tests without `-v` for the same package results in:
```
$ spack install --test=root py-libensemble@0.9.3
...
==> Installing py-libensemble-0.9.3-5prbuneeootut5fplscnx7mv2ews3xin
==> No binary for py-libensemble-0.9.3-5prbuneeootut5fplscnx7mv2ews3xin found: installing from source
==> Using cached archive: /usr/WS1/dahlgren/releases/spack/var/spack/cache/_source-cache/archive/00/00e5a65d6891feee6a686c048d8de72097b8bff164431f163be96ec130a9c390.tar.gz
==> No patches needed for py-libensemble
==> py-libensemble: Executing phase: 'install'
==> Error: TestFailure: 1 tests failed.

Command exited with status 1:
    '/usr/tce/bin/python3.7' '-c' 'raise RuntimeError("fail")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: fail
...
See build log for details:
  /var/tmp/dahlgren/spack-stage/spack-stage-py-libensemble-0.9.3-5prbuneeootut5fplscnx7mv2ews3xin/spack-build-out.txt

See test log for details:
  /var/tmp/dahlgren/spack-stage/spack-stage-py-libensemble-0.9.3-5prbuneeootut5fplscnx7mv2ews3xin/install-time-test-log.txt

199.725u 30.088s 4:00.49 95.5%	0+0k 1024+5688io 0pf+0w
``` 

Note:
```
$ spack  -v test run py-libensemble@0.9.2  # shows tests and, if a failure, log path
$ spack test run py-libensemble@0.9.3  # does not show details or the log path

TODO

- [x] add/update unit tests