### PR TITLE
tests/hdf5: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -556,6 +556,12 @@ class Hdf5(CMakePackage):
     def setup_build_environment(self, env):
         env.set("SZIP_INSTALL", self.spec["szip"].prefix)
 
+    def setup_run_environment(self, env):
+        # According to related github posts and problems running test_install
+        # as a stand-alone test, it appears the lib path must be added to
+        # LD_LIBRARY_PATH.
+        env.append_path("LD_LIBRARY_PATH", self.prefix.lib)
+
     @run_before("cmake")
     def fortran_check(self):
         if "+fortran" in self.spec and not self.compiler.fc:
@@ -689,9 +695,9 @@ class Hdf5(CMakePackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_install(self):
-        self._check_install()
+        self.test_install()
 
-    def _check_install(self):
+    def test_install(self):
         # Build and run a small program to test the installed HDF5 library
         spec = self.spec
         print("Checking HDF5 installation...")
@@ -768,7 +774,7 @@ HDF5 version {version} {version}
                 raise RuntimeError("HDF5 install check failed")
         shutil.rmtree(checkdir)
 
-    def _test_check_versions(self):
+    def test_check_version(self):
         """Perform version checks on selected installed package binaries."""
         spec_vers_str = "Version {0}".format(self.spec.version)
         if "develop" in spec_vers_str:
@@ -789,55 +795,33 @@ HDF5 version {version} {version}
         ]
         use_short_opt = ["h52gif", "h5repart", "h5unjam"]
         for exe in exes:
-            reason = "test: ensuring version of {0} is {1}".format(exe, spec_vers_str)
+            reason = "ensure version of {0} is {1}".format(exe, spec_vers_str)
             option = "-V" if exe in use_short_opt else "--version"
-            self.run_test(
-                exe, option, spec_vers_str, installed=True, purpose=reason, skip_missing=True
-            )
+            with test_part(self, "test_check_version_{0}".format(exe), purpose=reason):
+                path = join_path(self.prefix.bin, exe)
+                if not os.path.isfile(path):
+                    raise SkipTest("{0} is not installed".format(path))
 
-    def _test_example(self):
-        """This test performs copy, dump, and diff on an example hdf5 file."""
+                prog = which(exe_path)
+                output = prog(option, output=str.split, error=str.split)
+                assert spec_vers_str in output
+
+    def test_example(self):
+        """copy, dump, and diff example hdf5 file"""
         test_data_dir = self.test_suite.current_test_data_dir
 
-        filename = "spack.h5"
-        h5_file = test_data_dir.join(filename)
+        with working_dir(test_data_dir, create=True):
+            filename = "spack.h5"
+            h5dump = which(join_path(self.prefix.bin, "h5dump"))
+            out = h5dump(filename, output=str.split, error=str.split)
+            expected = get_escaped_text_output("dump.out")
+            for exp in expected:
+                assert re.search(exp, out), "Expected '{0}' in output".format(exp)
 
-        reason = "test: ensuring h5dump produces expected output"
-        expected = get_escaped_text_output(test_data_dir.join("dump.out"))
-        self.run_test(
-            "h5dump",
-            filename,
-            expected,
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=test_data_dir,
-        )
+            h5copy = which(join_path(self.prefix.bin, "h5copy"))
+            copyname = "test.h5"
+            options = ["-i", filename, "-s", "Spack", "-o", copyname, "-d", "Spack"]
+            h5copy(*options)
 
-        reason = "test: ensuring h5copy runs"
-        options = ["-i", h5_file, "-s", "Spack", "-o", "test.h5", "-d", "Spack"]
-        self.run_test(
-            "h5copy", options, [], installed=True, purpose=reason, skip_missing=True, work_dir="."
-        )
-
-        reason = "test: ensuring h5diff shows no differences between orig and" " copy"
-        self.run_test(
-            "h5diff",
-            [h5_file, "test.h5"],
-            [],
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=".",
-        )
-
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        # Simple version check tests on known binaries
-        self._test_check_versions()
-
-        # Run sequence of commands on an hdf5 file
-        self._test_example()
-
-        # Run existing install check
-        self._check_install()
+            h5diff = which(join_path(self.prefix.bin, "h5diff"))
+            h5diff(filename, copyfile)


### PR DESCRIPTION
Convert the stand-alone tests to use the new process.

Results for the latest and develop (see TBD for complete outputs):
```
$ spack -v test run hdf5
==> Spack test edohcbwphwl77uhwd3lml335bluch3pi
==> Testing package hdf5-1.14.1-2-fuew4wj
==> [2023-05-24-17:06:11.586449] test: test_check_prog: build, run and check output of check.c
Checking HDF5 installation...
...
==> [2023-05-24-17:06:12.300258] Completed testing
==> [2023-05-24-17:06:12.300418] 
======================== SUMMARY: hdf5-1.14.1-2-fuew4wj ========================
Hdf5::test_check_prog .. PASSED
Hdf5::test_example .. PASSED
Hdf5::test_version_h5copy .. PASSED
Hdf5::test_version_h5diff .. PASSED
Hdf5::test_version_h5dump .. PASSED
Hdf5::test_version_h5format_convert .. PASSED
Hdf5::test_version_h5ls .. PASSED
Hdf5::test_version_h5mkgrp .. PASSED
Hdf5::test_version_h5repack .. PASSED
Hdf5::test_version_h5stat .. PASSED
Hdf5::test_version_h5unjam .. PASSED
Hdf5::test_version .. PASSED
============================ 12 passed of 12 parts =============================
==> Testing package hdf5-develop-1.15-kwr5rsx
...
==> [2023-05-24-17:06:13.971900] Completed testing
==> [2023-05-24-17:06:13.972049] 
====================== SUMMARY: hdf5-develop-1.15-kwr5rsx ======================
Hdf5::test_check_prog .. PASSED
Hdf5::test_example .. PASSED
Hdf5::test_version_h5copy .. PASSED
Hdf5::test_version_h5diff .. PASSED
Hdf5::test_version_h5dump .. PASSED
Hdf5::test_version_h5format_convert .. PASSED
Hdf5::test_version_h5ls .. PASSED
Hdf5::test_version_h5mkgrp .. PASSED
Hdf5::test_version_h5repack .. PASSED
Hdf5::test_version_h5stat .. PASSED
Hdf5::test_version_h5unjam .. PASSED
Hdf5::test_version .. PASSED
============================ 12 passed of 12 parts =============================
============================= 2 passed of 2 specs ==============================
```