### PR TITLE
Update xtb 6.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/tblite/package.py
+++ b/var/spack/repos/builtin/packages/tblite/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Tblite(MesonPackage):
+    """Light-weight tight-binding framework"""
+
+    homepage = "https://tblite.readthedocs.io"
+    url = "https://github.com/tblite/tblite/releases/download/v0.3.0/tblite-0.3.0.tar.xz"
+    git = "https://github.com/tblite/tblite.git"
+
+    maintainers = ["awvwgk"]
+
+    version("0.3.0", "46d77c120501ac55ed6a64dea8778d6593b26fb0653c591f8e8c985e35884f0a")
+
+    variant("openmp", default=True, description="Use OpenMP parallelisation")
+    variant("python", default=False, description="Build Python extension module")
+
+    depends_on("blas")
+    depends_on("dftd4@3:")
+    depends_on("lapack")
+    depends_on("mctc-lib@0.3:")
+    depends_on("meson@0.57.2:", type="build")  # mesonbuild/meson#8377
+    depends_on("pkgconfig", type="build")
+    depends_on("py-cffi", when="+python")
+    depends_on("py-numpy", when="+python")
+    depends_on("python@3.6:", when="+python")
+    depends_on("simple-dftd3")
+    depends_on("toml-f")
+
+    extends("python", when="+python")
+
+    def meson_args(self):
+        lapack = self.spec["lapack"].libs.names[0]
+        if lapack == "lapack":
+            lapack = "netlib"
+        elif lapack.startswith("mkl"):
+            lapack = "mkl"
+        elif lapack != "openblas":
+            lapack = "auto"
+
+        return [
+            "-Dlapack={0}".format(lapack),
+            "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
+            "-Dpython={0}".format(str("+python" in self.spec).lower()),
+        ]

--- a/var/spack/repos/builtin/packages/tblite/package.py
+++ b/var/spack/repos/builtin/packages/tblite/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -13,7 +13,7 @@ class Tblite(MesonPackage):
     url = "https://github.com/tblite/tblite/releases/download/v0.3.0/tblite-0.3.0.tar.xz"
     git = "https://github.com/tblite/tblite.git"
 
-    maintainers = ["awvwgk"]
+    maintainers("awvwgk")
 
     version("0.3.0", "46d77c120501ac55ed6a64dea8778d6593b26fb0653c591f8e8c985e35884f0a")
 

--- a/var/spack/repos/builtin/packages/xtb/package.py
+++ b/var/spack/repos/builtin/packages/xtb/package.py
@@ -10,10 +10,11 @@ class Xtb(MesonPackage):
     """Semiempirical extended tight binding program package"""
 
     homepage = "https://xtb-docs.readthedocs.org"
-    url = "https://github.com/grimme-lab/xtb/releases/download/v6.5.1/xtb-6.5.1-source.tar.xz"
+    url = "https://github.com/grimme-lab/xtb/releases/download/v6.6.0/xtb-6.6.0-source.tar.xz"
 
     maintainers("awvwgk")
 
+    version("6.6.0", sha256="8460113f2678dcb23220af17b734f1221af302f42126bb54e3ae356530933b85")
     version("6.5.1", sha256="0922205cc224fe79e28f3d75be4e10c03efa8f3f666aedec8346fed82b272cad")
     version("6.5.0", sha256="5f780656bf7b440a8e1f753a9a877401a7d497fb3160762f48bdefc8a9914976")
 
@@ -22,6 +23,7 @@ class Xtb(MesonPackage):
     depends_on("meson@0.57.2:", type="build")
     depends_on("mctc-lib")
     depends_on("pkgconfig", type="build")
+    depends_on("tblite", when="@6.6.0:")
 
     variant("openmp", default=True, description="Use OpenMP parallelisation")
 
@@ -32,7 +34,9 @@ class Xtb(MesonPackage):
         elif lapack != "openblas":
             lapack = "netlib"
 
+        lapack_opt = "-Dlapack={0}" if self.version > Version("6.6.0") else "-Dla_backend={0}"
+
         return [
-            "-Dla_backend={0}".format(lapack),
+            lapack_opt.format(lapack),
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
         ]


### PR DESCRIPTION
Released at https://github.com/grimme-lab/xtb/releases/tag/v6.6.0