### PR TITLE
meme add perl-xml-simple dependency

### DIFF
--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -31,6 +31,7 @@ class Meme(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("imagemagick", type=("build", "run"), when="+image-magick")
     depends_on("perl-xml-parser", type=("build", "run"))
+    depends_on("perl-xml-simple", when="@4.5.0:")
     depends_on("libxml2", type=("build", "run"))
     depends_on("libxslt", type=("build", "run"))
 


### PR DESCRIPTION
Meme 4.5.0 has the first occurrence of the string
```
use XML::Simple
```
I found this by doing a binary search manually extracting tarballs until `grep` came up empty.

I would assume that this would be a runtime dependency only, but I don't know enough about perl to say that with 100% confidence.