### PR TITLE
Start using paths found in extra_rpaths in compilers.yaml when building

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -6,6 +6,7 @@
 import os.path
 import re
 import sys
+import itertools
 
 from spack.package import *
 
@@ -286,7 +287,12 @@ class Mvapich(AutotoolsPackage):
             args.append("--enable-registration-cache")
         else:
             args.append("--disable-registration-cache")
-
+       
+        ld = ''
+        for path in itertools.chain(self.compiler.extra_rpaths, self.compiler.implicit_rpaths()):
+                    ld += "-Wl,-rpath," + path + " "     
+        if ld != '':   
+            args.append("LDFLAGS="+ld)
         args.extend(self.process_manager_options)
         args.extend(self.network_options)
         args.extend(self.file_system_options)

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -20,7 +20,7 @@ class Mvapich(AutotoolsPackage):
     url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-3.0a.tar.gz"
     list_url = "https://mvapich.cse.ohio-state.edu/downloads/"
 
-    maintainers("natshineman", "harisubramoni", "ndcontini")
+    maintainers("natshineman", "harisubramoni", "MatthewLieber")
 
     executables = ["^mpiname$", "^mpichversion$"]
 
@@ -287,12 +287,12 @@ class Mvapich(AutotoolsPackage):
             args.append("--enable-registration-cache")
         else:
             args.append("--disable-registration-cache")
-       
-        ld = ''
+
+        ld = ""
         for path in itertools.chain(self.compiler.extra_rpaths, self.compiler.implicit_rpaths()):
-                    ld += "-Wl,-rpath," + path + " "     
-        if ld != '':   
-            args.append("LDFLAGS="+ld)
+            ld += "-Wl,-rpath," + path + " "
+        if ld != "":
+            args.append("LDFLAGS=" + ld)
         args.extend(self.process_manager_options)
         args.extend(self.network_options)
         args.extend(self.file_system_options)

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import os.path
 import re
 import sys
-import itertools
 
 from spack.package import *
 


### PR DESCRIPTION
When built MVAPICH will now use the paths found in extra rpaths within the compilers.yaml file