### PR TITLE
py-scipy: use --config-settings

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -198,10 +198,10 @@ class PyScipy(PythonPackage):
             lapack += "-dynamic-lp64-seq"
 
         return {
-            "blas": blas,
-            "lapack": lapack,
-            "debug": False,
-            "optimization": 2,
+            "setup-args=-Dblas": blas,
+            "setup-args=-Dlapack": lapack,
+            "setup-args=-Ddebug": False,
+            "setup-args=-Doptimization": 2,
         }
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
-import os
-
 from spack.package import *
 
 


### PR DESCRIPTION
@rgommers @eli-schwartz @FFY00 If I'm understanding correctly, the latest versions of meson-python support passing options via `--config-settings`, so we can remove the hacks we had in place to build scipy. Hopefully I got the syntax correct, may take a few iterations.