### PR TITLE
Package slate,blaspp,lapackpp: Updating download locations

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -13,9 +13,9 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
     Innovative Computing Laboratory at the University of Tennessee,
     Knoxville."""
 
-    homepage = "https://bitbucket.org/icl/blaspp"
+    homepage = "https://github.com/icl-utk-edu/blaspp"
     git = homepage
-    url = "https://bitbucket.org/icl/blaspp/downloads/blaspp-2020.09.00.tar.gz"
+    url = "https://github.com/icl-utk-edu/blaspp/releases/download/v2023.01.00/blaspp-2023.01.00.tar.gz"
     maintainers("teonnik", "Sely85", "G-Ragghianti", "mgates3")
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -25,9 +25,9 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     by the Innovative Computing Laboratory at the University of Tennessee,
     Knoxville."""
 
-    homepage = "https://bitbucket.org/icl/lapackpp"
+    homepage = "https://github.com/icl-utk-edu/lapackpp"
     git = homepage
-    url = "https://bitbucket.org/icl/lapackpp/downloads/lapackpp-2020.09.00.tar.gz"
+    url = "https://github.com/icl-utk-edu/lapackpp/releases/download/v2023.01.00/lapackpp-2023.01.00.tar.gz"
     maintainers("teonnik", "Sely85", "G-Ragghianti", "mgates3")
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -16,8 +16,8 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     solvers."""
 
     homepage = "https://icl.utk.edu/slate/"
-    git = "https://bitbucket.org/icl/slate"
-    url = "https://bitbucket.org/icl/slate/downloads/slate-2020.10.00.tar.gz"
+    git = "https://github.com/icl-utk-edu/slate"
+    url = "https://github.com/icl-utk-edu/slate/releases/download/v2022.07.00/slate-2022.07.00.tar.gz"
     maintainers("G-Ragghianti", "mgates3")
 
     tags = ["e4s"]


### PR DESCRIPTION
Moving official repo and download locations for slate, blaspp, and lapackpp.

All new download locations and archive hashes has been verified.