### PR TITLE
tests/berkeley-db: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import re
 
 from spack.package import *
@@ -93,25 +94,40 @@ class BerkeleyDb(AutotoolsPackage):
 
         return config_args
 
-    def test(self):
-        """Perform smoke tests on the installed package binaries."""
-        exes = [
-            "db_checkpoint",
-            "db_deadlock",
-            "db_dump",
-            "db_load",
-            "db_printlog",
-            "db_stat",
-            "db_upgrade",
-            "db_verify",
-        ]
-        for exe in exes:
-            reason = "test version of {0} is {1}".format(exe, self.spec.version)
-            self.run_test(
-                exe,
-                ["-V"],
-                [self.spec.version.string],
-                installed=True,
-                purpose=reason,
-                skip_missing=True,
-            )
+    def check_exe_version(self, exe):
+        """Check that the installed executable prints the correct version."""
+        installed_exe = join_path(self.prefix.bin, exe)
+        if not os.path.exists(installed_exe):
+            raise SkipTest(f"{exe} is not installed")
+
+        exe = which(installed_exe)
+        out = exe("-V", output=str.split, error=str.split)
+        assert self.spec.version.string in out
+
+    def test_db_checkpoint(self):
+        """check db_checkpoint version"""
+        self.check_exe_version("db_checkpoint")
+
+    def test_db_deadlock(self):
+        """check db_deadlock version"""
+        self.check_exe_version("db_deadlock")
+
+    def test_db_dump(self):
+        """check db_dump version"""
+        self.check_exe_version("db_dump")
+
+    def test_db_load(self):
+        """check db_load version"""
+        self.check_exe_version("db_load")
+
+    def test_db_stat(self):
+        """check db_stat version"""
+        self.check_exe_version("db_stat")
+
+    def test_db_upgrade(self):
+        """check db_upgrade version"""
+        self.check_exe_version("db_upgrade")
+
+    def test_db_verify(self):
+        """check db_verify version"""
+        self.check_exe_version("db_verify")


### PR DESCRIPTION
Converted the package to use the new stand-alone test process (in release 0.20).

```
$ spack -v test run berkeley-db
==> Spack test csh73kt4tyaxlxopbmevw2q57qwhst3d
==> Testing package berkeley-db-18.1.40-ndhyhwk
==> [2023-05-22-11:43:22.093187] test: test_db_checkpoint: check db_checkpoint version
==> [2023-05-22-11:43:22.103933] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_checkpoint' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_checkpoint
==> [2023-05-22-11:43:22.271433] test: test_db_deadlock: check db_deadlock version
==> [2023-05-22-11:43:22.273669] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_deadlock' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_deadlock
==> [2023-05-22-11:43:22.291492] test: test_db_dump: check db_dump version
==> [2023-05-22-11:43:22.293910] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_dump' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_dump
==> [2023-05-22-11:43:22.318748] test: test_db_load: check db_load version
==> [2023-05-22-11:43:22.320726] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_load' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_load
==> [2023-05-22-11:43:22.343228] test: test_db_stat: check db_stat version
==> [2023-05-22-11:43:22.345831] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_stat' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_stat
==> [2023-05-22-11:43:22.481434] test: test_db_upgrade: check db_upgrade version
==> [2023-05-22-11:43:22.483932] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_upgrade' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_upgrade
==> [2023-05-22-11:43:22.521294] test: test_db_verify: check db_verify version
==> [2023-05-22-11:43:22.523625] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/berkeley-db-18.1.40-ndhyhwkzrigmrhnzddktn3hwho4mwneb/bin/db_verify' '-V'
Berkeley DB 18.1.40: (May 29, 2020)
PASSED: BerkeleyDb::test_db_verify
==> [2023-05-22-11:43:22.546296] Completed testing
==> [2023-05-22-11:43:22.546528] 
===================== SUMMARY: berkeley-db-18.1.40-ndhyhwk =====================
BerkeleyDb::test_db_checkpoint .. PASSED
BerkeleyDb::test_db_deadlock .. PASSED
BerkeleyDb::test_db_dump .. PASSED
BerkeleyDb::test_db_load .. PASSED
BerkeleyDb::test_db_stat .. PASSED
BerkeleyDb::test_db_upgrade .. PASSED
BerkeleyDb::test_db_verify .. PASSED
============================= 7 passed of 7 parts ==============================
============================== 1 passed of 1 spec ==============================
```