### PR TITLE
libgd: add libx11 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -36,6 +36,7 @@ class Libgd(AutotoolsPackage):
     depends_on("jpeg")
     depends_on("libtiff")
     depends_on("fontconfig")
+    depends_on("libx11")
 
     def patch(self):
         p = self.spec["jpeg"].libs.search_flags


### PR DESCRIPTION
adding explicit dependency on X11 (needed when there is not a system install)