### PR TITLE
Add dependency on libxml2 in mesa package.

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -54,6 +54,7 @@ class Mesa(MesonPackage):
     depends_on("unwind")
     depends_on("expat")
     depends_on("zlib@1.2.3:")
+    depends_on("libxml2")
 
     # Override the build type variant so we can default to release
     variant(


### PR DESCRIPTION
While installing 
```
mesa@22.1.6%gcc@11.2.0+glx+llvm+opengl~opengles+osmesa~strip build_system=meson buildtype=release default_library=shared patches=3b8acf5,ee737d1 arch=linux-sles15-zen3
```
on Perlmutter, the build fails due to a missing `xml2` library.