### PR TITLE
py-packaging: add constrain on python version

### DIFF
--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -24,6 +24,7 @@ class PyPackaging(PythonPackage):
 
     depends_on("py-flit-core@3.3:", when="@22:", type="build")
 
+    # Needed to bootstrap Spack correctly on Python 3.6 (rhel8 platform-python)
     depends_on("python@3.7:", when="@22:", type=("build", "run"))
 
     # Historical dependencies

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -24,7 +24,7 @@ class PyPackaging(PythonPackage):
 
     depends_on("py-flit-core@3.3:", when="@22:", type="build")
 
-    depends_on("python@3.7:", when="@22:")
+    depends_on("python@3.7:", when="@22:", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-setuptools@40.8.0:", when="@20.8:21", type="build")

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -24,6 +24,8 @@ class PyPackaging(PythonPackage):
 
     depends_on("py-flit-core@3.3:", when="@22:", type="build")
 
+    depends_on("python@3.7:", when="@22:")
+
     # Historical dependencies
     depends_on("py-setuptools@40.8.0:", when="@20.8:21", type="build")
     depends_on("py-setuptools", when="@:20.7", type="build")


### PR DESCRIPTION
This should fix the failure we see when bootstrapping on rhel8. Was inadvertently introduced in https://github.com/spack/spack/pull/35279