### PR TITLE
tests/ginkgo: converted to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import re
 import sys
 
 from spack.package import *
@@ -181,8 +180,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         src_dir = self._cached_tests_src_dir(script)
 
         cmake_args = [
-            "-DCMAKE_C_COMPILER={0}".format(self.compiler.cc),
-            "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
+            f"-DCMAKE_C_COMPILER={os.environ['CC']}",
+            f"-DCMAKE_CXX_COMPILER={os.environ['CXX']}",
             src_dir,
         ]
 
@@ -200,13 +199,11 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             cmakelists.write(data)
             cmakelists.close()
 
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        make = which("make")
         with working_dir(src_dir):
-            cmake = which(self.spec["cmake"].prefix.bin.cmake)
             cmake(*cmake_args)
-
-            make = which("make")
             make()
-
             exe = which(script)
             output = exe(output=str.split, error=str.split)
             assert "correctly detected and is complete" in output

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 import sys
 
 from spack.package import *
@@ -15,6 +16,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://ginkgo-project.github.io/"
     git = "https://github.com/ginkgo-project/ginkgo.git"
+
+    test_requires_compiler = True
 
     maintainers("tcojean", "hartwiganzt")
 
@@ -160,33 +163,32 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
                 )
         return args
 
-    extra_install_tests = join_path("test", "test_install")
+    @property
+    def extra_install_tests(self):
+        return "test_install" if self.spec.satisfies("@1.3.0") else "test"
 
     @run_after("install")
     def cache_test_sources(self):
         self.cache_extra_test_sources(self.extra_install_tests)
 
-    @property
-    def _cached_tests_src_dir(self):
-        """The cached smoke test source directory."""
-        return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
+    def _cached_tests_src_dir(self, script):
+        """The cached smoke test source directory for the script."""
+        subdir = script if self.spec.satisfies("@1.4.0:") else ""
+        return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests, subdir)
 
-    @property
-    def _cached_tests_work_dir(self):
-        """The working directory for cached test sources."""
-        return join_path(self._cached_tests_src_dir, "build")
+    def _build_and_run_test(self, script):
+        """Build and run the test against the installation."""
+        src_dir = self._cached_tests_src_dir(script)
 
-    def _build_test(self):
-        cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
         cmake_args = [
             "-DCMAKE_C_COMPILER={0}".format(self.compiler.cc),
             "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
-            self._cached_tests_src_dir,
+            src_dir,
         ]
 
         # Fix: For HIP tests, add the ARCH compilation flags when not present
         if "+rocm" in self.spec:
-            src_path = join_path(self._cached_tests_src_dir, "CMakeLists.txt")
+            src_path = join_path(src_dir, "CMakeLists.txt")
             cmakelists = open(src_path, "rt")
             data = cmakelists.read()
             data = data.replace(
@@ -198,43 +200,41 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             cmakelists.write(data)
             cmakelists.close()
 
-        if not self.run_test(
-            cmake_bin,
-            options=cmake_args,
-            purpose="Generate the Makefile",
-            work_dir=self._cached_tests_work_dir,
-        ):
-            print("Skipping Ginkgo test: failed to generate Makefile")
-            return
+        with working_dir(src_dir):
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(*cmake_args)
 
-        if not self.run_test(
-            "make", purpose="Build test software", work_dir=self._cached_tests_work_dir
-        ):
-            print("Skipping Ginkgo test: failed to build test")
-            return
+            make = which("make")
+            make()
 
-    def test(self):
-        """Run the smoke tests."""
-        # For now only 1.4.0 and later releases support this scheme.
-        if self.spec.satisfies("@:1.3.0"):
-            print("SKIPPED: smoke tests not supported with this Ginkgo version.")
-            return
+            exe = which(script)
+            output = exe(output=str.split, error=str.split)
+            assert "correctly detected and is complete" in output
 
-        self._build_test()
+    def test_install(self):
+        """build, run and check results of test_install"""
+        if not self.spec.satisfies("@1.3.0:"):
+            raise SkipTest("Test is only available for v1.3.0:")
 
-        # Perform the test(s) created by setup_build_tests.
-        files = [
-            ("test_install", [r"REFERENCE", r"correctly detected and is complete"]),
-            ("test_install_cuda", [r"CUDA", r"correctly detected and is complete"]),
-            ("test_install_hip", [r"HIP", r"correctly detected and is complete"]),
-        ]
-        for f, expected in files:
-            self.run_test(
-                f,
-                [],
-                expected,
-                skip_missing=True,
-                installed=False,
-                purpose="test: Running {0}".format(f),
-                work_dir=self._cached_tests_work_dir,
-            )
+        self._build_and_run_test("test_install")
+
+    def test_install_cuda(self):
+        """build, run and check results of test_install_cuda"""
+        if not self.spec.satisfies("@1.4.0: +cuda"):
+            raise SkipTest("Test is only available for v1.4.0: +cuda")
+
+        self._build_and_run_test("test_install_cuda")
+
+    def test_install_hip(self):
+        """build, run and check results of test_install_hip"""
+        if not self.spec.satisfies("@1.4.0: +rocm"):
+            raise SkipTest("Test is only available for v1.4.0: +rocm")
+
+        self._build_and_run_test("test_install_hip")
+
+    def test_exportbuild(self):
+        """build, run and check results of test_exportbuild"""
+        if not self.spec.satisfies("@1.4.0:"):
+            raise SkipTest("Test is only available for v1.4.0:")
+
+        self._build_and_run_test("test_exportbuild")


### PR DESCRIPTION
Converted the stand-alone tests to the new process.

```
$ spack -v test run ginkgo
==> Testing package ginkgo-1.5.0-cc6dhae
==> [2023-05-24-16:28:36.172977] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/ginkgo-1.5.0-cc6dhaeu6aqxa3emvpsirxzonsg7gwaw/.spack/test to $SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo
==> [2023-05-24-16:28:36.737008] test: test_exportbuild: build, run and check results of test_exportbuild
==> [2023-05-24-16:28:36.742501] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '-DCMAKE_C_COMPILER=$SPACK_ROOT/lib/spack/env/gcc/gcc' '-DCMAKE_CXX_COMPILER=$SPACK_ROOT/lib/spack/env/gcc/g++' '$SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo/test/test_exportbuild'
-- The CXX compiler identification is GNU 10.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Configuring done (2.2s)
-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_C_COMPILER


-- Build files have been written to: $SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo/test/test_exportbuild
==> [2023-05-24-16:28:39.061580] '/usr/bin/make'
[ 50%] Building CXX object CMakeFiles/test_exportbuild.dir$SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo/test/test_install/test_install.cpp.o
[100%] Linking CXX executable test_exportbuild
[100%] Built target test_exportbuild
==> [2023-05-24-16:28:52.576772] './test_exportbuild'
test_install(REFERENCE): the Ginkgo installation was correctly detected and is complete.
PASSED: Ginkgo::test_exportbuild
==> [2023-05-24-16:28:52.626714] test: test_install: build, run and check results of test_install
==> [2023-05-24-16:28:52.629179] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '-DCMAKE_C_COMPILER=$SPACK_ROOT/lib/spack/env/gcc/gcc' '-DCMAKE_CXX_COMPILER=$SPACK_ROOT/lib/spack/env/gcc/g++' '$SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo/test/test_install'
-- The CXX compiler identification is GNU 10.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - NOTFOUND
-- Configuring done (2.5s)
-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_C_COMPILER


-- Build files have been written to: $SPACK_TEST_ROOT/5qaysgwr4pxrfogpzdstbxizzypt4eb3/ginkgo-1.5.0-cc6dhae/cache/ginkgo/test/test_install
==> [2023-05-24-16:28:55.204120] '/usr/bin/make'
[ 50%] Building CXX object CMakeFiles/test_install.dir/test_install.cpp.o
[100%] Linking CXX executable test_install
[100%] Built target test_install
==> [2023-05-24-16:29:09.023419] './test_install'
test_install(REFERENCE): the Ginkgo installation was correctly detected and is complete.
PASSED: Ginkgo::test_install
==> [2023-05-24-16:29:09.074838] test: test_install_cuda: build, run and check results of test_install_cuda
SKIPPED: Ginkgo::test_install_cuda: Test is only available for v1.4.0: +cuda
==> [2023-05-24-16:29:09.075855] test: test_install_hip: build, run and check results of test_install_hip
SKIPPED: Ginkgo::test_install_hip: Test is only available for v1.4.0: +rocm
==> [2023-05-24-16:29:09.078402] Completed testing
==> [2023-05-24-16:29:09.078525] 
======================== SUMMARY: ginkgo-1.5.0-cc6dhae =========================
Ginkgo::test_exportbuild .. PASSED
Ginkgo::test_install .. PASSED
Ginkgo::test_install_cuda .. SKIPPED
Ginkgo::test_install_hip .. SKIPPED
======================== 2 passed, 2 skipped of 4 parts ========================
============================== 1 passed of 1 spec =============================
```