### PR TITLE
tests/arborx/flibcpp/fortrilinos/formetis/swig: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/flibcpp/package.py
+++ b/var/spack/repos/builtin/packages/flibcpp/package.py
@@ -13,6 +13,8 @@ class Flibcpp(CMakePackage):
     git = "https://github.com/swig-fortran/flibcpp.git"
     url = "https://github.com/swig-fortran/flibcpp/archive/v1.0.1.tar.gz"
 
+    test_requires_compiler = True
+
     version("1.0.1", sha256="8569c71eab0257097a6aa666a6d86bdcb6cd6e31244d32cc5b2478d0e936ca7a")
     version("0.5.2", sha256="b9b4eb6431d5b56a54c37f658df7455eafd3d204a5534903b127e0c8a1c9b827")
     version("0.5.1", sha256="76db24ce7893f19ab97ea7260c39490ae1bd1e08a4cc5111ad7e70525a916993")
@@ -72,25 +74,20 @@ class Flibcpp(CMakePackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-    def test(self):
-        """Perform stand-alone/smoke tests."""
+    def test_examples(self):
+        """build and run examples"""
         cmake_args = [
             self.define("CMAKE_PREFIX_PATH", self.prefix),
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
         ]
         cmake_args.append(self.cached_tests_work_dir)
 
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
+        with working_dir(self.cached_tests_work_dir):
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(*cmake_args)
 
-        self.run_test(
-            "make", [], purpose="test: building the tests", work_dir=self.cached_tests_work_dir
-        )
+            make = which("make")
+            make()
 
-        self.run_test(
-            "run-examples.sh",
-            [],
-            purpose="test: running the examples",
-            work_dir=self.cached_tests_work_dir,
-        )
+            sh = which("sh")
+            sh("run-examples.sh")

--- a/var/spack/repos/builtin/packages/formetis/package.py
+++ b/var/spack/repos/builtin/packages/formetis/package.py
@@ -14,6 +14,8 @@ class Formetis(CMakePackage):
 
     maintainers("sethrj")
 
+    test_requires_compiler = True
+
     version("0.0.2", sha256="0067c03ca822f4a3955751acb470f21eed489256e2ec5ff24741eb2b638592f1")
 
     variant("mpi", default=False, description="Enable ParMETIS support")
@@ -53,8 +55,8 @@ class Formetis(CMakePackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-    def test(self):
-        """Perform stand-alone/smoke tests on the installed package."""
+    def test_metis(self):
+        """build and run metis"""
         cmake_args = [
             self.define("CMAKE_PREFIX_PATH", self.prefix),
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
@@ -64,19 +66,12 @@ class Formetis(CMakePackage):
             cmake_args.append(self.define("ParMETIS_ROOT", self.spec["parmetis"].prefix))
         cmake_args.append(self.cached_tests_work_dir)
 
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
+        with working_dir(self.cached_tests_work_dir):
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(*cmake_args)
 
-        self.run_test(
-            "make", [], purpose="test: building the tests", work_dir=self.cached_tests_work_dir
-        )
+            make = which("make")
+            make()
 
-        self.run_test(
-            "metis",
-            [],
-            [],
-            purpose="test: checking the installation",
-            installed=False,
-            work_dir=self.cached_tests_work_dir,
-        )
+            metis = which("metis")
+            metis()

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -91,27 +91,22 @@ class Fortrilinos(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.examples_src_dir])
 
-    def test(self):
-        """Perform stand-alone/smoke tests using installed package."""
+    def test_installation(self):
+        """build and run ctest against the installed software"""
         cmake_args = [
             self.define("CMAKE_PREFIX_PATH", self.prefix),
             self.define("CMAKE_CXX_COMPILER", self.compiler.cxx),
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
             self.cached_tests_work_dir,
         ]
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
 
-        self.run_test(
-            "make", [], purpose="test: calling make", work_dir=self.cached_tests_work_dir
-        )
+        with working_dir(self.cached_tests_work_dir, create=True):
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(*cmake_args)
 
-        self.run_test(
-            "ctest",
-            ["-V"],
-            ["100% tests passed"],
-            installed=False,
-            purpose="test: testing the installation",
-            work_dir=self.cached_tests_work_dir,
-        )
+            make = which("make")
+            make()
+
+            ctest = which("ctest")
+            out = ctest("-V", output=str.split, error=str.split)
+            assert "100% tests passed" in out


### PR DESCRIPTION
Depends on #34236 

This PR covers:
- arborx .. v1.3 passes
- flibcpp
- formetis
- fortrilinos
- swig

TODO:

- [x] cherry-pick remaining package and update as needed
- [x] (re)test arborx
- [ ] (re)test flibcpp
- [ ] (re)test formetis
- [ ] (re)test fortrilinos
- [ ] (re)test swig