### PR TITLE
openblas: Use more stable URL as source

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -14,7 +14,7 @@ class Openblas(MakefilePackage):
     """OpenBLAS: An optimized BLAS library"""
 
     homepage = "https://www.openblas.net"
-    url = "https://github.com/xianyi/OpenBLAS/archive/v0.2.19.tar.gz"
+    url = "https://github.com/xianyi/OpenBLAS/releases/download/v0.2.19/OpenBLAS-0.2.19.tar.gz"
     git = "https://github.com/xianyi/OpenBLAS.git"
 
     libraries = ["libopenblas"]


### PR DESCRIPTION
[Upon request](https://github.com/xianyi/OpenBLAS/issues/3903), OpenBLAS maintainer has kindly uploaded all git(hub)-generated tarballs as release artifacts, which provide more stable URLs for fetching the source code.  Sha256 checksums should be the same.