### PR TITLE
Make recipes consistent w.r. libintl, iconv, gettext

### DIFF
--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -26,8 +26,10 @@ class Acl(AutotoolsPackage):
     depends_on("attr")
     depends_on("gettext")
 
-    def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+    def flag_handler(self, name, flags):
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return self.build_system_flags(name, flags)
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -154,7 +154,8 @@ class Apex(CMakePackage):
             args.append("-DBFD_ROOT={0}".format(spec["binutils"].prefix))
 
         if "+binutils ^binutils+nls" in spec:
-            args.append("-DCMAKE_SHARED_LINKER_FLAGS=-lintl")
+            if "intl" in self.spec["gettext"].libs.names:
+                args.append("-DCMAKE_SHARED_LINKER_FLAGS=-lintl")
 
         if "+otf2" in spec:
             args.append("-DOTF2_ROOT={0}".format(spec["otf2"].prefix))

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Bash(AutotoolsPackage, GNUMirrorPackage):
@@ -177,8 +178,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         spec = self.spec
-
-        return [
+        args = [
             # https://github.com/Homebrew/legacy-homebrew/pull/23234
             # https://trac.macports.org/ticket/40603
             "CFLAGS=-DSSH_SOURCE_BASHRC",
@@ -186,8 +186,12 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             "--with-curses",
             "--enable-readline",
             "--with-installed-readline",
-            "--with-libiconv-prefix={0}".format(spec["iconv"].prefix),
         ]
+        if spec["iconv"].name == "libc":
+            args.append("--without-libiconv-prefix")
+        elif not is_system_path(spec["iconv"].prefix):
+            args.append("--with-libiconv-prefix={0}".format(spec["iconv"].prefix))
+        return args
 
     def check(self):
         make("tests")

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -24,15 +24,15 @@ class Bcache(MakefilePackage):
     depends_on("gettext")
     depends_on("pkgconfig", type="build")
 
-    def setup_build_environment(self, env):
-        # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
-        if "gettext" in self.spec and "intl" in self.spec["gettext"].libs.names:
-            env.append_flags("LDFLAGS", "-lintl")
-
     patch(
         "func_crc64.patch",
         sha256="558b35cadab4f410ce8f87f0766424a429ca0611aa2fd247326ad10da115737d",
     )
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return self.env_flags(name, flags)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/bind9/package.py
+++ b/var/spack/repos/builtin/packages/bind9/package.py
@@ -19,7 +19,7 @@ class Bind9(AutotoolsPackage):
     depends_on("libuv", type="link")
     depends_on("pkgconfig", type="build")
     depends_on("openssl", type="link")
-    depends_on("libiconv", type="link")
+    depends_on("iconv", type="link")
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -269,9 +269,12 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         # also grab the headers from the bfd directory
         install(join_path(self.build_directory, "bfd", "*.h"), extradir)
 
-    def setup_build_environment(self, env):
-        if self.spec.satisfies("%cce"):
-            env.append_flags("LDFLAGS", "-Wl,-z,muldefs")
-
-        if "+nls" in self.spec:
-            env.append_flags("LDFLAGS", "-lintl")
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        if name == "ldflags":
+            if spec.satisfies("%cce"):
+                flags.append("-Wl,-z,muldefs")
+        elif name == "ldlibs":
+            if "+nls" in self.spec and "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
+        return self.build_system_flags(name, flags)

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -7,6 +7,7 @@ import glob
 import os.path
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Elfutils(AutotoolsPackage, SourcewarePackage):
@@ -99,7 +100,12 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         files = glob.glob(os.path.join("*", "Makefile.in"))
         filter_file("-Werror", "", *files)
 
-    flag_handler = AutotoolsPackage.build_system_flags
+    def flag_handler(self, name, flags):
+        if name == "ldlibs":
+            spec = self.spec
+            if "+nls" in spec and "intl" in spec["gettext"].libs.names:
+                flags.append("-lintl")
+        return self.inject_flags(name, flags)
 
     def configure_args(self):
         spec = self.spec
@@ -120,9 +126,19 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         # zlib is required
         args.append("--with-zlib=%s" % spec["zlib"].prefix)
 
+        if spec.satisfies("@0.183:"):
+            if spec["iconv"].name == "libc":
+                args.append("--without-libiconv-prefix")
+            elif not is_system_path(spec["iconv"].prefix):
+                args.append("--with-libiconv-prefix=" + format(spec["iconv"].prefix))
+
         if "+nls" in spec:
-            # configure doesn't use LIBS correctly
-            args.append("LDFLAGS=-Wl,--no-as-needed -L%s -lintl" % spec["gettext"].prefix.lib)
+            # Prior to 0.183, only msgfmt is used from gettext.
+            if spec.satisfies("@0.183:"):
+                if "intl" not in spec["gettext"].libs.names:
+                    args.append("--without-libintl-prefix")
+                elif not is_system_path(spec["gettext"].prefix):
+                    args.append("--with-libintl-prefix=" + spec["gettext"].prefix)
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -127,14 +127,20 @@ class Extrae(AutotoolsPackage):
             make.add_default_arg("CXXFLAGS=%s" % self.compiler.cxx11_flag)
             args.append("CXXFLAGS=%s" % self.compiler.cxx11_flag)
 
+        return args
+
+    def flag_handler(self, name, flags):
         # This was added due to:
         # - configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
         # - linking error
         # https://github.com/bsc-performance-tools/extrae/issues/57
-        args.append("LDFLAGS=-lintl -pthread")
-
-        return args
+        if name == "ldlibs":
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
+        elif name == "ldflags":
+            flags.append("-pthread")
+        return self.build_system_flags(name, flags)
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -75,7 +75,7 @@ class Ffmpeg(AutotoolsPackage):
     variant("libx264", default=False, description="H.264 encoding")
 
     depends_on("alsa-lib", when="platform=linux")
-    depends_on("libiconv")
+    depends_on("iconv")
     depends_on("yasm@1.2.0:")
     depends_on("zlib")
 

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -31,7 +31,7 @@ class Fsl(Package, CudaPackage):
     depends_on("expat")
     depends_on("libx11")
     depends_on("glu")
-    depends_on("libiconv")
+    depends_on("iconv")
     depends_on("openblas", when="@6:")
     depends_on("vtk@:8")
 
@@ -40,7 +40,7 @@ class Fsl(Package, CudaPackage):
 
     patch("build_log.patch")
     patch("eddy_Makefile.patch", when="@6.0.4")
-    patch("iconv.patch")
+    patch("iconv.patch", when="^libiconv")
     patch("fslpython_install_v5.patch", when="@:5")
     patch("fslpython_install_v604.patch", when="@6.0.4")
     patch("fslpython_install_v605.patch", when="@6.0.5")

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -9,7 +9,7 @@ import sys
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
-from spack.util.environment import filter_system_paths
+from spack.util.environment import filter_system_paths, is_system_path
 
 
 class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
@@ -626,7 +626,6 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("hdf4", package="hdf"),
             self.with_or_without("hdf5", package="hdf5"),
             self.with_or_without("hdfs", package="hadoop"),
-            self.with_or_without("libiconv-prefix", variant="iconv", package="iconv"),
             self.with_or_without("idb", package="idb"),
             self.with_or_without("ingres", package="ingres"),
             self.with_or_without("jasper", package="jasper"),
@@ -680,6 +679,11 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("perl"),
             self.with_or_without("php"),
         ]
+        if "+iconv" in self.spec:
+            if self.spec["iconv"].name == "libc":
+                args.append("--without-libiconv-prefix")
+            elif not is_system_path(self.spec["iconv"].prefix):
+                args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
 
         # Renamed or modified flags
         if self.spec.satisfies("@3:"):

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Gettext(AutotoolsPackage, GNUMirrorPackage):
@@ -78,7 +79,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         config_args = [
             "--disable-java",
             "--disable-csharp",
-            "--with-libiconv-prefix={0}".format(spec["iconv"].prefix),
             "--with-included-glib",
             "--with-included-gettext",
             "--with-included-libcroco",
@@ -86,6 +86,11 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             "--with-lispdir=%s/emacs/site-lisp/gettext" % self.prefix.share,
             "--without-cvs",
         ]
+
+        if self.spec["iconv"].name == "libc":
+            config_args.append("--without-libiconv-prefix")
+        elif not is_system_path(self.spec["iconv"].prefix):
+            config_args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
 
         if "+curses" in spec:
             config_args.append("--with-ncurses-prefix={0}".format(spec["ncurses"].prefix))
@@ -111,6 +116,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             config_args.append("--with-included-libunistring")
 
         return config_args
+
+    @property
+    def gettext_libs(self):
+        return self.libs
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -118,10 +118,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         return config_args
 
     @property
-    def gettext_libs(self):
-        return self.libs
-
-    @property
     def libs(self):
         return find_libraries(
             ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "libintl"],

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Gnupg(AutotoolsPackage):
@@ -142,7 +143,6 @@ class Gnupg(AutotoolsPackage):
             "--disable-regex",
             "--with-zlib=" + self.spec["zlib"].prefix,
             "--without-tar",
-            "--without-libiconv-prefix",
             "--without-readline",
         ]
 
@@ -158,9 +158,12 @@ class Gnupg(AutotoolsPackage):
                     "--with-libassuan-prefix=" + self.spec["libassuan"].prefix,
                     "--with-ksba-prefix=" + self.spec["libksba"].prefix,
                     "--with-npth-prefix=" + self.spec["npth"].prefix,
-                    "--with-libiconv-prefix=" + self.spec["iconv"].prefix,
                 ]
             )
+            if self.spec["iconv"].name == "libc":
+                args.append("--without-libiconv-prefix")
+            elif not is_system_path(self.spec["iconv"].prefix):
+                args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
 
         if self.spec.satisfies("@:1"):
             args.extend(

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Groff(AutotoolsPackage, GNUMirrorPackage):
@@ -77,7 +78,10 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
         args.extend(self.with_or_without("x"))
         if "@1.22.4:" in self.spec:
             args.extend(self.with_or_without("uchardet"))
-        args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
+        if self.spec["iconv"].name == "libc":
+            args.append("--without-libiconv-prefix")
+        elif not is_system_path(self.spec["iconv"].prefix):
+            args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -81,10 +81,7 @@ class Krb5(AutotoolsPackage):
 
         return args
 
-    def setup_build_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["gettext"].prefix.lib)
-
     def flag_handler(self, name, flags):
-        if name == "ldlibs":
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
-        return (flags, None, None)
+        return inject_flags(name, flags)

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Lftp(AutotoolsPackage):
@@ -19,6 +20,7 @@ class Lftp(AutotoolsPackage):
     version("4.6.4", sha256="791e783779d3d6b519d0c23155430b9785f2854023eb834c716f5ba78873b15a")
 
     depends_on("expat")
+    depends_on("gettext")
     depends_on("iconv")
     depends_on("ncurses")
     depends_on("openssl")
@@ -26,11 +28,20 @@ class Lftp(AutotoolsPackage):
     depends_on("zlib")
 
     def configure_args(self):
-        return [
+        args = [
             "--with-expat={0}".format(self.spec["expat"].prefix),
-            "--with-libiconv={0}".format(self.spec["iconv"].prefix),
             "--with-openssl={0}".format(self.spec["openssl"].prefix),
             "--with-readline={0}".format(self.spec["readline"].prefix),
             "--with-zlib={0}".format(self.spec["zlib"].prefix),
             "--disable-dependency-tracking",
         ]
+        if self.spec["iconv"].name == "libc":
+            args.append("--without-libiconv-prefix")
+        elif not is_system_path(self.spec["iconv"].prefix):
+            args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
+        if "intl" not in self.spec["gettext"].libs.names:
+            args.append("--without-libintl-prefix")
+        elif not is_system_path(self.spec["gettext"].prefix):
+            args.append("--with-libintl-prefix={0}".format(self.spec["gettext"].prefix))
+
+        return args

--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Libarchive(AutotoolsPackage):
@@ -109,7 +110,7 @@ class Libarchive(AutotoolsPackage):
     depends_on("libxml2", when="xar=libxml2")
     depends_on("expat", when="xar=expat")
 
-    depends_on("libiconv", when="+iconv")
+    depends_on("iconv", when="+iconv")
 
     conflicts(
         "crypto=mbedtls", when="@:3.4.1", msg="mbed TLS is only supported from libarchive 3.4.2"
@@ -119,11 +120,19 @@ class Libarchive(AutotoolsPackage):
     # The build test suite cannot be built with Intel
 
     def configure_args(self):
+        spec = self.spec
         args = ["--without-libb2"]
         args += self.with_or_without("compression")
         args += self.with_or_without("crypto")
-        args += self.with_or_without("iconv")
         args += self.with_or_without("xar")
         args += self.enable_or_disable("programs")
+
+        if "+iconv" in spec:
+            if spec["iconv"].name == "libc":
+                args.append("--without-libiconv-prefix")
+            elif not is_system_path(spec["iconv"].prefix):
+                args.append("--with-libiconv-prefix={p}".format(p=spec["iconv"].prefix))
+        else:
+            args.append("--without-iconv")
 
         return args

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -26,9 +26,7 @@ class Libxpm(AutotoolsPackage, XorgPackage):
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 
-    def setup_build_environment(self, env):
-        # If libxpm is installed as an external package, gettext won't
-        # be available in the spec. See
-        # https://github.com/spack/spack/issues/9149 for details.
-        if "gettext" in self.spec and "intl" in self.spec["gettext"].libs.names:
-            env.append_flags("LDFLAGS", "-lintl")
+    def flag_handler(self, name, flags):
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return env_flags(name, flags)

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Mono(AutotoolsPackage):
@@ -74,6 +75,8 @@ class Mono(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        li = self.spec["iconv"].prefix
-        args.append("--with-libiconv-prefix={p}".format(p=li))
+        if self.spec["iconv"].name == "libc":
+            args.append("--without-libiconv-prefix")
+        elif not is_system_path(self.spec["iconv"].prefix):
+            args.append("--with-libiconv-prefix={p}".format(p=self.spec["iconv"].prefix))
         return args

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -94,7 +94,7 @@ class Neovim(CMakePackage):
     depends_on("jemalloc", type="link", when="platform=linux")
     depends_on("lua-lpeg")
     depends_on("lua-mpack")
-    depends_on("libiconv", type="link")
+    depends_on("iconv", type="link")
     depends_on("libtermkey", type="link")
     depends_on("libuv", type="link")
     depends_on("libluv", type="link")
@@ -117,7 +117,7 @@ class Neovim(CMakePackage):
     with when("@0.6:"):
         depends_on("cmake@3.10:", type="build")
         depends_on("gperf@3.1:", type="link")
-        depends_on("libiconv@1.15:", type="link")
+        conflicts("libiconv@:1.14")
         depends_on("libtermkey@0.22:", type="link")
         depends_on("libvterm@0.1.4:", type="link")
         depends_on("msgpack-c@3.0.0:", type="link")

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -29,9 +29,8 @@ class NfsUtils(AutotoolsPackage):
     depends_on("util-linux")
     depends_on("gettext")
 
-    def setup_build_environment(self, env):
-        env.append_flags("LIBS", "-lintl")
-
     def configure_args(self):
         args = ["--disable-gss", "--with-rpcgen=internal"]
+        if "intl" in self.spec["gettext"].libs.names:
+            args.append("LIBS=-lintl")
         return args

--- a/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
+++ b/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
@@ -27,9 +27,11 @@ class OciSystemdHook(AutotoolsPackage):
     depends_on("util-linux")
     depends_on("go-md2man")
 
-    def configure_args(self):
-        args = ["LDFLAGS=-lintl"]
-        return args
+    def flag_handler(self, name, flags):
+        if name == "ldlibs":
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
+        return self.build_system_flags(name, flags)
 
     def install(self, spec, prefix):
         oci_systemd_hook_jsondir = "oci_systemd_hook_jsondir="

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -595,7 +595,7 @@ class Opencv(CMakePackage, CudaPackage):
     with when("+wechat_qrcode"):
         conflicts("~dnn")
         conflicts("~imgproc")
-        depends_on("libiconv")
+        depends_on("iconv")
 
     with when("+xfeatures2d"):
         with when("+cuda"):

--- a/var/spack/repos/builtin/packages/pulseaudio/package.py
+++ b/var/spack/repos/builtin/packages/pulseaudio/package.py
@@ -37,7 +37,7 @@ class Pulseaudio(AutotoolsPackage):
     depends_on("gconf", when="+gconf")
     depends_on("json-c@0.11:")
     depends_on("libcap")
-    depends_on("libiconv")
+    depends_on("iconv")
     depends_on("libsndfile@1.0.18:")
     depends_on("libtool@2.4:")  # links to libltdl.so
     depends_on("libsm", when="+x11")

--- a/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
@@ -55,7 +55,7 @@ class PyOnnxRuntime(CMakePackage, PythonExtension):
     # https://github.com/cms-externals/onnxruntime/compare/5bc92df...d594f80
     patch("cms.patch", level=1, when="@1.7.2")
     # https://github.com/cms-externals/onnxruntime/compare/0d9030e...7a6355a
-    patch("cms_1_10.patch", when="@1.10")
+    patch("cms_1_10.patch", whe="@1.10")
     # https://github.com/microsoft/onnxruntime/issues/4234#issuecomment-698077636
     # only needed when iconv is provided by libiconv
     patch("libiconv.patch", level=0, when="@1.7.2 ^libiconv")

--- a/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
@@ -55,7 +55,7 @@ class PyOnnxRuntime(CMakePackage, PythonExtension):
     # https://github.com/cms-externals/onnxruntime/compare/5bc92df...d594f80
     patch("cms.patch", level=1, when="@1.7.2")
     # https://github.com/cms-externals/onnxruntime/compare/0d9030e...7a6355a
-    patch("cms_1_10.patch", whe="@1.10")
+    patch("cms_1_10.patch", when="@1.10")
     # https://github.com/microsoft/onnxruntime/issues/4234#issuecomment-698077636
     # only needed when iconv is provided by libiconv
     patch("libiconv.patch", level=0, when="@1.7.2 ^libiconv")

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -52,7 +52,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
     # https://github.com/cms-externals/onnxruntime/compare/5bc92df...d594f80
     patch("cms.patch", level=1, when="@1.7.2")
     # https://github.com/cms-externals/onnxruntime/compare/0d9030e...7a6355a
-    patch("cms_1_10.patch", whe="@1.10")
+    patch("cms_1_10.patch", when="@1.10")
     # https://github.com/microsoft/onnxruntime/issues/4234#issuecomment-698077636
     # only needed when iconv is provided by libiconv
     patch("libiconv.patch", level=0, when="@1.7.2 ^libiconv")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -368,10 +368,11 @@ class Qt(Package):
     # webkit requires libintl (gettext), but does not test for it
     # correctly, so add it here.
     def flag_handler(self, name, flags):
-        if "+webkit" in self.spec and name == "ldlibs":
-            flags.append("-lintl")
-
-        return (flags, None, None)
+        if self.name == "ldlibs":
+            spec = self.spec
+            if "+webkit" in spec and "intl" in spec["gettext"].libs.names:
+                flags.append("-lintl")
+        return self.inject_flags(name, flags)
 
     @when("@4 platform=darwin")
     def patch(self):

--- a/var/spack/repos/builtin/packages/r-rjava/package.py
+++ b/var/spack/repos/builtin/packages/r-rjava/package.py
@@ -27,7 +27,7 @@ class RRjava(RPackage):
     # these are not listed as dependencies but are needed
     depends_on("bzip2")
     depends_on("icu4c")
-    depends_on("libiconv")
+    depends_on("iconv")
     depends_on("pcre2")
     depends_on("xz")
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -20,7 +20,10 @@ class RpcsvcProto(AutotoolsPackage):
     depends_on("gettext")
 
     def configure_args(self):
-        return ["LIBS=-lintl"]
+        if "intl" in self.spec["gettext"].libs.names:
+            return ["LIBS=-lintl"]
+        else:
+            return []
 
     @run_before("build")
     def change_makefile(self):

--- a/var/spack/repos/builtin/packages/rrdtool/package.py
+++ b/var/spack/repos/builtin/packages/rrdtool/package.py
@@ -22,8 +22,9 @@ class Rrdtool(AutotoolsPackage):
     depends_on("perl-extutils-makemaker")
 
     def configure_args(self):
-        args = [
-            "LDFLAGS=-lintl",
-            "--with-systemdsystemunitdir=" + self.spec["rrdtool"].prefix.lib.systemd.system,
-        ]
-        return args
+        return ["--with-systemdsystemunitdir=" + self.spec["rrdtool"].prefix.lib.systemd.system]
+
+    def flag_handler(self, name, flags):
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return self.build_system_flags(name, flags)

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack.package import *
+from spack.util.environment import is_system_path
 
 
 class Subversion(AutotoolsPackage):
@@ -102,16 +103,14 @@ class Subversion(AutotoolsPackage):
             args.append("APXS=no")
 
         if "+nls" in spec:
-            args.extend(
-                [
-                    "LDFLAGS={0}".format(spec["gettext"].libs.search_flags),
-                    # Using .libs.link_flags is the canonical way to add these arguments,
-                    # but since libintl is much smaller than the rest and also the only
-                    # necessary one, we specify it by hand here.
-                    "LIBS=-lintl",
-                    "--enable-nls",
-                ]
-            )
+            args.append("--enable-nls")
+            if "intl" in spec["gettext"].libs.names:
+                # Using .libs.link_flags is the canonical way to add these arguments,
+                # but since libintl is much smaller than the rest and also the only
+                # necessary one, we would specify it by hand here
+                args.append("LIBS=-lintl")
+                if not is_system_path(spec["gettext"].prefix):
+                    args.append("LDFLAGS={0}".format(spec["gettext"].libs.search_flags))
         else:
             args.append("--disable-nls")
 

--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -28,6 +28,7 @@ class Systemtap(AutotoolsPackage):
     depends_on("py-setuptools", type="build")
     depends_on("python", type=("build", "run"))
 
-    def configure_args(self):
-        args = ["LDFLAGS=-lintl"]
-        return args
+    def flag_handler(self, name, flags):
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return self.build_system_flags(name, flags)

--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -28,7 +28,7 @@ class UniversalCtags(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("libiconv", type="link")
+    depends_on("iconv", type="link")
     depends_on("pkgconfig", type="build")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -32,10 +32,9 @@ class Xfd(AutotoolsPackage, XorgPackage):
     # Xfd requires libintl (gettext), but does not test for it
     # correctly, so add it here.
     def flag_handler(self, name, flags):
-        if name == "ldlibs":
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
-
-        return (flags, None, None)
+        return self.inject_flags(name, flags)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -25,8 +25,10 @@ class Xfsdump(MakefilePackage):
     depends_on("attr")
     depends_on("xfsprogs@:4.20.0")
 
-    def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-lintl")
+    def flag_handler(self, name, flags):
+        if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
+            flags.append("-lintl")
+        return build_system_flags(name, flags)
 
     def build(self, spec, prefix):
         make(

--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -28,7 +28,7 @@ class Xfsdump(MakefilePackage):
     def flag_handler(self, name, flags):
         if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
-        return build_system_flags(name, flags)
+        return env_flags(name, flags)
 
     def build(self, spec, prefix):
         make(

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -31,7 +31,7 @@ class Xfsprogs(AutotoolsPackage):
         elif name == "ldlibs":
             if "intl" in self.spec["gettext"].libs.names:
                 flags.append("-lintl")
-        return build_system_flags(name, iflags)
+        return build_system_flags(name, flags)
 
     def setup_build_environment(self, env):
         env.append_path("C_INCLUDE_PATH", self.spec["util-linux"].prefix.include.blkid)

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -25,21 +25,19 @@ class Xfsprogs(AutotoolsPackage):
     depends_on("util-linux")
 
     def flag_handler(self, name, flags):
-        iflags = []
         if name == "cflags":
             if self.spec.satisfies("@:5.4.0 %gcc@10:"):
-                iflags.append("-fcommon")
-        return (iflags, None, flags)
+                flags.append("-fcommon")
+        elif name == "ldlibs":
+            if "intl" in self.spec["gettext"].libs.names:
+                flags.append("-lintl")
+        return build_system_flags(name, iflags)
 
     def setup_build_environment(self, env):
         env.append_path("C_INCLUDE_PATH", self.spec["util-linux"].prefix.include.blkid)
 
     def configure_args(self):
-        args = [
-            "LDFLAGS=-lintl",
-            "--with-systemd-unit-dir=" + self.spec["xfsprogs"].prefix.lib.systemd.system,
-        ]
-        return args
+        return ["--with-systemd-unit-dir=" + self.spec["xfsprogs"].prefix.lib.systemd.system]
 
     def install(self, spec, prefix):
         make("install")


### PR DESCRIPTION
Following
[discussion](https://github.com/spack/spack/wiki/Telcon:-2023-02-08) re
#34541 and friends, I noted that I had a fork with comprehensive changes
purporting to solve the whole mess with `iconv`/`libiconv`/`libc`,
`libintl`/`libc`, and `gettext`, and all the dependents thereof.

This set of changes not only gives consistent build stack behavior with
respect to the above, but also works with externals.
