### PR TITLE
Ignore black reformat in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
-# Formatted entire codebase with black
+# Formatted entire codebase with black 23
+603569e321013a1a63a637813c94c2834d0a0023
+# Formatted entire codebase with black 22
 f52f6e99dbf1131886a80112b8c79dfc414afb7c


### PR DESCRIPTION
Ignore #35351 when looking at blame.