### PR TITLE
netcdf-fortran: fix static linking in some cases

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -37,6 +37,12 @@ class NetcdfFortran(AutotoolsPackage):
     depends_on("netcdf-c@4.7.4:", when="@4.5.3:")  # nc_def_var_szip required
     depends_on("doxygen", when="+doc", type="build")
 
+    # We need to use MPI wrappers when building against static MPI-enabled NetCDF and/or HDF5:
+    with when("^netcdf-c~shared"):
+        depends_on("mpi", when="^netcdf-c+mpi")
+        depends_on("mpi", when="^netcdf-c+parallel-netcdf")
+        depends_on("mpi", when="^hdf5+mpi~shared")
+
     # Enable 'make check' for NAG, which is too strict.
     patch("nag_testing.patch", when="@4.4.5%nag")
 
@@ -125,6 +131,12 @@ class NetcdfFortran(AutotoolsPackage):
                 # not run by default and explicitly disabled above. To avoid the
                 # configuration failure, we set the following cache variable:
                 config_args.append("ac_cv_func_MPI_File_open=yes")
+
+        if "~shared" in netcdf_c_spec:
+            nc_config = which("nc-config")
+            config_args.append("LIBS={0}".format(nc_config("--libs", output=str)))
+            if any(s in netcdf_c_spec for s in ["+mpi", "+parallel-netcdf", "^hdf5+mpi~shared"]):
+                config_args.append("CC=%s" % self.spec["mpi"].mpicc)
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -134,7 +134,7 @@ class NetcdfFortran(AutotoolsPackage):
 
         if "~shared" in netcdf_c_spec:
             nc_config = which("nc-config")
-            config_args.append("LIBS={0}".format(nc_config("--libs", output=str)))
+            config_args.append("LIBS={0}".format(nc_config("--libs", output=str).strip()))
             if any(s in netcdf_c_spec for s in ["+mpi", "+parallel-netcdf", "^hdf5+mpi~shared"]):
                 config_args.append("CC=%s" % self.spec["mpi"].mpicc)
 


### PR DESCRIPTION
I'm not ready yet to overhaul all NetCDF packages (and their dependencies) but this should be enough, for now, to produce static-only installations of `netcdf-fortran` and `netcdf-c` in some (maybe most) cases.