### PR TITLE
gobject-introspection 1.7.2 also requires libffi@:3.3

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -42,7 +42,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("glib@2.48.1", when="@1.48.0")
     depends_on("libffi")
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
-    depends_on("libffi@:3.3", when="@:1.70")  # libffi 3.4 caused seg faults
+    depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults
     depends_on("python")
 
     # This package creates several scripts from


### PR DESCRIPTION
My attempt to rebase #31349 blew up, so this is a replacement PR.