### PR TITLE
Catch SameFileError errors when contructing RPath on Windows

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2407,7 +2407,7 @@ class WindowsSimulatedRPath(object):
             # For py2 compatibility, we have to catch the specific Windows error code
             # associate with trying to create a file that already exists (winerror 183)
             except OSError as e:
-                if sys.platform == "win32" and e.winerror == 183:
+                if sys.platform == "win32" and (e.winerror == 183 or e.errno == errno.EEXIST):
                     # We have either already symlinked or we are encoutering a naming clash
                     # either way, we don't want to overwrite existing libraries
                     already_linked = islink(dest_file)

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2410,7 +2410,6 @@ class WindowsSimulatedRPath(object):
                 if sys.platform == "win32" and (
                     e.winerror == 183
                     or e.errno == errno.EEXIST
-                    or isinstance(e, shutil.SameFileError)
                 ):
                     # We have either already symlinked or we are encoutering a naming clash
                     # either way, we don't want to overwrite existing libraries

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2407,7 +2407,11 @@ class WindowsSimulatedRPath(object):
             # For py2 compatibility, we have to catch the specific Windows error code
             # associate with trying to create a file that already exists (winerror 183)
             except OSError as e:
-                if sys.platform == "win32" and (e.winerror == 183 or e.errno == errno.EEXIST):
+                if sys.platform == "win32" and (
+                    e.winerror == 183
+                    or e.errno == errno.EEXIST
+                    or isinstance(e, shutil.SameFileError)
+                ):
                     # We have either already symlinked or we are encoutering a naming clash
                     # either way, we don't want to overwrite existing libraries
                     already_linked = islink(dest_file)

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2407,10 +2407,7 @@ class WindowsSimulatedRPath(object):
             # For py2 compatibility, we have to catch the specific Windows error code
             # associate with trying to create a file that already exists (winerror 183)
             except OSError as e:
-                if sys.platform == "win32" and (
-                    e.winerror == 183
-                    or e.errno == errno.EEXIST
-                ):
+                if sys.platform == "win32" and (e.winerror == 183 or e.errno == errno.EEXIST):
                     # We have either already symlinked or we are encoutering a naming clash
                     # either way, we don't want to overwrite existing libraries
                     already_linked = islink(dest_file)

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -30,9 +30,15 @@ def symlink(real_path, link_path):
         try:
             # Try to use junctions
             _win32_junction(real_path, link_path)
-        except OSError:
-            # If all else fails, fall back to copying files
-            shutil.copyfile(real_path, link_path)
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                # we manually raised this error, we know shutil will fail the copy
+                # due to a same file error
+                # skip and report
+                raise e
+            else:
+                # If all else fails, fall back to copying files
+                shutil.copyfile(real_path, link_path)
 
 
 def islink(path):

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -32,10 +32,10 @@ def symlink(real_path, link_path):
             _win32_junction(real_path, link_path)
         except OSError as e:
             if e.errno == errno.EEXIST:
-                # we manually raised this error, we know shutil will fail the copy
-                # due to a same file error
-                # skip and report
-                raise e
+                # EEXIST error indicates that file we're trying to "link"
+                # is already present, don't bother trying to copy which will also fail
+                # just raise
+                raise
             else:
                 # If all else fails, fall back to copying files
                 shutil.copyfile(real_path, link_path)


### PR DESCRIPTION
Improve error handling during link phase of Windows simulated RPaths. The symlink module, with symlinks disabled on Windows, will defer to junctions. Junctions first test if the link is viable by checking if the error already exists. For some reason in this scenario, we were previously trying to let  `shutil` copy the file, which we know will fail. This PR improves the error handling by catching the SameFileError from `shutil` and additionally, skips that code path altogether if we know we'll hit an `EEXIST` error.

In short this PR avoids an unnecessary operation, and improves the RPath error handling.