### PR TITLE
Separate concretization of build dependencies (iterative)

### DIFF
--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -11,7 +11,7 @@ import spack.spec
 all_deptypes = ("build", "link", "run", "test")
 
 #: Default dependency type if none is specified
-default_deptype = ("build", "link")
+default_deptype = ("link",)
 
 #: Type hint for the arguments accepting a dependency type
 DependencyArgument = Union[str, List[str], Tuple[str, ...]]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -213,6 +213,19 @@ attr(Name, A1, A2, A3, A4) :- impose(ID), imposed_constraint(ID, Name, A1, A2, A
 concrete(Package) :- attr("hash", Package, _), attr("node", Package).
 
 %-----------------------------------------------------------------------------
+% Build requirements
+%-----------------------------------------------------------------------------
+attr("build_requirement", Package, Requirement) :- build_requirement(Package, Requirement).
+build_requirement(Package, Requirement) :-
+  condition_holds(ID),
+  possible_build_requirement(ID, Package, Requirement).
+
+% TODO: add error condition coming from feedback
+
+#defined avoid_build_requirement/2.
+#defined possible_build_requirement/3.
+
+%-----------------------------------------------------------------------------
 % Dependency semantics
 %-----------------------------------------------------------------------------
 % Dependencies of any type imply that one package "depends on" another

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -14,6 +14,9 @@
 #show attr/3.
 #show attr/4.
 
+% Build requirements
+#show build_requirement/2.
+
 % names of optimization criteria
 #show opt_criterion/2.
 

--- a/lib/spack/spack/solver/iterative.py
+++ b/lib/spack/spack/solver/iterative.py
@@ -1,0 +1,220 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import collections
+import collections.abc
+from typing import List
+
+import spack.environment.environment as ev
+import spack.spec
+
+from .asp import (
+    OutputConfiguration,
+    PyclingoDriver,
+    Solver,
+    SolverMode,
+    SpackSolverSetup,
+    SpecBuilder,
+    _develop_specs_from_env,
+)
+
+
+def _merge_spec_strings(specs: List[str]) -> spack.spec.Spec:
+    starting_spec, *constraints = specs
+    result = spack.spec.Spec(starting_spec)
+    for constraint in constraints:
+        result.constrain(constraint)
+    return result
+
+
+class SinglePackageRequirements(collections.abc.MutableSequence):
+    """Collect and manipulate requirements for a single build spec.
+
+    This class contains requirements for a single build spec, and behaves like a built-in list.
+    It's client responsibility to ensure the requirements are all for the same package.
+    """
+
+    def __init__(self):
+        self.requirements: List[str] = []
+
+    def __getitem__(self, item):
+        return self.requirements[item]
+
+    def __setitem__(self, key, value):
+        self.requirements[key] = value
+
+    def __delitem__(self, key):
+        del self.requirements[key]
+
+    def __len__(self):
+        return len(self.requirements)
+
+    def insert(self, index: int, value: str) -> None:
+        self.requirements.insert(index, value)
+
+    def merged(self) -> spack.spec.Spec:
+        """Return a single spec with all the constraints merged"""
+        if not self.requirements:
+            return spack.spec.Spec()
+
+        starting_spec, *constraints = self.requirements
+        result = spack.spec.Spec(starting_spec)
+        for constraint in constraints:
+            result.constrain(constraint)
+        return result
+
+    def errors(self, pkg):
+        # TODO: implement errors
+        raise NotImplementedError("Still to be implemented")
+
+
+class BuildRequirements:
+    """Collect all the build requirement from a single package"""
+
+    def __init__(self):
+        self.requirements = collections.defaultdict(SinglePackageRequirements)
+
+    def add(self, requirement: str):
+        """Add a new build requirement to the ones managed by this object"""
+        requirement_spec = spack.spec.Spec(requirement)
+        key = requirement_spec.name
+        self.requirements[key].append(requirement_spec)
+
+    def items(self):
+        return self.requirements.items()
+
+
+class PartialSpecBuilder(SpecBuilder):
+    def build_requirement(self, pkg, requirement_str):
+        if not hasattr(self._specs[pkg], "build_requirements"):
+            self._specs[pkg].build_requirements = BuildRequirements()
+        self._specs[pkg].build_requirements.add(requirement_str)
+
+    def finalize_specs(self, roots_to_be_installed):
+        pass
+
+
+PartialResult = collections.namedtuple("PartialResult", ["result", "build_requirements"])
+
+
+class SpecComposer:
+    def __init__(self):
+        #: Used as a stack of partial results
+        self.solve_stack = []
+        #: True when push_final is called
+        self.closed = False
+
+    def push_partial(self, result):
+        assert self.closed is False, "cannot push a partial result when the stack is closed"
+        build_requirements = collections.defaultdict(list)
+
+        for root_spec in result.all_specs_by_package.values():
+            br = getattr(root_spec, "build_requirements", None)
+            if br is None:
+                continue
+            for pkg_name, requirements in br.items():
+                build_requirements[requirements.merged()].append(root_spec)
+        partial = PartialResult(
+            result=result,
+            build_requirements=build_requirements,
+        )
+        self.solve_stack.append(partial)
+        return list(build_requirements)
+
+    def push_final(self, *results):
+        assert self.closed is False, "cannot push a final result when the stack is closed"
+        partial = PartialResult(
+            result=results,
+            build_requirements=None,
+        )
+        self.solve_stack.append(partial)
+        self.closed = True
+
+    def pop(self, invalidate):
+        raise NotImplementedError("Still to be implemented")
+
+    def compose(self):
+        assert self.closed is True, "cannot compose from an open stack"
+        current_concrete = self.solve_stack.pop()
+        current_partial = self.solve_stack.pop()
+
+        for build_result in current_concrete.result:
+            for input_spec, build_spec in build_result.specs_by_input.items():
+                root_specs = current_partial.build_requirements[input_spec]
+                for root_spec in root_specs:
+                    root_spec.add_build_dependency(build_spec)
+
+        result = current_partial.result
+
+        # FIXME: Unify duplicated code from UnifiedBuilder.finalize_specs
+        # Add external paths to specs with just external modules
+        for s in result.all_specs_by_package.values():
+            spack.spec.Spec.ensure_external_path_if_external(s)
+
+        for s in result.all_specs_by_package.values():
+            _develop_specs_from_env(s, ev.active_environment())
+
+        # mark concrete and assign hashes to all specs in the solve
+        for root in result.all_specs_by_package.values():
+            root._finalize_concretization()
+
+        for s in result.all_specs_by_package.values():
+            spack.spec.Spec.ensure_no_deprecated(s)
+
+        # Add git version lookup info to concrete Specs (this is generated for
+        # abstract specs as well but the Versions may be replaced during the
+        # concretization process)
+        for root in result.all_specs_by_package.values():
+            for spec in root.traverse():
+                if isinstance(spec.version, spack.version.GitVersion):
+                    spec.version.generate_git_lookup(spec.fullname)
+
+        # Add synthetic edges for externals that are extensions
+        for root in result.all_specs_by_package.values():
+            for dep in root.traverse():
+                if dep.external:
+                    dep.package.update_external_dependencies()
+
+        # Unify specs
+        keys = list(result.answers[0][2])
+        for key in keys:
+            item = result.answers[0][2][key]
+            result.answers[0][2][key] = spack.spec.Spec.from_json(item.to_json())
+
+        return result
+
+
+class IterativeSolver:
+    def __init__(self):
+        self.driver = PyclingoDriver()
+        # These properties are settable via spack configuration, and overridable
+        # by setting them directly as properties.
+        self.reuse = spack.config.get("concretizer:reuse", False)
+        self.composer = SpecComposer()
+
+    def solve(
+        self,
+        specs,
+        out=None,
+        timers=False,
+        stats=False,
+        tests=False,
+    ):
+        # FIXME: Add back reusable specs
+        setup = SpackSolverSetup(tests=tests)
+
+        setup.mode = SolverMode.SEPARATE_BUILD_DEPENDENCIES
+        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
+        result, _, _ = self.driver.solve(
+            setup, specs, reuse=[], output=output, builder_cls=PartialSpecBuilder
+        )
+
+        build_requirements = self.composer.push_partial(result)
+
+        solver = Solver()
+        build_results = [x for x in solver.solve_in_rounds(build_requirements, tests=tests)]
+        self.composer.push_final(*build_results)
+
+        result = self.composer.compose()
+        return result

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1541,7 +1541,7 @@ class Spec(object):
             dspec = next(dspec for dspec in orig if deptypes == dspec.deptypes)
             dspec.spec.constrain(spec)
         except StopIteration:
-            self.add_dependency_edge(spec, deptypes)
+            self.add_dependency_edge(spec, deptypes=deptypes)
             return
             # raise DuplicateDependencyError("Cannot depend on '%s' twice" % spec)
         except spack.error.UnsatisfiableSpecError:
@@ -1555,7 +1555,7 @@ class Spec(object):
         Args:
             build_dependency (Spec): build dependency to be added
         """
-        assert build_dependency.concrete, "Cannot add an abstract build dependency"
+        # assert build_dependency.concrete, "Cannot add an abstract build dependency"
         dependency_type = ("build",)
         edges = self._dependencies.get(build_dependency.name, tuple())
         for edge in edges:
@@ -1566,7 +1566,7 @@ class Spec(object):
             except spack.error.UnsatisfiableSpecError:
                 continue
         else:
-            self.add_dependency_edge(build_dependency, dependency_type)
+            self.add_dependency_edge(build_dependency, deptypes=dependency_type)
 
     def add_dependency_edge(self, dependency_spec: "Spec", *, deptypes: dp.DependencyArgument):
         """Add a dependency edge to this spec.

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -97,8 +97,7 @@ class PyNumpy(PythonPackage):
     depends_on("python@3.7:3.10", type=("build", "link", "run"), when="@1.20:1.21")
     depends_on("python@3.8:", type=("build", "link", "run"), when="@1.22:")
     # https://github.com/spack/spack/pull/32078
-    depends_on("py-setuptools@:63", type=("build", "run"))
-    depends_on("py-setuptools@:59", when="@:1.22.1", type=("build", "run"))
+    depends_on("py-setuptools@:59", type=("build", "run"))
     # Check pyproject.toml for updates to the required cython version
     depends_on("py-cython@0.29.13:2", when="@1.18.0:", type="build")
     depends_on("py-cython@0.29.14:2", when="@1.18.1:", type="build")


### PR DESCRIPTION
This draft PR is a tentative implementation of the following iterative procedure to get separate concretization of build dependencies:

![iterative_procedure](https://user-images.githubusercontent.com/4199709/221925354-b72ab7ec-82c0-4bf1-a085-a2426e8a7ede.png)


The basic idea is to decouple the problem and:
1. Solve first the link/run subDAG of the root specs, and keep track of their build requirements
2. Perform another solve unifying on every dependency type (like we do now) and concretize the build requirements
3. Compose the initial spec from the two solutions

Step two is performed as a single "build environment" concretized with `unify: when_possible` and can have different requirements from the specs concretized at step one. In this draft,  for instance, we use the default compiler for build dependencies. This allow us to concretize:
```console
$ spack graph -d --color py-shapely %oneapi
```
and obtain the following graph (build dependencies in red):
![shapely](https://user-images.githubusercontent.com/4199709/221928078-8020d3a2-c620-43b0-ac96-61b709301fc0.png)

In case we have a conflict during the solve at 2 the idea is to go back at point one with additional integrity constraints, which would prevent the offending build requirements to be in a valid solution.

Additional notes:
- During step 1 we have to take particular care to concretize build dependencies for extensions (like `py-setuptools`) correctly. This is because those build dependencies need to share the same compiler etc. than the underlying interpreter. See `py-setuptools` for an example of that in the graph above
- The feedback cycle is not implemented here, so any conflict when computing build dependencies currently leads to a failure
- The algorithm can be extended to have more than one "build environment" levels. This fits cases like having to build an intermediate compiler when the system provides an ancient one and we want e.g. to bootstrap the latest.