### PR TITLE
libdistributed, sz*, plus: converted to new stand-alone test process; removed redundant make(test)

### DIFF
--- a/var/spack/repos/builtin/packages/libdistributed/package.py
+++ b/var/spack/repos/builtin/packages/libdistributed/package.py
@@ -45,8 +45,3 @@ class Libdistributed(CMakePackage):
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/libpressio-opt/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-opt/package.py
@@ -42,8 +42,3 @@ class LibpressioOpt(CMakePackage):
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/libpressio-rmetric/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-rmetric/package.py
@@ -36,8 +36,3 @@ class LibpressioRmetric(CMakePackage):
             args.append("-DBUILD_TESTING=OFF")
 
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/libpressio-tools/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tools/package.py
@@ -94,8 +94,3 @@ class LibpressioTools(CMakePackage):
             args.append("-DBUILD_TESTING=OFF")
 
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/libpressio-tthresh/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tthresh/package.py
@@ -32,8 +32,3 @@ class LibpressioTthresh(CMakePackage):
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/libstdcompat/package.py
+++ b/var/spack/repos/builtin/packages/libstdcompat/package.py
@@ -91,8 +91,3 @@ class Libstdcompat(CMakePackage):
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test(self):
-        make("test")

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -82,87 +82,25 @@ class Sz(CMakePackage, AutotoolsPackage):
         if "+hdf5" in self.spec:
             env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
 
-    def _test_2d_float(self):
-        """This test performs simple 2D compression/decompression (float)"""
-        test_data_dir = self.test_suite.current_test_data_dir
+    def test_2d_float(self):
+        """run simple 2D compression/decompression (float)"""
+        orifile = "testfloat_8_8_128.dat"
+        decfile = "testfloat_8_8_128.dat.sz"
+        sz = which(self.prefix.bin.sz)
+        with working_dir(self.test_suite.current_test_data_dir):
+            sz("-z", "-f", "-i", orifile, "-M", "REL", "-R", "1E-3", "-2", "8", "1024")
 
-        filename = "testfloat_8_8_128.dat"
-        orifile = test_data_dir.join(filename)
+            sz("-x", "-f", "-i", orifile, "-s", decfile, "-2", "8", "1024", "-a")
 
-        exe = "sz"
-        reason = "testing 2D compression of {0}".format(exe)
-        options = ["-z", "-f", "-i", orifile, "-M", "REL", "-R", "1E-3", "-2", "8", "1024"]
+    def test_3d_float(self):
+        """run simple 3D compression/decompression (float)"""
+        orifile = "testfloat_8_8_128.dat"
+        decfile = "testfloat_8_8_128.dat.sz"
+        sz = which(self.prefix.bin.sz)
 
-        self.run_test(
-            exe,
-            options,
-            [],
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=test_data_dir,
-        )
-
-        filename = "testfloat_8_8_128.dat.sz"
-        decfile = test_data_dir.join(filename)
-
-        reason = "testing 2D decompression of {0}".format(exe)
-        options = ["-x", "-f", "-i", orifile, "-s", decfile, "-2", "8", "1024", "-a"]
-
-        self.run_test(
-            exe,
-            options,
-            [],
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=test_data_dir,
-        )
-
-    def _test_3d_float(self):
-        """This test performs simple 3D compression/decompression (float)"""
-
-        test_data_dir = self.test_suite.current_test_data_dir
-
-        filename = "testfloat_8_8_128.dat"
-        orifile = test_data_dir.join(filename)
-
-        exe = "sz"
-        reason = "testing 3D compression of {0}".format(exe)
-        options = ["-z", "-f", "-i", orifile, "-M", "REL", "-R", "1E-3", "-3", "8", "8", "128"]
-
-        self.run_test(
-            exe,
-            options,
-            [],
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=test_data_dir,
-        )
-
-        filename = "testfloat_8_8_128.dat.sz"
-        decfile = test_data_dir.join(filename)
-
-        reason = "testing 3D decompression of {0}".format(exe)
-        options = ["-x", "-f", "-i", orifile, "-s", decfile, "-3", "8", "8", "128", "-a"]
-
-        self.run_test(
-            exe,
-            options,
-            [],
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=test_data_dir,
-        )
-
-    def test(self):
-        """Perform smoke tests on the installed package"""
-        # run 2D compression and decompression (float)
-        self._test_2d_float()
-        # run 3D compression and decompression (float)
-        self._test_3d_float()
+        with working_dir(self.test_suite.current_test_data_dir):
+            sz("-z", "-f", "-i", orifile, "-M", "REL", "-R", "1E-3", "-3", "8", "8", "128")
+            sz("-x", "-f", "-i", orifile, "-s", decfile, "-3", "8", "8", "128", "-a")
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):

--- a/var/spack/repos/builtin/packages/sz3/package.py
+++ b/var/spack/repos/builtin/packages/sz3/package.py
@@ -42,12 +42,21 @@ class Sz3(CMakePackage):
             self.define_from_variant("BUILD_H5Z_FILTER", "hdf5"),
         ]
 
-    def test(self):
+    def test_sz3_smoke_test(self):
+        """ "check sz3_smoke_test works"""
         if self.spec.satisfies("@:3.1.6"):
-            print("smoke tests are only supported on 3.1.7 and later, skipping")
-            return
+            raise SkipTest("Test only supported on 3.1.7 and later")
 
-        self.run_test(self.prefix.bin.sz3_smoke_test, purpose="sz3 works")
+        sz3_smoke_test = which(self.prefix.bin.sz3_smoke_test)
+        sz3_smoke_test()
 
-        if "+mdz" in self.spec:
-            self.run_test(self.prefix.bin.mdz_smoke_test, purpose="mdz works")
+    def test_mdz_smoke_test(self):
+        """ "check mdz_smoke_test works"""
+        if self.spec.satisfies("@:3.1.6"):
+            raise SkipTest("Test only supported on 3.1.7 and later")
+
+        if "+mdz" not in self.spec:
+            raise SkipTest("Test only supported for +mdz builds")
+
+        mdz_smoke_test = which(self.prefix.bin.mdz_smoke_test)
+        mdz_smoke_test()


### PR DESCRIPTION
Depends on #34236 

Several packages simply had their post-`build` phase methods that run `make("test")` removed since they inherit from `CMakePackage`, which automatically runs that check if it is found in the makefile.

The rest have been converted to the new stand-alone test process.

TODO:
- [ ] (re) test converted packages