### PR TITLE
Improve error handling in buildcache downloads

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2630,3 +2630,28 @@ def temporary_dir(
             yield tmp_dir
     finally:
         remove_directory_contents(tmp_dir)
+
+
+def filesummary(path, print_bytes=16) -> Tuple[int, bytes]:
+    """Create a small summary of the given file. Does not error
+    when file does not exist.
+
+    Args:
+        print_bytes (int): Number of bytes to print from start/end of file
+
+    Returns:
+        Tuple of size and byte string containing first n .. last n bytes.
+        Size is 0 if file cannot be read."""
+    try:
+        n = print_bytes
+        with open(path, "rb") as f:
+            size = os.fstat(f.fileno()).st_size
+            if size <= 2 * n:
+                short_contents = f.read(2 * n)
+            else:
+                short_contents = f.read(n)
+                f.seek(-n, 2)
+                short_contents += b"..." + f.read(n)
+        return size, short_contents
+    except OSError:
+        return 0, b""

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -556,7 +556,7 @@ class NoChecksumException(spack.error.SpackError):
 
     def __init__(self, path, algorithm, expected, computed):
         size, contents = fsys.filesummary(path)
-        super(NoChecksumException).__init__(
+        super(NoChecksumException, self).__init__(
             f"{algorithm} checksum failed for {path}",
             f"Expected {expected} but got {computed}. "
             f"File size = {size} bytes. Contents = {contents!r}",

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -89,22 +89,6 @@ def _ensure_one_stage_entry(stage_path):
     return os.path.join(stage_path, stage_entries[0])
 
 
-def _filesummary(path, print_bytes=16):
-    try:
-        n = print_bytes
-        with open(path, "rb") as f:
-            size = os.fstat(f.fileno()).st_size
-            if size <= 2 * n:
-                short_contents = f.read(2 * n)
-            else:
-                short_contents = f.read(n)
-                f.seek(-n, 2)
-                short_contents += b"..." + f.read(n)
-        return size, short_contents
-    except OSError:
-        return 0, b""
-
-
 def fetcher(cls):
     """Decorator used to register fetch strategies."""
     all_strategies.append(cls)
@@ -513,7 +497,7 @@ class URLFetchStrategy(FetchStrategy):
             # On failure, provide some information about the file size and
             # contents, so that we can quickly see what the issue is (redirect
             # was not followed, empty file, text instead of binary, ...)
-            size, contents = _filesummary(self.archive_file)
+            size, contents = fs.filesummary(self.archive_file)
             raise ChecksumError(
                 f"{checker.hash_name} checksum failed for {self.archive_file}",
                 f"Expected {self.digest} but got {checker.sum}. "

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1755,14 +1755,16 @@ class PackageInstaller(object):
                 raise
 
             except binary_distribution.NoChecksumException as exc:
-                if not task.cache_only:
-                    # Checking hash on downloaded binary failed.
-                    err = "Failed to install {0} from binary cache due to {1}:"
-                    err += " Requeueing to install from source."
-                    tty.error(err.format(pkg.name, str(exc)))
-                    task.use_cache = False
-                    self._requeue_task(task)
-                    continue
+                if task.cache_only:
+                    raise
+
+                # Checking hash on downloaded binary failed.
+                err = "Failed to install {0} from binary cache due to {1}:"
+                err += " Requeueing to install from source."
+                tty.error(err.format(pkg.name, str(exc)))
+                task.use_cache = False
+                self._requeue_task(task)
+                continue
 
             except (Exception, SystemExit) as exc:
                 self._update_failed(task, True, exc)

--- a/lib/spack/spack/test/fetch_strategy.py
+++ b/lib/spack/spack/test/fetch_strategy.py
@@ -14,13 +14,3 @@ def test_fetchstrategy_bad_url_scheme():
 
     with pytest.raises(ValueError):
         fetcher = fetch_strategy.from_url_scheme("bogus-scheme://example.com/a/b/c")  # noqa: F841
-
-
-def test_filesummary(tmpdir):
-    p = str(tmpdir.join("xyz"))
-    with open(p, "wb") as f:
-        f.write(b"abcdefghijklmnopqrstuvwxyz")
-
-    assert fetch_strategy._filesummary(p, print_bytes=8) == (26, b"abcdefgh...stuvwxyz")
-    assert fetch_strategy._filesummary(p, print_bytes=13) == (26, b"abcdefghijklmnopqrstuvwxyz")
-    assert fetch_strategy._filesummary(p, print_bytes=100) == (26, b"abcdefghijklmnopqrstuvwxyz")

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -861,3 +861,13 @@ def test_remove_linked_tree_doesnt_change_file_permission(tmpdir, initial_mode):
     fs.remove_linked_tree(str(file_instead_of_dir))
     final_stat = os.stat(str(file_instead_of_dir))
     assert final_stat == initial_stat
+
+
+def test_filesummary(tmpdir):
+    p = str(tmpdir.join("xyz"))
+    with open(p, "wb") as f:
+        f.write(b"abcdefghijklmnopqrstuvwxyz")
+
+    assert fs.filesummary(p, print_bytes=8) == (26, b"abcdefgh...stuvwxyz")
+    assert fs.filesummary(p, print_bytes=13) == (26, b"abcdefghijklmnopqrstuvwxyz")
+    assert fs.filesummary(p, print_bytes=100) == (26, b"abcdefghijklmnopqrstuvwxyz")


### PR DESCRIPTION
The `NoChecksumException` was completely useles, not printing
anything except that "something" was wrong.

And the exception was caught just to be ignored in the case of
`--use-buildcache=only`, took me a while to figure that one out...

Before:

```
bash-4.2# 'spack' -e '/builds/spack/spack/jobs_scratch_dir/concrete_environment' install --verbose --fail-fast --use-buildcache=only '--no-check-signature'  --only-concrete --only=package --no-add /h4i7bewott2ievjpvg2sfchke3tqsegv 
==> Installing gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv
==> Extracting gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv from binary cache
==> Error: gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv: Package was not installed
==> Error: Installation request failed.  Refer to reported errors for failing package(s).
```

After this PR:

```
bash-4.2# 'spack' -e '/builds/spack/spack/jobs_scratch_dir/concrete_environment' install --verbose --fail-fast --use-buildcache=only '--no-check-signature'  --only-concrete --only=package --no-add /h4i7bewott2ievjpvg2sfchke3tqsegv 
==> Installing gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv
==> Extracting gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv from binary cache
==> Error: sha256 checksum failed for /tmp/root/spack-stage/spack-stage-nhlyu41o/linux-amzn2-x86_64_v3-gcc-7.3.1-gettext-0.21.1-h4i7bewott2ievjpvg2sfchke3tqsegv.spack
Expected 3109c3592de6fdc315459ab31788221025b4e33108716f92358bf1f6786601d5 but got 9aec85763b10e7b358119dfc9d08c35a9321d0c45f7d9de721c216e9d2eccccc. File size = 11185007 bytes. Contents = b'\x1f\x8b\x08\x08\xc2{\xefc\x00\xfflinux-...\x91#G\x8e\xbeb\xfa\x1f\xde\x02R\x1e\x00\x80\xdc\x02'
```

