### PR TITLE
Revert "Disable module generation by default"

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -40,8 +40,9 @@ modules:
     roots:
      tcl:    $spack/share/spack/modules
      lmod:   $spack/share/spack/lmod
-    # What type of modules to use ("tcl" and/or "lmod")
-    enable: []
+    # What type of modules to use
+    enable:
+      - tcl
 
     tcl:
       all:


### PR DESCRIPTION
Reverts spack/spack#35564

This one was merged too hastily, so we're going to revert that and poll users for the default value change.