### PR TITLE
lammps: GPU/Kokkos package updates

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/hip_cmake.patch
+++ b/var/spack/repos/builtin/packages/lammps/hip_cmake.patch
@@ -1,0 +1,58 @@
+From b11049ba1a5fa22ff575f4d4afa6579973425962 Mon Sep 17 00:00:00 2001
+From: Richard Berger <richard.berger@outlook.com>
+Date: Sun, 5 Mar 2023 19:03:38 -0700
+Subject: [PATCH] CMake: Use hip::host and hip::hipcub targets
+
+---
+ cmake/Modules/Packages/GPU.cmake | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/cmake/Modules/Packages/GPU.cmake b/cmake/Modules/Packages/GPU.cmake
+index 8ac1decc86..21d046606f 100644
+--- a/cmake/Modules/Packages/GPU.cmake
++++ b/cmake/Modules/Packages/GPU.cmake
+@@ -412,7 +412,8 @@ elseif(GPU_API STREQUAL "HIP")
+       set_property(TARGET gpu PROPERTY CXX_STANDARD 14)
+     endif()
+     # add hipCUB
+-    target_include_directories(gpu PRIVATE ${HIP_ROOT_DIR}/../include)
++    find_package(hipcub REQUIRED)
++    target_link_libraries(gpu PRIVATE hip::hipcub)
+     target_compile_definitions(gpu PRIVATE -DUSE_HIP_DEVICE_SORT)
+ 
+     if(HIP_PLATFORM STREQUAL "nvcc")
+@@ -461,30 +462,22 @@ elseif(GPU_API STREQUAL "HIP")
+ 
+   add_executable(hip_get_devices ${LAMMPS_LIB_SOURCE_DIR}/gpu/geryon/ucl_get_devices.cpp)
+   target_compile_definitions(hip_get_devices PRIVATE -DUCL_HIP)
+-  target_link_libraries(hip_get_devices hip::host)
++  target_link_libraries(hip_get_devices PRIVATE hip::host)
+ 
+   if(HIP_PLATFORM STREQUAL "nvcc")
+     target_compile_definitions(gpu PRIVATE -D__HIP_PLATFORM_NVCC__)
+-    target_include_directories(gpu PRIVATE ${HIP_ROOT_DIR}/../include)
+     target_include_directories(gpu PRIVATE ${CUDA_INCLUDE_DIRS})
+     target_link_libraries(gpu PRIVATE ${CUDA_LIBRARIES} ${CUDA_CUDA_LIBRARY})
+ 
+     target_compile_definitions(hip_get_devices PRIVATE -D__HIP_PLATFORM_NVCC__)
+-    target_include_directories(hip_get_devices PRIVATE ${HIP_ROOT_DIR}/include)
+     target_include_directories(hip_get_devices PRIVATE ${CUDA_INCLUDE_DIRS})
+     target_link_libraries(hip_get_devices PRIVATE ${CUDA_LIBRARIES} ${CUDA_CUDA_LIBRARY})
+   elseif(HIP_PLATFORM STREQUAL "hcc")
+     target_compile_definitions(gpu PRIVATE -D__HIP_PLATFORM_HCC__)
+-    target_include_directories(gpu PRIVATE ${HIP_ROOT_DIR}/../include)
+-
+     target_compile_definitions(hip_get_devices PRIVATE -D__HIP_PLATFORM_HCC__)
+-    target_include_directories(hip_get_devices PRIVATE ${HIP_ROOT_DIR}/../include)
+   elseif(HIP_PLATFORM STREQUAL "amd")
+     target_compile_definitions(gpu PRIVATE -D__HIP_PLATFORM_AMD__)
+-    target_include_directories(gpu PRIVATE ${HIP_ROOT_DIR}/../include)
+-
+     target_compile_definitions(hip_get_devices PRIVATE -D__HIP_PLATFORM_AMD__)
+-    target_include_directories(hip_get_devices PRIVATE ${HIP_ROOT_DIR}/../include)
+   endif()
+ 
+   target_link_libraries(lammps PRIVATE gpu)
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -572,6 +572,15 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipcub", when="~kokkos +rocm")
     depends_on("llvm-amdgpu +openmp", when="+rocm +openmp", type="build")
 
+    # propagate CUDA and ROCm architecture when +kokkos
+    for arch in CudaPackage.cuda_arch_values:
+        depends_on("kokkos+cuda cuda_arch=%s" % arch, when="+kokkos+cuda cuda_arch=%s" % arch)
+
+    for arch in ROCmPackage.amdgpu_targets:
+        depends_on(
+            "kokkos+rocm amdgpu_target=%s" % arch, when="+kokkos+rocm amdgpu_target=%s" % arch
+        )
+
     depends_on("googletest", type="test")
     depends_on("libyaml", type="test")
 
@@ -616,7 +625,11 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         when="^adios2+mpi",
         msg="With +adios, mpi setting for adios2 and lammps must be the same",
     )
-    conflicts("~kokkos+rocm", when="@:20220602", msg="ROCm builds of the GPU package were not supported by this spackage prior to version 20220623")
+    conflicts(
+        "~kokkos+rocm",
+        when="@:20220602",
+        msg="ROCm builds of the GPU package not maintained prior to version 20220623",
+    )
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -513,6 +513,14 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         values=("single", "double"),
         multi=False,
     )
+    variant(
+        "gpu_precision",
+        default="mixed",
+        when="~kokkos",
+        description="Select GPU precision (used by GPU package)",
+        values=("double", "mixed", "single"),
+        multi=False,
+    )
 
     depends_on("mpi", when="+mpi")
     depends_on("mpi", when="+mpiio")
@@ -570,6 +578,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     extends("python", when="+python")
 
     conflicts("+cuda", when="+opencl")
+    conflicts("+rocm", when="+opencl")
     conflicts("+body", when="+poems@:20180628")
     conflicts("+latte", when="@:20170921")
     conflicts("+python", when="~lib")
@@ -645,6 +654,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
             if "+cuda" in spec:
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "cuda"))
+                args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
                 cuda_arch = spec.variants["cuda_arch"].value
                 if cuda_arch != "none":
                     args.append(self.define("GPU_ARCH", "sm_{0}".format(cuda_arch[0])))
@@ -654,9 +664,11 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
                 args.append(self.define("USE_STATIC_OPENCL_LOADER", False))
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "opencl"))
+                args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
             elif "+rocm" in spec:
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "hip"))
+                args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
                 args.append(self.define_from_variant("HIP_ARCH", "amdgpu_target"))
             else:
                 args.append(self.define("PKG_GPU", False))


### PR DESCRIPTION
LAMMPS has multiple GPU backends. The most actively developed one is for Kokkos, but the older GPU package also supports various backends, including HIP. 

This adds the missing `rocm` variant to lammps. By default, if kokkos is not enabled, it will build with the GPU package, as has been the case with the existing `+opencl` and `+cuda` variants.

The patch is necessary because of the hipcub dependency. It gets installed into a non-standard location when used via Spack. The current LAMMPS cmake was making some assumptions which break in that case. Since I have to choose some sort of cutoff for maintaining this, the patch is only applied beginning from the last stable release.

This and another issue in upstream `develop` should be resolved soon with https://github.com/lammps/lammps/pull/3674

I've also added a new dependent variant `gpu_precision`, which was/is actually the most significant benefit of the GPU package over Kokkos, as it allows you to choose between single, mixed, or double precision when doing the offloading.

For `+kokkos`, I've also added the propagation of the `cuda_arch` and `amdgpu_target` properties.