### PR TITLE
mpich: fix macos problem with -flat-namespace

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -98,9 +98,9 @@ spack package at this time.""",
     variant("fortran", default=True, description="Enable Fortran support")
 
     variant(
-        "two_level_namespace",
-        default=False,
-        description="""Build shared libraries and programs
+        'two_level_namespace',
+        default=(sys.platform == 'darwin'),
+        description='''Build shared libraries and programs
 built with the mpicc/mpifort/etc. compiler wrappers
 with '-Wl,-commons,use_dylibs' and without
 '-Wl,-flat_namespace'.""",

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -98,15 +98,6 @@ spack package at this time.""",
     variant("fortran", default=True, description="Enable Fortran support")
 
     variant(
-        'two_level_namespace',
-        default=(sys.platform == 'darwin'),
-        description='''Build shared libraries and programs
-built with the mpicc/mpifort/etc. compiler wrappers
-with '-Wl,-commons,use_dylibs' and without
-'-Wl,-flat_namespace'.""",
-    )
-
-    variant(
         "vci",
         default=False,
         when="@4: device=ch4",
@@ -279,9 +270,6 @@ with '-Wl,-commons,use_dylibs' and without
 
     # see https://github.com/pmodels/mpich/pull/5031
     conflicts("%clang@:7", when="@3.4:3.4.1")
-
-    # see https://github.com/pmodels/mpich/issues/5530
-    conflicts('~two_level_namespace', when='platform=darwin')
 
     @classmethod
     def determine_version(cls, exe):
@@ -499,6 +487,10 @@ with '-Wl,-commons,use_dylibs' and without
             "--with-yaksa={0}".format(spec["yaksa"].prefix if "^yaksa" in spec else "embedded"),
         ]
 
+        # see https://github.com/pmodels/mpich/issues/5530
+        if sys.platform == "darwin":
+            config_args.append("--enable-two-level-namespace")
+
         # hwloc configure option changed in 4.0
         if spec.satisfies("@4.0:"):
             config_args.append(
@@ -580,9 +572,6 @@ with '-Wl,-commons,use_dylibs' and without
         if "+argobots" in spec:
             config_args.append("--with-thread-package=argobots")
             config_args.append("--with-argobots=" + spec["argobots"].prefix)
-
-        if "+two_level_namespace" in spec:
-            config_args.append("--enable-two-level-namespace")
 
         if "+vci" in spec:
             config_args.append("--enable-thread-cs=per-vci")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -280,6 +280,9 @@ with '-Wl,-commons,use_dylibs' and without
     # see https://github.com/pmodels/mpich/pull/5031
     conflicts("%clang@:7", when="@3.4:3.4.1")
 
+    # see https://github.com/pmodels/mpich/issues/5530
+    conflicts('~two_level_namespace', when='platform=darwin')
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)(output=str, error=str)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -488,7 +488,7 @@ spack package at this time.""",
         ]
 
         # see https://github.com/pmodels/mpich/issues/5530
-        if sys.platform == "darwin":
+        if spec.platform == "darwin":
             config_args.append("--enable-two-level-namespace")
 
         # hwloc configure option changed in 4.0


### PR DESCRIPTION
See discussion in #27429, it is just applying what has been decided there.

I had to create a new one due to a mess I did with the branch on my fork.