### PR TITLE
MSBuild: Proper toolchain version expression

### DIFF
--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -77,7 +77,7 @@ class MSBuildBuilder(BaseBuilder):
         Override this method to select a specific version of the toolchain or change
         selection heuristics.
         Default is whatever version of msvc has been selected by concretization"""
-        return self.compiler.msvc_version
+        return "v" + self.pkg.compiler.platform_toolset_ver
 
     @property
     def std_msbuild_args(self):


### PR DESCRIPTION
Prior to #35098 Spack had no explicit concept of toolset versioning for the MSVC toolchain. Now that #35098 vendors such support, integrate into MSBuild builder. 

PRs: #35099 and #35095 depend on this PR