### PR TITLE
Add alluxio v2.9.1 and deprecate previous versions due to CVE-2022-23848

### DIFF
--- a/var/spack/repos/builtin/packages/alluxio/package.py
+++ b/var/spack/repos/builtin/packages/alluxio/package.py
@@ -17,9 +17,24 @@ class Alluxio(Package):
     list_url = "https://downloads.alluxio.io/downloads/files"
     list_depth = 1
 
-    version("2.7.2", sha256="e428acfe0704cc68801ae2aa7b7ba920a0e35af9dded66b280649fc1d280a3d4")
-    version("2.2.1", sha256="0c6b0afcc4013437afb8113e1dfda9777561512269ea349c7fbf353dc0efd28a")
-    version("2.2.0", sha256="635847ea1a0f8ad04c99518620de035d4962fbfa9e5920bb0911ccf8e5ea82fc")
+    version("2.9.1", sha256="e9456db7a08488af22dee3a44e4135bc03a0444e31c7753bf00f72465f68ffb9")
+
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-23848
+    version(
+        "2.7.2",
+        sha256="e428acfe0704cc68801ae2aa7b7ba920a0e35af9dded66b280649fc1d280a3d4",
+        deprecated=True,
+    )
+    version(
+        "2.2.1",
+        sha256="0c6b0afcc4013437afb8113e1dfda9777561512269ea349c7fbf353dc0efd28a",
+        deprecated=True,
+    )
+    version(
+        "2.2.0",
+        sha256="635847ea1a0f8ad04c99518620de035d4962fbfa9e5920bb0911ccf8e5ea82fc",
+        deprecated=True,
+    )
 
     depends_on("java@8", type="run")
 


### PR DESCRIPTION
Add Alluxio v2.9.1 which includes multiple bug and vulnerability fixes. Deprecated previous versions due to CVE-2022-23848.

**Summarized Changelog:**
- Fix bug for ufs journal dumper when read regular checkpoint.
- Fix concurrent sync dedup.
- Add more observability on inode tree corruption.
- Add compression level option for RocksDB checkpoint.
- Support log source ip to rpc debug log.

Full changelog can be found [here](https://www.alluxio.io/download/releases/alluxio-2-9-1-release/).