### PR TITLE
cgns: enable tools

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/no-matherr.patch
+++ b/var/spack/repos/builtin/packages/cgns/no-matherr.patch
@@ -1,0 +1,58 @@
+Description: Remove matherr hack
+ Remove matherr hack, that is only needed for Sun shared libraries and
+ causes an FTBFS with glibc 2.27 onwards, as SVID error handling has
+ been removed.
+Author: Aurelien Jarno <aurel32@debian.org>
+Last-Update: 2018-02-12
+
+--- libcgns-3.3.0.orig/src/cgnstools/cgnscalc/calcwish.c
++++ libcgns-3.3.0/src/cgnstools/cgnscalc/calcwish.c
+@@ -15,14 +15,6 @@
+ #include "tk.h"
+ #include "locale.h"
+ 
+-/*
+- * The following variable is a special hack that is needed in order for
+- * Sun shared libraries to be used for Tcl.
+- */
+-
+-extern int matherr();
+-int *tclDummyMathPtr = (int *) matherr;
+-
+ #ifdef TK_TEST
+ extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
+ extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));
+--- libcgns-3.3.0.orig/src/cgnstools/cgnsplot/plotwish.c
++++ libcgns-3.3.0/src/cgnstools/cgnsplot/plotwish.c
+@@ -15,14 +15,6 @@
+ #include "tk.h"
+ #include "locale.h"
+ 
+-/*
+- * The following variable is a special hack that is needed in order for
+- * Sun shared libraries to be used for Tcl.
+- */
+-
+-extern int matherr();
+-int *tclDummyMathPtr = (int *) matherr;
+-
+ extern int Cgnstcl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+ extern int Tkogl_Init _ANSI_ARGS_((Tcl_Interp *interp));
+ 
+--- libcgns-3.3.0.orig/src/cgnstools/cgnsview/cgiowish.c
++++ libcgns-3.3.0/src/cgnstools/cgnsview/cgiowish.c
+@@ -15,14 +15,6 @@
+ #include "tk.h"
+ #include "locale.h"
+ 
+-/*
+- * The following variable is a special hack that is needed in order for
+- * Sun shared libraries to be used for Tcl.
+- */
+-
+-extern int matherr();
+-int *tclDummyMathPtr = (int *) matherr;
+-
+ #ifdef TK_TEST
+ extern int		Tcltest_Init _ANSI_ARGS_((Tcl_Interp *interp));
+ extern int		Tktest_Init _ANSI_ARGS_((Tcl_Interp *interp));

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -53,8 +53,8 @@ class Cgns(CMakePackage):
     depends_on("hdf5+mpi", when="+hdf5+mpi")
     depends_on("mpi", when="+mpi")
 
-    # cgnsview requires `spack load tk` to run
-    depends_on("tk", when="+tools")
+    # cgnsview requires tk to run
+    depends_on("tk", when="+tools", type=("build", "link", "run"))
     depends_on("tcl", when="+tools")
     depends_on("gl", when="+tools")
     depends_on("glu", when="+tools")

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -44,6 +44,7 @@ class Cgns(CMakePackage):
     variant("testing", default=False, description="Build CGNS testing")
     variant("legacy", default=False, description="Enable legacy options")
     variant("mem_debug", default=False, description="Enable memory debugging option")
+    variant("tools", default=False, description="Enable CGNS tools")
 
     depends_on("cmake@3.12:", when="@4.3:", type="build")
     depends_on("cmake@3.8:", when="@4.2:", type="build")
@@ -51,6 +52,18 @@ class Cgns(CMakePackage):
     depends_on("hdf5~mpi", when="+hdf5~mpi")
     depends_on("hdf5+mpi", when="+hdf5+mpi")
     depends_on("mpi", when="+mpi")
+
+    # cgnsview requires `spack load tk` to run
+    depends_on("tk", when="+tools")
+    depends_on("tcl", when="+tools")
+    depends_on("gl", when="+tools")
+    depends_on("glu", when="+tools")
+    depends_on("libxmu", when="+tools")
+    depends_on("libsm", when="+tools")
+
+    # patch for error undefined reference to `matherr, see
+    # https://bugs.gentoo.org/662210
+    patch("no-matherr.patch", when="@:3.3.1 +tools")
 
     def cmake_args(self):
         spec = self.spec
@@ -63,7 +76,7 @@ class Cgns(CMakePackage):
                 self.define_from_variant("CGNS_ENABLE_PARALLEL", "mpi"),
                 "-DCGNS_ENABLE_TESTS:BOOL=OFF",
                 self.define_from_variant("CGNS_BUILD_TESTING", "testing"),
-                "-DCGNS_BUILD_CGNSTOOLS:BOOL=OFF",
+                self.define_from_variant("CGNS_BUILD_CGNSTOOLS", "tools"),
                 self.define_from_variant("CGNS_BUILD_SHARED", "shared"),
                 self.define_from_variant("CGNS_BUILD_STATIC", "static"),
                 self.define_from_variant("CGNS_ENABLE_BASE_SCOPE", "base_scope"),


### PR DESCRIPTION
- added a `tools` variant that activates the option `CGNS_BUILD_CGNSTOOLS` and the necessary dependencies
- added a patch for older versions of cgns (see https://bugs.gentoo.org/662210)
