### PR TITLE
CI: TensorFlow needs huge runners

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -277,6 +277,7 @@ spack:
           - llvm-amdgpu
           - rocblas
           - paraview
+          - py-tensorflow
           - py-torch
         runner-attributes:
           tags: [ "spack", "huge", "x86_64" ]
@@ -302,7 +303,6 @@ spack:
           - openturns
           - plumed
           - precice
-          - py-tensorflow
           - qt
           - raja
           - rocfft

--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -121,6 +121,7 @@ spack:
         - llvm-amdgpu
         - rocblas
         - paraview
+        - py-tensorflow
         - py-torch
         runner-attributes:
           tags: [ "spack", "huge", "x86_64" ]
@@ -146,7 +147,6 @@ spack:
         - openturns
         - plumed
         - precice
-        - py-tensorflow
         - qt
         - raja
         - rocfft


### PR DESCRIPTION
Add the TensorFlow package to the Huge mapping group.