### PR TITLE
tests/bricks: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/bricks/package.py
+++ b/var/spack/repos/builtin/packages/bricks/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -71,25 +73,17 @@ class Bricks(CMakePackage):
         ]
         self.cache_extra_test_sources(srcs)
 
-    def test(self):
-        """Test bricklib package"""
-        # Test prebuilt binary
+    def test_bricklib_example(self):
+        """build and run pre-built example"""
         source_dir = join_path(self.test_suite.current_test_cache_dir, "examples", "external")
+        if not os.path.exists(source_dir):
+            raise SkipTest("{0} is missing".format(source_dir))
 
-        self.run_test(
-            exe="cmake", options=["."], purpose="Configure bricklib example", work_dir=source_dir
-        )
+        with working_dir(source_dir):
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(".")
 
-        self.run_test(
-            exe="cmake",
-            options=["--build", "."],
-            purpose="Build bricklib example",
-            work_dir=source_dir,
-        )
+            cmake("--build", ".")
 
-        self.run_test(
-            exe=join_path(source_dir, "example"),
-            options=[],
-            purpose="Execute bricklib example",
-            work_dir=source_dir,
-        )
+            example = which("example")
+            example()


### PR DESCRIPTION
Depends on #34236 

Example test run post-rebase:
```
$ spack test run bricks
==> Spack test opekzisqbo6t7kdjegekikgi5m6uyzop
==> Testing package bricks-r0.1-v7mvifh
============================== 1 passed of 1 spec ==============================
761.754u 3.917s 0:40.56 1887.7%	0+0k 2096+6312io 1pf+0w
$ spack test results -l
==> Results for test suite 'opekzisqbo6t7kdjegekikgi5m6uyzop':
==> test specs:
==>   bricks-r0.1-v7mvifh PASSED
==> Testing package bricks-r0.1-v7mvifh
==> [2023-05-10-13:54:02.287355] Installing $spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/bricks-r0.1-v7mvifhhniv5s4stkydwx23dc365jell/.spack/test to $spack_test/opekzisqbo6t7kdjegekikgi5m6uyzop/bricks-r0.1-v7mvifh/cache/bricks
==> [2023-05-10-13:54:02.336636] test: test_bricklib_example: build and run pre-built example
==> [2023-05-10-13:54:02.340431] '$spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '.'
-- The C compiler identification is GNU 10.3.1
-- The CXX compiler identification is GNU 10.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: $spack/lib/spack/env/gcc/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $spack/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /usr/tce/packages/python/python-3.9.12/bin/python3.9 (found suitable version "3.9.12", minimum required is "3.6") found components: Interpreter 
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Performing Test HAS_MARCH
-- Performing Test HAS_MARCH - Success
-- Using march=native
-- Configuring done (5.6s)
-- Generating done (0.1s)
-- Build files have been written to: $spack_test/opekzisqbo6t7kdjegekikgi5m6uyzop/bricks-r0.1-v7mvifh/cache/bricks/examples/external
==> [2023-05-10-13:54:08.070448] '$spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '--build' '.'
[ 33%] [VS][B7PT] Vector Scatter transformation

$spack_test/opekzisqbo6t7kdjegekikgi5m6uyzop/bricks-r0.1-v7mvifh/cache/bricks/examples/external
main.cpp 124
Total of 1 fixed
A total of 1 stages
A total of 1 buffers
main.cpp 96 double (8, 8, 8)
BACKEND FLEX
Using flex layout for tiled format, setting VECLEN to the size of last dimension
Fold is set to VECLEN for Tiled
Total of 1 fixed
A total of 1 stages
A total of 1 buffers
[ 66%] Building CXX object CMakeFiles/brick-7pt.dir/main-out.cpp.o
[100%] Linking CXX executable example
[100%] Built target brick-7pt
==> [2023-05-10-13:54:10.801270] './example'
d3pt7
Arr: 0.0233574
Bri: 0.224315
Arr Scatter: 0.0466443
Trans: 0.0267423
PASSED: Bricks::test_bricklib_example
==> [2023-05-10-13:54:37.069994] Completed testing
==> [2023-05-10-13:54:37.070262] 
========================= SUMMARY: bricks-r0.1-v7mvifh =========================
Bricks::test_bricklib_example .. PASSED
============================= 1 passed of 1 parts ==============================

============================== 1 passed of 1 spec ==============================
```

TODO:

- [x] (re)test .. vr0.1 passes