### PR TITLE
fontconfig: add v2.14.2

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -12,6 +12,7 @@ class Fontconfig(AutotoolsPackage):
     homepage = "https://www.freedesktop.org/wiki/Software/fontconfig/"
     url = "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.3.tar.gz"
 
+    version("2.14.2", sha256="3ba2dd92158718acec5caaf1a716043b5aa055c27b081d914af3ccb40dce8a55")
     version("2.13.94", sha256="246d1640a7e54fba697b28e4445f4d9eb63dda1b511d19986249368ee7191882")
     version("2.13.93", sha256="0f302a18ee52dde0793fe38b266bf269dfe6e0c0ae140e30d72c6cca5dc08db5")
     version("2.13.1", sha256="9f0d852b39d75fc655f9f53850eb32555394f36104a044bb2b2fc9e66dbbfa7f")


### PR DESCRIPTION
Add fontconfig v2.14.2.

**Summarized Changelog:**
- Adujst indentation between programlisting in fontconfig-user.sgml.
- Add some missing constant names for weight.
- Report more detailed logs instead of assertion.
- Fix a typo in description for HAVE_STDATOMIC_PRIMITIVES

Full changelog [here](https://www.freedesktop.org/software/fontconfig/release/ChangeLog-2.14.2).