### PR TITLE
[WIP] py-build: bootstrap without pip

### DIFF
--- a/var/spack/repos/builtin/packages/py-attrs/package.py
+++ b/var/spack/repos/builtin/packages/py-attrs/package.py
@@ -15,18 +15,66 @@ class PyAttrs(Package, PythonExtension):
     list_url = "https://pypi.org/simple/attrs/"
     git = "https://github.com/python-attrs/attrs"
 
-    version("22.2.0", sha256="29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836", expand=False)
-    version("22.1.0", sha256="86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c", expand=False)
-    version("21.4.0", sha256="2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4", expand=False)
-    version("21.2.0", sha256="149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1", expand=False)
-    version("20.3.0", sha256="31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6", expand=False)
-    version("20.2.0", sha256="fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc", expand=False)
-    version("20.1.0", sha256="2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff", expand=False)
-    version("19.3.0", sha256="08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c", expand=False)
-    version("19.2.0", sha256="ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2", expand=False)
-    version("19.1.0", sha256="69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", expand=False)
-    version("18.1.0", sha256="4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265", expand=False)
-    version("16.3.0", sha256="c59426b15b45e39a7bc408eb6ba7e7188d9532764f873cc691199ddd975c97ef", expand=False)
+    version(
+        "22.2.0",
+        sha256="29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+        expand=False,
+    )
+    version(
+        "22.1.0",
+        sha256="86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c",
+        expand=False,
+    )
+    version(
+        "21.4.0",
+        sha256="2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+        expand=False,
+    )
+    version(
+        "21.2.0",
+        sha256="149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+        expand=False,
+    )
+    version(
+        "20.3.0",
+        sha256="31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+        expand=False,
+    )
+    version(
+        "20.2.0",
+        sha256="fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc",
+        expand=False,
+    )
+    version(
+        "20.1.0",
+        sha256="2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff",
+        expand=False,
+    )
+    version(
+        "19.3.0",
+        sha256="08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+        expand=False,
+    )
+    version(
+        "19.2.0",
+        sha256="ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
+        expand=False,
+    )
+    version(
+        "19.1.0",
+        sha256="69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+        expand=False,
+    )
+    version(
+        "18.1.0",
+        sha256="4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+        expand=False,
+    )
+    version(
+        "16.3.0",
+        sha256="c59426b15b45e39a7bc408eb6ba7e7188d9532764f873cc691199ddd975c97ef",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-attrs/package.py
+++ b/var/spack/repos/builtin/packages/py-attrs/package.py
@@ -6,27 +6,38 @@
 from spack.package import *
 
 
-class PyAttrs(PythonPackage):
+class PyAttrs(Package, PythonExtension):
     """Classes Without Boilerplate"""
 
     homepage = "https://attrs.org/"
-    pypi = "attrs/attrs-20.3.0.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py2/a/attrs/attrs-22.2.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/attrs/"
     git = "https://github.com/python-attrs/attrs"
 
-    version("22.1.0", sha256="29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6")
-    version("21.4.0", sha256="626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd")
-    version("21.2.0", sha256="ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb")
-    version("20.3.0", sha256="832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700")
-    version("20.2.0", sha256="26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594")
-    version("20.1.0", sha256="0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a")
-    version("19.3.0", sha256="f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72")
-    version("19.2.0", sha256="f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396")
-    version("19.1.0", sha256="f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399")
-    version("18.1.0", sha256="e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b")
-    version("16.3.0", sha256="80203177723e36f3bbe15aa8553da6e80d47bfe53647220ccaa9ad7a5e473ccc")
+    version("22.2.0", sha256="29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836", expand=False)
+    version("22.1.0", sha256="86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c", expand=False)
+    version("21.4.0", sha256="2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4", expand=False)
+    version("21.2.0", sha256="149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1", expand=False)
+    version("20.3.0", sha256="31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6", expand=False)
+    version("20.2.0", sha256="fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc", expand=False)
+    version("20.1.0", sha256="2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff", expand=False)
+    version("19.3.0", sha256="08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c", expand=False)
+    version("19.2.0", sha256="ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2", expand=False)
+    version("19.1.0", sha256="69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", expand=False)
+    version("18.1.0", sha256="4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265", expand=False)
+    version("16.3.0", sha256="c59426b15b45e39a7bc408eb6ba7e7188d9532764f873cc691199ddd975c97ef", expand=False)
 
-    depends_on("python@3.5:", when="@22.1.0:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.5:", when="@21.2.0:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("py-setuptools@40.6.0:", when="@19.1.0:", type="build")
-    depends_on("py-setuptools", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/{0}/a/attrs/attrs-{1}-{0}-none-any.whl"
+        if version >= Version("22.2"):
+            language = "py3"
+        else:
+            language = "py2.py3"
+        return url.format(language, version)
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-build/isolation.patch
+++ b/var/spack/repos/builtin/packages/py-build/isolation.patch
@@ -1,10 +1,10 @@
---- a/src/build/env.py	2021-09-16 16:20:01.000000000 -0500
-+++ b/src/build/env.py	2022-01-23 15:08:26.000000000 -0600
-@@ -254,6 +254,7 @@
-     """
-     import venv
- 
-+    os.environ.pop('PYTHONPATH', None)
-     venv.EnvBuilder(with_pip=True, symlinks=_fs_supports_symlink()).create(path)
-     executable, script_dir, purelib = _find_executable_and_scripts(path)
- 
+--- a/src/build/env.py	2023-01-11 14:09:08.000000000 -0600
++++ b/src/build/env.py	2023-02-03 12:04:04.000000000 -0600
+@@ -269,6 +269,7 @@
+         with warnings.catch_warnings():
+             if sys.version_info[:3] == (3, 11, 0):
+                 warnings.filterwarnings('ignore', 'check_home argument is deprecated and ignored.', DeprecationWarning)
++            os.environ.pop('PYTHONPATH', None)
+             venv.EnvBuilder(with_pip=True, symlinks=symlinks).create(path)
+     except subprocess.CalledProcessError as exc:
+         raise build.FailedProcessError(exc, 'Failed to create venv. Maybe try installing virtualenv.') from None

--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -3,28 +3,46 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack.package import *
 
 
-class PyBuild(PythonPackage):
-    """A simple, correct PEP517 package builder."""
+class PyBuild(Package, PythonExtension):
+    """A simple, correct Python build frontend."""
 
     homepage = "https://github.com/pypa/build"
-    pypi = "build/build-0.7.0.tar.gz"
+    url = "https://files.pythonhosted.org/packages/source/b/build/build-0.10.0.tar.gz"
+    list_url = "https://pypi.org/simple/build/"
 
-    version("0.7.0", sha256="1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f")
+    version("0.10.0", sha256="d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269")
 
-    variant("virtualenv", default=False, description="Install optional virtualenv dependency")
+    extends("python")
+    depends_on("py-installer", type="build")
 
-    depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-flit-core@3.4:", type="build")
     depends_on("py-packaging@19:", type=("build", "run"))
-    depends_on("py-pep517@0.9.1:", type=("build", "run"))
-    depends_on("py-tomli@1:", type=("build", "run"))
+    depends_on("py-pyproject-hooks", type=("build", "run"))
     depends_on("py-colorama", when="platform=windows", type=("build", "run"))
     depends_on("py-importlib-metadata@0.22:", when="^python@:3.7", type=("build", "run"))
-    depends_on("py-virtualenv@20.0.35:", when="+virtualenv", type=("build", "run"))
+    depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))
 
     # https://github.com/pypa/build/issues/266
     # https://github.com/pypa/build/issues/406
-    patch("isolation.patch", when="@0.7.0")
+    patch("isolation.patch")
+
+    def setup_build_environment(self, env):
+        # To build build from source, we need to use build to bootstrap itself
+        env.prepend_path("PYTHONPATH", "src")
+
+    def install(self, spec, prefix):
+        python("-m", "build", "--no-isolation", ".")
+        wheel = glob.glob(os.path.join("dist", "*.whl"))[0]
+        installer("--prefix", prefix, wheel)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        build = dependent_spec["python"].command
+        build.add_default_arg("-m")
+        build.add_default_arg("build")
+        setattr(module, "build", build)

--- a/var/spack/repos/builtin/packages/py-colorama/package.py
+++ b/var/spack/repos/builtin/packages/py-colorama/package.py
@@ -6,17 +6,18 @@
 from spack.package import *
 
 
-class PyColorama(PythonPackage):
+class PyColorama(Package, PythonExtension):
     """Cross-platform colored terminal text."""
 
     homepage = "https://github.com/tartley/colorama"
-    pypi = "colorama/colorama-0.3.7.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py2.py3/c/colorama/colorama-0.4.6-py2.py3-none-any.whl"
+    list_url = "https://pypi.org/simple/colorama/"
 
-    version("0.4.5", sha256="e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4")
-    version("0.4.4", sha256="5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b")
-    version("0.4.1", sha256="05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d")
-    version("0.3.7", sha256="e043c8d32527607223652021ff648fbb394d5e19cba9f1a698670b338c9d782b")
+    version("0.4.6", sha256="4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", expand=False)
 
-    depends_on("python@2.7:2.8,3.5:", when="@0.4.2:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-colorama/package.py
+++ b/var/spack/repos/builtin/packages/py-colorama/package.py
@@ -15,6 +15,10 @@ class PyColorama(Package, PythonExtension):
     list_url = "https://pypi.org/simple/colorama/"
 
     version("0.4.6", sha256="4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", expand=False)
+    version("0.4.5", sha256="854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da", expand=False)
+    version("0.4.4", sha256="9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2", expand=False)
+    version("0.4.1", sha256="f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48", expand=False)
+    version("0.3.7", sha256="a4c0f5bc358a62849653471e309dcc991223cf86abafbec17cd8f41327279e89", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-colorama/package.py
+++ b/var/spack/repos/builtin/packages/py-colorama/package.py
@@ -14,11 +14,31 @@ class PyColorama(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py2.py3/c/colorama/colorama-0.4.6-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/colorama/"
 
-    version("0.4.6", sha256="4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", expand=False)
-    version("0.4.5", sha256="854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da", expand=False)
-    version("0.4.4", sha256="9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2", expand=False)
-    version("0.4.1", sha256="f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48", expand=False)
-    version("0.3.7", sha256="a4c0f5bc358a62849653471e309dcc991223cf86abafbec17cd8f41327279e89", expand=False)
+    version(
+        "0.4.6",
+        sha256="4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+        expand=False,
+    )
+    version(
+        "0.4.5",
+        sha256="854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+        expand=False,
+    )
+    version(
+        "0.4.4",
+        sha256="9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
+        expand=False,
+    )
+    version(
+        "0.4.1",
+        sha256="f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48",
+        expand=False,
+    )
+    version(
+        "0.3.7",
+        sha256="a4c0f5bc358a62849653471e309dcc991223cf86abafbec17cd8f41327279e89",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -11,22 +11,68 @@ class PyFlitCore(Package, PythonExtension):
 
     homepage = "https://github.com/takluyver/flit"
     # Must be installed from wheel to avoid circular dependency on build
-    url = "https://files.pythonhosted.org/packages/py3/f/flit-core/flit_core-3.8.0-py3-none-any.whl"
+    url = (
+        "https://files.pythonhosted.org/packages/py3/f/flit-core/flit_core-3.8.0-py3-none-any.whl"
+    )
     list_url = "https://pypi.org/simple/flit-core/"
 
     maintainers("takluyver")
 
-    version("3.8.0", sha256="64a29ec845164a6abe1136bf4bc5ae012bdfe758ed42fc7571a9059a7c80bd83", expand=False)
-    version("3.7.1", sha256="e454fdbf68c7036e1c7435ec7479383f9d9a1650ca5b304feb184eba1efcdcef", expand=False)
-    version("3.6.0", sha256="7661029dedadd456c1d94e0a4765222447f00808bb1fcc767e4270a883ba8b4c", expand=False)
-    version("3.5.1", sha256="42d144fa25df9493bfb655036279c4a4ed323e2e3db178b757e898af5aba0334", expand=False)
-    version("3.5.0", sha256="81f0b35a7abedeb2233c66cd801d07130593c272efbbe789634f6a680946a6f0", expand=False)
-    version("3.4.0", sha256="dcd076725ea009ff4b4db65f173ffa9fadb07e736601a4773f1c6b6fcf5f4b0e", expand=False)
-    version("3.3.0", sha256="9b247b3095cb3c43933a59a7433f92ddfdd7fc843e08ef0f4550d53a9cfbbef6", expand=False)
-    version("3.2.0", sha256="6f25843e908dfc3e907b6b9ee71e3d185bcb5aebab8c3431e4e34c261e5ff1b5", expand=False)
-    version("3.1.0", sha256="1d06e64a6af7e1fd1496563b160df29dd32714e00b473f3b763f6e6810476517", expand=False)
-    version("3.0.0", sha256="a787754978cfe3c192a5fc6baf2179ae85b05395804de7d7fe2864d9431e8d03", expand=False)
-    version("2.3.0", sha256="a8f8904b534966712390e0a2e434cd33f76037730a0aaed299a286f9e18cac2b", expand=False)
+    version(
+        "3.8.0",
+        sha256="64a29ec845164a6abe1136bf4bc5ae012bdfe758ed42fc7571a9059a7c80bd83",
+        expand=False,
+    )
+    version(
+        "3.7.1",
+        sha256="e454fdbf68c7036e1c7435ec7479383f9d9a1650ca5b304feb184eba1efcdcef",
+        expand=False,
+    )
+    version(
+        "3.6.0",
+        sha256="7661029dedadd456c1d94e0a4765222447f00808bb1fcc767e4270a883ba8b4c",
+        expand=False,
+    )
+    version(
+        "3.5.1",
+        sha256="42d144fa25df9493bfb655036279c4a4ed323e2e3db178b757e898af5aba0334",
+        expand=False,
+    )
+    version(
+        "3.5.0",
+        sha256="81f0b35a7abedeb2233c66cd801d07130593c272efbbe789634f6a680946a6f0",
+        expand=False,
+    )
+    version(
+        "3.4.0",
+        sha256="dcd076725ea009ff4b4db65f173ffa9fadb07e736601a4773f1c6b6fcf5f4b0e",
+        expand=False,
+    )
+    version(
+        "3.3.0",
+        sha256="9b247b3095cb3c43933a59a7433f92ddfdd7fc843e08ef0f4550d53a9cfbbef6",
+        expand=False,
+    )
+    version(
+        "3.2.0",
+        sha256="6f25843e908dfc3e907b6b9ee71e3d185bcb5aebab8c3431e4e34c261e5ff1b5",
+        expand=False,
+    )
+    version(
+        "3.1.0",
+        sha256="1d06e64a6af7e1fd1496563b160df29dd32714e00b473f3b763f6e6810476517",
+        expand=False,
+    )
+    version(
+        "3.0.0",
+        sha256="a787754978cfe3c192a5fc6baf2179ae85b05395804de7d7fe2864d9431e8d03",
+        expand=False,
+    )
+    version(
+        "2.3.0",
+        sha256="a8f8904b534966712390e0a2e434cd33f76037730a0aaed299a286f9e18cac2b",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -6,30 +6,20 @@
 from spack.package import *
 
 
-class PyFlitCore(PythonPackage):
+class PyFlitCore(Package, PythonExtension):
     """Distribution-building parts of Flit."""
 
     homepage = "https://github.com/takluyver/flit"
-    pypi = "flit-core/flit_core-3.3.0.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/f/flit-core/flit_core-3.8.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/flit-core/"
+
     maintainers("takluyver")
 
-    version("3.7.1", sha256="14955af340c43035dbfa96b5ee47407e377ee337f69e70f73064940d27d0a44f")
-    version("3.6.0", sha256="5892962ab8b8ea945835b3a288fe9dd69316f1903d5288c3f5cafdcdd04756ad")
-    version("3.5.1", sha256="3083720351a6cb00e0634a1ec0e26eae7b273174c3c6c03d5b597a14203b282e")
-    version("3.5.0", sha256="2db800d33ff41e4c6e7c1b594666cb2a11553024106655272c7245933b1d75bd")
-    version("3.4.0", sha256="29468fa2330969167d1f5c23eb9c0661cb6dacfcd46f361a274609a7f4197530")
-    version("3.3.0", sha256="b1404accffd6504b5f24eeca9ec5d3c877f828d16825348ba81515fa084bd5f0")
-    version("3.2.0", sha256="ff87f25c5dbc24ef30ea334074e35030e4885e4c5de3bf4e21f15746f6d99431")
-    version("3.1.0", sha256="22ff73be39a2b3c9e0692dfbbea3ad4a9d127e5733736a87dbb8ddcbf7309b1e")
-    version("3.0.0", sha256="a465052057e2d6d957e6850e9915245adedfc4fd0dd5737d0791bf3132417c2d")
-    version("2.3.0", sha256="a50bcd8bf5785e3a7d95434244f30ba693e794c5204ac1ee908fc07c4acdbf80")
+    version("3.8.0", sha256="64a29ec845164a6abe1136bf4bc5ae012bdfe758ed42fc7571a9059a7c80bd83", expand=False)
 
-    # pyproject.toml
-    depends_on("python@3.6:", when="@3.4:", type=("build", "run"))
-    depends_on("python@3.4:", when="@3:", type=("build", "run"))
-    depends_on("python@2.7,3.4:", type=("build", "run"))
+    extends("python")
+    depends_on("py-installer", type="build")
 
-    # flit_core/build_thyself.py
-    depends_on("py-tomli", when="@3.4:3.5", type="run")
-    depends_on("py-toml", when="@3.1:3.3", type="run")
-    depends_on("py-pytoml", when="@:3.0", type="run")
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -17,9 +17,32 @@ class PyFlitCore(Package, PythonExtension):
     maintainers("takluyver")
 
     version("3.8.0", sha256="64a29ec845164a6abe1136bf4bc5ae012bdfe758ed42fc7571a9059a7c80bd83", expand=False)
+    version("3.7.1", sha256="e454fdbf68c7036e1c7435ec7479383f9d9a1650ca5b304feb184eba1efcdcef", expand=False)
+    version("3.6.0", sha256="7661029dedadd456c1d94e0a4765222447f00808bb1fcc767e4270a883ba8b4c", expand=False)
+    version("3.5.1", sha256="42d144fa25df9493bfb655036279c4a4ed323e2e3db178b757e898af5aba0334", expand=False)
+    version("3.5.0", sha256="81f0b35a7abedeb2233c66cd801d07130593c272efbbe789634f6a680946a6f0", expand=False)
+    version("3.4.0", sha256="dcd076725ea009ff4b4db65f173ffa9fadb07e736601a4773f1c6b6fcf5f4b0e", expand=False)
+    version("3.3.0", sha256="9b247b3095cb3c43933a59a7433f92ddfdd7fc843e08ef0f4550d53a9cfbbef6", expand=False)
+    version("3.2.0", sha256="6f25843e908dfc3e907b6b9ee71e3d185bcb5aebab8c3431e4e34c261e5ff1b5", expand=False)
+    version("3.1.0", sha256="1d06e64a6af7e1fd1496563b160df29dd32714e00b473f3b763f6e6810476517", expand=False)
+    version("3.0.0", sha256="a787754978cfe3c192a5fc6baf2179ae85b05395804de7d7fe2864d9431e8d03", expand=False)
+    version("2.3.0", sha256="a8f8904b534966712390e0a2e434cd33f76037730a0aaed299a286f9e18cac2b", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")
+
+    # flit_core/build_thyself.py
+    depends_on("py-tomli", when="@3.4:3.5", type=("build", "run"))
+    depends_on("py-toml", when="@3.1:3.3", type=("build", "run"))
+    depends_on("py-pytoml", when="@:3.0", type=("build", "run"))
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/{0}/f/flit-core/flit_core-{1}-{0}-none-any.whl"
+        if version >= Version("3"):
+            language = "py3"
+        else:
+            language = "py2.py3"
+        return url.format(language, version)
 
     def install(self, spec, prefix):
         installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -16,6 +16,13 @@ class PyImportlibMetadata(Package, PythonExtension):
     git = "https://github.com/python/importlib_metadata"
 
     version("6.0.0", sha256="7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad", expand=False)
+    version("4.12.0", sha256="7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23", expand=False)
+    version("4.11.1", sha256="e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094", expand=False)
+    version("4.8.2", sha256="53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100", expand=False)
+    version("4.8.1", sha256="b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15", expand=False)
+    version("4.6.1", sha256="9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e", expand=False)
+    version("3.10.1", sha256="2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6", expand=False)
+    version("3.10.0", sha256="d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -6,34 +6,22 @@
 from spack.package import *
 
 
-class PyImportlibMetadata(PythonPackage):
+class PyImportlibMetadata(Package, PythonExtension):
     """Read metadata from Python packages."""
 
-    homepage = "https://importlib-metadata.readthedocs.io/"
-    pypi = "importlib_metadata/importlib_metadata-1.2.0.tar.gz"
+    homepage = "https://github.com/python/importlib_metadata"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/i/importlib-metadata/importlib_metadata-6.0.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/importlib-metadata/"
     git = "https://github.com/python/importlib_metadata"
 
-    version("4.12.0", sha256="637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670")
-    version("4.11.1", sha256="175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c")
-    version("4.8.2", sha256="75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb")
-    version("4.8.1", sha256="f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1")
-    version("4.6.1", sha256="079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac")
-    version("3.10.1", sha256="c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1")
-    version("3.10.0", sha256="c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a")
-    version("2.0.0", sha256="77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da")
-    version("1.7.0", sha256="90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83")
-    version("1.2.0", sha256="41e688146d000891f32b1669e8573c57e39e5060e7f5f647aa617cd9a9568278")
-    version("0.23", sha256="aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26")
-    version("0.19", sha256="23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8")
-    version("0.18", sha256="cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db")
+    version("6.0.0", sha256="7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad", expand=False)
 
-    depends_on("python@3.7:", when="@4.9:", type=("build", "run"))
-    depends_on("python@3.6:", when="@3:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
-    depends_on("py-setuptools@56:", when="@4.6.4:", type="build")
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm@3.4.1:+toml", when="@3:", type="build")
-    depends_on("py-setuptools-scm", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
 
     depends_on("py-zipp@0.5:", type=("build", "run"))
-    depends_on("py-typing-extensions@3.6.4:", when="@3: ^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions@3.6.4:", when="^python@:3.7", type=("build", "run"))
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -23,12 +23,26 @@ class PyImportlibMetadata(Package, PythonExtension):
     version("4.6.1", sha256="9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e", expand=False)
     version("3.10.1", sha256="2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6", expand=False)
     version("3.10.0", sha256="d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe", expand=False)
+    version("2.0.0", sha256="cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3", expand=False)
+    version("1.7.0", sha256="dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070", expand=False)
+    version("1.2.0", sha256="3a8b2dfd0a2c6a3636e7c016a7e54ae04b997d30e69d5eacdca7a6c2221a1402", expand=False)
+    version("0.23", sha256="d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af", expand=False)
+    version("0.19", sha256="80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3", expand=False)
+    version("0.18", sha256="6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")
 
     depends_on("py-zipp@0.5:", type=("build", "run"))
-    depends_on("py-typing-extensions@3.6.4:", when="^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions@3.6.4:", when="@3: ^python@:3.7", type=("build", "run"))
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/{0}/i/importlib-metadata/importlib_metadata-{1}-{0}-none-any.whl"
+        if version >= Version("3"):
+            language = "py3"
+        else:
+            language = "py2.py3"
+        return url.format(language, version)
 
     def install(self, spec, prefix):
         installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -15,20 +15,76 @@ class PyImportlibMetadata(Package, PythonExtension):
     list_url = "https://pypi.org/simple/importlib-metadata/"
     git = "https://github.com/python/importlib_metadata"
 
-    version("6.0.0", sha256="7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad", expand=False)
-    version("4.12.0", sha256="7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23", expand=False)
-    version("4.11.1", sha256="e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094", expand=False)
-    version("4.8.2", sha256="53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100", expand=False)
-    version("4.8.1", sha256="b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15", expand=False)
-    version("4.6.1", sha256="9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e", expand=False)
-    version("3.10.1", sha256="2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6", expand=False)
-    version("3.10.0", sha256="d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe", expand=False)
-    version("2.0.0", sha256="cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3", expand=False)
-    version("1.7.0", sha256="dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070", expand=False)
-    version("1.2.0", sha256="3a8b2dfd0a2c6a3636e7c016a7e54ae04b997d30e69d5eacdca7a6c2221a1402", expand=False)
-    version("0.23", sha256="d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af", expand=False)
-    version("0.19", sha256="80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3", expand=False)
-    version("0.18", sha256="6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7", expand=False)
+    version(
+        "6.0.0",
+        sha256="7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+        expand=False,
+    )
+    version(
+        "4.12.0",
+        sha256="7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
+        expand=False,
+    )
+    version(
+        "4.11.1",
+        sha256="e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094",
+        expand=False,
+    )
+    version(
+        "4.8.2",
+        sha256="53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100",
+        expand=False,
+    )
+    version(
+        "4.8.1",
+        sha256="b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+        expand=False,
+    )
+    version(
+        "4.6.1",
+        sha256="9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e",
+        expand=False,
+    )
+    version(
+        "3.10.1",
+        sha256="2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6",
+        expand=False,
+    )
+    version(
+        "3.10.0",
+        sha256="d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe",
+        expand=False,
+    )
+    version(
+        "2.0.0",
+        sha256="cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3",
+        expand=False,
+    )
+    version(
+        "1.7.0",
+        sha256="dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070",
+        expand=False,
+    )
+    version(
+        "1.2.0",
+        sha256="3a8b2dfd0a2c6a3636e7c016a7e54ae04b997d30e69d5eacdca7a6c2221a1402",
+        expand=False,
+    )
+    version(
+        "0.23",
+        sha256="d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af",
+        expand=False,
+    )
+    version(
+        "0.19",
+        sha256="80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3",
+        expand=False,
+    )
+    version(
+        "0.18",
+        sha256="6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -12,6 +12,7 @@ class PyInstaller(Package, PythonExtension):
     """A library for installing Python wheels."""
 
     homepage = "https://github.com/pradyunsg/installer"
+    # Must be installed from wheel to avoid circular dependency on build
     url = "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
     list_url = "https://pypi.org/simple/installer/"
 

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -3,16 +3,37 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
-class PyInstaller(PythonPackage):
+class PyInstaller(Package, PythonExtension):
     """A library for installing Python wheels."""
 
     homepage = "https://github.com/pradyunsg/installer"
-    pypi = "installer/installer-0.4.0.tar.gz"
+    url = "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/installer/"
 
-    version("0.4.0", sha256="17d7ca174039fbd85f268e16042e3132ebb03d91e1bbe0f63b9ec6b40619414a")
+    version("0.6.0", sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038", expand=False)
 
-    depends_on("python@2.7,3.5:", type=("build", "run"))
-    depends_on("py-flit-core@2", type="build")
+    extends("python")
+
+    def install(self, spec, prefix):
+        # To build and install installer from source, you need flit-core, build, and installer
+        # already installed. We get around this by using a pre-built wheel to install itself.
+        # See https://github.com/pypa/installer/issues/150 for details.
+
+        # We can't do this in setup_build_environment because self.stage.archive_file is undefined
+        wheel = self.stage.archive_file
+        path = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = os.pathsep.join([wheel, path])
+
+        args = ["-m", "installer", "--prefix", prefix, wheel]
+        python(*args)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        installer = dependent_spec["python"].command
+        installer.add_default_arg("-m")
+        installer.add_default_arg("installer")
+        setattr(module, "installer", installer)

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -13,10 +13,16 @@ class PyInstaller(Package, PythonExtension):
 
     homepage = "https://github.com/pradyunsg/installer"
     # Must be installed from wheel to avoid circular dependency on build
-    url = "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    url = (
+        "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    )
     list_url = "https://pypi.org/simple/installer/"
 
-    version("0.6.0", sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038", expand=False)
+    version(
+        "0.6.0",
+        sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038",
+        expand=False,
+    )
 
     extends("python")
 

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -15,9 +15,31 @@ class PyPackaging(Package, PythonExtension):
     list_url = "https://pypi.org/simple/packaging/"
 
     version("23.0", sha256="714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2", expand=False)
+    version("21.3", sha256="ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522", expand=False)
+    version("21.0", sha256="c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14", expand=False)
+    version("20.9", sha256="67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a", expand=False)
+    version("19.2", sha256="d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108", expand=False)
+    version("19.1", sha256="a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9", expand=False)
+    version("19.0", sha256="9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3", expand=False)
+    version("17.1", sha256="e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0", expand=False)
+    version("16.8", sha256="99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")
+
+    depends_on("py-pyparsing@2.0.2:3.0.4,3.0.6:", when="@21.3:21", type=("build", "run"))
+    depends_on("py-pyparsing@2.0.2:2", when="@21.1:21.2", type=("build", "run"))
+    depends_on("py-pyparsing@2.0.2:", when="@:21.0", type=("build", "run"))
+    depends_on("py-six", when="@:20.7", type=("build", "run"))
+    depends_on("py-attrs", when="@19.1", type=("build", "run"))
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/{0}/p/packaging/packaging-{1}-{0}-none-any.whl"
+        if version >= Version("21"):
+            language = "py3"
+        else:
+            language = "py2.py3"
+        return url.format(language, version)
 
     def install(self, spec, prefix):
         installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -6,32 +6,18 @@
 from spack.package import *
 
 
-class PyPackaging(PythonPackage):
+class PyPackaging(Package, PythonExtension):
     """Core utilities for Python packages."""
 
     homepage = "https://github.com/pypa/packaging"
-    pypi = "packaging/packaging-19.2.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/p/packaging/packaging-23.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/packaging/"
 
-    version("23.0", sha256="b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97")
-    version("21.3", sha256="dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb")
-    version("21.0", sha256="7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7")
-    version("20.9", sha256="5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5")
-    version("19.2", sha256="28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47")
-    version("19.1", sha256="c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe")
-    version("19.0", sha256="0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af")
-    version("17.1", sha256="f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b")
-    version("16.8", sha256="5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e")
+    version("23.0", sha256="714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2", expand=False)
 
-    depends_on("py-flit-core@3.3:", when="@22:", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
 
-    # Needed to bootstrap Spack correctly on Python 3.6 (rhel8 platform-python)
-    depends_on("python@3.7:", when="@22:", type=("build", "run"))
-
-    # Historical dependencies
-    depends_on("py-setuptools@40.8.0:", when="@20.8:21", type="build")
-    depends_on("py-setuptools", when="@:20.7", type="build")
-    depends_on("py-pyparsing@2.0.2:3.0.4,3.0.6:", when="@21.3:21", type=("build", "run"))
-    depends_on("py-pyparsing@2.0.2:2", when="@21.1:21.2", type=("build", "run"))
-    depends_on("py-pyparsing@2.0.2:", when="@:21.0", type=("build", "run"))
-    depends_on("py-six", when="@:20.7", type=("build", "run"))
-    depends_on("py-attrs", when="@19.1", type=("build", "run"))
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -14,15 +14,51 @@ class PyPackaging(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/p/packaging/packaging-23.0-py3-none-any.whl"
     list_url = "https://pypi.org/simple/packaging/"
 
-    version("23.0", sha256="714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2", expand=False)
-    version("21.3", sha256="ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522", expand=False)
-    version("21.0", sha256="c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14", expand=False)
-    version("20.9", sha256="67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a", expand=False)
-    version("19.2", sha256="d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108", expand=False)
-    version("19.1", sha256="a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9", expand=False)
-    version("19.0", sha256="9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3", expand=False)
-    version("17.1", sha256="e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0", expand=False)
-    version("16.8", sha256="99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388", expand=False)
+    version(
+        "23.0",
+        sha256="714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+        expand=False,
+    )
+    version(
+        "21.3",
+        sha256="ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522",
+        expand=False,
+    )
+    version(
+        "21.0",
+        sha256="c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14",
+        expand=False,
+    )
+    version(
+        "20.9",
+        sha256="67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a",
+        expand=False,
+    )
+    version(
+        "19.2",
+        sha256="d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108",
+        expand=False,
+    )
+    version(
+        "19.1",
+        sha256="a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
+        expand=False,
+    )
+    version(
+        "19.0",
+        sha256="9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3",
+        expand=False,
+    )
+    version(
+        "17.1",
+        sha256="e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
+        expand=False,
+    )
+    version(
+        "16.8",
+        sha256="99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -6,26 +6,33 @@
 from spack.package import *
 
 
-class PyPyparsing(PythonPackage):
-    """A Python Parsing Module."""
+class PyPyparsing(Package, PythonExtension):
+    """Python parsing module."""
 
     homepage = "https://pyparsing-docs.readthedocs.io/en/latest/"
-    pypi = "pyparsing/pyparsing-2.4.2.tar.gz"
-
-    version("3.0.9", sha256="2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb")
-    version("3.0.6", sha256="d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81")
-    version("2.4.7", sha256="c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1")
-    version("2.4.2", sha256="6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80")
-    version("2.4.0", sha256="1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a")
-    version("2.3.1", sha256="66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a")
-    version("2.2.0", sha256="0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04")
-    version("2.1.10", sha256="811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188")
-    version("2.0.3", sha256="06e729e1cbf5274703b1f47b6135ed8335999d547f9d8cf048b210fb8ebf844f")
-
-    depends_on("python@3.6.8:", when="@3.0.9:", type=("build", "run"))
-    depends_on("python@3.6:", when="@3:", type=("build", "run"))
-    depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
-    depends_on("py-setuptools", when="@:3.0.8", type="build")
-    depends_on("py-flit-core@3.2:3", when="@3.0.9:", type="build")
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/p/pyparsing/pyparsing-3.0.9-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/pyparsing/"
 
     import_modules = ["pyparsing"]
+
+    version("3.0.9", sha256="5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc", expand=False)
+    version("3.0.6", sha256="04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4", expand=False)
+    version("2.4.7", sha256="ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b", expand=False)
+    version("2.4.2", sha256="d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4", expand=False)
+    version("2.4.0", sha256="9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03", expand=False)
+    version("2.3.1", sha256="f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3", expand=False)
+
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/{0}/p/pyparsing/pyparsing-{1}-{0}-none-any.whl"
+        if version >= Version("3"):
+            language = "py3"
+        else:
+            language = "py2.py3"
+        return url.format(language, version)
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -11,17 +11,43 @@ class PyPyparsing(Package, PythonExtension):
 
     homepage = "https://pyparsing-docs.readthedocs.io/en/latest/"
     # Must be installed from wheel to avoid circular dependency on build
-    url = "https://files.pythonhosted.org/packages/py3/p/pyparsing/pyparsing-3.0.9-py3-none-any.whl"
+    url = (
+        "https://files.pythonhosted.org/packages/py3/p/pyparsing/pyparsing-3.0.9-py3-none-any.whl"
+    )
     list_url = "https://pypi.org/simple/pyparsing/"
 
     import_modules = ["pyparsing"]
 
-    version("3.0.9", sha256="5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc", expand=False)
-    version("3.0.6", sha256="04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4", expand=False)
-    version("2.4.7", sha256="ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b", expand=False)
-    version("2.4.2", sha256="d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4", expand=False)
-    version("2.4.0", sha256="9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03", expand=False)
-    version("2.3.1", sha256="f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3", expand=False)
+    version(
+        "3.0.9",
+        sha256="5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
+        expand=False,
+    )
+    version(
+        "3.0.6",
+        sha256="04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+        expand=False,
+    )
+    version(
+        "2.4.7",
+        sha256="ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b",
+        expand=False,
+    )
+    version(
+        "2.4.2",
+        sha256="d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4",
+        expand=False,
+    )
+    version(
+        "2.4.0",
+        sha256="9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03",
+        expand=False,
+    )
+    version(
+        "2.3.1",
+        sha256="f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-pyproject-hooks/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproject-hooks/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyprojectHooks(Package, PythonExtension):
+    """Wrappers to call pyproject.toml-based build backend hooks."""
+
+    homepage = "https://github.com/pypa/pyproject-hooks"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/p/pyproject_hooks/pyproject_hooks-1.0.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/pyproject_hooks/"
+
+    version("1.0.0", sha256="283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8", expand=False)
+
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-pyproject-hooks/package.py
+++ b/var/spack/repos/builtin/packages/py-pyproject-hooks/package.py
@@ -14,7 +14,11 @@ class PyPyprojectHooks(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/p/pyproject_hooks/pyproject_hooks-1.0.0-py3-none-any.whl"
     list_url = "https://pypi.org/simple/pyproject_hooks/"
 
-    version("1.0.0", sha256="283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8", expand=False)
+    version(
+        "1.0.0",
+        sha256="283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-pytoml/package.py
+++ b/var/spack/repos/builtin/packages/py-pytoml/package.py
@@ -12,6 +12,7 @@ class PyPytoml(Package, PythonExtension):
     Deprecated: use py-toml instead."""
 
     homepage = "https://github.com/avakar/pytoml"
+    # Must be installed from wheel to avoid circular dependency on build
     url = "https://files.pythonhosted.org/packages/py2.py3/p/pytoml/pytoml-0.1.21-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/pytoml/"
 

--- a/var/spack/repos/builtin/packages/py-pytoml/package.py
+++ b/var/spack/repos/builtin/packages/py-pytoml/package.py
@@ -6,14 +6,19 @@
 from spack.package import *
 
 
-class PyPytoml(PythonPackage):
+class PyPytoml(Package, PythonExtension):
     """A parser for TOML-0.4.0.
 
     Deprecated: use py-toml instead."""
 
     homepage = "https://github.com/avakar/pytoml"
-    pypi = "pytoml/pytoml-0.1.21.tar.gz"
+    url = "https://files.pythonhosted.org/packages/py2.py3/p/pytoml/pytoml-0.1.21-py2.py3-none-any.whl"
+    list_url = "https://pypi.org/simple/pytoml/"
 
-    version("0.1.21", sha256="8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7")
+    version("0.1.21", sha256="57a21e6347049f73bfb62011ff34cd72774c031b9828cb628a752225136dfc33", expand=False)
 
-    depends_on("py-setuptools", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-pytoml/package.py
+++ b/var/spack/repos/builtin/packages/py-pytoml/package.py
@@ -16,7 +16,11 @@ class PyPytoml(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py2.py3/p/pytoml/pytoml-0.1.21-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/pytoml/"
 
-    version("0.1.21", sha256="57a21e6347049f73bfb62011ff34cd72774c031b9828cb628a752225136dfc33", expand=False)
+    version(
+        "0.1.21",
+        sha256="57a21e6347049f73bfb62011ff34cd72774c031b9828cb628a752225136dfc33",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -14,14 +14,46 @@ class PySix(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py2.py3/s/six/six-1.16.0-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/six/"
 
-    version("1.16.0", sha256="8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", expand=False)
-    version("1.15.0", sha256="8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced", expand=False)
-    version("1.14.0", sha256="8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c", expand=False)
-    version("1.12.0", sha256="3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", expand=False)
-    version("1.11.0", sha256="832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb", expand=False)
-    version("1.10.0", sha256="0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1", expand=False)
-    version("1.9.0", sha256="418a93c397a7edab23e5588dbc067ac74a723edb3d541bd4936f79476e7645da", expand=False)
-    version("1.8.0", sha256="facfe0c7cceafd49e8f7e472111294566605fdfddc23011da06cc3a4601c9f7d", expand=False)
+    version(
+        "1.16.0",
+        sha256="8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        expand=False,
+    )
+    version(
+        "1.15.0",
+        sha256="8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced",
+        expand=False,
+    )
+    version(
+        "1.14.0",
+        sha256="8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c",
+        expand=False,
+    )
+    version(
+        "1.12.0",
+        sha256="3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+        expand=False,
+    )
+    version(
+        "1.11.0",
+        sha256="832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+        expand=False,
+    )
+    version(
+        "1.10.0",
+        sha256="0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
+        expand=False,
+    )
+    version(
+        "1.9.0",
+        sha256="418a93c397a7edab23e5588dbc067ac74a723edb3d541bd4936f79476e7645da",
+        expand=False,
+    )
+    version(
+        "1.8.0",
+        sha256="facfe0c7cceafd49e8f7e472111294566605fdfddc23011da06cc3a4601c9f7d",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -6,20 +6,25 @@
 from spack.package import *
 
 
-class PySix(PythonPackage):
+class PySix(Package, PythonExtension):
     """Python 2 and 3 compatibility utilities."""
 
-    pypi = "six/six-1.11.0.tar.gz"
+    homepage = "https://github.com/benjaminp/six"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py2.py3/s/six/six-1.16.0-py2.py3-none-any.whl"
+    list_url = "https://pypi.org/simple/six/"
 
-    version("1.16.0", sha256="1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926")
-    version("1.15.0", sha256="30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259")
-    version("1.14.0", sha256="236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a")
-    version("1.12.0", sha256="d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73")
-    version("1.11.0", sha256="70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9")
-    version("1.10.0", sha256="105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a")
-    version("1.9.0", sha256="e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5")
-    version("1.8.0", sha256="047bbbba41bac37c444c75ddfdf0573dd6e2f1fbd824e6247bb26fa7d8fa3830")
+    version("1.16.0", sha256="8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", expand=False)
+    version("1.15.0", sha256="8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced", expand=False)
+    version("1.14.0", sha256="8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c", expand=False)
+    version("1.12.0", sha256="3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", expand=False)
+    version("1.11.0", sha256="832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb", expand=False)
+    version("1.10.0", sha256="0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1", expand=False)
+    version("1.9.0", sha256="418a93c397a7edab23e5588dbc067ac74a723edb3d541bd4936f79476e7645da", expand=False)
+    version("1.8.0", sha256="facfe0c7cceafd49e8f7e472111294566605fdfddc23011da06cc3a4601c9f7d", expand=False)
 
-    extends("python", ignore=r"bin/pytest")
-    depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-toml/package.py
+++ b/var/spack/repos/builtin/packages/py-toml/package.py
@@ -6,17 +6,18 @@
 from spack.package import *
 
 
-class PyToml(PythonPackage):
-    """A Python library for parsing and creating TOML configuration files.
-    For more information on the TOML standard, see
-    https://github.com/toml-lang/toml.git"""
+class PyToml(Package, PythonExtension):
+    """Python Library for Tom's Obvious, Minimal Language."""
 
     homepage = "https://github.com/uiri/toml.git"
-    url = "https://github.com/uiri/toml/archive/0.10.2.tar.gz"
+    url = "https://files.pythonhosted.org/packages/py2.py3/t/toml/toml-0.10.2-py2.py3-none-any.whl"
+    list_url = "https://pypi.org/simple/toml/"
 
-    version("0.10.2", sha256="71d4039bbdec91e3e7591ec5d6c943c58f9a2d17e5f6783acdc378f743fcdd2a")
-    version("0.10.0", sha256="c3821b94be15da61d631bfff45b5c58074f01149792182e68f8690829cabfcf6")
-    version("0.9.3", sha256="633a90ecb1f5665b58f0c94153fcf519313ef53e1de0eac90929cd6b6a014235")
+    version("0.10.2", sha256="806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", expand=False)
+    version("0.10.0", sha256="235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", expand=False)
 
-    depends_on("py-setuptools", type="build")
-    depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-toml/package.py
+++ b/var/spack/repos/builtin/packages/py-toml/package.py
@@ -10,6 +10,7 @@ class PyToml(Package, PythonExtension):
     """Python Library for Tom's Obvious, Minimal Language."""
 
     homepage = "https://github.com/uiri/toml.git"
+    # Must be installed from wheel to avoid circular dependency on build
     url = "https://files.pythonhosted.org/packages/py2.py3/t/toml/toml-0.10.2-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/toml/"
 

--- a/var/spack/repos/builtin/packages/py-toml/package.py
+++ b/var/spack/repos/builtin/packages/py-toml/package.py
@@ -14,8 +14,16 @@ class PyToml(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py2.py3/t/toml/toml-0.10.2-py2.py3-none-any.whl"
     list_url = "https://pypi.org/simple/toml/"
 
-    version("0.10.2", sha256="806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", expand=False)
-    version("0.10.0", sha256="235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", expand=False)
+    version(
+        "0.10.2",
+        sha256="806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+        expand=False,
+    )
+    version(
+        "0.10.0",
+        sha256="235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-tomli/package.py
+++ b/var/spack/repos/builtin/packages/py-tomli/package.py
@@ -6,24 +6,21 @@
 from spack.package import *
 
 
-class PyTomli(PythonPackage):
-    """Tomli is a Python library for parsing TOML.
-
-    Tomli is fully compatible with TOML v1.0.0."""
+class PyTomli(Package, PythonExtension):
+    """Tomli is a Python library for parsing TOML. Tomli is fully compatible with TOML v1.0.0."""
 
     homepage = "https://github.com/hukkin/tomli"
-    pypi = "tomli/tomli-2.0.1.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/t/tomli/tomli-2.0.1-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/tomli/"
     git = "https://github.com/hukkin/tomli.git"
 
     maintainers("charmoniumq")
 
-    version("2.0.1", sha256="de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f")
-    version("1.2.2", sha256="c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee")
-    version("1.2.1", sha256="a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442")
+    version("2.0.1", sha256="939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", expand=False)
 
-    # https://github.com/hukkin/tomli/blob/2.0.1/pyproject.toml#L2
-    depends_on("py-flit-core@3.2:3", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
 
-    # https://github.com/hukkin/tomli/blob/2.0.1/pyproject.toml#L13
-    depends_on("python@3.6:", type=("build", "run"))
-    depends_on("python@3.7:", type=("build", "run"), when="@2.0.1:")
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-tomli/package.py
+++ b/var/spack/repos/builtin/packages/py-tomli/package.py
@@ -17,7 +17,11 @@ class PyTomli(Package, PythonExtension):
 
     maintainers("charmoniumq")
 
-    version("2.0.1", sha256="939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", expand=False)
+    version(
+        "2.0.1",
+        sha256="939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -6,30 +6,18 @@
 from spack.package import *
 
 
-class PyTypingExtensions(PythonPackage):
-    """The typing_extensions module contains both backports of these
-    changes as well as experimental types that will eventually be
-    added to the typing module, such as Protocol (see PEP 544 for
-    details about protocols and static duck typing)."""
+class PyTypingExtensions(Package, PythonExtension):
+    """Backported and Experimental Type Hints for Python 3.7+."""
 
-    homepage = "https://github.com/python/typing/tree/master/typing_extensions"
-    pypi = "typing_extensions/typing_extensions-3.7.4.tar.gz"
+    homepage = "https://github.com/python/typing_extensions"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/t/typing-extensions/typing_extensions-4.4.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/typing-extensions/"
 
-    version("4.3.0", sha256="e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6")
-    version("4.2.0", sha256="f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376")
-    version("4.1.1", sha256="1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42")
-    version("3.10.0.2", sha256="49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e")
-    version("3.10.0.0", sha256="50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342")
-    version("3.7.4.3", sha256="99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c")
-    version("3.7.4", sha256="2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95")
-    version("3.7.2", sha256="fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71")
-    version("3.6.6", sha256="51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f")
+    version("4.4.0", sha256="16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e", expand=False)
 
-    # typing-extensions 4+ uses flit
-    depends_on("python@3.7:", when="@4.2:", type=("build", "run"))
-    depends_on("python@3.6:", when="@4:", type=("build", "run"))
-    depends_on("py-flit-core@3.4:3", when="@4:", type="build")
+    extends("python")
+    depends_on("py-installer", type="build")
 
-    # typing-extensions 3 uses setuptools
-    depends_on("python@2.7:2.8,3.4:", when="@:3", type=("build", "run"))
-    depends_on("py-setuptools", when="@:3", type="build")
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -15,6 +15,14 @@ class PyTypingExtensions(Package, PythonExtension):
     list_url = "https://pypi.org/simple/typing-extensions/"
 
     version("4.4.0", sha256="16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e", expand=False)
+    version("4.3.0", sha256="25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02", expand=False)
+    version("4.2.0", sha256="6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708", expand=False)
+    version("4.1.1", sha256="21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2", expand=False)
+    version("3.10.0.2", sha256="f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34", expand=False)
+    version("3.10.0.0", sha256="779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84", expand=False)
+    version("3.7.4", sha256="d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed", expand=False)
+    version("3.7.2", sha256="f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c", expand=False)
+    version("3.6.6", sha256="55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d", expand=False)
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -20,6 +20,7 @@ class PyTypingExtensions(Package, PythonExtension):
     version("4.1.1", sha256="21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2", expand=False)
     version("3.10.0.2", sha256="f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34", expand=False)
     version("3.10.0.0", sha256="779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84", expand=False)
+    version("3.7.4.3", sha256="7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918", expand=False)
     version("3.7.4", sha256="d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed", expand=False)
     version("3.7.2", sha256="f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c", expand=False)
     version("3.6.6", sha256="55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d", expand=False)

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -14,16 +14,56 @@ class PyTypingExtensions(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/t/typing-extensions/typing_extensions-4.4.0-py3-none-any.whl"
     list_url = "https://pypi.org/simple/typing-extensions/"
 
-    version("4.4.0", sha256="16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e", expand=False)
-    version("4.3.0", sha256="25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02", expand=False)
-    version("4.2.0", sha256="6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708", expand=False)
-    version("4.1.1", sha256="21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2", expand=False)
-    version("3.10.0.2", sha256="f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34", expand=False)
-    version("3.10.0.0", sha256="779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84", expand=False)
-    version("3.7.4.3", sha256="7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918", expand=False)
-    version("3.7.4", sha256="d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed", expand=False)
-    version("3.7.2", sha256="f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c", expand=False)
-    version("3.6.6", sha256="55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d", expand=False)
+    version(
+        "4.4.0",
+        sha256="16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
+        expand=False,
+    )
+    version(
+        "4.3.0",
+        sha256="25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+        expand=False,
+    )
+    version(
+        "4.2.0",
+        sha256="6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708",
+        expand=False,
+    )
+    version(
+        "4.1.1",
+        sha256="21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2",
+        expand=False,
+    )
+    version(
+        "3.10.0.2",
+        sha256="f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34",
+        expand=False,
+    )
+    version(
+        "3.10.0.0",
+        sha256="779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84",
+        expand=False,
+    )
+    version(
+        "3.7.4.3",
+        sha256="7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+        expand=False,
+    )
+    version(
+        "3.7.4",
+        sha256="d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed",
+        expand=False,
+    )
+    version(
+        "3.7.2",
+        sha256="f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c",
+        expand=False,
+    )
+    version(
+        "3.6.6",
+        sha256="55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")

--- a/var/spack/repos/builtin/packages/py-zipp/package.py
+++ b/var/spack/repos/builtin/packages/py-zipp/package.py
@@ -6,22 +6,18 @@
 from spack.package import *
 
 
-class PyZipp(PythonPackage):
+class PyZipp(Package, PythonExtension):
     """Backport of pathlib-compatible object wrapper for zip files."""
 
     homepage = "https://github.com/jaraco/zipp"
-    pypi = "zipp/zipp-0.6.0.tar.gz"
+    # Must be installed from wheel to avoid circular dependency on build
+    url = "https://files.pythonhosted.org/packages/py3/z/zipp/zipp-3.12.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/zipp/"
 
-    version("3.8.1", sha256="05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2")
-    version("3.6.0", sha256="71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832")
-    version("0.6.0", sha256="3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e")
-    version("0.5.1", sha256="ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3")
+    version("3.12.0", sha256="9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86", expand=False)
 
-    depends_on("python@2.7:", type=("build", "run"))
-    depends_on("python@3.6:", type=("build", "run"), when="@2.0.0:")
-    depends_on("python@3.7:", type=("build", "run"), when="@3.8.1:")
-    depends_on("py-setuptools@34.4:", type="build", when="@0.3.3:")
-    depends_on("py-setuptools@56:", type="build", when="@3.5.1:")
-    depends_on("py-setuptools-scm@1.15.0:", type="build")
-    depends_on("py-setuptools-scm@3.4.1: +toml", type="build", when="@2.0.1:")
-    depends_on("py-more-itertools", type=("build", "run"), when="@0.6.0:2.1.0")
+    extends("python")
+    depends_on("py-installer", type="build")
+
+    def install(self, spec, prefix):
+        installer("--prefix", prefix, self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/py-zipp/package.py
+++ b/var/spack/repos/builtin/packages/py-zipp/package.py
@@ -14,7 +14,11 @@ class PyZipp(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/z/zipp/zipp-3.12.0-py3-none-any.whl"
     list_url = "https://pypi.org/simple/zipp/"
 
-    version("3.12.0", sha256="9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86", expand=False)
+    version(
+        "3.12.0",
+        sha256="9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86",
+        expand=False,
+    )
 
     extends("python")
     depends_on("py-installer", type="build")


### PR DESCRIPTION
Spack currently uses pip to install all Python libraries. However, pip is an entire package manager, and provides many features we don't need. We would like to move towards using build/installer instead of pip to simplify the installation process. This PR is the first step in that direction. We need to be able to bootstrap build/installer without pip in order to do that.

Unfortunately, build has the worst cyclic dependency problem I've ever seen. In order to build build, build needs to be installed (this isn't that bad), but all of builds dependencies also need to be installed. All of the following packages need to be installed from wheels in order to get a working build:

* installer (build-time only)
* flit-core (build-time only)
  * toml (3.1–3.3 only)
  * pytoml (–3.0 only)
* packaging
  * pyparsing (–21 only)
  * six (–20.7 only)
  * attrs (19.1 only)
* pyproject-hooks
* colorama (Windows only)
* importlib-metadata (Python 3.7 only)
  * zipp
  * typing-extensions (Python 3.7 only)
* tomli (Python 3.7–3.10 only)

It's also worth noting that installer only supports Python 3.7+, which means none of these packages can be built for EOL Python versions. This is relevant because Spack currently supports bootstrapping its style dependencies with Python 3.6. With this PR, that will no longer be supported. Curious how @tgamblin and @alalazo feel about this.

If we really do need to be able to install these with Python 3.6, we would need to add a new `WheelPackage` base class that supports installing with pip (Python 2+) or installer (Python 3.7+). This would also require 2 new builders. I was hoping to try to tackle this in a follow-up PR, but I can turn this into one massive PR if needed.

References:

* https://github.com/pypa/build/issues/470
* https://github.com/pypa/installer/issues/150