### PR TITLE
Set preferred version of OOMMF

### DIFF
--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -49,7 +49,8 @@ class Oommf(Package):
     maintainers("fangohr")
 
     version(
-        "20b0_20220930", sha256="764f1983d858fbad4bae34c720b217940ce56f745647ba94ec74de4b185f1328"
+        "20b0_20220930", sha256="764f1983d858fbad4bae34c720b217940ce56f745647ba94ec74de4b185f1328",
+        preferred=True
     )
 
     version(

--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -49,8 +49,9 @@ class Oommf(Package):
     maintainers("fangohr")
 
     version(
-        "20b0_20220930", sha256="764f1983d858fbad4bae34c720b217940ce56f745647ba94ec74de4b185f1328",
-        preferred=True
+        "20b0_20220930",
+        sha256="764f1983d858fbad4bae34c720b217940ce56f745647ba94ec74de4b185f1328",
+        preferred=True,
     )
 
     version(


### PR DESCRIPTION
With the last merge request for OOMMF [1], the intention was to have version 20b0_20220930 as the preferred version, and provide 20b0_20220930-vanilla as an additional version for the unlikely case anybody needed that.

I made the (wrong) assumption that the `version` listed first in the `package.py` file would be the preferred version. This merge request is to correct that by explicitly tagging the preferred version with `preferred=True`.

[1] https://github.com/spack/spack/pull/33072/files