### PR TITLE
cython: force through env variable

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/5307.patch
+++ b/var/spack/repos/builtin/packages/py-cython/5307.patch
@@ -1,0 +1,24 @@
+From 0d01d90aaa0574868db867f64c8504fc847bae9b Mon Sep 17 00:00:00 2001
+From: Stefan Behnel <stefan_ml@behnel.de>
+Date: Wed, 2 Feb 2022 23:41:45 +0100
+Subject: [PATCH] Allow globally forcing C file regeneration by setting the env
+ var CYTHON_FORCE_REGEN=1, e.g. from external build systems.
+
+---
+ Cython/Build/Dependencies.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Cython/Build/Dependencies.py b/Cython/Build/Dependencies.py
+index 1ba574d52f..28c48ed8c3 100644
+--- a/Cython/Build/Dependencies.py
++++ b/Cython/Build/Dependencies.py
+@@ -963,6 +963,9 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False,
+         pythran_options.cplus = True
+         pythran_options.np_pythran = True
+ 
++    if force is None:
++        force = os.environ.get("CYTHON_FORCE_REGEN") == "1"  # allow global overrides for build systems
++
+     c_options = CompilationOptions(**options)
+     cpp_options = CompilationOptions(**options); cpp_options.cplus = True
+     ctx = c_options.create_context()

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -53,6 +53,9 @@ class PyCython(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("gdb@7.2:", type="test")
 
+    # Backports CYTHON_FORCE_REGEN environment variable
+    patch("5307.patch", when="@0.29")
+
     @property
     def command(self):
         """Returns the Cython command"""
@@ -70,8 +73,9 @@ class PyCython(PythonPackage):
         # https://github.com/cython/cython/issues/5089
 
         # Backport for support for this variable in 0.29 is pending
-        # https://github.com/cython/cython/pull/5307
-        if self.spec.version >= Version("3"):
+        # https://github.com/cython/cython/pull/5307, we apply a patch in
+        # Spack to use it already.
+        if self.spec.version >= Version("0.29"):
             env.set("CYTHON_FORCE_REGEN", "1")
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -58,6 +58,22 @@ class PyCython(PythonPackage):
         """Returns the Cython command"""
         return Executable(self.prefix.bin.cython)
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # If cython is used as a dep, ensure it's used even when pre-generated
+        # C files are distributed in the tarball. Cython is a small build dep, and
+        # the time generating C-files is typically less than compiling them. So it's
+        # fine. It solves an issue where distributed C-sources were generated with
+        # an old, buggy Cython. In particular Cython regularly depends on cpython
+        # internals, which can change even in Python patch releases. It looks like
+        # the Cython folks are coming back from their recommendation to *include*
+        # pre-generated C-sources in tarballs, see also
+        # https://github.com/cython/cython/issues/5089
+
+        # Backport for support for this variable in 0.29 is pending
+        # https://github.com/cython/cython/pull/5307
+        if self.spec.version >= Version("3"):
+            env.set("CYTHON_FORCE_REGEN", "1")
+
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def build_test(self):


### PR DESCRIPTION
So, the cython folks used to recommend shipping generated C files, kinda like
autotools packages include generated configure scripts and docs etc so you need
fewer dependencies.

But it turns out: cython relies a lot on cpython internals, meaning that it's
bound to be forward incompatible with Python, and that may even include
patch releases of Python, e.g. `3.10.1` -> `3.10.2`.

Since cython itself is only a small build dep, and it takes less time to
generate C files than to compile them, it'd be better to force regeneration
using the new `CYTHON_FORCE_REGEN` environment variable.

I've opened a backport for it to 0.29, let's see if that gets accepted, then
the lowerbound for the env variable can be changed:

https://github.com/cython/cython/pull/5307


