### PR TITLE
py-installer: bootstrap without pip

### DIFF
--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -3,16 +3,41 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
-class PyInstaller(PythonPackage):
+class PyInstaller(Package, PythonExtension):
     """A library for installing Python wheels."""
 
-    homepage = "https://github.com/pradyunsg/installer"
-    pypi = "installer/installer-0.4.0.tar.gz"
+    homepage = "https://github.com/pypa/installer"
+    url = "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/installer/"
 
-    version("0.4.0", sha256="17d7ca174039fbd85f268e16042e3132ebb03d91e1bbe0f63b9ec6b40619414a")
+    version(
+        "0.6.0",
+        sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038",
+        expand=False,
+    )
 
-    depends_on("python@2.7,3.5:", type=("build", "run"))
-    depends_on("py-flit-core@2", type="build")
+    extends("python")
+
+    def install(self, spec, prefix):
+        # To build and install installer from source, you need flit-core, build, and installer
+        # already installed. We get around this by using a pre-built wheel to install itself.
+        # See https://github.com/pypa/installer/issues/150 for details.
+
+        # We can't do this in setup_build_environment because self.stage.archive_file is undefined
+        wheel = self.stage.archive_file
+        path = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = os.pathsep.join([wheel, path])
+
+        args = ["-m", "installer", "--prefix", prefix, wheel]
+        python(*args)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        installer = dependent_spec["python"].command
+        installer.add_default_arg("-m")
+        installer.add_default_arg("installer")
+        setattr(module, "installer", installer)

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -12,7 +12,9 @@ class PyInstaller(Package, PythonExtension):
     """A library for installing Python wheels."""
 
     homepage = "https://github.com/pypa/installer"
-    url = "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    url = (
+        "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.6.0-py3-none-any.whl"
+    )
     list_url = "https://pypi.org/simple/installer/"
 
     version(


### PR DESCRIPTION
Extracted from #35326. The rest of that PR seems unlikely to be merged, but this part should be good to go.

In a follow-up PR, I'll likely update most of our wheel installations to switch from pip to installer since the latter is much more lightweight and faster. Our builds will likely continue to use pip unless build resolves it's circular dependency issues.