### PR TITLE
py-pygments 2.12; fix py-docutils, again

### DIFF
--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -35,6 +35,9 @@ class PyDocutils(PythonPackage):
     depends_on("python@2.4:", when="@:0.13", type=("build", "run"))
     depends_on("py-setuptools", when="@0.15:", type="build")
 
+    # Uses 2to3
+    depends_on("py-setuptools@:57", when="@0.15", type="build")
+
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:0.15")
 

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -33,7 +33,7 @@ class PyDocutils(PythonPackage):
     depends_on("python@2.7:2.8,3.5:", when="@0.16:", type=("build", "run"))
     depends_on("python@2.6:2.8,3.3:", when="@0.14:0.15", type=("build", "run"))
     depends_on("python@2.4:", when="@:0.13", type=("build", "run"))
-    depends_on("py-setuptools", when="@0.15:", type="build")
+    depends_on("py-setuptools", type="build")
 
     # Uses 2to3
     depends_on("py-setuptools@:57", when="@0.15", type="build")

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -36,7 +36,7 @@ class PyDocutils(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     # Uses 2to3
-    depends_on("py-setuptools@:57", when="@0.15", type="build")
+    depends_on("py-setuptools@:57", when="@:0.15", type="build")
 
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:0.15")

--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -13,6 +13,7 @@ class PyPygments(PythonPackage):
     pypi = "Pygments/Pygments-2.4.2.tar.gz"
 
     version("2.13.0", sha256="56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1")
+    version("2.12.0", sha256="5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb")
     version("2.10.0", sha256="f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6")
     version("2.6.1", sha256="647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44")
     version("2.4.2", sha256="881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297")


### PR DESCRIPTION
`2.12` is the latest for which our style hack works, beyond that we need
our own package to make a plugin.

Old docutils needs old setuptools
