### PR TITLE
ParaView: add latest release v5.11.1-RC1

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -27,6 +27,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("master", branch="master", submodules=True)
+    version("5.11.1-RC1", sha256="80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880")
     version(
         "5.11.0",
         sha256="9a0b8fe8b1a2cdfd0ace9a87fa87e0ec21ee0f6f0bcb1fdde050f4f585a25165",

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -27,7 +27,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("master", branch="master", submodules=True)
-    version("5.11.1-RC1", sha256="80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880")
+    version(
+        "5.11.1-RC1", sha256="80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880"
+    )
     version(
         "5.11.0",
         sha256="9a0b8fe8b1a2cdfd0ace9a87fa87e0ec21ee0f6f0bcb1fdde050f4f585a25165",


### PR DESCRIPTION
:tada: :tada: :tada:

ParaView 5.11.1-RC1 is out

This PR updates the ParaView Spack package to include this new release while keeping its last final release ParaView v5.11.0 as the preferred version.

Let me know if we need to change anything else in the package.

:tada: :tada: :tada: