### PR TITLE
atk: add v2.38.0

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -17,6 +17,7 @@ class Atk(Package):
     list_url = "https://ftp.gnome.org/pub/gnome/sources/atk"
     list_depth = 1
 
+    version("2.38.0", sha256="ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36")
     version("2.36.0", sha256="fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788")
     version("2.30.0", sha256="dd4d90d4217f2a0c1fee708a555596c2c19d26fef0952e1ead1938ab632c027b")
     version("2.28.1", sha256="cd3a1ea6ecc268a2497f0cd018e970860de24a6d42086919d6bf6c8e8d53f4fc")


### PR DESCRIPTION
Add ATK v2.38.0.

**Summarized Changelog:**
* Require Meson 0.56.2
* Add g_autoptr support for ATK types
* Add ATK_STATE_COLLAPSED, matching AT-SPI's state
* Improve support for ATK as a Meson subproject
* Ensure that atk_value_get_value_and_text() can deal with NULL out arguments

Full changelog can be found [here](https://gitlab.gnome.org/GNOME/atk/-/tags/2.38.0).