### PR TITLE
buildcache create: reproducible tarballs

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1143,7 +1143,9 @@ def generate_key_index(key_prefix, tmpdir=None):
 def gzip_compressed_tarfile(path):
     """Create a reproducible, compressed tarfile"""
     # Create gzip compressed tarball of the install prefix
-    # 1) Use explicit empty filename and mtime 0 for gzip header reproducibility
+    # 1) Use explicit empty filename and mtime 0 for gzip header reproducibility.
+    #    If the filename="" is dropped, Python will use fileobj.name instead.
+    #    This should effectively mimick `gzip --no-name`.
     # 2) On AMD Ryzen 3700X and an SSD disk, we have the following on compression speed:
     # compresslevel=6 gzip default: llvm takes 4mins, roughly 2.1GB
     # compresslevel=9 python default: llvm takes 12mins, roughly 2.1GB

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1172,7 +1172,15 @@ def deterministic_tarinfo(tarinfo: tarfile.TarInfo):
     # Reset mtime to epoch time, our prefixes are not truly immutable, so files may get
     # touched; as long as the content does not change, this ensures we get stable tarballs.
     tarinfo.mtime = 0
-    # tarinfo.mode = ? # todo: should we normalize permissions?
+
+    # Normalize mode
+    if tarinfo.isfile() or tarinfo.islnk():
+        # If user can execute, use 0o755; else 0o644
+        # This is to avoid potentially unsafe world writable & exeutable files that may get
+        # extracted when Python or tar is run with privileges
+        tarinfo.mode = 0o644 if tarinfo.mode & 0o100 == 0 else 0o755
+    else:  # symbolic link and directories
+        tarinfo.mode = 0o755
 
     return tarinfo
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1281,8 +1281,6 @@ def _build_tarball(
         elif not allow_root:
             ensure_package_relocatable(buildinfo, binaries_dir)
     except Exception as e:
-        shutil.rmtree(workdir)
-        shutil.rmtree(tarfile_dir)
         shutil.rmtree(tmpdir)
         tty.die(e)
 

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -995,3 +995,40 @@ def test_reproducible_tarball_is_reproducible(tmpdir):
             "pkg/.spack",
             "pkg/.spack/binary_distribution",
         }
+
+
+def test_tarball_normalized_permissions(tmpdir):
+    p = tmpdir.mkdir("prefix")
+    p.mkdir("bin")
+    p.mkdir("share")
+    p.mkdir(".spack")
+
+    app = p.join("bin", "app")
+    data = p.join("share", "file")
+    tarball = str(tmpdir.join("prefix.tar.gz"))
+
+    # Everyone can write & execute. This should turn into 0o755 when the tarball is
+    # extracted (on a different system).
+    with open(app, "w", opener=lambda path, flags: os.open(path, flags, 0o777)) as f:
+        f.write("hello world")
+
+    # User doesn't have execute permissions, but group/world have; this should also
+    # turn into 0o644 (user read/write, group&world only read).
+    with open(data, "w", opener=lambda path, flags: os.open(path, flags, 0o477)) as f:
+        f.write("hello world")
+
+    bindist._do_create_tarball(tarball, binaries_dir=p, pkg_dir="pkg", buildinfo={})
+
+    with tarfile.open(tarball) as tar:
+        path_to_member = {member.name: member for member in tar.getmembers()}
+
+    # directories should have 0o755
+    assert path_to_member["pkg"].mode == 0o755
+    assert path_to_member["pkg/bin"].mode == 0o755
+    assert path_to_member["pkg/.spack"].mode == 0o755
+
+    # executable-by-user files should be 0o755
+    assert path_to_member["pkg/bin/app"].mode == 0o755
+
+    # not-executable-by-user files should be 0o644
+    assert path_to_member["pkg/share/file"].mode == 0o644


### PR DESCRIPTION
Currently `spack buildcache create` creates compressed tarballs that
differ between each invocation (even when nothing is modified in the
prefix), thanks to:

1. The gzip header containing mtime set to time.time()
2. tar.add() copying stat info (uid/gid/uname/gname/mtime). 

To avoid this, construct GZipFile explicitly (since the Python API doesn't
expose the mtime arg) and update the tarinfo entries.

Notice that for distribution (spack buildcache create), there is no point
in recording the the user and group ids and names, since they don't
exist on other systems. In fact, that data is only ever used when python
is run with privileges, since only then it can try and restore the
ownership. I think it's a really bad idea to have this in Spack, in fact it
may cause problems when extracting a binary tarball in a docker
container where the user is root, and Python fails to change user ids
because the users don't exist there. (We've seen this in the past for
source tarballs actually, so we changed to --no-same-owner or smth). 

To fix the ownership issue: set uid/gid to 0, meaning that if run under
elevated privileges, the user is "changed" to root, i.e. not changed at
all.

Lastly, in binary distribution, we should only ever add dirs, files, symlinks
and hardlinks to the tarball, not character/block devices and fifos, so
this change explicitly drops those types of entries.

For file modes, normalize like `git`: `0o644` for files/links that are not
executable by user, and `0o755` otherwise (including dirs, symlinks).
This also prevents surprises when extracting a tarball with `tar xf`,
since users wouldn't have to worry (as much) about newly created
files being world-writable and executable.

A test is added that checks for bitwise reproducibility of a compressed
tarball, even when the timestamps on disk are altered. Also a test is
added to check file mode normalization.