### PR TITLE
Provide openmp from rocm-open-extras when tensile uses openmp

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-tensile/0003-require-openmp-extras-when-tensile-use-openmp.patch
+++ b/var/spack/repos/builtin/packages/rocm-tensile/0003-require-openmp-extras-when-tensile-use-openmp.patch
@@ -1,0 +1,24 @@
+From 2567ef30dea031fb1b894b74294c82856e47b2a6 Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Wed, 1 Mar 2023 17:38:17 +0000
+Subject: [PATCH] Include rocm-openmp-extras headers when tensile using openmp
+
+---
+ Tensile/Source/client/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Tensile/Source/client/CMakeLists.txt b/Tensile/Source/client/CMakeLists.txt
+index c04a6b7..7001364 100644
+--- a/Tensile/Source/client/CMakeLists.txt
++++ b/Tensile/Source/client/CMakeLists.txt
+@@ -76,6 +76,7 @@ if(NOT WIN32)
+ endif()
+ 
+ if(TENSILE_USE_OPENMP)
++    target_include_directories(TensileClient PUBLIC "${ROCM_OPENMP_EXTRAS_DIR}/include")
+     target_link_libraries(TensileClient PRIVATE custom_openmp_cxx)
+ endif()
+ 
+-- 
+2.31.1
+

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -160,17 +160,7 @@ class RocmTensile(CMakePackage):
         depends_on("llvm-amdgpu@" + ver + "~openmp", when="@" + ver + "~openmp")
         depends_on("rocminfo@" + ver, type="build", when="@" + ver)
 
-    for ver in [
-        "5.1.0",
-        "5.1.3",
-        "5.2.0",
-        "5.2.1",
-        "5.2.3",
-        "5.3.0",
-        "5.3.3",
-        "5.4.0",
-        "5.4.3",
-    ]:
+    for ver in ["5.1.0", "5.1.3", "5.2.0", "5.2.1", "5.2.3", "5.3.0", "5.3.3", "5.4.0", "5.4.3"]:
         depends_on("rocm-openmp-extras@" + ver, when="@" + ver + "+openmp")
 
     for ver in ["3.5.0", "3.7.0", "3.8.0", "3.9.0"]:

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -160,7 +160,7 @@ class RocmTensile(CMakePackage):
         depends_on("llvm-amdgpu@" + ver + "~openmp", when="@" + ver + "~openmp")
         depends_on("rocminfo@" + ver, type="build", when="@" + ver)
 
-for ver in [
+    for ver in [
         "5.1.0",
         "5.1.3",
         "5.2.0",

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -157,11 +157,10 @@ class RocmTensile(CMakePackage):
         depends_on("rocm-cmake@" + ver, type="build", when="@" + ver)
         depends_on("hip@" + ver, when="@" + ver)
         depends_on("comgr@" + ver, when="@" + ver)
-        depends_on("llvm-amdgpu@" + ver + "~openmp", when="@" + ver + "~openmp")
         depends_on("rocminfo@" + ver, type="build", when="@" + ver)
 
     for ver in ["5.1.0", "5.1.3", "5.2.0", "5.2.1", "5.2.3", "5.3.0", "5.3.3", "5.4.0", "5.4.3"]:
-        depends_on("rocm-openmp-extras@" + ver, when="@" + ver + "+openmp")
+        depends_on("rocm-openmp-extras@" + ver, when="@" + ver)
 
     for ver in ["3.5.0", "3.7.0", "3.8.0", "3.9.0"]:
         depends_on("rocm-smi@" + ver, type="build", when="@" + ver)
@@ -214,7 +213,6 @@ class RocmTensile(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("amd_comgr_DIR", self.spec["comgr"].prefix),
-            self.define("ROCM_OPENMP_EXTRAS_DIR", self.spec["rocm-openmp-extras"].prefix),
             self.define("Tensile_COMPILER", "hipcc"),
             self.define("Tensile_LOGIC", "asm_full"),
             self.define("Tensile_CODE_OBJECT_VERSION", "V3"),
@@ -226,6 +224,9 @@ class RocmTensile(CMakePackage):
             args.append(self.define("Tensile_LIBRARY_FORMAT", "msgpack"))
         if "@5.1.0:" in self.spec:
             args.append(self.define("TENSILE_USE_OPENMP", "ON")),
+            args.append(
+                self.define("ROCM_OPENMP_EXTRAS_DIR", self.spec["rocm-openmp-extras"].prefix)
+            ),
         else:
             args.append(self.define("TENSILE_USE_OPENMP", "OFF")),
 

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -157,9 +157,21 @@ class RocmTensile(CMakePackage):
         depends_on("rocm-cmake@" + ver, type="build", when="@" + ver)
         depends_on("hip@" + ver, when="@" + ver)
         depends_on("comgr@" + ver, when="@" + ver)
-        depends_on("rocm-openmp-extras@" + ver, when="@" + ver + "+openmp")
         depends_on("llvm-amdgpu@" + ver + "~openmp", when="@" + ver + "~openmp")
         depends_on("rocminfo@" + ver, type="build", when="@" + ver)
+
+for ver in [
+        "5.1.0",
+        "5.1.3",
+        "5.2.0",
+        "5.2.1",
+        "5.2.3",
+        "5.3.0",
+        "5.3.3",
+        "5.4.0",
+        "5.4.3",
+    ]:
+        depends_on("rocm-openmp-extras@" + ver, when="@" + ver + "+openmp")
 
     for ver in ["3.5.0", "3.7.0", "3.8.0", "3.9.0"]:
         depends_on("rocm-smi@" + ver, type="build", when="@" + ver)


### PR DESCRIPTION
Requires openmp from rocm-open-extras when tensile uses openmp