### PR TITLE
Remove unused `ignore` parameter of `extends()` directive

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2726,29 +2726,6 @@ variant(s) are selected.  This may be accomplished with conditional
        extends("python", when="+python")
        ...
 
-Sometimes, certain files in one package will conflict with those in
-another, which means they cannot both be used in a view at the
-same time.  In this case, you can tell Spack to ignore those files:
-
-.. code-block:: python
-
-   class PySncosmo(Package):
-       ...
-       # py-sncosmo binaries are duplicates of those from py-astropy
-       extends("python", ignore=r"bin/.*")
-       depends_on("py-astropy")
-       ...
-
-The code above will prevent everything in the ``$prefix/bin/`` directory
-from being linked in a view.
-
-.. note::
-
-   You can call *either* ``depends_on`` or ``extends`` on any one
-   package, but not both.  For example you cannot both
-   ``depends_on("python")`` and ``extends("python")`` in the same
-   package.  ``extends`` implies ``depends_on``.
-
 -----
 Views
 -----

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -46,17 +46,12 @@ class Libxml2(AutotoolsPackage):
 
     # avoid cycle dependency for concretizer
     with when("+python"):
+        extends("python")
         depends_on("python+shared~libxml2")
         # A note about python versions: libxml 2.10.1 (and presumably earlier) has
         # a bug in its configure script that fails to properly parse python
         # version strings with more than one character for the minor version.
         depends_on("python@:3.9", when="@:2.10.1")
-    extends(
-        "python",
-        when="+python",
-        ignore=r"(bin.*$)|(include.*$)|(share.*$)|(lib/libxml2.*$)|"
-        "(lib/xml2.*$)|(lib/cmake.*$)",
-    )
 
     # XML Conformance Test Suites
     # See https://www.w3.org/XML/Test/ for information

--- a/var/spack/repos/builtin/packages/py-abipy/package.py
+++ b/var/spack/repos/builtin/packages/py-abipy/package.py
@@ -18,16 +18,6 @@ class PyAbipy(PythonPackage):
     variant("gui", default=False, description="Build the GUI")
     variant("ipython", default=False, description="Build IPython support")
 
-    extends(
-        "python",
-        ignore=(
-            "bin/("
-            "feff_.*|gaussian_analyzer|get_environment|html2text|"
-            "nc3tonc4|nc4tonc3|ncinfo|pmg|pydii|tabulate|tqdm"
-            ")"
-        ),
-    )
-
     depends_on("python@2.7:")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-autopep8/package.py
+++ b/var/spack/repos/builtin/packages/py-autopep8/package.py
@@ -21,7 +21,6 @@ class PyAutopep8(PythonPackage):
     version("1.2.4", sha256="38e31e266e29808e8a65a307778ed8e402e1f0d87472009420d6d18146cdeaa2")
     version("1.2.2", sha256="ecc51614755c7f697e83478f87eb6bbd009075a397c15080f0311aaecbbdfca8")
 
-    extends("python", ignore="bin/pep8")
     depends_on("python@2.6:2.8,3.2:", type=("build", "run"))
 
     depends_on("py-pycodestyle@1.5.7:1.7.0", when="@:1.2.4", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-fava/package.py
+++ b/var/spack/repos/builtin/packages/py-fava/package.py
@@ -15,11 +15,6 @@ class PyFava(PythonPackage):
 
     version("1.18", sha256="21336b695708497e6f00cab77135b174c51feb2713b657e0e208282960885bf5")
 
-    # For some reason Fava adds a whole bunch of executables to
-    # its bin directory, and this causes clashes when loading
-    # the module.
-    extends("python", ignore="bin/^(?!fava).*")
-
     # Some of the dependencies are not listed as required at
     # build or run time, but actually are.
     # - py-setuptools

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -27,7 +27,6 @@ class PyFlake8(PythonPackage):
     version("3.0.4", sha256="b4c210c998f07d6ff24325dd91fbc011f2c37bcd6bf576b188de01d8656e970d")
     version("2.5.4", sha256="cc1e58179f6cf10524c7bfdd378f5536d0a61497688517791639a5ecc867492f")
 
-    extends("python", ignore="bin/(pyflakes|pycodestyle)")
     depends_on("python@3.6.1:", when="@5:", type=("build", "run"))
     depends_on("python@3.6:", when="@4:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@3.9.2:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-logilab-common/package.py
+++ b/var/spack/repos/builtin/packages/py-logilab-common/package.py
@@ -15,6 +15,5 @@ class PyLogilabCommon(PythonPackage):
     version("1.4.2", sha256="cdda9ed0deca7c68f87f7a404ad742e47aaa1ca5956d12988236a5ec3bda13a0")
     version("1.2.0", sha256="d4e5cec3be3a89f06ff05e359a221e69bd1da33cb7096cad648ddcccea8465b7")
 
-    extends("python", ignore=r"bin/pytest")
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-six@1.4.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pylint/package.py
+++ b/var/spack/repos/builtin/packages/py-pylint/package.py
@@ -34,7 +34,6 @@ class PyPylint(PythonPackage):
     version("2.3.1", sha256="723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1")
     version("2.3.0", sha256="ee80c7af4f127b2a480d83010c9f0e97beb8eaa652b78c2837d3ed30b12e1182")
 
-    extends("python", ignore=r"bin/pytest")
     depends_on("python@3.4:", when="@2:2.7", type=("build", "run"))
     depends_on("python@3.6:", when="@2.8.2:", type=("build", "run"))
     depends_on("python@3.6.2:", when="@2.13.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -20,8 +20,6 @@ class PyPymatgen(PythonPackage):
         "2020.12.31", sha256="5002490facd47c55d2dae42c35712e061c1f5d881180485c0543a899589856d6"
     )
 
-    extends("python@3.7:", ignore="bin/tabulate")
-
     depends_on("py-setuptools@18.0:", type="build")
 
     depends_on("py-numpy@1.9:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-cov/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-cov/package.py
@@ -16,8 +16,6 @@ class PyPytestCov(PythonPackage):
     version("2.8.1", sha256="cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b")
     version("2.3.1", sha256="fa0a212283cdf52e2eecc24dd6459bb7687cc29adb60cb84258fab73be8dda0f")
 
-    extends("python", ignore=r"bin/*")
-
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"), when="@3.0.0:")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-pytest-httpbin/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-httpbin/package.py
@@ -16,8 +16,6 @@ class PyPytestHttpbin(PythonPackage):
     version("0.2.3", sha256="c5b698dfa474ffc9caebcb35e34346b753eb226aea5c2e1b69fefedbcf161bf8")
     version("0.0.7", sha256="03af8a7055c8bbcb68b14d9a14c103c82c97aeb86a8f1b29cd63d83644c2f021")
 
-    extends("python", ignore=r"bin/flask")
-
     depends_on("py-setuptools", type="build")
     depends_on("py-flask", when="@:0.2", type=("build", "run"))
     depends_on("py-decorator", when="@:0.2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-mock/package.py
@@ -22,8 +22,6 @@ class PyPytestMock(PythonPackage):
         url="https://pypi.io/packages/source/p/pytest-mock/pytest-mock-1.2.zip",
     )
 
-    extends("python", ignore=r"bin/*")
-
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"), when="@:1.11.1")
     depends_on("python@3.7:", type=("build", "run"), when="@3.10.0:")
 

--- a/var/spack/repos/builtin/packages/py-reportlab/package.py
+++ b/var/spack/repos/builtin/packages/py-reportlab/package.py
@@ -16,12 +16,6 @@ class PyReportlab(PythonPackage):
     version("3.6.12", sha256="b13cebf4e397bba14542bcd023338b6ff2c151a3a12aabca89eecbf972cb361a")
     version("3.4.0", sha256="5beaf35e59dfd5ebd814fdefd76908292e818c982bd7332b5d347dfd2f01c343")
 
-    # py-reportlab provides binaries that duplicate those of other packages,
-    # thus interfering with activation.
-    # - easy_install, provided by py-setuptools
-    # - pip, provided by py-pip
-    extends("python", ignore=r"bin/.*")
-
     depends_on("python@3.7:3", when="@3.6.9:", type=("build", "run"))
     depends_on("py-setuptools@2.2:", type="build")
     depends_on("py-pip@1.4.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -20,6 +20,5 @@ class PySix(PythonPackage):
     version("1.9.0", sha256="e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5")
     version("1.8.0", sha256="047bbbba41bac37c444c75ddfdf0573dd6e2f1fbd824e6247bb26fa7d8fa3830")
 
-    extends("python", ignore=r"bin/pytest")
     depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-sncosmo/package.py
+++ b/var/spack/repos/builtin/packages/py-sncosmo/package.py
@@ -16,8 +16,6 @@ class PySncosmo(PythonPackage):
     version("1.2.0", sha256="f3969eec5b25f60c70418dbd64765a2b4735bb53c210c61d0aab68916daea588")
 
     # Required dependencies
-    # py-sncosmo binaries are duplicates of those from py-astropy
-    extends("python", ignore=r"bin/.*")
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -59,8 +59,6 @@ class PySphinx(PythonPackage):
     version("1.4.5", sha256="c5df65d97a58365cbf4ea10212186a9a45d89c61ed2c071de6090cdf9ddb4028")
     version("1.3.1", sha256="1a6e5130c2b42d2de301693c299f78cc4bd3501e78b610c08e45efc70e2b5114")
 
-    extends("python", ignore="bin/(pybabel|pygmentize)")
-
     depends_on("py-flit-core@3.7:", when="@5.2:", type="build")
     depends_on("py-setuptools", when="@4.4:5.1", type="build")
     depends_on("py-setuptools", when="@:4.3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tap-py/package.py
+++ b/var/spack/repos/builtin/packages/py-tap-py/package.py
@@ -15,8 +15,6 @@ class PyTapPy(PythonPackage):
     version("3.0", sha256="f5eeeeebfd64e53d32661752bb4c288589a3babbb96db3f391a4ec29f1359c70")
     version("2.6.2", sha256="5f219d92dbad5e378f8f7549cdfe655b0d5fd2a778f9c83bee51b61c6ca40efb")
 
-    extends("python", ignore="bin/nosetests|bin/pygmentize")
-
     depends_on("python@3.5:3.7", when="@3.0:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:3.7", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-wcsaxes/package.py
+++ b/var/spack/repos/builtin/packages/py-wcsaxes/package.py
@@ -15,7 +15,6 @@ class PyWcsaxes(PythonPackage):
 
     version("0.8", sha256="9c6addc1ec04cc99617850354b2c03dbd4099d2e43b45a81f8bc3069de9c8e83")
 
-    extends("python", ignore=r"bin/")
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))


### PR DESCRIPTION
If I'm understanding correctly, the `ignore` parameter was only used for `spack activate/deactivate`, it isn't used by Spack Environments which has its own handling of file conflicts. We should remove it.

Is there somewhere I can check for this and issue a deprecation warning? Or is it harmlessly ignored anyway? This is one of those situations where we use kwargs where we really shouldn't, but have to keep doing so due to old Python version support.