### PR TITLE
tests/AML: Convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -109,15 +109,13 @@ class Aml(AutotoolsPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.smoke_test_src)
 
-    def run_install_tutorial_check(self):
-        """Run tutorial tests as install checks"""
-
-        src = join_path(self.test_suite.current_test_cache_dir, self.smoke_test_src)
-        cc_exe = os.environ["CC"]
+    def test_check_tutorial(self):
+        """Compile and run the tutorial tests as install checks"""
+        cc = which(os.environ["CC"])
         cc_options = [
             "-o",
             self.smoke_test,
-            src,
+            join_path(self.test_suite.current_test_cache_dir, self.smoke_test_src),
             "-I{0}".format(self.prefix.include),
             "-I{0}".format(self.spec["numactl"].prefix.include),
             "-L{0}".format(self.prefix.lib),
@@ -125,11 +123,8 @@ class Aml(AutotoolsPackage):
             "-lexcit",
             "-lpthread",
         ]
+        cc(*cc_options)
 
-        self.run_test(
-            cc_exe, cc_options, purpose="test: compile {0} tutorial".format(self.smoke_test)
-        )
-        self.run_test(self.smoke_test, purpose="test: run {0} tutorial".format(self.smoke_test))
-
-    def test(self):
-        self.run_install_tutorial_check()
+        smoke_test = which(self.smoke_test)
+        out = smoke_test(output=str.split, error=str.split)
+        assert "Hello world" in out


### PR DESCRIPTION
Depends on #34236 

Post 34236 merge rebase results are:
```
$ ==> Testing package aml-0.2.0-6xqw4ru
==> [2023-05-11-18:34:22.593396] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/aml-0.2.0-6xqw4rues7ggyamiu6lmde2p7zycemcg/.spack/test to $SPACK_TEST_STAGE/gxhjgpiqmrcgcd4m2uosbpnmcqagdwrjw/aml-0.2.0-6xqw4ru/cache/aml
==> [2023-05-11-18:34:22.617722] test: test_check_tutorial: Compile and run the tutorial tests as install checks
==> [2023-05-11-18:34:22.619567] '$SPACK_ROOT/lib/spack/env/gcc/gcc' '-o' '0_hello' '$SPACK_TEST_STAGE/gxhjgpiqmrcgcd4m2uosbpnmcqagdwrjw/aml-0.2.0-6xqw4ru/cache/aml/doc/tutorials/hello_world/0_hello.c' '-I$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/aml-0.2.0-6xqw4rues7ggyamiu6lmde2p7zycemcg/include' '-I$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/numactl-2.0.14-i2lqldbcf2wshtomzzdfv3mkw6zdsnqr/include' '-L$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/aml-0.2.0-6xqw4rues7ggyamiu6lmde2p7zycemcg/lib' '-laml' '-lexcit' '-lpthread'
==> [2023-05-11-18:34:22.912981] './0_hello'
Hello world!
PASSED: Aml::test_check_tutorial
==> [2023-05-11-18:34:22.960778] Completed testing
==> [2023-05-11-18:34:22.960935] 
========================== SUMMARY: aml-0.2.0-6xqw4ru ==========================
Aml::test_check_tutorial .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```

TODO

- [x] (re)test .. v0.2.0 passes