### PR TITLE
Fix kokkos package.py to filter spack wrappers in launch compiler and cmake configs

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -226,6 +226,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
+    # A few spack-generated files may include links to the spack compiler wrappers
+    # Filter these out to point to the proper compiler
+    filter_compiler_wrappers("kokkos_launch_compiler", 
+                             relative_root="bin")
+    filter_compiler_wrappers("KokkosConfigCommon.cmake", 
+                             relative_root=os.path.join("lib64", "cmake", "Kokkos"))
+    
     @classmethod
     def get_microarch(cls, target):
         """Get the Kokkos microarch name for a Spack target (spec.target)."""

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -226,12 +226,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
-    # A few spack-generated files may include links to the spack compiler wrappers
-    # Filter these out to point to the proper compiler
-    filter_compiler_wrappers("kokkos_launch_compiler", 
-                             relative_root="bin")
-    filter_compiler_wrappers("KokkosConfigCommon.cmake", 
-                             relative_root=os.path.join("lib64", "cmake", "Kokkos"))
+    # Filter spack-generated files that may include links to the 
+    # spack compiler wrappers
+    filter_compiler_wrappers("kokkos_launch_compiler", relative_root="bin")
+    filter_compiler_wrappers(
+        "KokkosConfigCommon.cmake", 
+        relative_root=os.path.join("lib64", "cmake", "Kokkos")
+    )
     
     @classmethod
     def get_microarch(cls, target):

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -230,8 +230,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # spack compiler wrappers
     filter_compiler_wrappers("kokkos_launch_compiler", relative_root="bin")
     filter_compiler_wrappers(
-        "KokkosConfigCommon.cmake",
-        relative_root=os.path.join("lib64", "cmake", "Kokkos")
+        "KokkosConfigCommon.cmake", relative_root=os.path.join("lib64", "cmake", "Kokkos")
     )
 
     @classmethod

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -226,14 +226,14 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
-    # Filter spack-generated files that may include links to the 
+    # Filter spack-generated files that may include links to the
     # spack compiler wrappers
     filter_compiler_wrappers("kokkos_launch_compiler", relative_root="bin")
     filter_compiler_wrappers(
-        "KokkosConfigCommon.cmake", 
+        "KokkosConfigCommon.cmake",
         relative_root=os.path.join("lib64", "cmake", "Kokkos")
     )
-    
+
     @classmethod
     def get_microarch(cls, target):
         """Get the Kokkos microarch name for a Spack target (spec.target)."""


### PR DESCRIPTION
Kokkos when compiled by spack without +wrapper could potentially capture the spack compiler wrappers, resulting in cmake configs and kokkos_launch_compiler incorrectly trying to run the spack compiler wrapper after installation.