### PR TITLE
py-mypy: add v1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -14,6 +14,7 @@ class PyMypy(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("1.0.0", sha256="f34495079c8d9da05b183f9f7daec2878280c2ad7cc81da686ef0b484cea2ecf")
     version("0.991", sha256="3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06")
     version("0.990", sha256="72382cb609142dba3f04140d016c94b4092bc7b4d98ca718740dc989e5271b8d")
     version("0.982", sha256="85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746")
@@ -58,9 +59,6 @@ class PyMypy(PythonPackage):
 
     # setup.py
     depends_on("python@3.7:", when="@0.981:", type=("build", "run"))
-    depends_on("python@3.6:", when="@0.920:", type=("build", "run"))
-    depends_on("python@3.5:", when="@0.700:", type=("build", "run"))
-    depends_on("python@3.4:", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-toml", when="@0.900:0.910", type=("build", "run"))


### PR DESCRIPTION
Mypy switched to semver!

Successfully builds and runs on macOS 10.15.7 with Python 3.10.8 and Apple Clang 12.0.0.