### PR TITLE
ci: re-enable macos stack, build in consistent path, do not relocate

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -46,7 +46,6 @@ default:
   script:
     - uname -a || true
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
-    - nproc || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
@@ -179,112 +178,119 @@ protected-publish:
 # still run on UO runners and be signed
 # using the previous approach.
 ########################################
-# .e4s-mac:
-#   variables:
-#     SPACK_CI_STACK_NAME: e4s-mac
-#   allow_failure: True
+.e4s-mac:
+  variables:
+    SPACK_CI_STACK_NAME: e4s-mac
+  allow_failure: True
 
-# .mac-pr:
-#   only:
-#   - /^pr[\d]+_.*$/
-#   - /^github\/pr[\d]+_.*$/
-#   variables:
-#     SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}"
-#     SPACK_PRUNE_UNTOUCHED: "True"
+.mac-pr:
+  only:
+  - /^pr[\d]+_.*$/
+  - /^github\/pr[\d]+_.*$/
+  variables:
+    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}"
+    SPACK_PRUNE_UNTOUCHED: "True"
 
-# .mac-protected:
-#   only:
-#   - /^develop$/
-#   - /^releases\/v.*/
-#   - /^v.*/
-#   - /^github\/develop$/
-#   variables:
-#     SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
+.mac-protected:
+  only:
+  - /^develop$/
+  - /^releases\/v.*/
+  - /^v.*/
+  - /^github\/develop$/
+  variables:
+    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
 
-# .mac-pr-build:
-#   extends: [ ".mac-pr", ".build" ]
-#   variables:
-#     AWS_ACCESS_KEY_ID: ${PR_MIRRORS_AWS_ACCESS_KEY_ID}
-#     AWS_SECRET_ACCESS_KEY: ${PR_MIRRORS_AWS_SECRET_ACCESS_KEY}
-# .mac-protected-build:
-#   extends: [ ".mac-protected", ".build" ]
-#   variables:
-#     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
-#     AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
-#     SPACK_SIGNING_KEY: ${PACKAGE_SIGNING_KEY}
+.mac-pr-build:
+  extends: [ ".mac-pr", ".build" ]
+  variables:
+    AWS_ACCESS_KEY_ID: ${PR_MIRRORS_AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${PR_MIRRORS_AWS_SECRET_ACCESS_KEY}
+.mac-protected-build:
+  extends: [ ".mac-protected", ".build" ]
+  variables:
+    AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
+    SPACK_SIGNING_KEY: ${PACKAGE_SIGNING_KEY}
 
-# e4s-mac-pr-generate:
-#   extends: [".e4s-mac", ".mac-pr"]
-#   stage: generate
-#   script:
-#     - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
-#     - . "./share/spack/setup-env.sh"
-#     - spack --version
-#     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
-#     - spack env activate --without-view .
-#     - spack ci generate --check-index-only
-#       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
-#       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
-#       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
-#   artifacts:
-#     paths:
-#       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
-#   tags:
-#   - lambda
-#   interruptible: true
-#   retry:
-#     max: 2
-#     when:
-#       - runner_system_failure
-#       - stuck_or_timeout_failure
-#   timeout: 60 minutes
+e4s-mac-pr-generate:
+  extends: [".e4s-mac", ".mac-pr"]
+  stage: generate
+  script:
+    - export SPACK_DISABLE_LOCAL_CONFIG=1
+    - export SPACK_USER_CACHE_PATH=$(pwd)/_user_cache
+    - . "./share/spack/setup-env.sh"
+    - spack --version
+    - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
+    - spack env activate --without-view .
+    - spack ci generate --check-index-only
+      --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
+      --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
+      --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
+  artifacts:
+    paths:
+      - "${CI_PROJECT_DIR}/jobs_scratch_dir"
+  tags:
+  - apple-clang-14
+  - m1
+  - macos-ventura
+  interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+  timeout: 60 minutes
 
-# e4s-mac-protected-generate:
-#   extends: [".e4s-mac", ".mac-protected"]
-#   stage: generate
-#   script:
-#     - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
-#     - . "./share/spack/setup-env.sh"
-#     - spack --version
-#     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
-#     - spack env activate --without-view .
-#     - spack ci generate --check-index-only
-#       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
-#       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
-#   artifacts:
-#     paths:
-#       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
-#   tags:
-#   - omicron
-#   interruptible: true
-#   retry:
-#     max: 2
-#     when:
-#       - runner_system_failure
-#       - stuck_or_timeout_failure
-#   timeout: 60 minutes
+e4s-mac-protected-generate:
+  extends: [".e4s-mac", ".mac-protected"]
+  stage: generate
+  script:
+    - export SPACK_DISABLE_LOCAL_CONFIG=1
+    - export SPACK_USER_CACHE_PATH=$(pwd)/_user_cache
+    - . "./share/spack/setup-env.sh"
+    - spack --version
+    - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
+    - spack env activate --without-view .
+    - spack ci generate --check-index-only
+      --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
+      --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
+      --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
+  artifacts:
+    paths:
+      - "${CI_PROJECT_DIR}/jobs_scratch_dir"
+  tags:
+  - apple-clang-14
+  - m1
+  - macos-ventura
+  interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+  timeout: 60 minutes
 
-# e4s-mac-pr-build:
-#   extends: [ ".e4s-mac", ".mac-pr-build" ]
-#   trigger:
-#     include:
-#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: e4s-mac-pr-generate
-#     strategy: depend
-#   needs:
-#     - artifacts: True
-#       job: e4s-mac-pr-generate
+e4s-mac-pr-build:
+  extends: [ ".e4s-mac", ".mac-pr-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-mac-pr-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-mac-pr-generate
 
-# e4s-mac-protected-build:
-#   extends: [ ".e4s-mac", ".mac-protected-build" ]
-#   trigger:
-#     include:
-#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: e4s-mac-protected-generate
-#     strategy: depend
-#   needs:
-#     - artifacts: True
-#       job: e4s-mac-protected-generate
+e4s-mac-protected-build:
+  extends: [ ".e4s-mac", ".mac-protected-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-mac-protected-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-mac-protected-generate
 
 ########################################
 # E4S pipeline

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -186,9 +186,8 @@ protected-publish:
 .mac-pr:
   only:
   - /^pr[\d]+_.*$/
-  - /^github\/pr[\d]+_.*$/
   variables:
-    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}"
+    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
     SPACK_PRUNE_UNTOUCHED: "True"
 
 .mac-protected:
@@ -196,7 +195,6 @@ protected-publish:
   - /^develop$/
   - /^releases\/v.*/
   - /^v.*/
-  - /^github\/develop$/
   variables:
     SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -5,73 +5,78 @@ spack:
     reuse: false
     unify: false
 
-  config:
-    concretizer: clingo
-    install_tree:
-      root: $SPACK_ROOT/opt/spack
-      padded_length: 512
-      projections:
-        all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
-
   packages:
     all:
-      compiler: [apple-clang@13.1.6]
+      require: "%apple-clang@14.0.0"
       target: [m1]
 
-  definitions:
-  - easy_specs:
-    - berkeley-db
-    - ncurses
-    - gcc
-    - py-jupyterlab
-    - py-scipy
-    - py-matplotlib
-    - py-pandas
-
-  - arch:
-    - '%apple-clang@13.1.6 target=m1'
+  compilers:
+  - compiler:
+      spec: apple-clang@14.0.0
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: /opt/homebrew/bin/gfortran-12
+        fc: /opt/homebrew/bin/gfortran-12
+      flags: {}
+      operating_system: ventura
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
 
   specs:
-
-  - matrix:
-    - - $easy_specs
-    - - $arch
+  - bash
+  - py-numpy
+  - py-scipy
+  - py-matplotlib
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s-mac" }
 
   gitlab-ci:
 
     script:
-      - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
-      - . "./share/spack/setup-env.sh"
-      - spack --version
-      - spack arch
-      - cd ${SPACK_CONCRETE_ENV_DIR}
-      - spack env activate --without-view .
-      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+    - uname -a || true
+    - ls -ld /opt/spack
+    - rm -rf /opt/spack/*
+    - rm -rf /opt/spack/.* || true
+    - cp -r $CI_PROJECT_DIR/* /opt/spack/.
+    - export SPACK_DISABLE_LOCAL_CONFIG=1
+    - export SPACK_USER_CACHE_PATH=$(pwd)/_user_cache
+    - . /opt/spack/share/spack/setup-env.sh
+    - spack --version
+    - spack arch
+    - spack compiler find
+    - spack compiler list
+    - cd ${SPACK_CONCRETE_ENV_DIR}
+    - spack env activate --without-view .
+    - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+    - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
 
     match_behavior: first
     mappings:
-      - match: ['os=monterey']
+      - match: ['os=ventura']
         runner-attributes:
           tags:
-          - lambda
+          - apple-clang-14
+          - m1
+          - macos-ventura
 
     broken-specs-url: "s3://spack-binaries/broken-specs"
 
     service-job-attributes:
       before_script:
+      - export SPACK_DISABLE_LOCAL_CONFIG=1
       - export SPACK_USER_CACHE_PATH=$(pwd)/.spack-user-cache
-      - export SPACK_USER_CONFIG_PATH=$(pwd)/.spack-user-config
-      - . "./share/spack/setup-env.sh"
+      - . share/spack/setup-env.sh
       - spack --version
       tags:
-      - lambda
+      - apple-clang-14
+      - m1
+      - macos-ventura
 
   cdash:
-    build-group: E4S Mac
+    build-group: E4S MacOS
     url: https://cdash.spack.io
     project: Spack Testing
     site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -41,6 +41,7 @@ spack:
     - rm -rf /opt/spack/*
     - rm -rf /opt/spack/.* || true
     - cp -r $CI_PROJECT_DIR/* /opt/spack/.
+    - cp -r $CI_PROJECT_DIR/.git /opt/spack/.
     - export SPACK_DISABLE_LOCAL_CONFIG=1
     - export SPACK_USER_CACHE_PATH=$(pwd)/_user_cache
     - . /opt/spack/share/spack/setup-env.sh


### PR DESCRIPTION
Try simple MacOS stack using:
* M1 Mac Studio
* MacOS Ventura
* `%apple-clang@14.0.0`

Build only a small Python stack to start.

Do not perform any relocation, always build in same path, until we figure out how to deal with Apple's trusted build preventing relocation (See Issue https://github.com/spack/spack/issues/32571)

Allow this pipeline to fail, mainly due to expectation of job timeouts in periods of high activity when our runner may not be able to keep up with load -- we don't want this pipeline to hold up PRs in that case.

CC @wspear