### PR TITLE
hpctoolkit: adjust dependency and conflict for xz

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -131,7 +131,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on("libunwind@1.4: +xz+pic")
     depends_on("mbedtls+pic", when="@:2022.03")
     depends_on("xerces-c transcoder=iconv")
-    depends_on("xz+pic@:5.2.6", type="link")
+    depends_on("xz+pic libs=static", type="link")
     depends_on("yaml-cpp@0.7.0: +shared", when="@2022.10:")
     depends_on("zlib+shared")
 
@@ -163,6 +163,7 @@ class Hpctoolkit(AutotoolsPackage):
     conflicts("%gcc@:4", when="@:2020", msg="hpctoolkit requires gnu gcc 5.x or later")
 
     conflicts("^binutils@2.35:2.35.1", msg="avoid binutils 2.35 and 2.35.1 (spews errors)")
+    conflicts("xz@5.2.7:5.2.8", msg="avoid xz 5.2.7:5.2.8 (broken symbol versions)")
 
     conflicts("+cray", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")
     conflicts("+mpi", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")


### PR DESCRIPTION
Hpctoolkit doesn't build cleanly with xz 5.2.7 and 5.2.8 due to a misuse of the symver attribute.  This is now fixed in 5.2.9 and later.

----------

I think the problem with symver is that -fPIC is broken for static
archives for GNU compilers earlier than 12.x (I think).  So, this
issue may affect other packages.

There are two additional things we may want to do.

1. Adapt a patch from xz for 5.2.7 and 5.2.8.  At first glance, this
might not be so simple, I don't know.

2. Drop xz versions 5.2.7 and 5.2.8 entirely and just use 5.2.9 or 5.2.10.

Anyway, this PR solves the problem for hpctoolkit.