### PR TITLE
ci: gpu test stack: turn off cuda@11.7 builds

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -59,8 +59,6 @@ spack:
 
   specs:
   - kokkos +rocm amdgpu_target=gfx90a
-  - kokkos +wrapper +cuda cuda_arch=80 ^cuda@11.7.1
-  - raja +cuda cuda_arch=80 ^cuda@11.7.1
   - raja +cuda cuda_arch=80 ^cuda@12.0.0
 
   # FAILURES
@@ -106,14 +104,6 @@ spack:
         - kokkos +rocm amdgpu_target=gfx90a
         runner-attributes:
           tags: [ "rocm-5.4.0", "mi210" ]
-          variables:
-            CI_JOB_SIZE: large
-
-      - match:
-        - kokkos +cuda cuda_arch=80 ^cuda@11.7.1
-        - raja +cuda cuda_arch=80 ^cuda@11.7.1
-        runner-attributes:
-          tags: [ "nvidia-515.65.01", "cuda-11.7", "a100" ]
           variables:
             CI_JOB_SIZE: large
 


### PR DESCRIPTION
Turning these off so we can complete the upgrade of our GPU runners to NVIDIA Driver 525.85.12 and CUDA 12