### PR TITLE
docbook: resolve conflict in spack env view

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -26,7 +26,7 @@ class DocbookXml(Package):
 
     @property
     def catalog(self):
-        return join_path(self.prefix, "catalog")
+        return join_path(self.prefix, "xml-catalog")
 
     @run_after("install")
     def config_docbook(self):

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -29,7 +29,7 @@ class DocbookXsl(Package):
 
     @property
     def catalog(self):
-        return join_path(self.prefix, "catalog")
+        return join_path(self.prefix, "xsl-catalog")
 
     @run_after("install")
     def config_docbook(self):


### PR DESCRIPTION
If the docbook packages
- docbook-xml
- docbook-xsl

are installed in a spack environment view the catalog files will be in conflict in the view directory. This PR resolves that by adding an appropriate prefix to each catalog name so that they are unique in the view. The resulting XML_CATALOG_FILES environment variable will then be able to point to both of them.