### PR TITLE
binary_distribution: needs_rebuild: check for .spec.json.sig

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2210,7 +2210,7 @@ def needs_rebuild(spec, mirror_url):
     # format of the name, in order to determine if the package
     # needs to be rebuilt.
     cache_prefix = build_cache_prefix(mirror_url)
-    specfile_name = tarball_name(spec, ".spec.json")
+    specfile_name = tarball_name(spec, ".spec.json.sig")
     specfile_path = os.path.join(cache_prefix, specfile_name)
 
     # Only check for the presence of the json version of the spec.  If the


### PR DESCRIPTION
Shouldn't we be checking for .spec.json.sig now? This fix provokes expected behavior in `spack buildcache check` for checking mirrors if a spec is already there.

