### PR TITLE
Drop --dev and drop set -x

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -552,7 +552,7 @@ def ci_rebuild(args):
 
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
-        [SPACK_COMMAND, "-e", env.path, "bootstrap", "now", "--dev"],
+        [SPACK_COMMAND, "-e", env.path, "bootstrap", "now"],
         [
             SPACK_COMMAND,
             "-e",

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -24,7 +24,7 @@ ci:
       - - cat /proc/loadavg || true
       variables:
         CI_JOB_SIZE: "default"
-        SPACK_VERBOSE_SCRIPT: "1"
+        # SPACK_VERBOSE_SCRIPT: "1"
 
   - signing-job:
       image: { "name": "ghcr.io/spack/notary:latest", "entrypoint": [""] }


### PR DESCRIPTION
Not sure why it was considered necessary to bootstrap Spack
dev packages *in every job* in Gitlab CI, and why it wasn't
fixed yet.

Due to #34272 
