### PR TITLE
CMake: Change default build type to Release

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -55,7 +55,7 @@ class CMakePackage(spack.package_base.PackageBase):
         # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
         variant(
             "build_type",
-            default="RelWithDebInfo",
+            default="Release",
             description="CMake build type",
             values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
         )

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -33,7 +33,7 @@ class MesonPackage(spack.package_base.PackageBase):
     with when("build_system=meson"):
         variant(
             "buildtype",
-            default="debugoptimized",
+            default="release",
             description="Meson build type",
             values=("plain", "debug", "debugoptimized", "release", "minsize"),
         )


### PR DESCRIPTION
This PR changes the default build type of CMake packages from `RelWithDebInfo` to `Release`.

While `RelWithDebInfo` enables debug information, it drops the optimization level down to `-02`.
`Release` uses `-03`, which enables some additional optimizations.

Side effects for CMake packages will be:
* smaller installation size
* additional optimizations
* no debug information by default

Package providers relying on the default to include debug information now need to change their config to `RelWithDebInfo` or by adding `-g` as a compile flag.

Also changes the default meson build type to release for consistency.