### PR TITLE
py-torch: NNPACK requires AVX2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -74,7 +74,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     variant("nccl", default=True, description="Use NCCL", when="+cuda platform=cray")
     variant("nccl", default=True, description="Use NCCL", when="+rocm platform=linux")
     variant("nccl", default=True, description="Use NCCL", when="+rocm platform=cray")
-    variant("nnpack", default=True, description="Use NNPACK")
+    # Requires AVX2: https://discuss.pytorch.org/t/107518
+    variant("nnpack", default=True, description="Use NNPACK", when="target=x86_64_v3:")
     variant("numa", default=True, description="Use NUMA", when="platform=linux")
     variant("numa", default=True, description="Use NUMA", when="platform=cray")
     variant("numpy", default=True, description="Use NumPy")


### PR DESCRIPTION
The build doesn't fail if AVX2 isn't present, but every time you run PyTorch Lightning you see:
```
[W NNPACK.cpp:53] Could not initialize NNPACK! Reason: Unsupported hardware.
```
There isn't yet an easy way to add this to the `nnpack` package so I didn't.