### PR TITLE
Add py-python-lsp-server v1.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
+++ b/var/spack/repos/builtin/packages/py-python-lsp-server/package.py
@@ -14,6 +14,7 @@ class PyPythonLspServer(PythonPackage):
 
     maintainers("alecbcs")
 
+    version("1.7.1", sha256="67473bb301f35434b5fa8b21fc5ed5fac27dc8a8446ccec8bae456af52a0aef6")
     version("1.7.0", sha256="401ce78ea2e98cadd02d94962eb32c92879caabc8055b9a2f36d7ef44acc5435")
     version("1.6.0", sha256="d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b")
 


### PR DESCRIPTION
Add py-python-lsp-server v1.7.1 which includes multiple bug fixes.

**Changelog:**
- Improves Jedi file completions for directories.
- Includes missing Pylint "information" category.
- Fixes an error with the Pydocstyle 6.2.0+

Full changelog can be found [here](https://github.com/python-lsp/python-lsp-server/releases/tag/v1.7.1).

**Test Plan:**
Built locally and used within Emacs to check a python file and discover functions from within an external library.