### PR TITLE
tests/openpmd-api/warpx: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -150,17 +150,12 @@ class OpenpmdApi(CMakePackage):
             # later tests
             ctest("--output-on-failure", "-j1")
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        exes = ["openpmd-ls"]  # in 0.11.1+
-        for exe in exes:
-            spec_vers_str = "{0}".format(self.spec.version)
-            reason = "test version of {0} is {1}".format(exe, spec_vers_str)
-            self.run_test(
-                exe,
-                ["--version"],
-                [spec_vers_str],
-                installed=True,
-                purpose=reason,
-                skip_missing=False,
-            )
+    def test_openpmd_ls(self):
+        """check version of openpmd-ls"""
+        if not self.spec.satisfies("@0.11.1:"):
+            raise SkipTest("Test is only available for version 0.11.1 on")
+
+        openpmd_ls = which(join_path(self.prefix.bin, "openpmd-ls"))
+        out = openpmd_ls("--version", output=str.split, error=str.split)
+        spec_vers_str = "{0}".format(self.spec.version)
+        assert spec_vers_str in out

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -265,16 +265,13 @@ class Warpx(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.examples_src_dir])
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
+    def test_example(self):
+        """run variant-dependent example"""
         if "+app" not in self.spec:
-            print("WarpX smoke tests skipped: requires variant +app")
-            return
-
-        # our executable names are a variant-dependent and naming evolves
-        exe = find(self.prefix.bin, "warpx.*", recursive=False)[0]
+            raise SkipTest("Test is only available for +app builds")
 
         cli_args = self._get_input_options(True)
-        self.run_test(
-            exe, cli_args, [], installed=True, purpose="Smoke test for WarpX", skip_missing=False
-        )
+
+        # our evolving executable names are variant-dependent
+        exe = which(find(self.prefix.bin, "warpx.*", recursive=False)[0])
+        exe(*cli_args)


### PR DESCRIPTION
Depends on #34236 

TODO:

- [ ] Update after above PR is merged
- [ ] (re)test