### PR TITLE
Add py-mpi4py as a dependency for henson

### DIFF
--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -14,6 +14,8 @@ class Henson(CMakePackage):
 
     version("master", branch="master")
 
+    maintainers("mrzv")
+
     depends_on("mpi")
 
     variant("python", default=False, description="Build Python bindings")

--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -20,7 +20,7 @@ class Henson(CMakePackage):
 
     variant("python", default=False, description="Build Python bindings")
     extends("python", when="+python")
-    depends_on("py-mpi4py", when="+python")
+    depends_on("py-mpi4py", when="+python", type=("build", "run"))
     variant("mpi-wrappers", default=False, description="Build MPI wrappers (PMPI)")
 
     conflicts("^openmpi", when="+mpi-wrappers")

--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -18,6 +18,7 @@ class Henson(CMakePackage):
 
     variant("python", default=False, description="Build Python bindings")
     extends("python", when="+python")
+    depends_on("py-mpi4py", when="+python")
     variant("mpi-wrappers", default=False, description="Build MPI wrappers (PMPI)")
 
     conflicts("^openmpi", when="+mpi-wrappers")


### PR DESCRIPTION
Adds a missing dependency for henson, when `+python` variant is chosen.