### PR TITLE
gts: missing pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gts/package.py
+++ b/var/spack/repos/builtin/packages/gts/package.py
@@ -27,3 +27,4 @@ class Gts(AutotoolsPackage):
     version("121130", sha256="c23f72ab74bbf65599f8c0b599d6336fabe1ec2a09c19b70544eeefdc069b73b")
 
     depends_on("glib")
+    depends_on("pkgconfig", type=("build"))


### PR DESCRIPTION
On an ubuntu-22.04 without the pkg-config system package installed `gts` configure fails with :

```
==> Installing gts-121130-26fgbdb4g63qlmfmcf2mqpnnv2ug7e7l
==> No binary for gts-121130-26fgbdb4g63qlmfmcf2mqpnnv2ug7e7l found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/c2/c23f72ab74bbf65599f8c0b599d6336fabe1ec2a09c19b70544eeefdc069b73b.tar.gz
==> No patches needed for gts
==> gts: Executing phase: 'autoreconf'
==> gts: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/root/spack-stage/spack-stage-gts-121130-26fgbdb4g63qlmfmcf2mqpnnv2ug7e7l/spack-src/configure' '--prefix=/spack/opt/spack/linux-ubuntu22.04-icelake/gcc-11.3.0/gts-121130-26fgbdb4g63qlmfmcf2mqpnnv2ug7e7l'

2 errors found in build log:
     46     checking for ar... ar
     47     checking for archiver @FILE support... @
     48     checking for strip... strip
     49     checking for ranlib... ranlib
     50     checking command to parse /usr/bin/nm -B output from /spack/lib/spack/env/gcc/gcc object... ok
     51     checking for sysroot... no
  >> 52     /tmp/root/spack-stage/spack-stage-gts-121130-26fgbdb4g63qlmfmcf2mqpnnv2ug7e7l/spack-src/configure: line 6166: /usr/bin/file: No such file or direct
            ory
     53     checking for mt... no
     54     checking if : is a manifest tool... no
     55     checking how to run the C preprocessor... /spack/lib/spack/env/gcc/gcc -E
     56     checking for ANSI C header files... yes
     57     checking for sys/types.h... yes
     58     checking for sys/stat.h... yes

     ...

     102    checking for glib-config... no
     103    checking for GLIB - version >= 1.2.8... no
     104    *** The glib-config script installed by GLIB could not be found
     105    *** If GLIB was installed in PREFIX, make sure PREFIX/bin is in
     106    *** your path, or set the GLIB_CONFIG environment variable to the
     107    *** full path to glib-config.
  >> 108    configure: error:
     109    *** GLIB 1.2.8 or better is required. The latest version of GLIB
     110    *** is always available from ftp://ftp.gtk.org/.
```
The `pkgconfig` dependency seems to be needed in order to find `glib`.