### PR TITLE
Disable module generation by default

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -40,9 +40,8 @@ modules:
     roots:
      tcl:    $spack/share/spack/modules
      lmod:   $spack/share/spack/lmod
-    # What type of modules to use
-    enable:
-      - tcl
+    # What type of modules to use ("tcl" and/or "lmod")
+    enable: []
 
     tcl:
       all:


### PR DESCRIPTION
1. It's used by site administrators, so it's niche, the rest of the Spack users does not need this;
2. If it's used by site administrators, they likely need to modify the config anyhow, so the default config only serves as an example on how to get started;
3. it's too arbitrary to enable tcl, but disable lmod
4. modules can be generated with `spack modules [type] refresh ...`, so nothing is lost.

To get the old behavior back, one can simply run

```
spack config --scope site add modules:default:enable:[tcl]
```