### PR TITLE
ftxui: add v4.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/ftxui/package.py
+++ b/var/spack/repos/builtin/packages/ftxui/package.py
@@ -13,4 +13,5 @@ class Ftxui(CMakePackage):
     homepage = "https://arthursonzogni.github.io"
     url = "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v2.0.0.tar.gz"
 
+    version("4.0.0", sha256="7276e4117429ebf8e34ea371c3ea4e66eb99e0f234cb4c5c85fca17174a53dfa")
     version("2.0.0", sha256="d891695ef22176f0c09f8261a37af9ad5b262dd670a81e6b83661a23abc2c54f")


### PR DESCRIPTION
Add FTXUI v4.0.0.

**Summarized Changelog:**
- Bugfix: Forward the selected/focused area from the child in gridbox.
- Bugfix: Fix incorrect Canvas computed dimensions.
- Bugfix: Fix vscroll_indicator hidding the last column.
- Feature: Add the Modal component.
- Feature: Use a blinking bar in the Input component.

Full changelog [here](https://github.com/ArthurSonzogni/FTXUI/releases/tag/v4.0.0).