### PR TITLE
Add activemq v5.17.3 and deprecate previous version due to CVE-2018-11775

### DIFF
--- a/var/spack/repos/builtin/packages/activemq/package.py
+++ b/var/spack/repos/builtin/packages/activemq/package.py
@@ -15,7 +15,16 @@ class Activemq(Package):
     homepage = "https://archive.apache.org/dist/activemq"
     url = "https://archive.apache.org/dist/activemq/5.14.0/apache-activemq-5.14.0-bin.tar.gz"
 
-    version("5.14.0", sha256="81c623465af277dd50a141a8d9308d6ec8e1b78d9019b845873dc12d117aa9a6")
+    version("5.17.3", sha256="a4cc4c3a2f136707c2c696f3bb3ee2a86dbeff1b9eb5e237b14edc0c5e5a328f")
+
+    # https://nvd.nist.gov/vuln/detail/CVE-2018-11775
+    version(
+        "5.14.0",
+        sha256="81c623465af277dd50a141a8d9308d6ec8e1b78d9019b845873dc12d117aa9a6",
+        deprecated=True,
+    )
+
+    depends_on("java")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
Add Activemq v5.17.3 which includes multiple bug and vulnerability fixes. Deprecated previous versions due to CVE-2018-11775.

**Summarized Changelog:**
- When use LDAP auth, Activemq should not always connect to ldap service to do authentication.
- Jolokia-agent - File not found exception.
- ActiveMQ 5.17.1: Web Console is not working in KARAF 4.4.1.
- HTTP Proxy Exclusions are not applied to ActiveMQ Connections.
- Closing many consumers causes CPU to spike to 100%.
- Fix Slow Consumer Advisory for Queue subscriptions.
- Fix TwoSecureBrokerRequestReplyTest.
- MessageDelivered advisory causes NPE on non persistent broker when using transactions.

Full changelog can be found [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12352201).