### PR TITLE
Add restic v0.15.1

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -14,10 +14,12 @@ class Restic(Package):
 
     maintainers("alecbcs")
 
+    version("0.15.1", sha256="fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52")
     version("0.15.0", sha256="85a6408cfb0798dab52335bcb00ac32066376c32daaa75461d43081499bc7de8")
     version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")
     version("0.12.1", sha256="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb")
 
+    depends_on("go@1.18:", type="build", when="@0.15.0:")
     depends_on("go@1.15:", type="build", when="@0.14.0:")
     depends_on("go", type="build")
 


### PR DESCRIPTION
Add Restic v0.15.1 which includes multiple bug fixes.

**Summarized Changelog:**
- Remove b2_download_file_by_name: 404 warning from B2 backend.
- Make prune --quiet not print progress bar.
- Make self-update --output work with new filename on Windows.
- Add missing ETA in backup progress bar.
- Ignore empty lock files.

Full changelog can be found [here](https://github.com/restic/restic/releases/tag/v0.15.1).

**Test Plan:**
Tested v0.15.1 by building locally and backing up a couple of directories to an s3 bucket.