### PR TITLE
Don't use CDash upload URL as report filename

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -6,6 +6,7 @@
 
 import argparse
 import os.path
+import textwrap
 
 from llnl.util.lang import stable_partition
 
@@ -413,6 +414,40 @@ the build yourself.  Format: %%Y%%m%%d-%%H%%M-[cdash-track]"""
     cdash_subgroup = subparser.add_mutually_exclusive_group()
     cdash_subgroup.add_argument("--cdash-track", default="Experimental", help=cdash_help["track"])
     cdash_subgroup.add_argument("--cdash-buildstamp", default=None, help=cdash_help["buildstamp"])
+
+
+def print_cdash_help():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+environment variables:
+SPACK_CDASH_AUTH_TOKEN
+                    authentication token to present to CDash
+                    """
+        ),
+    )
+    add_cdash_args(parser, True)
+    parser.print_help()
+
+
+def sanitize_reporter_options(namespace: argparse.Namespace):
+    """Sanitize options that affect generation and configuration of reports, like
+    CDash or JUnit.
+
+    Args:
+        namespace: options parsed from cli
+    """
+    has_any_cdash_option = (
+        namespace.cdash_upload_url or namespace.cdash_build or namespace.cdash_site
+    )
+    if namespace.log_format == "junit" and has_any_cdash_option:
+        raise argparse.ArgumentTypeError("cannot pass any cdash option when --log-format=junit")
+
+    # If any CDash option is passed, assume --log-format=cdash is implied
+    if namespace.log_format is None and has_any_cdash_option:
+        namespace.log_format = "cdash"
+        namespace.reporter = _cdash_reporter(namespace)
 
 
 class ConfigSetAction(argparse.Action):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -260,7 +260,7 @@ def default_log_file(spec):
 
 def report_filename(args: argparse.Namespace, specs: List[spack.spec.Spec]) -> str:
     """Return the filename to be used for reporting to JUnit or CDash format."""
-    result = args.log_file or args.cdash_upload_url or default_log_file(specs[0])
+    result = args.log_file or default_log_file(specs[0])
     return result
 
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -7,7 +7,6 @@ import argparse
 import os
 import shutil
 import sys
-import textwrap
 from typing import List
 
 import llnl.util.filesystem as fs
@@ -348,21 +347,6 @@ def install_specs_outside_environment(specs, install_kwargs):
     builder.install()
 
 
-def print_cdash_help():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=textwrap.dedent(
-            """\
-environment variables:
-SPACK_CDASH_AUTH_TOKEN
-                    authentication token to present to CDash
-                    """
-        ),
-    )
-    arguments.add_cdash_args(parser, True)
-    parser.print_help()
-
-
 def install_all_specs_from_active_environment(
     install_kwargs, only_concrete, cli_test_arg, reporter_factory
 ):
@@ -496,7 +480,7 @@ def install(parser, args):
     tty.set_verbose(args.verbose or args.install_verbose)
 
     if args.help_cdash:
-        print_cdash_help()
+        spack.cmd.common.arguments.print_cdash_help()
         return
 
     if args.no_checksum:
@@ -504,6 +488,8 @@ def install(parser, args):
 
     if args.deprecated:
         spack.config.set("config:deprecated", True, scope="command_line")
+
+    spack.cmd.common.arguments.sanitize_reporter_options(args)
 
     def reporter_factory(specs):
         if args.log_format is None:

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -11,7 +11,6 @@ import os
 import re
 import shutil
 import sys
-import textwrap
 
 from llnl.util import lang, tty
 from llnl.util.tty import colify
@@ -171,19 +170,10 @@ def test_run(args):
 
     # cdash help option
     if args.help_cdash:
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            epilog=textwrap.dedent(
-                """\
-environment variables:
-  SPACK_CDASH_AUTH_TOKEN
-                        authentication token to present to CDash
-                        """
-            ),
-        )
-        arguments.add_cdash_args(parser, True)
-        parser.print_help()
+        arguments.print_cdash_help()
         return
+
+    arguments.sanitize_reporter_options(args)
 
     # set config option for fail-fast
     if args.fail_fast:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1187,3 +1187,16 @@ def test_padded_install_runtests_root(install_mockery_mutable_config, mock_fetch
     spack.config.set("config:install_tree:padded_length", 255)
     output = install("--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False)
     assert output.count("method not implemented") == 1
+
+
+@pytest.mark.regression("35337")
+def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
+    """Test that the temporary file used to write the XML for CDash is not the upload URL"""
+    parser = argparse.ArgumentParser()
+    spack.cmd.install.setup_parser(parser)
+    args = parser.parse_args(
+        ["--cdash-upload-url", "https://blahblah/submit.php?project=debugging", "a"]
+    )
+    _, specs = spack.cmd.install.specs_from_cli(args, {})
+    filename = spack.cmd.install.report_filename(args, specs)
+    assert filename != "https://blahblah/submit.php?project=debugging"


### PR DESCRIPTION
fixes #35337

Modifications:
- [x] Don't use CDash upload URL as report filename
- [x] Sanitize report related command line options
- [x] Assume any CDash option given on command line in absence of the `--log-format` implies `--log-format=cdash`