### PR TITLE
Add httpd v2.4.55 and deprecate previous versions due to CVE-2022-31813

### DIFF
--- a/var/spack/repos/builtin/packages/httpd/package.py
+++ b/var/spack/repos/builtin/packages/httpd/package.py
@@ -13,10 +13,29 @@ class Httpd(AutotoolsPackage):
     homepage = "https://httpd.apache.org/"
     url = "https://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2"
 
-    version("2.4.43", sha256="a497652ab3fc81318cdc2a203090a999150d86461acff97c1065dc910fe10f43")
-    version("2.4.41", sha256="133d48298fe5315ae9366a0ec66282fa4040efa5d566174481077ade7d18ea40")
-    version("2.4.39", sha256="b4ca9d05773aa59b54d66cd8f4744b945289f084d3be17d7981d1783a5decfa2")
-    version("2.4.38", sha256="7dc65857a994c98370dc4334b260101a7a04be60e6e74a5c57a6dee1bc8f394a")
+    version("2.4.55", sha256="11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac")
+
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-31813
+    version(
+        "2.4.43",
+        sha256="a497652ab3fc81318cdc2a203090a999150d86461acff97c1065dc910fe10f43",
+        deprecated=True,
+    )
+    version(
+        "2.4.41",
+        sha256="133d48298fe5315ae9366a0ec66282fa4040efa5d566174481077ade7d18ea40",
+        deprecated=True,
+    )
+    version(
+        "2.4.39",
+        sha256="b4ca9d05773aa59b54d66cd8f4744b945289f084d3be17d7981d1783a5decfa2",
+        deprecated=True,
+    )
+    version(
+        "2.4.38",
+        sha256="7dc65857a994c98370dc4334b260101a7a04be60e6e74a5c57a6dee1bc8f394a",
+        deprecated=True,
+    )
 
     depends_on("m4", type="build")
     depends_on("autoconf", type="build")


### PR DESCRIPTION
Add httpd v2.4.55 which includes new features as well as multiple vulnerability and bug fixes. Deprecated previous versions due to CVE-2022-31813. 

**Changelogs:**
Full changelog for new features can be found [here](https://httpd.apache.org/docs/2.4/new_features_2_4.html).
Full changelog for vulnerability mitigations can be found [here](https://httpd.apache.org/security/vulnerabilities_24.html).
