### PR TITLE
Fix superlu-dist package for cray fortran

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -72,7 +72,7 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
 
     patch("xl-611.patch", when="@:6.1.1 %xl")
     patch("xl-611.patch", when="@:6.1.1 %xl_r")
-    patch("superlu-cray-ftn-case.patch", when="@7.1.1: %cce")
+    patch("superlu-cray-ftn-case.patch", when="@7.1.1 %cce")
     patch("CMAKE_INSTALL_LIBDIR.patch", when="@7.0.0:7.2.0")
 
     def cmake_args(self):


### PR DESCRIPTION
The superlu-dist code developers the build such that the patch is no longer needer for `@7.2.0:`  (the patch will actually fail)