### PR TITLE
Set workflow:rules in spack ci pipelines

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1443,6 +1443,9 @@ def generate_gitlab_ci_yaml(
         if spack_stack_name:
             output_object["variables"]["SPACK_CI_STACK_NAME"] = spack_stack_name
 
+        # Ensure the child pipeline always runs
+        output_object["workflow"] = {"rules": [{"when": "always"}]}
+
         if spack_buildcache_copy:
             # Write out the file describing specs that should be copied
             copy_specs_dir = os.path.join(pipeline_artifacts_dir, "specs_to_copy")


### PR DESCRIPTION
Depending on the settings used for the parent pipeline, it's possible that the `trigger:` for a `spack ci` pipeline will fail due to the inherited `workflow:rules`. This PR adds this setting to the generated pipeline, setting it to `always` run.

Note that the pipeline can always be disabled via `rules:` on the `trigger:` job itself (in the parent pipeline), so there's no reason the generated pipeline would ever need to disable itself. Unless you like failing CI pipelines.

CC @kwryankrattiger