### PR TITLE
hugo: add v0.111.1

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -18,6 +18,7 @@ class Hugo(Package):
 
     maintainers("alecbcs")
 
+    version("0.111.1", sha256="a71d4e1f49ca7156d3811c0b10957816b75ff2e01b35ef326e7af94dfa554ec0")
     version("0.110.0", sha256="eeb137cefcea1a47ca27dc5f6573df29a8fe0b7f1ed0362faf7f73899e313770")
     version("0.109.0", sha256="35a5ba92057fe2c20b2218c374e762887021e978511d19bbe81ce4d9c21f0c78")
     version("0.108.0", sha256="dc90e9de22ce87c22063ce9c309cefacba89269a21eb369ed556b90b22b190c5")


### PR DESCRIPTION
Add Hugo v0.111.1 which includes multiple bug fixes.

**Changelog:**
- strings: fix Truncate behavior for formatted html.
- Fix shortcode error when closing without .Inner.
- create: Fix typo in error message.
- resource_transformers/tocss: Fixed hugo:vars casting.
- markup: Fix linenos codeblock hl option case regression.
- Fix slow HTML elements collector for the pre case.
- commands: Fix server url rewrites (http status 200).
- Fix description of collections.Uniq.
- Fix shortcode detection in RenderString

Full changelog can be found [here](https://github.com/gohugoio/hugo/releases/tag/v0.111.0).

**Test Plan:**
Tested v0.111.1 by compiling and serving a test site.