### PR TITLE
rocm: detect amdgpu_target in external find

### DIFF
--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -247,6 +247,13 @@ class Rocblas(CMakePackage):
             ver = None
         return ver
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        targets = set()
+        for exe in exes:
+            targets |= ROCmPackage.determine_amdgpu_targets(exe)
+        return "amdgpu_target={}".format(",".join(sorted(list(targets))))
+
     def cmake_args(self):
         args = [
             self.define("BUILD_CLIENTS_TESTS", self.run_tests and "@4.2.0:" in self.spec),

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -169,6 +169,13 @@ class Rocfft(CMakePackage):
             ver = None
         return ver
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        targets = set()
+        for exe in exes:
+            targets |= ROCmPackage.determine_amdgpu_targets(exe)
+        return "amdgpu_target={}".format(",".join(sorted(list(targets))))
+
     def cmake_args(self):
         args = [
             self.define("BUILD_CLIENTS_TESTS", self.run_tests),

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -252,6 +252,13 @@ class Rocrand(CMakePackage):
             ver = None
         return ver
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        targets = set()
+        for exe in exes:
+            targets |= ROCmPackage.determine_amdgpu_targets(exe)
+        return "amdgpu_target={}".format(",".join(sorted(list(targets))))
+
     def cmake_args(self):
         args = [self.define("BUILD_BENCHMARK", "OFF"), self.define("BUILD_TEST", self.run_tests)]
 

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -186,6 +186,13 @@ class Rocsolver(CMakePackage):
             ver = None
         return ver
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        targets = set()
+        for exe in exes:
+            targets |= ROCmPackage.determine_amdgpu_targets(exe)
+        return "amdgpu_target={}".format(",".join(sorted(list(targets))))
+
     def cmake_args(self):
         args = [
             self.define("BUILD_CLIENTS_SAMPLES", "OFF"),

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -319,6 +319,13 @@ class Rocsparse(CMakePackage):
             ver = None
         return ver
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        targets = set()
+        for exe in exes:
+            targets |= ROCmPackage.determine_amdgpu_targets(exe)
+        return "amdgpu_target={}".format(",".join(sorted(list(targets))))
+
     def cmake_args(self):
         args = [
             self.define("BUILD_CLIENTS_SAMPLES", "OFF"),


### PR DESCRIPTION
This is a working proof-of-concept for determining the amdgpu_target variant from `spack external find`.