### PR TITLE
ci: Increase the amount of pruning possible for PR pipelines

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -27,6 +27,7 @@ default:
     SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
     SPACK_PIPELINE_TYPE: "spack_pull_request"
     SPACK_PRUNE_UNTOUCHED: "True"
+    SPACK_UNTOUCHED_PRUNING_DEPENDENT_DEPTH: 1
 
 .protected-refs:
   only:


### PR DESCRIPTION
Now that we have a knob for controlling the amount of traversal done in the case of "untouched spec pruning" (#35274), use it to increase the amount of pruning possible for PR pipelines.  By setting the traversal depth to 1, only specs matching changed packages and direct dependents of those (and of course all dependencies of that set) are removed from pruning candidacy.