### PR TITLE
qwt: lift restrictions on qt version and added an opengl variant and VisIt use

### DIFF
--- a/var/spack/repos/builtin/packages/qwt/no-opengl_6_1.patch
+++ b/var/spack/repos/builtin/packages/qwt/no-opengl_6_1.patch
@@ -1,0 +1,12 @@
+diff -Naur qwt-6.1.4_orig/qwtconfig.pri qwt-6.1.4_dest/qwtconfig.pri
+--- qwt-6.1.4_orig/qwtconfig.pri	2019-01-02 17:21:31.556467499 +0100
++++ qwt-6.1.4_dest/qwtconfig.pri	2023-02-24 12:21:06.730207447 +0100
+@@ -99,7 +99,7 @@
+ # If you want to use a OpenGL plot canvas
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtOpenGL
++#QWT_CONFIG     += QwtOpenGL
+ 
+ ######################################################################
+ # You can use the MathML renderer of the Qt solutions package to

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -23,11 +23,18 @@ class Qwt(QMakePackage):
     version("5.2.2", sha256="36bf2ee51ca9c74fde1322510ffd39baac0db60d5d410bb157968a78d9c1464b")
 
     variant("designer", default=False, description="Build extensions to QT designer")
+    variant("opengl", default=False, description="Build OpenGL plot canvas")
 
     patch("no-designer.patch", when="~designer")
+    patch("no-opengl_6_1.patch", when="@6.1 ~opengl")
 
-    depends_on("qt@:5.14.2+opengl")
     depends_on("qt+tools", when="+designer")
+    depends_on("qt+opengl", when="+opengl")
+
+    depends_on("qt")
+    # the qt@5.14.2 limitation was lifted in qwt@6.1.5
+    # https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1
+    depends_on("qt@:5.14.2", when="@:6.1.4")
     # Qwt 6.1.1 and older use a constant that was removed in Qt 5.4
     # https://bugs.launchpad.net/ubuntu/+source/qwt-qt5/+bug/1485213
     depends_on("qt@:5.3", when="@:6.1.1")

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -124,7 +124,7 @@ class Visit(CMakePackage):
 
     # VisIt doesn't work with later versions of qt.
     depends_on("qt+gui+opengl@5:5.14", when="+gui")
-    depends_on("qwt", when="+gui")
+    depends_on("qwt+opengl", when="+gui")
 
     # python@3.8 doesn't work with VisIt.
     depends_on("python@3.2:3.7", when="+python")


### PR DESCRIPTION
- qwt prior to 6.1.5 was limited to qt@5.14, which was reflected in the recipe; this limitation is lifted for versions >= 6.1.5
https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1
- added an `opengl` variant with a patch to disable it in the qwtconfig.pri file, similar to what has been done for designer,  that allows building against a `qt~opengl`