### PR TITLE
hpctoolkit: fix broken patches

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/411d62544717873432c49ef45c7cb99cc5de2fb8.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/411d62544717873432c49ef45c7cb99cc5de2fb8.patch
@@ -1,0 +1,91 @@
+From 411d62544717873432c49ef45c7cb99cc5de2fb8 Mon Sep 17 00:00:00 2001
+From: "Mark W. Krentel" <krentel@rice.edu>
+Date: Thu, 15 Dec 2022 16:43:43 -0600
+Subject: [PATCH] Add a temporary hack to allow both ROCM 5.2/5.3 to build
+ cleanly.
+
+There were some corner cases (build 5.3 pieces from spack and feed
+into autotools) that didn't work.  After the next release, I will want
+to rework ROCM configure more extensively.
+---
+ configure    | 21 +++++++++++++--------
+ configure.ac | 17 +++++++++++------
+ 2 files changed, 24 insertions(+), 14 deletions(-)
+
+diff --git a/configure b/configure
+index 1760e678e8..814376b3bd 100755
+--- a/configure
++++ b/configure
+@@ -23891,10 +23891,13 @@ $as_echo "$as_me: found $ROCM/rocprofiler/lib/librocprofiler64.so" >&6;}
+     fi
+ 
+     # HSA
+-    if test -f "$ROCM/include/hsa/hsa.h" ; then
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: found $ROCM/include/hsa/hsa.h" >&5
+-$as_echo "$as_me: found $ROCM/include/hsa/hsa.h" >&6;}
+-      ROCM_HSA_IFLAGS="-I$ROCM/include/hsa"
++    # FIXME: as of rocm 5.2/5.3, this was not fully switched over,
++    # so temporarily use both paths.
++    if test -f "$ROCM/include/hsa/hsa.h" || test -f "$ROCM/include/hsa.h"
++    then
++      { $as_echo "$as_me:${as_lineno-$LINENO}: found $ROCM: hsa.h" >&5
++$as_echo "$as_me: found $ROCM: hsa.h" >&6;}
++      ROCM_HSA_IFLAGS="-I$ROCM/include -I$ROCM/include/hsa"
+       ROCM_HSA_INC_MESG="$ROCM/hsa"
+       found=yes
+     fi
+@@ -24020,10 +24023,12 @@ case "$ROCM_HSA" in
+     require_rocm=yes
+     found=no
+ 
+-    if test -f "$ROCM_HSA/include/hsa/hsa.h" ; then
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: found $ROCM_HSA/include/hsa/hsa.h" >&5
+-$as_echo "$as_me: found $ROCM_HSA/include/hsa/hsa.h" >&6;}
+-      ROCM_HSA_IFLAGS="-I$ROCM_HSA/include/hsa"
++    # FIXME: again, temporarily use both paths
++    if test -f "$ROCM_HSA/include/hsa/hsa.h" || test -f "$ROCM_HSA/include/hsa.h"
++    then
++      { $as_echo "$as_me:${as_lineno-$LINENO}: found $ROCM_HSA: hsa.h" >&5
++$as_echo "$as_me: found $ROCM_HSA: hsa.h" >&6;}
++      ROCM_HSA_IFLAGS="-I$ROCM_HSA/include -I$ROCM_HSA/include/hsa"
+       ROCM_HSA_INC_MESG="$ROCM_HSA"
+       found=yes
+     fi
+diff --git a/configure.ac b/configure.ac
+index a14b15835f..9d5ed46134 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4885,9 +4885,12 @@ case "$ROCM" in
+     fi
+ 
+     # HSA
+-    if test -f "$ROCM/include/hsa/hsa.h" ; then
+-      AC_MSG_NOTICE([found $ROCM/include/hsa/hsa.h])
+-      ROCM_HSA_IFLAGS="-I$ROCM/include/hsa"
++    # FIXME: as of rocm 5.2/5.3, this was not fully switched over,
++    # so temporarily use both paths.
++    if test -f "$ROCM/include/hsa/hsa.h" || test -f "$ROCM/include/hsa.h"
++    then
++      AC_MSG_NOTICE([found $ROCM: hsa.h])
++      ROCM_HSA_IFLAGS="-I$ROCM/include -I$ROCM/include/hsa"
+       ROCM_HSA_INC_MESG="$ROCM/hsa"
+       found=yes
+     fi
+@@ -5002,9 +5005,11 @@ case "$ROCM_HSA" in
+     require_rocm=yes
+     found=no
+ 
+-    if test -f "$ROCM_HSA/include/hsa/hsa.h" ; then
+-      AC_MSG_NOTICE([found $ROCM_HSA/include/hsa/hsa.h])
+-      ROCM_HSA_IFLAGS="-I$ROCM_HSA/include/hsa"
++    # FIXME: again, temporarily use both paths
++    if test -f "$ROCM_HSA/include/hsa/hsa.h" || test -f "$ROCM_HSA/include/hsa.h"
++    then
++      AC_MSG_NOTICE([found $ROCM_HSA: hsa.h])
++      ROCM_HSA_IFLAGS="-I$ROCM_HSA/include -I$ROCM_HSA/include/hsa"
+       ROCM_HSA_INC_MESG="$ROCM_HSA"
+       found=yes
+     fi
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/hpctoolkit/511afd95b01d743edc5940c84e0079f462b2c23e.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/511afd95b01d743edc5940c84e0079f462b2c23e.patch
@@ -1,0 +1,130 @@
+From 511afd95b01d743edc5940c84e0079f462b2c23e Mon Sep 17 00:00:00 2001
+From: "Mark W. Krentel" <krentel@rice.edu>
+Date: Tue, 18 May 2021 14:54:41 -0500
+Subject: [PATCH] Cleanup some usage for gcc/g++ 11.x (#413)
+
+1. Change epsilon to hpc_epsilon in prof/Metric header files.  This
+ conflicted with using epsilon in some STL template libraries.
+
+ 2. Add const to some comparison operators that are used in some STL
+ maps.
+---
+ src/lib/banal/Struct-Inline.hpp   | 6 +++---
+ src/lib/prof/Metric-AExpr.cpp     | 4 ++--
+ src/lib/prof/Metric-AExpr.hpp     | 2 +-
+ src/lib/prof/Metric-AExprIncr.hpp | 6 +++---
+ src/lib/support/StringTable.hpp   | 2 +-
+ 5 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/lib/banal/Struct-Inline.hpp b/src/lib/banal/Struct-Inline.hpp
+index ffb93355fd..0099ad112d 100644
+--- a/src/lib/banal/Struct-Inline.hpp
++++ b/src/lib/banal/Struct-Inline.hpp
+@@ -150,14 +150,14 @@ public:
+     pretty_index = strTab.str2index(node.getPrettyName());
+   }
+ 
+-  bool operator == (const FLPIndex rhs)
++  bool operator == (const FLPIndex rhs) const
+   {
+     return file_index == rhs.file_index
+       && line_num == rhs.line_num
+       && pretty_index == rhs.pretty_index;
+   }
+ 
+-  bool operator != (const FLPIndex rhs)
++  bool operator != (const FLPIndex rhs) const
+   {
+     return ! (*this == rhs);
+   }
+@@ -167,7 +167,7 @@ public:
+ // Compare (file, line, proc) indices lexigraphically.
+ class FLPCompare {
+ public:
+-  bool operator() (const FLPIndex t1, const FLPIndex t2)
++  bool operator() (const FLPIndex t1, const FLPIndex t2) const
+   {
+     if (t1.file_index < t2.file_index) { return true; }
+     if (t1.file_index > t2.file_index) { return false; }
+diff --git a/src/lib/prof/Metric-AExpr.cpp b/src/lib/prof/Metric-AExpr.cpp
+index 2ce43e6d39..5b32ff67d1 100644
+--- a/src/lib/prof/Metric-AExpr.cpp
++++ b/src/lib/prof/Metric-AExpr.cpp
+@@ -483,7 +483,7 @@ CoefVar::eval(const Metric::IData& mdata) const
+   double sdev = sqrt(v_m.first); // always non-negative
+   double mean = v_m.second;
+   double z = 0.0;
+-  if (mean > epsilon) {
++  if (mean > hpc_epsilon) {
+     z = sdev / mean;
+   }
+ 
+@@ -522,7 +522,7 @@ RStdDev::eval(const Metric::IData& mdata) const
+   double sdev = sqrt(v_m.first); // always non-negative
+   double mean = v_m.second;
+   double z = 0.0;
+-  if (mean > epsilon) {
++  if (mean > hpc_epsilon) {
+     z = (sdev / mean) * 100;
+   }
+ 
+diff --git a/src/lib/prof/Metric-AExpr.hpp b/src/lib/prof/Metric-AExpr.hpp
+index 56359cc9df..d75189f763 100644
+--- a/src/lib/prof/Metric-AExpr.hpp
++++ b/src/lib/prof/Metric-AExpr.hpp
+@@ -97,7 +97,7 @@
+ 
+ //****************************************************************************
+ 
+-#define epsilon  (0.000001)
++#define hpc_epsilon  (0.000001)
+ 
+ namespace Prof {
+ 
+diff --git a/src/lib/prof/Metric-AExprIncr.hpp b/src/lib/prof/Metric-AExprIncr.hpp
+index f1b38d7f74..d0c0feb7e6 100644
+--- a/src/lib/prof/Metric-AExprIncr.hpp
++++ b/src/lib/prof/Metric-AExprIncr.hpp
+@@ -97,7 +97,7 @@
+ 
+ //****************************************************************************
+ 
+-#define epsilon  (0.000001)
++#define hpc_epsilon  (0.000001)
+ 
+ namespace Prof {
+ 
+@@ -841,7 +841,7 @@ public:
+     double sdev = finalizeStdDev(mdata);
+     double mean = accumVar(1, mdata);
+     double z = 0.0;
+-    if (mean > epsilon) {
++    if (mean > hpc_epsilon) {
+       z = sdev / mean;
+     }
+     accumVar(0, mdata) = z;
+@@ -927,7 +927,7 @@ public:
+     double sdev = finalizeStdDev(mdata);
+     double mean = accumVar(1, mdata);
+     double z = 0.0;
+-    if (mean > epsilon) {
++    if (mean > hpc_epsilon) {
+       z = (sdev / mean) * 100;
+     }
+     accumVar(0, mdata) = z;
+diff --git a/src/lib/support/StringTable.hpp b/src/lib/support/StringTable.hpp
+index 9930bc5649..36ce5b7fa9 100644
+--- a/src/lib/support/StringTable.hpp
++++ b/src/lib/support/StringTable.hpp
+@@ -75,7 +75,7 @@ namespace HPC {
+ // compare the strings, not the pointers
+ class StringCompare {
+ public:
+-  bool operator() (const std::string *s1, const std::string *s2)
++  bool operator() (const std::string *s1, const std::string *s2) const
+   {
+     return *s1 < *s2;
+   }
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -162,17 +162,11 @@ class Hpctoolkit(AutotoolsPackage):
     # Fix the build for old revs with gcc 10.x.
     patch("gcc10-enum.patch", when="@2020.01.01:2020.08 %gcc@10.0:")
 
-    patch(
-        "https://gitlab.com/hpctoolkit/hpctoolkit/-/commit/511afd95b01d743edc5940c84e0079f462b2c23e.patch",
-        sha256="8da18df88a80847c092da8d0892de51ea2bf2523124148b6305ab8717707d897",
-        when="@2019.08.01:2021.03 %gcc@11.0:",
-    )
+    patch("511afd95b01d743edc5940c84e0079f462b2c23e.patch", when="@2019.08.01:2021.03 %gcc@11.0:")
 
     # Update configure for rocm 5.3.0
     patch(
-        "https://gitlab.com/hpctoolkit/hpctoolkit/-/commit/411d62544717873432c49ef45c7cb99cc5de2fb8.patch",
-        sha256="484045891a665cdba3b0f141540c89f0d691ed32c5912ef62a93670d44c2786c",
-        when="@2022.04:2022.10 +rocm ^hip@5.3.0:",
+        "411d62544717873432c49ef45c7cb99cc5de2fb8.patch", when="@2022.04:2022.10 +rocm ^hip@5.3.0:"
     )
 
     # Change python to python3 for some old revs that use a script


### PR DESCRIPTION
The patches don't have a stable checksum:

```
7eb3a21c9bf9e1b65ef0375609665d36e5f7a74c664eb474cba728faada9baeb *411d62544717873432c49ef45c7cb99cc5de2fb8.patch
ccf7a319be0362d8a047953aa5d594b386acc7d6ea21fdc15925e926f83c7bd0 *511afd95b01d743edc5940c84e0079f462b2c23e.patch
```