### PR TITLE
aws-parallelcluster: add v3.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -26,6 +26,7 @@ class AwsParallelcluster(PythonPackage):
         "lukeseawalker",
     )
 
+    version("3.5.0", sha256="6b086f404b916129fbeffc1f8969bf7bbf05dac290c87cf5883c4f5a72d08471")
     version("2.11.9", sha256="615de4d59d9fd56a31d4feb3aeefe685346538a8dd0c1c35b660029f891d4dfd")
     version("2.11.8", sha256="acf33f48f8e48b0bc7be20f539d61baa1e27248765ba355df753bdfca4abd3cb")
     version("2.11.7", sha256="f7c51cf1c94787f56e0661e39860ecc9275efeacc88716b7c9f14053ec7fbd35")


### PR DESCRIPTION
Add aws-parallelcluster v3.5.0 which includes multiple bug fixes.

**Summarized Changelog:**
- Fix cluster DB creation by verifying the cluster name is no longer than 40 characters when Slurm accounting is enabled.
- Fix an issue in clustermgtd that caused compute nodes rebooted via Slurm to be replaced if the EC2 instance status checks fail.
- Fix an issue where compute nodes could not launch with capacity reservations shared by other accounts because of a wrong IAM policy on head node.
- Fix an issue where custom AMI creation failed in Ubuntu 20.04 on MySQL packages installation.
- Fix an issue where pcluster configure command failed when the account had no IPv4 CIDR subnet.

Full changelog [here](https://github.com/aws/aws-parallelcluster/releases/tag/v3.5.0).