### PR TITLE
Fix the detection of Cray slingshot network

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -37,7 +37,7 @@ _xc_craype_dir = "/opt/cray/pe/cdt"
 
 
 def slingshot_network():
-    return os.path.exists("/lib64/libcxi.so")
+    return os.path.exists("/opt/cray/pe") and os.path.exists("/lib64/libcxi.so")
 
 
 def _target_name_from_craype_target_name(name):


### PR DESCRIPTION
Detection of Cray's slingshot detection has relied on the presence of
a shared library /lib64/libcxi.so, which seems to also appear on other non-slingshot systems.  This patch also checks to make sure that there is a Cray programming enviornment in /opt/cray/pe in addition to the shared library.