### PR TITLE
Add RPC lib path to wrapper flags for HDF4

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -170,6 +170,7 @@ class Hdf(AutotoolsPackage):
             # We should not specify '--disable-hdf4-xdr' due to a bug in the
             # configure script.
             config_args.append("LIBS=%s" % self.spec["rpc"].libs.link_flags)
+            config_args.append("LDFLAGS=%s" % self.spec["rpc"].libs.search_flags)
 
         # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
         if self.spec.satisfies("%gcc@10:"):


### PR DESCRIPTION
This PR supersedes #34653.

This PR resolves a build failure when compiling HDF4 using certain compilers. The configure script will do a version check, but if you use a non-system RPC library, the LIBS variable is set to something (e.g., -ltirpc) and this gets appended to the conf test compile. Since the Spack wrapper is running in vcheck mode, no library paths are added.

This command works for most compilers, presumably because they respect LIBRARY_PATH which is set, but Cray's Fortran compiler does not do anything with LIBRARY_PATH and so you get an error that -ltirpc cannot be found. The most recent `nvhpc` compilers also fail without this set.

This PR sets LDFLAGS to include the search paths for RPC packages when +external-xdr is set. There is no obvious downside to doing this across the board, and it should make HDF compiles more robust to compiler idiosyncrasies.