### PR TITLE
scale mpi dependency is incorrect

### DIFF
--- a/var/spack/repos/builtin/packages/scale/package.py
+++ b/var/spack/repos/builtin/packages/scale/package.py
@@ -28,7 +28,7 @@ class Scale(MakefilePackage):
     version("5.3.6", sha256="3ab0d42cdb16eee568c65b880899e861e464e92088ceb525066c726f31d04848")
     version("5.2.6", sha256="e63141d05810e3f41fc89c9eb15e2319d753832adabdac8f7c8dd7acc0f5f8ed")
 
-    depends_on("openmpi", type=("build", "link", "run"))
+    depends_on("mpi@2:", type=("build", "link", "run"))
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
     depends_on("parallel-netcdf")


### PR DESCRIPTION
@t-yamaura this fixes the problem with `scale` not working with `fujitsu-mpi`