### PR TITLE
Add spack config require-upstream

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -472,6 +472,7 @@ def config_prefer_upstream(args):
 
     tty.msg("Updated config at {0}".format(config_file))
 
+
 def config_require_upstream(args):
     """Generate a strict packages config based on the configuration of all
     upstream installs."""
@@ -505,11 +506,7 @@ def config_require_upstream(args):
         variants.sort()
         variants = " ".join(variants)
 
-        pkg["require"][0]["any_of"].append(
-            "@{0} %{1} {2}".format(
-                version, compiler, variants
-            )
-        )
+        pkg["require"][0]["any_of"].append("@{0} %{1}{2}".format(version, compiler, "" if not variants else " " + variants))
 
     # Clean up entries so the package listing is a simple
     #       require: "@{version} %{compiler} {variants}"
@@ -526,6 +523,7 @@ def config_require_upstream(args):
     config_file = spack.config.config.get_config_filename(scope, section)
 
     tty.msg("Updated config at {0}".format(config_file))
+
 
 def config(parser, args):
     action = {

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -508,7 +508,9 @@ def config_require_upstream(args):
 
         # Require string. The conditional formatting for {2} is there to prevent
         # trailing whitespace when there are no non-default variants for a spec.
-        pkg["require"][0]["any_of"].append("@{0} %{1}{2}".format(version, compiler, "" if not variants else " " + variants))
+        pkg["require"][0]["any_of"].append(
+            "@{0} %{1}{2}".format(version, compiler, "" if not variants else " " + variants)
+        )
 
     # Clean up entries so the package listing is a simple
     #       require: "@{version} %{compiler} {variants}"

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -506,6 +506,8 @@ def config_require_upstream(args):
         variants.sort()
         variants = " ".join(variants)
 
+        # Require string. The conditional formatting for {2} is there to prevent
+        # trailing whitespace when there are no non-default variants for a spec.
         pkg["require"][0]["any_of"].append("@{0} %{1}{2}".format(version, compiler, "" if not variants else " " + variants))
 
     # Clean up entries so the package listing is a simple

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -671,15 +671,13 @@ def test_config_require_upstream(
     db_for_test = spack.database.Database(downstream_db_root, upstream_dbs=[prepared_db])
     monkeypatch.setattr(spack.store, "db", db_for_test)
 
-    output = config("require-upstream")
+    config("require-upstream")
     scope = spack.config.default_modify_scope("packages")
     cfg_file = spack.config.config.get_config_filename(scope, "packages")
     packages = syaml.load(open(cfg_file))["packages"]
 
     # Make sure version, compiler, and non-default variants are set.
-    assert packages["boost"] == {
-        "require": "@1.63.0 %gcc@10.2.1 +debug +graph"
-    }
+    assert packages["boost"] == {"require": "@1.63.0 %gcc@10.2.1 +debug +graph"}
     # Need trailing whitespace after a spec with no variants
     assert packages["dependency-install"] == {"require": "@2.0 %gcc@10.2.1"}
     # Ensure that hdf5 has two specs required with any_of

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -724,7 +724,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list add prefer-upstream remove rm update revert"
+        SPACK_COMPREPLY="get blame edit list add prefer-upstream require-upstream remove rm update revert"
     fi
 }
 
@@ -769,6 +769,10 @@ _spack_config_add() {
 }
 
 _spack_config_prefer_upstream() {
+    SPACK_COMPREPLY="-h --help --local"
+}
+
+_spack_config_require_upstream() {
     SPACK_COMPREPLY="-h --help --local"
 }
 


### PR DESCRIPTION
Adds `spack config require-upstream` command to Spack.

`spack config prefer-upstream` is useful for telling Spack to prefer reusing upstream builds during concretization. However, there are cases when this constraint is too weak - for example, if the downstream environment sets `require: 'oneapi'` for all packages, it will not reuse any upstream packages that are not build with `oneapi`.

This PR adds a `spack config require-upstream` command which functions very similarly to `prefer-upstream`, but it imposes `require` for upstream packages. Here are a few implementation details:
- only the version, compiler, and non-default variants are required, so the required specs will look like `@version %compiler +variants`
- if there is one upstream spec for a package, the generated config will be `require: 'spec1'`
- in the case of multiple upstream specs for one package, the generated config will be 
```
require:
  - any_of:
    - 'spec1'
    - 'spec2'
    - ...
```
- the command has a `--local` option which will generate the same config but for locally installed packages. I'm not sure this is necessary or useful, but it was part of `prefer-upstream` so I kept it.

This PR also adds a `spack/test/cmd/config.py::test_config_require_upstream` unit test modeled after the prefer-upstream unit test.

There is a lot of shared code with prefer-upstream so it's possible that I could combine `config_prefer_upstream()` and `config_require_upstream()`; not sure what's preferable since this would need a number of `if else` blocks. I can also combine the spack commands and make require into an option (i.e. `spack config prefer-upstream --require`).