### PR TITLE
py-radiant-mlhub: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
+++ b/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
@@ -14,6 +14,8 @@ class PyRadiantMlhub(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("0.5.5", sha256="93cabc3c8e9ba343cdb3b0bfaec01bf7a36aae75704fabfe96c8bf5cab9fa899")
+    version("0.5.3", sha256="f111983910e41f2ce40bf401ccf9e33b393e52cc1989f8f8b74c6b4e2bdd0127")
     version("0.5.2", sha256="d310afce962508a44c60f5738fef164c50e78f76c3e85813653824b39a189ca3")
     version("0.5.1", sha256="b7daff4a127e96e27c64eda66e393d9727e61a87c887f86738753486cc44fa46")
     version("0.5.0", sha256="fff788aaa5f8afcb0f6eabff4147eaaf7de375f0a43ecaf2238033fc3a62e2c2")
@@ -23,10 +25,9 @@ class PyRadiantMlhub(PythonPackage):
     version("0.3.0", sha256="dd66479f12317e7bf366abe8d692841485e9497918c30ab14cd6db9e69ce3dbb")
     version("0.2.2", sha256="0d9f634b7e29c7f7294b81a10cf712ac63251949a9c5a07aa6c64c0d5b77e1ba")
     version("0.2.1", sha256="75a2f096b09a87191238fe557dc64dda8c44156351b4026c784c848c7d84b6fb")
+    version("0.2.0", sha256="4a3e4c301c5e74f282bbf77b7d65db5a1d6c2a4dc6d18637eff6e1228ca2eb9d")
 
     depends_on("python@3.8:", when="@0.5:", type=("build", "run"))
-    depends_on("python@3.7:", when="@0.3:", type=("build", "run"))
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-click@7.1.2:8", when="@0.3:", type=("build", "run"))
     depends_on("py-click@7.1.2:7.1", when="@:0.2", type=("build", "run"))
@@ -48,4 +49,7 @@ class PyRadiantMlhub(PythonPackage):
     depends_on("py-tqdm@4.64:4", when="@0.5.0:0.5.1", type=("build", "run"))
     depends_on("py-tqdm@4.56:4", when="@0.3:0.4", type=("build", "run"))
     depends_on("py-tqdm@4.56", when="@:0.2", type=("build", "run"))
+    depends_on("py-urllib3@1.26.11:1.26", when="@0.5.5:", type=("build", "run"))
+
+    # Historical dependencies
     depends_on("py-typing-extensions@3.7:", when="@0.4.1:0.4 ^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.10.8 and Apple Clang 12.0.0.