### PR TITLE
tests/bolt: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -33,8 +33,6 @@ class Bolt(CMakePackage):
     version("1.0.1", sha256="769e30dfc4042cee7ebbdadd23cf08796c03bcd8b335f516dc8cbc3f8adfa597")
     version("1.0", sha256="1c0d2f75597485ca36335d313a73736594e75c8a36123c5a6f54d01b5ba5c384")
 
-    test_requires_compiler = True
-
     depends_on("argobots")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
Converted to use the new stand-alone test process.

```
spack -v test run bolt
==> Spack test va4533pxyofffe7jeqsbuyfposvbarup
==> Testing package bolt-2.0-s5t6euf
==> [2023-05-10-14:14:08.057853] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/bolt-2.0-s5t6eufznrqbtceepy4hkf6bizt3ak3r/.spack/test to $spack_test_stage/g/va4533pxyofffe7jeqsbuyfposvbarup/bolt-2.0-s5t6euf/cache/bolt
==> [2023-05-10-14:14:08.432108] test: test_sample_nested_example: build and run sample_nested
==> [2023-05-10-14:14:08.442289] '$SPACK_ROOT/lib/spack/env/gcc/g++' '-L$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/bolt-2.0-s5t6eufznrqbtceepy4hkf6bizt3ak3r/lib' '-I$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/bolt-2.0-s5t6eufznrqbtceepy4hkf6bizt3ak3r/include' '$spack_test_stage/g/va4533pxyofffe7jeqsbuyfposvbarup/bolt-2.0-s5t6euf/cache/bolt/examples/sample_nested.c' '-o' 'sample_nested' '-lomp' '-lbolt'
==> [2023-05-10-14:14:08.694398] './sample_nested'
1 0.000040
PASSED: Bolt::test_sample_nested_example
==> [2023-05-10-14:14:08.785482] Completed testing
==> [2023-05-10-14:14:08.785716]
========================== SUMMARY: bolt-2.0-s5t6euf ===========================
Bolt::test_sample_nested_example .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```

TODO:

- [x] (re)test .. v2.0 passes