### PR TITLE
tests/biobambam2: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/biobambam2/package.py
+++ b/var/spack/repos/builtin/packages/biobambam2/package.py
@@ -38,17 +38,15 @@ class Biobambam2(AutotoolsPackage):
     @run_after("install")
     def cache_test_sources(self):
         """Copy the test source files after the package is installed to an
-        install test subdirectory for use during `spack test run`."""
+        install test subdirectory for use during `spack test run` AND fix
+        the script path in the cached copy."""
         self.cache_extra_test_sources(self.test_src_dir)
         self._fix_shortsort()
 
-    def test(self):
-        """Perform stand-alone/smoke test on installed package."""
+    def test_short_sort(self):
+        """run testshortsort.sh to check alignments sorted by coordinate"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        self.run_test(
-            "sh",
-            ["testshortsort.sh"],
-            expected="Alignments sorted by coordinate.",
-            purpose="test: checking alignments",
-            work_dir=test_dir,
-        )
+        with working_dir(test_dir):
+            sh = which("sh")
+            out = sh("testshortsort.sh", output=str.split, error=str.split)
+            assert "Alignments sorted by coordinate." in out

--- a/var/spack/repos/builtin/packages/biobambam2/package.py
+++ b/var/spack/repos/builtin/packages/biobambam2/package.py
@@ -30,18 +30,11 @@ class Biobambam2(AutotoolsPackage):
         args = ["--with-libmaus2={0}".format(self.spec["libmaus2"].prefix)]
         return args
 
-    def _fix_shortsort(self):
-        """Fix the testshortsort.sh file copied during installation."""
-        test_dir = join_path(self.install_test_root, self.test_src_dir)
-        filter_file("../src/", "", join_path(test_dir, "testshortsort.sh"))
-
     @run_after("install")
     def cache_test_sources(self):
         """Copy the test source files after the package is installed to an
-        install test subdirectory for use during `spack test run` AND fix
-        the script path in the cached copy."""
+        install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.test_src_dir)
-        self._fix_shortsort()
 
     def test_short_sort(self):
         """run testshortsort.sh to check alignments sorted by coordinate"""


### PR DESCRIPTION
Converted to use the new stand-alone test process.

```
$ spack test run biobambam2
==> Spack test mnplbz36mdyq74issyh5x32ro6qaxsqv
==> Testing package biobambam2-2.0.177-dsg2own
============================== 1 passed of 1 spec ==============================

$ spack test results -l
==> Results for test suite 'mnplbz36mdyq74issyh5x32ro6qaxsqv':
==> test specs:
==>   biobambam2-2.0.177-dsg2own PASSED
==> Testing package biobambam2-2.0.177-dsg2own
==> [2023-05-10-15:32:13.725517] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/biobambam2-2.0.177-dsg2ownxthfijahwt3dtt4z6nynkdfow/.spack/test to $SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2
==> [2023-05-10-15:32:15.348443] test: test_short_sort: run testshortsort.sh to check alignments sorted by coordinate
==> [2023-05-10-15:32:15.350386] '/usr/bin/sh' 'testshortsort.sh'
$SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test $SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test
$SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test
$SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test $SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test
$SPACK_TEST_STAGE/mnplbz36mdyq74issyh5x32ro6qaxsqv/biobambam2-2.0.177-dsg2own/cache/biobambam2/test
[V] Reading alignments from source.
[V] read 4 alignments
[V] producing sorted output
[V] wrote 4 alignments
[V] 3
Alignments sorted by coordinate.
PASSED: Biobambam2::test_short_sort
==> [2023-05-10-15:32:16.107846] Completed testing
==> [2023-05-10-15:32:16.108035]
===================== SUMMARY: biobambam2-2.0.177-dsg2own ======================
Biobambam2::test_short_sort .. PASSED
============================= 1 passed of 1 parts ==============================

============================== 1 passed of 1 spec ==============================
```

TODO:

- [x] (re)test .. v2.0.177 passes