### PR TITLE
tests/no maintainer packages: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -114,11 +114,12 @@ class Open3d(CMakePackage, CudaPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test(self):
-        if "+python" in self.spec:
-            self.run_test(
-                self.spec["python"].command.path,
-                ["-c", "import open3d"],
-                purpose="checking import of open3d",
-                work_dir="spack-test",
-            )
+    def check_python_import(self):
+        if "+python" not in self.spec:
+            return
+
+        with test_part(
+            self, "check_import_open3d", purpose="checking import of open3d", work_dir="spack-test"
+        ):
+            python = self.spec["python"].command
+            python("-c", "import open3d")

--- a/var/spack/repos/builtin/packages/openrasmol/package.py
+++ b/var/spack/repos/builtin/packages/openrasmol/package.py
@@ -58,11 +58,13 @@ class Openrasmol(MakefilePackage):
             bash = which("bash")
             bash("./rasmol_install.sh", "--prefix={0}".format(prefix))
 
-    def test(self):
-        testdir = self.test_suite.current_test_data_dir
-        opts = []
-        opts.append("-insecure")
-        opts.append("-script")
-        opts.append(join_path(testdir, "test.rsc"))
-        opts.append(join_path(self.prefix.sample, "1crn.pdb"))
-        self.run_test("rasmol", options=opts)
+    def test_rasmol(self):
+        """run rasmol on sample"""
+        opts = [
+            "-insecure",
+            "-script",
+            join_path(self.test_suite.current_test_data_dir, "test.rsc"),
+            join_path(self.prefix.sample, "1crn.pdb"),
+        ]
+        rasmol = which(self.prefix.bin.rasmol)
+        rasmol(*opts)

--- a/var/spack/repos/builtin/packages/povray/package.py
+++ b/var/spack/repos/builtin/packages/povray/package.py
@@ -146,12 +146,11 @@ class Povray(AutotoolsPackage):
 
         return extra_args
 
-    def test(self):
+    def test_render_sample(self):
+        """check render of sample file"""
         povs = find(self.prefix.share, "biscuit.pov")[0]
         copy(povs, ".")
-        self.run_test(
-            "povray",
-            options=["biscuit.pov"],
-            purpose="test: render sample file",
-            expected=["POV-Ray finished"],
-        )
+
+        povray = which(self.prefix.bin.povray)
+        out = povray("biscuit.pov", output=str.split, error=str.split)
+        assert "POV-Ray finished" in out

--- a/var/spack/repos/builtin/packages/qthreads/package.py
+++ b/var/spack/repos/builtin/packages/qthreads/package.py
@@ -31,7 +31,7 @@ class Qthreads(AutotoolsPackage):
 
     url = "https://github.com/Qthreads/qthreads/releases/download/1.10/qthread-1.10.tar.bz2"
     test_requires_compiler = True
-    test_base_path = "test/basics/"
+    test_base_path = join_path("test", "basics")
     test_list = ["hello_world_multi", "hello_world"]
 
     tags = ["e4s"]
@@ -99,41 +99,35 @@ class Qthreads(AutotoolsPackage):
         tests = self.test_list
         relative_test_dir = self.test_base_path
         files_to_cpy = []
-        header = "test/argparsing.h"
+        header = join_path("test", "argparsing.h")
         for test in tests:
             test_path = join_path(relative_test_dir, test + ".c")
             files_to_cpy.append(test_path)
         files_to_cpy.append(header)
         self.cache_extra_test_sources(files_to_cpy)
 
-    def build_tests(self):
+    def test_example(self):
         """Build and run the added smoke (install) test."""
         tests = self.test_list
         relative_test_dir = self.test_base_path
 
         for test in tests:
-            options = [
-                "-I{0}".format(self.prefix.include),
-                "-I{0}".format(self.install_test_root + "/test"),
-                join_path(self.install_test_root, relative_test_dir, test + ".c"),
-                "-o",
-                test,
-                "-L{0}".format(self.prefix.lib),
-                "-lqthread",
-                "{0}{1}".format(self.compiler.cc_rpath_arg, self.prefix.lib),
-            ]
-            reason = "test:{0}: Checking ability to link to the library.".format(test)
-            self.run_test("cc", options, [], installed=False, purpose=reason)
+            test_src = "{0}.c".format(test)
+            with test_part(
+                self, "test_example_{0}".format(test), purpose="build and run {0}".format(test)
+            ):
+                options = [
+                    "-I{0}".format(self.prefix.include),
+                    "-I{0}".format(join_path(self.install_test_root, "test")),
+                    join_path(self.install_test_root, relative_test_dir, test_src),
+                    "-o",
+                    test,
+                    "-L{0}".format(self.prefix.lib),
+                    "-lqthread",
+                    "{0}{1}".format(self.compiler.cc_rpath_arg, self.prefix.lib),
+                ]
+                cc = which(self.compiler.cc)
+                cc(*options)
 
-    def run_tests(self):
-        tests = self.test_list
-        # Now run the program
-        for test in tests:
-            reason = "test:{0}: Checking ability to execute.".format(test)
-            self.run_test(test, [], purpose=reason)
-
-    def test(self):
-        # Build
-        self.build_tests()
-        # Run test programs pulled from the build
-        self.run_tests()
+                exe = which(test)
+                exe()

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -75,12 +75,12 @@ class Tix(AutotoolsPackage):
         if "platform=darwin" in self.spec:
             fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))
 
-    def test(self):
+    def test_tcl(self):
+        """test that tix can be loaded"""
         test_data_dir = self.test_suite.current_test_data_dir
         test_file = test_data_dir.join("test.tcl")
-        self.run_test(
-            self.spec["tcl"].command.path, test_file, purpose="test that tix can be loaded"
-        )
+        tcl = self.spec["tcl"].command
+        tcl(test_file)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -89,14 +89,22 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         with working_dir(self.prefix.bin):
             symlink("wish{0}".format(self.version.up_to(2)), "wish")
 
-    def test(self):
-        self.run_test(self.spec["tk"].command.path, ["-h"], purpose="test wish command")
+    def test_tk_help(self):
+        """run tk help"""
+        tk = self.spec["tk"].command
+        tk("-h")
 
+    def test_wish(self):
+        """run wish"""
+        wish = self.command
+        wish()
+
+    def test_tk_load(self):
+        """check that tk can be loaded"""
         test_data_dir = self.test_suite.current_test_data_dir
         test_file = test_data_dir.join("test.tcl")
-        self.run_test(
-            self.spec["tcl"].command.path, test_file, purpose="test that tk can be loaded"
-        )
+        tcl = self.spec["tcl"].command
+        tcl(test_file)
 
     @property
     def command(self):


### PR DESCRIPTION
Depends on #34236 

This PR changes the following packages to reflect the new stand-alone test process:
~~- improved-rdock~~
~~- mptensor~~
~~- open3d~~
~~-openrasmol~~
~~- papyrus~~
~~- povray~~
~~- qthreads~~
~~- tix~~
~~- tk~~
