### PR TITLE
singularity-eos:  Fix Cray CCE fortran module naming

### DIFF
--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -106,6 +106,16 @@ class SingularityEos(CMakePackage, CudaPackage):
         depends_on("py-h5py" + _flag, when="@:1.6.2 " + _flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
+    def flag_handler(self, name, flags):
+        if name == "fflags":
+            if self.spec.satisfies("%cce+fortran"):
+                # The Cray fortran compiler generates module files with
+                # uppercase names by default, which is not handled by the
+                # CMake scripts. The following flag forces the compiler to
+                # produce module files with lowercase names.
+                flags.append("-ef")
+        return (flags, None, None)
+
     def cmake_args(self):
         args = [
             self.define("SINGULARITY_PATCH_MPARK_VARIANT", False),


### PR DESCRIPTION
By default the Cray CCE Fortran compiler names Fortran module files in uppercase (e.g., "MODULENAME.mod").
However, `singularity-eos` appears to be expecting a lowercase name:
```bash
  file INSTALL cannot find
  "/tmp/quellyn/spack-stage/spack-stage-singularity-eos-1.6.2-xlpm47zdhk32jyblj5j4ej4ibprmbepv/spack-build-xlpm47z/singularity_eos.mod":
  No such file or directory.
```
Using the "-ef" compiler flag to override this behavior and produce modulefile names in lowercase, e.g. "modulename.mod") solves this issue.

Tested on a Cray EX system (LLNL RZVernal, CCE 15.0.1) and also on a non-Cray system (LANL Darwin, Intel Skylake, GCC 8.5.0).

@rbberger, @DarylGrunau 