### PR TITLE
llvm: Fix compatibility with hwloc@1 and hwloc@:2.3

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -236,7 +236,7 @@ class Llvm(CMakePackage, CudaPackage):
     # openmp dependencies
     depends_on("perl-data-dumper", type=("build"))
     depends_on("hwloc")
-    depends_on("hwloc@2.0.1:", when="@9:")
+    depends_on("hwloc@2.0.1:", when="@13")
     depends_on("elf", when="+cuda")  # libomptarget
     depends_on("libffi", when="+libomptarget")  # libomptarget
 
@@ -374,6 +374,13 @@ class Llvm(CMakePackage, CudaPackage):
     # TODO: adjust version constraint and switch to fetching from the upstream GitHub repo
     #  when/if the bugfix is merged
     patch("D133513.diff", level=0, when="@14:15+lldb+python")
+
+    # Fix hwloc@:2.3 (Conditionally disable hwloc@2.0 and hwloc@2.4 code)
+    patch(
+        "https://github.com/llvm/llvm-project/commit/3a362a9f38b95978160377ee408dbc7d14af9aad.patch?full_index=1",
+        sha256="25bc503f7855229620e56e76161cf4654945aef0be493a2d8d9e94a088157b7c",
+        when="@14:15",
+    )
 
     # The functions and attributes below implement external package
     # detection for LLVM. See:


### PR DESCRIPTION
This PR applies [a patch from `llvm@16`](https://github.com/llvm/llvm-project/commit/3a362a9f38b95978160377ee408dbc7d14af9aad) to `llvm@14:15` to fix `hwloc@:2.3` compatibility. Also relax hwloc contraint for `llvm@:12`. So only `llvm@13` has issues with `hwloc@1`.

Here is what I tested with spack 0.20, on ubuntu 22.04, gcc 11, no system hwloc (important to catch missing include):

- `llvm@9,12 ^hwloc@1` OK for me (no constraint, no patch)
- `llvm@13 ^hwloc@1` FAIL: needs `hwloc@2.0:` (1)
- `llvm@13 patches=thispr` FAIL: patch does not apply
- `llvm@14,15 ^hwloc@1` FAIL: needs `hwloc@2.0:`, maybe even `hwloc@2.4:` (2)
- `llvm@14,15 patches=thispr ^hwloc@1` OK
- `llvm@16: ^hwloc@1:2` OK for me (the patch comes from llvm@16)

So I think #34780's constraint `llvm@9: ^hwloc@2.0.1:` is not actually exact, and we can be further relaxed with the patch. 

Do you think I miss something @kwryankrattiger ?

(1): With `llvm@13 ^hwloc@1` I get `error: no member named 'kind' in 'hwloc_obj_attr_u::hwloc_group_attr_s`

(2): As seen in [the patch](https://github.com/llvm/llvm-project/commit/3a362a9f38b95978160377ee408dbc7d14af9aad) there actually seem to be `hwloc@2.4` code.

EDIT: tested `llvm@16`

---

I have another issue with `llvm/lib/libomp.so` missing a NEEDED to libhwloc since at least `llvm@12` (it's ok in `llvm@9`). I don't know if this is intentional yet, but anyway this will be for another PR if I find something.

