### PR TITLE
Enable environment tests for Windows

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -5,70 +5,152 @@
 import errno
 import os
 import shutil
+import sys
 import tempfile
-from os.path import exists, join
-from sys import platform as _platform
 
-from llnl.util import lang
+from llnl.util import lang, tty
 
-is_windows = _platform == "win32"
+from spack.error import SpackError
 
-if is_windows:
+if sys.platform == "win32":
     from win32file import CreateHardLink
 
 
-def symlink(real_path, link_path):
+def symlink(real_path: str, link_path: str):
     """
-    Create a symbolic link.
+    Try to create a symbolic link.
 
-    On Windows, use junctions if os.symlink fails.
+    On non-Windows and Windows with System Administrator
+    privleges this will be a normal symbolic link via
+    os.symlink.
+
+    On Windows without privledges the link will be a
+    junction for a directory and a hardlink for a file.
+    On Windows the various link types are:
+
+    Symbolic Link: A link to a file or directory on the
+    same or different volume (drive letter) or even to
+    a remote file or directory (using UNC in its path).
+    Need System Administrator privileges to make these.
+
+    Hard Link: A link to a file on the same volume (drive
+    letter) only. Every file (file's data) has at least 1
+    hard link (file's name). But when this method creates
+    a new hard link there will be 2. Deleting all hard
+    links effectively deletes the file. Don't need System
+    Administrator privileges.
+
+    Junction (sometimes called soft link): A link to a
+    directory on the same or different volume (drive
+    letter) but not to a remote directory. Don't need
+    System Administrator privileges.
     """
-    if not is_windows:
-        os.symlink(real_path, link_path)
-    elif _win32_can_symlink():
-        # Windows requires target_is_directory=True when the target is a dir.
-        os.symlink(real_path, link_path, target_is_directory=os.path.isdir(real_path))
+    real_path = os.path.abspath(real_path)
+    link_path = os.path.abspath(link_path)
+
+    if os.path.exists(link_path):
+        raise SymlinkError(f"Link path ({link_path}) already exists. Cannot create link.")
+    elif not os.path.exists(real_path):
+        raise SymlinkError(f"Source path ({real_path}) does not exist. Cannot create link.")
+    elif sys.platform == "win32" and not _windows_can_symlink():
+        _windows_create_link(real_path, link_path)
     else:
-        try:
-            # Try to use junctions
-            _win32_junction(real_path, link_path)
-        except OSError:
-            # If all else fails, fall back to copying files
-            shutil.copyfile(real_path, link_path)
+        os.symlink(real_path, link_path, target_is_directory=os.path.isdir(real_path))
+
+    if not os.path.exists(link_path):
+        raise SymlinkError(f"Failed to create link: {link_path}")
 
 
-def islink(path):
-    return os.path.islink(path) or _win32_is_junction(path)
+def islink(path: str) -> bool:
+    """Override os.islink to give correct answer for spack logic.
+
+    For Non-Windows: a link can be determined with the os.path.islink method.
+    Windows-only methods will return false for other operating systems.
+
+    For Windows: spack considers symlinks, hard links, and junctions to
+    all be links, so if any of those are True, return True.
+
+    Args:
+        path (str): path to check if it is a link.
+
+    Returns:
+         bool - whether the path is any kind link or not.
+    """
+    try:
+        return any([os.path.islink(path), _windows_is_junction(path), _windows_is_hardlink(path)])
+    except Exception as e:
+        raise SymlinkError("Could not determine if given path is a link") from e
 
 
-# '_win32' functions based on
-# https://github.com/Erotemic/ubelt/blob/master/ubelt/util_links.py
-def _win32_junction(path, link):
-    # junctions require absolute paths
-    if not os.path.isabs(link):
-        link = os.path.abspath(link)
+def _windows_is_hardlink(path: str) -> bool:
+    """Determines if a path is a windows hard link. This is accomplished
+    by looking at the number of links using os.stat. A non-hard-linked file
+    will have a st_nlink value of 1, whereas a hard link will have a value
+    larger than 1. Note that both the original and hard-linked file will
+    return True because they share the same inode.
 
-    # os.symlink will fail if link exists, emulate the behavior here
-    if exists(link):
-        raise OSError(errno.EEXIST, "File  exists: %s -> %s" % (link, path))
+    Args:
+        path (str): Windows path to check for a hard link
 
-    if not os.path.isabs(path):
-        parent = os.path.join(link, os.pardir)
-        path = os.path.join(parent, path)
-        path = os.path.abspath(path)
+    Returns:
+         bool - Whether the path is a hard link or not.
+    """
+    if sys.platform != "win32" or os.path.islink(path) or not os.path.exists(path):
+        return False
 
-    CreateHardLink(link, path)
+    try:
+        return os.stat(path).st_nlink > 1
+    except Exception as e:
+        raise SymlinkError("Could not determine if path is a hard link") from e
+
+
+def _windows_is_junction(path: str) -> bool:
+    """Determines if a path is a windows junction. A junction can be
+    determined using a bitwise AND operation between the file's
+    attribute bitmask and the known junction bitmask (0x400).
+
+    Args:
+        path (str): A non-file path
+
+    Returns:
+        bool - whether the path is a junction or not.
+    """
+    if sys.platform != "win32" or os.path.islink(path) or os.path.isfile(path):
+        return False
+
+    import ctypes.wintypes
+
+    get_file_attributes = ctypes.windll.kernel32.GetFileAttributesW  # type: ignore[attr-defined]
+    get_file_attributes.argtypes = (ctypes.wintypes.LPWSTR,)
+    get_file_attributes.restype = ctypes.wintypes.DWORD
+
+    invalid_file_attributes = 0xFFFFFFFF
+    reparse_point = 0x400
+    file_attr = get_file_attributes(path)
+
+    if file_attr == invalid_file_attributes:
+        return False
+
+    return file_attr & reparse_point > 0
 
 
 @lang.memoized
-def _win32_can_symlink():
+def _windows_can_symlink() -> bool:
+    """
+    Determines if windows is able to make a symlink depending on
+    the system configuration and the level of the user's permissions.
+    """
+    if sys.platform != "win32":
+        tty.warn("windows_can_symlink method can't be used on non-Windows OS.")
+        return False
+
     tempdir = tempfile.mkdtemp()
 
-    dpath = join(tempdir, "dpath")
-    fpath = join(tempdir, "fpath.txt")
+    dpath = os.path.join(tempdir, "dpath")
+    fpath = os.path.join(tempdir, "fpath.txt")
 
-    dlink = join(tempdir, "dlink")
-    flink = join(tempdir, "flink.txt")
+    dlink = os.path.join(tempdir, "dlink")
+    flink = os.path.join(tempdir, "flink.txt")
 
     import llnl.util.filesystem as fs
 
@@ -92,24 +174,65 @@ def _win32_can_symlink():
     return can_symlink_directories and can_symlink_files
 
 
-def _win32_is_junction(path):
+def _windows_create_link(path: str, link: str):
     """
-    Determines if a path is a win32 junction
+    Attempts to create a Hard Link or Junction as an alternative
+    to a symbolic link. This is called when symbolic links cannot
+    be created.
     """
-    if os.path.islink(path):
-        return False
+    if sys.platform != "win32":
+        tty.warn("windows_create_link method can't be used on non-Windows OS.")
+        return
 
-    if is_windows:
-        import ctypes.wintypes
+    if os.path.isdir(path):
+        _windows_create_junction(path=path, link=link)
+    elif os.path.isfile(path):
+        _windows_create_hard_link(path=path, link=link)
+    else:
+        raise SymlinkError(
+            f"Cannot create link from {path}. It is neither a file nor a directory."
+        )
 
-        GetFileAttributes = ctypes.windll.kernel32.GetFileAttributesW
-        GetFileAttributes.argtypes = (ctypes.wintypes.LPWSTR,)
-        GetFileAttributes.restype = ctypes.wintypes.DWORD
 
-        INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
-        FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+def _windows_create_junction(path: str, link: str):
+    """Duly verify that the path and link are eligible to create a junction,
+    then create the junction.
+    """
+    if sys.platform != "win32":
+        tty.warn("windows_create_junction method can't be used on non-Windows OS.")
+        return
+    import subprocess
 
-        res = GetFileAttributes(path)
-        return res != INVALID_FILE_ATTRIBUTES and bool(res & FILE_ATTRIBUTE_REPARSE_POINT)
+    try:
+        cmd = ["cmd", "/C", "mklink", "/J", link, path]
+        proc = subprocess.run(cmd, capture_output=True)
+        if proc.returncode != 0:
+            # TODO: How do we know that this only happens if the
+            #  junction already exists?
+            raise OSError(errno.EEXIST, "Junction exists: %s" % link)
+    except subprocess.CalledProcessError as e:
+        raise SymlinkError(f"Failed to make junction {link} from directory {path}") from e
 
-    return False
+
+def _windows_create_hard_link(path: str, link: str):
+    """Duly verify that the path and link are eligible to create a hard
+    link, then create the hard link.
+    """
+    if sys.platform != "win32":
+        tty.warn("windows_create_hard_link method can't be used on non-Windows OS.")
+        return
+    elif not os.path.exists(path):
+        raise SymlinkError(f"File path {path} does not exist. Cannot create hard link.")
+    elif os.path.exists(link):
+        raise SymlinkError(f"Link path ({link}) already exists. Cannot create hard link.")
+    elif not os.path.isfile(path):
+        raise SymlinkError(f"File path ({link}) is not a file. Cannot create hard link.")
+    else:
+        tty.debug(f"Creating hard link {link} pointing to {path}")
+        CreateHardLink(link, path)
+
+
+class SymlinkError(SpackError):
+    """Exception class for errors raised while creating symlinks,
+    junctions and hard links
+    """

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -154,6 +154,7 @@ def _windows_can_symlink() -> bool:
 
     import llnl.util.filesystem as fs
 
+    fs.mkdirp(dpath)
     fs.touchp(fpath)
 
     try:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -21,7 +21,7 @@ import llnl.util.tty as tty
 import llnl.util.tty.color as clr
 from llnl.util.lang import dedupe
 from llnl.util.link_tree import ConflictingSpecsError
-from llnl.util.symlink import symlink
+from llnl.util.symlink import symlink, islink
 
 import spack.compilers
 import spack.concretize
@@ -467,10 +467,10 @@ class ViewDescriptor(object):
 
     @property
     def _current_root(self):
-        if not os.path.islink(self.root):
+        if not islink(self.root):
             return None
 
-        root = os.readlink(self.root)
+        root = os.path.realpath(self.root)
         if os.path.isabs(root):
             return root
 
@@ -1072,6 +1072,8 @@ class Environment(object):
 
     def destroy(self):
         """Remove this environment from Spack entirely."""
+        if os.path.exists(self.view_path_default):
+                os.unlink(self.view_path_default)
         shutil.rmtree(self.path)
 
     def update_stale_references(self, from_list=None):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -195,6 +195,8 @@ def _do_fake_install(pkg):
     packages_dir = spack.store.layout.build_packages_path(pkg.spec)
     dump_packages(pkg.spec, packages_dir)
 
+    fs.touch(os.path.join(pkg.prefix, '.spack', 'spack-build-out.txt'))
+
 
 def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
     """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import sys
 from argparse import Namespace
+import pathlib
 
 import pytest
 
@@ -778,18 +779,16 @@ def mpileaks_env_config(include_path):
     """Return the contents of an environment that includes the provided
     path and lists mpileaks as the sole spec."""
 
-    file_seperator = "//"
-    if is_windows:
-      file_seperator = "///"
+    include_path = pathlib.Path(include_path).as_uri()
 
     return """\
 env:
   include:
-  - file:{1}{0}
+  - {0}
   specs:
   - mpileaks
 """.format(
-        include_path, file_seperator
+        include_path
     )
 
 
@@ -819,10 +818,9 @@ def test_env_with_included_config_file_url(tmpdir, mutable_empty_config, package
 
     spack_yaml = tmpdir.join("spack.yaml")
     with spack_yaml.open("w") as f:
-        file_seperator = "//"
-        if is_windows:
-          file_seperator = "///"
-        f.write("spack:\n  include:\n    - file:{1}{0}\n".format(packages_file, file_seperator))
+        packages_file = pathlib.Path(packages_file).as_uri()
+
+        f.write("spack:\n  include:\n    - {0}\n".format(packages_file))
 
     env = ev.Environment(tmpdir.strpath)
     ev.activate(env)
@@ -840,10 +838,8 @@ def test_env_with_included_config_missing_file(tmpdir, mutable_empty_config):
     spack_yaml = tmpdir.join("spack.yaml")
     missing_file = tmpdir.join("packages.yaml")
     with spack_yaml.open("w") as f:
-        file_seperator = "//"
-        if is_windows:
-          file_seperator = "///"
-        f.write("spack:\n  include:\n    - file:{1}{0}\n".format(missing_file.strpath, file_seperator))
+        file = pathlib.Path(missing_file.strpath).as_uri()
+        f.write("spack:\n  include:\n    - {0}\n".format(file))
 
     env = ev.Environment(tmpdir.strpath)
     with pytest.raises(spack.config.ConfigError, match="missing include path"):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -881,7 +881,20 @@ def test_env_with_included_config_var_path(packages_file):
     """Test inclusion of a package configuration file with path variables
     "staged" in the environment's configuration stage directory."""
     config_var_path = os.path.join("$tempdir", "included-config.yaml")
-    test_config = mpileaks_env_config(config_var_path)
+
+    file_seperator = "//"
+    if is_windows:
+      file_seperator = "///"
+
+    test_config = """\
+      env:
+        include:
+        - file:{0}{1}
+        specs:
+        - mpileaks
+      """.format(
+              file_seperator, config_var_path
+          )
 
     _env_create("test", io.StringIO(test_config))
     e = ev.read("test")

--- a/lib/spack/spack/test/data/sourceme_first.bat
+++ b/lib/spack/spack/test/data/sourceme_first.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+set new_var=new
+set unset_me=overridden

--- a/lib/spack/spack/test/data/sourceme_lmod.bat
+++ b/lib/spack/spack/test/data/sourceme_lmod.bat
@@ -1,0 +1,13 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+set lmod_variable=foo
+set lmod_another_variable=bar
+set new_var=new
+

--- a/lib/spack/spack/test/data/sourceme_parameters.bat
+++ b/lib/spack/spack/test/data/sourceme_parameters.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+
+if "%1"=="intel64" (set foo=intel64) else (set foo=default)

--- a/lib/spack/spack/test/data/sourceme_second.bat
+++ b/lib/spack/spack/test/data/sourceme_second.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+set path_list=\path\first;\path\second;\path\fourth
+set empty_path_list=

--- a/lib/spack/spack/test/data/sourceme_unicode.bat
+++ b/lib/spack/spack/test/data/sourceme_unicode.bat
@@ -1,0 +1,17 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+
+:: Set an environment variable with some unicode in it to ensure that
+:: Spack can decode it.
+::
+:: This has caused squashed commits on develop to break, as some
+:: committers use unicode in their messages, and Travis sets the
+:: current commit message in an environment variable.
+set unicode_var=don\xe2\x80\x99t

--- a/lib/spack/spack/test/data/sourceme_unset.bat
+++ b/lib/spack/spack/test/data/sourceme_unset.bat
@@ -1,0 +1,10 @@
+@echo off
+
+:: Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+:: Spack Project Developers. See the top-level COPYRIGHT file for details.
+::
+:: SPDX-License-Identifier: (Apache-2.0 OR MIT)
+::#######################################################################
+::
+
+set unset_me=

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -14,10 +14,6 @@ import llnl.util.filesystem as fs
 import spack.environment as ev
 import spack.spec
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="Envs are not supported on windows"
-)
-
 
 def test_hash_change_no_rehash_concrete(tmpdir, mock_packages, config):
     # create an environment

--- a/lib/spack/spack/test/llnl/util/symlink.py
+++ b/lib/spack/spack/test/llnl/util/symlink.py
@@ -1,0 +1,206 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Tests for ``llnl/util/symlink.py``"""
+import os
+import shutil
+import sys
+import tempfile
+
+import pytest
+
+from llnl.util import symlink
+
+
+@pytest.fixture(scope="session")
+def stage(tmpdir_factory):
+    """Creates a stage with the parent directory for the tests to run in."""
+
+    test_parent_dir = tmpdir_factory.mktemp("symlink_test")
+    assert os.path.exists(test_parent_dir)
+
+    # Run tests
+    yield test_parent_dir
+
+    # Clean up test directory
+    shutil.rmtree(test_parent_dir)
+
+
+def test_symlink__file(stage):
+    """Test the symlink.symlink functionality on all operating systems for a file"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
+    try:
+        assert os.path.exists(real_file)
+        link_file = tempfile.mktemp(prefix="link", suffix=".txt", dir=test_dir)
+        assert os.path.exists(link_file) is False
+        symlink.symlink(real_path=real_file, link_path=link_file)
+        assert os.path.exists(link_file)
+        assert symlink.islink(link_file)
+    finally:
+        os.close(fd)
+
+
+def test_symlink__dir(stage):
+    """Test the symlink.symlink functionality on all operating systems for a directory"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    real_dir = os.path.join(test_dir, "real_dir")
+    link_dir = os.path.join(test_dir, "link_dir")
+    os.mkdir(real_dir)
+    assert os.path.exists(real_dir)
+    symlink.symlink(real_path=real_dir, link_path=link_dir)
+    assert os.path.exists(link_dir)
+    assert symlink.islink(link_dir)
+
+
+def test_symlink__source_not_exists(stage):
+    """Test the symlink.symlink method for the case where a source path does not exist"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    real_dir = os.path.join(test_dir, "real_dir")
+    link_dir = os.path.join(test_dir, "link_dir")
+    assert not os.path.exists(real_dir)
+    assert not os.path.exists(link_dir)
+    try:
+        symlink.symlink(real_path=real_dir, link_path=link_dir)
+        assert False, "symlink command succeeded when it should have failed."
+    except symlink.SymlinkError:
+        ...
+
+
+def test_symlink__link_exists(stage):
+    """Test the symlink.symlink method for the case where a link already exists"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    real_dir = os.path.join(test_dir, "real_dir")
+    link_dir = os.path.join(test_dir, "link_dir")
+    os.mkdir(real_dir)
+    symlink.symlink(real_dir, link_dir)
+    assert os.path.exists(real_dir)
+    assert os.path.exists(link_dir)
+    try:
+        symlink.symlink(real_path=real_dir, link_path=link_dir)
+        assert False, "symlink command succeeded when it should have failed."
+    except symlink.SymlinkError:
+        ...
+
+
+@pytest.mark.skipif(not symlink._windows_can_symlink(), reason="Test requires elevated privileges")
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_symlink__win_file(stage):
+    """Check that symlink.symlink makes a symlink file when run with elevated permissions"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
+    try:
+        assert os.path.exists(real_file)
+        link_file = tempfile.mktemp(prefix="link", suffix=".txt", dir=test_dir)
+        assert os.path.exists(link_file) is False
+        symlink.symlink(real_path=real_file, link_path=link_file)
+        # Verify that all expected conditions are met
+        assert os.path.exists(link_file)
+        assert symlink.islink(link_file)
+        assert os.path.islink(link_file)
+        assert not symlink._windows_is_hardlink(link_file)
+        assert not symlink._windows_is_junction(link_file)
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.skipif(not symlink._windows_can_symlink(), reason="Test requires elevated privileges")
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_symlink__win_dir(stage):
+    """Check that symlink.symlink makes a symlink dir when run with elevated permissions"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    real_dir = os.path.join(test_dir, "real")
+    link_dir = os.path.join(test_dir, "link")
+    os.mkdir(real_dir)
+    assert os.path.exists(real_dir)
+    symlink.symlink(real_path=real_dir, link_path=link_dir)
+    # Verify that all expected conditions are met
+    assert os.path.exists(link_dir)
+    assert symlink.islink(link_dir)
+    assert os.path.islink(link_dir)
+    assert not symlink._windows_is_hardlink(link_dir)
+    assert not symlink._windows_is_junction(link_dir)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_windows_create_junction(stage):
+    """Test the symlink._windows_create_junction method"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    junction_real_dir = os.path.join(test_dir, "real_dir")
+    junction_link_dir = os.path.join(test_dir, "link_dir")
+    os.mkdir(junction_real_dir)
+    assert os.path.exists(junction_real_dir)
+    assert not os.path.exists(junction_link_dir)
+    assert symlink._windows_is_junction(junction_real_dir) is False
+    symlink._windows_create_junction(junction_real_dir, junction_link_dir)
+    # Verify that all expected conditions are met
+    assert os.path.exists(junction_link_dir)
+    assert symlink._windows_is_junction(junction_link_dir)
+    assert symlink.islink(junction_link_dir)
+    assert not os.path.islink(junction_link_dir)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_windows_create_hard_link(stage):
+    """Test the symlink._windows_create_hard_link method"""
+    test_dir = tempfile.mkdtemp(dir=stage)
+    fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
+    try:
+        assert os.path.exists(real_file)
+        link_file = tempfile.mktemp(prefix="link", suffix=".txt", dir=test_dir)
+        assert os.path.exists(link_file) is False
+        symlink._windows_create_hard_link(real_file, link_file)
+        # Verify that all expected conditions are met
+        assert os.path.exists(link_file)
+        assert symlink._windows_is_hardlink(real_file)
+        assert symlink._windows_is_hardlink(link_file)
+        assert symlink.islink(link_file)
+        assert not os.path.islink(link_file)
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_windows_create_link__dir(stage):
+    """Test the functionality of the windows_create_link method with a directory
+    which should result in making a junction.
+    """
+    test_dir = tempfile.mkdtemp(dir=stage)
+    real_dir = os.path.join(test_dir, "real")
+    link_dir = os.path.join(test_dir, "link")
+    os.mkdir(real_dir)
+    assert os.path.exists(real_dir)
+    assert not os.path.exists(link_dir)
+    symlink._windows_create_link(real_dir, link_dir)
+    # Verify that all expected conditions are met
+    assert os.path.exists(real_dir)
+    assert os.path.exists(link_dir)
+    assert symlink.islink(link_dir)
+    assert not symlink._windows_is_hardlink(link_dir)
+    assert symlink._windows_is_junction(link_dir)
+    assert not os.path.islink(link_dir)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+def test_windows_create_link__file(stage):
+    """Test the functionality of the windows_create_link method with a file
+    which should result in the creation of a hard link.
+    """
+    test_dir = tempfile.mkdtemp(dir=stage)
+    fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
+    try:
+        assert os.path.exists(real_file)
+        link_file = tempfile.mktemp(prefix="link", suffix=".txt", dir=test_dir)
+        assert os.path.exists(link_file) is False
+        symlink._windows_create_link(real_file, link_file)
+        # Verify that all expected conditions are met
+        assert os.path.exists(link_file)
+        assert symlink._windows_is_hardlink(real_file)
+        assert symlink._windows_is_hardlink(link_file)
+        assert symlink.islink(link_file)
+        assert not symlink._windows_is_junction(link_file)
+        assert not os.path.islink(link_file)
+    finally:
+        os.close(fd)

--- a/var/spack/repos/builtin.mock/packages/view-dir-symlinked-dir/package.py
+++ b/var/spack/repos/builtin.mock/packages/view-dir-symlinked-dir/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack.package import *
+from llnl.util.symlink import symlink
 
 
 class ViewDirSymlinkedDir(Package):
@@ -19,8 +20,8 @@ class ViewDirSymlinkedDir(Package):
     version("0.1.0", sha256="cc89a8768693f1f11539378b21cdca9f0ce3fc5cb564f9b3e4154a051dcea69b")
 
     def install(self, spec, prefix):
-        os.mkdir(os.path.join(prefix, "bin"))
-        os.mkdir(os.path.join(prefix, "bin", "y"))
-        with open(os.path.join(prefix, "bin", "y", "file_in_symlinked_dir"), "wb") as f:
+        mkdirp(join_path(prefix, "bin"))
+        mkdirp(join_path(prefix, "bin", "y"))
+        with open(join_path(prefix, "bin", "y", "file_in_symlinked_dir"), "wb") as f:
             f.write(b"hello world")
-        os.symlink("y", os.path.join(prefix, "bin", "x"))
+        symlink("y", join_path(prefix, "bin", "x"))


### PR DESCRIPTION
Slight changes to environments to enable windows environment tests. Opens up support for enviroments through batfiles to match the functionality for environments with bash files on linux.

Note: this is rebased on top of [windows symlink changes](https://github.com/spack/spack/pull/34701) which is where the symlink file changes come from