### PR TITLE
fio: add a new version

### DIFF
--- a/var/spack/repos/builtin/packages/fio/package.py
+++ b/var/spack/repos/builtin/packages/fio/package.py
@@ -19,6 +19,7 @@ class Fio(AutotoolsPackage):
     homepage = "https://github.com/axboe/fio"
     url = "https://github.com/axboe/fio/archive/fio-3.26.tar.gz"
 
+    version("3.33", sha256="f48b2547313ffd1799c58c6a170175176131bbd42bc847b5650784eaf6d914b3")
     version("3.26", sha256="8bd6987fd9b8c2a75d3923661566ade50b99f61fa4352148975e65577ffa4024")
     version("3.25", sha256="d8157676bc78a50f3ac82ffc6f80ffc3bba93cbd892fc4882533159a0cdbc1e8")
     version("3.19", sha256="809963b1d023dbc9ac7065557af8129aee17b6895e0e8c5ca671b0b14285f404")


### PR DESCRIPTION
The latest is 3.33. 
See also #35520.