### PR TITLE
remove 120s db timeout since 60s is the default now

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -553,14 +553,6 @@ def ci_rebuild(args):
             SPACK_COMMAND,
             "-e",
             env.path,
-            "config",
-            "add",
-            "config:db_lock_timeout:120",  # 2 minutes for processes to fight for a db lock
-        ],
-        [
-            SPACK_COMMAND,
-            "-e",
-            env.path,
             "env",
             "depfile",
             "-o",


### PR DESCRIPTION
See https://github.com/spack/spack/pull/35517, probably enough.
