### PR TITLE
tests/amrex: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -314,43 +314,20 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
 
         return args
 
-    # TODO: Replace this method and its 'get' use for cmake path with
-    #   join_path(self.spec['cmake'].prefix.bin, 'cmake') once stand-alone
-    #   tests can access build dependencies through self.spec['cmake'].
-    def cmake_bin(self, set=True):
-        """(Hack) Set/get cmake dependency path."""
-        filepath = join_path(self.install_test_root, "cmake_bin_path.txt")
-        if set:
-            with open(filepath, "w") as out_file:
-                cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
-                out_file.write("{0}\n".format(cmake_bin))
-        else:
-            with open(filepath, "r") as in_file:
-                return in_file.read().strip()
-
     @run_after("build")
     def setup_smoke_test(self):
-        """Skip setup smoke tests for AMReX versions less than 21.12."""
+        """Setup smoke tests for AMReX versions from 21.12 on."""
         if self.spec.satisfies("@:21.11"):
             return
 
         self.cache_extra_test_sources(["Tests"])
 
-        # TODO: Remove once self.spec['cmake'] is available here
-        self.cmake_bin(set=True)
-
-    def test(self):
-        """Skip smoke tests for AMReX versions less than 21.12."""
+    def test_run_install_test(self):
+        """build and run AmrCore test"""
         if self.spec.satisfies("@:21.11"):
-            print("SKIPPED: Stand-alone tests not supported for this version of AMReX.")
-            return
+            raise SkipTest("Test is not supported for versions @:21.11")
 
-        """Perform smoke tests on installed package."""
-        # TODO: Remove/replace once self.spec['cmake'] is available here
-        cmake_bin = self.cmake_bin(set=False)
-
-        args = []
-        args.append("-S./cache/amrex/Tests/SpackSmokeTest")
+        args = ["-S{0}".format(join_path(".", "cache", "amrex", "Tests", "SpackSmokeTest"))]
         args.append("-DAMReX_ROOT=" + self.prefix)
         if "+mpi" in self.spec:
             args.append("-DMPI_C_COMPILER=" + self.spec["mpi"].mpicc)
@@ -360,15 +337,15 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             args.append("-DCMAKE_CUDA_COMPILER=" + join_path(self.spec["cuda"].prefix.bin, "nvcc"))
 
         args.extend(self.cmake_args())
-        self.run_test(cmake_bin, args, purpose="Configure with CMake")
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        cmake(*args)
 
-        self.run_test("make", [], purpose="Compile")
+        make = which("make")
+        make()
 
-        self.run_test(
-            "install_test",
-            ["./cache/amrex/Tests/Amr/Advection_AmrCore/Exec/inputs-ci"],
-            ["finalized"],
-            installed=False,
-            purpose="AMReX Stand-Alone Smoke Test -- AmrCore",
-            skip_missing=False,
+        install_test = which("install_test")
+        inputs_path = join_path(
+            ".", "cache", "amrex", "Tests", "Amr", "Advection_AmrCore", "Exec", "inputs-ci"
         )
+        out = install_test(inputs_path, output=str.split, error=str.split)
+        assert "finalized" in out

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -315,8 +315,8 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
         return args
 
     @run_after("build")
-    def setup_smoke_test(self):
-        """Setup smoke tests for AMReX versions from 21.12 on."""
+    def setup_standalone_test(self):
+        """Setup stand-alonetests for AMReX versions from 21.12 on."""
         if self.spec.satisfies("@:21.11"):
             return
 


### PR DESCRIPTION
Depends on #34236 

Post 34236 rebase (with initial #37602 changes) for v21.10, 21.11, and 23.05:
```
$ spack -v test run amrex
==> Spack test bh4zl5uwgid7s3ntztk3hmaoxttmiuo5
==> Testing package amrex-21.11-c5zlps6
==> [2023-05-10-18:35:07.994419] test: test_run_install_test: build and run AmrCore test
SKIPPED: Amrex::test_run_install_test: Test is not supported for versions @:21.11
==> [2023-05-10-18:35:07.997003] Completed testing
==> [2023-05-10-18:35:07.997168] 
========================= SUMMARY: amrex-21.11-c5zlps6 =========================
Amrex::test_run_install_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package amrex-23.05-3j2ybow
==> [2023-05-10-18:35:12.879354] Installing $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/amrex-23.05-3j2ybowi5iamfrqesqonooonf2kjgkyg/.spack/test to $HOME/.spack/test/bh4zl5uwgid7s3ntztk3hmaoxttmiuo5/amrex-23.05-3j2ybow/cache/amrex
==> [2023-05-10-18:35:23.863530] test: test_run_install_test: build and run AmrCore test
==> [2023-05-10-18:35:23.882685] '$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '-S./cache/amrex/Tests/SpackSmokeTest' '-DAMReX_ROOT=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/amrex-23.05-3j2ybowi5iamfrqesqonooonf2kjgkyg' '-DMPI_C_COMPILER=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpicc' '-DMPI_CXX_COMPILER=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpic++' '-DUSE_XSDK_DEFAULTS=ON' '-DAMReX_SPACEDIM:STRING=3' '-DBUILD_SHARED_LIBS:BOOL=OFF' '-DAMReX_MPI:BOOL=ON' '-DAMReX_OMP:BOOL=OFF' '-DXSDK_PRECISION:STRING=DOUBLE' '-DXSDK_ENABLE_Fortran:BOOL=OFF' '-DAMReX_FORTRAN_INTERFACES:BOOL=OFF' '-DAMReX_EB:BOOL=OFF' '-DAMReX_LINEAR_SOLVERS:BOOL=ON' '-DAMReX_AMRDATA:BOOL=OFF' '-DAMReX_PARTICLES:BOOL=OFF' '-DAMReX_PLOTFILE_TOOLS:BOOL=OFF' '-DAMReX_TINY_PROFILE:BOOL=OFF' '-DAMReX_HDF5:BOOL=OFF' '-DAMReX_HYPRE:BOOL=OFF' '-DAMReX_PETSC:BOOL=OFF' '-DAMReX_SUNDIALS:BOOL=OFF' '-DAMReX_PIC:BOOL=OFF'
-- The C compiler identification is GNU 10.3.1
-- The CXX compiler identification is GNU 10.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: $SPACK_ROOT/releases/spack/lib/spack/env/gcc/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/releases/spack/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- Found MPI_C: $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/lib/libmpi.so (found version "3.1") 
-- Found MPI_CXX: $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/lib/libmpi.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1") found components: C CXX 
-- Configuring done (5.8s)
-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    AMReX_LINEAR_SOLVERS
    AMReX_PLOTFILE_TOOLS
    AMReX_SUNDIALS
    USE_XSDK_DEFAULTS
    XSDK_ENABLE_Fortran
    XSDK_PRECISION


-- Build files have been written to: $HOME/.spack/test/bh4zl5uwgid7s3ntztk3hmaoxttmiuo5/amrex-23.05-3j2ybow
==> [2023-05-10-18:35:29.833625] '/usr/bin/make'
[ 16%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp.o
[ 33%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp.o
[ 50%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp.o
[ 66%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp.o
[ 83%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/main.cpp.o
[100%] Linking CXX executable install_test
[100%] Built target install_test
==> [2023-05-10-18:35:54.203103] './install_test' './cache/amrex/Tests/Amr/Advection_AmrCore/Exec/inputs-ci'
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (23.05) initialized
Successfully read inputs file ... 
Writing plotfile plt00000

Coarse STEP 1 starts ...
[Level 0 step 1] ADVANCE with time = 0 dt = 0.01093983378
[Level 0 step 1] Advanced 32768 cells
[Level 1 step 1] ADVANCE with time = 0 dt = 0.005469916891
[Level 1 step 1] Advanced 65536 cells
[Level 2 step 1] ADVANCE with time = 0 dt = 0.002734958446
[Level 2 step 1] Advanced 204800 cells
[Level 2 step 2] ADVANCE with time = 0.002734958446 dt = 0.002734958446
[Level 2 step 2] Advanced 204800 cells
[Level 1 step 2] ADVANCE with time = 0.005469916891 dt = 0.005469916891
[Level 1 step 2] Advanced 65536 cells
[Level 2 step 3] ADVANCE with time = 0.005469916891 dt = 0.002734958446
[Level 2 step 3] Advanced 204800 cells
[Level 2 step 4] ADVANCE with time = 0.008204875337 dt = 0.002734958446
[Level 2 step 4] Advanced 204800 cells
Coarse STEP 1 ends. TIME = 0.01093983378 DT = 0.01093983378 Sum(Phi) = 33797.09926

Coarse STEP 2 starts ...
[Level 0 step 2] ADVANCE with time = 0.01093983378 dt = 0.01094187841
[Level 0 step 2] Advanced 32768 cells
[Level 1 step 3] ADVANCE with time = 0.01093983378 dt = 0.005470939206
[Level 1 step 3] Advanced 65536 cells
[Level 2 step 5] ADVANCE with time = 0.01093983378 dt = 0.002735469603
[Level 2 step 5] Advanced 225280 cells
[Level 2 step 6] ADVANCE with time = 0.01367530339 dt = 0.002735469603
[Level 2 step 6] Advanced 225280 cells
[Level 1 step 4] ADVANCE with time = 0.01641077299 dt = 0.005470939206
[Level 1 step 4] Advanced 65536 cells
[Level 2 step 7] ADVANCE with time = 0.01641077299 dt = 0.002735469603
[Level 2 step 7] Advanced 225280 cells
[Level 2 step 8] ADVANCE with time = 0.01914624259 dt = 0.002735469603
[Level 2 step 8] Advanced 225280 cells
Coarse STEP 2 ends. TIME = 0.02188171219 DT = 0.01094187841 Sum(Phi) = 33797.09926

Coarse STEP 3 starts ...
[Level 0 step 3] ADVANCE with time = 0.02188171219 dt = 0.01094713318
[Level 0 step 3] Advanced 32768 cells
[Level 1 step 5] ADVANCE with time = 0.02188171219 dt = 0.005473566591
[Level 1 step 5] Advanced 65536 cells
[Level 2 step 9] ADVANCE with time = 0.02188171219 dt = 0.002736783295
[Level 2 step 9] Advanced 247808 cells
[Level 2 step 10] ADVANCE with time = 0.02461849549 dt = 0.002736783295
[Level 2 step 10] Advanced 247808 cells
[Level 1 step 6] ADVANCE with time = 0.02735527878 dt = 0.005473566591
[Level 1 step 6] Advanced 65536 cells
[Level 2 step 11] ADVANCE with time = 0.02735527878 dt = 0.002736783295
[Level 2 step 11] Advanced 247808 cells
[Level 2 step 12] ADVANCE with time = 0.03009206208 dt = 0.002736783295
[Level 2 step 12] Advanced 247808 cells
Coarse STEP 3 ends. TIME = 0.03282884538 DT = 0.01094713318 Sum(Phi) = 33797.09926

Coarse STEP 4 starts ...
[Level 0 step 4] ADVANCE with time = 0.03282884538 dt = 0.01095563625
[Level 0 step 4] Advanced 32768 cells
[Level 1 step 7] ADVANCE with time = 0.03282884538 dt = 0.005477818126
[Level 1 step 7] Advanced 65536 cells
[Level 2 step 13] ADVANCE with time = 0.03282884538 dt = 0.002738909063
[Level 2 step 13] Advanced 247808 cells
[Level 2 step 14] ADVANCE with time = 0.03556775444 dt = 0.002738909063
[Level 2 step 14] Advanced 247808 cells
[Level 1 step 8] ADVANCE with time = 0.0383066635 dt = 0.005477818126
[Level 1 step 8] Advanced 65536 cells
[Level 2 step 15] ADVANCE with time = 0.0383066635 dt = 0.002738909063
[Level 2 step 15] Advanced 247808 cells
[Level 2 step 16] ADVANCE with time = 0.04104557256 dt = 0.002738909063
[Level 2 step 16] Advanced 247808 cells
Coarse STEP 4 ends. TIME = 0.04378448163 DT = 0.01095563625 Sum(Phi) = 33797.09926

Coarse STEP 5 starts ...
[Level 0 step 5] ADVANCE with time = 0.04378448163 dt = 0.01096740925
[Level 0 step 5] Advanced 32768 cells
[Level 1 step 9] ADVANCE with time = 0.04378448163 dt = 0.005483704627
[Level 1 step 9] Advanced 65536 cells
[Level 2 step 17] ADVANCE with time = 0.04378448163 dt = 0.002741852314
[Level 2 step 17] Advanced 247808 cells
[Level 2 step 18] ADVANCE with time = 0.04652633394 dt = 0.002741852314
[Level 2 step 18] Advanced 247808 cells
[Level 1 step 10] ADVANCE with time = 0.04926818625 dt = 0.005483704627
[Level 1 step 10] Advanced 65536 cells
[Level 2 step 19] ADVANCE with time = 0.04926818625 dt = 0.002741852314
[Level 2 step 19] Advanced 247808 cells
[Level 2 step 20] ADVANCE with time = 0.05201003857 dt = 0.002741852314
[Level 2 step 20] Advanced 247808 cells
Coarse STEP 5 ends. TIME = 0.05475189088 DT = 0.01096740925 Sum(Phi) = 33797.09926
Writing plotfile plt00005

Total Time: 12.35738275
Unused ParmParse Variables:
  [TOP]::amr.do_tracers(nvals = 1)  :: [1]

AMReX (23.05) finalized
PASSED: Amrex::test_run_install_test
==> [2023-05-10-18:36:06.960638] Completed testing
==> [2023-05-10-18:36:06.960817] 
========================= SUMMARY: amrex-23.05-3j2ybow =========================
Amrex::test_run_install_test .. PASSED
============================= 1 passed of 1 parts ==============================
==> Testing package amrex-21.10-qy3z336
==> [2023-05-10-18:36:13.558201] test: test_run_install_test: build and run AmrCore test
SKIPPED: Amrex::test_run_install_test: Test is not supported for versions @:21.11
==> [2023-05-10-18:36:13.561322] Completed testing
==> [2023-05-10-18:36:13.561533] 
========================= SUMMARY: amrex-21.10-qy3z336 =========================
Amrex::test_run_install_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
======================== 2 skipped, 1 passed of 3 specs ========================
32.148u 5.759s 1:23.12 45.5%	0+0k 19888+35960io 21pf+0w
```

TODO:

- [x] (re)test using 21.10 and 21.11 (skip) and 23.05 (passes)