### PR TITLE
env activation: all user environment modifications relative to view

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -77,7 +77,8 @@ def environment_modifications_for_spec(spec, view=None, set_package_py_globals=T
     """
     spec = spec.copy()
     if view and not spec.external:
-        spec.prefix = prefix.Prefix(view.get_projection_for_spec(spec))
+        for node in spec.traverse():
+            node.prefix = prefix.Prefix(view.get_projection_for_spec(node))
 
     # generic environment modifications determined by inspecting the spec
     # prefix


### PR DESCRIPTION
Currently, environment modifications from dependencies via `setup_dependent_run_environment` may be evaluated relative to the install prefix instead of the view.

Awaiting confirmation from @glennpj that this resolves the issue as discussed on slack.