### PR TITLE
modules: add support for autoloading only run dependencies

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -45,11 +45,13 @@ modules:
 
     tcl:
       all:
-        autoload: direct
+        autoload: run
+      hide_implicits: true
 
     # Default configurations if lmod is enabled
     lmod:
       all:
-        autoload: direct
+        autoload: run
+      hide_implicits: true
       hierarchy:
         - mpi

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -654,7 +654,7 @@ Autoloading can also be enabled conditionally:
 The configuration file above will produce module files that will
 load their direct dependencies if the package installed depends on ``python``.
 The allowed values for the ``autoload`` statement are either ``none``,
-``direct`` or ``all``.
+``run``, ``direct`` or ``all``.
 
 .. note::
   Tcl prerequisites

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -926,11 +926,12 @@ class SetupContext:
     """This class encapsulates the logic to determine environment modifications, and is used as
     well to set globals in modules of package.py."""
 
-    def __init__(self, *specs: spack.spec.Spec, context: Context) -> None:
+    def __init__(self, *specs: spack.spec.Spec, context: Context, run_root: bool = True) -> None:
         """Construct a ModificationsFromDag object.
         Args:
             specs: single root spec for build/test context, possibly more for run context
-            context: build, run, or test"""
+            context: build, run, or test
+            run_root: whether root spec should be runnable"""
         if (context == Context.BUILD or context == Context.TEST) and not len(specs) == 1:
             raise ValueError("Cannot setup build environment for multiple specs")
         specs_with_type = effective_deptypes(*specs, context=context)
@@ -953,7 +954,7 @@ class SetupContext:
         self.should_setup_dependent_build_env = UseMode.BUILDTIME | UseMode.BUILDTIME_DIRECT
         self.should_setup_build_env = UseMode.ROOT if context == Context.BUILD else UseMode(0)
 
-        if context == Context.RUN or context == Context.TEST:
+        if (context == Context.RUN or context == Context.TEST) and run_root:
             self.should_be_runnable |= UseMode.ROOT
             self.should_setup_run_env |= UseMode.ROOT
 

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -32,7 +32,7 @@ array_of_strings = {"type": "array", "default": [], "items": {"type": "string"}}
 
 dictionary_of_strings = {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "string"}}}
 
-dependency_selection = {"type": "string", "enum": ["none", "direct", "all"]}
+dependency_selection = {"type": "string", "enum": ["none", "run", "direct", "all"]}
 
 module_file_configuration = {
     "type": "object",

--- a/lib/spack/spack/test/data/modules/lmod/autoload_run.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/autoload_run.yaml
@@ -1,0 +1,10 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@3.3'
+  hierarchy:
+    - mpi
+
+  all:
+    autoload: run

--- a/lib/spack/spack/test/data/modules/tcl/autoload_run.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/autoload_run.yaml
@@ -1,0 +1,5 @@
+enable:
+  - tcl
+tcl:
+  all:
+    autoload: run

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -120,6 +120,20 @@ class TestLmod:
         assert "whatis([[Version : 3.0.4]])" in content
         assert 'family("mpi")' in content
 
+    def test_autoload_run(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of direct dependencies."""
+
+        module_configuration("autoload_run")
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "depends_on(" in x]) == 1
+
     def test_autoload_direct(self, modulefile_content, module_configuration):
         """Tests the automatic loading of direct dependencies."""
 

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -31,6 +31,20 @@ class TestTcl:
 
         assert "module-whatis {mpich @3.0.4}" in content
 
+    def test_autoload_run(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of run dependencies."""
+
+        module_configuration("autoload_run")
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "module load " in x]) == 1
+
     def test_autoload_direct(self, modulefile_content, module_configuration):
         """Tests the automatic loading of direct dependencies."""
 


### PR DESCRIPTION
This adds support for autoloading run dependencies in module files and makes it the default since Spack already takes care of link dependencies via rpath. In contrast to `direct`, this can significantly speed up module loading.

This Git module autoloads all direct dependencies:
```
Benchmark 1: module load git
  Time (mean ± σ):     695.4 ms ±  23.4 ms    [User: 676.6 ms, System: 18.7 ms]
  Range (min … max):   658.5 ms … 736.6 ms    10 runs
```

This Git module autoloads only run dependencies:
```
Benchmark 1: module load git
  Time (mean ± σ):      38.9 ms ±   2.9 ms    [User: 31.2 ms, System: 8.1 ms]
  Range (min … max):    36.0 ms …  52.1 ms    73 runs
```