### PR TITLE
armadillo: add v12.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -14,6 +14,7 @@ class Armadillo(CMakePackage):
     homepage = "http://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-8.100.1.tar.xz"
 
+    version("12.0.1", sha256="230a5c75daad52dc47e1adce8f5a50f9aa4e4354e0f1bb18ea84efa2e70e20df")
     version("10.5.0", sha256="ea990c34dc6d70d7c95b4354d9f3b0819bde257dbb67796348e91e196082cb87")
     version("9.800.3", sha256="a481e1dc880b7cb352f8a28b67fe005dc1117d4341277f12999a2355d40d7599")
     version("8.100.1", sha256="54773f7d828bd3885c598f90122b530ded65d9b195c9034e082baea737cd138d")


### PR DESCRIPTION
Add armadillo v12.0.1.

**Changelog:**
- faster fft() and ifft() via optional use of FFTW3
- faster min() and max()
- faster index_min() and index_max()
- added .col_as_mat() and .row_as_mat() which return matrix representation of cube column and cube row
- added csv_opts::strict option to loading CSV files to interpret missing values as NaN
- added check_for_zeros option to form 4 of sparse matrix batch constructors
- inv() and inv_sympd() with options inv_opts::no_ugly or inv_opts::allow_approx now use a scaled threshold similar to pinv()
- set_cout_stream() and set_cerr_stream() are now no-ops; instead use the options ARMA_WARN_LEVEL, or ARMA_COUT_STREAM, or ARMA_CERR_STREAM

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.

