### PR TITLE
arrow: explicitly disable RE2 and UTF8PROC flags when not in dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -148,7 +148,7 @@ class Arrow(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("ARROW_WITH_ZLIB", "zlib"))
         args.append(self.define_from_variant("ARROW_WITH_ZSTD", "zstd"))
 
-        if not self.spec.satisfies("^re2"):
+        if not self.spec.dependencies("re2"):
             args.append(self.define("ARROW_WITH_RE2", False))
         if not self.spec.satisfies("^utf8proc"):
             args.append(self.define("ARROW_WITH_UTF8PROC", False))

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -150,7 +150,7 @@ class Arrow(CMakePackage, CudaPackage):
 
         if not self.spec.dependencies("re2"):
             args.append(self.define("ARROW_WITH_RE2", False))
-        if not self.spec.satisfies("^utf8proc"):
+        if not self.spec.dependencies("utf8proc"):
             args.append(self.define("ARROW_WITH_UTF8PROC", False))
 
         if self.spec.satisfies("@:8"):

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -148,7 +148,7 @@ class Arrow(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("ARROW_WITH_ZLIB", "zlib"))
         args.append(self.define_from_variant("ARROW_WITH_ZSTD", "zstd"))
 
-        if not self.spec.satisfies('^re2'):
+        if not self.spec.satisfies("^re2"):
             args.append(self.define("ARROW_WITH_RE2", False))
         if not self.spec.satisfies("^utf8proc"):
             args.append(self.define("ARROW_WITH_UTF8PROC", False))

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -148,6 +148,11 @@ class Arrow(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("ARROW_WITH_ZLIB", "zlib"))
         args.append(self.define_from_variant("ARROW_WITH_ZSTD", "zstd"))
 
+        if not self.spec.satisfies('^re2'):
+            args.append(self.define("ARROW_WITH_RE2", False))
+        if not self.spec.satisfies("^utf8proc"):
+            args.append(self.define("ARROW_WITH_UTF8PROC", False))
+
         if self.spec.satisfies("@:8"):
             args.extend(
                 [


### PR DESCRIPTION
Without ARROW_WITH_RE2 set to False, building fails with:
```
-- Checking for module 're2'
-- No package 're2' found
```

Without ARROW_WITH_UTF8PROC set to False, building fails with:
```
Could NOT find utf8proc: Found unsuitable version "", but required is at
```