### PR TITLE
Require HiOp 0.7.1 for ExaGO 1.5.0+.

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -112,7 +112,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hiop@0.3.99:", when="@0.99:+hiop")
     depends_on("hiop@0.5.1:", when="@1.1.0:+hiop")
     depends_on("hiop@0.5.3:", when="@1.3.0:+hiop")
-    depends_on("hiop@0.7.0:", when="@1.5.0:+hiop")
+    depends_on("hiop@0.7.0:0.7.1", when="@1.5.0:+hiop")
 
     depends_on("hiop~mpi", when="+hiop~mpi")
     depends_on("hiop+mpi", when="+hiop+mpi")


### PR DESCRIPTION
HiOp's develop branch has breaking API changes with header files which requires a patch to ExaGO.

We will limit compatibility up to 0.7.1 until a new HiOp patch and associated ExaGO patch.