### PR TITLE
tests/languages: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -14,21 +14,17 @@ class C(Package):
     homepage = "http://open-std.org/JTC1/SC22/WG14/www/standards"
     virtual = True
 
-    def test_c_exes(self):
+    def test_c(self):
         """build and run C examples"""
+        cc = which(os.environ["CC"])
+        expected = ["Hello world", "YES!"]
+
         test_source = self.test_suite.current_test_data_dir
-
         for test in os.listdir(test_source):
-            with test_part(
-                self, "test_{0}".format(test), purpose="build and run {0}".format(test)
-            ):
+            with test_part(self, f"test_c_{test}", purpose=f"build and run {test}"):
                 filepath = test_source.join(test)
-                exe_name = "{0}.exe".format(test)
-
-                cc = which(os.environ["CC"])
+                exe_name = f"{test}.exe"
                 cc("-o", exe_name, filepath)
-
                 exe = which(exe_name)
                 out = exe(output=str.split, error=str.split)
-                for expected in ["Hello world", "YES!"]:
-                    assert expected in out
+                checkoutputs(expected, out)

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -14,17 +14,21 @@ class C(Package):
     homepage = "http://open-std.org/JTC1/SC22/WG14/www/standards"
     virtual = True
 
-    def test(self):
+    def test_c_exes(self):
+        """build and run C examples"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
-            filepath = test_source.join(test)
-            exe_name = "%s.exe" % test
+            with test_part(
+                self, "test_{0}".format(test), purpose="build and run {0}".format(test)
+            ):
+                filepath = test_source.join(test)
+                exe_name = "{0}.exe".format(test)
 
-            cc_exe = os.environ["CC"]
-            cc_opts = ["-o", exe_name, filepath]
-            compiled = self.run_test(cc_exe, options=cc_opts, installed=True)
+                cc = which(os.environ["CC"])
+                cc("-o", exe_name, filepath)
 
-            if compiled:
-                expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+                exe = which(exe_name)
+                out = exe(output=str.split, error=str.split)
+                for expected in ["Hello world", "YES!"]:
+                    assert expected in out

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -14,15 +14,15 @@ class Cxx(Package):
     homepage = "https://isocpp.org/std/the-standard"
     virtual = True
 
-    def test_cxx_exes(self):
+    def test_cxx(self):
         """build and run basic Cxx executables"""
-        test_source = self.test_suite.current_test_data_dir
+        cxx = which(os.environ["CXX"])
+        expected = ["Hello world", "YES!"]
 
+        test_source = self.test_suite.current_test_data_dir
         for test in os.listdir(test_source):
             filepath = os.path.join(test_source, test)
-            exe_name = "%s.exe" % test
-
-            cxx_exe = os.environ["CXX"]
+            exe_name = f"{test}.exe"
 
             # standard options
             # Hack to get compiler attributes
@@ -33,19 +33,10 @@ class Cxx(Package):
             compiler = c_cls(c_spec, None, None, ["fakecc", "fakecxx"])
 
             cxx_opts = [compiler.cxx11_flag] if "c++11" in test else []
-
             cxx_opts += ["-o", exe_name, filepath]
 
-            with test_part(
-                self,
-                "test_cxx_exes_{0}".format(exe_name),
-                purpose="build and run {0}".format(exe_name),
-            ):
-                cxx = which(cxx_exe)
+            with test_part(self, f"test_cxx_{exe_name}", purpose=f"build and run {exe_name}"):
                 cxx(*cxx_opts)
-
                 exe = which(exe_name)
                 out = exe(output=str.split, error=str.split)
-
-                expected = ["Hello world", "YES!"]
                 check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -14,7 +14,8 @@ class Cxx(Package):
     homepage = "https://isocpp.org/std/the-standard"
     virtual = True
 
-    def test(self):
+    def test_cxx_exes(self):
+        """build and run basic Cxx executables"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
@@ -34,8 +35,17 @@ class Cxx(Package):
             cxx_opts = [compiler.cxx11_flag] if "c++11" in test else []
 
             cxx_opts += ["-o", exe_name, filepath]
-            compiled = self.run_test(cxx_exe, options=cxx_opts, installed=True)
 
-            if compiled:
+            with test_part(
+                self,
+                "test_cxx_exes_{0}".format(exe_name),
+                purpose="build and run {0}".format(exe_name),
+            ):
+                cxx = which(cxx_exe)
+                cxx(*cxx_opts)
+
+                exe = which(exe_name)
+                out = exe(output=str.split, error=str.split)
+
                 expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+                check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -14,18 +14,18 @@ class Fortran(Package):
     homepage = "https://wg5-fortran.org/"
     virtual = True
 
-    def test(self):
+    def test_hello(self):
+        """build and run hello examples"""
         test_source = self.test_suite.current_test_data_dir
+        expected = ["Hello world", "YES!"]
 
         for test in os.listdir(test_source):
-            filepath = os.path.join(test_source, test)
             exe_name = "%s.exe" % test
 
-            fc_exe = os.environ["FC"]
-            fc_opts = ["-o", exe_name, filepath]
+            filepath = os.path.join(test_source, test)
+            fc = which(os.environ["FC"])
+            fc("-o", exe_name, filepath)
 
-            compiled = self.run_test(fc_exe, options=fc_opts, installed=True)
-
-            if compiled:
-                expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+            exe = which(exe_name)
+            out = exe(output=str.split, error=str.split)
+            checkoutputs(expected, out)

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -16,16 +16,14 @@ class Fortran(Package):
 
     def test_hello(self):
         """build and run hello examples"""
-        test_source = self.test_suite.current_test_data_dir
         expected = ["Hello world", "YES!"]
+        fc = which(os.environ["FC"])
 
+        test_source = self.test_suite.current_test_data_dir
         for test in os.listdir(test_source):
-            exe_name = "%s.exe" % test
-
+            exe_name = f"{test}.exe"
             filepath = os.path.join(test_source, test)
-            fc = which(os.environ["FC"])
             fc("-o", exe_name, filepath)
-
             exe = which(exe_name)
             out = exe(output=str.split, error=str.split)
             checkoutputs(expected, out)


### PR DESCRIPTION
Depends on #34236 

This PR covers the following packages:
- c
- cxx
- fortran

TODO:
- [ ] test c , cxx, fortran .. can only be done via provider packages