### PR TITLE
cmake build system: make "generator" a variant

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -8,7 +8,7 @@ import os
 import platform
 import re
 import sys
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import llnl.util.filesystem as fs
 
@@ -16,7 +16,7 @@ import spack.build_environment
 import spack.builder
 import spack.package_base
 import spack.util.path
-from spack.directives import build_system, depends_on, variant
+from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 
 from ._checks import BaseBuilder, execute_build_time_tests
@@ -33,6 +33,43 @@ def _extract_primary_generator(generator):
     """
     primary_generator = _primary_generator_extractor.match(generator).group(1)
     return primary_generator
+
+
+def generator(*names: str, default: Optional[str] = None):
+    """The build system generator to use.
+
+    See ``cmake --help`` for a list of valid generators.
+    Currently, "Unix Makefiles" and "Ninja" are the only generators
+    that Spack supports. Defaults to "Unix Makefiles".
+
+    See https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
+    for more information.
+
+    Args:
+        names: allowed generators for this package
+        default: default generator
+    """
+    allowed_values = ("make", "ninja")
+    if any(x not in allowed_values for x in names):
+        msg = "only 'make' and 'ninja' are allowed for CMake's 'generator' directive"
+        raise ValueError(msg)
+
+    default = default or names[0]
+    not_used = [x for x in allowed_values if x not in names]
+
+    def _values(x):
+        return x in allowed_values
+
+    _values.__doc__ = f"{','.join(names)}"
+
+    variant(
+        "generator",
+        default=default,
+        values=_values,
+        description="the build system generator to use",
+    )
+    for x in not_used:
+        conflicts(f"generator={x}")
 
 
 class CMakePackage(spack.package_base.PackageBase):
@@ -67,8 +104,15 @@ class CMakePackage(spack.package_base.PackageBase):
             when="^cmake@3.9:",
             description="CMake interprocedural optimization",
         )
+
+        if sys.platform == "win32":
+            generator("ninja")
+        else:
+            generator("ninja", "make", default="make")
+
         depends_on("cmake", type="build")
-        depends_on("ninja", type="build", when="platform=windows")
+        depends_on("gmake", type="build", when="generator=make")
+        depends_on("ninja", type="build", when="generator=ninja")
 
     def flags_to_build_system_args(self, flags):
         """Return a list of all command line arguments to pass the specified
@@ -138,18 +182,6 @@ class CMakeBuilder(BaseBuilder):
         | :py:meth:`~.CMakeBuilder.build_directory`     | Directory where to |
         |                                               | build the package  |
         +-----------------------------------------------+--------------------+
-
-    The generator used by CMake can be specified by providing the ``generator``
-    attribute. Per
-    https://cmake.org/cmake/help/git-master/manual/cmake-generators.7.html,
-    the format is: [<secondary-generator> - ]<primary_generator>.
-
-    The full list of primary and secondary generators supported by CMake may be found
-    in the documentation for the version of CMake used; however, at this time Spack
-    supports only the primary generators "Unix Makefiles" and "Ninja." Spack's CMake
-    support is agnostic with respect to primary generators. Spack will generate a
-    runtime error if the generator string does not follow the prescribed format, or if
-    the primary generator is not supported.
     """
 
     #: Phases of a CMake package
@@ -160,7 +192,6 @@ class CMakeBuilder(BaseBuilder):
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes: Tuple[str, ...] = (
-        "generator",
         "build_targets",
         "install_targets",
         "build_time_test_callbacks",
@@ -170,16 +201,6 @@ class CMakeBuilder(BaseBuilder):
         "build_dirname",
         "build_directory",
     )
-
-    #: The build system generator to use.
-    #:
-    #: See ``cmake --help`` for a list of valid generators.
-    #: Currently, "Unix Makefiles" and "Ninja" are the only generators
-    #: that Spack supports. Defaults to "Unix Makefiles".
-    #:
-    #: See https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
-    #: for more information.
-    generator = "Ninja" if sys.platform == "win32" else "Unix Makefiles"
 
     #: Targets to be used during the build phase
     build_targets: List[str] = []
@@ -203,11 +224,19 @@ class CMakeBuilder(BaseBuilder):
         return self.pkg.stage.source_path
 
     @property
+    def generator(self):
+        if self.spec.satisfies("generator=make"):
+            return "Unix Makefiles"
+        if self.spec.satisfies("generator=ninja"):
+            return "Ninja"
+        msg = f'{self.spec.format()} has an unsupported value for the "generator" variant'
+        raise ValueError(msg)
+
+    @property
     def std_cmake_args(self):
         """Standard cmake arguments provided as a property for
         convenience of package writers
         """
-        # standard CMake arguments
         std_cmake_args = CMakeBuilder.std_args(self.pkg, generator=self.generator)
         std_cmake_args += getattr(self.pkg, "cmake_flag_args", [])
         return std_cmake_args

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -36,7 +36,7 @@ from spack.build_systems.cached_cmake import (
     cmake_cache_path,
     cmake_cache_string,
 )
-from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.cmake import CMakePackage, generator
 from spack.build_systems.cuda import CudaPackage
 from spack.build_systems.generic import Package
 from spack.build_systems.gnu import GNUMirrorPackage

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -268,16 +268,18 @@ class TestCMakePackage(object):
         s = default_mock_concretization("mpich")
         assert spack.build_systems.cmake.CMakeBuilder.std_args(s.package)
 
-    def test_cmake_bad_generator(self, monkeypatch, default_mock_concretization):
+    def test_cmake_bad_generator(self, default_mock_concretization):
         s = default_mock_concretization("cmake-client")
-        monkeypatch.setattr(type(s.package), "generator", "Yellow Sticky Notes", raising=False)
         with pytest.raises(spack.package_base.InstallError):
-            s.package.builder.std_cmake_args
+            spack.build_systems.cmake.CMakeBuilder.std_args(
+                s.package, generator="Yellow Sticky Notes"
+            )
 
     def test_cmake_secondary_generator(self, default_mock_concretization):
         s = default_mock_concretization("cmake-client")
-        s.package.generator = "CodeBlocks - Unix Makefiles"
-        assert s.package.builder.std_cmake_args
+        assert spack.build_systems.cmake.CMakeBuilder.std_args(
+            s.package, generator="CodeBlocks - Unix Makefiles"
+        )
 
     def test_define(self, default_mock_concretization):
         s = default_mock_concretization("cmake-client")

--- a/var/spack/repos/builtin.mock/packages/gmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/gmake/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gmake(Package):
+    """Dummy GMake Package"""
+
+    homepage = "https://www.gnu.org/software/make"
+    url = "https://ftpmirror.gnu.org/make/make-4.4.tar.gz"
+
+    version("4.4", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")

--- a/var/spack/repos/builtin/packages/3dtk/package.py
+++ b/var/spack/repos/builtin/packages/3dtk/package.py
@@ -42,7 +42,7 @@ class _3dtk(CMakePackage):
     conflicts("~opencv", when="platform=darwin")
     conflicts("+compact_octree", when="~opengl")
 
-    generator = "Ninja"
+    generator("ninja")
 
     depends_on("cmake@3.5:", when="@trunk", type="build")
     depends_on("cmake@2.6.1:2", when="@1.2", type="build")

--- a/var/spack/repos/builtin/packages/3dtk/package.py
+++ b/var/spack/repos/builtin/packages/3dtk/package.py
@@ -46,7 +46,6 @@ class _3dtk(CMakePackage):
 
     depends_on("cmake@3.5:", when="@trunk", type="build")
     depends_on("cmake@2.6.1:2", when="@1.2", type="build")
-    depends_on("ninja", type="build")
     depends_on(
         "boost@:1.75+serialization+graph+regex+filesystem+system+thread+date_time+program_options"
     )

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -146,7 +146,6 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+nccl", when="+rccl", msg="NCCL and RCCL support are mutually exclusive")
 
     generator("ninja")
-    depends_on("ninja", type="build")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -145,7 +145,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="+rocm", msg="CUDA and ROCm support are mutually exclusive")
     conflicts("+nccl", when="+rccl", msg="NCCL and RCCL support are mutually exclusive")
 
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja", type="build")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -27,7 +27,7 @@ class Archer(CMakePackage):
     depends_on("ninja@1.5:", type="build")
     depends_on("llvm-openmp-ompt@tr6_forwards")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def patch(self):
         if self.spec.satisfies("^llvm@8.0.0:"):

--- a/var/spack/repos/builtin/packages/cepgen/package.py
+++ b/var/spack/repos/builtin/packages/cepgen/package.py
@@ -11,7 +11,7 @@ class Cepgen(CMakePackage):
 
     homepage = "https://cepgen.hepforge.org/"
     url = "https://github.com/cepgen/cepgen/archive/refs/tags/1.0.2patch1.tar.gz"
-    generator = "Ninja"
+    generator("ninja")
 
     tags = ["hep"]
 

--- a/var/spack/repos/builtin/packages/cepgen/package.py
+++ b/var/spack/repos/builtin/packages/cepgen/package.py
@@ -11,13 +11,14 @@ class Cepgen(CMakePackage):
 
     homepage = "https://cepgen.hepforge.org/"
     url = "https://github.com/cepgen/cepgen/archive/refs/tags/1.0.2patch1.tar.gz"
-    generator("ninja")
 
     tags = ["hep"]
 
     version(
         "1.0.2patch1", sha256="333bba0cb1965a98dec127e00c150eab1a515cd348a90f7b1d66d5cd8d206d21"
     )
+
+    generator("ninja")
 
     depends_on("gsl")
     depends_on("openblas")
@@ -26,5 +27,3 @@ class Cepgen(CMakePackage):
     depends_on("lhapdf")
     depends_on("pythia6")
     depends_on("root")
-
-    depends_on("ninja", type="build")

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -27,7 +27,7 @@ class Cpuinfo(CMakePackage):
     depends_on("cmake@3.5:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -24,10 +24,8 @@ class Cpuinfo(CMakePackage):
     version("2018-05-13", commit="1e6c8c99d27f2b5eb9d2e6231055c6a4115b85e5")  # py-torch@0.4.1
     version("2018-04-04", commit="831dc28341b5f20d13e840caf87eaba644d82643")  # py-torch@:0.4.0
 
-    depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-
     generator("ninja")
+    depends_on("cmake@3.5:", type="build")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -92,7 +92,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("smm=blas", when="+opencl")
 
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja@1.10:", type="build")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -137,7 +137,6 @@ class Dd4hep(CMakePackage):
     )
 
     depends_on("cmake @3.12:", type="build")
-    depends_on("ninja", type="build")
     depends_on("boost @1.49:")
     depends_on("boost +iostreams", when="+ddg4")
     depends_on("boost +system +filesystem", when="%gcc@:7")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -101,7 +101,7 @@ class Dd4hep(CMakePackage):
         deprecated=True,
     )
 
-    generator = "Ninja"
+    generator("ninja")
 
     # Workarounds for various TBB issues in DD4hep v1.11
     # See https://github.com/AIDASoft/DD4hep/pull/613 .

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -140,7 +140,6 @@ class Dealii(CMakePackage, CudaPackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     depends_on("lapack")
-    depends_on("ninja", type="build")
     depends_on("suite-sparse")
     depends_on("zlib")
 

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -23,7 +23,7 @@ class Dealii(CMakePackage, CudaPackage):
     # only add for immediate deps.
     transitive_rpaths = False
 
-    generator = "Ninja"
+    generator("ninja")
 
     version("master", branch="master")
     version("9.4.0", sha256="238677006cd9173658e5b69cdd1861f800556982db6005a3cc5eb8329cc1e36c")

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -117,7 +117,6 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("half", when="+half")
 
     generator("ninja")
-    depends_on("ninja", type="build")
     depends_on("cmake@3.17.0:", type="build")
 
     depends_on("spdlog", when="@:0.1,0.2:")

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -116,7 +116,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("half", when="+half")
 
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja", type="build")
     depends_on("cmake@3.17.0:", type="build")
 

--- a/var/spack/repos/builtin/packages/fairlogger/package.py
+++ b/var/spack/repos/builtin/packages/fairlogger/package.py
@@ -16,7 +16,6 @@ class Fairlogger(CMakePackage):
     url = "https://github.com/FairRootGroup/FairLogger/archive/v1.2.0.tar.gz"
     git = "https://github.com/FairRootGroup/FairLogger.git"
     maintainers("dennisklein", "ChristianTackeGSI")
-    # generator("ninja")'Ninja'
 
     version("develop", branch="dev", get_full_repo=True)
     version("1.9.0", sha256="13bcaa0d4129f8d4e69a0a2ece8e5b7073760082c8aa028e3fc0c11106503095")

--- a/var/spack/repos/builtin/packages/fairlogger/package.py
+++ b/var/spack/repos/builtin/packages/fairlogger/package.py
@@ -16,7 +16,7 @@ class Fairlogger(CMakePackage):
     url = "https://github.com/FairRootGroup/FairLogger/archive/v1.2.0.tar.gz"
     git = "https://github.com/FairRootGroup/FairLogger.git"
     maintainers("dennisklein", "ChristianTackeGSI")
-    # generator = 'Ninja'
+    # generator("ninja")'Ninja'
 
     version("develop", branch="dev", get_full_repo=True)
     version("1.9.0", sha256="13bcaa0d4129f8d4e69a0a2ece8e5b7073760082c8aa028e3fc0c11106503095")

--- a/var/spack/repos/builtin/packages/fbgemm/package.py
+++ b/var/spack/repos/builtin/packages/fbgemm/package.py
@@ -61,7 +61,7 @@ class Fbgemm(CMakePackage):
 
     conflicts("%gcc@:4", msg="FBGEMM requires GCC 5+")
 
-    generator = "Ninja"
+    generator("ninja")
 
     @run_before("cmake")
     def check_requirements(self):

--- a/var/spack/repos/builtin/packages/fbgemm/package.py
+++ b/var/spack/repos/builtin/packages/fbgemm/package.py
@@ -54,14 +54,12 @@ class Fbgemm(CMakePackage):
         "2018-12-04", commit="0d5a159b944252e70a677236b570f291943e0543", submodules=True
     )  # py-torch@1.0.0
 
+    generator("ninja")
     depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type="build")
     depends_on("llvm-openmp", when="%apple-clang")
 
     conflicts("%gcc@:4", msg="FBGEMM requires GCC 5+")
-
-    generator("ninja")
 
     @run_before("cmake")
     def check_requirements(self):

--- a/var/spack/repos/builtin/packages/foundationdb/package.py
+++ b/var/spack/repos/builtin/packages/foundationdb/package.py
@@ -30,7 +30,7 @@ class Foundationdb(CMakePackage):
     # for instance depends_on('boost +filesystem')
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja", type="build")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/foundationdb/package.py
+++ b/var/spack/repos/builtin/packages/foundationdb/package.py
@@ -31,7 +31,6 @@ class Foundationdb(CMakePackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     generator("ninja")
-    depends_on("ninja", type="build")
 
     def cmake_args(self):
         args = ["-DUSE_WERROR=ON"]

--- a/var/spack/repos/builtin/packages/fp16/package.py
+++ b/var/spack/repos/builtin/packages/fp16/package.py
@@ -22,7 +22,7 @@ class Fp16(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     resource(
         name="psimd",

--- a/var/spack/repos/builtin/packages/fp16/package.py
+++ b/var/spack/repos/builtin/packages/fp16/package.py
@@ -19,10 +19,8 @@ class Fp16(CMakePackage):
     version("2018-10-10", commit="34d4bf01bbf7376f2baa71b8fa148b18524d45cf")  # py-torch@1.0
     version("2018-02-25", commit="43d6d17df48ebf622587e7ed9472ea76573799b9")  # py-torch@:0.4
 
-    depends_on("cmake@2.8.12:", type="build")
-    depends_on("ninja", type="build")
-
     generator("ninja")
+    depends_on("cmake@2.8.12:", type="build")
 
     resource(
         name="psimd",

--- a/var/spack/repos/builtin/packages/fxdiv/package.py
+++ b/var/spack/repos/builtin/packages/fxdiv/package.py
@@ -17,11 +17,9 @@ class Fxdiv(CMakePackage):
     version("2018-11-16", commit="b742d1143724d646cd0f914646f1240eacf5bd73")  # py-torch@1.0:1.5
     version("2018-02-24", commit="811b482bcd9e8d98ad80c6c78d5302bb830184b0")  # py-torch@0.4
 
-    depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-    depends_on("python", type="build")
-
     generator("ninja")
+    depends_on("cmake@3.5:", type="build")
+    depends_on("python", type="build")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/fxdiv/package.py
+++ b/var/spack/repos/builtin/packages/fxdiv/package.py
@@ -21,7 +21,7 @@ class Fxdiv(CMakePackage):
     depends_on("ninja", type="build")
     depends_on("python", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -235,8 +235,8 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     )
 
     with when("build_system=cmake"):
+        generator("ninja")
         depends_on("cmake@3.9:", type="build")
-        depends_on("ninja", type="build")
 
     with when("build_system=autotools"):
         depends_on("gmake", type="build")
@@ -463,8 +463,6 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
 
 class CMakeBuilder(CMakeBuilder):
-    generator("ninja")
-
     def cmake_args(self):
         # https://gdal.org/build_hints.html
         args = [

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -463,7 +463,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
 
 
 class CMakeBuilder(CMakeBuilder):
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         # https://gdal.org/build_hints.html

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -51,11 +51,9 @@ class Geos(CMakePackage):
     version("3.3.4", sha256="cd5400aa5f3fe32246dfed5d238c5017e1808162c865c016480b3e6c07271904")
     version("3.3.3", sha256="dfcf4bd70ab212a5b7bad21d01b84748f101a545092b56dafdc3882ef3bddec9")
 
+    generator("ninja")
     depends_on("cmake@3.13:", when="@3.10:", type="build")
     depends_on("cmake@3.8:", type="build")
-    depends_on("ninja", type="build")
-
-    generator("ninja")
 
     patch(
         "https://github.com/libgeos/geos/pull/461.patch?full_index=1",

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -55,7 +55,7 @@ class Geos(CMakePackage):
     depends_on("cmake@3.8:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     patch(
         "https://github.com/libgeos/geos/pull/461.patch?full_index=1",

--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -32,11 +32,8 @@ class Gloo(CMakePackage, CudaPackage):
         sha256="8e6e9a44e0533ba4303a95a651b1934e5d73632cab08cc7d5a9435e1e64aa424",
         when="@:2023-01-16",
     )
-
-    depends_on("cmake@2.8.12:", type="build")
-    depends_on("ninja", type="build")
-
     generator("ninja")
+    depends_on("cmake@2.8.12:", type="build")
 
     def cmake_args(self):
         return [self.define_from_variant("USE_CUDA", "cuda")]

--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -36,7 +36,7 @@ class Gloo(CMakePackage, CudaPackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         return [self.define_from_variant("USE_CUDA", "cuda")]

--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -50,7 +50,7 @@ class Gplates(CMakePackage):
 
     # When built in parallel, headers are not generated before they are used
     # (specifically, ViewportWindowUi.h) with the Makefiles generator.
-    generator = "Ninja"
+    generator("ninja")
 
     @when("@:2.1")
     def patch(self):

--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -25,7 +25,6 @@ class Gplates(CMakePackage):
     depends_on("cmake@3.5:", when="@2.3:", type="build")
     depends_on("cmake@2.8.8:", when="@2.1", type="build")
     depends_on("cmake@2.6.2:", when="@2.0", type="build")
-    depends_on("ninja", type="build")
     depends_on("gl")
     depends_on("glu")
     depends_on("glew")

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -22,7 +22,7 @@ class Halide(CMakePackage, PythonExtension):
         description="The build type to build",
         values=("Release", "Debug", "RelWithDebInfo"),
     )
-    generator = "Ninja"
+    generator("ninja")
     variant("python", default=False, description="Install python bindings")
     variant("tutorials", default=False, description="Install the Halide Tutorials.")
     variant("utils", default=False, description="Install the Halide Utilities.")

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -54,7 +54,6 @@ class Halide(CMakePackage, PythonExtension):
     variant("sharedllvm", default=False, description="Link to the shared version of LLVM.")
 
     depends_on("cmake@3.22:", type="build")
-    depends_on("ninja", type="build")
     depends_on("llvm+clang+lld build_type=Release", type=("link", "run"))
     depends_on("llvm@13.0.0:15", type=("link", "run"), when="@14.0.0")
     depends_on("llvm@14.0.0:16", type=("link", "run"), when="@15.0.0:")

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -36,7 +36,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     version("1.2.0", sha256="20942314bd90064d9775f63b0e58a8ea146af5260a4c84d0854f9f968077c170")
     version("1.1.0", sha256="1f28bbe58d8f0da600d60c3a74a644d75ac777b20a018a5c1c6030a470e8a1c9")
 
-    generator = "Ninja"
+    generator("ninja")
 
     map_cxxstd = lambda cxxstd: "2a" if cxxstd == "20" else cxxstd
     cxxstds = ("11", "14", "17", "20")

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -91,7 +91,6 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Build dependencies
     depends_on("python", type=("build", "test", "run"))
-    depends_on("ninja", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("git", type="build")
     depends_on("cmake", type="build")

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -140,7 +140,6 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     generator("ninja")
-    depends_on("ninja", type="build")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -139,7 +139,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
         msg="Hydrogen did not exist before v0.99. " + "Did you mean to use Elemental instead?",
     )
 
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja", type="build")
 
     @property

--- a/var/spack/repos/builtin/packages/kineto/package.py
+++ b/var/spack/repos/builtin/packages/kineto/package.py
@@ -26,9 +26,7 @@ class Kineto(CMakePackage):
 
     root_cmakelists_dir = "libkineto"
 
+    generator("ninja")
     depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type="build")
     depends_on("cuda")
-
-    generator("ninja")

--- a/var/spack/repos/builtin/packages/kineto/package.py
+++ b/var/spack/repos/builtin/packages/kineto/package.py
@@ -31,4 +31,4 @@ class Kineto(CMakePackage):
     depends_on("python", type="build")
     depends_on("cuda")
 
-    generator = "Ninja"
+    generator("ninja")

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -316,7 +316,6 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("zstr")
 
     generator("ninja")
-    depends_on("ninja", type="build")
 
     @property
     def common_config_args(self):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -315,7 +315,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("spdlog", when="@:0.90,0.102:")
     depends_on("zstr")
 
-    generator = "Ninja"
+    generator("ninja")
     depends_on("ninja", type="build")
 
     @property

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -17,7 +17,7 @@ class LlvmAmdgpu(CMakePackage):
     git = "https://github.com/RadeonOpenCompute/llvm-project.git"
     url = "https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
-    generator = "Ninja"
+    generator("ninja")
 
     maintainers("srekolam", "renjithravindrankannath", "haampie")
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -141,7 +141,6 @@ class LlvmAmdgpu(CMakePackage):
     depends_on("z3", type="link")
     depends_on("zlib", type="link")
     depends_on("ncurses+termlib", type="link")
-    depends_on("ninja", type="build")
     depends_on("pkgconfig", type="build")
 
     # openmp dependencies

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -117,7 +117,6 @@ class LlvmDoe(CMakePackage, CudaPackage):
     # Build dependency
     depends_on("cmake@3.4.3:", type="build")
     depends_on("cmake@3.13.4:", type="build", when="@12:")
-    depends_on("ninja", type="build")
     depends_on("python", when="~python", type="build")
     depends_on("pkgconfig", type="build")
 

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -26,7 +26,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
 
     tags = ["e4s"]
 
-    generator = "Ninja"
+    generator("ninja")
 
     family = "compiler"  # Used by lmod
 

--- a/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
@@ -48,7 +48,7 @@ class LlvmOpenmpOmpt(CMakePackage):
     depends_on("elf", when="+libomptarget")
     depends_on("libffi", when="+libomptarget")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         cmake_args = [

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -30,7 +30,7 @@ class Llvm(CMakePackage, CudaPackage):
 
     tags = ["e4s"]
 
-    generator = "Ninja"
+    generator("ninja")
 
     family = "compiler"  # Used by lmod
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -212,7 +212,6 @@ class Llvm(CMakePackage, CudaPackage):
     # Build dependency
     depends_on("cmake@3.4.3:", type="build")
     depends_on("cmake@3.13.4:", type="build", when="@12:")
-    depends_on("ninja", type="build")
     depends_on("python", when="~python", type="build")
     depends_on("pkgconfig", type="build")
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -47,8 +47,8 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
     variant("mkldnn", default=False, description="Build with MKL-DNN support")
     variant("python", default=True, description="Install python bindings")
 
+    generator("ninja")
     depends_on("cmake@3.13:", type="build")
-    depends_on("ninja", type="build")
     depends_on("pkgconfig", when="@1.6.0", type="build")
     depends_on("blas")
     depends_on("cuda@:10.2", when="@:1.8.0 +cuda")
@@ -84,7 +84,6 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
     # python/setup.py assumes libs can be found in build directory
     build_directory = "build"
-    generator("ninja")
 
     def setup_run_environment(self, env):
         env.set("MXNET_LIBRARY_PATH", self.spec["mxnet"].libs[0])

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -84,7 +84,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
     # python/setup.py assumes libs can be found in build directory
     build_directory = "build"
-    generator = "Ninja"
+    generator("ninja")
 
     def setup_run_environment(self, env):
         env.set("MXNET_LIBRARY_PATH", self.spec["mxnet"].libs[0])

--- a/var/spack/repos/builtin/packages/nnpack/package.py
+++ b/var/spack/repos/builtin/packages/nnpack/package.py
@@ -25,7 +25,7 @@ class Nnpack(CMakePackage):
     depends_on("python", type="build")
     depends_on("py-setuptools", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     resource(
         name="six",

--- a/var/spack/repos/builtin/packages/nnpack/package.py
+++ b/var/spack/repos/builtin/packages/nnpack/package.py
@@ -20,12 +20,10 @@ class Nnpack(CMakePackage):
     version("2018-05-21", commit="3eb0d453662d05a708f43b108bed9e17b705383e")  # py-torch@0.4.1
     version("2018-04-05", commit="b63fe1ba8963f1756b8decc593766615cee99c35")  # py-torch@:0.4.0
 
+    generator("ninja")
     depends_on("cmake@2.8.12:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type="build")
     depends_on("py-setuptools", type="build")
-
-    generator("ninja")
 
     resource(
         name="six",

--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -50,12 +50,10 @@ class Onnx(CMakePackage):
         "1.1.0_2018-04-19", commit="7e1bed51cc508a25b22130de459830b5d5063c41"
     )  # py-torch@0.4.0
 
+    generator("ninja")
     depends_on("cmake@3.1:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type="build")
     depends_on("protobuf")
-
-    generator("ninja")
 
     def cmake_args(self):
         # Try to get ONNX to use the same version of python as the spec is using

--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -55,7 +55,7 @@ class Onnx(CMakePackage):
     depends_on("python", type="build")
     depends_on("protobuf")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         # Try to get ONNX to use the same version of python as the spec is using

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -148,8 +148,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.3:", type="build")
     depends_on("cmake@3.21:", type="build", when="+rocm")
 
-    depends_on("ninja", type="build")
-
     extends("python", when="+python")
 
     # VTK < 8.2.1 can't handle Python 3.8
@@ -276,13 +274,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # Fix VTK to work with external freetype using CONFIG mode for find_package
     patch("FindFreetype.cmake.patch", when="@5.10.1:")
 
-    @property
-    def generator(self):
-        # https://gitlab.kitware.com/paraview/paraview/-/issues/21223
-        if self.spec.satisfies("%xl") or self.spec.satisfies("%xl_r"):
-            return "Unix Makefiles"
-        else:
-            return "Ninja"
+    generator("ninja", "make", default="ninja")
+    # https://gitlab.kitware.com/paraview/paraview/-/issues/21223
+    conflicts("generator=ninja", when="%xl")
+    conflicts("generator=ninja", when="%xl_r")
 
     def url_for_version(self, version):
         _urlfmt = "http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}"

--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -33,7 +33,6 @@ class PikaAlgorithms(CMakePackage):
 
     # Build dependencies
     depends_on("git", type="build")
-    depends_on("ninja", type="build")
     depends_on("cmake@3.22:", type="build")
 
     conflicts("%gcc@:8")

--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -20,7 +20,7 @@ class PikaAlgorithms(CMakePackage):
     version("0.1.0", sha256="64da008897dfa7373155595c46d2ce6b97a8a3cb5bea33ae7f2d1ff359f0d9b6")
     version("main", branch="main")
 
-    generator = "Ninja"
+    generator("ninja")
 
     map_cxxstd = lambda cxxstd: "2a" if cxxstd == "20" else cxxstd
     cxxstds = ("17", "20")

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -32,7 +32,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     version("0.1.0", sha256="aa0ae2396cd264d821a73c4c7ecb118729bb3de042920c9248909d33755e7327")
     version("main", branch="main")
 
-    generator = "Ninja"
+    generator("ninja")
 
     map_cxxstd = lambda cxxstd: "2a" if cxxstd == "20" else cxxstd
     cxxstds = ("17", "20")

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -73,7 +73,6 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     # Build dependencies
     depends_on("git", type="build")
-    depends_on("ninja", type="build")
     depends_on("cmake@3.18:", type="build")
     depends_on("cmake@3.22:", when="@0.8:", type="build")
 

--- a/var/spack/repos/builtin/packages/psimd/package.py
+++ b/var/spack/repos/builtin/packages/psimd/package.py
@@ -21,4 +21,4 @@ class Psimd(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")

--- a/var/spack/repos/builtin/packages/psimd/package.py
+++ b/var/spack/repos/builtin/packages/psimd/package.py
@@ -18,7 +18,5 @@ class Psimd(CMakePackage):
     version("2018-09-06", commit="90a938f30ba414ada2f4b00674ee9631d7d85e19")  # py-torch@1.0:1.4
     version("2017-10-26", commit="4ac61b112252778b174575931c641bef661ab3cd")  # py-torch@0.4
 
-    depends_on("cmake@2.8.12:", type="build")
-    depends_on("ninja", type="build")
-
     generator("ninja")
+    depends_on("cmake@2.8.12:", type="build")

--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -20,11 +20,9 @@ class Pthreadpool(CMakePackage):
     version("2018-10-08", commit="13da0b4c21d17f94150713366420baaf1b5a46f4")  # py-torch@1.0:1.4
     version("2018-02-25", commit="2b06b31f6a315162348e1f3c24325eedaf6cc559")  # py-torch@:0.4
 
-    depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-    depends_on("python", type="build")
-
     generator("ninja")
+    depends_on("cmake@3.5:", type="build")
+    depends_on("python", type="build")
 
     resource(
         name="fxdiv",

--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -24,7 +24,7 @@ class Pthreadpool(CMakePackage):
     depends_on("ninja", type="build")
     depends_on("python", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     resource(
         name="fxdiv",

--- a/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
@@ -28,7 +28,6 @@ class PyOnnxRuntime(CMakePackage, PythonExtension):
     variant("cuda", default=False, description="Build with CUDA support")
 
     depends_on("cmake@3.1:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type=("build", "run"))
     depends_on("py-pip", type="build")
     depends_on("protobuf")

--- a/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
@@ -74,7 +74,7 @@ class PyOnnxRuntime(CMakePackage, PythonExtension):
         description="AVX support level",
     )
 
-    generator = "Ninja"
+    generator("ninja")
     root_cmakelists_dir = "cmake"
     build_directory = "."
 

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -71,7 +71,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
         description="AVX support level",
     )
 
-    generator = "Ninja"
+    generator("ninja")
     root_cmakelists_dir = "cmake"
     build_directory = "."
 

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -25,7 +25,6 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
     variant("cuda", default=False, description="Build with CUDA support")
 
     depends_on("cmake@3.1:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type=("build", "run"))
     depends_on("py-pip", type="build")
     depends_on("protobuf")

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -59,7 +59,7 @@ class PyPybind11(CMakePackage, PythonExtension):
     extends("python")
 
     with when("build_system=cmake"):
-        depends_on("ninja", type="build")
+        generator("ninja")
         depends_on("cmake@3.13:", type="build")
         depends_on("cmake@3.18:", type="build", when="@2.6.0:")
 

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -69,7 +69,7 @@ class Qnnpack(CMakePackage):
         placement="pthreadpool",
     )
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -20,8 +20,8 @@ class Qnnpack(CMakePackage):
     version("2018-12-27", commit="6c62fddc6d15602be27e9e4cbb9e985151d2fa82")  # py-torch@1.2
     version("2018-12-04", commit="ef05e87cef6b8e719989ce875b5e1c9fdb304c05")  # py-torch@1.0:1.1
 
+    generator("ninja")
     depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python", type="build")
 
     resource(
@@ -68,8 +68,6 @@ class Qnnpack(CMakePackage):
         destination="deps",
         placement="pthreadpool",
     )
-
-    generator("ninja")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -31,13 +31,11 @@ class QtPackage(CMakePackage):
         _list_url = "https://github.com/qt/{}/tags"
         return _list_url.format(qualname.lower())
 
-    generator("ninja")
-
     maintainers("wdconinc", "sethrj")
 
     # Default dependencies for all qt-* components
+    generator("ninja")
     depends_on("cmake@3.16:", type="build")
-    depends_on("ninja", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("python", type="build")
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -31,7 +31,7 @@ class QtPackage(CMakePackage):
         _list_url = "https://github.com/qt/{}/tags"
         return _list_url.format(qualname.lower())
 
-    generator = "Ninja"
+    generator("ninja")
 
     maintainers("wdconinc", "sethrj")
 

--- a/var/spack/repos/builtin/packages/sleef/package.py
+++ b/var/spack/repos/builtin/packages/sleef/package.py
@@ -51,10 +51,8 @@ class Sleef(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
     )
 
-    depends_on("cmake@3.4.3:", type="build")
-    depends_on("ninja", type="build")
-
     generator("ninja")
+    depends_on("cmake@3.4.3:", type="build")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/sleef/package.py
+++ b/var/spack/repos/builtin/packages/sleef/package.py
@@ -54,7 +54,7 @@ class Sleef(CMakePackage):
     depends_on("cmake@3.4.3:", type="build")
     depends_on("ninja", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -146,7 +146,6 @@ class Spectre(CMakePackage):
 
     # Build dependencies
     depends_on("cmake@3.12:", type="build")
-    depends_on("ninja", type="build")
     depends_on("python@2.7:", type="build")
 
     # Link dependencies

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -26,7 +26,7 @@ class Spectre(CMakePackage):
 
     maintainers("nilsvu")
 
-    generator = "Ninja"
+    generator("ninja")
 
     version("develop", branch="develop")
     version(

--- a/var/spack/repos/builtin/packages/tensorpipe/package.py
+++ b/var/spack/repos/builtin/packages/tensorpipe/package.py
@@ -33,4 +33,4 @@ class Tensorpipe(CMakePackage):
     depends_on("ninja", type="build")
     depends_on("libuv@1.26:")
 
-    generator = "Ninja"
+    generator("ninja")

--- a/var/spack/repos/builtin/packages/tensorpipe/package.py
+++ b/var/spack/repos/builtin/packages/tensorpipe/package.py
@@ -29,8 +29,6 @@ class Tensorpipe(CMakePackage):
         "2020-06-26", commit="3b8089c9c6717038cff44b70b881d0ad6c93e679", submodules=True
     )  # py-torch@1.6
 
-    depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-    depends_on("libuv@1.26:")
-
     generator("ninja")
+    depends_on("cmake@3.5:", type="build")
+    depends_on("libuv@1.26:")

--- a/var/spack/repos/builtin/packages/tiramisu/package.py
+++ b/var/spack/repos/builtin/packages/tiramisu/package.py
@@ -32,8 +32,6 @@ class Tiramisu(CMakePackage, CudaPackage, PythonExtension):
     )
 
     depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-
     depends_on("halide@14.0.0:", type=("build", "link", "run"))
     depends_on("isl", type=("build", "link", "run"))
     depends_on("python@3.8:", type=("build", "link", "run"), when="+python")

--- a/var/spack/repos/builtin/packages/tiramisu/package.py
+++ b/var/spack/repos/builtin/packages/tiramisu/package.py
@@ -16,7 +16,7 @@ class Tiramisu(CMakePackage, CudaPackage, PythonExtension):
 
     maintainers("wraith1995")
 
-    generator = "Ninja"
+    generator("ninja")
 
     version("master", branch="master")
     version("2023-2-8", commit="2cd0c43cc1656bfa43cfb6e81d06f770cbf7251e")

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -69,7 +69,7 @@ class Visit(CMakePackage):
     version("3.0.1", sha256="a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd")
 
     root_cmakelists_dir = "src"
-    generator = "Ninja"
+    generator("ninja")
 
     variant("gui", default=True, description="Enable VisIt's GUI")
     variant("osmesa", default=False, description="Use OSMesa for off-screen CPU rendering")

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -99,7 +99,6 @@ class Visit(CMakePackage):
     conflicts("+gui", when="+osmesa")
 
     depends_on("cmake@3.14.7:", type="build")
-    depends_on("ninja", type="build")
 
     depends_on("mpi", when="+mpi")
 

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -32,7 +32,6 @@ class Xgboost(CMakePackage, CudaPackage):
 
     depends_on("cmake@3.13:", type="build")
     depends_on("cmake@3.16:", when="platform=darwin", type="build")
-    depends_on("ninja", type="build")
     depends_on("cuda@10:", when="+cuda")
     # https://github.com/dmlc/xgboost/pull/7379
     depends_on("cuda@10:11.4", when="@:1.5.0+cuda")

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -52,7 +52,7 @@ class Xgboost(CMakePackage, CudaPackage):
         "https://developer.nvidia.com/cuda-gpus",
     )
 
-    generator = "Ninja"
+    generator("ninja")
 
     def cmake_args(self):
         # https://xgboost.readthedocs.io/en/latest/build.html

--- a/var/spack/repos/builtin/packages/xnnpack/package.py
+++ b/var/spack/repos/builtin/packages/xnnpack/package.py
@@ -20,11 +20,9 @@ class Xnnpack(CMakePackage):
     version("2020-03-23", commit="1b354636b5942826547055252f3b359b54acff95")  # py-torch@1.6:1.7
     version("2020-02-24", commit="7493bfb9d412e59529bcbced6a902d44cfa8ea1c")  # py-torch@1.5
 
-    depends_on("cmake@3.5:", type="build")
-    depends_on("ninja", type="build")
-    depends_on("python", type="build")
-
     generator("ninja")
+    depends_on("cmake@3.5:", type="build")
+    depends_on("python", type="build")
 
     resource(
         name="clog",

--- a/var/spack/repos/builtin/packages/xnnpack/package.py
+++ b/var/spack/repos/builtin/packages/xnnpack/package.py
@@ -24,7 +24,7 @@ class Xnnpack(CMakePackage):
     depends_on("ninja", type="build")
     depends_on("python", type="build")
 
-    generator = "Ninja"
+    generator("ninja")
 
     resource(
         name="clog",


### PR DESCRIPTION
This PR make `generator` a variant in `CMakePackage`. This allows us to declare proper dependencies on `ninja` and `gmake`, and to select generators at concretization time where it makes sense.

Modifications:
- [x] Add a cmake specific generator directive, that builds on `variants` and `conflicts`
- [x] Modify `CMakePackage`s to use that directive