### PR TITLE
py-pyinstrument: add v4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyinstrument/package.py
+++ b/var/spack/repos/builtin/packages/py-pyinstrument/package.py
@@ -12,13 +12,24 @@ class PyPyinstrument(PythonPackage):
     homepage = "https://github.com/joerick/pyinstrument"
     pypi = "pyinstrument/pyinstrument-4.0.3.tar.gz"
 
+    version("4.4.0", sha256="be34a2e8118c14a616a64538e02430d9099d5d67d8a370f2888e4ac71e52bbb7")
     version("4.0.3", sha256="08caf41d21ae8f24afe79c664a34af1ed1e17aa5d4441cd9b1dc15f87bbbac95")
     version("3.1.3", sha256="353c7000a6563b16c0be0c6a04104d42b3154c5cd7c1979ab66efa5fdc5f5571")
     version("3.1.0", sha256="10c1fed4996a72c3e1e2bac1940334756894dbd116df3cc3b2d9743f2ae43016")
 
-    depends_on("python@3.7:", when="@4:", type=("build", "run"))
-    depends_on("python@3.6:", when="@3.3:3.4", type=("build", "run"))
-    depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-pytest-runner", when="@:3.1.3", type="build")
-    depends_on("npm", when="@:3", type="build")
-    depends_on("py-pyinstrument-cext@0.2.2:", when="@:3", type=("build", "run"))
+    variant("jupyter", default=False, description="Support Jupyter/IPython magic", when="@4.1:")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-ipython", when="+jupyter", type=("build", "run"))
+
+    # Historical dependencies
+    with when("@3"):
+        depends_on("py-pytest-runner", type="build")
+        depends_on("npm", type="build")
+        depends_on("py-pyinstrument-cext@0.2.2:", type=("build", "run"))
+
+    @property
+    def skip_modules(self):
+        if self.spec.satisfies("~jupyter"):
+            return ["pyinstrument.magic"]
+        return []


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.10.8 and Apple Clang 12.0.0.