### PR TITLE
tests/eigenexa: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/eigenexa/package.py
+++ b/var/spack/repos/builtin/packages/eigenexa/package.py
@@ -52,8 +52,8 @@ class Eigenexa(AutotoolsPackage):
         """Save off benchmark files for stand-alone tests."""
         self.cache_extra_test_sources("benchmark")
 
-    def test(self):
-        """Perform stand-alone/smoke tests using pre-built benchmarks."""
+    def test_benchmarks(self):
+        """run benchmark checks"""
         # NOTE: This package would ideally build the test program using
         #   the installed software *each* time the tests are run since
         #   this package installs a library.
@@ -61,20 +61,17 @@ class Eigenexa(AutotoolsPackage):
         test_cache_dir = join_path(self.test_suite.current_test_cache_dir, "benchmark")
         test_data_dir = self.test_suite.current_test_data_dir
 
-        opts = [
-            "run-test.sh",
-            self.spec["mpi"].prefix.bin.mpirun,
-            "-n",
-            "1",
-            join_path(test_cache_dir, "eigenexa_benchmark"),
-            "-f",
-            join_path(test_cache_dir, "IN"),
-        ]
-        env["OMP_NUM_THREADS"] = "1"
-        self.run_test(
-            "sh",
-            options=opts,
-            expected="EigenExa Test Passed !",
-            purpose="test: running benchmark checks",
-            work_dir=test_data_dir,
-        )
+        with working_dir(test_data_dir):
+            opts = [
+                "run-test.sh",
+                self.spec["mpi"].prefix.bin.mpirun,
+                "-n",
+                "1",
+                join_path(test_cache_dir, "eigenexa_benchmark"),
+                "-f",
+                join_path(test_cache_dir, "IN"),
+            ]
+            env["OMP_NUM_THREADS"] = "1"
+            sh = which("sh")
+            out = sh(*opts, output=str.split, error=str.split)
+            assert "EigenExa Test Passed !" in out


### PR DESCRIPTION
Depends on #34236

I appear to no longer be able to build the package to test the changes:

```
==> Installing eigenexa-2.6-7tr7akwatb5secxajcdzdnzlch3n2frc
==> No binary for eigenexa-2.6-7tr7akwatb5secxajcdzdnzlch3n2frc found: installing from source
==> Using cached archive: /usr/WS1/dahlgren/releases/spack/var/spack/cache/_source-cache/archive/a1/a1a4e571a8051443f28e7ea4889272993452a4babd036d2b4dd6b28154302f95.tgz
==> Applied patch /usr/WS1/dahlgren/releases/spack/var/spack/repos/builtin/packages/eigenexa/gcc_compiler.patch
==> eigenexa: Executing phase: 'autoreconf'
==> eigenexa: Executing phase: 'configure'
==> eigenexa: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j1' 'V=1'

7 errors found in build log:
     68    /usr/WS1/dahlgren/releases/spack/opt/spack/linux-rhel8-broadwell/gcc
           -10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpif77   
              -g -cpp -fPIC -DTIMER_PRINT=0 -DUSE_MKL=0 -DCODE_AKASHI=0 -J./ -O
           0 -fopenmp  -c -o comm.o comm.F
     69    /usr/WS1/dahlgren/releases/spack/opt/spack/linux-rhel8-broadwell/gcc
           -10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpif77   
              -g -cpp -fPIC -DTIMER_PRINT=0 -DUSE_MKL=0 -DCODE_AKASHI=0 -J./ -O
           3 -fopenmp  -c -o eigen_libs0.o eigen_libs0.F
     70    eigen_libs0.F:2422:42:
     71    
     72     2422 |       data const_pai2 /z'3ff921FB54442D18'/
     73          |                                          1
  >> 74    Error: BOZ literal constant near (1) cannot be assigned to a REAL va
           riable [see '-fno-allow-invalid-boz']
     75    eigen_libs0.F:2394:42:
     76    
     77     2394 |       data const_2pai /z'401921FB54442D18'/
     78          |                                          1
  >> 79    Error: BOZ literal constant near (1) cannot be assigned to a REAL va
           riable [see '-fno-allow-invalid-boz']
     80    eigen_libs0.F:2366:41:
     81    
     82     2366 |       data const_pai /z'400921FB54442D18'/
     83          |                                         1
  >> 84    Error: BOZ literal constant near (1) cannot be assigned to a REAL va
           riable [see '-fno-allow-invalid-boz']
     85    eigen_libs0.F:2338:35:
     86    
     87     2338 |       data eps /z'3CB0000000000000'/
     88          |                                   1
  >> 89    Error: BOZ literal constant near (1) cannot be assigned to a REAL va
           riable [see '-fno-allow-invalid-boz']
  >> 90    make[2]: *** [Makefile:660: eigen_libs0.o] Error 1
     91    make[2]: Leaving directory '/tmp/dahlgren/spack-stage/spack-stage-ei
           genexa-2.6-7tr7akwatb5secxajcdzdnzlch3n2frc/spack-src/src'
  >> 92    make[1]: *** [Makefile:410: all-recursive] Error 1
     93    make[1]: Leaving directory '/tmp/dahlgren/spack-stage/spack-stage-ei
           genexa-2.6-7tr7akwatb5secxajcdzdnzlch3n2frc/spack-src'
  >> 94    make: *** [Makefile:351: all] Error 2
```

TODO:
- [x] re-test .. v2.6 passed