### PR TITLE
py-gmsh-interop: Fix PyPI link

### DIFF
--- a/var/spack/repos/builtin/packages/py-gmsh-interop/package.py
+++ b/var/spack/repos/builtin/packages/py-gmsh-interop/package.py
@@ -10,7 +10,7 @@ class PyGmshInterop(PythonPackage):
     """Interoperability between Python and Gmsh"""
 
     homepage = "https://documen.tician.de/gmsh_interop"
-    pypi = "gmesh_interop/gmesh_interop-2021.1.1.tar.gz"
+    pypi = "gmsh_interop/gmsh_interop-2021.1.1.tar.gz"
     git = "https://github.com/inducer/gmsh_interop.git"
 
     maintainers("cgcgcg")


### PR DESCRIPTION
I pushed #35327 with a bad PyPI link. 
(In my local testing this probably worked due to caching.)