### PR TITLE
openblas: fix prereqs / make race

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/fix-shared-tests-prereqs.patch
+++ b/var/spack/repos/builtin/packages/openblas/fix-shared-tests-prereqs.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 967ab1bb6..98666e853 100644
+--- a/Makefile
++++ b/Makefile
+@@ -42,6 +42,9 @@ SUBDIRS_ALL = $(SUBDIRS) test ctest utest exports benchmark ../laswp ../bench cp
+ .PHONY : all libs netlib $(RELA) test ctest shared install
+ .NOTPARALLEL : all libs $(RELA) prof lapack-test install blas-test
+ 
++shared: libs netlib $(RELA)
++tests: libs netlib $(RELA) shared
++
+ all :: libs netlib $(RELA) tests shared
+ 	@echo
+ 	@echo " OpenBLAS build complete. ($(LIB_COMPONENTS))"

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -182,6 +182,10 @@ class Openblas(MakefilePackage):
         when="@0.3.21 %gcc@:9",
     )
 
+    # Generic fix (https://github.com/xianyi/OpenBLAS/pull/3902) so we don't
+    # have to build tests
+    patch("fix-shared-tests-prereqs.patch", when="@0.2.20:0.3.21")
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
     # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)


### PR DESCRIPTION
Fix a race in the makefile where the shared lib was built before the
object files were available when doing `make libs netlib shared`

See https://github.com/xianyi/OpenBLAS/issues/3899
