### PR TITLE
Correct grib-util dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -24,10 +24,11 @@ class GribUtil(CMakePackage):
     depends_on("jasper")
     depends_on("libpng")
     depends_on("zlib")
-    depends_on("w3nco")
+    depends_on("w3emc", when="@1.2.4:")
+    depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
     depends_on("bacio")
-    depends_on("ip")
+    depends_on("ip@:3.3.3")
     depends_on("sp")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -24,11 +24,10 @@ class GribUtil(CMakePackage):
     depends_on("jasper")
     depends_on("libpng")
     depends_on("zlib")
-    depends_on("w3emc", when="@1.2.4:")
-    depends_on("w3nco", when="@:1.2.3")
+    depends_on("w3nco")
     depends_on("g2")
     depends_on("bacio")
-    depends_on("ip@:3.3.3")
+    depends_on("ip")
     depends_on("sp")
 
     def cmake_args(self):


### PR DESCRIPTION
This PR reflects the w3nco->w3emc change in grib-util@1.2.4, and also limits ip to 3.3.3, as some functions needed by grib-util are not present in ip@4.0.0.