### PR TITLE
tests/cbench: renamed test_blas_linkage to check_blas_linkage

### DIFF
--- a/var/spack/repos/builtin/packages/cbench/package.py
+++ b/var/spack/repos/builtin/packages/cbench/package.py
@@ -56,7 +56,7 @@ class Cbench(MakefilePackage):
 
     @run_before("build")
     @on_package_attributes(run_tests=True)
-    def test_blas_linkage(self):
+    def check_blas_linkage(self):
         """Quick test to ensure that BLAS linkage is working correctly."""
 
         make("-C", "opensource/maketests", "clean")


### PR DESCRIPTION
Renames a build-phase check method due to stand-alone testing conversion being done in #34236 .