### PR TITLE
Spec matrices: preserve ordering of constraints

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2265,15 +2265,12 @@ def _concretize_from_constraints(spec_constraints, tests=False):
         m += "concretization target. all specs must have a single name "
         m += "constraint for concretization."
         raise InvalidSpecConstraintError(m)
-    spec_constraints.remove(root_spec[0])
 
     invalid_constraints = []
     while True:
-        # Attach all anonymous constraints to one named spec
-        s = root_spec[0].copy()
-        for c in spec_constraints:
-            if c not in invalid_constraints:
-                s.constrain(c)
+        # Combine constraints into a single spec
+        s = Spec(" ".join([str(c) for c in spec_constraints if c not in invalid_constraints]))
+
         try:
             return s.concretized(tests=tests)
         except spack.spec.InvalidDependencyError as e:

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -66,7 +66,6 @@ class SpecList(object):
             specs = []
             for item in self.specs_as_yaml_list:
                 if isinstance(item, dict):  # matrix of specs
-                    expanded = _expand_matrix_constraints(item)
                     specs.extend([Spec(" ".join(x)) for x in _expand_matrix_constraints(item)])
                 else:  # individual spec
                     specs.append(Spec(item))

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -75,8 +75,8 @@ env:
   - desired_specs: ["mpileaks@2.1"]
   specs:
   - matrix:
-    - [$compilers]
     - [$desired_specs]
+    - [$compilers]
 """
 
 

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -61,25 +61,25 @@ class TestSpecList(object):
     @pytest.mark.parametrize(
         "specs,expected",
         [
-            # Constraints are ordered randomly
+            # Constraints are ordered carefully to apply to appropriate node
             (
                 [
                     {
                         "matrix": [
-                            ["^zmpi"],
-                            ["%gcc@4.5.0"],
                             ["hypre", "libelf"],
                             ["~shared"],
-                            ["cflags=-O3", 'cflags="-g -O0"'],
                             ["^foo"],
+                            ["^zmpi"],
+                            ["%gcc@4.5.0"],
+                            ["cflags=-O3", 'cflags="-g -O0"'],
                         ]
                     }
                 ],
                 [
-                    "hypre cflags=-O3 ~shared %gcc@4.5.0 ^foo ^zmpi",
-                    'hypre cflags="-g -O0" ~shared %gcc@4.5.0 ^foo ^zmpi',
-                    "libelf cflags=-O3 ~shared %gcc@4.5.0 ^foo ^zmpi",
-                    'libelf cflags="-g -O0" ~shared %gcc@4.5.0 ^foo ^zmpi',
+                    "hypre ~shared ^foo ^zmpi cflags=-O3 %gcc@4.5.0",
+                    'hypre ~shared ^foo ^zmpi cflags="-g -O0" %gcc@4.5.0',
+                    "libelf ~shared ^foo ^zmpi cflags=-O3 %gcc@4.5.0",
+                    'libelf ~shared ^foo ^zmpi cflags="-g -O0" %gcc@4.5.0',
                 ],
             ),
             # A constraint affects both the root and a dependency


### PR DESCRIPTION
Currently it is not possible to use `concretizer:unify:when_possible` configuration to minimize the dependencies among a series of packages built with a combination of MPI/compiler combinations. The matrix:

```
- matrix:
  - [foo]
  - [^mpich]
  - [ '%gcc', '%clang']
```

resolves to specs `foo%gcc ^mpich` and `foo%clang ^mpich`.

With the `when_possible` unification option, the concretizer will concretize to use a single `mpich` in both cases (because it is possible to do so), mixing compilers rather than building with each combination of compiler/mpi.

With this PR, the previous behavior is preserved for the matrix:

```
- matrix:
  - [foo]
  - [ '%gcc', '%clang']
  - [^mpich]
```

but the original matrix produces the specs `foo ^mpich%gcc` and `foo ^mpich%clang`. Spack's preference to avoid mixing compilers when not otherwise instructed will then ensure that `foo` is built with both MPI/compiler combinations.

Includes docs and test case

@tgamblin this is the PR we discussed with @nicholas-sly on Tuesday.

