### PR TITLE
add nfft 3.2.4 (still the required version for octopus)

### DIFF
--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -16,6 +16,8 @@ class Nfft(AutotoolsPackage):
 
     version("3.4.1", sha256="1cf6060eec0afabbbba323929d8222397a77fa8661ca74927932499db26b4aaf")
     version("3.3.2", sha256="9dcebd905a82c4f0a339d0d5e666b68c507169d9173b66d5ac588aae5d50b57c")
+    version("3.2.4", sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
+            url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz")
 
     depends_on("fftw")
 

--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -16,8 +16,11 @@ class Nfft(AutotoolsPackage):
 
     version("3.4.1", sha256="1cf6060eec0afabbbba323929d8222397a77fa8661ca74927932499db26b4aaf")
     version("3.3.2", sha256="9dcebd905a82c4f0a339d0d5e666b68c507169d9173b66d5ac588aae5d50b57c")
-    version("3.2.4", sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
-            url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz")
+    version(
+        "3.2.4",
+        sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
+        url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz",
+    )
 
     depends_on("fftw")
 


### PR DESCRIPTION
Octupus requires an older version <=3.2.4 of nfft (when compiled with nfft support).
In this branch, we add that version to the spack nfft package.