### PR TITLE
pegtl: add v3.2.7

### DIFF
--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -15,7 +15,7 @@ class Pegtl(CMakePackage):
     """
 
     homepage = "https://github.com/taocpp/PEGTL"
-    url = "https://github.com/taocpp/PEGTL/archive/refs/tags/2.1.4.tar.gz"
+    url = "https://github.com/taocpp/PEGTL/tarball/2.1.4"
     git = "https://github.com/taocpp/PEGTL.git"
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -19,7 +19,7 @@ class Pegtl(CMakePackage):
     git = "https://github.com/taocpp/PEGTL.git"
 
     version("master", branch="master")
-    version("3.2.7", sha256="d6cd113d8bd14e98bcbe7b7f8fc1e1e33448dc359e8cd4cca30e034ec2f0642d")
+    version("3.2.7", sha256="444c3c33686c6b2d8d45ad03af5041b7bc910ef44ac10216237d8e3e8d6e7025")
     version("3.2.0", sha256="91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56")
     version("2.8.3", sha256="370afd0fbe6d73c448a33c10fbe4a7254f92077f5a217317d0a32a9231293015")
     version("2.1.4", sha256="d990dccc07b4d9ba548326d11c5c5e34fa88b34fe113cb5377da03dda29f23f2")

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -15,7 +15,7 @@ class Pegtl(CMakePackage):
     """
 
     homepage = "https://github.com/taocpp/PEGTL"
-    url = "https://github.com/taocpp/PEGTL/tarball/2.1.4"
+    url = "https://github.com/taocpp/PEGTL/archive/refs/tags/2.1.4.tar.gz"
     git = "https://github.com/taocpp/PEGTL.git"
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -19,6 +19,7 @@ class Pegtl(CMakePackage):
     git = "https://github.com/taocpp/PEGTL.git"
 
     version("master", branch="master")
+    version("3.2.7", sha256="d6cd113d8bd14e98bcbe7b7f8fc1e1e33448dc359e8cd4cca30e034ec2f0642d")
     version("3.2.0", sha256="91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56")
     version("2.8.3", sha256="370afd0fbe6d73c448a33c10fbe4a7254f92077f5a217317d0a32a9231293015")
     version("2.1.4", sha256="d990dccc07b4d9ba548326d11c5c5e34fa88b34fe113cb5377da03dda29f23f2")


### PR DESCRIPTION
This PR adds `v3.2.7` and changes the `url` package property to use GitHub tag archive URLs (the previous one made `spack checksum` to retrieve a lot of HTML garbage instead of actual archives).