### PR TITLE
rocm-tensile: fix tensile_architecture variant

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -250,6 +250,7 @@ class RocmTensile(CMakePackage):
             self.define("Tensile_LOGIC", "asm_full"),
             self.define("Tensile_CODE_OBJECT_VERSION", "V3"),
             self.define("Boost_USE_STATIC_LIBS", "OFF"),
+            self.define_from_variant("TENSILE_USE_OPENMP", "openmp"),
             self.define("BUILD_WITH_TENSILE_HOST", "ON" if "@3.7.0:" in self.spec else "OFF"),
         ]
 

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -265,9 +265,13 @@ class RocmTensile(CMakePackage):
             args.append(self.define("TENSILE_USE_OPENMP", "OFF")),
 
         if self.spec.satisfies("^cmake@3.21.0:"):
-            args.append(self.define("CMAKE_HIP_ARCHITECTURES", self.get_gpulist_for_tensile_support()))
+            args.append(
+                self.define("CMAKE_HIP_ARCHITECTURES", self.get_gpulist_for_tensile_support())
+            )
         else:
-            args.append(self.define("Tensile_ARCHITECTURE", self.get_gpulist_for_tensile_support()))
+            args.append(
+                self.define("Tensile_ARCHITECTURE", self.get_gpulist_for_tensile_support())
+            )
 
         if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
             args.append(self.define("__skip_rocmclang", "ON"))

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -244,7 +244,6 @@ class RocmTensile(CMakePackage):
             return arch
 
     def cmake_args(self):
-        arches = 
         args = [
             self.define("amd_comgr_DIR", self.spec["comgr"].prefix),
             self.define("Tensile_COMPILER", "hipcc"),

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -244,6 +244,7 @@ class RocmTensile(CMakePackage):
             return arch
 
     def cmake_args(self):
+        arches = 
         args = [
             self.define("amd_comgr_DIR", self.spec["comgr"].prefix),
             self.define("Tensile_COMPILER", "hipcc"),
@@ -264,7 +265,10 @@ class RocmTensile(CMakePackage):
         else:
             args.append(self.define("TENSILE_USE_OPENMP", "OFF")),
 
-        args.append(self.define("Tensile_ARCHITECTURE", self.get_gpulist_for_tensile_support()))
+        if self.spec.satisfies("^cmake@3.21.0:"):
+            args.append(self.define("CMAKE_HIP_ARCHITECTURES", self.get_gpulist_for_tensile_support()))
+        else:
+            args.append(self.define("Tensile_ARCHITECTURE", self.get_gpulist_for_tensile_support()))
 
         if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
             args.append(self.define("__skip_rocmclang", "ON"))


### PR DESCRIPTION
The AMD GPU architectures to build is now passed into CMake using the new `CMAKE_HIP_ARCHITECTURES` flag, available since CMake 3.21.