### PR TITLE
[WIP] pip: check dependencies before install

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -377,6 +377,8 @@ class PythonPipBuilder(BaseBuilder):
             "--ignore-installed",
             # Use env vars like PYTHONPATH
             "--no-build-isolation",
+            # Fail if dependencies are missing
+            "--check-build-dependencies",
             # Don't warn that prefix.bin is not in PATH
             "--no-warn-script-location",
             # Ignore the PyPI package index


### PR DESCRIPTION
If I'm understanding correctly, adding this flag will cause the build to fail if the dependencies are incorrect. I still need to test this, but a few gotchas I want to check for:

1. Is this only for build dependencies (setup_requires) or also run dependencies (install_requires)?
2. Will this break numpy where we relax the pinned build dep versions?
3. Will this break pillow-simd which we use as an alternative to pillow?