### PR TITLE
pgplot: made dependent packages set environment variables from pgplot

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -175,3 +175,7 @@ class Pgplot(MakefilePackage):
     def setup_run_environment(self, env):
         env.set("PGPLOT_FONT", self.prefix.include + "/grfont.dat")
         env.set("PGPLOT_DIR", self.prefix.lib + "/pgplot5")
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set("PGPLOT_FONT", self.prefix.include + "/grfont.dat")
+        env.set("PGPLOT_DIR", self.prefix.lib + "/pgplot5")


### PR DESCRIPTION
psrchive requires PGPLOT_DIR and PGPLOT_FONT set to work correctly.  I'm guessing this is the case for other packages that depend on pgplot.