### PR TITLE
tests/cpmd: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -71,7 +71,7 @@ class Cpmd(MakefilePackage):
     def install(self, spec, prefix):
         install_tree(".", prefix)
 
-    def test(self):
+    def test_cpmd(self):
         test_dir = self.test_suite.current_test_data_dir
         test_file = join_path(test_dir, "1-h2o-pbc-geoopt.inp")
         opts = []
@@ -83,9 +83,12 @@ class Cpmd(MakefilePackage):
             exe_name = "cpmd.x"
         opts.append(test_file)
         opts.append(test_dir)
+        cpmd = which(exe_name)
+        out = cpmd(*opts, output=str.split, error=str.split)
+
         expected = [
             "2       1        H        O              1.84444     0.97604",
             "3       1        H        O              1.84444     0.97604",
             "2   1   3         H     O     H              103.8663",
         ]
-        self.run_test(exe_name, options=opts, expected=expected)
+        check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -36,6 +36,7 @@ class Cpmd(MakefilePackage):
         else:
             fc = spack_fc
             cc = spack_cc
+            cp.filter(r"FFLAGS='([^']*)'", "FFLAGS='\\1 -fallow-argument-mismatch'")
 
         cp.filter("FC=.+", "FC='{0}'".format(fc))
         cp.filter("CC=.+", "CC='{0}'".format(cc))


### PR DESCRIPTION
UPDATE: This PR converts the stand-alone test to the new process _only for_ `cpmd`.  Unfortunately I have not been able to build the package using `spack install cpmd`, `spack install cpmd+mpi`, or `spack install cpmd+omp`.  I'm getting multiple `Type mismatch` errors.

UPDATE2: I add `-fallow-argument-mismatch` to the configuration of `FFLAGS` to get past the problem shown in `Argument Mismatch Failure` below.  Now the package builds for me using `spack install cpmd` and stand-alone test pass ([cpmd-4.3-tests.txt](https://github.com/spack/spack/files/12189324/cpmd-4.3-tests.txt)):

```
$ spack -v test run cpmd
==> Spack test cha44rvn2buaw444biiv36cnmn3ds2bu
==> Testing package cpmd-4.3-scuflyt
==> [2023-07-27-18:40:52.543393] test: test_cpmd: unspecified purpose
==> [2023-07-27-18:40:52.545928] 'SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/cpmd-4.3-scuflytrkefii7fnfayh2kg3rqss7kgp/bin/cpmd.x' 'SPACK_TEST_ROOT/cha44rvn2buaw444biiv36cnmn3ds2bu/cpmd-4.3-scuflyt/data/cpmd/1-h2o-pbc-geoopt.inp' 'SPACK_TEST_ROOT/cha44rvn2buaw444biiv36cnmn3ds2bu/cpmd-4.3-scuflyt/data/cpmd'
 compiler version: GCC version 12.1.1 20220628 (Red Hat 12.1.1-3)
 compiler options: -cpp -I /tmp/dahlgren/spack-stage/spack-stage-cpmd-4.3-scuflytrkefii7fnfayh2kg3rqss7kgp/spack-src/src -I /tmp/dahlgren/spack-stage/spack-stage-cpmd-4.3-scuflytrkefii7fnfayh2kg3rqss7kgp/spack-src//obj -I /tmp/dahlgren/spack-stage/spack-stage-cpmd-4.3-scuflytrkefii7fnfayh2kg3rqss7kgp/spack-src/src -I SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/openblas-0.3.23-i2xctuetfbzxnpgrkx5liqup5uwrjmw4/include -iprefix /collab/usr/global/tools/tce4/packages/gcc/gcc-12.1.1/bin/../lib/gcc/x86_64-redhat-linux/12/ -D __Linux -D __HAS_FFT_DEFAULT -D SVN_REV="rUnversioned directory" -march=x86-64-v3 -mtune=generic -O2 -Wall -ffree-line-length-none -falign-commons -fallow-argument-mismatch -fpre-include=/usr/include/finclude/math-vector-fortran.h
 MPI version of the library: not available
 MPI version of the standard: 0.0
...
       CPU TIME :    0 HOURS  2 MINUTES 21.58 SECONDS      
   ELAPSED TIME :    0 HOURS  2 MINUTES 22.48 SECONDS     

 PROGRAM CPMD ENDED AT:   2023-07-27 18:43:15.048   
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
PASSED: Cpmd::test_cpmd
==> [2023-07-27-18:43:15.060135] Completed testing
==> [2023-07-27-18:43:15.060274] 
========================== SUMMARY: cpmd-4.3-scuflyt ===========================
Cpmd::test_cpmd .. PASSED
============================= 1 passed of 1 parts =============================
```

### Argument Mismatch Failure
```
...
==> cpmd: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

9 errors found in build log:
     5670    /tmp/dahlgren/spack-stage/spack-stage-cpmd-4.3-43cykqwycei3vjcvti3
             bntxppfgvzgds/spack-src/src/pi_cntl_utils.mod.F90:511:26:
     5671    
     5672      510 |        CALL mp_bcast_byte(pimd1, size_in_bytes_of(pimd1),p
             arai%io_source,parai%cp_grp)
     5673          |                          2
     5674      511 |        CALL mp_bcast_byte(pimd2, size_in_bytes_of(pimd2),p
             arai%io_source,parai%cp_grp)
     5675          |                          1
  >> 5676    Error: Type mismatch between actual argument at (1) and actual arg
             ument at (2) (TYPE(pimd2_t)/TYPE(pimd1_t)).
```

Trying `spack install cpmd+omp`, will update when done.

TODO:
- [x] (re)test cpmd .. v4.3 passed (_before_ rebased to develop)