### PR TITLE
apr: add v1.7.2, apr-util 1.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -12,6 +12,7 @@ class AprUtil(AutotoolsPackage):
     homepage = "https://apr.apache.org/"
     url = "https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.gz"
 
+    version("1.6.3", sha256="2b74d8932703826862ca305b094eef2983c27b39d5c9414442e9976a9acf1983")
     version("1.6.1", sha256="b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459")
     version("1.6.0", sha256="483ef4d59e6ac9a36c7d3fd87ad7b9db7ad8ae29c06b9dd8ff22dda1cc416389")
     version("1.5.4", sha256="976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19")

--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -12,6 +12,7 @@ class Apr(AutotoolsPackage):
     homepage = "https://apr.apache.org/"
     url = "https://archive.apache.org/dist/apr/apr-1.7.0.tar.gz"
 
+    version("1.7.2", sha256="3d8999b216f7b6235343a4e3d456ce9379aa9a380ffb308512f133f0c5eb2db9")
     version("1.7.0", sha256="48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2")
     version("1.6.2", sha256="4fc24506c968c5faf57614f5d0aebe0e9d0b90afa47a883e1a1ca94f15f4a42e")
     version("1.5.2", sha256="1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb")


### PR DESCRIPTION
Add APT v1.7.2 which includes multiple bug fixes.

**Changelog:**
- configure: Fix various build issues for compilers enforcing strict C99 compliance.
- configure: Prefer posix name-based shared memory over SysV IPC.
- Fix handle leak in the Win32 apr_uid_current implementation.
- Add error handling for lseek() failures in apr_file_write() and apr_file_writev().
- Avoid an overflow on 32 bit platforms.
- Add --tag=CC to libtool invocations.
- Signals: Allow handling of SIGUSR2 in apr_signal_thread.

Full changelog available [here](https://downloads.apache.org/apr/CHANGES-APR-1.7).