### PR TITLE
Fix OpenCV detection on Ubuntu

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -822,9 +822,7 @@ class Opencv(CMakePackage, CudaPackage):
 
     @classmethod
     def determine_version(cls, lib):
-        ver = None
         for ext in library_extensions:
-            pattern = None
             if ext == "dylib":
                 # Darwin switches the order of the version compared to Linux
                 pattern = re.compile(r"libopencv_(\S*?)\.(\d+\.\d+\.\d+)\.%s" % ext)
@@ -832,8 +830,8 @@ class Opencv(CMakePackage, CudaPackage):
                 pattern = re.compile(r"libopencv_(\S*?)\.%s\.(\d+\.\d+\.\d+)" % ext)
             match = pattern.search(lib)
             if match:
-                ver = match.group(2)
-        return ver
+                return match.group(2)
+        return None
 
     @classmethod
     def determine_variants(cls, libs, version_str):

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -831,7 +831,6 @@ class Opencv(CMakePackage, CudaPackage):
             match = pattern.search(lib)
             if match:
                 return match.group(2)
-        return None
 
     @classmethod
     def determine_variants(cls, libs, version_str):

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -838,8 +838,8 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_variants(cls, libs, version_str):
         variants = []
-        remaining_modules = set(Opencv.modules + Opencv.contrib_modules)
-        contrib_module_set = set(Opencv.contrib_modules)
+        remaining_modules = set(cls.modules + cls.contrib_modules)
+        contrib_module_set = set(cls.contrib_modules)
         has_contrib = False
         for lib in libs:
             for ext in library_extensions:


### PR DESCRIPTION
Ubuntu installs its opencv libraries into `/usr/lib/x86_64-linux-gnu`, and the regexes over-greedily match everything from `lib`.
Also the detection fails if any of the detected libraries is not in `remaining_modules`, where we are missing `contrib` modules.
To avoid this kind of issue in the future, I guarded against the `KeyError` that would occur otherwise.

Old output:
```
$ spack -d external find opencv
==> [2023-02-04-13:37:01.230542] Imported external from built-in commands
==> [2023-02-04-13:37:01.232189] Imported external from built-in commands
==> [2023-02-04-13:37:01.232690] Reading config from file /home/tobi/spack/etc/spack/defaults/repos.yaml
==> [2023-02-04-13:37:01.327912] Reading config from file /home/tobi/spack/etc/spack/defaults/packages.yaml
==> [2023-02-04-13:37:01.347109] Reading config from file /home/tobi/.spack/packages.yaml
==> [2023-02-04-13:37:28.564620] Warning: error detecting "opencv" from prefix /lib/x86_64-linux-gnu ['64-linux-gnu/libopencv_objdetect']
==> [2023-02-04-13:37:28.564727] The following libraries in /lib/x86_64-linux-gnu were decidedly not part of the package opencv: /lib/x86_64-linux-gnu/libopencv_videoio.a, /lib/x86_64-linux-gnu/libopencv_imgproc.so, /lib/x86_64-linux-gnu/libopencv_photo.so.4.2, /lib/x86_64-linux-gnu/libopencv_objdetect.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_calib3d.so, /lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so.4.2, /lib/x86_64-linux-gnu/libopencv_calib3d.a, /lib/x86_64-linux-gnu/libopencv_flann.so, /lib/x86_64-linux-gnu/libopencv_imgproc.a, /lib/x86_64-linux-gnu/libopencv_flann.a, /lib/x86_64-linux-gnu/libopencv_videoio.so, /lib/x86_64-linux-gnu/libopencv_photo.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_photo.a, /lib/x86_64-linux-gnu/libopencv_highgui.so.4.2, /lib/x86_64-linux-gnu/libopencv_ml.a, /lib/x86_64-linux-gnu/libopencv_objdetect.a, /lib/x86_64-linux-gnu/libopencv_ml.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_calib3d.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_dnn_objdetect.a, /lib/x86_64-linux-gnu/libopencv_ts.a, /lib/x86_64-linux-gnu/libopencv_video.a, /lib/x86_64-linux-gnu/libopencv_stitching.a, /lib/x86_64-linux-gnu/libopencv_calib3d.so.4.2, /lib/x86_64-linux-gnu/libopencv_videostab.a, /lib/x86_64-linux-gnu/libopencv_video.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_highgui.so, /lib/x86_64-linux-gnu/libopencv_photo.so, /lib/x86_64-linux-gnu/libopencv_video.so, /lib/x86_64-linux-gnu/libopencv_dnn.so, /lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so, /lib/x86_64-linux-gnu/libopencv_stitching.so, /lib/x86_64-linux-gnu/libopencv_ml.so.4.2, /lib/x86_64-linux-gnu/libopencv_imgproc.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_dnn_superres.so, /lib/x86_64-linux-gnu/libopencv_stitching.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_dnn_superres.a, /lib/x86_64-linux-gnu/libopencv_dnn.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_dnn_superres.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_imgcodecs.so.4.2, /lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_imgcodecs.so, /lib/x86_64-linux-gnu/libopencv_ml.so, /lib/x86_64-linux-gnu/libopencv_dnn.a, /lib/x86_64-linux-gnu/libopencv_features2d.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_videoio.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_videostab.so, /lib/x86_64-linux-gnu/libopencv_highgui.a, /lib/x86_64-linux-gnu/libopencv_imgcodecs.a, /lib/x86_64-linux-gnu/libopencv_features2d.so.4.2, /lib/x86_64-linux-gnu/libopencv_objdetect.so, /lib/x86_64-linux-gnu/libopencv_flann.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_videoio.so.4.2, /lib/x86_64-linux-gnu/libopencv_flann.so.4.2, /lib/x86_64-linux-gnu/libopencv_imgcodecs.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_features2d.so, /lib/x86_64-linux-gnu/libopencv_video.so.4.2, /lib/x86_64-linux-gnu/libopencv_imgproc.so.4.2, /lib/x86_64-linux-gnu/libopencv_objdetect.so.4.2, /lib/x86_64-linux-gnu/libopencv_dnn.so.4.2, /lib/x86_64-linux-gnu/libopencv_stitching.so.4.2, /lib/x86_64-linux-gnu/libopencv_highgui.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_videostab.so.4.2.0, /lib/x86_64-linux-gnu/libopencv_dnn_superres.so.4.2, /lib/x86_64-linux-gnu/libopencv_videostab.so.4.2, /lib/x86_64-linux-gnu/libopencv_features2d.a
==> [2023-02-04-13:37:28.565560] Warning: error detecting "opencv" from prefix /usr/lib/x86_64-linux-gnu ['64-linux-gnu/libopencv_video']
==> [2023-02-04-13:37:28.565615] The following libraries in /usr/lib/x86_64-linux-gnu were decidedly not part of the package opencv: /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_calib3d.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_videostab.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_dnn.a, /usr/lib/x86_64-linux-gnu/libopencv_videostab.a, /usr/lib/x86_64-linux-gnu/libopencv_stitching.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.so, /usr/lib/x86_64-linux-gnu/libopencv_dnn_superres.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_imgproc.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_stitching.so, /usr/lib/x86_64-linux-gnu/libopencv_dnn_superres.so, /usr/lib/x86_64-linux-gnu/libopencv_photo.a, /usr/lib/x86_64-linux-gnu/libopencv_video.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_ml.a, /usr/lib/x86_64-linux-gnu/libopencv_videoio.so, /usr/lib/x86_64-linux-gnu/libopencv_flann.a, /usr/lib/x86_64-linux-gnu/libopencv_ml.so, /usr/lib/x86_64-linux-gnu/libopencv_dnn.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_videoio.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_highgui.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_flann.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_highgui.so, /usr/lib/x86_64-linux-gnu/libopencv_highgui.a, /usr/lib/x86_64-linux-gnu/libopencv_videoio.a, /usr/lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so, /usr/lib/x86_64-linux-gnu/libopencv_videostab.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_photo.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_stitching.a, /usr/lib/x86_64-linux-gnu/libopencv_highgui.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_features2d.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_calib3d.so, /usr/lib/x86_64-linux-gnu/libopencv_objdetect.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_ml.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_flann.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_objdetect.so, /usr/lib/x86_64-linux-gnu/libopencv_features2d.a, /usr/lib/x86_64-linux-gnu/libopencv_imgproc.a, /usr/lib/x86_64-linux-gnu/libopencv_features2d.so, /usr/lib/x86_64-linux-gnu/libopencv_photo.so, /usr/lib/x86_64-linux-gnu/libopencv_photo.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_objdetect.a, /usr/lib/x86_64-linux-gnu/libopencv_stitching.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_dnn.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_dnn_superres.a, /usr/lib/x86_64-linux-gnu/libopencv_dnn_superres.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_videoio.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_ts.a, /usr/lib/x86_64-linux-gnu/libopencv_video.so, /usr/lib/x86_64-linux-gnu/libopencv_ml.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_videostab.so, /usr/lib/x86_64-linux-gnu/libopencv_imgproc.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_dnn_objdetect.a, /usr/lib/x86_64-linux-gnu/libopencv_calib3d.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_imgproc.so, /usr/lib/x86_64-linux-gnu/libopencv_video.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_dnn.so, /usr/lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_video.a, /usr/lib/x86_64-linux-gnu/libopencv_objdetect.so.4.2.0, /usr/lib/x86_64-linux-gnu/libopencv_dnn_objdetect.so.4.2, /usr/lib/x86_64-linux-gnu/libopencv_calib3d.a, /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.a, /usr/lib/x86_64-linux-gnu/libopencv_flann.so
==> [2023-02-04-13:37:28.568065] No new external packages detected
```
New output:
```
==> [2023-02-04-13:38:08.435904] Imported external from built-in commands
==> [2023-02-04-13:38:08.436891] Imported external from built-in commands
==> [2023-02-04-13:38:08.437175] Reading config from file /home/tobi/spack/etc/spack/defaults/repos.yaml
==> [2023-02-04-13:38:08.535198] Reading config from file /home/tobi/spack/etc/spack/defaults/packages.yaml
==> [2023-02-04-13:38:08.555889] Reading config from file /home/tobi/.spack/packages.yaml
==> [2023-02-04-13:38:36.072644] no lib/ or lib64/ dir found in /lib/x86_64-linux-gnu. Cannot 
==> [2023-02-04-13:38:36.089610] The following specs have been detected on this system and added to /home/tobi/.spack/packages.yaml
opencv@4.2.0
```