### PR TITLE
add PIC flag in mpi-serial build

### DIFF
--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -36,7 +36,7 @@ class MpiSerial(AutotoolsPackage):
     provides("mpi")
 
     def configure_args(self):
-        args = []
+        args = ["CFLAGS={0}".format(self.compiler.cc_pic_flag)]
         realsize = int(self.spec.variants["fort-real-size"].value)
         if realsize != 4:
             args.extend(


### PR DESCRIPTION
I ran into a [known problem](https://github.com/spack/spack/issues/34370) with building mpi-serial and found that this change solves the problem.   