### PR TITLE
HDF5: is_enabled helper (ON)

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -489,9 +489,7 @@ class Hdf5(CMakePackage):
     @classmethod
     def determine_variants(cls, exes, version):
         def is_enabled(text):
-            if text in set(["t", "true", "enabled", "yes", "1"]):
-                return True
-            return False
+            return text.lower() in ["t", "true", "enabled", "yes", "1", "on"]
 
         results = []
         for exe in exes:


### PR DESCRIPTION
Related to `determine_variants` for finding external HDF5 installs by querying `-showconfig` from HDF5 executables.

Slightly generalize the `is_enabled` helper in the HDF5 package. `ON` is the most typical CMake bool option passed, besides many other possible `true` values, and should be included as a possible check to the config.

Loosely related to #35546 and https://github.com/HDFGroup/hdf5/issues/2488