### PR TITLE
Fix view support for optional Python extensions

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -113,9 +113,10 @@ class PythonExtension(spack.package_base.PackageBase):
         return conflicts
 
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
+        if not self.extendee_spec:
+            return super().add_files_to_view(view, merge_map, skip_if_exists)
+
         bin_dir = self.spec.prefix.bin
-        if self.extendee_spec is None:
-            return
         python_prefix = self.extendee_spec.prefix
         python_is_external = self.extendee_spec.external
         global_view = fs.same_path(python_prefix, view.get_projection_for_spec(self.spec))

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -114,6 +114,8 @@ class PythonExtension(spack.package_base.PackageBase):
 
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         bin_dir = self.spec.prefix.bin
+        if self.extendee_spec is None:
+            return
         python_prefix = self.extendee_spec.prefix
         python_is_external = self.extendee_spec.external
         global_view = fs.same_path(python_prefix, view.get_projection_for_spec(self.spec))


### PR DESCRIPTION
I have an environment containing a package (GDAL) which has an optional Python extension:
```python
extends("python", when="+python")
```
If `gdal+python` is in the spec, everything installs fine. However, if `gdal~python` is in the spec, the environment fails to symlink a view with the following error message:
```
Traceback (most recent call last):
  File "/projects/dali/spack/bin/spack", line 54, in <module>
    sys.exit(main())
  File "/projects/dali/spack/lib/spack/spack_installable/main.py", line 37, in main
    sys.exit(spack.main.main(argv))
  File "/projects/dali/spack/lib/spack/spack/main.py", line 1004, in main
    return _main(argv)
  File "/projects/dali/spack/lib/spack/spack/main.py", line 959, in _main
    return finish_parse_and_run(parser, cmd_name, env_format_error)
  File "/projects/dali/spack/lib/spack/spack/main.py", line 987, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
  File "/projects/dali/spack/lib/spack/spack/main.py", line 636, in _invoke_command
    return_val = command(parser, args)
  File "/projects/dali/spack/lib/spack/spack/cmd/install.py", line 513, in install
    reporter_factory=reporter_factory,
  File "/projects/dali/spack/lib/spack/spack/cmd/install.py", line 397, in install_all_specs_from_active_environment
    env.install_all(**install_kwargs)
  File "/projects/dali/spack/lib/spack/spack/environment/environment.py", line 1715, in install_all
    self.install_specs(None, **install_args)
  File "/projects/dali/spack/lib/spack/spack/environment/environment.py", line 1771, in install_specs
    self.regenerate_views()
  File "/projects/dali/spack/lib/spack/spack/environment/environment.py", line 1527, in regenerate_views
    view.regenerate(concretized_root_specs)
  File "/projects/dali/spack/lib/spack/spack/environment/environment.py", line 615, in regenerate
    raise e
  File "/projects/dali/spack/lib/spack/spack/environment/environment.py", line 599, in regenerate
    view.add_specs(*specs, with_dependencies=False)
  File "/projects/dali/spack/lib/spack/spack/filesystem_view.py", line 700, in add_specs
    spec.package.add_files_to_view(self, merge_map, skip_if_exists=False)
  File "/projects/dali/spack/lib/spack/spack/build_systems/python.py", line 119, in add_files_to_view
    python_prefix = self.extendee_spec.prefix
AttributeError: 'NoneType' object has no attribute 'prefix'
```
It seems like this function is being called even for packages where the extension is optional and deactivated. This PR is one proposed fix, although there may be a better place to fix this. But it allowed me to install my environment.