### PR TITLE
Reduce compilers.yaml verbosity

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -820,8 +820,7 @@ class InvalidCompilerConfigurationError(spack.error.SpackError):
     def __init__(self, compiler_spec):
         super(InvalidCompilerConfigurationError, self).__init__(
             'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
-            "Compiler configuration must contain entries for compilers: %s"
-            % _path_instance_vars,
+            f"Compiler configuration must contain entries for compilers: {_path_instance_vars}",
         )
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -86,7 +86,7 @@ def _to_dict(compiler):
     d["paths"] = dict(
         (attr, getattr(compiler, attr))
         for attr in _path_instance_vars
-        if hasattr(compiler, attr)
+        if getattr(compiler, attr) is not None
     )
     d["flags"] = dict((fname, " ".join(fvals)) for fname, fvals in compiler.flags.items())
     d["flags"].update(

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -22,11 +22,11 @@ properties = {
                     "compiler": {
                         "type": "object",
                         "additionalProperties": False,
-                        "required": ["paths", "spec", "modules", "operating_system"],
+                        "required": ["paths", "spec", "operating_system"],
                         "properties": {
                             "paths": {
                                 "type": "object",
-                                "required": ["cc", "cxx", "f77", "fc"],
+                                "required": ["cc"],
                                 "additionalProperties": False,
                                 "properties": {
                                     "cc": {"anyOf": [{"type": "string"}, {"type": "null"}]},

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -213,13 +213,16 @@ def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, clangdir):
 
     gfortran_path = str(clangdir.join("gfortran-8"))
 
-    assert clang["paths"] == {
-        "cc": str(clangdir.join("clang")),
-        "cxx": str(clangdir.join("clang++")),
-        # we only auto-detect mixed clang on macos
-        "f77": gfortran_path if sys.platform == "darwin" else None,
-        "fc": gfortran_path if sys.platform == "darwin" else None,
-    }
+    assert clang["paths"]["cc"] == str(clangdir.join("clang"))
+    assert clang["paths"]["cxx"] == str(clangdir.join("clang++"))
+
+    # we only auto-detect mixed clang on macos
+    if sys.platform == "darwin":
+        assert clang["paths"]["f77"] == gfortran_path
+        assert clang["paths"]["fc"] == gfortran_path
+    else:
+        assert "f77" not in clang["paths"]
+        assert "fc" not in clang["paths"]
 
     assert gcc["paths"] == {
         "cc": str(clangdir.join("gcc-8")),


### PR DESCRIPTION
Fortran compilers are not universal (llvm)
Modules I don't have to explain
Target makes generic environment configs non-portable
If there are no flags, why have a flags prop.

With this PR, you can get a slightly simpler compilers.yaml config that doesn't
make your environments unreadable and overly machine specific.

```
compilers:
- compiler:
    spec: apple-clang@14.0.0
    paths:
      cc: /usr/bin/clang
      cxx: /usr/bin/clang++
    operating_system: ventura
```

