### PR TITLE
py-rtoml: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMaturin(PythonPackage):
+    """Build and publish crates with pyo3, rust-cpython and cffi bindings
+    as well as rust binaries as python packages.
+    """
+
+    homepage = "https://github.com/pyo3/maturin"
+    pypi = "maturin/maturin-0.13.7.tar.gz"
+
+    version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-wheel@0.36.2:", type="build")
+    depends_on("py-setuptools-rust@1.4:", type="build")
+    depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-rtoml/package.py
+++ b/var/spack/repos/builtin/packages/py-rtoml/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRtoml(PythonPackage):
+    """A better TOML library for python implemented in rust."""
+
+    homepage = "https://github.com/samuelcolvin/rtoml"
+    pypi = "rtoml/rtoml-0.9.0.tar.gz"
+
+    version("0.9.0", sha256="113f2e133d152d9424269c475b4a7d0679987078b543e88fcb16c870dc2c460d")
+
+    depends_on("rust", type="build")
+    depends_on("py-maturin@0.13", type="build")


### PR DESCRIPTION
This PR adds Yet Another Build Backend (YABB): maturin

Maturin is kinda like setuptools-rust, which is kinda like setuptools, which is kinda like distutils. Not really sure what the difference is, but rtoml chose it, so we now support it.

Didn't bother adding it to the PythonPackage docs since dependency discovery is identical to all the rest and we only have one package so far that uses it. 

This is a rust/cargo package, so it downloads hundreds of dependencies during build time. We currently don't have better control of rust packages.

Successfully builds on macOS 10.15.7 with Python 3.10.8 and Apple Clang 12.0.0.