### PR TITLE
vtk-m: update to latest release

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -32,7 +32,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     version(
         "2.0.0",
         sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3",
-        preferred=True
+        preferred=True,
     )
     version("1.9.0", sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4")
     version("1.8.0", sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,12 +29,12 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
-    version("2.0.0-rc1", sha256="4dc018961eeeb3c6bd4e5443d72e79b9d5fb86901e38fb757f74a7a45dbbc0d8")
     version(
-        "1.9.0",
-        sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4",
-        preferred=True,
+        "2.0.0",
+        sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3",
+        preferred=True
     )
+    version("1.9.0", sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4")
     version("1.8.0", sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")
     version("1.7.1", sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63")
     version("1.7.0", sha256="a86667ac22057462fc14495363cfdcc486da125b366cb568ec23c86946439be4")


### PR DESCRIPTION
:tada: :tada: :tada: 


Finally! VTK-m v2.0.0 final release is out.

This bring exiting new features and bugfixes. Find the release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/2.0/release-notes.md

Let me know if we need to change anything else in the package

ViB

:tada: :tada: :tada: