### PR TITLE
dd4hep: depends_on root +webgui when +ddeve ^root @6.28:

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -141,6 +141,8 @@ class Dd4hep(CMakePackage):
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+ddeve")
+    depends_on("root @6.08:6.27", when="@:1.23 +ddeve")
+    # also: when +ddeve, +webgui is required for root @6.28:, see conflicts
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")
@@ -163,6 +165,7 @@ class Dd4hep(CMakePackage):
         msg="cmake version with buggy FindPython breaks dd4hep cmake config",
     )
     conflicts("~ddrec+dddetectors", msg="Need to enable +ddrec to build +dddetectors.")
+    conflicts("+ddeve ^root@6.28: ~webgui", msg="DDEve requires +webgui for ROOT 6.28 and later.")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -140,9 +140,10 @@ class Dd4hep(CMakePackage):
     depends_on("boost +iostreams", when="+ddg4")
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
-    depends_on("root @6.08: +gdml +math +python +x +opengl", when="+ddeve")
-    depends_on("root +webgui", when="+ddeve ^root@6.28:")
-    depends_on("root @6.08:6.27", when="@:1.23 +ddeve")
+    with when("+ddeve"):
+        depends_on("root @6.08: +x +opengl")
+        depends_on("root +webgui", when="^root@6.28:")
+        depends_on("root @:6.27", when="@:1.23")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -141,8 +141,8 @@ class Dd4hep(CMakePackage):
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+ddeve")
+    depends_on("root +webgui", when="+ddeve ^root@6.28:")
     depends_on("root @6.08:6.27", when="@:1.23 +ddeve")
-    # also: when +ddeve, +webgui is required for root @6.28:, see conflicts
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")
@@ -165,7 +165,6 @@ class Dd4hep(CMakePackage):
         msg="cmake version with buggy FindPython breaks dd4hep cmake config",
     )
     conflicts("~ddrec+dddetectors", msg="Need to enable +ddrec to build +dddetectors.")
-    conflicts("+ddeve ^root@6.28: ~webgui", msg="DDEve requires +webgui for ROOT 6.28 and later.")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
- After https://github.com/root-project/root/pull/11554, `+ddeve` needs `root +webgui` for `root @6.28:`.
- Until https://github.com/AIDASoft/DD4hep/pull/987, `+ddeve` needs `root @:6.27` for `@:1.23 +ddeve`.

~~Unfortunately I couldn't figure this out without conflicts, because the circular `depends_on("root +webgui", when="+ddeve ^root@6.28:")` does not seem accepted.~~