### PR TITLE
BinaryCache: Add SHA256 and ETag to spackfile

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -821,13 +821,7 @@ def _url_etag_group(url):
     if isinstance(url, str):
         parsed_url = urllib.parse.urlparse(url)
 
-    if parsed_url.scheme == "s3":
-        return "s3"
-    if parsed_url.scheme == "file":
-        return "file"
-    else:
-        return parsed_url.host()
-
+    return "{0}://{1}".format(parsed_url.sheme, parsed_url.netloc)
 
 def select_signing_key(key=None):
     if key is None:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -821,7 +821,12 @@ def _url_etag_group(url):
     if isinstance(url, str):
         parsed_url = urllib.parse.urlparse(url)
 
-    return parsed_url.geturl()
+    if parsed_url.scheme == "s3":
+        return "s3"
+    if parsed_url.scheme == "file":
+        return "file"
+    else:
+        return parsed_url.host()
 
 
 def select_signing_key(key=None):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -823,6 +823,7 @@ def _url_etag_group(url):
 
     return "{0}://{1}".format(parsed_url.sheme, parsed_url.netloc)
 
+
 def select_signing_key(key=None):
     if key is None:
         keys = spack.util.gpg.signing_keys()

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -118,7 +118,7 @@ def read_from_url(url, accept_content_type=None):
 
 def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
     """Push file to URL and get back the ETag of the remote file if supported by
-       remote location.
+    remote location.
     """
     remote_url = urllib.parse.urlparse(remote_path)
     if remote_url.scheme == "file":
@@ -154,7 +154,8 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
             Body=open(local_file_path, "rb"),
             Bucket=remote_url.netloc,
             Key=remote_path,
-            **extra_args)
+            **extra_args,
+        )
 
         if not keep_original:
             os.remove(local_file_path)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -841,7 +841,8 @@ def read_etag(url):
             raise FetchError("Could not obtain etag or s3 resource")
         return parse_etag(obj["ETag"])
     elif remote_url.scheme == "file":
-        return hashlib.md5(open(remote_url.path, "rb").read()).hexdigest()
+        remote_url_path = url_util.file_url_string_to_path(url)
+        return spack.util.crypto.checksum(hashlib.md5, remote_url_path)
     else:
         # TODO: Add a better way for handling getting etag from
         # different resource hosts.


### PR DESCRIPTION
This PR adds the extra SHA256 attribute to uploaded spack file binaries and gets the ETag from the binary after being moved to the binary cache. Currently only `file://` and `s3://` support getting the ETag of binaries in the build cache.

This PR is a first step to adding a `spack buildcache validation` method.

FYI: @tgamblin @scottwittenburg @haampie @alalazo 