### PR TITLE
Support pre-commit for styling

### DIFF
--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -53,6 +53,17 @@ jobs:
     - name: Run style tests
       run: |
           share/spack/qa/run-style-tests
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # @v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # @v2
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # @v3.0.0
   audit:
     uses: ./.github/workflows/audit.yaml
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+default_language_version:
+  python: python3
+
+# Most hooks should not operate on the external/vendored code, to avoid
+# refactoring all of it to fit the trend.
+exclude: ^lib/spack/external/
+
+repos:
+
+# ------------------------------------------------------------------------------------------------
+#  Formatting hooks:  Hooks that alter the syntax but not semantics of files
+# ------------------------------------------------------------------------------------------------
+
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+  # Blacken all Python code
+  - id: black
+    args: [--config, pyproject.toml]
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.12.0
+  hooks:
+  # Sort imports in all Python code
+  - id: isort
+    alias: isort-lib
+    args: [--settings-path, pyproject.toml]
+    files: ^lib/
+  # Sort imports in packages, and enforce a few extra rules
+  - id: isort
+    alias: isort-packages
+    args: [--settings-path, pyproject.toml,
+           # Packages should never import spack directly
+           --rm, spack, --rm, spack.pkgkit, --rm, spack.package_defs,
+           # Packages should always import spack.package.*
+           -a, 'from spack.package import *']
+    files: ^var/spack/repos/.*/package\.py$
+
+
+# ------------------------------------------------------------------------------------------------
+#  Linting hooks:  Hooks that do not alter files but ensures that they satisfy various conditions
+# ------------------------------------------------------------------------------------------------
+
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.0.0
+  hooks:
+  # All Python code must be Flake8-clean
+  - id: flake8
+    args: [--config, .flake8]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.0.1
+  hooks:
+  # Ensure the Spack core is also MyPy-clean
+  - id: mypy
+    alias: mypy-lib
+    args: [--config-file, pyproject.toml, --show-error-codes]
+    files: ^lib/spack/(llnl|spack)/
+  # Ensure packages are also MyPy-clean
+  - id: mypy
+    alias: mypy-packages
+    additional_dependencies: [types-six]
+    args: [--config-file, pyproject.toml, --show-error-codes, --explicit-package-bases,
+           --disable-error-code, no-redef]
+    # FIXME: We are playing tricks to make MyPy see all the package.py's as
+    # different "modules," but this trick doesn't work for packages who's names
+    # are not valid Python identifiers, e.g. 7zip or py-pip. These packages are
+    # currently excluded from the regex below.
+    files: ^var/spack/repos/builtin/packages/[a-zA-Z_]\w*/package\.py$

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -7,7 +7,7 @@ import os
 import os.path
 import stat
 import subprocess
-from typing import List
+from typing import List, Tuple
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -107,7 +107,7 @@ class AutotoolsBuilder(BaseBuilder):
     """
 
     #: Phases of a GNU Autotools package
-    phases = ("autoreconf", "configure", "build", "install")
+    phases: Tuple[str, ...] = ("autoreconf", "configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("configure_args", "check", "installcheck")

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -32,7 +32,7 @@ class GenericBuilder(BaseBuilder):
     """
 
     #: A generic package has only the "install" phase
-    phases = ("install",)
+    phases: Tuple[str, ...] = ("install",)
 
     #: Names associated with package methods in the old build-system format
     legacy_methods: Tuple[str, ...] = ()

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
-from typing import List
+from typing import List, Tuple
 
 import llnl.util.filesystem as fs
 
@@ -62,7 +62,7 @@ class MakefileBuilder(BaseBuilder):
         +-----------------------------------------------+--------------------+
     """
 
-    phases = ("edit", "build", "install")
+    phases: Tuple[str, ...] = ("edit", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("check", "installcheck")

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from typing import Tuple
+
 import llnl.util.filesystem as fs
 
 import spack.builder
@@ -42,7 +44,7 @@ class MavenBuilder(BaseBuilder):
         2. :py:meth:`~.MavenBuilder.install`
     """
 
-    phases = ("build", "install")
+    phases: Tuple[str, ...] = ("build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("build_args",)

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 import os
-from typing import List
+from typing import List, Tuple
 
 import llnl.util.filesystem as fs
 
@@ -80,7 +80,7 @@ class MesonBuilder(BaseBuilder):
         +-----------------------------------------------+--------------------+
     """
 
-    phases = ("meson", "build", "install")
+    phases: Tuple[str, ...] = ("meson", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("meson_args", "check")

--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 from typing import List  # novm
+from typing import Tuple
 
 import llnl.util.filesystem as fs
 
@@ -59,7 +60,7 @@ class MSBuildBuilder(BaseBuilder):
         +-----------------------------------------------+---------------------+
     """
 
-    phases = ("build", "install")
+    phases: Tuple[str, ...] = ("build", "install")
 
     #: Targets for ``make`` during the :py:meth:`~.MSBuildBuilder.build` phase
     build_targets: List[str] = []

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 from typing import List  # novm
+from typing import Tuple
 
 import llnl.util.filesystem as fs
 
@@ -59,7 +60,7 @@ class NMakeBuilder(BaseBuilder):
         +-----------------------------------------------+---------------------+
     """
 
-    phases = ("build", "install")
+    phases: Tuple[str, ...] = ("build", "install")
 
     #: Targets for ``make`` during the :py:meth:`~.NMakeBuilder.build` phase
     build_targets: List[str] = []

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
+from typing import Tuple
 
 import spack.builder
 import spack.package_base
@@ -37,7 +38,7 @@ class OctaveBuilder(BaseBuilder):
     1. :py:meth:`~.OctaveBuilder.install`
     """
 
-    phases = ("install",)
+    phases: Tuple[str, ...] = ("install",)
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ()

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 import os
+from typing import Tuple
 
 from llnl.util.filesystem import filter_file
 
@@ -50,7 +51,7 @@ class PerlBuilder(BaseBuilder):
     """
 
     #: Phases of a Perl package
-    phases = ("configure", "build", "install")
+    phases: Tuple[str, ...] = ("configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("configure_args", "check")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -6,7 +6,7 @@ import inspect
 import os
 import re
 import shutil
-from typing import Optional
+from typing import Optional, Tuple
 
 import archspec
 
@@ -345,7 +345,7 @@ class PythonPackage(PythonExtension):
 
 @spack.builder.builder("python_pip")
 class PythonPipBuilder(BaseBuilder):
-    phases = ("install",)
+    phases: Tuple[str, ...] = ("install",)
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("test",)

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
+from typing import Tuple
 
 from llnl.util.filesystem import working_dir
 
@@ -43,7 +44,7 @@ class QMakeBuilder(BaseBuilder):
     necessary will be to override :py:meth:`~.QMakeBuilder.qmake_args`.
     """
 
-    phases = ("qmake", "build", "install")
+    phases: Tuple[str, ...] = ("qmake", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("qmake_args", "check")

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import glob
 import inspect
+from typing import Tuple
 
 import spack.builder
 import spack.package_base
@@ -36,7 +37,7 @@ class RubyBuilder(BaseBuilder):
     #. :py:meth:`~.RubyBuilder.install`
     """
 
-    phases = ("build", "install")
+    phases: Tuple[str, ...] = ("build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ()

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
+from typing import Tuple
 
 import spack.builder
 import spack.package_base
@@ -43,7 +44,7 @@ class SConsBuilder(BaseBuilder):
     """
 
     #: Phases of a SCons package
-    phases = ("build", "install")
+    phases: Tuple[str, ...] = ("build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("build_test",)

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -5,6 +5,7 @@
 import inspect
 import os
 import re
+from typing import Tuple
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import find, join_path, working_dir
@@ -113,7 +114,7 @@ class SIPBuilder(BaseBuilder):
     options, run ``python configure.py --help``.
     """
 
-    phases = ("configure", "build", "install")
+    phases: Tuple[str, ...] = ("configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = ("configure_file", "configure_args", "build_args", "install_args")

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
+from typing import Tuple
 
 from llnl.util.filesystem import working_dir
 
@@ -57,7 +58,7 @@ class WafBuilder(BaseBuilder):
     function, which passes ``--prefix=/path/to/installation/prefix``.
     """
 
-    phases = ("configure", "build", "install")
+    phases: Tuple[str, ...] = ("configure", "build", "install")
 
     #: Names associated with package methods in the old build-system format
     legacy_methods = (

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -7,7 +7,7 @@ import collections.abc
 import copy
 import functools
 import inspect
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import spack.build_environment
 
@@ -581,5 +581,14 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
 
 
 # Export these names as standalone to be used in packages
-run_after = PhaseCallbacksMeta.run_after
-run_before = PhaseCallbacksMeta.run_before
+if TYPE_CHECKING:
+
+    def run_after(phase, when=None):
+        return PhaseCallbacksMeta.run_after(phase, when=when)
+
+    def run_before(phase, when=None):
+        return PhaseCallbacksMeta.run_before(phase, when=when)
+
+else:
+    run_after = PhaseCallbacksMeta.run_after
+    run_before = PhaseCallbacksMeta.run_before

--- a/var/spack/repos/builtin/packages/blast-legacy/package.py
+++ b/var/spack/repos/builtin/packages/blast-legacy/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/circos/package.py
+++ b/var/spack/repos/builtin/packages/circos/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -414,7 +414,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
 
 
 class NMakeBuilder(NMakeBuilder):
-    phases = ["install"]
+    phases = ("install",)
 
     def nmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/ds/package.py
+++ b/var/spack/repos/builtin/packages/ds/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/fasttree/package.py
+++ b/var/spack/repos/builtin/packages/fasttree/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/homer/package.py
+++ b/var/spack/repos/builtin/packages/homer/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/intel-pin/package.py
+++ b/var/spack/repos/builtin/packages/intel-pin/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import datetime as dt
+from typing import Dict
 
 import archspec
 
@@ -343,7 +344,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     # with the pre-existing `openmp` variant
     # version ranges generates using utility script:
     # https://gist.github.com/rbberger/fdaa38ff08e5961c4741624a4719cdb6
-    supported_packages = {
+    supported_packages: Dict[str, dict] = {
         "adios": {"when": "@20210702:"},
         "amoeba": {"when": "@20220803:"},
         "asphere": {},

--- a/var/spack/repos/builtin/packages/libmolgrid/package.py
+++ b/var/spack/repos/builtin/packages/libmolgrid/package.py
@@ -33,8 +33,5 @@ class Libmolgrid(CMakePackage):
         ob_incl = os.path.join(self.spec["openbabel"].prefix.include, "openbabel3")
         ob_libs = self.spec["openbabel"].libs.joined(";")
 
-        args = [
-            "-DOPENBABEL3_INCLUDE_DIR=" + ob_incl,
-            "-DOPENBABEL3_LIBRARIES=" + ob_libs,
-        ]
+        args = ["-DOPENBABEL3_INCLUDE_DIR=" + ob_incl, "-DOPENBABEL3_LIBRARIES=" + ob_libs]
         return args

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -36,7 +36,7 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
 
 
 class GenericBuilder(GenericBuilder):
-    phases = ["build", "install"]
+    phases = ("build", "install")
 
     def is_64bit(self):
         return "64" in self.pkg.spec.target.family

--- a/var/spack/repos/builtin/packages/ltr-retriever/package.py
+++ b/var/spack/repos/builtin/packages/ltr-retriever/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-jax/package.py
+++ b/var/spack/repos/builtin/packages/py-jax/package.py
@@ -34,11 +34,7 @@ class PyJax(PythonPackage):
     depends_on("py-scipy@1.2.1:", type=("build", "run"))
 
     # See _minimum_jaxlib_version in jax/version.py
-    jax_to_jaxlib = {
-        "0.4.3": "0.4.2",
-        "0.3.23": "0.3.15",
-        "0.2.25": "0.1.69",
-    }
+    jax_to_jaxlib = {"0.4.3": "0.4.2", "0.3.23": "0.3.15", "0.2.25": "0.1.69"}
 
     for jax, jaxlib in jax_to_jaxlib.items():
         depends_on(f"py-jaxlib@{jaxlib}:", when=f"@{jax}", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-nltk/resourcegen.py
+++ b/var/spack/repos/builtin/packages/py-nltk/resourcegen.py
@@ -6,7 +6,6 @@ import hashlib
 import sys
 import urllib.request
 import xml.etree.ElementTree
-from typing import Optional
 
 url = None  # type: Optional[str]
 url = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/index.xml"

--- a/var/spack/repos/builtin/packages/recon/package.py
+++ b/var/spack/repos/builtin/packages/recon/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/rmats/package.py
+++ b/var/spack/repos/builtin/packages/rmats/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/smof/package.py
+++ b/var/spack/repos/builtin/packages/smof/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 # See the Spack documentation for more information on packaging.
 
-from os import symlink
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/sombrero/package.py
+++ b/var/spack/repos/builtin/packages/sombrero/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 


### PR DESCRIPTION
Currently the canonical way to format and lint any Spack changes is to run `spack style`. This PR adds a slightly more convenient alternative that runs during `git commit` via [`pre-commit`](https://pre-commit.com). Just run `pre-commit install` in your checkouts and never `spack style` again!

The included configuration tries to replicate the effect of `spack style --fix` as closely as possible (`pre-commit` by design is always in `--fix` mode). The command that runs all hooks on all files, `pre-commit run -a`, is added as part of the `prechecks` phase in CI.

This new framework exposes latent linter failures in the codebase. Most (but not all) of these are simply missing type annotations, so this PR also provides simple and unobtrusive fixes to pass pre-commit.