### PR TITLE
nonexistent module concise error message

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -405,7 +405,7 @@ def get_module(module_type, spec, get_full_path, module_set_name="default", requ
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:
                 raise ModuleNotFoundError(
-                    "The module for package {} should be at {} but it does not exist!".format(
+                    "The module for package {} should be at {}, but it does not exist".format(
                         spec.format(fmt_str), writer.layout.filename
                     )
                 )

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -403,9 +403,7 @@ def get_module(module_type, spec, get_full_path, module_set_name="default", requ
         writer = spack.modules.module_types[module_type](spec, module_set_name)
         if not os.path.isfile(writer.layout.filename):
             if not writer.conf.excluded:
-                err_msg = "No module available for package {0} at {1}".format(
-                    spec, writer.layout.filename
-                )
+                err_msg = f"The module for package {spec.name}@{spec.version}/{spec.dag_hash()[:10]} should be at {writer.layout.filename} but it does not exist!"
                 raise ModuleNotFoundError(err_msg)
             elif required:
                 tty.debug("The module configuration has excluded {0}: " "omitting it".format(spec))

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -403,7 +403,8 @@ def get_module(module_type, spec, get_full_path, module_set_name="default", requ
         writer = spack.modules.module_types[module_type](spec, module_set_name)
         if not os.path.isfile(writer.layout.filename):
             if not writer.conf.excluded:
-                err_msg = f"The module for package {spec.name}@{spec.version}/{spec.dag_hash()[:10]} should be at {writer.layout.filename} but it does not exist!"
+                err_msg = f"The module for package {spec.name}@{spec.version}/{spec.dag_hash()[:10]}\
+                    should be at {writer.layout.filename} but it does not exist!"
                 raise ModuleNotFoundError(err_msg)
             elif required:
                 tty.debug("The module configuration has excluded {0}: " "omitting it".format(spec))

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -402,12 +402,19 @@ def get_module(module_type, spec, get_full_path, module_set_name="default", requ
     else:
         writer = spack.modules.module_types[module_type](spec, module_set_name)
         if not os.path.isfile(writer.layout.filename):
+            fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:
-                err_msg = f"The module for package {spec.name}@{spec.version}/{spec.dag_hash()[:10]}\
-                    should be at {writer.layout.filename} but it does not exist!"
-                raise ModuleNotFoundError(err_msg)
+                raise ModuleNotFoundError(
+                    "The module for package {} should be at {} but it does not exist!".format(
+                        spec.format(fmt_str), writer.layout.filename
+                    )
+                )
             elif required:
-                tty.debug("The module configuration has excluded {0}: " "omitting it".format(spec))
+                tty.debug(
+                    "The module configuration has excluded {}: omitting it".format(
+                        spec.format(fmt_str)
+                    )
+                )
             else:
                 return None
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/90859533/219241114-4a82a24b-c2d9-4ab0-ae22-8a64808d393a.png)

After:
![image](https://user-images.githubusercontent.com/90859533/219241163-f4bc4bd8-4834-4b29-83b7-67c40c899c37.png)

In the before case, I didn't realize that the information I was looking for (the module location) was right in front of me, because it was buried under all that crap.