### PR TITLE
Add path to MPI executables to ^mpi dependents

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -280,10 +280,12 @@ of the installed software. For instance, in the snippet below:
              set:
                BAR: 'bar'
          # This anonymous spec selects any package that
-         # depends on openmpi. The double colon at the
+         # depends on mpi. The double colon at the
          # end clears the set of rules that matched so far.
-         ^openmpi::
+         ^mpi::
            environment:
+             prepend_path:
+               PATH: '{^mpi.prefix}/bin'
              set:
                BAR: 'baz'
          # Selects any zlib package
@@ -298,7 +300,9 @@ of the installed software. For instance, in the snippet below:
              - FOOBAR
 
 you are instructing Spack to set the environment variable ``BAR=bar`` for every module,
-unless the associated spec satisfies ``^openmpi`` in which case ``BAR=baz``.
+unless the associated spec satisfies the abstract dependency ``^mpi`` in which case
+``BAR=baz``, and the directory containing the respective MPI executables is prepended
+to the ``PATH`` variable.
 In addition in any spec that satisfies ``zlib`` the value ``foo`` will be
 prepended to ``LD_LIBRARY_PATH`` and in any spec that satisfies ``zlib%gcc@4.8``
 the variable ``FOOBAR`` will be unset.


### PR DESCRIPTION
As suggested by Alan Sill in https://spackpm.slack.com/archives/C5WF9RXPZ/p1677596663117859?thread_ts=1677577570.857059&cid=C5WF9RXPZ
I changed the example from ^openmpi to ^mpi to add abstract dependency and keep changes minimal otherwise.