### PR TITLE
Update yaFyaml, pFlogger, and gFTL versions, add list_url

### DIFF
--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -12,6 +12,7 @@ class Fargparse(CMakePackage):
 
     homepage = "https://github.com/Goddard-Fortran-Ecosystem/fArgParse"
     url = "https://github.com/Goddard-Fortran-Ecosystem/fArgParse/archive/refs/tags/v1.4.1.tar.gz"
+    list_url = "https://github.com/Goddard-Fortran-Ecosystem/fArgParse/tags"
     git = "https://github.com/Goddard-Fortran-Ecosystem/fArgParse.git"
 
     maintainers("mathomp4", "tclune")

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -16,6 +16,7 @@ class GftlShared(CMakePackage):
     url = (
         "https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/archive/refs/tags/v1.5.0.tar.gz"
     )
+    list_url = "https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/tags"
     git = "https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared.git"
 
     maintainers("mathomp4", "tclune")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -38,6 +38,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.8.3", sha256="5864c6a427105c1194cbc0dcbe0dad2c3d14d42b2717f0a5e1626e0d56bba8a6")
     version("1.8.2", sha256="7ee9a1db62f6dd09e533516d7dc53fbc9c8c81464bb12f6eb558ad5d3bfd85ef")
     version("1.8.1", sha256="b8171ea69b108325816472ee47068618d709a3f563959142bc58ff38908a7210")
     version("1.8.0", sha256="e99def0a9a1b3031ceff22c416bee75e70558cf6b91ce4be70b0ad752dda26c6")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -31,6 +31,7 @@ class Gftl(CMakePackage):
 
     homepage = "https://github.com/Goddard-Fortran-Ecosystem/gFTL"
     url = "https://github.com/Goddard-Fortran-Ecosystem/gFTL/archive/refs/tags/v1.5.5.tar.gz"
+    list_url = "https://github.com/Goddard-Fortran-Ecosystem/gFTL/tags"
     git = "https://github.com/Goddard-Fortran-Ecosystem/gFTL.git"
 
     maintainers("mathomp4", "tclune")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -12,6 +12,7 @@ class Pflogger(CMakePackage):
 
     homepage = "https://github.com/Goddard-Fortran-Ecosystem/pFlogger"
     url = "https://github.com/Goddard-Fortran-Ecosystem/pFlogger/archive/refs/tags/v1.6.1.tar.gz"
+    list_url = "https://github.com/Goddard-Fortran-Ecosystem/pFlogger/tags"
     git = "https://github.com/Goddard-Fortran-Ecosystem/pFlogger.git"
 
     maintainers("mathomp4", "tclune")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -19,6 +19,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.9.3", sha256="f300fab515a25b728889ef6c2ab64aa90e7f94c98fd8190dd11a9b1ebd38117a")
     version("1.9.2", sha256="783879eb1326a911f6e22c016e8530644ed0d315660405f2b43df42ba8670acc")
     version("1.9.1", sha256="918965f5a748a3a62e54751578f5935a820407b988b8455f7f25c266b5b7fe3c")
     version("1.9.0", sha256="aacd9b7e188bee3a54a4e681adde32e3bd95bb556cbbbd2c725c81aca5008003")

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -25,6 +25,8 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.0.7", sha256="54f5c87e86c12e872e615fbc9540610ae38053f844f1e75d1e753724fea85c64")
+    version("1.0.6", sha256="8075e1349d900985f5b5a81159561568720f21c5f011c43557c46f5bbedd0661")
     version("1.0.5", sha256="84abad01cdcfe387240844c35e5fb36d5099f657b57a50d5d5909cc567e72200")
     version("1.0.4", sha256="93ba67c87cf96be7ebe479907ca5343251aa48072b2671b8630bd244540096d3")
     version("1.0.3", sha256="cfbc6b6db660c5688e37da56f9f0091e5cafeeaec395c2a038469066c83b0c65")

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -19,6 +19,7 @@ class Yafyaml(CMakePackage):
 
     homepage = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml"
     url = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/archive/refs/tags/v1.0.4.tar.gz"
+    list_url = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/tags"
     git = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml.git"
 
     maintainers("mathomp4", "tclune")


### PR DESCRIPTION
This PR adds newly (-ish) released versions of gFTL, yaFyaml, and pFlogger that weren't yet in spack.