### PR TITLE
tests/archer: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 import os
 
 from spack.package import *
@@ -50,25 +49,17 @@ class Archer(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(["test"])
 
-    def run_parallel_example_test(self):
-        """Run stand alone test: parallel-simple"""
-
+    def test_run_parallel_example(self):
+        """build and run parallel-simple"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, "test", "parallel")
-
         if not os.path.exists(test_dir):
-            print("Skipping archer test")
-            return
+            raise SkipTest("Parallel test directory does not exist")
 
-        exe = "parallel-simple"
+        test_exe = "parallel-simple"
+        test_src = "{0}.c".format(test_exe)
+        with working_dir(test_dir):
+            clang = which("clang-archer")
+            clang("-o", test_exe, test_src)
 
-        self.run_test(
-            "clang-archer",
-            options=["-o", exe, "{0}".format(join_path(test_dir, "parallel-simple.c"))],
-            purpose="test: compile {0} example".format(exe),
-            work_dir=test_dir,
-        )
-
-        self.run_test(exe, purpose="test: run {0} example".format(exe), work_dir=test_dir)
-
-    def test(self):
-        self.run_parallel_example_test()
+            parallel_simple = which(test_exe)
+            parallel_simple()


### PR DESCRIPTION
Converted to use the new stand-alone test process.

```
$ spack -v test run archer
==> Spack test l4bgrbb5i3ccoctep6nbp6g7dh3vq4xx
==> Testing package archer-2.0.0-h45opgo
==> [2023-05-10-17:27:33.140849] Installing /usr/WS1/$user/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/archer-2.0.0-h45opgoxl7ajr7d2wmuf7a4befcjudpd/.spack/test to /g/g21/$user/.spack/test/l4bgrbb5i3ccoctep6nbp6g7dh3vq4xx/archer-2.0.0-h45opgo/cache/archer
==> [2023-05-10-17:27:34.307269] test: test_run_parallel_example: build and run parallel-simple
==> [2023-05-10-17:27:34.310497] '/usr/WS1/$user/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/archer-2.0.0-h45opgoxl7ajr7d2wmuf7a4befcjudpd/bin/clang-archer' '-o' 'parallel-simple' 'parallel-simple.c'
==> [2023-05-10-17:27:34.970345] './parallel-simple'
DONE
PASSED: Archer::test_run_parallel_example
==> [2023-05-10-17:27:35.058905] Completed testing
==> [2023-05-10-17:27:35.059140] 
======================== SUMMARY: archer-2.0.0-h45opgo =========================
Archer::test_run_parallel_example .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```

TODO:

- [x] (re)test