### PR TITLE
reorder_flags: properly handle flags from concrete reused specs

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1258,6 +1258,9 @@ class TestConcretize(object):
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
     def test_reuse_with_flags(self, mutable_database, mutable_config):
+        if spack.config.get("config:concretizer") == "original":
+            pytest.xfail("Original concretizer does not reuse")
+
         spack.config.set("concretizer:reuse", True)
         spec = Spec("a cflags=-g cxxflags=-g").concretized()
         spack.store.db.add(spec, None)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1257,6 +1257,15 @@ class TestConcretize(object):
         # Structure and package hash will be different without reuse
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
+    def test_reuse_with_flags(self, mutable_database, mutable_config):
+        spack.config.set("concretizer:reuse", True)
+        spec = Spec("a cflags=-g cxxflags=-g").concretized()
+        spack.store.db.add(spec, None)
+
+        testspec = Spec("a cflags=-g")
+        testspec.concretize()
+        assert testspec == spec
+
     @pytest.mark.regression("20784")
     def test_concretization_of_test_dependencies(self):
         # With clingo we emit dependency_conditions regardless of the type


### PR DESCRIPTION
Fixes a bug reported by @lukebroskop on Slack.

Currently, Spack errors on compiler flags from reused specs. This is because the source of the compiler flag is the reused spec, and is not tracked.

To reproduce the error, run `spack install zlib cflags=-g && spack spec zlib` in a clean checkout of Spack.

With this PR, `SpecBuilder` now tracks which specs came from hashes, and uses the concrete spec as the source (rather than the CLI spec) if the spec was reused. The concrete spec is guaranteed to have a superset of the flags in the CLI spec, so this does not result in a loss of information.