### PR TITLE
tests/caliper: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -6,8 +6,6 @@
 import os
 import sys
 
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -149,44 +147,31 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([join_path("examples", "apps")])
 
-    def run_cxx_example_test(self):
-        """Run stand alone test: cxx_example"""
+    def test_cxx_example(self):
+        """build and run cxx-example"""
 
-        test_dir = self.test_suite.current_test_cache_dir.examples.apps
         exe = "cxx-example"
-        source_file = "cxx-example.cpp"
+        source_file = "{0}.cpp".format(exe)
 
-        if not os.path.isfile(join_path(test_dir, source_file)):
-            tty.warn("Skipping caliper test:" "{0} does not exist".format(source_file))
-            return
+        source_path = find_required_file(
+            self.test_suite.current_test_cache_dir, source_file, expected=1, recursive=True
+        )
 
-        if os.path.exists(self.prefix.lib):
-            lib_dir = self.prefix.lib
-        else:
-            lib_dir = self.prefix.lib64
+        lib_dir = self.prefix.lib if os.path.exists(self.prefix.lib) else self.prefix.lib64
 
-        options = [
-            "-L{0}".format(lib_dir),
-            "-I{0}".format(self.prefix.include),
-            "{0}".format(join_path(test_dir, source_file)),
-            "-o",
-            exe,
-            "-std=c++11",
-            "-lcaliper",
-            "-lstdc++",
-        ]
+        cxx = which(os.environ["CXX"])
+        test_dir = os.path.dirname(source_path)
+        with working_dir(test_dir):
+            cxx(
+                "-L{0}".format(lib_dir),
+                "-I{0}".format(self.prefix.include),
+                source_path,
+                "-o",
+                exe,
+                "-std=c++11",
+                "-lcaliper",
+                "-lstdc++",
+            )
 
-        if not self.run_test(
-            exe=os.environ["CXX"],
-            options=options,
-            purpose="test: compile {0} example".format(exe),
-            work_dir=test_dir,
-        ):
-            tty.warn("Skipping caliper test: failed to compile example")
-            return
-
-        if not self.run_test(exe, purpose="test: run {0} example".format(exe), work_dir=test_dir):
-            tty.warn("Skipping caliper test: failed to run example")
-
-    def test(self):
-        self.run_cxx_example_test()
+            cxx_example = which(exe)
+            cxx_example()


### PR DESCRIPTION
Depends on #34236 

Latest run of the tests:
```
$ spack -v test run caliper
==> Spack test zw4ofd6qqj4d6vmow3klqpvkx7jemr6x
==> Testing package caliper-2.9.0-3dmyjza
==> [2023-05-10-13:19:19.005788] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/caliper-2.9.0-3dmyjzade7eew72wpasvri4j5avdwc55/.spack/test to $SPACK_TEST_STAGE_ROOT/zw4ofd6qqj4d6vmow3klqpvkx7jemr6x/caliper-2.9.0-3dmyjza/cache/caliper
==> [2023-05-10-13:19:19.303761] test: test_cxx_example: build and run cxx-example
==> [2023-05-10-13:19:19.317889] '$SPACK_ROOT/lib/spack/env/gcc/g++' '-L$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/caliper-2.9.0-3dmyjzade7eew72wpasvri4j5avdwc55/lib64' '-I$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/caliper-2.9.0-3dmyjzade7eew72wpasvri4j5avdwc55/include' '$SPACK_TEST_STAGE_ROOT/zw4ofd6qqj4d6vmow3klqpvkx7jemr6x/caliper-2.9.0-3dmyjza/cache/caliper/examples/apps/cxx-example.cpp' '-o' 'cxx-example' '-std=c++11' '-lcaliper' '-lstdc++'
==> [2023-05-10-13:19:20.462544] './cxx-example'
PASSED: Caliper::test_cxx_example
==> [2023-05-10-13:19:20.519676] Completed testing
==> [2023-05-10-13:19:20.519796] 
======================== SUMMARY: caliper-2.9.0-3dmyjza ========================
Caliper::test_cxx_example .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```

TODO:
- [x] (re)Test (March 28th and again after post-34236 merge rebase on May 10)