### PR TITLE
Cws/pumi and zoltan no fortran

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -84,7 +84,6 @@ class Pumi(CMakePackage):
             "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,
             "-DCMAKE_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            "-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
             self.define_from_variant("PUMI_FORTRAN_INTERFACE", "fortran"),
             "-DMDS_ID_TYPE=%s" % ("long" if "+int64" in spec else "int"),
             "-DSKIP_SIMMETRIX_VERSION_CHECK=%s"
@@ -92,6 +91,8 @@ class Pumi(CMakePackage):
             self.define_from_variant("IS_TESTING", "testing"),
             "-DMESHES=%s" % join_path(self.stage.source_path, "pumi-meshes"),
         ]
+        if spec.satisfies("fortran"):
+            args += ["-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc]
         if spec.satisfies("@2.2.3"):
             args += ["-DCMAKE_CXX_STANDARD=11"]
         if self.spec.satisfies("simmodsuite=base"):

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -142,7 +142,7 @@ class Zoltan(AutotoolsPackage):
                 ]
             )
             if "+fortran" in spec:
-                config_args.extend( ["FC={0}".format(spec["mpi"].mpifc)] )
+                config_args.extend(["FC={0}".format(spec["mpi"].mpifc)])
 
         config_fcflags = config_cflags[:]
         if spec.satisfies("%gcc@10:+fortran"):

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -132,7 +132,6 @@ class Zoltan(AutotoolsPackage):
                 [
                     "CC={0}".format(spec["mpi"].mpicc),
                     "CXX={0}".format(spec["mpi"].mpicxx),
-                    "FC={0}".format(spec["mpi"].mpifc),
                     "--with-mpi={0}".format(spec["mpi"].prefix),
                     # NOTE: Zoltan assumes that it's linking against an MPI library
                     # that can be found with '-lmpi' which isn't the case for many
@@ -142,6 +141,8 @@ class Zoltan(AutotoolsPackage):
                     "--with-mpi-libs= ",
                 ]
             )
+            if "+fortran" in spec:
+               config_args.extend( ["FC={0}".format(spec["mpi"].mpifc)] )
 
         config_fcflags = config_cflags[:]
         if spec.satisfies("%gcc@10:+fortran"):

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -142,7 +142,7 @@ class Zoltan(AutotoolsPackage):
                 ]
             )
             if "+fortran" in spec:
-               config_args.extend( ["FC={0}".format(spec["mpi"].mpifc)] )
+                config_args.extend( ["FC={0}".format(spec["mpi"].mpifc)] )
 
         config_fcflags = config_cflags[:]
         if spec.satisfies("%gcc@10:+fortran"):


### PR DESCRIPTION
This PR allows pumi and zoltan to build when there is no fortran compiler available.