### PR TITLE
tests/sip: convert to new stand-alone test process

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -10,6 +10,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import find, join_path, working_dir
 
 import spack.builder
+import spack.install_test
 import spack.package_base
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
@@ -30,8 +31,8 @@ class SIPPackage(spack.package_base.PackageBase):
     #: Name of private sip module to install alongside package
     sip_module = "sip"
 
-    #: Callback names for install-time test
-    install_time_test_callbacks = ["test"]
+    #: Callback names for install-time testing
+    install_time_test_callbacks = ["test_imports"]
     #: Legacy buildsystem attribute used to deserialize and install old specs
     legacy_buildsystem = "sip"
 
@@ -94,7 +95,7 @@ class SIPPackage(spack.package_base.PackageBase):
         # not the ones in the source directory
         python = inspect.getmodule(self).python
         for module in self.import_modules:
-            with test_part(
+            with spack.install_test.test_part(
                 self,
                 "test_imports_{0}".format(module),
                 purpose="checking import of {0}".format(module),

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -87,18 +87,20 @@ class SIPPackage(spack.package_base.PackageBase):
         """The python ``Executable``."""
         inspect.getmodule(self).python(*args, **kwargs)
 
-    def test(self):
+    def test_imports(self):
         """Attempts to import modules of the installed package."""
 
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
+        python = inspect.getmodule(self).python
         for module in self.import_modules:
-            self.run_test(
-                inspect.getmodule(self).python.path,
-                ["-c", "import {0}".format(module)],
+            with test_part(
+                self,
+                "test_imports_{0}".format(module),
                 purpose="checking import of {0}".format(module),
                 work_dir="spack-test",
-            )
+            ):
+                python("-c", "import {0}".format(module))
 
 
 @spack.builder.builder("sip")


### PR DESCRIPTION
Depends on #34236 , #37600

Test results for `py-pyqt4` (but only after added a dependency so I could build the package):
```
$ spack -v test run py-pyqt4
==> Spack test a3nlaw4m2kguoabexnshw3a3aqwt5us3
==> Testing package py-pyqt4-4.12.3-cdyp3u5
==> [2023-05-10-14:49:02.208899] test: test_imports: Attempts to import modules of the installed package.
==> [2023-05-10-14:49:02.337129] Detected the following modules: ['PyQt4', 'PyQt4.uic', 'PyQt4.uic.Compiler', 'PyQt4.uic.Loader', 'PyQt4.uic.port_v2', 'PyQt4.uic.port_v3']
==> [2023-05-10-14:49:02.340749] test: test_imports_PyQt4: checking import of PyQt4
==> [2023-05-10-14:49:02.341307] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4'
PASSED: PyPyqt4::test_imports_PyQt4
==> [2023-05-10-14:49:02.539851] test: test_imports_PyQt4.uic: checking import of PyQt4.uic
==> [2023-05-10-14:49:02.540176] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4.uic'
PASSED: PyPyqt4::test_imports_PyQt4.uic
==> [2023-05-10-14:49:02.936472] test: test_imports_PyQt4.uic.Compiler: checking import of PyQt4.uic.Compiler
==> [2023-05-10-14:49:02.936791] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4.uic.Compiler'
PASSED: PyPyqt4::test_imports_PyQt4.uic.Compiler
==> [2023-05-10-14:49:03.254379] test: test_imports_PyQt4.uic.Loader: checking import of PyQt4.uic.Loader
==> [2023-05-10-14:49:03.254740] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4.uic.Loader'
PASSED: PyPyqt4::test_imports_PyQt4.uic.Loader
==> [2023-05-10-14:49:03.814682] test: test_imports_PyQt4.uic.port_v2: checking import of PyQt4.uic.port_v2
==> [2023-05-10-14:49:03.815049] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4.uic.port_v2'
PASSED: PyPyqt4::test_imports_PyQt4.uic.port_v2
==> [2023-05-10-14:49:04.425851] test: test_imports_PyQt4.uic.port_v3: checking import of PyQt4.uic.port_v3
==> [2023-05-10-14:49:04.426310] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import PyQt4.uic.port_v3'
PASSED: PyPyqt4::test_imports_PyQt4.uic.port_v3
PASSED: PyPyqt4::test_imports
==> [2023-05-10-14:49:04.973077] Completed testing
==> [2023-05-10-14:49:04.973242]
======================= SUMMARY: py-pyqt4-4.12.3-cdyp3u5 =======================
PyPyqt4::test_imports_PyQt4 .. PASSED
PyPyqt4::test_imports_PyQt4.uic .. PASSED
PyPyqt4::test_imports_PyQt4.uic.Compiler .. PASSED
PyPyqt4::test_imports_PyQt4.uic.Loader .. PASSED
PyPyqt4::test_imports_PyQt4.uic.port_v2 .. PASSED
PyPyqt4::test_imports_PyQt4.uic.port_v3 .. PASSED
PyPyqt4::test_imports .. PASSED
============================= 7 passed of 7 parts ==============================
============================== 1 passed of 1 spec ==============================
```

TODO: 
- [x] Test