### PR TITLE
scorep: fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -90,19 +90,20 @@ class Scorep(AutotoolsPackage):
     # two components of cube -- cubew and cubelib.
 
     # SCOREP 8
+    depends_on("binutils", type="link", when="@8:")
     depends_on("otf2@3:", when="@8:")
     depends_on("cubew@4.8:", when="@8:")
     depends_on("cubelib@4.8:", when="@8:")
     # fall through to Score-P 7's OPARI2, no new release
     # SCOREP 7
-    depends_on("otf2@2.3:2.3.99", when="@7:8")
-    depends_on("cubew@4.6:4.7.99", when="@7:8")
-    depends_on("cubelib@4.6:4.7.99", when="@7:8")
+    depends_on("otf2@2.3:2.3.99", when="@7.0:7")
+    depends_on("cubew@4.6:4.7.99", when="@7.0:7")
+    depends_on("cubelib@4.6:4.7.99", when="@7.0:7")
     depends_on("opari2@2.0.6:", when="@7:")
     # SCOREP 6
-    depends_on("otf2@2.2:", when="@6:")
+    depends_on("otf2@2.2:", when="@6.0:6")
     # SCOREP 4 and 5
-    depends_on("otf2@2.1:", when="@4:")
+    depends_on("otf2@2.1:", when="@4:5")
     depends_on("cubew@4.4:4.5", when="@4:6")
     depends_on("cubelib@4.4:4.5", when="@4:6")
     # SCOREP 3


### PR DESCRIPTION
The overlapping dependency version ranges caused the concretizer to pick version 7.1 even though version 8.0 is available:
```
==> Error: No version for 'cubelib' satisfies '@4.7.1' and '@4.8'
```

Moreover, Score-P 8.0 requires libbfd:
```
configure: error: bfd.h required
```