### PR TITLE
matrices: broadcast key combinatorially applies to all nodes in matrix

### DIFF
--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -30,6 +30,10 @@ spec_list_schema = {
                         "type": "array",
                         "items": {"type": "array", "items": {"type": "string"}},
                     },
+                    "broadcast": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"type": "string"}},
+                    },
                     "exclude": {"type": "array", "items": {"type": "string"}},
                 },
             },

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -219,7 +219,8 @@ class TestSpecList(object):
         matrix = {
             "matrix": [["mpileaks"], ["^callpath"]],
             "broadcast": [["%gcc", "%clang"], ["+debug", "~debug"]],
-            "exclude": ["+debug%clang"]}
+            "exclude": ["+debug%clang"],
+        }
         speclist = SpecList("specs", [matrix])
 
         assert len(speclist) == 3

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -218,7 +218,8 @@ class TestSpecList(object):
     def test_spec_list_broadcast(self, mock_packages):
         matrix = {
             "matrix": [["mpileaks"], ["^callpath"]],
-            "broadcast": [["%gcc", "%clang"], ["+debug", "~debug"]]}
+            "broadcast": [["%gcc", "%clang"], ["+debug", "~debug"]],
+        }
         speclist = SpecList("specs", [matrix])
 
         assert len(speclist) == 4

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -216,10 +216,13 @@ class TestSpecList(object):
         assert libdwarf_spec in speclist.specs[0]
 
     def test_spec_list_broadcast(self, mock_packages):
-        matrix = {"matrix": [["mpileaks"], ["^callpath"]], "broadcast": [["%gcc", "%clang"]]}
+        matrix = {
+            "matrix": [["mpileaks"], ["^callpath"]],
+            "broadcast": [["%gcc", "%clang"], ["+debug", "~debug"]]}
         speclist = SpecList("specs", [matrix])
 
-        assert len(speclist) == 2
+        assert len(speclist) == 4
         for spec in speclist:
             for node in spec.traverse():
                 assert node.compiler.name == spec.compiler.name
+                assert node.variants["debug"].value == spec.variants["debug"].value

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -214,3 +214,12 @@ class TestSpecList(object):
         speclist = SpecList("specs", [matrix])
         assert len(speclist.specs) == 1
         assert libdwarf_spec in speclist.specs[0]
+
+    def test_spec_list_broadcast(self, mock_packages):
+        matrix = {"matrix": [["mpileaks"], ["^callpath"]], "broadcast": [["%gcc", "%clang"]]}
+        speclist = SpecList("specs", [matrix])
+
+        assert len(speclist) == 2
+        for spec in speclist:
+            for node in spec.traverse():
+                assert node.compiler.name == spec.compiler.name

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -219,10 +219,10 @@ class TestSpecList(object):
         matrix = {
             "matrix": [["mpileaks"], ["^callpath"]],
             "broadcast": [["%gcc", "%clang"], ["+debug", "~debug"]],
-        }
+            "exclude": ["+debug%clang"]}
         speclist = SpecList("specs", [matrix])
 
-        assert len(speclist) == 4
+        assert len(speclist) == 3
         for spec in speclist:
             for node in spec.traverse():
                 assert node.compiler.name == spec.compiler.name


### PR DESCRIPTION
Supersedes #35529 

Currently it is not possible to use concretizer:unify:when_possible configuration to minimize the dependencies among a series of packages built with a combination of MPI/compiler combinations. The matrix:
```
- matrix:
  - [foo]
  - [^mpich]
  - [ '%gcc', '%clang']
```
resolves to specs `foo%gcc ^mpich` and `foo%clang ^mpich`.

With the when_possible unification option, the concretizer will concretize to use a single mpich in both cases (because it is possible to do so), mixing compilers rather than building with each combination of compiler/mpi.

With this PR, we introduce a `broadcast` key to matrices. The broadcasted constraints are applied to all nodes in the matrix. For example

```
- matrix:
  - [foo]
  - [^mpich]
  broadcast:
  - ['%gcc', '%clang']
```
resolves to two specs `foo%gcc^mpich%gcc` and `foo%clang^mpich%clang`.

The `broadcast` key accepts the same syntax as the matrix key, allowing for complex constraints.

```
- matrix:
  - [foo]
  - [^mpich]
  broadcast:
  - ['%gcc', '%clang']
  - [+debug, ~debug]
```
creates 4 specs.