### PR TITLE
feh: add v3.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/feh/package.py
+++ b/var/spack/repos/builtin/packages/feh/package.py
@@ -18,6 +18,7 @@ class Feh(MakefilePackage):
 
     maintainers("TheQueasle")
 
+    version("3.9.1", sha256="455c92711b588af149b945edc5c145f3e9aa137ed9689dabed49d5e4acac75fa")
     version("3.3", sha256="f3959958258111d5f7c9fbe2e165c52b9d5987f07fd1f37540a4abf9f9638811")
     version("3.1.1", sha256="61d0242e3644cf7c5db74e644f0e8a8d9be49b7bd01034265cc1ebb2b3f9c8eb")
 


### PR DESCRIPTION
Add feh v3.9.1.

**Changelog:**
- Set libcurl user agent to "feh/3.9.1". Previously, feh did not send a user agent.

Full changelog [here](https://feh.finalrewind.org/archive/3.9.1/).