### PR TITLE
py-pyscf: add v2.2.0,2.1.1,2.1.0 libcint: add v5.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/libcint/package.py
+++ b/var/spack/repos/builtin/packages/libcint/package.py
@@ -16,6 +16,7 @@ class Libcint(CMakePackage):
     #
     # Versions
     #
+    version("5.2.0", sha256="f9dba1040c445ee81ae5a2a59d9f1291fc0406edad0fb5ea37fceb66c2ef7799")
     version("5.1.3", sha256="a239275a0464360c904fd06e67d2e76ef1147e04bc634befb40c67d3e79b3638")
     version("3.0.13", sha256="ee64f0bc7fb6073063ac3c9bbef8951feada141e197b1a5cc389c8cccf8dc360")
     version("3.0.12", sha256="7409ef41f1465cf4c1ae9834dfc0b0585c0fdc63b55d8ee8b8a7a6d5e31f309d")

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -11,23 +11,28 @@ class PyPyscf(PythonPackage):
     """PySCF is a collection of electronic structure programs powered
     by Python."""
 
-    homepage = "https://sunqm.github.io/pyscf/"
+    homepage = "https://pyscf.org"
     git = "https://github.com/pyscf/pyscf"
 
     maintainers("naromero77")
 
+    version("2.1.1", tag="v2.1.1")
+    version("2.1.0", tag="v2.1.0")
     version("2.0.1", tag="v2.0.1")
     version("1.7.5", tag="v1.7.5")
     version("1.7.3", tag="v1.7.3")
 
     # dependencies
+    depends_on("cmake@3.10:", type="build", when="@2.1:")
     depends_on("cmake@2.8:", type="build")
+    depends_on("python@3.6:", type=("build", "run"), when="@2.1:")
     depends_on("python@2.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.8.0:", type=("build", "run"))
     depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@2:")
     conflicts("py-numpy@1.16:1.17", when="@2:")
     depends_on("py-scipy@0.12:", type=("build", "run"))
+    depends_on("py-scipy@0.19:", type=("build", "run"), when="@2.1:")
     conflicts("py-scipy@1.5.0:1.5.1", when="@2:")
     depends_on("py-h5py@2.3.0:", type=("build", "run"))
     depends_on("py-h5py@2.7.0:", type=("build", "run"), when="@2:")

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -35,7 +35,7 @@ class PyPyscf(PythonPackage):
     depends_on("py-scipy@0.12:", type=("build", "run"))
     depends_on("py-scipy@0.19:", type=("build", "run"), when="@2.1:")
     depends_on("py-scipy@:1.1.0", when="^python@:3.7 platform=darwin", type=("build", "run"))
-    conflicts("py-scipy@1.5.0:1.5.1", when="@2:")
+    conflicts("^py-scipy@1.5.0:1.5.1", when="@2:")
     depends_on("py-h5py@2.3.0:", type=("build", "run"))
     depends_on("py-h5py@2.7.0:", type=("build", "run"), when="@2:")
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -12,7 +12,7 @@ class PyPyscf(PythonPackage):
     by Python."""
 
     homepage = "https://pyscf.org"
-    url = "https://pypi.io/packages/source/p/pyscf/pyscf-2.2.0.tar.gz"
+    pypi = "pyscf/pyscf-2.2.0.tar.gz"
 
     maintainers("naromero77")
 

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -31,7 +31,7 @@ class PyPyscf(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.8.0:", type=("build", "run"))
     depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@2:")
-    conflicts("py-numpy@1.16:1.17", when="@2:")
+    conflicts("^py-numpy@1.16:1.17", when="@2:")
     depends_on("py-scipy@0.12:", type=("build", "run"))
     depends_on("py-scipy@0.19:", type=("build", "run"), when="@2.1:")
     depends_on("py-scipy@:1.1.0", when="^python@:3.7 platform=darwin", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -12,15 +12,16 @@ class PyPyscf(PythonPackage):
     by Python."""
 
     homepage = "https://pyscf.org"
-    git = "https://github.com/pyscf/pyscf"
+    url = "https://pypi.io/packages/source/p/pyscf/pyscf-2.2.0.tar.gz"
 
     maintainers("naromero77")
 
-    version("2.1.1", tag="v2.1.1")
-    version("2.1.0", tag="v2.1.0")
-    version("2.0.1", tag="v2.0.1")
-    version("1.7.5", tag="v1.7.5")
-    version("1.7.3", tag="v1.7.3")
+    version("2.2.0", sha256="8f65042cf7e86aa5088756988eb90418befcd18f07a6b8c597229a5f2ba4f644")
+    version("2.1.1", sha256="608442171f5db106b02a95c878c65798fbbd87dc0ce50551a2e081e7d206adb0")
+    version("2.1.0", sha256="45feecc9c9a0ce18dee73c5b178fb0faa3f0c0d3dd5f98b48dc2370c9e13d05b")
+    version("2.0.1", sha256="b2f00330f98edf7c5b8272904fc11ca74f4677219ba6468aaa7154580efd9edd")
+    version("1.7.5", sha256="52856b39f0ada2f6340757caa65dc5c1d9a3cdfceea2a6615ad8af92664a6c69")
+    version("1.7.3", sha256="62a26146a222140395b276ea33182f87809a21989ddcf78e2dcb8e35ebc57af2")
 
     # dependencies
     depends_on("cmake@3.10:", type="build", when="@2.1:")
@@ -33,6 +34,7 @@ class PyPyscf(PythonPackage):
     conflicts("py-numpy@1.16:1.17", when="@2:")
     depends_on("py-scipy@0.12:", type=("build", "run"))
     depends_on("py-scipy@0.19:", type=("build", "run"), when="@2.1:")
+    depends_on("py-scipy@:1.1.0", when="^python@:3.7 platform=darwin", type=("build", "run"))
     conflicts("py-scipy@1.5.0:1.5.1", when="@2:")
     depends_on("py-h5py@2.3.0:", type=("build", "run"))
     depends_on("py-h5py@2.7.0:", type=("build", "run"), when="@2:")


### PR DESCRIPTION
Note the most recent versions of the libxc library (6.1.0, 6.0.0) that py-pyscf depends on currently have broken download links.  Older versions appear to work fine, e.g.`spack install py-pyscf ^libxc@5.2.3` Current version dependencies are listed at https://pyscf.org/install.html#compiling-from-source-code
