### PR TITLE
MKL and AMDFFTW libraries are explicitly specified

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -230,7 +230,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
                         "--with-fftw3f={0}".format(spec[fftw_string].libs.ld_flags),
                     ]
                 )
-            elif ("^amdfftw" in spec):
+            elif "^amdfftw" in spec:
                 specAmdfftw = spec[fftw_string].token[0]
                 AMD_FFTW3_LIBS = "-lfftw3"
                 AMD_FFTW3F_LIBS = "-lfftw3f"
@@ -243,8 +243,10 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
               
                 config_args.extend(
                     [
-                        "--with-fftw3=-L{0} {1}".format(spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS),
-                        "--with-fftw3f=-L{0} {1}".format(spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS),
+                        "--with-fftw3=-L{0} {1}".format(
+                           spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS),
+                        "--with-fftw3f=-L{0} {1}".format(
+                           spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS),
                     ]
                 )
             else:
@@ -252,7 +254,8 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
                     [
                         "--with-fftw3-includedir=%s" % spec[fftw_string].prefix.include,
                         "--with-fftw3-libdir=%s" % spec[fftw_string].prefix.lib,
-                        "--with-fftw3f-includedir=%s" % spec[fftw_string].prefix.include,
+                        "--with-fftw3f-includedir=%s" 
+                        % spec[fftw_string].prefix.include,
                         "--with-fftw3f-libdir=%s" % spec[fftw_string].prefix.lib,
                     ]
                 )

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -240,13 +240,14 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
                 if "+threads" in specAmdfftw:
                     AMD_FFTW3_LIBS += " -lfftw3_threads"
                     AMD_FFTW3F_LIBS += " -lfftw3f_threads"
-              
                 config_args.extend(
                     [
                         "--with-fftw3=-L{0} {1}".format(
-                           spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS),
+                            spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS
+                        ),
                         "--with-fftw3f=-L{0} {1}".format(
-                           spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS),
+                            spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS
+                        ),
                     ]
                 )
             else:

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -223,14 +223,39 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
         if "+fftw" in spec:
             fftw_string = "fftw-api"
-            config_args.extend(
-                [
-                    "--with-fftw3-includedir=%s" % spec[fftw_string].prefix.include,
-                    "--with-fftw3-libdir=%s" % spec[fftw_string].prefix.lib,
-                    "--with-fftw3f-includedir=%s" % spec[fftw_string].prefix.include,
-                    "--with-fftw3f-libdir=%s" % spec[fftw_string].prefix.lib,
-                ]
-            )
+            if ("^intel-mkl" in spec) or ("^intel-oneapi-mkl" in spec):
+                config_args.extend(
+                    [
+                        "--with-fftw3={0}".format(spec[fftw_string].libs.ld_flags),
+                        "--with-fftw3f={0}".format(spec[fftw_string].libs.ld_flags),
+                    ]
+                )
+            elif ("^amdfftw" in spec):
+                specAmdfftw = spec[fftw_string].token[0]
+                AMD_FFTW3_LIBS = "-lfftw3"
+                AMD_FFTW3F_LIBS = "-lfftw3f"
+                if "+openmp" in specAmdfftw:
+                    AMD_FFTW3_LIBS += " -lfftw3_omp"
+                    AMD_FFTW3F_LIBS += " -lfftw3f_omp"
+                if "+threads" in specAmdfftw:
+                    AMD_FFTW3_LIBS += " -lfftw3_threads"
+                    AMD_FFTW3F_LIBS += " -lfftw3f_threads"
+              
+                config_args.extend(
+                    [
+                        "--with-fftw3=-L{0} {1}".format(spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS),
+                        "--with-fftw3f=-L{0} {1}".format(spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS),
+                    ]
+                )
+            else:
+                config_args.extend(
+                    [
+                        "--with-fftw3-includedir=%s" % spec[fftw_string].prefix.include,
+                        "--with-fftw3-libdir=%s" % spec[fftw_string].prefix.lib,
+                        "--with-fftw3f-includedir=%s" % spec[fftw_string].prefix.include,
+                        "--with-fftw3f-libdir=%s" % spec[fftw_string].prefix.lib,
+                    ]
+                )
         else:
             config_args.extend(["--without-fftw3", "--without-fftw3f"])
 

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -255,8 +255,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
                     [
                         "--with-fftw3-includedir=%s" % spec[fftw_string].prefix.include,
                         "--with-fftw3-libdir=%s" % spec[fftw_string].prefix.lib,
-                        "--with-fftw3f-includedir=%s" 
-                        % spec[fftw_string].prefix.include,
+                        "--with-fftw3f-includedir=%s" % spec[fftw_string].prefix.include,
                         "--with-fftw3f-libdir=%s" % spec[fftw_string].prefix.lib,
                     ]
                 )

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -243,10 +243,10 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
                 config_args.extend(
                     [
                         "--with-fftw3=-L{0} {1}".format(
-                            spec[fftw_string].libs.directories[0],AMD_FFTW3_LIBS
+                            spec[fftw_string].libs.directories[0], AMD_FFTW3_LIBS
                         ),
                         "--with-fftw3f=-L{0} {1}".format(
-                            spec[fftw_string].libs.directories[0],AMD_FFTW3F_LIBS
+                            spec[fftw_string].libs.directories[0], AMD_FFTW3F_LIBS
                         ),
                     ]
                 )


### PR DESCRIPTION
Previously, --with-fftw3-includedir and --with-fftw3-libdir are used to use MKL FFTW and AMDFFTW libraries and looked successful. However, Octave's configure script fell into the system FFTW3 library and those are not actually used.
Instead, --with-fftw3 is used to explicitly point to the above libraries.

I also realize that intel-oneapi-mkl packages actually provide sequential ones, and threaded versions are never referred to.
Meanwhile, intel-mkl provides threaded versions when the "threads" option is given.
The Octave package might be able to force to use threaded libraries of intel-oneapi-mkl, but it would be rather preferred that intel-oneapi-mkl has a switch between sequential and threaded versions as with intel-mkl.