### PR TITLE
libuv-julia: fix autoreconf

### DIFF
--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -2,6 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+import time
+
 from spack.package import *
 
 
@@ -19,11 +22,15 @@ class LibuvJulia(AutotoolsPackage):
     version("1.42.0", commit="3a63bf71de62c64097989254e4f03212e3bf5fc8")
 
     def autoreconf(self, spec, prefix):
-        # @haampie: Configure files are checked in, but git does not restore mtime
-        # by design. Therefore, touch files to avoid regenerating those.
-        touch("aclocal.m4")
-        touch("Makefile.in")
-        touch("configure")
+        # @haampie: Configure files are checked in, but git does not restore
+        # mtime by design. Therefore, touch files to avoid regenerating those.
+        # Make sure to set them all to the same time, otherwise weird problems
+        # might occur (https://github.com/spack/spack/pull/35945).
+        cur = time.time()
+        times = (cur, cur)
+        os.utime("aclocal.m4", times)
+        os.utime("Makefile.in", times)
+        os.utime("configure", times)
 
     @property
     def libs(self):


### PR DESCRIPTION
Sometimes, libuv-julia's build step fails with:
```
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh '$SPACK_STAGE/spack-src/missing' autoconf
$SPACK_STAGE/spack-src/missing: line 81: autoconf: command not found
WARNING: 'autoconf' is missing on your system.
         You should only need it if you modified 'configure.ac',
         or m4 files included by it.
         The 'autoconf' program is part of the GNU Autoconf package:
         <https://www.gnu.org/software/autoconf/>
         It also requires GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>
make: *** [Makefile:1538: configure] Error 127
```

This seems to be due to the `configure` target depending on `aclocal.m4`, which is also touched. At least on Ceph this seems to be racy. After removing the touches for `aclocal.m4` and `Makefile.in`, the problem seems to be gone.