### PR TITLE
Update cp2k recipe to use cmake or the current build system

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -896,8 +896,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         args += [
             self.define(
                 "CP2K_ENABLE_ELPA_OPENMP_SUPPORT",
-                (spec.satisfies("+openmp") and spec.satisfies("+elpa"))
-                or spec.satisfies("^elpa+openmp"),
+                ("+elpa +openmp" in spec) or ("^elpa +openmp" in spec),
             )
         ]
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -893,7 +893,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         lapack = spec["lapack"]
         blas = spec["blas"]
 
-        if spec["blas"].name in ["intel-mkl", "intel-parallel-studio"]:
+        if blas.name in ["intel-mkl", "intel-parallel-studio"]:
             args += ["-DCP2K_BLAS_VENDOR=MKL"]
             if sys.platform == "darwin":
                 args += [

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -50,11 +50,11 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         values=("libxsmm", "libsmm", "blas"),
         description="Library for small matrix multiplications",
     )
-    variant("plumed", default=False, description="Enable PLUMED support",)
+    variant("plumed", default=False, description="Enable PLUMED support")
     variant(
         "libint", default=True,  description="Use libint, required for HFX (and possibly others)",
     )
-    variant("libxc",  default=True,  description="Support additional functionals via libxc",)
+    variant("libxc", default=True,  description="Support additional functionals via libxc",)
     variant(
         "pexsi",
         default=False,
@@ -821,30 +821,30 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             args += ["-DCP2K_WITH_GPU={0}".format(gpuver), "-DCP2K_USE_ACCEL=hip"]
 
         args += [
-             self.define_from_variant("CP2K_USE_ELPA", "elpa"),
-             self.define_from_variant("CP2K_USE_LIBINT", "libint"),
-             self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
-             self.define_from_variant("CP2K_USE_SPLA", "spla"),
-             self.define_from_variant("CP2K_USE_COSMA", "cosma"),
-             self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
+            self.define_from_variant("CP2K_USE_ELPA", "elpa"),
+            self.define_from_variant("CP2K_USE_LIBINT", "libint"),
+            self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
+            self.define_from_variant("CP2K_USE_SPLA", "spla"),
+            self.define_from_variant("CP2K_USE_COSMA", "cosma"),
+            self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
         ]
 
         if spec.satisfies("+pytorch"):
             args += ["-DCP2K_USE_LIBTORCH=ON"]
 
         args += [
-             self.define_from_variant("CP2K_USE_METIS", "metis"),
-             self.define_from_variant("CP2K_USE_PLUMED", "plumed"),
-             self.define_from_variant("CP2K_USE_SPGLIB", "spglib"),
-             self.define_from_variant("CP2K_USE_VORI", "libvori"),
-             self.define_from_variant("CP2K_USE_SUPERLU", "superlu-dist"),
-             self.define_from_variant("CP2K_USE_SPLA", "spla"),
-             self.define_from_variant("CP2K_USE_QUIP", "quip"),
+            self.define_from_variant("CP2K_USE_METIS", "metis"),
+            self.define_from_variant("CP2K_USE_PLUMED", "plumed"),
+            self.define_from_variant("CP2K_USE_SPGLIB", "spglib"),
+            self.define_from_variant("CP2K_USE_VORI", "libvori"),
+            self.define_from_variant("CP2K_USE_SUPERLU", "superlu-dist"),
+            self.define_from_variant("CP2K_USE_SPLA", "spla"),
+            self.define_from_variant("CP2K_USE_QUIP", "quip"),
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though
         if (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or spec.satisfies(
-                "^elpa+openmp"
+            "^elpa+openmp"
         ):
             args += ["-DCP2K_ENABLE_ELPA_OPENMP_SUPPORT=ON"]
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -51,7 +51,9 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         description="Library for small matrix multiplications",
     )
     variant("plumed", default=False, description="Enable PLUMED support",)
-    variant("libint", default=True,  description="Use libint, required for HFX (and possibly others)",)
+    variant(
+        "libint", default=True,  description="Use libint, required for HFX (and possibly others)",
+    )
     variant("libxc",  default=True,  description="Support additional functionals via libxc",)
     variant(
         "pexsi",
@@ -69,22 +71,22 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         default=False,
         description="Enable planewave electronic structure" " calculations via SIRIUS",
     )
-    variant("cosma", default=False, description="Use COSMA for p?gemm",)
+    variant("cosma", default=False, description="Use COSMA for p?gemm")
     variant(
         "libvori",
         default=False,
         description="Enable support for Voronoi integration" " and BQB compression",
     )
-    variant("spglib", default=False, description="Enable support for spglib",)
+    variant("spglib", default=False, description="Enable support for spglib")
     variant(
         "spla",
         default=False,
         description="Use SPLA off-loading functionality. Only relevant when CUDA or ROCM are enabled",
     )
-    variant("pytorch", default=False, description="Enable libtorch support",)
-    variant("metis", default=False, description="Enable (par)metis support",)
-    variant("quip", default=False, description=("Enable quip support"),)
-    variant("superlu-dist", default=False, description=("Enable superlu support"),)
+    variant("pytorch", default=False, description="Enable libtorch support")
+    variant("metis", default=False, description="Enable (par)metis support")
+    variant("quip", default=False, description=("Enable quip support"))
+    variant("superlu-dist", default=False, description=("Enable superlu support"))
 
     with when("+cuda"):
         variant(
@@ -786,6 +788,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
             with working_dir(self.build_directory):
                 make("test", *self.build_targets)
 
+
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     """Use the new cmake build system to build cp2k. It is the default when
     building the master branch of cp2k."""
@@ -804,7 +807,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value[0]
 
-            gpu_map = { "35": "K40", "37": "K80", "60": "P100", "70": "V100", "80": "A100",}
+            gpu_map = {"35": "K40", "37": "K80", "60": "P100", "70": "V100", "80": "A100"}
 
             gpuver = gpu_map[cuda_arch]
 
@@ -840,7 +843,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though
-        if (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or spec.satisfies("^elpa+openmp"):
+        if (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or spec.satisfies(
+                "^elpa+openmp"
+        ):
             args += ["-DCP2K_ENABLE_ELPA_OPENMP_SUPPORT=ON"]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -843,11 +843,11 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         if spec.satisfies("+cuda") or spec.satisfies("+rocm"):
             if spec.satisfies("cuda_target"):
-                args += [self.define("CP2K_WITH_GPU", gpu_map[spec.variants["cuda_arch"].value])]
+                args += [self.define("CP2K_WITH_GPU", gpu_map[spec.variants["cuda_arch"].value[0])]
 
             if spec.satisfies("amdgpu_target"):
                 args += [
-                    self.define("CP2K_WITH_GPU", gpu_map[spec.variants["amdgpu_target"].value])
+                    self.define("CP2K_WITH_GPU", gpu_map[spec.variants["amdgpu_target"].value[0])
                 ]
 
         if spec.satisfies("+cuda"):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -641,7 +641,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
             acc_flags_var = "NVFLAGS"
             cppflags += ["-D__ACC"]
             cppflags += ["-D__DBCSR_ACC"]
-            gpuver = gpu_map[spec.variants["amdgpu_target"].value]
+            gpuver = gpu_map[spec.variants["amdgpu_target"].value[0]]
 
         if "smm=libsmm" in spec:
             lib_dir = join_path("lib", self.makefile_architecture, self.makefile_version)

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -50,25 +50,13 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         values=("libxsmm", "libsmm", "blas"),
         description="Library for small matrix multiplications",
     )
-    variant(
-        "plumed",
-        default=False,
-        description="Enable PLUMED support",
-    )
-    variant(
-        "libint",
-        default=True,
-        description="Use libint, required for HFX (and possibly others)",
-    )
-    variant(
-        "libxc",
-        default=True,
-        description="Support additional functionals via libxc",
-    )
+    variant("plumed", default=False, description="Enable PLUMED support",)
+    variant("libint", default=True,  description="Use libint, required for HFX (and possibly others)",)
+    variant("libxc",  default=True,  description="Support additional functionals via libxc",)
     variant(
         "pexsi",
         default=False,
-        description = "Enable the alternative PEXSI method" "for density matrix evaluation",
+        description="Enable the alternative PEXSI method" "for density matrix evaluation",
     )
     variant(
         "elpa",
@@ -79,48 +67,24 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     variant(
         "sirius",
         default=False,
-        description = "Enable planewave electronic structure" " calculations via SIRIUS",
+        description="Enable planewave electronic structure" " calculations via SIRIUS",
     )
-    variant(
-        "cosma",
-        default=False,
-        description="Use COSMA for p?gemm",
-    )
+    variant("cosma", default=False, description="Use COSMA for p?gemm",)
     variant(
         "libvori",
         default=False,
         description="Enable support for Voronoi integration" " and BQB compression",
     )
-    variant(
-        "spglib",
-        default=False,
-        description="Enable support for spglib",
-    )
+    variant("spglib", default=False, description="Enable support for spglib",)
     variant(
         "spla",
         default=False,
         description="Use SPLA off-loading functionality. Only relevant when CUDA or ROCM are enabled",
     )
-    variant(
-        "pytorch",
-        default=False,
-        description="Enable libtorch support",
-    )
-    variant(
-        "metis",
-        default=False,
-        description="Enable (par)metis support",
-    )
-    variant(
-        "quip",
-        default=False,
-        description=("Enable quip support"),
-    )
-    variant(
-        "superlu-dist",
-        default=False,
-        description=("Enable superlu support"),
-    )
+    variant("pytorch", default=False, description="Enable libtorch support",)
+    variant("metis", default=False, description="Enable (par)metis support",)
+    variant("quip", default=False, description=("Enable quip support"),)
+    variant("superlu-dist", default=False, description=("Enable superlu support"),)
 
     with when("+cuda"):
         variant(
@@ -840,13 +804,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value[0]
 
-            gpu_map = {
-                "35": "K40",
-                "37": "K80",
-                "60": "P100",
-                "70": "V100",
-                "80": "A100",
-            }
+            gpu_map = { "35": "K40", "37": "K80", "60": "P100", "70": "V100", "80": "A100",}
 
             gpuver = gpu_map[cuda_arch]
 
@@ -860,52 +818,52 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             args += ["-DCP2K_WITH_GPU={0}".format(gpuver), "-DCP2K_USE_ACCEL=hip"]
 
         args += [
-                self.define_from_variant("CP2K_USE_ELPA", "elpa"),
-                self.define_from_variant("CP2K_USE_LIBINT", "libint"),
-                self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
-                self.define_from_variant("CP2K_USE_SPLA", "spla"),
-                self.define_from_variant("CP2K_USE_COSMA", "cosma"),
-                self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
-            ]
+             self.define_from_variant("CP2K_USE_ELPA", "elpa"),
+             self.define_from_variant("CP2K_USE_LIBINT", "libint"),
+             self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
+             self.define_from_variant("CP2K_USE_SPLA", "spla"),
+             self.define_from_variant("CP2K_USE_COSMA", "cosma"),
+             self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
+        ]
 
         if spec.satisfies("+pytorch"):
             args += ["-DCP2K_USE_LIBTORCH=ON"]
 
         args += [
-                self.define_from_variant("CP2K_USE_METIS", "metis"),
-                self.define_from_variant("CP2K_USE_PLUMED", "plumed"),
-                self.define_from_variant("CP2K_USE_SPGLIB", "spglib"),
-                self.define_from_variant("CP2K_USE_VORI", "libvori"),
-                self.define_from_variant("CP2K_USE_SUPERLU", "superlu-dist"),
-                self.define_from_variant("CP2K_USE_SPLA", "spla"),
-                self.define_from_variant("CP2K_USE_QUIP", "quip"),
-            ]
+             self.define_from_variant("CP2K_USE_METIS", "metis"),
+             self.define_from_variant("CP2K_USE_PLUMED", "plumed"),
+             self.define_from_variant("CP2K_USE_SPGLIB", "spglib"),
+             self.define_from_variant("CP2K_USE_VORI", "libvori"),
+             self.define_from_variant("CP2K_USE_SUPERLU", "superlu-dist"),
+             self.define_from_variant("CP2K_USE_SPLA", "spla"),
+             self.define_from_variant("CP2K_USE_QUIP", "quip"),
+        ]
 
         # we force the use elpa openmp threading support. might need to be revisited though
         if (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or spec.satisfies("^elpa+openmp"):
-            args += [ "-DCP2K_ENABLE_ELPA_OPENMP_SUPPORT=ON" ]
+            args += ["-DCP2K_ENABLE_ELPA_OPENMP_SUPPORT=ON"]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
-            args += [ "-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON" ]
+            args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]
 
         if "fftw" in spec:
-            args += [ "-DCP2K_USE_FFTW=ON" ]
+            args += ["-DCP2K_USE_FFTW=ON"]
 
         with when("smm=libxsmm"):
-            args += [ "-DCP2K_USE_LIBXSMM=ON" ]
+            args += ["-DCP2K_USE_LIBXSMM=ON"]
 
         if spec["blas"].name in ["intel-mkl", "intel-parallel-studio", "cray-libsci", "openblas"]:
             if spec["blas"].name in ["intel-mkl", "intel-parallel-studio"]:
-                args += [ "-DCP2K_BLAS_VENDOR=MKL" ]
-                args += [ "-DCP2K_SCALAPACK_VENDOR=MKL" ]
+                args += ["-DCP2K_BLAS_VENDOR=MKL"]
+                args += ["-DCP2K_SCALAPACK_VENDOR=MKL"]
 
             if "^cray-libsci" in spec:
-                args += [ "-DCP2K_BLAS_VENDOR=SCI" ]
-                args += [ "-DCP2K_SCALAPACK_VENDOR=SCI" ]
+                args += ["-DCP2K_BLAS_VENDOR=SCI"]
+                args += ["-DCP2K_SCALAPACK_VENDOR=SCI"]
 
             if "^openblas" in spec:
-                args += [ "-DCP2K_BLAS_VENDOR=OpenBLAS" ]
-                args += [ "-DCP2K_SCALAPACK_VENDOR=GENERIC" ]
+                args += ["-DCP2K_BLAS_VENDOR=OpenBLAS"]
+                args += ["-DCP2K_SCALAPACK_VENDOR=GENERIC"]
         else:
             lapack = spec["lapack"]
             blas = spec["blas"]
@@ -918,9 +876,12 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                     self.define("CP2K_BLAS_LINK_LIBRARIES", blas.libs.joined(";")),
                     self.define("CP2K_SCALAPACK_FOUND", "true"),
                     self.define("CP2K_SCALAPACK_INCLUDE_DIRS", spec["scalapack"].prefix.include),
-                    self.define("CP2K_SCALAPACK_LINK_LIBRARIES", spec["scalapack"].libs.joined(";")),
+                    self.define(
+                        "CP2K_SCALAPACK_LINK_LIBRARIES", spec["scalapack"].libs.joined(";")
+                    ),
                 ]
             )
 
         return args
+
     pass

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -868,7 +868,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         if "+rocm" in spec:
             if len(spec.variants["amdgpu_target"].value) > 1:
-                raise InstallError("CP2K supports only one amdgpu_target at a time")
+                raise InstallError("CP2K supports only one amdgpu_target at a time.")
             else:
                 gpu_ver = gpu_map[spec.variants["amdgpu_target"].value[0]]
                 args += ["-DCP2K_USE_ACCEL=HIP"]

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -259,12 +259,13 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     # from the parent class, since the parent class defines constraints for all
     # versions. Instead just mark all unsupported cuda archs as conflicting.
 
-    supported_cuda_arch_list = ("35", "37", "60", "70")
+    supported_cuda_arch_list = ("35", "37", "60", "70", "80")
     gpu_map = {
         "35": "K40",
         "37": "K80",
         "60": "P100",
         "70": "V100",
+        "80": "A100",
         "gfx906": "Mi50",
         "gfx908": "Mi100",
         "gfx90a": "Mi250x",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -638,7 +638,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
             if cuda_arch == "35" and spec.satisfies("+cuda_arch_35_k20x"):
                 gpuver = "K20X"
 
-        if spec.satisfies(+rocm) and spec.satisfies("@2022:"):
+        if "@2022: +rocm" in spec:
             libs += [
                 "-L{}".format(spec["rocm"].libs.directories[0]),
                 "-L{}/stubs".format(spec["rocm"].libs.directories[0]),

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -91,6 +91,14 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     variant("pytorch", default=False, description="Enable libtorch support")
     variant("quip", default=False, description=("Enable quip support"))
 
+    variant(
+        "enable_regtests",
+        default=False,
+        description="Configure cp2k to run the regtests afterwards."
+        " It build cp2k normally but put the executables in exe/cmake-build-* instead of the"
+        " conventional location. This option is only relevant when regtests need to be run.",
+    )
+
     with when("+cuda"):
         variant(
             "cuda_arch_35_k20x",
@@ -849,6 +857,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             args += ["-DCP2K_USE_ACCEL=hip"]
 
         args += [
+            self.define_from_variant("CP2K_ENABLE_REGTESTS", "enable_regtests"),
             self.define_from_variant("CP2K_USE_ELPA", "elpa"),
             self.define_from_variant("CP2K_USE_LIBINT2", "libint"),
             self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -908,11 +908,11 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         else:
             args.extend(
                 [
-                    self.define("CP2K_LAPACK_FOUND", "true"),
+                    self.define("CP2K_LAPACK_FOUND", True),
                     self.define("CP2K_LAPACK_LINK_LIBRARIES", lapack.libs.joined(";")),
-                    self.define("CP2K_BLAS_FOUND", "true"),
+                    self.define("CP2K_BLAS_FOUND", True),
                     self.define("CP2K_BLAS_LINK_LIBRARIES", blas.libs.joined(";")),
-                    self.define("CP2K_SCALAPACK_FOUND", "true"),
+                    self.define("CP2K_SCALAPACK_FOUND", True),
                     self.define("CP2K_SCALAPACK_INCLUDE_DIRS", spec["scalapack"].prefix.include),
                     self.define("CP2K_BLAS_VENDOR", "CUSTOM"),
                     self.define("CP2K_SCALAPACK_VENDOR", "GENERIC"),

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -269,16 +269,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     # versions. Instead just mark all unsupported cuda archs as conflicting.
 
     supported_cuda_arch_list = ("35", "37", "60", "70", "80")
-    supported_rocm_arch_list = (
-        "60",
-        "70",
-        "80",
-        "gfx906",
-        "gfx908",
-        "gfx90a",
-        "gfx90a:xnack-",
-        "gfx90a:xnack+",
-    )
+    supported_rocm_arch_list = ("gfx906", "gfx908", "gfx90a", "gfx90a:xnack-", "gfx90a:xnack+")
     gpu_map = {
         "35": "K40",
         "37": "K80",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -85,7 +85,8 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     variant(
         "spla",
         default=False,
-        description="Use SPLA off-loading functionality. Only relevant when CUDA or ROCM are enabled",
+        description="Use SPLA off-loading functionality. Only relevant when CUDA or ROCM"
+        " are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
     variant("quip", default=False, description="Enable quip support")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -623,7 +623,8 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
                     cppflags += ["-D__PW_CUDA"]
                     libs += ["-lcufft", "-lcublas"]
 
-            gpuver = gpu_map[spec.variants["cuda_arch"].value]
+            cuda_arch = spec.variants["cuda_arch"].value[0]
+            gpuver = gpu_map[cuda_arch]
             if cuda_arch == "35" and spec.satisfies("+cuda_arch_35_k20x"):
                 gpuver = "K20X"
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -173,13 +173,13 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
             )
 
     with when("+libxc"):
-        depends_on("pkgconfig", type="build", when="@7.0:")
-        depends_on("libxc@2.2.2:3", when="@:5", type="build")
-        depends_on("libxc@4.0.3:4", when="@6.0:6.9", type="build")
+        depends_on("pkgconfig", when="@7.0:")
+        depends_on("libxc@2.2.2:3", when="@:5")
+        depends_on("libxc@4.0.3:4", when="@6.0:6.9")
         depends_on("libxc@4.0.3:4", when="@7.0:8.1")
         depends_on("libxc@5.1.3:5.1", when="@8.2:8")
-        depends_on("libxc@5.1.7:5.1", when="@9:2022")
-        depends_on("libxc@6:6.1", when="@2023:", type=("build"))
+        depends_on("libxc@5.1.7:5.1", when="@9:2022.2")
+        depends_on("libxc@6.1:", when="@2023.1:")
 
     with when("+mpi"):
         depends_on("mpi@2:")
@@ -187,7 +187,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         depends_on("scalapack")
 
     with when("+cosma"):
-        depends_on("cosma+scalapack", type=("build"))
+        depends_on("cosma+scalapack")
         depends_on("cosma@2.5.1:", when="@9:")
         depends_on("cosma@2.6.3:", when="@master:")
         depends_on("cosma+cuda", when="+cuda")
@@ -231,29 +231,29 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         conflicts("@:6")
 
     with when("+libvori"):
-        depends_on("libvori@201219:", when="@8.1", type=("build"))
-        depends_on("libvori@210412:", when="@8.2:", type=("build"))
-        depends_on("libvori@220621:", when="@2023.1:", type=("build"))
+        depends_on("libvori@201219:", when="@8.1")
+        depends_on("libvori@210412:", when="@8.2:")
+        depends_on("libvori@220621:", when="@2023.1:")
         # libvori support was introduced in 8+
         conflicts("@:7")
 
     # the bundled libcusmm uses numpy in the parameter prediction (v7+)
     # which is written using Python 3
-    depends_on("py-numpy", when="@7:+cuda", type="build")
-    depends_on("python@3.6:", when="@7:+cuda", type="build")
+    depends_on("py-numpy", when="@7:+cuda")
+    depends_on("python@3.6:", when="@7:+cuda")
 
     depends_on("spglib", when="+spglib")
 
     # Apparently cp2k@4.1 needs an "experimental" version of libwannier.a
     # which is only available contacting the developer directly. See INSTALL
     # in the stage of cp2k@4.1
-    depends_on("wannier90", when="@3.0+mpi", type="build")
+    depends_on("wannier90", when="@3.0+mpi")
 
     with when("build_system=cmake"):
         depends_on("dbcsr")
-        depends_on("dbcsr+openmp", when="+openmp", type=("build"))
-        depends_on("dbcsr+cuda", when="+cuda", type=("build"))
-        depends_on("dbcsr+rocm", when="+rocm", type=("build"))
+        depends_on("dbcsr+openmp", when="+openmp")
+        depends_on("dbcsr+cuda", when="+cuda")
+        depends_on("dbcsr+rocm", when="+rocm")
 
     # CP2K needs compiler specific compilation flags, e.g. optflags
     conflicts("%apple-clang")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -89,7 +89,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         " relevant when CUDA or ROCM are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
-    variant("quip", default=False, description=("Enable quip support"))
+    variant("quip", default=False, description="Enable quip support")
 
     variant(
         "enable_regtests",

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -282,7 +282,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         "gfx90a:xnack+": "Mi250",
     }
     cuda_msg = "cp2k only supports cuda_arch {0}".format(supported_cuda_arch_list)
-    rocm_msg = "cp2k only supports andgpu_target {0}".format(supported_rocm_arch_list)
+    rocm_msg = "cp2k only supports amdgpu_target {0}".format(supported_rocm_arch_list)
 
     conflicts("+cuda", when="cuda_arch=none")
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -268,7 +268,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         "80": "A100",
         "gfx906": "Mi50",
         "gfx908": "Mi100",
-        "gfx90a": "Mi250x",
+        "gfx90a": "Mi250",
     }
     cuda_msg = "cp2k only supports cuda_arch {0}".format(supported_cuda_arch_list)
 
@@ -850,7 +850,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         args += [
             self.define_from_variant("CP2K_USE_ELPA", "elpa"),
-            self.define_from_variant("CP2K_USE_LIBINT", "libint"),
+            self.define_from_variant("CP2K_USE_LIBINT2", "libint"),
             self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
             self.define_from_variant("CP2K_USE_SPLA", "spla"),
             self.define_from_variant("CP2K_USE_COSMA", "cosma"),

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -85,8 +85,7 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
     variant(
         "spla",
         default=False,
-        description="Use SPLA off-loading functionality. Only"
-        " relevant when CUDA or ROCM are enabled",
+        description="Use SPLA off-loading functionality. Only relevant when CUDA or ROCM are enabled",
     )
     variant("pytorch", default=False, description="Enable libtorch support")
     variant("quip", default=False, description="Enable quip support")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -875,10 +875,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         ]
 
         # we force the use elpa openmp threading support. might need to be revisited though
-        if (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or spec.satisfies(
-            "^elpa+openmp"
-        ):
-            args += ["-DCP2K_ENABLE_ELPA_OPENMP_SUPPORT=ON"]
+        args += [self.define("CP2K_ENABLE_ELPA_OPENMP_SUPPORT",
+                 (spec.satisfies("+openmp") and spec.satisfies("+elpa")) or
+                 spec.satisfies("^elpa+openmp"))]
 
         if "spla" in spec and (spec.satisfies("+cuda") or spec.satisfies("+rocm")):
             args += ["-DCP2K_USE_SPLA_GEMM_OFFLOADING=ON"]

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -864,12 +864,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("CP2K_USE_SPLA", "spla"),
             self.define_from_variant("CP2K_USE_COSMA", "cosma"),
             self.define_from_variant("CP2K_USE_LIBXC", "libxc"),
-        ]
-
-        if spec.satisfies("+pytorch"):
-            args += ["-DCP2K_USE_LIBTORCH=ON"]
-
-        args += [
+            self.define_from_variant("CP2K_USE_LIBTORCH", "pytorch"),
             self.define_from_variant("CP2K_USE_METIS", "pexsi"),
             self.define_from_variant("CP2K_USE_SUPERLU", "pexsi"),
             self.define_from_variant("CP2K_USE_PLUMED", "plumed"),

--- a/var/spack/repos/builtin/packages/libvori/package.py
+++ b/var/spack/repos/builtin/packages/libvori/package.py
@@ -12,7 +12,7 @@ class Libvori(CMakePackage):
     homepage = "https://brehm-research.de/voronoi.php"
     url = "https://www.cp2k.org/static/downloads/libvori-201217.tar.gz"
 
-    maintainers("dev-zero")
+    maintainers("dev-zero", "mtaillefumier")
 
     version("220621", sha256="1cfa98c564814bddacf1c0e7f11582137d758668f6307e6eb392c72317984c14")
     version("210412", sha256="331886aea9d093d8c44b95a07fab13d47f101b1f94a0640d7d670eb722bf90ac")

--- a/var/spack/repos/builtin/packages/py-fypp/package.py
+++ b/var/spack/repos/builtin/packages/py-fypp/package.py
@@ -12,6 +12,7 @@ class PyFypp(PythonPackage):
     homepage = "https://github.com/aradi/fypp"
     url = "https://github.com/aradi/fypp/archive/2.1.1.zip"
 
+    version("3.1", sha256="bac9d02be308b6bff7fd17da835f01fb9ce9b2dddaaad1ccd22ac7628b2dc53c")
     version("2.1.1", sha256="3744ad17045e91466bbb75a33ce0cab0f65bc2c377127067a932cdf15655e049")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Offers the possibility to build cp2k with the new cmake build system. commands like this are now supported

spack install cp2k@master build_system=cmake +.....

the recipe supports the following optional functionalities

- superlu, cosma, sirius, spglib, metis, spglib, libxc, libint, cuda/rocm, mkl/openblas/sci (and others), mpi, openmp, dbcsr
- dbcsr is built separately using the currently available recipe.

Two PRs need to be merged to be fully functional (cosma update in spack + one PR in cp2k github).

NB : to be fully functional two PRs need to be merged https://github.com/spack/spack/pull/35615 and one in cp2k repo. It is a temporary limitation at that point but I would like to receive feedback about recipe independently of the two PRs.

limitations are +cosma and +plumed are not properly working: +cosma is fixed (fix by https://github.com/spack/spack/pull/35615), +plumed is a typo in cp2k cmake build system. It is also better to use the cmake build system with the current master as it includes important fix for the cmake build system.

