### PR TITLE
Deprecate elpa rc2

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -28,6 +28,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2022.11.001.rc2",
         sha256="13d67e7d69894c631b48e4fcac905b51c4e41554c7eb4731e98c4e205f0fab9f",
+	deprecated=True,
     )
     version(
         "2021.11.001", sha256="fb361da6c59946661b73e51538d419028f763d7cb9dacf9d8cd5c9cd3fb7802f"

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -28,7 +28,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "2022.11.001.rc2",
         sha256="13d67e7d69894c631b48e4fcac905b51c4e41554c7eb4731e98c4e205f0fab9f",
-	deprecated=True,
+        deprecated=True,
     )
     version(
         "2021.11.001", sha256="fb361da6c59946661b73e51538d419028f763d7cb9dacf9d8cd5c9cd3fb7802f"


### PR DESCRIPTION
Deprecate ELPA's `rc2`. Reasons for deprecation:

* It's a release candidate
* `elpa@2022.11.001.rc2+cuda` does not work (https://github.com/marekandreas/elpa/issues/28)
* As far as I can tell there is no explicit dependency from `@2022.11.001.rc2` within Spack packages 
* It was added by @toxa81 in https://github.com/spack/spack/pull/33439, who agreed privately it should be deprecated/removed