### PR TITLE
Add gsi-ncdiag package

### DIFF
--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -10,23 +10,21 @@ class GsiNcdiag(CMakePackage):
     """GSI NetCDF Diagnostics Library and Utility Tools"""
 
     homepage = "https://github.com/NOAA-EMC/GSI-ncdiag"
-    url      = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.0.0.tar.gz"
+    url = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.0.0.tar.gz"
+    
+    maintainers = ["ulmononian"]
 
-    maintainers = ['ulmononian']
+    version("1.0.0", sha256="7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51")
 
-    version('1.0.0', sha256='7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51')
+    variant("serial", default=True, description="Enable Serial NetCDF diagnostics")
 
-    variant('serial', default=True, description='Enable Serial NetCDF diagnostics')
-
-    depends_on('mpi')
-    depends_on('netcdf-fortran@4.5.2:')
+    depends_on("mpi")
+    depends_on("netcdf-fortran@4.5.2:")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant('ENABLE_NCDIAG_SERIAL', 'serial')
-        ]
+        args = [self.define_from_variant("ENABLE_NCDIAG_SERIAL", "serial")]
 
-        args.append(self.define('CMAKE_C_COMPILER', self.spec['mpi'].mpicc))
-        args.append(self.define('CMAKE_Fortran_COMPILER', self.spec['mpi'].mpifc))
+        args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))
+        args.append(self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc))
 
         return args

--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -11,7 +11,7 @@ class GsiNcdiag(CMakePackage):
 
     homepage = "https://github.com/NOAA-EMC/GSI-ncdiag"
     url = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.0.0.tar.gz"
-    
+
     maintainers = ["ulmononian"]
 
     version("1.0.0", sha256="7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51")

--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class GsiNcdiag(CMakePackage):
+    """GSI NetCDF Diagnostics Library and Utility Tools"""
+
+    homepage = "https://github.com/NOAA-EMC/GSI-ncdiag"
+    url      = "https://github.com/NOAA-EMC/GSI-ncdiag/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers = ['ulmononian']
+
+    version('1.0.0', sha256='7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51')
+
+    variant('serial', default=True, description='Enable Serial NetCDF diagnostics')
+
+    depends_on('mpi')
+    depends_on('netcdf-fortran@4.5.2:')
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('ENABLE_NCDIAG_SERIAL', 'serial')
+        ]
+
+        args.append(self.define('CMAKE_C_COMPILER', self.spec['mpi'].mpicc))
+        args.append(self.define('CMAKE_Fortran_COMPILER', self.spec['mpi'].mpifc))
+
+        return args


### PR DESCRIPTION
The GSI NetCDF Diagnostics Library and Utility Tools [gsi-ncdiag](https://github.com/NOAA-EMC/GSI-ncdiag) library is utilized in NOAA's Gridpoint Statistical Interpolation ([GSI](https://github.com/NOAA-EMC/GSI)) for collecting and reporting observation space diagnostics. It is currently available in NOAA-EMC's spack fork, but not in the authoritative spack repository.

Therefore, this PR seeks to add the `gsi-ncdiag` package w/ its associated `package.py` script to spack.

