### PR TITLE
build-env: fix dump problem with output file mangling

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -138,7 +138,7 @@ def dump_environment(path, environment=None):
     use_env = environment or os.environ
     hidden_vars = set(["PS1", "PWD", "OLDPWD", "TERM_SESSION_ID"])
 
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as env_file:
         for var, val in sorted(use_env.items()):
             env_file.write(


### PR DESCRIPTION
If dump file existed it was not truncating the file, resulting in a file with unaltered filesize, with the new content at the beginning, "padded" with the tail of the old content, since the new content was not enough to overwrite it.


### TL;DR

From my findings (I was not able to confirm it from python doc), using `os` to work with files in "advanced" mode, divides `file-descriptor` and `file-object` concerns, so `modes` are also separated.

`os.fdopen('w')` operates on `file-object`, so it says that we will be able to call write-ops on the `file-object` (but `file-descriptor` might complain eventually).

Doc says that `mode='w'` stands for "open for writing, truncating the file first". It is true for the "standard" way, but for the "advanced" it will not truncate since it is an operation done on opening of the `file-descriptor`, and so it is a concern of `os.open`, for which we have to pass also `os.O_TRUNC`.

### Explanation
It must be said that for working with files we are using `os` module, i.e. `os.open` and `os.fdopen`, instead of the "standard" way `open`.

Quick recap:

1. "standard"/"classic"
    - `open`: `path -> file-object`
2. "advanced"
    - `os.open`: `path -> file-descriptor`
    - `os.fdopen`: `file-descriptor -> file-object`

My concern in using `os` module ones, is about the fact that it is possible to specify `mode` both for `file-descriptor` and for the `file-object`. By reading python official doc it is not clear to me how it should behave, but this is what I figured out by doing some tests.

1. With `os.open` you specify "`mode-descriptor`", which describes what operations are allowed on the file
4. With `os.fdopen` you specify "`mode-object`", which describes the set of services that the `file-object` provides

By operating on the `file-object` abstraction, you have to go through the two levels of "modes" above, and just if both of them are compatible it will work, otherwise it will raise an error at `file-object` or `file-descriptor` level.

In our case we have `mode-object = 'w'`, which reading [open()](https://docs.python.org/3/library/functions.html#open) (`os.fdopen` redirects to `open` for args doc) it should be _"open for writing, truncating the file first"_.

Actually, this would be valid if the call would take care of both levels, i.e. "standard" way.

Truncating, which is an operation done when the file descriptor is created, does not belong to the `file-object` usage, but to the `file-descriptor` opening. By using the "advanced" solution, we separated the opening from the usage, so the truncating part is not enforced by `mode-object = 'w'` and instead should be specified when the file descriptor is created, with `mode-descriptor |= os.O_TRUNC`.

I did some more tests, trying some combination of `mode-descriptor`/`mode-object`, and this is the explanation that makes most sense, but I was not able to find a confirmation in the python documentation in order to say it is correct or not.