### PR TITLE
relion: add patch to repair DoublePrec_CPU=OFF build

### DIFF
--- a/var/spack/repos/builtin/packages/relion/0003-Repair-DoublePrec_CPU-OFF-build-as-reported-by-Filip.patch
+++ b/var/spack/repos/builtin/packages/relion/0003-Repair-DoublePrec_CPU-OFF-build-as-reported-by-Filip.patch
@@ -1,0 +1,26 @@
+From 2daa7447c1c871be062cce99109b6041955ec5e9 Mon Sep 17 00:00:00 2001
+From: Takanori Nakane <nakane.t@gmail.com>
+Date: Thu, 29 Sep 2022 17:10:09 +0900
+Subject: [PATCH] Repair DoublePrec_CPU=OFF build (as reported by @FilipeMaia).
+
+---
+ src/ml_optimiser.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ml_optimiser.cpp b/src/ml_optimiser.cpp
+index b1148ceb..5643b092 100644
+--- a/src/ml_optimiser.cpp
++++ b/src/ml_optimiser.cpp
+@@ -6491,7 +6491,7 @@ void MlOptimiser::precalculateShiftedImagesCtfsAndInvSigma2s(bool do_also_unmask
+
+         if (do_subtomo_correction)
+                {
+-                       MultidimArray<double> STmult;
++                       MultidimArray<RFLOAT> STmult;
+             windowFourierTransform(exp_STMulti[img_id], STmult, exp_current_image_size);
+
+             if (is_for_store_wsums)
+-- 
+2.18.4
+
+

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -94,6 +94,7 @@ class Relion(CMakePackage, CudaPackage):
     # - Gctf
     # - ResMap
     patch("0002-Simple-patch-to-fix-intel-mkl-linking.patch", when="@:3.1.1 os=ubuntu18.04")
+    patch("0003-Repair-DoublePrec_CPU-OFF-build-as-reported-by-Filip.patch", when="@4.0.0")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -15,6 +15,7 @@ class Relion(CMakePackage, CudaPackage):
     homepage = "http://www2.mrc-lmb.cam.ac.uk/relion"
     git = "https://github.com/3dem/relion.git"
     url = "https://github.com/3dem/relion/archive/4.0.0.zip"
+    maintainers("dacolombo")
 
     version("4.0.0", sha256="0987e684e9d2dfd630f1ad26a6847493fe9fcd829ec251d8bc471d11701d51dd")
 


### PR DESCRIPTION
Hi all,

I have added a patch to fix the installation of Relion v4.0.0 for single precision CPU.
The installation of Relion in single precision for both GPU and CPU using spack fails, this is the spec that I tried to install:

```
relion@4.0.0 build_type=Release +cuda cuda_arch=70 ~mklfft ~double ~double-gpu +gui +ipo +allow_ctf_in_sagd ^cuda@11.5.1 ^libtiff@4.0.9 ^fftw@3.3.10+mpi+openmp precision=float ^intel-oneapi-mpi@2021.4.0
``` 

The fix in the patch has been added in Relion's repository just a few days after the release of v4.0.0 (https://github.com/3dem/relion/commit/2daa7447c1c871be062cce99109b6041955ec5e9).

I have tested the build of this version with this new patch and it works in my environment. However I could not run style tests before submitting this PR because of a problem that seems to be related to https://github.com/spack/spack/issues/35214

Let me know if I have to do more tests or to modify something for this pull request.

Daniele