### PR TITLE
tests/heffte/tasmanian: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -3,10 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -130,68 +126,38 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
         return args
 
-    def cmake_bin(self, set_path=True):
-        """(Hack) Set/get cmake dependency path. Sync with Tasmanian."""
-        filepath = join_path(self.install_test_root, "cmake_bin_path.txt")
-        if set_path:
-            with open(filepath, "w") as out_file:
-                cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
-                out_file.write("{0}\n".format(cmake_bin))
-        elif os.path.isfile(filepath):
-            with open(filepath, "r") as in_file:
-                return in_file.read().strip()
-
     @run_after("install")
     def setup_smoke_test(self):
         install_tree(
             self.prefix.share.heffte.testing, join_path(self.install_test_root, "testing")
         )
-        self.cmake_bin(set_path=True)
 
-    def test(self):
-        cmake_bin = self.cmake_bin(set_path=False)
-
-        if not cmake_bin:
-            tty.msg("Skipping heffte test: cmake_bin_path.txt not found")
-            return
-
+    def test_make_test(self):
+        """build and run make(test)"""
         # using the tests copied from <prefix>/share/heffte/testing
         cmake_dir = self.test_suite.current_test_cache_dir.testing
 
         options = [cmake_dir]
         if "+rocm" in self.spec:
-            options.append(
-                "-Dhip_DIR=" + join_path(self.spec["hip"].prefix, "lib", "cmake", "hip")
-            )
-            options.append(
-                "-DAMDDeviceLibs_DIR="
-                + join_path(self.spec["llvm-amdgpu"].prefix, "lib", "cmake", "AMDDeviceLibs")
-            )
-            options.append(
-                "-Damd_comgr_DIR="
-                + join_path(self.spec["comgr"].prefix, "lib", "cmake", "amd_comgr")
-            )
-            options.append(
-                "-Dhsa-runtime64_DIR="
-                + join_path(self.spec["hsa-rocr-dev"].prefix, "lib", "cmake", "hsa-runtime64")
-            )
-            options.append(
-                "-DHSA_HEADER=" + join_path(self.spec["hsa-rocr-dev"].prefix, "include")
-            )
-            options.append(
-                "-Drocfft_DIR=" + join_path(self.spec["rocfft"].prefix, "lib", "cmake", "rocfft")
+            options.extend(
+                [
+                    f"-Dhip_DIR={self.spec['hip'].prefix.lib.cmake.hip}",
+                    "-DAMDDeviceLibs_DIR="
+                    + f"{self.spec['llvm-amdgpu'].prefix.lib.cmake.AMDDeviceLibs}",
+                    f"-Damd_comgr_DIR={self.spec['comgr'].prefix.lib.cmake.amd_comgr}",
+                    "-Dhsa-runtime64_DIR="
+                    + f"{self.spec['hsa-rocr-dev'].prefix.lib.cmake.hsa-runtime64}",
+                    "-DHSA_HEADER={self.spec['hsa-rocr-dev'].prefix.include}",
+                    "-Drocfft_DIR={self.spec['rocfft'].prefix.lib.cmake.rocfft}",
+                ]
             )
 
-        # Provide the path to the MPI dependency so that the test can find an MPI launcher
-        options.append("-DMPI_HOME=" + self.spec["mpi"].prefix)
+        # Provide the root directory of the MPI installation.
+        options.append(f"-DMPI_HOME={self.spec['mpi'].prefix}")
 
-        if not self.run_test(cmake_bin, options=options, purpose="Generate the Makefile"):
-            tty.msg("Skipping heffte test: failed to generate Makefile")
-            return
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        cmake(*options)
 
-        if not self.run_test("make", purpose="Build test software"):
-            tty.msg("Skipping heffte test: failed to build test")
-            return
-
-        if not self.run_test("make", options=["test"], purpose="Run test"):
-            tty.msg("Failed heffte test: failed to run test")
+        make = which("make")
+        make()
+        make("test")


### PR DESCRIPTION
This PR converts the stand-alone tests for the two packages to use the new process.

```
$ spack -v test run heffte
==> Spack test d2ac2csic3gevoa4amlermpz6ih2b2qo
==> Testing package heffte-2.3.0-jq55tpg
==> [2023-06-13-13:20:54.041035] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/heffte-2.3.0-jq55tpgfitotohspuj24k5vlrk4fkcc6/.spack/test to $SPACK_TEST_ROOT/d2ac2csic3gevoa4amlermpz6ih2b2qo/heffte-2.3.0-jq55tpg/cache/heffte
==> [2023-06-13-13:20:54.060146] test: test_make_test: build and run make(test)
==> [2023-06-13-13:20:54.065759] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '$SPACK_TEST_ROOT/d2ac2csic3gevoa4amlermpz6ih2b2qo/heffte-2.3.0-jq55tpg/cache/heffte/testing' '-DMPI_HOME=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md'
-- The CXX compiler identification is GNU 10.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- heFFTe post-installation testing
-- Found MPI_CXX: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/lib/libmpi.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1")  
-- Found Heffte: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/heffte-2.3.0-jq55tpgfitotohspuj24k5vlrk4fkcc6 (found version 2.3.0)
-- Found Heffte modules:  SHARED GPUAWARE
-- Configuring done (2.1s)
-- Generating done (0.2s)
-- Build files have been written to: $SPACK_TEST_ROOT/d2ac2csic3gevoa4amlermpz6ih2b2qo/heffte-2.3.0-jq55tpg
==> [2023-06-13-13:20:56.490462] '/usr/bin/make'
[ 12%] Building CXX object examples/CMakeFiles/heffte_example_options.dir/heffte_example_options.cpp.o
[ 25%] Linking CXX executable heffte_example_options
[ 25%] Built target heffte_example_options
[ 37%] Building CXX object examples/CMakeFiles/heffte_example_vectors.dir/heffte_example_vectors.cpp.o
[ 50%] Linking CXX executable heffte_example_vectors
[ 50%] Built target heffte_example_vectors
[ 62%] Building CXX object examples/CMakeFiles/heffte_example_r2c.dir/heffte_example_r2c.cpp.o
[ 75%] Linking CXX executable heffte_example_r2c
[ 75%] Built target heffte_example_r2c
[ 87%] Building CXX object examples/CMakeFiles/heffte_example_r2r.dir/heffte_example_r2r.cpp.o
[100%] Linking CXX executable heffte_example_r2r
[100%] Built target heffte_example_r2r
==> [2023-06-13-13:21:10.132417] '/usr/bin/make' 'test'
Running tests...
Test project $SPACK_TEST_ROOT/d2ac2csic3gevoa4amlermpz6ih2b2qo/heffte-2.3.0-jq55tpg
    Start 1: example_r2r
1/4 Test #1: example_r2r ......................   Passed    1.45 sec
    Start 2: example_options
2/4 Test #2: example_options ..................   Passed    0.27 sec
    Start 3: example_vectors
3/4 Test #3: example_vectors ..................   Passed    0.25 sec
    Start 4: example_r2c
4/4 Test #4: example_r2c ......................   Passed    0.26 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   2.26 sec
PASSED: Heffte::test_make_test
==> [2023-06-13-13:21:12.571759] Completed testing
==> [2023-06-13-13:21:12.571950] 
======================== SUMMARY: heffte-2.3.0-jq55tpg =========================
Heffte::test_make_test .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
17.623u 4.521s 0:33.70 65.6%	0+0k 37944+15384io 103pf+0w
```

```
$ spack -v test run tasmanian
==> Spack test iewgqy6rhkqmyjxq7qrfmvp2u5c3kfdc
==> Testing package tasmanian-7.9-yefmrg4
==> [2023-06-13-13:44:52.005307] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/tasmanian-7.9-yefmrg4jymtaz47vzdmi26ew6rrkxpyw/.spack/test to $SPACK_TEST_ROOT/iewgqy6rhkqmyjxq7qrfmvp2u5c3kfdc/tasmanian-7.9-yefmrg4/cache/tasmanian
==> [2023-06-13-13:44:52.025013] test: test_make_test: build and run make(test)
==> [2023-06-13-13:44:52.028586] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '$SPACK_TEST_ROOT/iewgqy6rhkqmyjxq7qrfmvp2u5c3kfdc/tasmanian-7.9-yefmrg4/cache/tasmanian/testing'
-- The CXX compiler identification is GNU 10.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Tasmanian post-installation testing
-- Configuring done (0.8s)
-- Generating done (0.2s)
-- Build files have been written to: $SPACK_TEST_ROOT/iewgqy6rhkqmyjxq7qrfmvp2u5c3kfdc/tasmanian-7.9-yefmrg4
==> [2023-06-13-13:44:53.091146] '/usr/bin/make'
[  4%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_01.cpp.o
[  8%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_02.cpp.o
[ 12%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_03.cpp.o
[ 16%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_04.cpp.o
[ 20%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_05.cpp.o
[ 25%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_06.cpp.o
[ 29%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_07.cpp.o
[ 33%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_08.cpp.o
[ 37%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_09.cpp.o
[ 41%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_10.cpp.o
[ 45%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids_11.cpp.o
[ 50%] Building CXX object examples_cxx/CMakeFiles/example_sparse_grids.dir/example_sparse_grids.cpp.o
[ 54%] Linking CXX executable example_sparse_grids
Tasmanian Sparse Grids  version: 7.9
                        license: BSD 3-Clause with UT-Battelle disclaimer
          OpenMP multithreading: Disabled
          GPU backend framework: none
         Available acceleration:  none

[ 54%] Built target example_sparse_grids
[ 58%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream_01.cpp.o
[ 62%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream_02.cpp.o
[ 66%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream_03.cpp.o
[ 70%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream_04.cpp.o
[ 75%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream_05.cpp.o
[ 79%] Building CXX object examples_cxx/CMakeFiles/example_dream.dir/example_dream.cpp.o
[ 83%] Linking CXX executable example_dream
[ 83%] Built target example_dream
[ 87%] Building CXX object examples_cxx/CMakeFiles/example_optimization.dir/example_optimization_01.cpp.o
[ 91%] Building CXX object examples_cxx/CMakeFiles/example_optimization.dir/example_optimization_02.cpp.o
[ 95%] Building CXX object examples_cxx/CMakeFiles/example_optimization.dir/example_optimization.cpp.o
[100%] Linking CXX executable example_optimization
[100%] Built target example_optimization
==> [2023-06-13-13:45:48.730337] '/usr/bin/make' 'test'
Running tests...
Test project $SPACK_TEST_ROOT/iewgqy6rhkqmyjxq7qrfmvp2u5c3kfdc/tasmanian-7.9-yefmrg4
    Start 1: SparseGrids
1/3 Test #1: SparseGrids ......................   Passed    1.85 sec
    Start 2: DREAM
2/3 Test #2: DREAM ............................   Passed    2.76 sec
    Start 3: Optimization
3/3 Test #3: Optimization .....................   Passed    0.08 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   4.71 sec
PASSED: Tasmanian::test_make_test
==> [2023-06-13-13:45:53.481380] Completed testing
==> [2023-06-13-13:45:53.481876] 
======================== SUMMARY: tasmanian-7.9-yefmrg4 ========================
Tasmanian::test_make_test .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
50.848u 8.477s 1:13.21 81.0%	0+0k 18864+16264io 4pf+0w
```