### PR TITLE
Allowing use of srun from anywhere in the current PATH

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -130,6 +130,6 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
             make()
             test_args = ["-n", "4", "./ex05_blas"]
             mpi_path = self.spec["mpi"].prefix.bin
-            mpiexe_f = which("srun", "mpirun", "mpiexec", path=mpi_path)
+            mpiexe_f = which("srun") or which("mpirun", "mpiexec", path=mpi_path)
             self.run_test(mpiexe_f.command, test_args, purpose="SLATE smoke test")
             make("clean")


### PR DESCRIPTION
This modifies the smoke test such that it can use any available "srun" executable.  It was previously looking only in the MPI bin directory, but srun is not usually provided by MPI but by the resource scheduler (slurm). This should resolve the testing issues on perlmutter until a more comprehensive solution to finding smoke test dependencies is available in spack.