### PR TITLE
whizard: new version 3.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -20,6 +20,7 @@ class Whizard(AutotoolsPackage):
     maintainers("vvolkl")
 
     version("master", branch="master")
+    version("3.1.0", sha256="9dc5e6d1a25d2fc708625f85010cb81b63559ff02cceb9b35024cf9f426c0ad9")
     version("3.0.3", sha256="20f2269d302fc162a6aed8e781b504ba5112ef0711c078cdb08b293059ed67cf")
     version("3.0.2", sha256="f1db92cd95a0281f6afbf4ac32ab027670cb97a57ad8f5139c0d1f61593d66ec")
     version("3.0.1", sha256="1463abd6c50ffe72029abc6f5a7d28ec63013852bfe5914cb464b58202c1437c")


### PR DESCRIPTION
https://gitlab.tp.nt.uni-siegen.de/whizard/public/-/compare/v3.0.3...v3.1.0, no changes to package.py needed.