### PR TITLE
Bugfix: restore ability to run virtual tests

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-import inspect
 import textwrap
 from itertools import zip_longest
 
@@ -15,9 +14,10 @@ from llnl.util.tty.colify import colify
 
 import spack.cmd.common.arguments as arguments
 import spack.fetch_strategy as fs
+import spack.install_test
 import spack.repo
 import spack.spec
-from spack.package_base import has_test_method, preferred_version
+from spack.package_base import preferred_version
 
 description = "get detailed information on a particular package"
 section = "basic"
@@ -261,41 +261,7 @@ def print_tests(pkg):
     # if it has been overridden and, therefore, assumed to be implemented.
     color.cprint("")
     color.cprint(section_title("Stand-Alone/Smoke Test Methods:"))
-    names = []
-    pkg_cls = pkg if inspect.isclass(pkg) else pkg.__class__
-    if has_test_method(pkg_cls):
-        pkg_base = spack.package_base.PackageBase
-        test_pkgs = [
-            str(cls.test)
-            for cls in inspect.getmro(pkg_cls)
-            if issubclass(cls, pkg_base) and cls.test != pkg_base.test
-        ]
-        test_pkgs = list(set(test_pkgs))
-        names.extend([(test.split()[1]).lower() for test in test_pkgs])
-
-    # TODO Refactor START
-    # Use code from package_base.py's test_process IF this functionality is
-    # accepted.
-    v_names = list(set([vspec.name for vspec in pkg.virtuals_provided]))
-
-    # hack for compilers that are not dependencies (yet)
-    # TODO: this all eventually goes away
-    c_names = ("gcc", "intel", "intel-parallel-studio", "pgi")
-    if pkg.name in c_names:
-        v_names.extend(["c", "cxx", "fortran"])
-    if pkg.spec.satisfies("llvm+clang"):
-        v_names.extend(["c", "cxx"])
-    # TODO Refactor END
-
-    v_specs = [spack.spec.Spec(v_name) for v_name in v_names]
-    for v_spec in v_specs:
-        try:
-            pkg_cls = spack.repo.path.get_pkg_class(v_spec.name)
-            if has_test_method(pkg_cls):
-                names.append("{0}.test".format(pkg_cls.name.lower()))
-        except spack.repo.UnknownPackageError:
-            pass
-
+    names = spack.install_test.test_functions(pkg, add_virtuals=True, names=True)
     if names:
         colify(sorted(names), indent=4)
     else:

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -236,7 +236,7 @@ def test_list(args):
     tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag else set()
 
     def has_test_and_tags(pkg_class):
-        return spack.package_base.has_test_method(pkg_class) and (
+        return spack.install_test.test_functions(pkg_class) and (
             not args.tag or pkg_class.name in tagged
         )
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -123,11 +123,8 @@ def package_class(spec):
         try:
             cls = spec.package_class
         except spack.repo.UnknownPackageError as e:
-            tty.debug("{0}: Cannot retrieve class: {1}".format(spec.name, str(e)))
+            tty.debug("{0}: Cannot retrieve class from spec: {1}".format(spec.name, str(e)))
             return None
-    except spack.repo.UnknownPackageError as e:
-        tty.debug("{0}: Cannot retrieve class: {1}".format(spec.name, str(e)))
-        return None
 
     return cls
 
@@ -188,7 +185,7 @@ def virtuals(pkg):
     """Return a list of unique virtuals for the package.
 
     Args:
-        pkg (spack.package_base.PackageBase): package whose virtuals
+        pkg (spack.package_base.PackageBase): package of interest
     """
     # provides virtuals have to be deduped by name
     v_names = list(set([vspec.name for vspec in pkg.virtuals_provided]))

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -168,9 +168,12 @@ def test_functions(spec_or_pkg, add_virtuals=False, names=False):
 
     cls = package_class(spec_or_pkg)
     if not cls:
-        tty.debug(
-            "{0}: skipping test function retrieval since no package class found".format(spec.name)
+        name = (
+            "{0}: ".format(spec_or_pkg.name)
+            if isinstance(spec_or_pkg, (spack.package_base.PackageBase, spack.spec.Spec))
+            else ""
         )
+        tty.debug("{0}skipping test function retrieval since no package class found".format(name))
         return []
 
     methods = inspect.getmembers(cls, predicate=lambda x: inspect.isfunction(x))

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -170,9 +170,6 @@ def test_functions(spec_or_pkg, add_virtuals=False, names=False):
         raise ValueError("Cannot retrieve test methods for {0}".format(spec_or_pkg))
 
     methods = inspect.getmembers(cls, predicate=lambda x: inspect.isfunction(x))
-    if not methods:
-        return []
-
     tests = []
     for name, test_fn in methods:
         if not name == "test":

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -54,13 +54,7 @@ import spack.util.environment
 import spack.util.path
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
-from spack.install_test import (
-    TestFailure,
-    TestSuite,
-    package_class,
-    test_functions,
-    virtuals,
-)
+from spack.install_test import TestFailure, TestSuite, package_class, test_functions, virtuals
 from spack.installer import InstallError, PackageInstaller
 from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2469,24 +2469,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 raise TestFailure(builder.pkg.test_failures)
 
 
-def has_test_method(pkg):
-    """Determine if the package defines its own stand-alone test method.
-
-    Args:
-        pkg (str): the package being checked
-
-    Returns:
-        (bool): ``True`` if the package overrides the default method; else
-            ``False``
-    """
-    if not inspect.isclass(pkg):
-        tty.die("{0}: is not a class, it is {1}".format(pkg, type(pkg)))
-
-    return (issubclass(pkg, PackageBase) and pkg.test != PackageBase.test) or (
-        isinstance(pkg, PackageBase) and pkg.test.__func__ != PackageBase.test
-    )
-
-
 def print_test_message(logger, msg, verbose):
     if verbose:
         with logger.force_echo():

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -117,11 +117,6 @@ def deprecated_version(pkg, version):
     return False
 
 
-def package_directory(cls):
-    """Returns the path to the package class directory."""
-    return os.path.abspath(os.path.dirname(cls.module.__file__))
-
-
 def preferred_version(pkg):
     """
     Returns a sorted list of the preferred versions of the package.
@@ -798,7 +793,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     @classproperty
     def package_dir(cls):
         """Directory where the package.py file lives."""
-        return package_directory(cls)
+        return os.path.abspath(os.path.dirname(cls.module.__file__))
 
     @classproperty
     def module(cls):
@@ -2493,8 +2488,8 @@ def copy_test_files(pkg, spec):
         tty.debug("{0}: skipping test data copy since no package class found".format(spec.name))
         return
 
-    package_dir = package_directory(pkg_cls)
-    data_source = Prefix(package_dir).test
+    pkg_dir = pkg_cls.package_dir
+    data_source = Prefix(pkg_dir).test
     data_dir = pkg.test_suite.current_test_data_dir
     if os.path.isdir(data_source) and not os.path.exists(data_dir):
         # We assume data dir is used read-only

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1067,7 +1067,6 @@ class Repo(object):
         fs.mkdirp(path)
         try:
             for patch in itertools.chain.from_iterable(spec.package.patches.values()):
-
                 if patch.path:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1065,12 +1065,17 @@ class Repo(object):
 
         # Install patch files needed by the package.
         fs.mkdirp(path)
-        for patch in itertools.chain.from_iterable(spec.package.patches.values()):
-            if patch.path:
-                if os.path.exists(patch.path):
-                    fs.install(patch.path, path)
-                else:
-                    tty.warn("Patch file did not exist: %s" % patch.path)
+        try:
+            for patch in itertools.chain.from_iterable(spec.package.patches.values()):
+
+                if patch.path:
+                    if os.path.exists(patch.path):
+                        fs.install(patch.path, path)
+                    else:
+                        tty.warn("Patch file did not exist: %s" % patch.path)
+        except AssertionError:
+            # virtual specs won't have a package to install
+            pass
 
         # Install the package.py file itself.
         fs.install(self.filename_for_package_name(spec.name), path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1073,12 +1073,18 @@ class Repo(object):
                         fs.install(patch.path, path)
                     else:
                         tty.warn("Patch file did not exist: %s" % patch.path)
-        except AssertionError:
-            # virtual specs won't have a package to install
-            pass
+        except AssertionError as e:
+            # virtual specs won't have patches to install
+            tty.debug(
+                "Could not copy patch files for virtual package {0}: {1}".format(spec.name, str(e))
+            )
 
-        # Install the package.py file itself.
-        fs.install(self.filename_for_package_name(spec.name), path)
+        # Install the package.py file itself, if it exists.
+        try:
+            fs.install(self.filename_for_package_name(spec.name), path)
+        except IOError as e:
+            # package-less virtuals won't have a package.py to copy
+            tty.debug("Could not copy package.py for {0}: {1}".format(spec.name, str(e)))
 
     def purge(self):
         """Clear entire package instance cache."""

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1063,20 +1063,15 @@ class Repo(object):
                 "Repository %s does not contain package %s." % (self.namespace, spec.fullname)
             )
 
-        # Install patch files needed by the package.
+        # Install patch files needed by the (concrete) package.
         fs.mkdirp(path)
-        try:
+        if spec.concrete:
             for patch in itertools.chain.from_iterable(spec.package.patches.values()):
                 if patch.path:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)
                     else:
                         tty.warn("Patch file did not exist: %s" % patch.path)
-        except AssertionError as e:
-            # virtual specs won't have patches to install
-            tty.debug(
-                "Could not copy patch files for virtual package {0}: {1}".format(spec.name, str(e))
-            )
 
         # Install the package.py file itself, if it exists.
         try:

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -248,15 +248,6 @@ def test_test_list(mock_packages, mock_archive, mock_fetch, install_mockery_muta
     assert pkg_with_tests in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
-def test_has_test_method_fails(capsys):
-    with pytest.raises(SystemExit):
-        spack.package_base.has_test_method("printing-package")
-
-    captured = capsys.readouterr()[1]
-    assert "is not a class" in captured
-
-
 def test_read_old_results(mock_packages, mock_test_stage):
     """Take test data generated before the switch to full hash everywhere
     and make sure we can still read it in"""

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -192,3 +192,14 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
 
     # Perform a little cleanup
     shutil.rmtree(os.path.dirname(source_path))
+
+
+def test_package_copy_test_files_fails(mock_packages, ensure_debug, capsys):
+    vspec = spack.spec.Spec("something")
+
+    # Package shouldn't be needed since shouldn't reach the code to determine
+    # the test destination directory.
+    spack.package_base.copy_test_files(None, vspec)
+    out = capsys.readouterr()
+    assert "skipping test data copy" in out[1]
+    assert "no package class found" in out[1]

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -309,14 +309,6 @@ def test_fetch_options(version_str, digest_end, extra_options):
     assert fetcher.extra_options == extra_options
 
 
-def test_has_test_method_fails(capsys):
-    with pytest.raises(SystemExit):
-        spack.package_base.has_test_method("printing-package")
-
-    captured = capsys.readouterr()[1]
-    assert "is not a class" in captured
-
-
 def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
     pkg_cls = spack.repo.path.get_pkg_class(spec.name)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -150,3 +150,15 @@ def test_repo_path_handles_package_removal(tmpdir, mock_packages):
     with spack.repo.use_repositories(builder.root, override=False) as repos:
         r = repos.repo_for_pkg("c")
         assert r.namespace == "builtin.mock"
+
+
+def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages):
+    # Start with a package-less virtual
+    vspec = spack.spec.Spec("something")
+    with pytest.raises(OSError):
+        mutable_mock_repo.dump_provenance(vspec, tmpdir)
+
+    # Now with a virtual with a package
+    vspec = spack.spec.Spec("externalvirtual")
+    mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -152,13 +152,17 @@ def test_repo_path_handles_package_removal(tmpdir, mock_packages):
         assert r.namespace == "builtin.mock"
 
 
-def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages):
+def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_debug, capsys):
     # Start with a package-less virtual
     vspec = spack.spec.Spec("something")
-    with pytest.raises(OSError):
-        mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    captured = capsys.readouterr()[1]
+    assert "Could not copy patch files" in captured
+    assert "Could not copy package" in captured
 
     # Now with a virtual with a package
     vspec = spack.spec.Spec("externalvirtual")
     mutable_mock_repo.dump_provenance(vspec, tmpdir)
+    captured = capsys.readouterr()[1]
+    assert "Could not copy patch files" in captured
     assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -157,12 +157,10 @@ def test_repo_dump_virtuals(tmpdir, mutable_mock_repo, mock_packages, ensure_deb
     vspec = spack.spec.Spec("something")
     mutable_mock_repo.dump_provenance(vspec, tmpdir)
     captured = capsys.readouterr()[1]
-    assert "Could not copy patch files" in captured
     assert "Could not copy package" in captured
 
     # Now with a virtual with a package
     vspec = spack.spec.Spec("externalvirtual")
     mutable_mock_repo.dump_provenance(vspec, tmpdir)
     captured = capsys.readouterr()[1]
-    assert "Could not copy patch files" in captured
     assert "package.py" in os.listdir(tmpdir), "Expected the virtual's package to be copied"

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -211,3 +211,20 @@ def test_test_functions(mock_packages, install_mockery, virtuals, names):
         names=names,
     )
     check_results(fns)
+
+
+def test_test_package_class_unknown(mock_packages):
+    """Ensure expected result for existing mock virtual spec with no package."""
+    vspec = spack.spec.Spec("something")
+    assert not spack.install_test.package_class(vspec), "Expected UnknownPackageError"
+
+
+def test_test_functions_error_or_none(mock_packages):
+    """Ensure expected results when test_functions called with incorrect values."""
+    flag = spack.spec.CompilerFlag("cflags")
+    with pytest.raises(ValueError):
+        _ = spack.install_test.test_functions(flag)
+
+    assert not spack.install_test.test_functions(
+        flag.__class__
+    ), "Expected no test methods for a class that doesn't have any"

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -222,9 +222,8 @@ def test_test_functions_error_or_none(mock_packages):
     with pytest.raises(ValueError):
         _ = spack.install_test.test_functions(flag)
 
-    assert not spack.install_test.test_functions(
-        flag.__class__
-    ), "Expected no test methods for a class that doesn't have any"
+    with pytest.raises(ValueError):
+        _ = spack.install_test.test_functions(flag.__class__)
 
 
 # TODO: This test should go away when compilers as dependencies is supported

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -186,13 +186,7 @@ def test_get_test_suite_too_many(mock_packages, mock_test_stage):
 
 
 @pytest.mark.parametrize(
-    "virtuals,names",
-    [
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ],
+    "virtuals,names", [(False, False), (False, True), (True, False), (True, True)]
 )
 def test_test_functions(mock_packages, install_mockery, virtuals, names):
     spec = spack.spec.Spec("printing-package").concretized()
@@ -207,9 +201,7 @@ def test_test_functions(mock_packages, install_mockery, virtuals, names):
     check_results(fns)
 
     fns = spack.install_test.test_functions(
-        spec.package.__class__,
-        add_virtuals=virtuals,
-        names=names,
+        spec.package.__class__, add_virtuals=virtuals, names=names
     )
     check_results(fns)
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -182,3 +182,32 @@ def test_get_test_suite_too_many(mock_packages, mock_test_stage):
     with pytest.raises(spack.install_test.TestSuiteNameError) as exc_info:
         spack.install_test.get_test_suite(name)
     assert "many suites named" in str(exc_info)
+
+
+@pytest.mark.parametrize(
+    "virtuals,names",
+    [
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    ],
+)
+def test_test_functions(mock_packages, install_mockery, virtuals, names):
+    spec = spack.spec.Spec("printing-package").concretized()
+    expected = "printing-package.test" if names else "test"
+
+    def check_results(fns):
+        tests = fns if names else [f.__name__ for f in fns]
+        assert len(tests) == 1, "expecting only one test function"
+        assert tests[0] == expected
+
+    fns = spack.install_test.test_functions(spec.package, add_virtuals=virtuals, names=names)
+    check_results(fns)
+
+    fns = spack.install_test.test_functions(
+        spec.package.__class__,
+        add_virtuals=virtuals,
+        names=names,
+    )
+    check_results(fns)


### PR DESCRIPTION
Fixes #35519 (at least should)

This PR restores the ability to run stand-alone tests on virtual provider packages, including the ability to "inherit" tests from the virtual packages.

Also fixes an issue reported by @jfinney10 on slack:

```
$ spack -d test run
[...snip...]
  File "$spack/lib/spack/spack/repo.py", line 1153, in dump_provenance
    spec.package.patches.values()):
  File "$spack/lib/spack/spack/spec.py", line 1520, in package
    assert self.concrete, "Spec.package can only be called on concrete specs"
AssertionError: Spec.package can only be called on concrete specs
```

TODO

- [x] Stand-alone testing
- [x] Ensure pulled all of the relevant code from (local) #34236 