### PR TITLE
osi: add version 0.108.7

### DIFF
--- a/var/spack/repos/builtin/packages/osi/package.py
+++ b/var/spack/repos/builtin/packages/osi/package.py
@@ -20,8 +20,10 @@ class Osi(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Osi"
     url = "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz"
 
+    depends_on("pkg-config")
     depends_on("coinutils")
 
+    version("0.108.7", sha256="f1bc53a498585f508d3f8d74792440a30a83c8bc934d0c8ecf8cd8bc0e486228")
     version("0.108.6", sha256="984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5")
 
     build_directory = "spack-build"

--- a/var/spack/repos/builtin/packages/osi/package.py
+++ b/var/spack/repos/builtin/packages/osi/package.py
@@ -20,7 +20,7 @@ class Osi(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Osi"
     url = "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz"
 
-    depends_on("pkg-config")
+    depends_on("pkg-config", type="build")
     depends_on("coinutils")
 
     version("0.108.7", sha256="f1bc53a498585f508d3f8d74792440a30a83c8bc934d0c8ecf8cd8bc0e486228")


### PR DESCRIPTION
Add version 0.108.7 to package osi.

Add pkg-config dependency.  On hosts without pkg-config installed (e.g. Ubuntu 22.04 +build-essential), the OSI install cannot find the CoinUtils dependency and fails.