### PR TITLE
py-fiona: add upper bounds to Python versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiona/package.py
+++ b/var/spack/repos/builtin/packages/py-fiona/package.py
@@ -22,11 +22,23 @@ class PyFiona(PythonPackage):
     version("1.8.21", sha256="3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc")
     version("1.8.20", sha256="a70502d2857b82f749c09cb0dea3726787747933a2a1599b5ab787d74e3c143b")
     version("1.8.18", sha256="b732ece0ff8886a29c439723a3e1fc382718804bb057519d537a81308854967a")
-    version("1.8.6", sha256="fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e")
-    version("1.7.12", sha256="8b54eb8422d7c502bb7776b184018186bede1a489cf438a7a47f992ade6a0e51")
+    version(
+        "1.8.6",
+        sha256="fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e",
+        deprecated=True,
+    )
+    version(
+        "1.7.12",
+        sha256="8b54eb8422d7c502bb7776b184018186bede1a489cf438a7a47f992ade6a0e51",
+        deprecated=True,
+    )
 
     # pyproject.toml
-    depends_on("python", type=("build", "link", "run"))
+    depends_on("python@3.7:", when="@1.9:", type=("build", "link", "run"))
+    depends_on("python@2.6:", when="@1.8.22:1.8", type=("build", "link", "run"))
+    depends_on("python@2.6:3.10", when="@1.8.21", type=("build", "link", "run"))
+    depends_on("python@2.6:3.9", when="@1.8.12:1.8.20", type=("build", "link", "run"))
+    depends_on("python@2.6:3.8", when="@:1.8.11", type=("build", "link", "run"))
     depends_on("py-cython@0.29.29:0.29", when="@1.9:", type="build")
     depends_on("py-setuptools@61:", when="@1.9:", type="build")
     depends_on("py-attrs@19.2:", when="@1.9:", type=("build", "run"))
@@ -46,3 +58,5 @@ class PyFiona(PythonPackage):
 
     # Historical dependencies
     depends_on("py-six@1.7:", when="@:1.8", type=("build", "run"))
+
+    conflicts("%apple-clang@12:", when="@:1.8.9")

--- a/var/spack/repos/builtin/packages/py-fiona/package.py
+++ b/var/spack/repos/builtin/packages/py-fiona/package.py
@@ -59,4 +59,5 @@ class PyFiona(PythonPackage):
     # Historical dependencies
     depends_on("py-six@1.7:", when="@:1.8", type=("build", "run"))
 
+    # error: implicit declaration of function 'OSRFixup' is invalid in C99
     conflicts("%apple-clang@12:", when="@:1.8.9")


### PR DESCRIPTION
Discovered entirely through trial and error. Older versions don't build due to C99 implicit declaration errors, so I couldn't test farther back, but I'm guessing only Python 3.7 works, and we're deprecating 3.7 soon anyway, so I deprecated those versions too.