### PR TITLE
cp2k: fix builds on macOS, workaround reported issue with __contains__

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -5,6 +5,7 @@
 import copy
 import os
 import os.path
+import sys
 
 import spack.util.environment
 from spack.package import *
@@ -274,31 +275,14 @@ class Cp2k(MakefilePackage, CudaPackage):
     def edit(self, spec, prefix):
         pkgconf = which("pkg-config")
 
-        if "^fftw" in spec:
-            fftw = spec["fftw:openmp" if "+openmp" in spec else "fftw"]
-            fftw_header_dir = fftw.headers.directories[0]
-        elif "^amdfftw" in spec:
-            fftw = spec["amdfftw:openmp" if "+openmp" in spec else "amdfftw"]
-            fftw_header_dir = fftw.headers.directories[0]
-        elif "^armpl-gcc" in spec:
-            fftw = spec["armpl-gcc:openmp" if "+openmp" in spec else "armpl-gcc"]
-            fftw_header_dir = fftw.headers.directories[0]
-        elif "^intel-mkl" in spec:
-            fftw = spec["intel-mkl"]
-            fftw_header_dir = fftw.headers.directories[0] + "/fftw"
-        elif "^intel-oneapi-mkl" in spec:
-            fftw = spec["intel-oneapi-mkl"]
-            fftw_header_dir = fftw.headers.directories[0] + "/fftw"
-        elif "^intel-parallel-studio+mkl" in spec:
-            fftw = spec["intel-parallel-studio"]
-            fftw_header_dir = "<NOTFOUND>"
-            for incdir in [join_path(f, "fftw") for f in fftw.headers.directories]:
-                if os.path.exists(incdir):
-                    fftw_header_dir = incdir
-                    break
-        elif "^cray-fftw" in spec:
-            fftw = spec["cray-fftw"]
-            fftw_header_dir = fftw.headers.directories[0]
+        fftw = spec["fftw-api"]
+        fftw_header_dir = fftw.headers.directories[0]
+
+        # some providers (mainly Intel) keep the fftw headers in a subdirectory, find it
+        for incdir in [join_path(f, "fftw") for f in fftw.headers.directories]:
+            if os.path.exists(incdir):
+                fftw_header_dir = incdir
+                break
 
         optimization_flags = {
             "gcc": ["-O2", "-funroll-loops", "-ftree-vectorize"],
@@ -401,11 +385,12 @@ class Cp2k(MakefilePackage, CudaPackage):
         ldflags.append((lapack + blas).search_flags)
         libs.extend([str(x) for x in (fftw.libs, lapack, blas)])
 
-        if any(
-            p in spec for p in ("^intel-mkl", "^intel-parallel-studio+mkl", "^intel-oneapi-mkl")
-        ):
+        if sys.platform == "darwin":
+            cppflags.extend(["-D__NO_STATM_ACCESS"])
+
+        if spec["blas"].name in ("intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"):
             cppflags += ["-D__MKL"]
-        elif "^accelerate" in spec:
+        elif spec["blas"].name == "accelerate":
             cppflags += ["-D__ACCELERATE"]
 
         if "+cosma" in spec:
@@ -418,15 +403,15 @@ class Cp2k(MakefilePackage, CudaPackage):
         if "+mpi" in spec:
             cppflags.extend(["-D__parallel", "-D__SCALAPACK"])
 
-            if "^intel-oneapi-mpi" in spec:
+            if spec["mpi"].name == "intel-oneapi-mpi":
                 mpi = [join_path(spec["intel-oneapi-mpi"].libs.directories[0], "libmpi.so")]
             else:
                 mpi = spec["mpi:cxx"].libs
 
             # while intel-mkl has a mpi variant and adds the scalapack
             # libs to its libs, intel-oneapi-mkl does not.
-            if "^intel-oneapi-mkl" in spec:
-                mpi_impl = "openmpi" if "^openmpi" in spec else "intelmpi"
+            if spec["scalapack"].name == "intel-oneapi-mkl":
+                mpi_impl = "openmpi" if spec["mpi"] == "openmpi" else "intelmpi"
                 scalapack = [
                     join_path(
                         spec["intel-oneapi-mkl"].libs.directories[0], "libmkl_scalapack_lp64.so"
@@ -662,10 +647,10 @@ class Cp2k(MakefilePackage, CudaPackage):
                 #
                 # and use `-fpp` instead
                 mkf.write("CPP = # {0} -P\n".format(spack_cc))
-                mkf.write("AR  = {0}/xiar -r\n".format(intel_bin_dir))
+                mkf.write("AR  = {0}/xiar -qs\n".format(intel_bin_dir))
             else:
                 mkf.write("CPP = # {0} -E\n".format(spack_cc))
-                mkf.write("AR  = ar -r\n")
+                mkf.write("AR  = ar -qs\n")  # r = qs is a GNU extension
 
             if "+cuda" in spec:
                 mkf.write(
@@ -762,7 +747,7 @@ class Cp2k(MakefilePackage, CudaPackage):
                 content += " " + self.spec["lapack"].libs.ld_flags
                 content += " " + self.spec["fftw-api"].libs.ld_flags
 
-                if "^fftw+openmp" in self.spec:
+                if (self.spec["fftw-api"].name == "fftw") and ("+openmp" in self.spec["fftw"]):
                     content += " -lfftw3_omp"
 
                 content += "\n"

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -385,7 +385,7 @@ class Cp2k(MakefilePackage, CudaPackage):
         ldflags.append((lapack + blas).search_flags)
         libs.extend([str(x) for x in (fftw.libs, lapack, blas)])
 
-        if sys.platform == "darwin":
+        if self.spec.satisfies("platform=darwin"):
             cppflags.extend(["-D__NO_STATM_ACCESS"])
 
         if spec["blas"].name in ("intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -5,7 +5,6 @@
 import copy
 import os
 import os.path
-import sys
 
 import spack.util.environment
 from spack.package import *

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from os.path import dirname, isdir
 
 from spack.package import *
 
@@ -153,7 +154,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if "+cluster" in self.spec:
             libs.append(self._xlp64_lib("libmkl_blacs_intelmpi"))
 
-        return find_libraries(libs, self.component_prefix.lib.intel64, shared=shared)
+        lib_path = join_path(self.component_prefix, "lib", "intel64")
+        lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
+
+        return find_libraries(libs, lib_path, shared=shared)
 
     def _xlp64_lib(self, lib):
         return lib + ("_ilp64" if "+ilp64" in self.spec else "_lp64")

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -154,7 +154,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if "+cluster" in self.spec:
             libs.append(self._xlp64_lib("libmkl_blacs_intelmpi"))
 
-        lib_path = join_path(self.component_prefix, "lib", "intel64")
+        lib_path = self.component_prefix.lib.intel64
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
         return find_libraries(libs, lib_path, shared=shared)

--- a/var/spack/repos/builtin/packages/netlib-scalapack/fix-build-macos.patch
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/fix-build-macos.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 85ea82a..86222e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,7 +232,7 @@ append_subdir_files(src-C "SRC")
+
+ if (UNIX)
+    add_library(scalapack ${blacs} ${tools} ${tools-C} ${extra_lapack} ${pblas} ${pblas-F} ${ptzblas} ${ptools} ${pbblas} ${redist} ${src} ${src-C})
+-   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
++   target_link_libraries( scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+    scalapack_install_library(scalapack)
+ else (UNIX) # Need to separate Fortran and C Code
+    OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON )

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -44,6 +44,8 @@ class ScalapackBase(CMakePackage):
         sha256="072b006e485f0ca4cba56096912a986e4d3da73aae51c2205928aa5eb842cefd",
         when="@2.2.0",
     )
+    # From Homebrew, integrated @upstream in different form over multiple commits
+    patch("fix-build-macos.patch", when="@2.2.0")
 
     def flag_handler(self, name, flags):
         iflags = []


### PR DESCRIPTION
- netlib-scalapack: fix build on macOS (and possibly others)
- intel-oneapi-mkl: fix lib discovery on macOS for external lib
- cp2k: fix building on non-GNU systems, workaround #35597 
