### PR TITLE
easybuild: add v4.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -18,11 +18,12 @@ class Easybuild(PythonPackage):
     version("4.7.0", sha256="e68c280e3a508965aefbdf234872919f777f739cf4787cb11bb97a56e0cf74a6")
     version("4.0.0", sha256="21bcc1048525ad6219667cc97a7421b5388068c670cabba356712e474896de40")
 
-    depends_on("python@2.6:2.8,3.5:", when="@4:", type=("build", "run"))
+
+    depends_on("python@3.5:", type=("build", "run"))
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")
 
-    for v in ["@4.0.0"]:
+    for v in ["@4.0.0", "@4.7.0"]:
         depends_on("py-easybuild-framework" + v, when=v, type="run")
         depends_on("py-easybuild-easyblocks" + v, when=v, type="run")
         depends_on("py-easybuild-easyconfigs" + v, when=v, type="run")

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -18,7 +18,6 @@ class Easybuild(PythonPackage):
     version("4.7.0", sha256="e68c280e3a508965aefbdf234872919f777f739cf4787cb11bb97a56e0cf74a6")
     version("4.0.0", sha256="21bcc1048525ad6219667cc97a7421b5388068c670cabba356712e474896de40")
 
-
     depends_on("python@3.5:", type=("build", "run"))
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -15,6 +15,7 @@ class Easybuild(PythonPackage):
     pypi = "easybuild/easybuild-4.0.0.tar.gz"
     maintainers("boegel")
 
+    version("4.7.0", sha256="e68c280e3a508965aefbdf234872919f777f739cf4787cb11bb97a56e0cf74a6")
     version("4.0.0", sha256="21bcc1048525ad6219667cc97a7421b5388068c670cabba356712e474896de40")
 
     depends_on("python@2.6:2.8,3.5:", when="@4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -16,10 +16,11 @@ class PyEasybuildEasyblocks(PythonPackage):
     maintainers("boegel")
 
     version("4.0.0", sha256="a0fdef6c33c786e323bde1b28bab942fd8e535c26842877d705e692e85b31b07")
+    version("4.7.0", sha256="c23e81cbaa3e4fa5ab1bb8b2db759332867d61110bf4ec34763ea170780f0655")
 
-    depends_on("python@2.6:2.8,3.5:", when="@4:", type=("build", "run"))
+    depends_on("python@3.5:", type=("build", "run"))
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")
 
-    for v in ["@4.0.0"]:
+    for v in ["@4.0.0", "@4.7.0"]:
         depends_on("py-easybuild-framework" + v, when=v, type="run")

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -15,8 +15,8 @@ class PyEasybuildEasyblocks(PythonPackage):
     pypi = "easybuild-easyblocks/easybuild-easyblocks-4.0.0.tar.gz"
     maintainers("boegel")
 
-    version("4.0.0", sha256="a0fdef6c33c786e323bde1b28bab942fd8e535c26842877d705e692e85b31b07")
     version("4.7.0", sha256="c23e81cbaa3e4fa5ab1bb8b2db759332867d61110bf4ec34763ea170780f0655")
+    version("4.0.0", sha256="a0fdef6c33c786e323bde1b28bab942fd8e535c26842877d705e692e85b31b07")
 
     depends_on("python@3.5:", type=("build", "run"))
     # pip silently replaces distutils with setuptools

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -15,12 +15,13 @@ class PyEasybuildEasyconfigs(PythonPackage):
     pypi = "easybuild-easyconfigs/easybuild-easyconfigs-4.0.0.tar.gz"
     maintainers("boegel")
 
+    version("4.7.0", sha256="c688f14a3b0dce45c6cc90d746f05127dbf7368bd9b5873ce50757992d8e6261")
     version("4.0.0", sha256="90d4e8f8abb11e7ae2265745bbd1241cd69d02570e9b4530175c4b2e2aba754e")
 
-    depends_on("python@2.6:2.8,3.5:", when="@4:", type=("build", "run"))
+    depends_on("python@3.5:", type=("build", "run"))
     # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")
 
-    for v in ["@4.0.0"]:
+    for v in ["@4.0.0", "@4.7.0"]:
         depends_on("py-easybuild-framework{0}:".format(v), when=v + ":", type="run")
         depends_on("py-easybuild-easyblocks{0}:".format(v), when=v, type="run")

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -16,6 +16,7 @@ class PyEasybuildFramework(PythonPackage):
     maintainers("boegel")
 
     version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
+    version("4.7.0", sha256="ea51c3cb88fca27daadd2fb55ee31f5f51fc60c4e3519ee9d275954540312df8")
 
-    depends_on("python@2.6:2.8,3.5:", type=("build", "run"))
+    depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -15,8 +15,8 @@ class PyEasybuildFramework(PythonPackage):
     pypi = "easybuild-framework/easybuild-framework-4.0.0.tar.gz"
     maintainers("boegel")
 
-    version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
     version("4.7.0", sha256="ea51c3cb88fca27daadd2fb55ee31f5f51fc60c4e3519ee9d275954540312df8")
+    version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
 
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
Add easybuilld v4.7.0. 

**Summarized Changelog:**
- also run unit tests with Python 3.11;
- add support for checksums specified in external checksums.json file;
- take into account custom configuration options specified in easystack files - see also [docs](https://docs.easybuild.io/en/latest/Easystack-files.html);
- add support for using --output-format=md (MarkDown);
- add support for postinstallmsgs;
- add gfbf as subtoolchain of foss;
- make iimkl toolchain aware of intel-compilers;
- add generic easyblocks for installing (bundle of) Julia packages: JuliaPackage + JuliaBundle;

Full changelog [here](https://github.com/easybuilders/easybuild/releases/tag/easybuild-v4.7.0).