### PR TITLE
ESMF should use Spack wrappers directly

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -199,8 +199,8 @@ class Esmf(MakefilePackage):
             env.set("ESMF_CXX", spec["mpi"].mpicxx)
             env.set("ESMF_F90", spec["mpi"].mpifc)
         else:
-            env.set("ESMF_CXX", env["CXX"])
-            env.set("ESMF_F90", env["FC"])
+            env.set("ESMF_CXX", spack_cxx)
+            env.set("ESMF_F90", spack_fc)
 
         # This environment variable controls the build option.
         if "+debug" in spec:


### PR DESCRIPTION
When building esmf@8.0~mpi using develop, I get the following error:

```
==> Error: TypeError: 'EnvironmentModifications' object is not subscriptable

/glade/gust/scratch/vanderwb/spack-tests/gust/23.03b/spack/var/spack/repos/builtin/packages/esmf/package.py:202, in setup_build_environment:
        199            env.set("ESMF_CXX", spec["mpi"].mpicxx)
        200            env.set("ESMF_F90", spec["mpi"].mpifc)
        201        else:
  >>    202            env.set("ESMF_CXX", env["CXX"])
        203            env.set("ESMF_F90", env["FC"])
        204
        205        # This environment variable controls the build option.
```

In this PR, I propose fixing this error and simplifying the logic by assigning `ESMF_CXX` and `ESMF_F90` to the Spack compiler wrappers directly using the variables `spack_cxx` and `spack_fc`.