### PR TITLE
clp: add version 1.17.7

### DIFF
--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -13,7 +13,7 @@ class Clp(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Clp"
     url = "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
 
-    depends_on("pkg-config")
+    depends_on("pkg-config", type="build")
     depends_on("coinutils")
     depends_on("osi")
 

--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -13,9 +13,11 @@ class Clp(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Clp"
     url = "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
 
+    depends_on("pkg-config")
     depends_on("coinutils")
     depends_on("osi")
 
+    version("1.17.7", sha256="c4c2c0e014220ce8b6294f3be0f3a595a37bef58a14bf9bac406016e9e73b0f5")
     version("1.17.6", sha256="afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9")
     version("1.17.4", sha256="ef412cde00cb1313d9041115a700d8d59d4b8b8b5e4dde43e9deb5108fcfbea8")
     version("1.16.11", sha256="b525451423a9a09a043e6a13d9436e13e3ee7a7049f558ad41a110742fa65f39")


### PR DESCRIPTION
Add version 1.17.7 to package clp. 

Add pkg-config dependency.  On hosts without pkg-config/pkgconf installed (e.g. Ubuntu 22.04 +build-essential), the clpI install cannot find CoinUtils and fails.