### PR TITLE
QE: Adding support for AOCC 4.0 and zen4

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/configure_qe-7.1_aocc.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/configure_qe-7.1_aocc.patch
@@ -1,0 +1,76 @@
+diff --git a/install/configure b/install/configure_aocc
+index c8f62eb..bca4e4d 100755
+--- a/install/configure
++++ b/install/configure_aocc
+@@ -3183,6 +3183,7 @@ echo $ECHO_N "checking version of $mpif90... $ECHO_C"
+ ifort_version=`$mpif90 -V 2>&1 | grep "Intel(R)"`
+ pgf_version=`$mpif90 -V 2>&1 | grep "^pgf"`
+ nvfortran_version=`$mpif90 -V 2>&1 | grep "^nvfortran"`
++aoccflang_version=`$mpif90 -v 2>&1 | grep "AMD clang version"`
+ gfortran_version=`$mpif90 -v 2>&1 | grep "gcc version"`
+ nagfor_version=`$mpif90 -v 2>&1 | grep "NAG Fortran"`
+ xlf_version=`$mpif90 -v 2>&1 | grep "xlf"`
+@@ -3203,6 +3204,12 @@ then
+ 	f90_minor_version=`echo $version | cut -d. -f2 | cut -d- -f1`
+         echo "${ECHO_T}nvfortran $version"
+         f90_in_mpif90="nvfortran"
++elif test "$aoccflang_version" != ""
++then
++        version=`echo $aoccflang_version | cut -d" " -f 5`
++        echo "${ECHO_T}mpif90 $version"
++        f90_in_mpif90="mpif90"
++        try_foxflags="-D__PGI"	
+ elif test "$pgf_version" != ""
+ then
+         version=`echo $pgf_version | cut -d ' ' -f2`
+@@ -3374,6 +3381,9 @@ ppc64-bg*:*xlf90_r )
+ ppc64-bg*:*xlf90 )
+         try_cc="bgxlc"
+         ;;
++*:mpif90 )
++        try_cc="mpicc $try_cc"
++        ;;	
+ ppc64:*xlf* | ppc64le:*xlf* )
+         try_cc="xlc_r $try_cc"
+         ;;
+@@ -3763,11 +3773,14 @@ ppc64-bg:* )
+ ppc64-bgq:* )
+         try_cflags="-O3"
+         ;;
++x86_64:* )
++        try_cflags="-Ofast -Mstack_arrays"
++        try_dflags="-D__OPENMP"
++        ;;
+ ppc64:xlc*)
+         try_cflags="-O3 -q64 -qthreaded"
+         c_ldflags="-q64"
+         ;;
+-
+ esac
+ if test "$cflags" = "" ; then cflags=$try_cflags ; fi
+ echo setting CFLAGS... $cflags
+@@ -3926,6 +3939,16 @@ x86_64:nagfor* )
+         try_dflags="$try_dflags -D__NAG"
+         have_cpp=0
+         ;;
++*:*mpif90 )
++        try_fflags="-Ofast -Mstack_arrays"
++        try_fflags_openmp="-fopenmp"
++        try_f90flags=" \$(FFLAGS) -cpp -Ofast -Mpreprocess -Mstack_arrays"
++        try_foxflags="-D__PGI"
++        try_fflags_noopt="-O0"
++        try_ldflags=""
++        try_ldflags_openmp="-fopenmp"
++        try_ldflags_static="-static"
++        ;;
+ craype*:cray* )
+         try_fflags_nomain=""
+         #NOTE: by default OpenMP is always ON (see crayftn man page)
+@@ -7392,6 +7415,7 @@ $as_echo "$as_me: WARNING: *** HDF5 version must be 1.8.16 or later" >&2;};
+                 hdf5_libs=$with_hdf5_libline
+              else
+                 hdf5_libs=`$with_hdf5_path/bin/h5pfc -show | awk -F'-L' '{$1=""; for (i=2; i<=NF;i++) $i="-L"$i; print $0}'`
++		hdf5_libs=`$with_hdf5_path/bin/h5pfc -show | awk -F'-L' '{$1=""; for (i=2; i<=NF;i++) $i="-L"$i; print $0}' | xargs`
+              fi
+          elif command -v h5pfc >/dev/null; then
+              if test $with_hdf5_libs -eq 1; then

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -368,6 +368,7 @@ class QuantumEspresso(CMakePackage, Package):
 
     # Configure updated to work with AOCC compilers
     patch("configure_aocc.patch", when="@6.7:7.0 %aocc")
+    patch("configure_qe-7.1_aocc.patch", when="@7.1: %aocc")
 
     # Configure updated to work with NVIDIA compilers
     patch("nvhpc.patch", when="@6.5 %nvhpc")
@@ -601,6 +602,9 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
             parallel_build_on = False
         else:
             parallel_build_on = True
+        # Parallel build fails with 7.1 
+        if spec.satisfies("@7.1"):
+            parallel_build_on = False    
 
         if "+epw" in spec:
             make("all", "epw", parallel=parallel_build_on)

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -592,7 +592,7 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
                 filter_file(zlib_libs, format(spec["zlib"].libs.ld_flags), make_inc)
 
         # Filer file must be applied for AOCC due to incorrect make.inc generation
-        if spec.satisfies("%aocc") and spec.satisfies("@6.8:"):
+        if spec.satisfies("@6.8: %aocc"):
             make_inc = join_path(self.stage.source_path, "make.inc")
             filter_file("FOX_FLAGS = -D__PGI", "FOX_FLAGS = -D__PGI -cpp", make_inc)
 

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -596,15 +596,14 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
             make_inc = join_path(self.stage.source_path, "make.inc")
             filter_file("FOX_FLAGS = -D__PGI", "FOX_FLAGS = -D__PGI -cpp", make_inc)
 
-
         # QE 6.8 and later has parallel builds fixed
         if spec.satisfies("@:6.7"):
             parallel_build_on = False
         else:
             parallel_build_on = True
-        # Parallel build fails with 7.1 
+        # Parallel build fails with 7.1
         if spec.satisfies("@7.1"):
-            parallel_build_on = False    
+            parallel_build_on = False
 
         if "+epw" in spec:
             make("all", "epw", parallel=parallel_build_on)

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -367,7 +367,7 @@ class QuantumEspresso(CMakePackage, Package):
     )
 
     # Configure updated to work with AOCC compilers
-    patch("configure_aocc.patch", when="@6.7:6.8 %aocc")
+    patch("configure_aocc.patch", when="@6.7:7.0 %aocc")
 
     # Configure updated to work with NVIDIA compilers
     patch("nvhpc.patch", when="@6.5 %nvhpc")
@@ -589,6 +589,12 @@ class GenericBuilder(spack.build_systems.generic.GenericBuilder):
                 make_inc = join_path(self.pkg.stage.source_path, "make.inc")
                 zlib_libs = spec["zlib"].prefix.lib + " -lz"
                 filter_file(zlib_libs, format(spec["zlib"].libs.ld_flags), make_inc)
+
+        # Filer file must be applied for AOCC due to incorrect make.inc generation
+        if spec.satisfies("%aocc") and spec.satisfies("@6.8:"):
+            make_inc = join_path(self.stage.source_path, "make.inc")
+            filter_file("FOX_FLAGS = -D__PGI", "FOX_FLAGS = -D__PGI -cpp", make_inc)
+
 
         # QE 6.8 and later has parallel builds fixed
         if spec.satisfies("@:6.7"):


### PR DESCRIPTION
This pull request adds support for AOCC compiler for QE 7.1 and fixes compatibility between AOCC and QE 7.0