### PR TITLE
py-pytorch-lightning: torch~distributed not supported in 1.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -128,6 +128,8 @@ class PyPytorchLightning(PythonPackage):
     depends_on("py-torchtext@0.7:", when="@1.5+extra", type=("build", "run"))
     depends_on("py-torchtext@0.5:", when="@:1.4+extra", type=("build", "run"))
 
+    # https://github.com/Lightning-AI/lightning/issues/16637
+    conflicts("^py-torch~distributed", when="@1.9.0")
     # https://github.com/Lightning-AI/lightning/issues/15494
     conflicts("^py-torch~distributed", when="@1.8.0")
     # https://github.com/Lightning-AI/lightning/issues/10348


### PR DESCRIPTION
https://github.com/Lightning-AI/lightning/issues/16931
https://github.com/Lightning-AI/lightning/issues/16637
https://github.com/Lightning-AI/lightning/pull/16658