### PR TITLE
tests/etsf-io: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/etsf-io/package.py
+++ b/var/spack/repos/builtin/packages/etsf-io/package.py
@@ -52,23 +52,10 @@ class EtsfIo(Package):
         make("check")
         make("install")
 
-    def test(self):
-        """Run this smoke test when requested explicitly"""
+    def test_etsf_io_help(self):
+        """check etsf_io can execute (--help)"""
 
-        # Test is to run "etsf_io --help"
-        spec = self.spec
-        exe = join_path(spec["etsf-io"].prefix.bin, "etsf_io")
-        options = ["--help"]
-        purpose = "Check etsf_io can execute (--help)"
-        expected = ["Usage: etsf_io"]
-
-        self.run_test(
-            exe,
-            options=options,
-            expected=expected,
-            status=[0],
-            installed=False,
-            purpose=purpose,
-            skip_missing=False,
-            work_dir=None,
-        )
+        path = self.spec["etsf-io"].prefix.bin.etsf_io
+        etsfio = which(path)
+        out = etsfio("--help", output=str.split, error=str.split)
+        assert "Usage: etsf_io" in out


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v test run etsf-io
==> Spack test lr5nv56th2wqo7vpae2ryrs2anwziv6j
==> Testing package etsf-io-1.0.4-ajokso7
==> [2023-06-13-12:56:03.177249] test: test_etsf_io_help: check etsf_io can execute (--help)
==> [2023-06-13-12:56:03.179316] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/etsf-io-1.0.4-ajokso7tnnvai7byd5nsgauqx4yo7nmh/bin/etsf_io' '--help'

Usage: etsf_io [-h | -a action] [[-i file]...] [[-f flag]...]
               [-o file] [arguments]

   Handle ETSF files, see --action option.
-h --help             : show this little help.
-a --action value     : give the action to perform.
                        Possible action may be:
                        * 'merge' to gather several files that
                          have been splitted.
                        * 'content' to get the name of
                          specifications the file matches.
                        * 'check' to check the validity of
                          the file against specifications.
-o --output-file file : give the path to the output ETSF file.
-i --input-file file  : give the path for an input file. This
                        option can be used one or several times.
-l --list             : when action is check, it give the list
                        of available flags.
-f --flag value       : give a flag name (get valid names from
                        -l option).

   Examples:
Merge three files, etsf_io -a merge -i file1.nc -i file2.nc
                   -i file3.nc -o output.nc

Get the contents of file test.nc, etsf_io -a content test.nc

Get the list of flags for validity checks, etsf_io -a check -l

Checks with two flags, etsf_io -a check -f flag1 -f flag2 test.nc
PASSED: EtsfIo::test_etsf_io_help
==> [2023-06-13-12:56:03.236107] Completed testing
==> [2023-06-13-12:56:03.236326] 
======================== SUMMARY: etsf-io-1.0.4-ajokso7 ========================
EtsfIo::test_etsf_io_help .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```