### PR TITLE
tests/hypre/petsc/superlu*: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import sys
 
 from spack.package import *
@@ -97,31 +98,29 @@ class HypreCmake(CMakePackage, CudaPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
 
-    def test(self):
-        """Perform smoke test on installed HYPRE package."""
+    def test_bigint(self):
+        """build and run bigint tests"""
         if "+mpi" not in self.spec:
-            print("Skipping: HYPRE must be installed with +mpi to run tests")
-            return
+            raise SkipTest("Package must be installed with +mpi")
 
         # Build copied and cached test examples
-        self.run_test(
-            "make",
-            ["HYPRE_DIR={0}".format(self.prefix), "bigint"],
-            purpose="test: building selected examples",
-            work_dir=self._cached_tests_work_dir,
-        )
+        make = which("make")
+        make("HYPRE_DIR={0}".format(self.prefix), "bigint")
 
         # Run the examples built above
-        for exe in ["./ex5big", "./ex15big"]:
-            self.run_test(
-                exe,
-                [],
-                [],
-                installed=False,
-                purpose="test: ensuring {0} runs".format(exe),
-                skip_missing=True,
+        for _bin in ["ex5big", "ex15big"]:
+            with test_part(
+                self,
+                "test_bigint_{0}".format(_bin),
+                purpose="ensuring {0} runs".format(_bin),
                 work_dir=self._cached_tests_work_dir,
-            )
+            ):
+                exe_path = join_path(".", _bin)
+                if not os.path.isfile(exe_path):
+                    raise SkipTest("{0} is missing".format(_bin))
+
+                exe = which(exe_path)
+                exe()
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -621,12 +621,16 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        if self.spec.satisfies("@3.13:"):
-            self.cache_extra_test_sources("src/ksp/ksp/tutorials")
-            self.cache_extra_test_sources("src/snes/tutorials")
+        if not self.spec.satisfies("@3.13:"):
+            tty.warn("Stand-alone tests only available for v3.13:")
+            return
 
-    def test(self):
-        # solve Poisson equation in 2D to make sure nothing is broken:
+        self.cache_extra_test_sources(
+            [join_path("src", "ksp", "ksp", "tutorials"), join_path("src", "snes", "tutorials")]
+        )
+
+    def get_runner(self):
+        """Set key environment variables and return runner and options."""
         spec = self.spec
         env["PETSC_DIR"] = self.prefix
         env["PETSC_ARCH"] = ""
@@ -634,11 +638,19 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             runexe = Executable(join_path(spec["mpi"].prefix.bin, "mpiexec")).command
             runopt = ["-n", "4"]
         else:
-            runexe = Executable(join_path(self.prefix, "lib/petsc/bin/petsc-mpiexec.uni")).command
+            runexe = Executable(join_path(self.prefix.lib.petsc.bin, "petsc-mpiexec.uni")).command
             runopt = ["-n", "1"]
-        w_dir = join_path(self.install_test_root, "src/ksp/ksp/tutorials")
+        return runexe, runopt
+
+    def test_ex50(self):
+        """build and run ex50 to solve Poisson equation in 2D"""
+        # solve Poisson equation in 2D to make sure nothing is broken:
+        make = which("make")
+        runexe, runopts = self.get_runner()
+
+        w_dir = join_path(self.test_suite.current_test_cache_dir, "src", "ksp", "ksp", "tutorials")
         with working_dir(w_dir):
-            testexe = ["ex50", "-da_grid_x", "4", "-da_grid_y", "4"]
+            baseopts = ["ex50", "-da_grid_x", "4", "-da_grid_y", "4"]
             testdict = {
                 None: [],
                 "+superlu-dist": ["-pc_type", "lu", "-pc_factor_mat_solver_type", "superlu_dist"],
@@ -647,40 +659,63 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 "+mkl-pardiso": ["-pc_type", "lu", "-pc_factor_mat_solver_type", "mkl_pardiso"],
             }
             make("ex50", parallel=False)
-            for feature, featureopt in testdict.items():
+            for feature, featureopts in testdict.items():
                 if not feature or feature in spec:
-                    self.run_test(runexe, runopt + testexe + featureopt)
-            if "+cuda" in spec:
-                make("ex7", parallel=False)
-                testexe = [
-                    "ex7",
-                    "-mat_type",
-                    "aijcusparse",
-                    "-sub_pc_factor_mat_solver_type",
-                    "cusparse",
-                    "-sub_ksp_type",
-                    "preonly",
-                    "-sub_pc_type",
-                    "ilu",
-                    "-use_gpu_aware_mpi",
-                    "0",
-                ]
-                self.run_test(runexe, runopt + testexe)
-            make("clean", parallel=False)
-        w_dir = join_path(self.install_test_root, "src/snes/tutorials")
+                    name = "_{0}".format(feature[1:]) if feature else ""
+                    options = runopts + baseopts + featureopts
+                    with test_part(
+                        self, "test_ex50{0}".format(name), purpose="run {0}".format(options)
+                    ):
+                        runexe(*options)
+
+    def test_ex7(self):
+        """build and run ex7"""
+        if "+cuda" not in self.spec:
+            raise SkipTest("Test requires +cuda")
+
+        make = which("make")
+        runexe, runopts = self.get_runner()
+
+        w_dir = join_path(self.test_suite.current_test_cache_dir, "src", "ksp", "ksp", "tutorials")
         with working_dir(w_dir):
-            if "+kokkos" in spec:
-                make("ex3k", parallel=False)
-                testexe = [
-                    "ex3k",
-                    "-view_initial",
-                    "-dm_vec_type",
-                    "kokkos",
-                    "-dm_mat_type",
-                    "aijkokkos",
-                    "-use_gpu_aware_mpi",
-                    "0",
-                    "-snes_monitor",
-                ]
-                self.run_test(runexe, runopt + testexe)
-            make("clean", parallel=False)
+            make("ex7", parallel=False)
+            exeopts = [
+                "ex7",
+                "-mat_type",
+                "aijcusparse",
+                "-sub_pc_factor_mat_solver_type",
+                "cusparse",
+                "-sub_ksp_type",
+                "preonly",
+                "-sub_pc_type",
+                "ilu",
+                "-use_gpu_aware_mpi",
+                "0",
+            ]
+            options = runopts + exeopts
+            runexe(*options)
+
+    def test_ex3k(self):
+        """build and run ex3k"""
+        if "+kokkos" not in self.spec:
+            raise SkipTest("Test requires +kokkos")
+
+        make = which("make")
+        runexe, runopts = self.get_runner()
+
+        w_dir = join_path(self.test_suite.current_test_cache_dir, "src", "snes", "tutorials")
+        with working_dir(w_dir):
+            make("ex3k", parallel=False)
+            exeopts = [
+                "ex3k",
+                "-view_initial",
+                "-dm_vec_type",
+                "kokkos",
+                "-dm_mat_type",
+                "aijkokkos",
+                "-use_gpu_aware_mpi",
+                "0",
+                "-snes_monitor",
+            ]
+            options = runopts + exeopts
+            runexe(*options)

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -171,48 +171,36 @@ class Slepc(Package, CudaPackage, ROCmPackage):
             join_path(self.stage.source_path, "make.log"),
         ]
 
-    def run_hello_test(self):
-        """Run stand alone test: hello"""
+    def test_hello(self):
+        """build and run hello"""
         test_dir = self.test_suite.current_test_data_dir
-
         if not os.path.exists(test_dir):
-            print("Skipping slepc test")
-            return
+            raise SkipTest("Test data directory ({0}) is missing".format(test_dir))
 
-        exe = "hello"
-        cc_exe = os.environ["CC"]
+        test_exe = "hello"
+        options = [
+            "-I{0}".format(self.prefix.include),
+            "-L",
+            self.prefix.lib,
+            "-l",
+            "slepc",
+            "-L",
+            self.spec["petsc"].prefix.lib,
+            "-l",
+            "petsc",
+            "-L",
+            self.spec["mpi"].prefix.lib,
+            "-l",
+            "mpi",
+            "-o",
+            test_exe,
+            join_path(test_dir, "{0}.c".format(test_exe)),
+        ]
 
-        self.run_test(
-            exe=cc_exe,
-            options=[
-                "-I{0}".format(self.prefix.include),
-                "-L",
-                self.prefix.lib,
-                "-l",
-                "slepc",
-                "-L",
-                self.spec["petsc"].prefix.lib,
-                "-l",
-                "petsc",
-                "-L",
-                self.spec["mpi"].prefix.lib,
-                "-l",
-                "mpi",
-                "-o",
-                exe,
-                join_path(test_dir, "hello.c"),
-            ],
-            purpose="test: compile {0} example".format(exe),
-            work_dir=test_dir,
-        )
+        cc = which(os.environ["CC"])
+        with working_dir(test_dir):
+            cc(*options)
 
-        self.run_test(
-            exe=exe,
-            options=[],
-            expected=["Hello world"],
-            purpose="test: run {0} example".format(exe),
-            work_dir=test_dir,
-        )
-
-    def test(self):
-        self.run_hello_test()
+            hello = which(test_exe)
+            out = hello(output=str.split, error=str.split)
+            assert "Hello world" in out

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -154,26 +154,17 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.examples_src_dir])
 
-    def test(self):
-        test_dir = join_path(self.install_test_root, self.examples_src_dir)
+    def test_pddrive(self):
+        """run cached pddrive"""
+        if not self.spec.satisfies("@7.2.0:"):
+            raise SkipTest("Test is only available for v7.2.0 on")
+
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
         superludriver = join_path(self.prefix.lib, "EXAMPLE", "pddrive")
-        with working_dir(test_dir, create=False):
+
+        with working_dir(test_dir):
             # Smoke test input parameters: -r 2 -c 2 g20.rua
             test_args = ["-n", "4", superludriver, "-r", "2", "-c", "2", "g20.rua"]
             # Find the correct mpirun command
             mpiexe_f = which("srun", "mpirun", "mpiexec")
-            if mpiexe_f:
-                if self.spec.satisfies("@7.2.0:"):
-                    self.run_test(
-                        mpiexe_f.command,
-                        test_args,
-                        work_dir=".",
-                        purpose="superlu-dist smoke test",
-                    )
-                else:
-                    self.run_test(
-                        "echo",
-                        options=["skip test"],
-                        work_dir=".",
-                        purpose="superlu-dist smoke test",
-                    )
+            mpiexe_f(*test_args)


### PR DESCRIPTION
Depends on #34236 

This PR converts stand-alone tests for the following packages:
~~- hypre-cmake~~
~~- hypre~~
~~- petsc~~
~~- slepc~~
~~- superlu-dist~~
~~- superlu~~

TODO

- [ ] (re)test