### PR TITLE
curl: Allow compiling recent versions with MbedTLS 2

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -273,7 +273,7 @@ class Curl(NMakePackage, AutotoolsPackage):
     conflicts("platform=linux", when="tls=secure_transport", msg="Only supported on macOS")
 
     depends_on("gnutls", when="tls=gnutls")
-    depends_on("mbedtls@3: +pic", when="@7.79: tls=mbedtls")
+    depends_on("mbedtls@2: +pic", when="@7.79: tls=mbedtls")
     depends_on("mbedtls@:2 +pic", when="@:7.78 tls=mbedtls")
     depends_on("nss", when="tls=nss")
     depends_on("openssl", when="tls=openssl")


### PR DESCRIPTION
Curl 7.79 started *supporting* MbedTLS 3, but it did ***not*** *require* that version dropping support for v2.  

With this PR I was able to compile successfully curl versions  7.79.0, 7.79.1, 7.80.0, 7.83.0, 7.87.0, 7.88.1 with MbedTLS 2.28.0 (`curl@X ^mbedtls@2.28.0`).

This PR reverts the needless restriction placed by #26877.