### PR TITLE
Support packages for using scitokens on OSG

### DIFF
--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -17,7 +17,7 @@ class OsgCaCerts(Package):
     _igtf_base_url = "https://dist.eugridpma.info/distribution/igtf/current/igtf-policy-installation-bundle-{igtf_version}.tar.gz"
     _letsencrypt_base_url = "https://github.com/opensciencegrid/letsencrypt-certificates/archive/v{letsencrypt_version}/letsencrypt-certificates.tar.gz"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     releases = [
         {

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -33,12 +33,15 @@ class OsgCaCerts(Package):
 
         version(
             _version,
-            url=_osg_base_url.format(osg_version = release["osg_version"], igtf_version = release["igtf_version"]),
-            sha256=release["osg_sha256"])
+            url=_osg_base_url.format(
+                osg_version=release["osg_version"], igtf_version=release["igtf_version"]
+            ),
+            sha256=release["osg_sha256"],
+        )
 
         resource(
-            name="igtf-{igtf_version}".format(igtf_version = release["igtf_version"]),
-            url=_igtf_base_url.format(igtf_version = release["igtf_version"]),
+            name="igtf-{igtf_version}".format(igtf_version=release["igtf_version"]),
+            url=_igtf_base_url.format(igtf_version=release["igtf_version"]),
             sha256=release["igtf_sha256"],
             when="@{0}".format(_version),
         )
@@ -63,6 +66,8 @@ class OsgCaCerts(Package):
         env.set("X509_CERT_DIR", join_path(self.prefix, "certificates"))
 
     def install(self, spec, prefix):
-        copy_tree("letsencrypt-certificates-master/letsencrypt-certificates", "letsencrypt-certificates")
+        copy_tree(
+            "letsencrypt-certificates-master/letsencrypt-certificates", "letsencrypt-certificates"
+        )
         Executable(join_path(self.stage.source_path, "build-certificates-dir.sh"))()
         install_tree("certificates", join_path(prefix, "certificates"))

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OsgCaCerts(Package):
+    """OSG Packaging of the IGTF CA Certs and OSG-specific CAs,
+    in the OpenSSL 1.0.* format."""
+
+    homepage = "http://repo.opensciencegrid.org/cadist"
+    url = "https://github.com/opensciencegrid/osg-certificates/archive/v1.109.igtf.1.117/osg-certificates-1.109.igtf.1.117.tar.gz"
+
+    _osg_base_url = "https://github.com/opensciencegrid/osg-certificates/archive/v{osg_version}.igtf.{igtf_version}/osg-certificates-{osg_version}.igtf.{igtf_version}.tar.gz"
+    _igtf_base_url = "https://dist.eugridpma.info/distribution/igtf/current/igtf-policy-installation-bundle-{igtf_version}.tar.gz"
+    _letsencrypt_base_url = "https://github.com/opensciencegrid/letsencrypt-certificates/archive/v{letsencrypt_version}/letsencrypt-certificates.tar.gz"
+
+    maintainers = ["wdconinc"]
+
+    releases = [
+        {
+            "osg_version": "1.109",
+            "igtf_version": "1.117",
+            "osg_sha256": "41e12c05aedb4df729bf326318cc29b9b79eb097564fd68c6af2e1448ec74f75",
+            "igtf_sha256": "130d4d95cd65d01d2db250ee24c539341e3adc899b7eff1beafef1ba4674807d",
+        },
+    ]
+
+    for release in releases:
+        _version = "{0}.igtf.{1}".format(release["osg_version"], release["igtf_version"])
+
+        version(
+            _version,
+            url=_osg_base_url.format(osg_version = release["osg_version"], igtf_version = release["igtf_version"]),
+            sha256=release["osg_sha256"])
+
+        resource(
+            name="igtf-{igtf_version}".format(igtf_version = release["igtf_version"]),
+            url=_igtf_base_url.format(igtf_version = release["igtf_version"]),
+            sha256=release["igtf_sha256"],
+            when="@{0}".format(_version),
+        )
+
+    resource(
+        name="letsencrypt",
+        git="https://github.com/opensciencegrid/letsencrypt-certificates",
+        branch="master",
+        destination="letsencrypt-certificates-master",
+    )
+
+    depends_on("openssl")
+
+    def setup_build_environment(self, env):
+        env.set("OSG_CERTS_VERSION", self.version[:2])
+        env.set("OUR_CERTS_VERSION", str(self.version[:2]) + "NEW")
+        env.set("IGTF_CERTS_VERSION", self.version[3:])
+        env.set("CADIST", join_path(self.stage.source_path, "certificates"))
+        env.set("PKG_NAME", self.spec.name)
+
+    def setup_run_environment(self, env):
+        env.set("X509_CERT_DIR", join_path(self.prefix, "certificates"))
+
+    def install(self, spec, prefix):
+        copy_tree("letsencrypt-certificates-master/letsencrypt-certificates", "letsencrypt-certificates")
+        Executable(join_path(self.stage.source_path, "build-certificates-dir.sh"))()
+        install_tree("certificates", join_path(prefix, "certificates"))

--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -13,7 +13,7 @@ class PyGssapi(PythonPackage):
     homepage = "https://github.com/pythongssapi/python-gssapi"
     pypi = "gssapi/gssapi-1.8.2.tar.gz"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     depends_on("py-cython@0.29.29:2", type="build")
     depends_on("py-setuptools@40.6.0:", type="build")

--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -14,7 +14,7 @@ class PyGssapi(PythonPackage):
     pypi = "gssapi/gssapi-1.8.2.tar.gz"
 
     maintainers = ["wdconinc"]
-    
+
     depends_on("py-cython@0.29.29:2", type="build")
     depends_on("py-setuptools@40.6.0:", type="build")
 

--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -15,9 +15,9 @@ class PyGssapi(PythonPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")
+
     depends_on("py-cython@0.29.29:2", type="build")
     depends_on("py-setuptools@40.6.0:", type="build")
 
     depends_on("py-decorator")
-
-    version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")

--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGssapi(PythonPackage):
+    """Python-GSSAPI provides both low-level and high level wrappers
+    around the GSSAPI C libraries."""
+
+    homepage = "https://github.com/pythongssapi/python-gssapi"
+    pypi = "gssapi/gssapi-1.8.2.tar.gz"
+
+    maintainers = ["wdconinc"]
+    
+    depends_on("py-cython@0.29.29:2", type="build")
+    depends_on("py-setuptools@40.6.0:", type="build")
+
+    depends_on("py-decorator")
+
+    version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")

--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -20,4 +20,4 @@ class PyGssapi(PythonPackage):
     depends_on("py-cython@0.29.29:2", type="build")
     depends_on("py-setuptools@40.6.0:", type="build")
 
-    depends_on("py-decorator")
+    depends_on("py-decorator", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHtgettoken(PythonPackage):
+    """htgettoken gets OIDC authentication tokens for High Throughput Computing
+    via a Hashicorp vault server."""
+
+    homepage = "https://github.com/fermitools/htgettoken"
+
+    # htgettoken is not available on PyPi
+    url = "https://github.com/fermitools/htgettoken/archive/refs/tags/v1.16.tar.gz"
+    list_url = "https://github.com/fermitools/htgettoken/releases/"
+    git = "https://github.com/fermitools/htgettoken.git"
+
+    maintainers = ["wdconinc"]
+
+    version("1.16-33-g3788bb4", commit="3788bb4733e5e8f856cee51566df9a36cbfe097d")
+    version("1.16-20-g8b72f48", commit="8b72f4800ef99923dac99dbe0756a26266a27886")
+    # Older versions do not have a python build system
+    version("1.16", sha256="984fd4746082086356d968b4db536f7b35d30e65a6589fa357caa3266cb98268", deprecated=True)
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-gssapi", type="run")
+    depends_on("py-paramiko", type="run")
+    depends_on("py-urllib3", type="run")
+
+    def setup_run_environment(self, env):
+        if env.get("XDG_RUNTIME_DIR") and env.get("UID"):
+            env.set("BEARER_TOKEN", join_path(env.get("XDG_RUNTIME_DIR"), "bt_u" + env.get("UID")))

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -24,12 +24,7 @@ class PyHtgettoken(PythonPackage):
     # they are special reproducible version numbers from `git describe`
     version("1.16-33-g3788bb4", commit="3788bb4733e5e8f856cee51566df9a36cbfe097d")
     version("1.16-20-g8b72f48", commit="8b72f4800ef99923dac99dbe0756a26266a27886")
-    # Older versions do not have a python build system but included for completeness
-    version(
-        "1.16",
-        sha256="984fd4746082086356d968b4db536f7b35d30e65a6589fa357caa3266cb98268",
-        deprecated=True,
-    )
+    # Older versions do not have a python build system
 
     depends_on("py-setuptools@30.3:", type="build")
 

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -18,9 +18,11 @@ class PyHtgettoken(PythonPackage):
 
     maintainers("wdconinc")
 
+    # The following versions refer to setuptools-buildable commits after 1.16;
+    # they are special reproducible version numbers from `git describe`
     version("1.16-33-g3788bb4", commit="3788bb4733e5e8f856cee51566df9a36cbfe097d")
     version("1.16-20-g8b72f48", commit="8b72f4800ef99923dac99dbe0756a26266a27886")
-    # Older versions do not have a python build system
+    # Older versions do not have a python build system but included for completeness
     version(
         "1.16",
         sha256="984fd4746082086356d968b4db536f7b35d30e65a6589fa357caa3266cb98268",

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -14,7 +14,6 @@ class PyHtgettoken(PythonPackage):
 
     # htgettoken is not available on PyPi
     url = "https://github.com/fermitools/htgettoken/archive/refs/tags/v1.16.tar.gz"
-    list_url = "https://github.com/fermitools/htgettoken/releases/"
     git = "https://github.com/fermitools/htgettoken.git"
 
     maintainers("wdconinc")

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -17,7 +17,7 @@ class PyHtgettoken(PythonPackage):
     list_url = "https://github.com/fermitools/htgettoken/releases/"
     git = "https://github.com/fermitools/htgettoken.git"
 
-    maintainers = ["wdconinc"]
+    maintainers("wdconinc")
 
     version("1.16-33-g3788bb4", commit="3788bb4733e5e8f856cee51566df9a36cbfe097d")
     version("1.16-20-g8b72f48", commit="8b72f4800ef99923dac99dbe0756a26266a27886")

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -29,11 +29,11 @@ class PyHtgettoken(PythonPackage):
         deprecated=True,
     )
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@30.3:", type="build")
 
-    depends_on("py-gssapi", type="run")
-    depends_on("py-paramiko", type="run")
-    depends_on("py-urllib3", type="run")
+    depends_on("py-gssapi", type=("build", "run"))
+    depends_on("py-paramiko", type=("build", "run"))
+    depends_on("py-urllib3", type=("build", "run"))
 
     def setup_run_environment(self, env):
         if env.get("XDG_RUNTIME_DIR") and env.get("UID"):

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -22,7 +22,11 @@ class PyHtgettoken(PythonPackage):
     version("1.16-33-g3788bb4", commit="3788bb4733e5e8f856cee51566df9a36cbfe097d")
     version("1.16-20-g8b72f48", commit="8b72f4800ef99923dac99dbe0756a26266a27886")
     # Older versions do not have a python build system
-    version("1.16", sha256="984fd4746082086356d968b4db536f7b35d30e65a6589fa357caa3266cb98268", deprecated=True)
+    version(
+        "1.16",
+        sha256="984fd4746082086356d968b4db536f7b35d30e65a6589fa357caa3266cb98268",
+        deprecated=True,
+    )
 
     depends_on("py-setuptools", type="build")
 

--- a/var/spack/repos/builtin/packages/py-htgettoken/package.py
+++ b/var/spack/repos/builtin/packages/py-htgettoken/package.py
@@ -36,5 +36,8 @@ class PyHtgettoken(PythonPackage):
     depends_on("py-urllib3", type=("build", "run"))
 
     def setup_run_environment(self, env):
-        if env.get("XDG_RUNTIME_DIR") and env.get("UID"):
-            env.set("BEARER_TOKEN", join_path(env.get("XDG_RUNTIME_DIR"), "bt_u" + env.get("UID")))
+        dir = env.get("XDG_RUNTIME_DIR") or "/tmp"
+        uid = env.get("UID") or os.geteuid()
+        file = join_path(dir, "bt_u" + uid)
+        env.set("BEARER_TOKEN", file)
+        env.set("BEARER_TOKEN_FILE", file)


### PR DESCRIPTION
The Open Science Grid (OSG)  encourages scitokens to provide certain services (e.g. writing to xrootd). Spack already supports this through scitokens-cpp and xrootd +scitokens-cpp.

This adds py-htgettoken, a python utility to get a scitoken from a vault through web authentication. To support htgettoken, this also adds py-gssapi.

This also adds the OSG CA cert collection which is typically at /etc/grid-security but pointed to in user installations by the X509_CERT_DIR variable.

This allows userspace support through spack for functionality that otherwise depends on installing the RPMs provided by OSG.