### PR TITLE
Simpler package API for jobserver support v2

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -536,7 +536,7 @@ def determine_number_of_jobs(
         max_cpus (int or None): maximum number of CPUs available. When None, this
             value is automatically determined.
     """
-    if not parallel:
+    if not parallel or env_flag(SPACK_NO_PARALLEL_MAKE):
         return 1
 
     if command_line is None and "command_line" in spack.config.scopes():

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import inspect
 import os
 from typing import Optional, Tuple
 
@@ -10,10 +11,8 @@ import llnl.util.lang as lang
 import llnl.util.tty as tty
 
 import spack.builder
-from spack.build_environment import SPACK_NO_PARALLEL_MAKE, determine_number_of_jobs
 from spack.directives import build_system, extends, maintainers
 from spack.package_base import PackageBase
-from spack.util.environment import env_flag
 from spack.util.executable import Executable, ProcessError
 
 
@@ -78,7 +77,6 @@ class RacketBuilder(spack.builder.Builder):
         """Install everything from build directory."""
         raco = Executable("raco")
         with fs.working_dir(self.build_directory):
-            parallel = self.pkg.parallel and (not env_flag(SPACK_NO_PARALLEL_MAKE))
             args = [
                 "pkg",
                 "install",
@@ -92,7 +90,7 @@ class RacketBuilder(spack.builder.Builder):
                 "--copy",
                 "-i",
                 "-j",
-                str(determine_number_of_jobs(parallel)),
+                str(inspect.getmodule(self.pkg).make_jobs),
                 "--",
                 os.getcwd(),
             ]

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -501,6 +501,14 @@ def test_build_jobs_defaults():
     )
 
 
+def test_build_jobs_spack_no_parallel_make(working_env):
+    os.environ["SPACK_NO_PARALLEL_MAKE"] = "1"
+    assert (
+        determine_number_of_jobs(parallel=True, command_line=10, config_default=10, max_cpus=10)
+        == 1
+    )
+
+
 def test_dirty_disable_module_unload(config, mock_packages, working_env, mock_module_cmd):
     """Test that on CRAY platform 'module unload' is not called if the 'dirty'
     option is on.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -9,7 +9,6 @@ import sys
 
 import spack.build_environment
 from spack.package import *
-from spack.util.environment import env_flag
 
 is_windows = sys.platform == "win32"
 
@@ -328,10 +327,9 @@ class Cmake(Package):
         if not sys.platform == "win32":
             args.append("--prefix={0}".format(self.prefix))
 
-            jobs = 1 if env_flag(spack.build_environment.SPACK_NO_PARALLEL_MAKE) else make_jobs
-            jobserver = jobs > 1 and should_support_jobserver and self.generator.supports_jobserver
-            if not jobserver:
-                args.append("--parallel={0}".format(jobs))
+            support_jobserver = should_support_jobserver and self.generator.supports_jobserver
+            if not support_jobserver:
+                args.append("--parallel={0}".format(make_jobs))
 
             if "+ownlibs" in spec:
                 # Build and link to the CMake-provided third-party libraries

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -9,6 +9,7 @@ import sys
 
 import spack.build_environment
 from spack.package import *
+from spack.util.environment import env_flag
 
 is_windows = sys.platform == "win32"
 
@@ -327,12 +328,9 @@ class Cmake(Package):
         if not sys.platform == "win32":
             args.append("--prefix={0}".format(self.prefix))
 
-            jobs = spack.build_environment.get_effective_jobs(
-                make_jobs,
-                parallel=self.parallel,
-                supports_jobserver=self.generator.supports_jobserver,
-            )
-            if jobs is not None:
+            jobs = 1 if env_flag(spack.build_environment.SPACK_NO_PARALLEL_MAKE) else make_jobs
+            jobserver = jobs > 1 and should_support_jobserver and self.generator.supports_jobserver
+            if not jobserver:
                 args.append("--parallel={0}".format(jobs))
 
             if "+ownlibs" in spec:

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -6,7 +6,7 @@
 import os
 import re
 
-from spack.build_environment import MakeExecutable, determine_number_of_jobs
+from spack.build_environment import MakeExecutable
 from spack.package import *
 
 
@@ -80,9 +80,5 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
             os.symlink("make", prefix.bin.gmake)
 
     def setup_dependent_package(self, module, dspec):
-        module.make = MakeExecutable(
-            self.spec.prefix.bin.make, determine_number_of_jobs(parallel=dspec.package.parallel)
-        )
-        module.gmake = MakeExecutable(
-            self.spec.prefix.bin.gmake, determine_number_of_jobs(parallel=dspec.package.parallel)
-        )
+        module.make = MakeExecutable(self.spec.prefix.bin.make, module.make_jobs)
+        module.gmake = MakeExecutable(self.spec.prefix.bin.gmake, module.make_jobs)

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.build_environment import MakeExecutable, determine_number_of_jobs
+from spack.build_environment import MakeExecutable
 from spack.package import *
 from spack.util.executable import which_string
 
@@ -94,6 +94,6 @@ class NinjaFortran(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=dspec.package.parallel),
+            module.make_jobs,
             supports_jobserver=True,  # This fork supports jobserver
         )

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
-from spack.build_environment import MakeExecutable, determine_number_of_jobs
+from spack.build_environment import MakeExecutable
 from spack.package import *
 from spack.util.executable import which_string
 
@@ -83,6 +83,6 @@ class Ninja(Package):
 
         module.ninja = MakeExecutable(
             which_string(name, path=[self.spec.prefix.bin], required=True),
-            determine_number_of_jobs(parallel=dspec.package.parallel),
+            module.make_jobs,
             supports_jobserver=self.spec.version == ver("kitware"),
         )

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -220,7 +220,9 @@ class PyHorovod(PythonPackage, CudaPackage):
         env.set("PKG_CONFIG_EXECUTABLE", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
         if "cmake" in self.spec:
             env.set("HOROVOD_CMAKE", self.spec["cmake"].command.path)
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
 
         # Frameworks
         if "frameworks=tensorflow" in self.spec:

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -222,7 +222,7 @@ class PyHorovod(PythonPackage, CudaPackage):
             env.set("HOROVOD_CMAKE", self.spec["cmake"].command.path)
 
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
 
         # Frameworks
         if "frameworks=tensorflow" in self.spec:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -312,7 +312,7 @@ class Qt(Package):
 
     def setup_build_environment(self, env):
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
         if self.version >= Version("5.11"):
             # QDoc uses LLVM as of 5.11; remove the LLVM_INSTALL_DIR to
             # disable

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -311,7 +311,8 @@ class Qt(Package):
         return url
 
     def setup_build_environment(self, env):
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
         if self.version >= Version("5.11"):
             # QDoc uses LLVM as of 5.11; remove the LLVM_INSTALL_DIR to
             # disable

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -216,7 +216,7 @@ class R(AutotoolsPackage):
         # Use the number of make_jobs set in spack. The make program will
         # determine how many jobs can actually be started.
         if not should_support_jobserver:
-            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+            env.append_flags("MAKEFLAGS", "-j{0}".format(make_jobs))
         env.set("R_HOME", join_path(self.prefix, "rlib", "R"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -215,7 +215,8 @@ class R(AutotoolsPackage):
 
         # Use the number of make_jobs set in spack. The make program will
         # determine how many jobs can actually be started.
-        env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
+        if not should_support_jobserver:
+            env.set("MAKEFLAGS", "-j{0}".format(make_jobs))
         env.set("R_HOME", join_path(self.prefix, "rlib", "R"))
 
     def setup_dependent_run_environment(self, env, dependent_spec):


### PR DESCRIPTION
Simplify packages parallel job count computation, and jobserver support:

- Replace `get_effective_jobs(...supports_jobserver...)` by a `should_support_jobserver` variable in package modules

- The environment variable `SPACK_NO_PARALLEL_MAKE` now affects all packages via `make_jobs` instead of just `MakeExecutable`

Also fix a few packages to support jobserver.

Supersedes #35183 and #35199.

Quick summary about packaging:

- You have nothing to do if you use `make()`, `ninja()`, `CMakePackage`, `MakefilePackage` , or derived
- If you can support jobserver elsewhere: use `should_support_jobserver` to test if you should
- If you don't support jobserver: `make_jobs` is fine

