### PR TITLE
Halide: Add 15.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -14,6 +14,7 @@ class Halide(CMakePackage, PythonExtension):
     git = "https://github.com/halide/Halide.git"
     maintainers = ["wraith1995"]
     version("main", branch="main")
+    version("15.0.0", sha256="6680424f80c5731a85d977c06327096afe5af31da3667e91d4d36a25fabdda15")
     version("14.0.0", sha256="f9fc9765217cbd10e3a3e3883a60fc8f2dbbeaac634b45c789577a8a87999a01")
     variant(
         "build_type",
@@ -54,7 +55,9 @@ class Halide(CMakePackage, PythonExtension):
 
     depends_on("cmake@3.22:", type="build")
     depends_on("ninja", type="build")
-    depends_on("llvm@14.0.0:14+clang+lld build_type=Release", type=("link", "run"))
+    depends_on("llvm+clang+lld build_type=Release", type=("link", "run"))
+    depends_on("llvm@13.0.0:15", type=("link", "run"), when="@14.0.0")
+    depends_on("llvm@14.0.0:16", type=("link", "run"), when="@15.0.0:")
     for v in _values:
         depends_on(
             "llvm targets={0}".format(v), type=("link", "run"), when="targets={0}".format(v)

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -12,7 +12,7 @@ class Halide(CMakePackage, PythonExtension):
     homepage = "https://halide-lang.org/"
     url = "https://github.com/halide/Halide/archive/refs/tags/v14.0.0.tar.gz"
     git = "https://github.com/halide/Halide.git"
-    maintainers = ["wraith1995"]
+    maintainers("wraith1995")
     version("main", branch="main")
     version("15.0.0", sha256="6680424f80c5731a85d977c06327096afe5af31da3667e91d4d36a25fabdda15")
     version("14.0.0", sha256="f9fc9765217cbd10e3a3e3883a60fc8f2dbbeaac634b45c789577a8a87999a01")

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -108,10 +108,7 @@ class Halide(CMakePackage, PythonExtension):
             args += [
                 self.define("Python3_EXECUTABLE", spec["python"].command.path),
                 self.define("PYBIND11_USE_FETCHCONTENT", False),
-                self.define(
-                    "Halide_INSTALL_PYTHONDIR",
-                    python_platlib,
-                ),
+                self.define("Halide_INSTALL_PYTHONDIR", python_platlib),
             ]
         return args
 


### PR DESCRIPTION
This adds the latest release of Halide and conforms the llvm dependency to the Halide docs: llvm version \in [halide version - 1, halide version + 1].