### PR TITLE
julia: fix for libuv and Julia on Polaris

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -63,7 +63,7 @@ class Julia(MakefilePackage):
         depends_on("libblastrampoline@5.1.0:5")
         depends_on("libgit2@1.3.0:1.3")
         depends_on("libssh2@1.10.0:1.10")
-        depends_on("llvm@13.0.1 shlib_symbol_version=jl")
+        depends_on("llvm@13.0.1 shlib_symbol_version=JL_LLVM_13.0")
         depends_on("mbedtls@2.28.0:2.28")
         depends_on("openlibm@0.8.1:0.8", when="+openlibm")
         depends_on("nghttp2@1.47.0:1.47")

--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -17,7 +17,12 @@ class LibuvJulia(AutotoolsPackage):
     version("1.44.1", commit="1b2d16477fe1142adea952168d828a066e03ee4c")
     version("1.42.0", commit="3a63bf71de62c64097989254e4f03212e3bf5fc8")
 
-    depends_on("automake@1.16", type="build", when="@1.44.2:")
+    def autoreconf(self, spec, prefix):
+        # @haampie: Configure files are checked in, but git does not restore mtime
+        # by design. Therefore, touch files to avoid regenerating those.
+        touch("aclocal.m4")
+        touch("Makefile.in")
+        touch("configure")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -17,6 +17,8 @@ class LibuvJulia(AutotoolsPackage):
     version("1.44.1", commit="1b2d16477fe1142adea952168d828a066e03ee4c")
     version("1.42.0", commit="3a63bf71de62c64097989254e4f03212e3bf5fc8")
 
+    depends_on("automake@1.16", type="build", when="@1.44.2:")
+
     @property
     def libs(self):
         return find_libraries(["libuv"], root=self.prefix, recursive=True, shared=False)


### PR DESCRIPTION
When I went to use Julia@1.8.3 on Polaris at ALCF, I noticed the following issues with Julia in Spack.

1. It requires `aclocal-16` which is only installed with `automake@1.16` or else you get a build failure saying that this command doesn't exist
2. I tried using the `CUDA` julia package which uses some LLVM features that typical usages of Julia don't use.  When it uses these features, it looks for an shared library ABI version of `JL_LLVM_13.0` instead of `jl` as the soname.  I was able to run several different codes with this configuration.  You can reproduce these issues by running the following julia code:

```julia
using CUDA
cu(ones(5,5)) + cu(ones(5,5))
```