### PR TITLE
mpifileutils: add DAOS variant

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -68,6 +68,8 @@ class Mpifileutils(Package):
     variant("experimental", default=False, description="Install experimental tools")
     conflicts("+experimental", when="@:0.6")
 
+    variant("daos", default=False, description="Enable DAOS support", when="@0.11:")
+
     def flag_handler(self, name, flags):
         spec = self.spec
         iflags = []
@@ -101,6 +103,9 @@ class Mpifileutils(Package):
             args.append("-DENABLE_EXPERIMENTAL=ON")
         else:
             args.append("-DENABLE_EXPERIMENTAL=OFF")
+
+        if "+daos" in self.spec:
+            args.append("-DENABLE_DAOS=ON")
 
         return args
 

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -50,6 +50,8 @@ class Mpifileutils(Package):
 
     depends_on("attr", when="@0.11.1:+xattr")
 
+    depends_on("daos", when="+daos")
+
     depends_on("bzip2")
 
     depends_on("libcap")
@@ -106,6 +108,9 @@ class Mpifileutils(Package):
 
         if "+daos" in self.spec:
             args.append("-DENABLE_DAOS=ON")
+            args.append("-DWITH_DAOS_PREFIX=%s" % self.spec["daos"].prefix)
+        else:
+            args.append("-DENABLE_DAOS=OFF")
 
         return args
 

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -86,27 +86,27 @@ class Mpifileutils(Package):
         args.append("-DWITH_DTCMP_PREFIX=%s" % self.spec["dtcmp"].prefix)
         args.append("-DWITH_LibCircle_PREFIX=%s" % self.spec["libcircle"].prefix)
 
-        if "+xattr" in self.spec:
+        if self.spec.satisfies("+xattr"):
             args.append("-DENABLE_XATTRS=ON")
         else:
             args.append("-DENABLE_XATTRS=OFF")
 
-        if "+lustre" in self.spec:
+        if self.spec.satisfies("+lustre"):
             args.append("-DENABLE_LUSTRE=ON")
         else:
             args.append("-DENABLE_LUSTRE=OFF")
 
-        if "+gpfs" in self.spec:
+        if self.spec.satisfies("+gpfs"):
             args.append("-DENABLE_GPFS=ON")
         else:
             args.append("-DENABLE_GPFS=OFF")
 
-        if "+experimental" in self.spec:
+        if self.spec.satisfies("+experimental"):
             args.append("-DENABLE_EXPERIMENTAL=ON")
         else:
             args.append("-DENABLE_EXPERIMENTAL=OFF")
 
-        if "+daos" in self.spec:
+        if self.spec.satisfies("+daos"):
             args.append("-DENABLE_DAOS=ON")
             args.append("-DWITH_DAOS_PREFIX=%s" % self.spec["daos"].prefix)
         else:
@@ -145,16 +145,16 @@ class Mpifileutils(Package):
         )
         args.append("--with-dtcmp=%s" % self.spec["dtcmp"].prefix)
 
-        if "+xattr" in self.spec:
+        if self.spec.satisfies("+xattr"):
             args.append("CFLAGS=-DDCOPY_USE_XATTRS")
 
-        if "+lustre" in self.spec:
+        if self.spec.satisfies("+lustre"):
             args.append("--enable-lustre")
         else:
             args.append("--disable-lustre")
 
         if self.spec.satisfies("@0.7:"):
-            if "+experimental" in self.spec:
+            if self.spec.satisfies("+experimental"):
                 args.append("--enable-experimental")
             else:
                 args.append("--disable-experimental")


### PR DESCRIPTION
Adds variant for DAOS support (see https://mpifileutils.readthedocs.io/en/v0.11.1/build.html#daos-support).