### PR TITLE
spack help --spec: fix indentation

### DIFF
--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -49,9 +49,9 @@ spec expression syntax:
       @r{-variant} or @r{~variant}          disable <variant>
       @r{--variant} or @r{~~variant}        propagate disable <variant>
       @B{variant=value}                 set non-boolean <variant> to <value>
-      @B{variant==value}                 propagate non-boolean <variant> to <value>
+      @B{variant==value}                propagate non-boolean <variant> to <value>
       @B{variant=value1,value2,value3}  set multi-value <variant> values
-      @B{variant==value1,value2,value3}  propagate multi-value <variant> values
+      @B{variant==value1,value2,value3} propagate multi-value <variant> values
 
     architecture variants:
       @m{platform=platform}             linux, darwin, cray, etc.


### PR DESCRIPTION
The spacing of these two lines was off and the columns didn't line up.