### PR TITLE
Add namd2.15a2 + AOCC4.0 support

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/charm_6.10_aocc.patch
+++ b/var/spack/repos/builtin/packages/charmpp/charm_6.10_aocc.patch
@@ -1,0 +1,49 @@
+diff -aur a/src/arch/mpi-linux-x86_64/cc-mpicxx.sh b/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+--- a/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2020-08-05 05:13:21.000000000 +0000
++++ b/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2023-02-09 17:02:01.782662750 +0000
+@@ -15,6 +15,7 @@
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "${CMK_REAL_COMPILER##*/}" in
+ gcc|g++|gcc-*|g++-*)   CMK_AMD64="-m64 -fPIC" ;;
++clang++)  CMK_AMD64="-m64 -fPIC" ;;
+ icpc)  CMK_AMD64="-m64";;
+ pgCC)  CMK_AMD64="-DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ FCC)   CMK_AMD64="-Kfast -DCMK_FIND_FIRST_OF_PREDICATE=1 --variadic_macros";;
+diff -aur a/src/arch/mpi-linux-x86_64/conv-mach.sh b/src/arch/mpi-linux-x86_64/conv-mach.sh
+--- a/src/arch/mpi-linux-x86_64/conv-mach.sh	2020-08-05 05:13:21.000000000 +0000
++++ b/src/arch/mpi-linux-x86_64/conv-mach.sh	2023-02-09 17:02:01.782662750 +0000
+@@ -3,6 +3,7 @@
+ CMK_GCC64='-fPIC'
+ 
+ case "$CMK_REAL_COMPILER" in
++clang++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ g++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ pgCC)  CMK_AMD64_CC='-fPIC'; CMK_AMD64_CXX='-fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std ' ;;
+ charmc)  echo "Error> charmc can not call AMPI's mpicxx/mpiCC wrapper! Please fix your PATH."; exit 1 ;;
+@@ -17,10 +18,10 @@
+ #CMK_SYSLIBS="-lmpich"
+ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
+ 
+-CMK_NATIVE_CC='gcc'
+-CMK_NATIVE_LD='gcc'
+-CMK_NATIVE_CXX='g++'
+-CMK_NATIVE_LDXX='g++'
++CMK_NATIVE_CC='clang'
++CMK_NATIVE_LD='clang'
++CMK_NATIVE_CXX='clang++'
++CMK_NATIVE_LDXX='clang++'
+ CMK_NATIVE_LIBS=''
+ 
+ CMK_NATIVE_CC_FLAGS="$CMK_GCC64 "
+diff -aur a/src/QuickThreads/Makefile b/src/QuickThreads/Makefile
+--- a/src/QuickThreads/Makefile	2020-08-05 05:13:21.000000000 +0000
++++ b/src/QuickThreads/Makefile	2023-02-09 17:02:01.782662750 +0000
+@@ -1,5 +1,5 @@
+ 
+-CC=gcc -I. -O2
++CC=clang -I. -O2
+ 
+ all: qt stp testpgm
+ 
+Only in b/src/scripts: Makefile.orig
+Only in b/tests/charm++/megatest: Makefile.orig

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -48,6 +48,7 @@ class Charmpp(Package):
     # Patch for AOCC
     patch("charm_6.7.1_aocc.patch", when="@6.7.1 %aocc", level=1)
     patch("charm_6.8.2_aocc.patch", when="@6.8.2 %aocc", level=3)
+    patch("charm_6.10_aocc.patch", when="@6.10.0:6.10.2 %aocc")
 
     # support Fujitsu compiler
     patch("fj.patch", when="%fj")
@@ -98,7 +99,6 @@ class Charmpp(Package):
     variant("omp", default=False, description="Support for the integrated LLVM OpenMP runtime")
     variant("pthreads", default=False, description="Compile with pthreads Converse threads")
     variant("cuda", default=False, description="Enable CUDA toolkit")
-
     variant("shared", default=True, description="Enable shared link support")
     variant("production", default=True, description="Build charm++ with all optimizations")
     variant("tracing", default=False, description="Enable tracing modules")
@@ -271,6 +271,13 @@ class Charmpp(Package):
 
         if "@:6.8.2 %aocc" not in spec:
             options.append(os.path.basename(self.compiler.fc))
+
+        if "cxxflags" in self.compiler.flags:
+            for arg in self.compiler.flags["cxxflags"]:
+                if arg.startswith("-I"):
+                    options.append("--incdir={}".format(arg[2:]))
+                if arg.startswith("-L"):
+                    options.append("--libdir={}".format(arg[2:]))
 
         options.append("-j%d" % make_jobs)
         options.append("--destination=%s" % builddir)

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -22,7 +22,8 @@ class Namd(MakefilePackage, CudaPackage):
     manual_download = True
 
     version("master", branch="master")
-    version("2.15a1", branch="master", tag="release-2-15-alpha-1")
+    version("2.15a2", sha256="8748cbaa93fc480f92fc263d9323e55bce6623fc693dbfd4a40f59b92669713e")
+    version("2.15a1", sha256="474006e98e32dddae59616b3b75f13a2bb149deaf7a0d617ce7fb9fd5a56a33a")
     version(
         "2.14",
         sha256="34044d85d9b4ae61650ccdba5cda4794088c3a9075932392dd0752ef8c049235",
@@ -44,6 +45,8 @@ class Namd(MakefilePackage, CudaPackage):
         values=("none", "tcl", "python"),
         description="Enables TCL and/or python interface",
     )
+
+    variant("avxtiles", default=False, description="Enable avxtiles")
 
     # init_tcl_pointers() declaration and implementation are inconsistent
     # "src/colvarproxy_namd.C", line 482: error: inherited member is not
@@ -68,6 +71,8 @@ class Namd(MakefilePackage, CudaPackage):
 
     depends_on("tcl", when="interface=python")
     depends_on("python", when="interface=python")
+
+    conflicts("+avxtiles", when="@:2.14,3:", msg="AVXTiles algorithm requires NAMD 2.15")
 
     # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
     # https://www.ks.uiuc.edu/Research/namd/2.13/features.html
@@ -118,6 +123,7 @@ class Namd(MakefilePackage, CudaPackage):
                                         -ffast-math -lpthread "
                         + archopt,
                         "intel": "-O2 -ip -qopenmp-simd" + archopt,
+                        "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
                         "aocc": m64
                         + "-O3 -ffp-contract=fast -ffast-math \
                                         -fopenmp "
@@ -130,11 +136,18 @@ class Namd(MakefilePackage, CudaPackage):
                                         -ffast-math -lpthread "
                         + archopt,
                         "intel": "-O2 -ip " + archopt,
+                        "clang": m64 + "-O3 -ffast-math " + archopt,
                         "aocc": m64
                         + "-O3 -ffp-contract=fast \
                                         -ffast-math "
                         + archopt,
                     }
+
+                if "avx512" in spec.target and self.spec.satisfies("+avxtiles"):
+                    optims_opts["aocc"] += " -DNAMD_AVXTILES"
+                    optims_opts["clang"] += " -DNAMD_AVXTILES"
+                    optims_opts["gcc"] += " -DNAMD_AVXTILES"
+                    optims_opts["intel"] += " -DNAMD_AVXTILES"
 
                 optim_opts = (
                     optims_opts[self.compiler.name] if self.compiler.name in optims_opts else ""
@@ -200,6 +213,10 @@ class Namd(MakefilePackage, CudaPackage):
             self._edit_arch_generic(spec, prefix)
 
     def edit(self, spec, prefix):
+
+        if "avx512" not in spec.target:
+            raise UnsupportedPlatformError("AVXTiles algorithm requires AVX512 target support")
+
         self._edit_arch(spec, prefix)
 
         self._copy_arch_file("base")
@@ -256,6 +273,7 @@ class Namd(MakefilePackage, CudaPackage):
         with working_dir(self.build_directory):
             mkdirp(prefix.bin)
             install("namd2", prefix.bin)
+            install("psfgen", prefix.bin)
 
             # I'm not sure this is a good idea or if an autoload of the charm
             # module would not be better.


### PR DESCRIPTION
Adds new NAMD version 2.15a2 - providing AVXTiles algorithm support for non-Intel compilers (AOCC, Clang, GCC)

Also adds support for building charm 6.10.x with the AOCC compiler