### PR TITLE
New package: PyNucleus & dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-gmsh-interop/package.py
+++ b/var/spack/repos/builtin/packages/py-gmsh-interop/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGmshInterop(PythonPackage):
+    """Interoperability between Python and Gmsh"""
+
+    homepage = "https://documen.tician.de/gmsh_interop"
+    pypi = "gmesh_interop/gmesh_interop-2021.1.1.tar.gz"
+    git = "https://github.com/inducer/gmsh_interop.git"
+
+    maintainers("cgcgcg")
+
+    version("2021.1.1", sha256="5456903283327dfa57fd973bb463c5fbc1c98c8f7ad15327441acb75da10b5f1")
+
+    depends_on("python@3.6:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy@1.6:", type=("build", "run"))
+    depends_on("py-pytools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-meshpy/package.py
+++ b/var/spack/repos/builtin/packages/py-meshpy/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMeshpy(PythonPackage):
+    """Simplicial Mesh Generation from Python"""
+
+    homepage = "https://documen.tician.de/meshpy/"
+    pypi = "MeshPy/MeshPy-2022.1.3.tar.gz"
+    git = "https://github.com/inducer/meshpy.git"
+
+    maintainers("cgcgcg")
+
+    version("2022.1.3", sha256="a7158e31ece25fa6c6cebce9fd1e968157d661dc8769fb30ceba69c351478475")
+
+    depends_on("python@3.6:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pybind11", type="build")
+    depends_on("py-pytools@2011.2:", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-gmsh-interop", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-modepy/package.py
+++ b/var/spack/repos/builtin/packages/py-modepy/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyModepy(PythonPackage):
+    """Basis Functions and Node Sets for Interpolation"""
+
+    homepage = "http://documen.tician.de/modepy"
+    pypi = "modepy/modepy-2021.1.tar.gz"
+    git = "https://github.com/inducer/modepy.git"
+
+    maintainers("cgcgcg")
+
+    version("2021.1", sha256="4cddd2d4720128356e0019e8d972d979552eafad059f4acef01e106b22d8d297")
+
+    depends_on("python@3.6:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-pytools@2013.1:", type=("build", "run"))
+    depends_on("py-pytest@2.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pymbolic/package.py
+++ b/var/spack/repos/builtin/packages/py-pymbolic/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPymbolic(PythonPackage):
+    """A simple package to do symbolic math (focus on code gen and DSLs)"""
+
+    homepage = "http://mathema.tician.de/software/pymbolic"
+    pypi = "pymbolic/pymbolic-2022.2.tar.gz"
+    git = "https://github.com/inducer/pymbolic.git"
+
+    maintainers("cgcgcg")
+
+    version("2022.2", sha256="f82776942bb3cb72329fa1f1aa2b68ec09f237db9178c95cfdc92a6aea7cec89")
+
+    depends_on("python@3.8:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pytools@2:", type="run")

--- a/var/spack/repos/builtin/packages/py-pynucleus/package.py
+++ b/var/spack/repos/builtin/packages/py-pynucleus/package.py
@@ -1,0 +1,64 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPynucleus(PythonPackage):
+    """PyNucleus is a finite element code that specifically targets nonlocal operators."""
+
+    homepage = "https://sandialabs.github.io/PyNucleus/index.html"
+    git = "https://github.com/sandialabs/PyNucleus.git"
+
+    maintainers("cgcgcg")
+
+    refs = ["master", "develop"]
+
+    for ref in refs:
+        version(ref, branch=ref)
+
+    depends_on("py-mpi4py@2.0.0:", type=("build", "link", "run"))
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "link", "run"))
+    depends_on("py-scipy", type=("build", "link", "run"))
+    depends_on("metis", type=("build", "link", "run"))
+    depends_on("parmetis", type=("build", "link", "run"))
+    depends_on("suite-sparse", type=("build", "run"))
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-tabulate", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-scikit-sparse", type=("build", "run"))
+    depends_on("py-modepy", type=("build", "run"))
+    depends_on("py-meshpy", type=("build", "run"))
+    depends_on("py-pytools", type=("build", "run"))
+    depends_on("py-psutil", type="run")
+
+    variant("examples", default=True, description="Install examples")
+
+    import_modules = [
+        "PyNucleus",
+        "PyNucleus-packageTools",
+        "PyNucleus-base",
+        "PyNucleus-metisCy",
+        "PyNucleus-fem",
+        "PyNucleus-multilevelSolver",
+        "PyNucleus-nl",
+    ]
+
+    @run_before("install")
+    def install_python(self):
+        prefix = self.prefix
+        for subpackage in ["packageTools", "base", "metisCy", "fem", "multilevelSolver", "nl"]:
+            with working_dir(subpackage):
+                args = std_pip_args + ["--prefix=" + prefix, "."]
+                pip(*args)
+
+    @run_after("install")
+    def install_additional_files(self):
+        spec = self.spec
+        prefix = self.prefix
+        if "+examples" in spec:
+            install_tree("drivers", prefix.drivers)

--- a/var/spack/repos/builtin/packages/py-pytools/package.py
+++ b/var/spack/repos/builtin/packages/py-pytools/package.py
@@ -12,6 +12,7 @@ class PyPytools(PythonPackage):
     homepage = "https://github.com/inducer/pytools"
     pypi = "pytools/pytools-2019.1.1.tar.gz"
 
+    version("2022.1.14", sha256="41017371610bb2a03685597c5285205e6597c7f177383d95c8b871244b12c14e")
     version("2022.1.12", sha256="4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4")
     version("2021.2.9", sha256="db6cf83c9ba0a165d545029e2301621486d1e9ef295684072e5cd75316a13755")
     version("2019.1.1", sha256="ce2d702ae4ef10a70197b00b93141461140d00578f2a862fa946ca1446a300db")
@@ -28,4 +29,5 @@ class PyPytools(PythonPackage):
     depends_on("py-numpy@1.6.0:", when="@2022.1.12: +numpy", type=("build", "run"))
     depends_on("py-typing-extensions@4.0:", when="@2021.2.9: ^python@:3.10", type=("build", "run"))
     depends_on("python@2.6:2.8,3.4:", type=("build", "run"))
-    depends_on("python@3.6:3", when="@2021.2.9:", type=("build", "run"))
+    depends_on("python@3.6:3", when="@2021.2.9:2022.1.12", type=("build", "run"))
+    depends_on("python@3.8:3", when="@2022.1.14:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-scikit-sparse/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-sparse/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyScikitSparse(PythonPackage):
+    """Sparse matrix tools extending scipy.sparse, but with incompatible licenses"""
+
+    homepage = "https://github.com/scikit-sparse/scikit-sparse"
+    pypi = "scikit-sparse/scikit-sparse-0.4.8.tar.gz"
+    git = "https://github.com/scikit-sparse/scikit-sparse.git"
+
+    maintainers("cgcgcg")
+
+    version("0.4.8", sha256="2a224c60da3ef951975242ea777478583d3265efc72db5cfb7861686521a4009")
+
+    depends_on("python@3.6:3.11", type=("build", "link", "run"))
+    depends_on("py-setuptools@40.8:", type="build")
+    depends_on("py-cython@0.22:", type="build")
+    depends_on("py-numpy@1.13.3:", type=("build", "link", "run"))
+    depends_on("py-scipy@0.19:", type="run")
+    depends_on("suite-sparse", type=("build", "link", "run"))
+
+    import_modules = ["sksparse"]


### PR DESCRIPTION
This adds packages:
- py-scikit-sparse
- py-gmesh-interop
- py-modepy
- py-pymbolic
- py-meshpy
- py-pynucleus

I listed myself as the maintainer for all of these, but will reach out to the code owners to see if they would like to be listed in my place.

If preferable, I can split the PR into subsets of packages.