### PR TITLE
xyce: change cmake cxx compiler variable

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -131,7 +131,7 @@ class Xyce(CMakePackage):
     patch(
         "https://github.com/xyce/xyce/commit/40dbc0e0341a5cf9a7fa82a87313869dc284fdd9.patch?full_index=1",
         sha256="3c32faeeea0bb29be44ec20e414670c9fd375f9ed921a7f6e9fd3de02c28859d",
-        when="@:7.5 +shared",
+        when="@7.3:7.5 +shared",
     )
 
     def cmake_args(self):
@@ -142,7 +142,7 @@ class Xyce(CMakePackage):
         if "+mpi" in spec:
             options.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
         else:
-            options.append(self.define("CMAKE_CXX_COMPILER", self.compiler.cxx))
+            options.append(self.define("CMAKE_CXX_COMPILER", spack_cxx))
 
         options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         options.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))


### PR DESCRIPTION
Switched from using `self.compiler.cxx` to `spack_cxx` in `cmake_args()` function when `+mpi` is not in spec (mpi case remains the same). Previously, this was resulting in RPATH information not being propagated into the executable in the `~mpi` case.

Also updated a patch to only be applied `when="@7.3:7.5 +shared"` rather than `when="@:7.5 +shared"` because the patch was not applicable to version 7.2.