### PR TITLE
nag: update the versioning scheme

### DIFF
--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -4,7 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 from typing import List
+
+import llnl.util.lang
 
 import spack.compiler
 
@@ -32,7 +35,13 @@ class Nag(spack.compiler.Compiler):
     }
 
     version_argument = "-V"
-    version_regex = r"NAG Fortran Compiler Release ([0-9.]+)"
+
+    @classmethod
+    @llnl.util.lang.memoized
+    def extract_version_from_output(cls, output):
+        match = re.search(r"NAG Fortran Compiler Release (\d+).(\d+)\(.*\) Build (\d+)", output)
+        if match:
+            return ".".join(match.groups())
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -281,7 +281,7 @@ def test_oneapi_version_detection(version_str, expected_version):
         (
             "NAG Fortran Compiler Release 6.0(Hibiya) Build 1037\n"
             "Product NPL6A60NA for x86-64 Linux\n",
-            "6.0",
+            "6.0.1037",
         )
     ],
 )

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -17,6 +17,7 @@ class Nag(Package):
     homepage = "https://www.nag.com/nagware/np.asp"
     maintainers("skosukhin")
 
+    version("7.1.7125", sha256="738ed9ed943ebeb05d337cfdc603b9c88b8642b3d0cafea8d2872f36201adb37")
     version("7.1.7101", sha256="18640737b232cebeb532ba36187675cdaf36d5b1fc235a780fc9e588c19a3ed2")
     version("7.0.7048", sha256="6d509208533d79139e5a9f879b7b93e7b58372b78d404d51f35e491ecbaa54c7")
     version("6.2.6252", sha256="9b60f6ffa4f4be631079676963e74eea25e8824512e5c864eb06758b2a3cdd2d")

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -18,10 +18,20 @@ class Nag(Package):
     maintainers("skosukhin")
 
     version("7.1.7125", sha256="738ed9ed943ebeb05d337cfdc603b9c88b8642b3d0cafea8d2872f36201adb37")
-    version("7.1.7101", sha256="18640737b232cebeb532ba36187675cdaf36d5b1fc235a780fc9e588c19a3ed2")
+    version(
+        "7.1.7101",
+        sha256="18640737b232cebeb532ba36187675cdaf36d5b1fc235a780fc9e588c19a3ed2",
+        url="file://{0}/npl6a71na_amd64.tgz".format(os.getcwd()),
+        deprecated=True,
+    )
     version("7.0.7048", sha256="6d509208533d79139e5a9f879b7b93e7b58372b78d404d51f35e491ecbaa54c7")
     version("6.2.6252", sha256="9b60f6ffa4f4be631079676963e74eea25e8824512e5c864eb06758b2a3cdd2d")
-    version("6.1.6136", sha256="32580e0004e6798abf1fa52f0070281b28abeb0da2387530a4cc41218e813c7c")
+    version(
+        "6.1.6136",
+        sha256="32580e0004e6798abf1fa52f0070281b28abeb0da2387530a4cc41218e813c7c",
+        url="file://{0}/npl6a61na_amd64.tgz".format(os.getcwd()),
+        deprecated=True,
+    )
 
     # Licensing
     license_required = True

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -17,10 +17,10 @@ class Nag(Package):
     homepage = "https://www.nag.com/nagware/np.asp"
     maintainers("skosukhin")
 
-    version("7.1", sha256="18640737b232cebeb532ba36187675cdaf36d5b1fc235a780fc9e588c19a3ed2")
-    version("7.0", sha256="6d509208533d79139e5a9f879b7b93e7b58372b78d404d51f35e491ecbaa54c7")
-    version("6.2", sha256="9b60f6ffa4f4be631079676963e74eea25e8824512e5c864eb06758b2a3cdd2d")
-    version("6.1", sha256="32580e0004e6798abf1fa52f0070281b28abeb0da2387530a4cc41218e813c7c")
+    version("7.1.7101", sha256="18640737b232cebeb532ba36187675cdaf36d5b1fc235a780fc9e588c19a3ed2")
+    version("7.0.7048", sha256="6d509208533d79139e5a9f879b7b93e7b58372b78d404d51f35e491ecbaa54c7")
+    version("6.2.6252", sha256="9b60f6ffa4f4be631079676963e74eea25e8824512e5c864eb06758b2a3cdd2d")
+    version("6.1.6136", sha256="32580e0004e6798abf1fa52f0070281b28abeb0da2387530a4cc41218e813c7c")
 
     # Licensing
     license_required = True
@@ -37,7 +37,7 @@ class Nag(Package):
         # TODO: url and checksum are architecture dependent
         # TODO: We currently only support x86_64
         url = "https://www.nag.com/downloads/impl/npl6a{0}na_amd64.tgz"
-        return url.format(version.joined)
+        return url.format(version.up_to(2).joined)
 
     def install(self, spec, prefix):
         # Set installation directories


### PR DESCRIPTION
We have been ignoring the `Build` version number of the NAG compiler for too long and it's finally time to add it to the versioning scheme of the compiler. It looks like for every `<major>.<minor>` version it's possible to download only the latest `<build>` version. To be able to install other `<build>` versions, we have to rely on Spack's cache.