### PR TITLE
wrf: fix v4.4.2 checksum

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -73,7 +73,7 @@ class Wrf(Package):
 
     version(
         "4.4.2",
-        sha256="5d6237f1500c44a33626362936ba0a4388360c5070d9d53262e5a950c586da85",
+        sha256="488b992e8e994637c58e3c69e869ad05acfe79419c01fbef6ade1f624e50dc3a",
         url="https://github.com/wrf-model/WRF/releases/download/v4.4.2/v4.4.2.tar.gz",
     )
     version(


### PR DESCRIPTION
The WRF 4.4.2 checksum seems to have changed since it was added in #35244. Not sure if this is due to the recent GitHub hashing change or not. I have a feeling it isn't since that should only affect the auto-generated tarballs, not the manually uploaded assets. Should I open an issue with the WRF developers to investigate?

(the previous checksum does not match any of the other tar or zip, auto or manual downloads)

CI is currently failing because of this: https://gitlab.spack.io/spack/spack/-/jobs/5466213

@t-brown @tldahlgren 