### PR TITLE
Enforce carriage return on Windows bat files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.py diff=python
 *.lp linguist-language=Prolog
 lib/spack/external/* linguist-vendored
+*.bat text eol=crlf

--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -226,7 +226,7 @@ for %%Z in ("%_pa_new_path%") do if EXIST %%~sZ\NUL (
 exit /b 0
 
 :: set module system roots
-:_sp_multi_pathadd 
+:_sp_multi_pathadd
 for %%I in (%~2) do (
     for %%Z in (%_sp_compatible_sys_types%) do (
         :pathadd "%~1" "%%I\%%Z"


### PR DESCRIPTION
Batch scripts in general will not function without carriage return line endings on Windows. We rely on these scripts to support cmd, so we should not allow these scripts to be converted to lf. Note: Windows 11 supports lf line endings due to the use of Windows Terminal. Once support for Windows 10 is dropped, this change can be reverted.