### PR TITLE
QE: Migrating AOCC to use CMake Build System

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/configure_aocc.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/configure_aocc.patch
@@ -38,7 +38,7 @@ index 66337d1..d2c04af 100755
          try_cflags="-O3"
          ;;
 +x86_64:* )
-+        try_cflags="-Ofast -Mstack_arrays"
++        try_cflags=" -Mstack_arrays"
 +        try_dflags="-D__OPENMP"
 +        ;;
  ppc64-bg:* )
@@ -49,9 +49,9 @@ index 66337d1..d2c04af 100755
          have_cpp=0
          ;;
 +*:*mpif90 )
-+        try_fflags="-Ofast -Mstack_arrays"
++        try_fflags="-Mstack_arrays"
 +        try_fflags_openmp="-fopenmp"
-+        try_f90flags=" \$(FFLAGS) -cpp -Ofast -Mpreprocess -Mstack_arrays"
++        try_f90flags=" \$(FFLAGS) -cpp -Mpreprocess -Mstack_arrays"
 +        try_foxflags="-D__PGI"
 +        try_fflags_noopt="-O0"
 +        try_ldflags=""

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -263,9 +263,7 @@ class QuantumEspresso(CMakePackage, Package):
         "build_system=generic", when="@6.8: %aocc", msg="Please use CMake to build with AOCC"
     )
 
-    conflicts(
-        "~openmp", when="^amdlibflame", msg="amdlibflame requires OpenMP"
-    )
+    conflicts("~openmp", when="^amdlibflame", msg="amdlibflame requires OpenMP")
 
     # QMCPACK converter patches for QE 6.8, 6.7, 6.4.1, 6.4, and 6.3
     conflicts(

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -370,12 +370,8 @@ class QuantumEspresso(CMakePackage, Package):
         when="+patch@6.4.1:6.5.0",
     )
 
-    # Configure updated to work with AOCC compilers
-    # patch("configure_aocc.patch", when="@6.7:7.0 %aocc")
-    # Restrict the patch to just version 6.7, 
-    ## because it is not needed for the CMake build version
+    # Patch automake configure for AOCC compilers
     patch("configure_aocc.patch", when="@6.7 %aocc")
- #   patch("configure_qe-7.1_aocc.patch", when="@7.1: %aocc")
 
     # Configure updated to work with NVIDIA compilers
     patch("nvhpc.patch", when="@6.5 %nvhpc")

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -257,6 +257,10 @@ class QuantumEspresso(CMakePackage, Package):
     # THIRD-PARTY PATCHES
     # NOTE: *SOME* third-party patches will require deactivation of
     # upstream patches using `~patch` variant
+    
+    # Conflict add for aocc with qe version >= 6.8 ,force use of CMAKE  
+    ## BUILD SYSTEM
+    conflicts("build_system=generic", when="@6.8: %aocc", msg="Please use CMake to build with AOCC")
 
     # QMCPACK converter patches for QE 6.8, 6.7, 6.4.1, 6.4, and 6.3
     conflicts(
@@ -367,7 +371,11 @@ class QuantumEspresso(CMakePackage, Package):
     )
 
     # Configure updated to work with AOCC compilers
-    patch("configure_aocc.patch", when="@6.7:6.8 %aocc")
+    # patch("configure_aocc.patch", when="@6.7:7.0 %aocc")
+    # Restrict the patch to just version 6.7, 
+    ## because it is not needed for the CMake build version
+    patch("configure_aocc.patch", when="@6.7 %aocc")
+ #   patch("configure_qe-7.1_aocc.patch", when="@7.1: %aocc")
 
     # Configure updated to work with NVIDIA compilers
     patch("nvhpc.patch", when="@6.5 %nvhpc")

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -257,10 +257,11 @@ class QuantumEspresso(CMakePackage, Package):
     # THIRD-PARTY PATCHES
     # NOTE: *SOME* third-party patches will require deactivation of
     # upstream patches using `~patch` variant
-    
-    # Conflict add for aocc with qe version >= 6.8 ,force use of CMAKE  
-    ## BUILD SYSTEM
-    conflicts("build_system=generic", when="@6.8: %aocc", msg="Please use CMake to build with AOCC")
+
+    # Only CMake will work for @6.8: %aocc
+    conflicts(
+        "build_system=generic", when="@6.8: %aocc", msg="Please use CMake to build with AOCC"
+    )
 
     # QMCPACK converter patches for QE 6.8, 6.7, 6.4.1, 6.4, and 6.3
     conflicts(

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -263,6 +263,10 @@ class QuantumEspresso(CMakePackage, Package):
         "build_system=generic", when="@6.8: %aocc", msg="Please use CMake to build with AOCC"
     )
 
+    conflicts(
+        "~openmp", when="^amdlibflame", msg="amdlibflame requires OpenMP"
+    )
+
     # QMCPACK converter patches for QE 6.8, 6.7, 6.4.1, 6.4, and 6.3
     conflicts(
         "@:6.2,6.5:6.6",


### PR DESCRIPTION
This PR removes the use of `-Ofast` and migrates to CMake build system for AOCC