### PR TITLE
ExaGO 1.5.1 release

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -121,7 +121,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("umpire@6.0.0:6", when="@1.1.0:+raja")
     depends_on("camp@0.2.3:0.2", when="@1.1.0:+raja")
     # This is no longer a requirement in RAJA > 0.14
-    depends_on("umpire+cuda~shared", when="+raja+cuda")
+    depends_on("umpire+cuda~shared", when="+raja+cuda ^raja@:0.14")
 
     depends_on("petsc@3.13:3.14", when="@:1.2.99")
     depends_on("petsc@3.16.0:3.16", when="@1.3.0:1.4")

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -14,7 +14,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://gitlab.pnnl.gov/exasgd/frameworks/exago"
     git = "https://gitlab.pnnl.gov/exasgd/frameworks/exago.git"
     maintainers("ryandanehy", "CameronRutherford", "pelesh")
-    
+
     version("1.5.1", commit="7abe482c8da0e247f9de4896f5982c4cacbecd78", submodules=True)
     version("1.5.0", commit="227f49573a28bdd234be5500b3733be78a958f15", submodules=True)
     version("1.4.1", commit="ea607c685444b5f345bfdc9a59c345f0f30adde2", submodules=True)
@@ -33,9 +33,9 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     # Progrmming model options
     variant("mpi", default=True, description="Enable/Disable MPI")
-    variant("raja", default=False, when='+hiop', description="Enable/Disable RAJA with HiOp")
-    variant("python", default=True, when='@1.4:', description="Enable/Disable Python bindings")
-    variant("logging", default=True, description"Enable/Disable spdlog based logging")
+    variant("raja", default=False, when="+hiop", description="Enable/Disable RAJA with HiOp")
+    variant("python", default=True, when="@1.4:", description="Enable/Disable Python bindings")
+    variant("logging", default=True, description="Enable/Disable spdlog based logging")
     conflicts(
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
@@ -50,7 +50,8 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     )
     # You can use Python with PFLOW if desired ~ipopt~hiop
     conflicts(
-        "~hiop~ipopt+python @:1.5.0", msg="ExaGO Python wrapper requires at least one solver enabled."
+        "~hiop~ipopt+python @:1.5.0",
+        msg="ExaGO Python wrapper requires at least one solver enabled.",
     )
 
     # Dependencies

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -132,7 +132,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("ginkgo@1.5.0.glu_experimental", when="+ginkgo")
 
-
     flag_handler = build_system_flags
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -116,7 +116,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts(
         "+shared",
-        when="+cuda+raja",
+        when="+cuda+raja ^raja@:0.14",
         msg="umpire+cuda exports device code and requires static libs",
     )
 

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -112,7 +112,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp@0.2.3:0.2", when="@0.5.0:+raja")
 
     # This is no longer a requirement in RAJA > 0.14
-    depends_on("umpire+cuda~shared", when="+raja+cuda")
+    depends_on("umpire+cuda~shared", when="+raja+cuda ^raja@:0.14")
 
     conflicts(
         "+shared",

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -80,14 +80,18 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("magma {0}".format(cuda_dep), when=cuda_dep)
         depends_on("raja {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
         depends_on("ginkgo {0}".format(cuda_dep), when="+ginkgo {0}".format(cuda_dep))
-        depends_on("umpire ~shared {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
+        depends_on("umpire {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
+        # Camp GPU arch doesn't get propogated correctly
+        depends_on("camp {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
 
     for arch in ROCmPackage.amdgpu_targets:
         rocm_dep = "+rocm amdgpu_target={0}".format(arch)
         depends_on("magma {0}".format(rocm_dep), when=rocm_dep)
         depends_on("raja {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
-        depends_on("umpire {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
         depends_on("ginkgo {0}".format(rocm_dep), when="+ginkgo {0}".format(rocm_dep))
+        depends_on("umpire {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
+        # Camp GPU arch doesn't get propogated correctly
+        depends_on("camp {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
 
     magma_ver_constraints = (("2.5.4", "0.4"), ("2.6.1", "0.4.6"), ("2.6.2", "0.5.4"))
 
@@ -101,9 +105,20 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("umpire", when="+raja")
     depends_on("raja+openmp", when="+raja~cuda~rocm")
 
-    # Umpire > 0.14 and RAJA > 6.0 require c++ std 14
-    depends_on("raja@0.14.0:0.14", when="@0.5.0:0.6.2+raja")
-    depends_on("umpire@6.0.0:", when="@0.5.0:0.6.2+raja")
+    # RAJA > 0.14 and Umpire > 6.0 require c++ std 14
+    # We are working on supporting newer Umpire/RAJA versions
+    depends_on("raja@0.14.0:0.14", when="@0.5.0:+raja")
+    depends_on("umpire@6.0.0:6", when="@0.5.0:+raja")
+    depends_on("camp@0.2.3:0.2", when="@0.5.0:+raja")
+
+    # This is no longer a requirement in RAJA > 0.14
+    depends_on("umpire+cuda~shared", when="+raja+cuda")
+
+    conflicts(
+        "+shared",
+        when="+cuda+raja",
+        msg="umpire+cuda exports device code and requires static libs",
+    )
 
     depends_on("hip", when="+rocm")
     depends_on("hipblas", when="+rocm")
@@ -117,11 +132,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("ginkgo@1.5.0.glu_experimental", when="+ginkgo")
 
-    conflicts(
-        "+shared",
-        when="+cuda+raja",
-        msg="umpire+cuda exports device code and requires static libs",
-    )
 
     flag_handler = build_system_flags
 


### PR DESCRIPTION
Version release for ExaGO, along with some QOL life changes to the ExaGO/HiOp packages.

Since HiOp is the main package that uses RAJA within the ExaSGD stack, I decided that having RAJA version constraint logic, as well as cuda arch specification consolidated to HiOp makes the most sense.

cc @pelesh @ryandanehy @jaelynlitz