### PR TITLE
Set GOMAXPROCS for go package to limit build processes

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -116,6 +116,7 @@ class Go(Package):
         # internal Spack wrappers and fail.
         env.set("CC_FOR_TARGET", self.compiler.cc)
         env.set("CXX_FOR_TARGET", self.compiler.cxx)
+        env.set("GOMAXPROCS", make_jobs)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before go modules' install() methods.


### PR DESCRIPTION
This PR sets `$GOMAXPROCS` in the `go` package in order to limit the number of build processes based on `make_jobs`. On high-CPU count systems, the build can fail due to ulimits.