### PR TITLE
Add new versions of Julia dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -13,6 +13,7 @@ class LibuvJulia(AutotoolsPackage):
     git = "https://github.com/JuliaLang/libuv.git"
 
     # julia's libuv fork doesn't tag (all?) releases, so we fix commits.
+    version("1.44.3", commit="2723e256e952be0b015b3c0086f717c3d365d97e")
     version("1.44.2", commit="e6f0e4900e195c8352f821abe2b3cffc3089547b")
     version("1.44.1", commit="1b2d16477fe1142adea952168d828a066e03ee4c")
     version("1.42.0", commit="3a63bf71de62c64097989254e4f03212e3bf5fc8")

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -34,7 +34,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
     depends_on("autoconf-archive", when="@4.0.2:", type="build")
-    depends_on("texinfo", when="@4.1.0", type="build")
+    depends_on("texinfo", when="@4.1.0:", type="build")
 
     variant(
         "libs",

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -13,6 +13,8 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.mpfr.org/"
     gnu_mirror_path = "mpfr/mpfr-4.0.2.tar.bz2"
 
+    version("4.2.0", sha256="691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d")
+    version("4.1.1", sha256="85fdf11614cc08e3545386d6b9c8c9035e3db1e506211a45f4e108117fe3c951")
     version("4.1.0", sha256="feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926")
     version("4.0.2", sha256="c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc")
     version("4.0.1", sha256="a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b")

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -13,6 +13,10 @@ class Nghttp2(AutotoolsPackage):
     homepage = "https://nghttp2.org/"
     url = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
 
+    version("1.52.0", sha256="9877caa62bd72dde1331da38ce039dadb049817a01c3bdee809da15b754771b8")
+    version("1.51.0", sha256="2a0bef286f65b35c24250432e7ec042441a8157a5b93519412d9055169d9ce54")
+    version("1.50.0", sha256="d162468980dba58e54e31aa2cbaf96fd2f0890e6dd141af100f6bd1b30aa73c6")
+    version("1.48.0", sha256="66d4036f9197bbe3caba9c2626c4565b92662b3375583be28ef136d62b092998")
     version("1.47.0", sha256="62f50f0e9fc479e48b34e1526df8dd2e94136de4c426b7680048181606832b7c")
     version("1.44.0", sha256="3e4824d02ae27eca931e0bb9788df00a26e5fd8eb672cf52cbb89c1463ba16e9")
     version("1.26.0", sha256="daf7c0ca363efa25b2cbb1e4bd925ac4287b664c3d1465f6a390359daa3f0cf1")


### PR DESCRIPTION
In preparation for the upcoming Julia v1.9.0, I updated the versions of some of its dependencies.

I haven't touched p7zip, because we're now using a different upstream: https://github.com/p7zip-project/p7zip/, which is a fork of http://p7zip.sourceforge.net, which is basically unmaintained (last release is from 7 years ago).  I'm not sure what to do with that: create a new package here in Spack?  Continue with the same package, but use a different URL scheme for newer versions?  Else?  Note that also [HomeBrew](https://github.com/Homebrew/homebrew-core/pull/71650) moved to the new fork.