### PR TITLE
bazel: add v6.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -20,6 +20,7 @@ class Bazel(Package):
 
     tags = ["build-tools"]
 
+    version("6.0.0", sha256="7bc0c5145c19a56d82a08fce6908c5e1a0e75e4fbfb3b6f12b4deae7f4b38cbc")
     version("5.2.0", sha256="820a94dbb14071ed6d8c266cf0c080ecb265a5eea65307579489c4662c2d582a")
     version("5.1.1", sha256="7f5d3bc1d344692b2400f3765fd4b5c0b636eb4e7a8a7b17923095c7b56a4f78")
     version("5.1.0", sha256="4de301f509fc6d0cbc697b2017384ecdc94df8f36245bbcbedc7ea6780acc9f5")


### PR DESCRIPTION
Add Bazel v6.0.0.

**Summarized Changelog:**
- [Bzlmod](https://bazel.build/versions/6.0.0/build/bzlmod), the new external dependency system in Bazel, is now generally available (though still disabled by default). Use --enable_bzlmod to enable it.
- Toolchain types may now be [optional](https://bazel.build/versions/6.0.0/extending/toolchains#optional-toolchains), in addition to mandatory.
- Bazel no longer stamps cc_common.link actions for tool dependencies.
- Bazel now correctly configures shell actions for multiplatform builds.

Full changelog can be found [here](https://github.com/bazelbuild/bazel/releases/tag/6.0.0).