### PR TITLE
enabling test for hipcub and rocprim

### DIFF
--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -106,6 +106,7 @@ class Hipcub(CMakePackage):
     depends_on("cmake@3.10.2:", type="build", when="@4.2.0:")
     depends_on("cmake@3.5.1:", type="build")
     depends_on("numactl", type="link", when="@3.7.0:")
+    depends_on("googletest@1.10.0:", type="test")
 
     for ver in [
         "3.5.0",
@@ -140,7 +141,7 @@ class Hipcub(CMakePackage):
         env.set("CXX", self.spec["hip"].hipcc)
 
     def cmake_args(self):
-        args = []
+        args = [self.define("BUILD_TEST", self.run_tests)]
 
         if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
             args.append(self.define("__skip_rocmclang", "ON"))

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -109,6 +109,7 @@ class Rocprim(CMakePackage):
     depends_on("cmake@3.10.2:", type="build", when="@4.2.0:")
     depends_on("cmake@3.5.1:", type="build")
     depends_on("numactl", type="link", when="@3.7.0:")
+    depends_on("googletest@1.10.0:", type="test")
 
     for ver in [
         "3.5.0",
@@ -149,8 +150,8 @@ class Rocprim(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("ONLY_INSTALL", "ON"),
-            self.define("BUILD_TEST", "OFF"),
+            self.define("ONLY_INSTALL", (not self.run_tests)),
+            self.define("BUILD_TEST", self.run_tests),
             self.define("BUILD_BENCHMARK", "OFF"),
             self.define("BUILD_EXAMPLE", "OFF"),
         ]


### PR DESCRIPTION
Installation and testing commands:
```
spack install --verbose --test=root hipcub
spack install --verbose --test=root rocprim
```

hipcub logs:
[install-time-test-log.txt](https://github.com/spack/spack/files/10818677/install-time-test-log.txt)
[LastTest.log](https://github.com/spack/spack/files/10818679/LastTest.log)

rocprim logs:
[install-time-test-log.txt](https://github.com/spack/spack/files/10818681/install-time-test-log.txt)
[LastTest.log](https://github.com/spack/spack/files/10818682/LastTest.log)

