### PR TITLE
cce compiler: bugfix for version regex to avoid conflation with apple-clang

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -61,7 +61,7 @@ class Cce(Compiler):
         return version >= ver("9.0") and "classic" not in str(version)
 
     version_argument = "--version"
-    version_regex = r"[Cc]ray (?:clang )?[Vv]ersion.*?(\d+(\.\d+)+)"
+    version_regex = r"[Cc]ray (?:clang|C :|C\+\+ :|Fortran :) [Vv]ersion.*?(\d+(\.\d+)+)"
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -61,7 +61,7 @@ class Cce(Compiler):
         return version >= ver("9.0") and "classic" not in str(version)
 
     version_argument = "--version"
-    version_regex = r"[Vv]ersion.*?(\d+(\.\d+)+)"
+    version_regex = r"[Cc]ray (clang )?[Vv]ersion.*?(\d+(\.\d+)+)"
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -61,7 +61,7 @@ class Cce(Compiler):
         return version >= ver("9.0") and "classic" not in str(version)
 
     version_argument = "--version"
-    version_regex = r"[Cc]ray (clang )?[Vv]ersion.*?(\d+(\.\d+)+)"
+    version_regex = r"[Cc]ray (?:clang )?[Vv]ersion.*?(\d+(\.\d+)+)"
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -58,6 +58,7 @@ def test_arm_version_detection(version_str, expected_version):
     [
         ("Cray C : Version 8.4.6  Mon Apr 15, 2019  12:13:39\n", "8.4.6"),
         ("Cray C++ : Version 8.4.6  Mon Apr 15, 2019  12:13:45\n", "8.4.6"),
+        ("Cray clang Version 8.4.6  Mon Apr 15, 2019  12:13:45\n", "8.4.6"),
         ("Cray Fortran : Version 8.4.6  Mon Apr 15, 2019  12:13:55\n", "8.4.6"),
     ],
 )
@@ -487,3 +488,24 @@ def test_cray_frontend_compiler_detection(compiler, version, tmpdir, monkeypatch
 def test_aocc_version_detection(version_str, expected_version):
     version = spack.compilers.aocc.Aocc.extract_version_from_output(version_str)
     assert version == expected_version
+
+
+@pytest.mark.regression("33901")
+@pytest.mark.parametrize("version_str", [
+    (
+        "Apple clang version 11.0.0 (clang-1100.0.33.8)\n"
+        "Target: x86_64-apple-darwin18.7.0\n"
+        "Thread model: posix\n"
+        "InstalledDir: "
+        "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+        "XcodeDefault.xctoolchain/usr/bin\n"
+    ),
+    (
+        "Apple LLVM version 7.0.2 (clang-700.1.81)\n"
+        "Target: x86_64-apple-darwin15.2.0\n"
+        "Thread model: posix\n"
+    ),
+])
+def test_apple_clang_not_detected_as_cce(version_str):
+    version = spack.compilers.cce.Cce.extract_version_from_output(version_str)
+    assert version == "unknown"

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -491,21 +491,23 @@ def test_aocc_version_detection(version_str, expected_version):
 
 
 @pytest.mark.regression("33901")
-@pytest.mark.parametrize("version_str", [
-    (
-        "Apple clang version 11.0.0 (clang-1100.0.33.8)\n"
-        "Target: x86_64-apple-darwin18.7.0\n"
-        "Thread model: posix\n"
-        "InstalledDir: "
-        "/Applications/Xcode.app/Contents/Developer/Toolchains/"
-        "XcodeDefault.xctoolchain/usr/bin\n"
-    ),
-    (
-        "Apple LLVM version 7.0.2 (clang-700.1.81)\n"
-        "Target: x86_64-apple-darwin15.2.0\n"
-        "Thread model: posix\n"
-    ),
-])
+@pytest.mark.parametrize("version_str",
+    [
+        (
+            "Apple clang version 11.0.0 (clang-1100.0.33.8)\n"
+            "Target: x86_64-apple-darwin18.7.0\n"
+            "Thread model: posix\n"
+            "InstalledDir: "
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+            "XcodeDefault.xctoolchain/usr/bin\n"
+        ),
+        (
+            "Apple LLVM version 7.0.2 (clang-700.1.81)\n"
+            "Target: x86_64-apple-darwin15.2.0\n"
+            "Thread model: posix\n"
+        ),
+    ],
+)
 def test_apple_clang_not_detected_as_cce(version_str):
     version = spack.compilers.cce.Cce.extract_version_from_output(version_str)
     assert version == "unknown"

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -491,7 +491,8 @@ def test_aocc_version_detection(version_str, expected_version):
 
 
 @pytest.mark.regression("33901")
-@pytest.mark.parametrize("version_str",
+@pytest.mark.parametrize(
+    "version_str",
     [
         (
             "Apple clang version 11.0.0 (clang-1100.0.33.8)\n"


### PR DESCRIPTION
Currently apple-clang is detected as cce, and it should not be.

Fixes #33901

@adamjstewart thanks for reminding me of this.