### PR TITLE
windows: use `sys.platform == "win32"` instead of `is_windows`

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -5,15 +5,13 @@
 import errno
 import os
 import shutil
+import sys
 import tempfile
 from os.path import exists, join
-from sys import platform as _platform
 
 from llnl.util import lang
 
-is_windows = _platform == "win32"
-
-if is_windows:
+if sys.platform == "win32":
     from win32file import CreateHardLink
 
 
@@ -23,7 +21,7 @@ def symlink(real_path, link_path):
 
     On Windows, use junctions if os.symlink fails.
     """
-    if not is_windows:
+    if sys.platform != "win32":
         os.symlink(real_path, link_path)
     elif _win32_can_symlink():
         # Windows requires target_is_directory=True when the target is a dir.
@@ -99,7 +97,7 @@ def _win32_is_junction(path):
     if os.path.islink(path):
         return False
 
-    if is_windows:
+    if sys.platform == "win32":
         import ctypes.wintypes
 
         GetFileAttributes = ctypes.windll.kernel32.GetFileAttributesW

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -26,7 +26,6 @@ import spack.paths
 description = "run spack's unit tests (wrapper around pytest)"
 section = "developer"
 level = "long"
-is_windows = sys.platform == "win32"
 
 
 def setup_parser(subparser):
@@ -212,7 +211,7 @@ def unit_test(parser, args, unknown_args):
     # mock configuration used by unit tests
     # Note: skip on windows here because for the moment,
     # clingo is wholly unsupported from bootstrap
-    if not is_windows:
+    if sys.platform != "win32":
         with spack.bootstrap.ensure_bootstrap_configuration():
             spack.bootstrap.ensure_core_dependencies()
             if pytest is None:

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -28,8 +28,6 @@ from spack.util.path import system_path_filter
 
 __all__ = ["Compiler"]
 
-is_windows = sys.platform == "win32"
-
 
 @llnl.util.lang.memoized
 def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
@@ -598,7 +596,7 @@ class Compiler(object):
         suffixes = [""]
         # Windows compilers generally have an extension of some sort
         # as do most files on Windows, handle that case here
-        if is_windows:
+        if sys.platform == "win32":
             ext = r"\.(?:exe|bat)"
             cls_suf = [suf + ext for suf in cls.suffixes]
             ext_suf = [ext]

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -29,7 +29,6 @@ import spack.spec
 import spack.util.spack_yaml
 import spack.util.windows_registry
 
-is_windows = sys.platform == "win32"
 #: Information on a package that has been detected
 DetectedPackage = collections.namedtuple("DetectedPackage", ["spec", "prefix"])
 
@@ -184,7 +183,7 @@ def library_prefix(library_dir):
     elif "lib" in lowered_components:
         idx = lowered_components.index("lib")
         return os.sep.join(components[:idx])
-    elif is_windows and "bin" in lowered_components:
+    elif sys.platform == "win32" and "bin" in lowered_components:
         idx = lowered_components.index("bin")
         return os.sep.join(components[:idx])
     else:
@@ -260,13 +259,13 @@ class WindowsCompilerExternalPaths(object):
 
 
 class WindowsKitExternalPaths(object):
-    if is_windows:
+    if sys.platform == "win32":
         plat_major_ver = str(winOs.windows_version()[0])
 
     @staticmethod
     def find_windows_kit_roots():
         """Return Windows kit root, typically %programfiles%\\Windows Kits\\10|11\\"""
-        if not is_windows:
+        if sys.platform != "win32":
             return []
         program_files = os.environ["PROGRAMFILES(x86)"]
         kit_base = os.path.join(
@@ -359,7 +358,7 @@ def compute_windows_program_path_for_package(pkg):
         pkg (spack.package_base.PackageBase): package for which
                            Program Files location is to be computed
     """
-    if not is_windows:
+    if sys.platform != "win32":
         return []
     # note windows paths are fine here as this method should only ever be invoked
     # to interact with Windows
@@ -379,7 +378,7 @@ def compute_windows_user_path_for_package(pkg):
     installs see:
     https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=netframework-4.8
     """
-    if not is_windows:
+    if sys.platform != "win32":
         return []
 
     # Current user directory

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -31,8 +31,6 @@ from .common import (  # find_windows_compiler_bundled_packages,
     path_to_dict,
 )
 
-is_windows = sys.platform == "win32"
-
 
 def common_windows_package_paths():
     paths = WindowsCompilerExternalPaths.find_windows_compiler_bundled_packages()
@@ -57,7 +55,7 @@ def executables_in_path(path_hints):
         path_hints (list): list of paths to be searched. If None the list will be
             constructed based on the PATH environment variable.
     """
-    if is_windows:
+    if sys.platform == "win32":
         path_hints.extend(common_windows_package_paths())
     search_paths = llnl.util.filesystem.search_paths_for_executables(*path_hints)
     return path_to_dict(search_paths)
@@ -149,7 +147,7 @@ def by_library(packages_to_check, path_hints=None):
 
     path_to_lib_name = (
         libraries_in_ld_and_system_library_path(path_hints=path_hints)
-        if not is_windows
+        if sys.platform != "win32"
         else libraries_in_windows_paths(path_hints)
     )
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -21,7 +21,6 @@ import spack.spec
 import spack.util.spack_json as sjson
 from spack.error import SpackError
 
-is_windows = sys.platform == "win32"
 # Note: Posixpath is used here as opposed to
 # os.path.join due to spack.spec.Spec.format
 # requiring forward slash path seperators at this stage
@@ -346,7 +345,7 @@ class DirectoryLayout(object):
 
         # Windows readonly files cannot be removed by Python
         # directly, change permissions before attempting to remove
-        if is_windows:
+        if sys.platform == "win32":
             kwargs = {
                 "ignore_errors": False,
                 "onerror": fs.readonly_file_handler(ignore_errors=False),

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -28,7 +28,6 @@ import os
 import os.path
 import re
 import shutil
-import sys
 import urllib.parse
 from typing import List, Optional
 
@@ -53,7 +52,6 @@ from spack.util.string import comma_and, quote
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []
-is_windows = sys.platform == "win32"
 
 CONTENT_TYPE_MISMATCH_WARNING_TEMPLATE = (
     "The contents of {subject} look like {content_type}.  Either the URL"

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -30,8 +30,7 @@ else:
 
 #: Groupdb does not exist on Windows, prevent imports
 #: on supported systems
-is_windows = sys.platform == "win32"
-if not is_windows:
+if sys.platform != "win32":
     import grp
 
 #: Spack itself also limits the shebang line to at most 4KB, which should be plenty.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -84,9 +84,6 @@ STATUS_DEQUEUED = "dequeued"
 #: queue invariants).
 STATUS_REMOVED = "removed"
 
-is_windows = sys.platform == "win32"
-is_osx = sys.platform == "darwin"
-
 
 class InstallAction(object):
     #: Don't perform an install
@@ -169,9 +166,9 @@ def _do_fake_install(pkg):
     if not pkg.name.startswith("lib"):
         library = "lib" + library
 
-    plat_shared = ".dll" if is_windows else ".so"
-    plat_static = ".lib" if is_windows else ".a"
-    dso_suffix = ".dylib" if is_osx else plat_shared
+    plat_shared = ".dll" if sys.platform == "win32" else ".so"
+    plat_static = ".lib" if sys.platform == "win32" else ".a"
+    dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
 
     # Install fake command
     fs.mkdirp(pkg.prefix.bin)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -92,9 +92,6 @@ _spack_times_log = "install_times.json"
 _spack_configure_argsfile = "spack-configure-args.txt"
 
 
-is_windows = sys.platform == "win32"
-
-
 def deprecated_version(pkg, version):
     """Return True if the version is deprecated, False otherwise.
 
@@ -165,7 +162,7 @@ class WindowsRPath(object):
 
         Performs symlinking to incorporate rpath dependencies to Windows runtime search paths
         """
-        if is_windows:
+        if sys.platform == "win32":
             self.win_rpath.add_library_dependent(*self.win_add_library_dependent())
             self.win_rpath.add_rpath(*self.win_add_rpath())
             self.win_rpath.establish_link()
@@ -210,7 +207,7 @@ class DetectablePackageMeta(object):
                 plat_exe = []
                 if hasattr(cls, "executables"):
                     for exe in cls.executables:
-                        if is_windows:
+                        if sys.platform == "win32":
                             exe = to_windows_exe(exe)
                         plat_exe.append(exe)
                 return plat_exe
@@ -2401,7 +2398,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # on Windows, libraries of runtime interest are typically
         # stored in the bin directory
-        if is_windows:
+        if sys.platform == "win32":
             rpaths = [self.prefix.bin]
             rpaths.extend(d.prefix.bin for d in deps if os.path.isdir(d.prefix.bin))
         else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -54,7 +54,6 @@ import io
 import itertools
 import os
 import re
-import sys
 import warnings
 from typing import Tuple
 
@@ -118,7 +117,6 @@ __all__ = [
     "SpecDeprecatedError",
 ]
 
-is_windows = sys.platform == "win32"
 #: Valid pattern for an identifier in Spack
 
 identifier_re = r"\w[\w-]*"

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -16,8 +16,6 @@ import spack.detection.path
 from spack.main import SpackCommand
 from spack.spec import Spec
 
-is_windows = sys.platform == "win32"
-
 
 @pytest.fixture
 def executables_found(monkeypatch):
@@ -39,7 +37,7 @@ def _platform_executables(monkeypatch):
 
 
 def define_plat_exe(exe):
-    if is_windows:
+    if sys.platform == "win32":
         exe += ".bat"
     return exe
 

--- a/lib/spack/spack/test/cmd/resource.py
+++ b/lib/spack/spack/test/cmd/resource.py
@@ -7,7 +7,6 @@ import sys
 
 from spack.main import SpackCommand
 
-is_windows = sys.platform == "win32"
 resource = SpackCommand("resource")
 
 #: these are hashes used in mock packages
@@ -23,7 +22,7 @@ mock_hashes = (
         "bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c",
         "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730",
     ]
-    if not is_windows
+    if sys.platform != "win32"
     else [
         "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
         "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd",
@@ -68,7 +67,7 @@ def test_resource_list_only_hashes(mock_packages, capfd):
 def test_resource_show(mock_packages, capfd):
     test_hash = (
         "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8"
-        if not is_windows
+        if sys.platform != "win32"
         else "3c5b65abcd6a3b2c714dbf7c31ff65fe3748a1adc371f030c283007ca5534f11"
     )
     with capfd.disabled():

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -14,8 +14,6 @@ import spack.config
 import spack.extensions
 import spack.main
 
-is_windows = sys.platform == "win32"
-
 
 class Extension:
     """Helper class to simplify the creation of simple command extension
@@ -274,7 +272,7 @@ def test_variable_in_extension_path(config, working_env):
     os.environ["_MY_VAR"] = os.path.join("my", "var")
     ext_paths = [os.path.join("~", "${_MY_VAR}", "spack-extension-1")]
     # Home env variable is USERPROFILE on Windows
-    home_env = "USERPROFILE" if is_windows else "HOME"
+    home_env = "USERPROFILE" if sys.platform == "win32" else "HOME"
     expected_ext_paths = [
         os.path.join(os.environ[home_env], os.environ["_MY_VAR"], "spack-extension-1")
     ]

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -25,8 +25,6 @@ from spack.solver.asp import UnsatisfiableSpecError
 from spack.spec import Spec
 from spack.version import ver
 
-is_windows = sys.platform == "win32"
-
 
 def check_spec(abstract, concrete):
     if abstract.versions.concrete:
@@ -1138,7 +1136,7 @@ class TestConcretize(object):
     def test_all_patches_applied(self):
         uuidpatch = (
             "a60a42b73e03f207433c5579de207c6ed61d58e4d12dd3b5142eb525728d89ea"
-            if not is_windows
+            if sys.platform != "win32"
             else "d0df7988457ec999c148a4a2af25ce831bfaad13954ba18a4446374cb0aef55e"
         )
         localpatch = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -54,8 +54,6 @@ from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.util.pattern import Bunch
 from spack.util.web import FetchError
 
-is_windows = sys.platform == "win32"
-
 
 def ensure_configuration_fixture_run_before(request):
     """Ensure that fixture mutating the configuration run before the one where
@@ -621,7 +619,7 @@ def ensure_debug(monkeypatch):
     tty.set_debug(current_debug_level)
 
 
-@pytest.fixture(autouse=is_windows, scope="session")
+@pytest.fixture(autouse=sys.platform == "win32", scope="session")
 def platform_config():
     spack.config.add_default_platform_scope(spack.platforms.real_host().name)
 
@@ -633,7 +631,7 @@ def default_config():
     This ensures we can test the real default configuration without having
     tests fail when the user overrides the defaults that we test against."""
     defaults_path = os.path.join(spack.paths.etc_path, "defaults")
-    if is_windows:
+    if sys.platform == "win32":
         defaults_path = os.path.join(defaults_path, "windows")
     with spack.config.use_configuration(defaults_path) as defaults_config:
         yield defaults_config
@@ -690,7 +688,7 @@ def configuration_dir(tmpdir_factory, linux_os):
     tmpdir.ensure("user", dir=True)
 
     # Slightly modify config.yaml and compilers.yaml
-    if is_windows:
+    if sys.platform == "win32":
         locks = False
     else:
         locks = True
@@ -1675,11 +1673,11 @@ def mock_executable(tmpdir):
     """
     import jinja2
 
-    shebang = "#!/bin/sh\n" if not is_windows else "@ECHO OFF"
+    shebang = "#!/bin/sh\n" if sys.platform != "win32" else "@ECHO OFF"
 
     def _factory(name, output, subdir=("bin",)):
         f = tmpdir.ensure(*subdir, dir=True).join(name)
-        if is_windows:
+        if sys.platform == "win32":
             f += ".bat"
         t = jinja2.Template("{{ shebang }}{{ output }}\n")
         f.write(t.render(shebang=shebang, output=output))

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -33,8 +33,6 @@ import spack.store
 from spack.schema.database_index import schema
 from spack.util.executable import Executable
 
-is_windows = sys.platform == "win32"
-
 pytestmark = pytest.mark.db
 
 
@@ -451,7 +449,7 @@ def test_005_db_exists(database):
     lock_file = os.path.join(database.root, ".spack-db", "lock")
     assert os.path.exists(str(index_file))
     # Lockfiles not currently supported on Windows
-    if not is_windows:
+    if sys.platform != "win32":
         assert os.path.exists(str(lock_file))
 
     with open(index_file) as fd:

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -24,8 +24,6 @@ import spack.spec
 import spack.store
 import spack.util.lock as lk
 
-is_windows = sys.platform == "win32"
-
 
 def _mock_repo(root, namespace):
     """Create an empty repository at the specified root
@@ -528,7 +526,7 @@ def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
 
     # The call to install_tree will raise the exception since not mocking
     # creation of dependency package files within *install* directories.
-    with pytest.raises(IOError, match=path if not is_windows else ""):
+    with pytest.raises(IOError, match=path if sys.platform != "win32" else ""):
         inst.dump_packages(spec, path)
 
     # Now try the error path, which requires the mock directory structure
@@ -879,7 +877,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     metadatadir = spack.store.layout.metadata_path(spec)
     # Regex matching with Windows style paths typically fails
     # so we skip the match check here
-    if is_windows:
+    if sys.platform == "win32":
         metadatadir = None
     # Should fail with a "not a directory" error
     with pytest.raises(OSError, match=metadatadir):

--- a/lib/spack/spack/test/link_paths.py
+++ b/lib/spack/spack/test/link_paths.py
@@ -11,9 +11,8 @@ import pytest
 import spack.paths
 from spack.compiler import _parse_non_system_link_dirs
 
-is_windows = sys.platform == "win32"
 drive = ""
-if is_windows:
+if sys.platform == "win32":
     match = re.search(r"[A-Za-z]:", spack.paths.test_path)
     if match:
         drive = match.group()
@@ -210,7 +209,7 @@ def test_obscure_parsing_rules():
     ]
 
     # TODO: add a comment explaining why this happens
-    if is_windows:
+    if sys.platform == "win32":
         paths.remove(os.path.join(root, "second", "path"))
 
     check_link_paths("obscure-parsing-rules.txt", paths)

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -13,8 +13,6 @@ from llnl.util.filesystem import HeaderList, LibraryList, find, find_headers, fi
 
 import spack.paths
 
-is_windows = sys.platform == "win32"
-
 
 @pytest.fixture()
 def library_list():
@@ -28,7 +26,7 @@ def library_list():
             "/dir3/libz.so",
             "libmpi.so.20.10.1",  # shared object libraries may be versioned
         ]
-        if not is_windows
+        if sys.platform != "win32"
         else [
             "/dir1/liblapack.lib",
             "/dir2/libpython3.6.dll",
@@ -59,10 +57,10 @@ def header_list():
 
 
 # TODO: Remove below when llnl.util.filesystem.find_libraries becomes spec aware
-plat_static_ext = "lib" if is_windows else "a"
+plat_static_ext = "lib" if sys.platform == "win32" else "a"
 
 
-plat_shared_ext = "dll" if is_windows else "so"
+plat_shared_ext = "dll" if sys.platform == "win32" else "so"
 
 
 plat_apple_shared_ext = "dylib"
@@ -78,7 +76,8 @@ class TestLibraryList(object):
         expected = " ".join(
             [
                 "/dir1/liblapack.%s" % plat_static_ext,
-                "/dir2/libpython3.6.%s" % (plat_apple_shared_ext if not is_windows else "dll"),
+                "/dir2/libpython3.6.%s"
+                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
                 "/dir1/libblas.%s" % plat_static_ext,
                 "/dir3/libz.%s" % plat_shared_ext,
                 "libmpi.%s.20.10.1" % plat_shared_ext,
@@ -93,7 +92,8 @@ class TestLibraryList(object):
         expected = ";".join(
             [
                 "/dir1/liblapack.%s" % plat_static_ext,
-                "/dir2/libpython3.6.%s" % (plat_apple_shared_ext if not is_windows else "dll"),
+                "/dir2/libpython3.6.%s"
+                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
                 "/dir1/libblas.%s" % plat_static_ext,
                 "/dir3/libz.%s" % plat_shared_ext,
                 "libmpi.%s.20.10.1" % plat_shared_ext,

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -62,8 +62,7 @@ import llnl.util.lock as lk
 import llnl.util.multiproc as mp
 from llnl.util.filesystem import getuid, touch
 
-is_windows = sys.platform == "win32"
-if not is_windows:
+if sys.platform != "win32":
     import fcntl
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
@@ -127,7 +126,7 @@ def make_readable(*paths):
     # stat.S_IREAD constants or a corresponding integer value). All other
     # bits are ignored."
     for path in paths:
-        if not is_windows:
+        if sys.platform != "win32":
             mode = 0o555 if os.path.isdir(path) else 0o444
         else:
             mode = stat.S_IREAD
@@ -136,7 +135,7 @@ def make_readable(*paths):
 
 def make_writable(*paths):
     for path in paths:
-        if not is_windows:
+        if sys.platform != "win32":
             mode = 0o755 if os.path.isdir(path) else 0o744
         else:
             mode = stat.S_IWRITE
@@ -616,7 +615,7 @@ def test_read_lock_read_only_dir_writable_lockfile(lock_dir, lock_path):
             pass
 
 
-@pytest.mark.skipif(False if is_windows else getuid() == 0, reason="user is root")
+@pytest.mark.skipif(False if sys.platform == "win32" else getuid() == 0, reason="user is root")
 def test_read_lock_no_lockfile(lock_dir, lock_path):
     """read-only directory, no lockfile (so can't create)."""
     with read_only(lock_dir):

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -20,7 +20,6 @@ import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import Executable
-from spack.util.path import is_windows
 
 # various sha256 sums (using variables for legibility)
 # many file based shas will differ between Windows and other platforms
@@ -29,22 +28,22 @@ from spack.util.path import is_windows
 # files with contents 'foo', 'bar', and 'baz'
 foo_sha256 = (
     "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
-    if not is_windows
+    if sys.platform != "win32"
     else "bf874c7dd3a83cf370fdc17e496e341de06cd596b5c66dbf3c9bb7f6c139e3ee"
 )
 bar_sha256 = (
     "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
-    if not is_windows
+    if sys.platform != "win32"
     else "556ddc69a75d0be0ecafc82cd4657666c8063f13d762282059c39ff5dbf18116"
 )
 baz_sha256 = (
     "bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c"
-    if not is_windows
+    if sys.platform != "win32"
     else "d30392e66c636a063769cbb1db08cd3455a424650d4494db6379d73ea799582b"
 )
 biz_sha256 = (
     "a69b288d7393261e613c276c6d38a01461028291f6e381623acc58139d01f54d"
-    if not is_windows
+    if sys.platform != "win32"
     else "2f2b087a8f84834fd03d4d1d5b43584011e869e4657504ef3f8b0a672a5c222e"
 )
 
@@ -56,7 +55,7 @@ url2_archive_sha256 = "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
 
 platform_url_sha = (
     "252c0af58be3d90e5dc5e0d16658434c9efa5d20a5df6c10bf72c2d77f780866"
-    if not is_windows
+    if sys.platform != "win32"
     else "ecf44a8244a486e9ef5f72c6cb622f99718dcd790707ac91af0b8c9a4ab7a2bb"
 )
 
@@ -160,17 +159,17 @@ def test_patch_order(mock_packages, config):
 
     mid2_sha256 = (
         "mid21234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
-        if not is_windows
+        if sys.platform != "win32"
         else "mid21234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
     )
     mid1_sha256 = (
         "0b62284961dab49887e31319843431ee5b037382ac02c4fe436955abef11f094"
-        if not is_windows
+        if sys.platform != "win32"
         else "aeb16c4dec1087e39f2330542d59d9b456dd26d791338ae6d80b6ffd10c89dfa"
     )
     top_sha256 = (
         "f7de2947c64cb6435e15fb2bef359d1ed5f6356b2aebb7b20535e3772904e6db"
-        if not is_windows
+        if sys.platform != "win32"
         else "ff34cb21271d16dbf928374f610bb5dd593d293d311036ddae86c4846ff79070"
     )
 
@@ -219,7 +218,7 @@ def test_patched_dependency(mock_packages, config, install_mockery, mock_fetch):
     # make sure the patch makes it into the dependency spec
     t_sha = (
         "c45c1564f70def3fc1a6e22139f62cb21cd190cc3a7dbe6f4120fa59ce33dcb8"
-        if not is_windows
+        if sys.platform != "win32"
         else "3c5b65abcd6a3b2c714dbf7c31ff65fe3748a1adc371f030c283007ca5534f11"
     )
     assert (t_sha,) == spec["libelf"].variants["patches"].value

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -11,8 +11,6 @@ import pytest
 
 import spack.util.environment as envutil
 
-is_windows = sys.platform == "win32"
-
 
 @pytest.fixture()
 def prepare_environment_for_tests():
@@ -23,14 +21,14 @@ def prepare_environment_for_tests():
 
 
 def test_is_system_path():
-    sys_path = "C:\\Users" if is_windows else "/usr/bin"
+    sys_path = "C:\\Users" if sys.platform == "win32" else "/usr/bin"
     assert envutil.is_system_path(sys_path)
     assert not envutil.is_system_path("/nonsense_path/bin")
     assert not envutil.is_system_path("")
     assert not envutil.is_system_path(None)
 
 
-if is_windows:
+if sys.platform == "win32":
     test_paths = [
         "C:\\Users",
         "C:\\",
@@ -51,7 +49,7 @@ else:
 
 
 def test_filter_system_paths():
-    nonsense_prefix = "C:\\nonsense_path" if is_windows else "/nonsense_path"
+    nonsense_prefix = "C:\\nonsense_path" if sys.platform == "win32" else "/nonsense_path"
     expected = [p for p in test_paths if p.startswith(nonsense_prefix)]
     filtered = envutil.filter_system_paths(test_paths)
     assert expected == filtered

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -14,13 +14,11 @@ import spack
 import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 
-is_windows = sys.platform == "win32"
-
 
 def test_read_unicode(tmpdir, working_env):
     script_name = "print_unicode.py"
     # read the unicode back in and see whether things work
-    if is_windows:
+    if sys.platform == "win32":
         script = ex.Executable("%s %s" % (sys.executable, script_name))
     else:
         script = ex.Executable("./%s" % script_name)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -13,9 +13,6 @@ import llnl.util.tty as tty
 import spack.config
 import spack.util.path as sup
 
-is_windows = sys.platform == "win32"
-
-
 #: Some lines with lots of placeholders
 padded_lines = [
     "==> [2021-06-23-15:59:05.020387] './configure' '--prefix=/Users/gamblin2/padding-log-test/opt/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_pla/darwin-bigsur-skylake/apple-clang-12.0.5/zlib-1.2.11-74mwnxgn6nujehpyyalhwizwojwn5zga",  # noqa: E501
@@ -36,7 +33,7 @@ def test_sanitze_file_path(tmpdir):
     """Test filtering illegal characters out of potential file paths"""
     # *nix illegal files characters are '/' and none others
     illegal_file_path = str(tmpdir) + "//" + "abcdefghi.txt"
-    if is_windows:
+    if sys.platform == "win32":
         # Windows has a larger set of illegal characters
         illegal_file_path = os.path.join(tmpdir, 'a<b>cd?e:f"g|h*i.txt')
     real_path = sup.sanitize_file_path(illegal_file_path)
@@ -46,7 +43,7 @@ def test_sanitze_file_path(tmpdir):
 # This class pertains to path string padding manipulation specifically
 # which is used for binary caching. This functionality is not supported
 # on Windows as of yet.
-@pytest.mark.skipif(is_windows, reason="Padding funtionality unsupported on Windows")
+@pytest.mark.skipif(sys.platform == "win32", reason="Padding funtionality unsupported on Windows")
 class TestPathPadding:
     @pytest.mark.parametrize("padded,fixed", zip(padded_lines, fixed_lines))
     def test_padding_substitution(self, padded, fixed):
@@ -122,7 +119,7 @@ def test_path_debug_padded_filter(debug, monkeypatch):
     string = fmt.format(prefix, os.sep, os.sep.join([sup.SPACK_PATH_PADDING_CHARS] * 2), suffix)
     expected = (
         fmt.format(prefix, os.sep, "[padded-to-{0}-chars]".format(72), suffix)
-        if debug <= 1 and not is_windows
+        if debug <= 1 and sys.platform != "win32"
         else string
     )
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -28,8 +28,6 @@ ALLOWED_ARCHIVE_TYPES = (
 
 ALLOWED_SINGLE_EXT_ARCHIVE_TYPES = PRE_EXTS + EXTS + NOTAR_EXTS
 
-is_windows = sys.platform == "win32"
-
 try:
     import bz2  # noqa
 
@@ -158,7 +156,7 @@ def _unzip(archive_file):
         archive_file (str): absolute path of the file to be decompressed
     """
     extracted_file = os.path.basename(strip_extension(archive_file, "zip"))
-    if is_windows:
+    if sys.platform == "win32":
         return _untar(archive_file)
     else:
         exe = "unzip"
@@ -170,7 +168,7 @@ def _unzip(archive_file):
 
 
 def _unZ(archive_file):
-    if is_windows:
+    if sys.platform == "win32":
         result = _7zip(archive_file)
     else:
         result = _system_gunzip(archive_file)
@@ -189,7 +187,7 @@ def _lzma_decomp(archive_file):
             with lzma.open(archive_file) as lar:
                 shutil.copyfileobj(lar, ar)
     else:
-        if is_windows:
+        if sys.platform == "win32":
             return _7zip(archive_file)
         else:
             return _xz(archive_file)
@@ -227,7 +225,7 @@ def _xz(archive_file):
     """Decompress lzma compressed .xz files via xz command line
     tool. Available only on Unix
     """
-    if is_windows:
+    if sys.platform == "win32":
         raise RuntimeError("XZ tool unavailable on Windows")
     decompressed_file = os.path.basename(strip_extension(archive_file, "xz"))
     working_dir = os.getcwd()
@@ -310,7 +308,7 @@ unrecognized file extension: '%s'"
     # Catch tar.xz/tar.Z files here for Windows
     # as the tar utility on Windows cannot handle such
     # compression types directly
-    if ("xz" in extension or "Z" in extension) and is_windows:
+    if ("xz" in extension or "Z" in extension) and sys.platform == "win32":
         return _win_compressed_tarball_handler
 
     return _untar

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -21,8 +21,6 @@ import spack.config
 import spack.error
 import spack.paths
 
-is_windows = sys.platform == "win32"
-
 
 class Lock(llnl.util.lock.Lock):
     """Lock that can be disabled.
@@ -34,7 +32,7 @@ class Lock(llnl.util.lock.Lock):
 
     def __init__(self, *args, **kwargs):
         super(Lock, self).__init__(*args, **kwargs)
-        self._enable = spack.config.get("config:locks", not is_windows)
+        self._enable = spack.config.get("config:locks", sys.platform != "win32")
 
     def _lock(self, op, timeout=0):
         if self._enable:

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -22,8 +22,6 @@ from llnl.util.lang import memoized
 
 import spack.util.spack_yaml as syaml
 
-is_windows = sys.platform == "win32"
-
 __all__ = ["substitute_config_variables", "substitute_path_variables", "canonicalize_path"]
 
 
@@ -153,7 +151,7 @@ def sanitize_file_path(pth):
     # instances of illegal characters on join
     pth_cmpnts = pth.split(os.path.sep)
 
-    if is_windows:
+    if sys.platform == "win32":
         drive_match = r"[a-zA-Z]:"
         is_abs = bool(re.match(drive_match, pth_cmpnts[0]))
         drive = pth_cmpnts[0] + os.path.sep if is_abs else ""
@@ -210,7 +208,7 @@ def system_path_filter(_func=None, arg_slice=None):
 def get_system_path_max():
     # Choose a conservative default
     sys_max_path_length = 256
-    if is_windows:
+    if sys.platform == "win32":
         sys_max_path_length = 260
     else:
         try:
@@ -238,7 +236,7 @@ class Path:
 
     unix = 0
     windows = 1
-    platform_path = windows if is_windows else unix
+    platform_path = windows if sys.platform == "win32" else unix
 
 
 def format_os_path(path, mode=Path.unix):
@@ -487,7 +485,7 @@ def debug_padded_filter(string, level=1):
     Returns (str): filtered string if current debug level does not exceed
         level and not windows; otherwise, unfiltered string
     """
-    if is_windows:
+    if sys.platform == "win32":
         return string
 
     return padding_filter(string) if tty.debug_level() <= level else string

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -13,8 +13,7 @@ from contextlib import contextmanager
 
 from llnl.util import tty
 
-is_windows = sys.platform == "win32"
-if is_windows:
+if sys.platform == "win32":
     import winreg
 
 
@@ -154,7 +153,7 @@ class WindowsRegistryView(object):
                          to get an entrypoint, the HKEY constants are always open, or an already
                          open key can be used instead.
         """
-        if not is_windows:
+        if sys.platform != "win32":
             raise RuntimeError(
                 "Cannot instantiate Windows Registry class on non Windows platforms"
             )
@@ -167,7 +166,7 @@ class WindowsRegistryView(object):
         try:
             yield
         except FileNotFoundError as e:
-            if e.winerror == 2:
+            if sys.platform == "win32" and e.winerror == 2:
                 tty.debug("Key %s at position %s does not exist" % (self.key, str(self.root)))
             else:
                 raise e
@@ -182,7 +181,7 @@ class WindowsRegistryView(object):
                 winreg.OpenKeyEx(self.root.hkey, self.key, access=winreg.KEY_READ),
             )
         except FileNotFoundError as e:
-            if e.winerror == 2:
+            if sys.platform == "win32" and e.winerror == 2:
                 self._reg = -1
                 tty.debug("Key %s at position %s does not exist" % (self.key, str(self.root)))
             else:

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -8,8 +8,6 @@ import sys
 
 from spack.package import *
 
-is_windows = sys.platform == "win32"
-
 
 def check(condition, msg):
     """Raise an install error if condition is False."""
@@ -59,7 +57,7 @@ class Cmake(Package):
             os.environ["for_install"] == "for_install",
             "Couldn't read env var set in compile envieonmnt",
         )
-        cmake_exe_ext = ".exe" if is_windows else ""
+        cmake_exe_ext = ".exe" if sys.platform == "win32" else ""
         cmake_exe = join_path(prefix.bin, "cmake{}".format(cmake_exe_ext))
         touch(cmake_exe)
         set_executable(cmake_exe)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -10,8 +10,6 @@ import sys
 import spack.build_environment
 from spack.package import *
 
-is_windows = sys.platform == "win32"
-
 
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
@@ -187,7 +185,11 @@ class Cmake(Package):
         default=False,
         description="Enables the generation of html and man page documentation",
     )
-    variant("ncurses", default=not is_windows, description="Enables the build of the ncurses gui")
+    variant(
+        "ncurses",
+        default=sys.platform != "win32",
+        description="Enables the build of the ncurses gui",
+    )
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -22,8 +22,6 @@ from spack.package import *
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
 
-is_windows = sys.platform == "win32"
-
 
 class Python(Package):
     """The Python programming language."""
@@ -125,12 +123,12 @@ class Python(Package):
     # See https://legacy.python.org/dev/peps/pep-0394/
     variant(
         "pythoncmd",
-        default=not is_windows,
+        default=sys.platform != "win32",
         description="Symlink 'python3' executable to 'python' (not PEP 394 compliant)",
     )
 
     # Optional Python modules
-    variant("readline", default=not is_windows, description="Build readline module")
+    variant("readline", default=sys.platform != "win32", description="Build readline module")
     variant("ssl", default=True, description="Build ssl module")
     variant("sqlite3", default=True, description="Build sqlite3 module")
     variant("dbm", default=True, description="Build dbm module")
@@ -147,7 +145,7 @@ class Python(Package):
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=cray")
 
-    if not is_windows:
+    if sys.platform != "win32":
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("gettext ~libxml2", when="~libxml2")
@@ -298,7 +296,7 @@ class Python(Package):
                 variants += "~tix"
 
         # Some modules are platform-dependent
-        if not is_windows:
+        if sys.platform != "win32":
             try:
                 python("-c", "import crypt", error=os.devnull)
                 variants += "+crypt"
@@ -542,7 +540,7 @@ class Python(Package):
         and an appropriately set prefix.
         """
         with working_dir(self.stage.source_path, create=True):
-            if is_windows:
+            if sys.platform == "win32":
                 pass
             else:
                 options = getattr(self, "configure_flag_args", [])
@@ -557,7 +555,7 @@ class Python(Package):
         # Windows builds use a batch script to drive
         # configure and build in one step
         with working_dir(self.stage.source_path):
-            if is_windows:
+            if sys.platform == "win32":
                 pcbuild_root = os.path.join(self.stage.source_path, "PCbuild")
                 builder_cmd = os.path.join(pcbuild_root, "build.bat")
                 try:
@@ -580,7 +578,7 @@ class Python(Package):
         :py:attr:``~.AutotoolsPackage.install_targets``
         """
         with working_dir(self.stage.source_path):
-            if is_windows:
+            if sys.platform == "win32":
                 self.win_installer(prefix)
             else:
                 make(*self.install_targets)
@@ -593,7 +591,7 @@ class Python(Package):
         If this isn't done, they'll have CC and CXX set to Spack's generic
         cc and c++. We want them to be bound to whatever compiler
         they were built with."""
-        if is_windows:
+        if sys.platform == "win32":
             return
         kwargs = {"ignore_absent": True, "backup": False, "string": True}
 
@@ -605,7 +603,7 @@ class Python(Package):
 
     @run_after("install")
     def symlink(self):
-        if is_windows:
+        if sys.platform == "win32":
             return
         spec = self.spec
         prefix = self.prefix
@@ -723,7 +721,7 @@ class Python(Package):
         # in that order if using python@3.11.0, for example.
         version = self.spec.version
         for ver in [version.up_to(2), version.up_to(1), ""]:
-            if not is_windows:
+            if sys.platform != "win32":
                 path = os.path.join(self.prefix.bin, "python{0}".format(ver))
             else:
                 path = os.path.join(self.prefix, "python{0}.exe".format(ver))
@@ -772,11 +770,11 @@ print(json.dumps(config))
 """
 
         dag_hash = self.spec.dag_hash()
-        lib_prefix = "lib" if not is_windows else ""
+        lib_prefix = "lib" if sys.platform != "win32" else ""
         if dag_hash not in self._config_vars:
             # Default config vars
             version = self.version.up_to(2)
-            if is_windows:
+            if sys.platform == "win32":
                 version = str(version).split(".")[0]
             config = {
                 # get_config_vars
@@ -886,9 +884,9 @@ print(json.dumps(config))
     @property
     def libs(self):
         py_version = self.version.up_to(2)
-        if is_windows:
+        if sys.platform == "win32":
             py_version = str(py_version).replace(".", "")
-        lib_prefix = "lib" if not is_windows else ""
+        lib_prefix = "lib" if sys.platform != "win32" else ""
         # The values of LDLIBRARY and LIBRARY aren't reliable. Intel Python uses a
         # static binary but installs shared libraries, so sysconfig reports
         # libpythonX.Y.a but only libpythonX.Y.so exists. So we add our own paths, too.
@@ -1121,7 +1119,7 @@ print(json.dumps(config))
             # fact that LDSHARED is set in the environment, therefore we export
             # the variable only if the new value is different from what we got
             # from the sysconfigdata file:
-            if config_link != new_link and not is_windows:
+            if config_link != new_link and sys.platform != "win32":
                 env.set(link_var, new_link)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
@@ -1180,7 +1178,7 @@ print(json.dumps(config))
                 view.link(new_link_target, dst, spec=self.spec)
 
     def remove_files_from_view(self, view, merge_map):
-        bin_dir = self.spec.prefix.bin if not is_windows else self.spec.prefix
+        bin_dir = self.spec.prefix.bin if sys.platform != "win32" else self.spec.prefix
         for src, dst in merge_map.items():
             if not path_contains_subdirectory(src, bin_dir):
                 view.remove_file(src, dst)

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -7,8 +7,6 @@ import sys
 
 from spack.package import *
 
-is_windows = sys.platform == "win32"
-
 
 class Re2c(Package):
     """re2c: a free and open-source lexer generator for C and C++"""
@@ -33,7 +31,7 @@ class Re2c(Package):
 
     @property
     def make_tool(self):
-        if is_windows:
+        if sys.platform == "win32":
             return ninja
         else:
             return make

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -6,8 +6,6 @@ import sys
 
 from spack.package import *
 
-is_windows = sys.platform == "win32"
-
 
 class Scons(PythonPackage):
     """SCons is a software construction tool"""
@@ -55,7 +53,7 @@ class Scons(PythonPackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib.scons)
 
     def setup_dependent_package(self, module, dspec):
-        if is_windows:
+        if sys.platform == "win32":
             module.scons = Executable(self.spec.prefix.Scripts.scons)
         else:
             module.scons = Executable(self.spec.prefix.bin.scons)

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -5,18 +5,16 @@
 
 import glob
 import re
+import sys
 import time
 from os.path import basename
 from subprocess import PIPE, Popen
-from sys import platform, stdout
 
 from llnl.util import tty
 
 from spack.package import *
 
-is_windows = platform == "win32"
-
-if not is_windows:
+if sys.platform != "win32":
     from fcntl import F_GETFL, F_SETFL, fcntl
     from os import O_NONBLOCK
 
@@ -333,7 +331,7 @@ class Wrf(Package):
             )
 
         p = Popen("./configure", stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        if not is_windows:
+        if sys.platform != "win32":
             setNonBlocking(p.stdout)
             setNonBlocking(p.stderr)
 
@@ -358,7 +356,7 @@ class Wrf(Package):
                 time.sleep(0.1)  # Try to do a bit of rate limiting
                 stallcounter += 1
                 continue
-            stdout.write(line)
+            sys.stdout.write(line)
             stallcounter = 0
             outputbuf += line
             if "Enter selection" in outputbuf or "Compile for nesting" in outputbuf:


### PR DESCRIPTION
`mypy` only understands `sys.platform == "win32"`, not indirect assignments of that value to things like `is_windows`.  See https://github.com/python/mypy/issues/9242#issuecomment-667586397.

If we don't use the accepted platform checks, `mypy` registers many Windows-only symbols as not present on Linux, when it should skip the checks for platform-specific code. 

I'd like to get us to where we can enable `check_untyped_defs` in `mypy` (see #35639), so I've pulled this off of #35639 and made it a first PR.  I realize this may look uglier to some people, but I don't see a good way around it as long as `mypy` is going to be dumb.