### PR TITLE
`py-pyarrow`: fix build environment

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -66,13 +66,13 @@ class PyPyarrow(PythonPackage, CudaPackage):
     patch("for_aarch64.patch", when="@0 target=aarch64:")
 
     def setup_build_environment(self, env):
-        if spec.satisfies("+parquet"):
-            env.set("PYARROW_PARQUET", "1")
-        if spec.satisfies("+cuda"):
+        if self.spec.satisfies("+parquet"):
+            env.set("PYARROW_WITH_PARQUET", "1")
+        if self.spec.satisfies("+cuda"):
             env.set("PYARROW_WITH_CUDA", "1")
-        if spec.satisfies("+orc"):
+        if self.spec.satisfies("+orc"):
             env.set("PYARROW_WITH_ORC", "1")
-        if spec.satisfies("+dataset"):
+        if self.spec.satisfies("+dataset"):
             env.set("PYARROW_WITH_DATASET", "1")
 
     def install_options(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -66,14 +66,10 @@ class PyPyarrow(PythonPackage, CudaPackage):
     patch("for_aarch64.patch", when="@0 target=aarch64:")
 
     def setup_build_environment(self, env):
-        if self.spec.satisfies("+parquet"):
-            env.set("PYARROW_WITH_PARQUET", "1")
-        if self.spec.satisfies("+cuda"):
-            env.set("PYARROW_WITH_CUDA", "1")
-        if self.spec.satisfies("+orc"):
-            env.set("PYARROW_WITH_ORC", "1")
-        if self.spec.satisfies("+dataset"):
-            env.set("PYARROW_WITH_DATASET", "1")
+        env.set("PYARROW_WITH_PARQUET", self.spec.satisfies("+parquet"))
+        env.set("PYARROW_WITH_CUDA", self.spec.satisfies("+cuda"))
+        env.set("PYARROW_WITH_ORC", self.spec.satisfies("+orc"))
+        env.set("PYARROW_WITH_DATASET", self.spec.satisfies("+dataset"))
 
     def install_options(self, spec, prefix):
         args = []


### PR DESCRIPTION
Fixes the undefined spec variable + wrong env variable passed to the build environment.