### PR TITLE
Tutorial fixes for next time

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -870,9 +870,11 @@ aws-isc-aarch64-protected-build:
 
 tutorial-pr-generate:
   extends: [ ".tutorial", ".pr-generate"]
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2021-05-05
 
 tutorial-protected-generate:
   extends: [ ".tutorial", ".protected-generate"]
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2021-05-05
 
 tutorial-pr-build:
   extends: [ ".tutorial", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -870,11 +870,11 @@ aws-isc-aarch64-protected-build:
 
 tutorial-pr-generate:
   extends: [ ".tutorial", ".pr-generate"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2021-05-05
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-05
 
 tutorial-protected-generate:
   extends: [ ".tutorial", ".protected-generate"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2021-05-05
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-05
 
 tutorial-pr-build:
   extends: [ ".tutorial", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,26 +23,26 @@ spack:
         - hdf5+hl+mpi ^mpich
         - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
-        - gcc@8.4.0
+        - gcc@12.1.0
         - mpileaks
         - lmod
         - macsio@1.1+scr^scr@2.0.0~fortran^silo~fortran^hdf5~fortran
-      - ['%gcc@7.5.0']
+      - ['%gcc@11.3.0']
   - gcc_old_packages:
-    - zlib%gcc@6.5.0
+    - zlib%gcc@10.4.0
   - clang_packages:
     - matrix:
       - [zlib, tcl ^zlib@1.2.8]
-      - ['%clang@7.0.0']
+      - ['%clang@14.0.0']
   - gcc_spack_built_packages:
     - matrix:
       - [netlib-scalapack]
       - [^mpich, ^openmpi]
       - [^openblas, ^netlib-lapack]
-      - ['%gcc@8.4.0']
+      - ['%gcc@12.1.0']
     - matrix:
       - [py-scipy^openblas, armadillo^openblas, netlib-lapack, openmpi, mpich, elpa^mpich]
-      - ['%gcc@8.4.0']
+      - ['%gcc@12.1.0']
   specs:
   - $gcc_system_packages
   - $gcc_old_packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -55,7 +55,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-05
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -15,9 +15,9 @@ spack:
     - matrix:
       - - zlib
         - zlib@1.2.8
-        - zlib@1.2.8 cppflags=-O3
+        - zlib@1.2.8 cflags=-O3
         - tcl
-        - tcl ^zlib@1.2.8 cppflags=-O3
+        - tcl ^zlib@1.2.8 cflags=-O3
         - hdf5
         - hdf5~mpi
         - hdf5+hl+mpi ^mpich


### PR DESCRIPTION
Use `cflags` instead of `cppflags`

Bump Ubuntu to 22.04 (@alalazo do you know where this image is created?)
