### PR TITLE
py-earthengine-api: add v0.1.344

### DIFF
--- a/var/spack/repos/builtin/packages/py-earthengine-api/package.py
+++ b/var/spack/repos/builtin/packages/py-earthengine-api/package.py
@@ -13,11 +13,15 @@ class PyEarthengineApi(PythonPackage):
     homepage = "https://github.com/google/earthengine-api"
     pypi = "earthengine-api/earthengine-api-0.1.186.tar.gz"
 
+    version("0.1.344", sha256="bc5a270b8296aaae8574e68dfd93fe878bc5fbe77d1c41f90bcb5e5b830ca5c8")
     version("0.1.186", sha256="ced86dc969f5db13eea91944e29c39146bacbb7026a46f4b4ac349b365979627")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-google-cloud-storage", when="@0.1.344:", type=("build", "run"))
+    depends_on("py-google-api-python-client@1.12.1:", when="@0.1.344:", type=("build", "run"))
     depends_on("py-google-api-python-client", type=("build", "run"))
     depends_on("py-google-auth@1.4.1:", type=("build", "run"))
     depends_on("py-google-auth-httplib2@0.0.3:", type=("build", "run"))
-    depends_on("py-httplib2@0.9.2:", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-httplib2@0.9.2:0", type=("build", "run"))
+    depends_on("py-requests", when="@0.1.344:", type=("build", "run"))
+    depends_on("py-six", when="@:0.1.186", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-api-core/package.py
+++ b/var/spack/repos/builtin/packages/py-google-api-core/package.py
@@ -16,13 +16,21 @@ class PyGoogleApiCore(PythonPackage):
     # Leave them out of 'import_modules' to avoid optional dependency.
     import_modules = ["google.api_core", "google.api_core.future"]
 
+    version("2.11.0", sha256="4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22")
     version("1.14.2", sha256="2c23fbc81c76b941ffb71301bb975ed66a610e9b03f918feacd1ed59cf43a6ec")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("py-googleapis-common-protos@1.6:1", type=("build", "run"))
-    depends_on("py-protobuf@3.4.0:", type=("build", "run"))
-    depends_on("py-google-auth@0.4:1", type=("build", "run"))
-    depends_on("py-requests@2.18:2", type=("build", "run"))
-    depends_on("py-setuptools@34.0.0:", type=("build", "run"))
-    depends_on("py-six@1.10.0:", type=("build", "run"))
-    depends_on("py-pytz", type=("build", "run"))
+    with when("@2:"):
+        depends_on("py-setuptools", type=("build", "run"))
+        depends_on("py-googleapis-common-protos@1.56.2:1", type=("build", "run"))
+        depends_on("py-protobuf@3.19.5:3.19,3.20.2:4.20,4.21.6:4", type=("build", "run"))
+        depends_on("py-google-auth@2.14.1:2", type=("build", "run"))
+        depends_on("py-requests@2.18:2", type=("build", "run"))
+
+    with when("@:1"):
+        depends_on("py-googleapis-common-protos@1.6:1", type=("build", "run"))
+        depends_on("py-protobuf@3.4.0:", type=("build", "run"))
+        depends_on("py-google-auth@0.4:1", type=("build", "run"))
+        depends_on("py-requests@2.18:2", type=("build", "run"))
+        depends_on("py-setuptools@34.0.0:", type=("build", "run"))
+        depends_on("py-six@1.10.0:", type=("build", "run"))
+        depends_on("py-pytz", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-api-python-client/package.py
+++ b/var/spack/repos/builtin/packages/py-google-api-python-client/package.py
@@ -13,12 +13,21 @@ class PyGoogleApiPythonClient(PythonPackage):
     homepage = "https://github.com/google/google-api-python-client/"
     pypi = "google-api-python-client/google-api-python-client-1.7.10.tar.gz"
 
+    version("2.80.0", sha256="51dd62d467da7ad3df63c3f0e6fca84266ce50c2218691204b2e8cd651a0719a")
     version("1.7.10", sha256="2e55a5c7b56233c68945b6804c73e253445933f4d485d4e69e321b38772b9dd6")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-httplib2@0.9.2:", type=("build", "run"))
-    depends_on("py-google-auth@1.4.1:", type=("build", "run"))
-    depends_on("py-google-auth-httplib2@0.0.3:", type=("build", "run"))
-    depends_on("py-six@1.6.1:", type=("build", "run"))
-    depends_on("py-uritemplate@3.0.0:", type=("build", "run"))
+
+    with when("@2:"):
+        depends_on("py-httplib2@0.15:0", type=("build", "run"))
+        depends_on("py-google-auth@1.19:2", type=("build", "run"))
+        depends_on("py-google-auth-httplib2@0.1:", type=("build", "run"))
+        depends_on("py-google-api-core@1.31.5:1,2.3.1:2", type=("build", "run"))
+        depends_on("py-uritemplate@3.0.1:4", type=("build", "run"))
+
+    with when("@:1"):
+        depends_on("py-httplib2@0.9.2:", type=("build", "run"))
+        depends_on("py-google-auth@1.4.1:", type=("build", "run"))
+        depends_on("py-google-auth-httplib2@0.0.3:", type=("build", "run"))
+        depends_on("py-six@1.6.1:", type=("build", "run"))
+        depends_on("py-uritemplate@3.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-auth-httplib2/package.py
+++ b/var/spack/repos/builtin/packages/py-google-auth-httplib2/package.py
@@ -12,8 +12,11 @@ class PyGoogleAuthHttplib2(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2"
     pypi = "google-auth-httplib2/google-auth-httplib2-0.0.3.tar.gz"
 
+    version("0.1.0", sha256="a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac")
     version("0.0.3", sha256="098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-google-auth", type=("build", "run"))
+    depends_on("py-httplib2@0.15:", when="@0.1:", type=("build", "run"))
     depends_on("py-httplib2@0.9.1:", type=("build", "run"))
+    depends_on("py-six", when="@0.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-auth/package.py
+++ b/var/spack/repos/builtin/packages/py-google-auth/package.py
@@ -13,18 +13,16 @@ class PyGoogleAuth(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-auth-library-python"
     pypi = "google-auth/google-auth-1.6.3.tar.gz"
 
+    version("2.16.2", sha256="07e14f34ec288e3f33e00e2e3cc40c8942aa5d4ceac06256a28cd8e786591420")
     version("2.11.0", sha256="ed65ecf9f681832298e29328e1ef0a3676e3732b2e56f41532d45f70a22de0fb")
     version("2.3.2", sha256="2dc5218ee1192f9d67147cece18f47a929a9ef746cb69c50ab5ff5cfc983647b")
     version("1.6.3", sha256="0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.6:", when="@1.24:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@40.3.0:", when="@2.3.2:", type="build")
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-cachetools@2:5", when="@2.11:", type=("build", "run"))
+    depends_on("py-cachetools@2:4", when="@2.3", type=("build", "run"))
+    depends_on("py-cachetools@2:", type=("build", "run"))
     depends_on("py-pyasn1-modules@0.2.1:", type=("build", "run"))
+    depends_on("py-rsa@3.1.4:4", when="@2.3:", type=("build", "run"))
     depends_on("py-rsa@3.1.4:", type=("build", "run"))
-    depends_on("py-rsa@3.1.4:4", when="@2.3.2:", type=("build", "run"))
-    depends_on("py-six@1.9.0:", type=("build", "run"))
-    depends_on("py-cachetools@2.0.0:", type=("build", "run"))
-    depends_on("py-cachetools@2.0.0:4", when="@2.3.2:2.3", type=("build", "run"))
-    depends_on("py-cachetools@2.0.0:5", when="@2.11.0:", type=("build", "run"))
+    depends_on("py-six@1.9:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-cloud-core/package.py
+++ b/var/spack/repos/builtin/packages/py-google-cloud-core/package.py
@@ -12,8 +12,10 @@ class PyGoogleCloudCore(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python"
     pypi = "google-cloud-core/google-cloud-core-1.0.3.tar.gz"
 
+    version("2.3.2", sha256="b9529ee7047fd8d4bf4a2182de619154240df17fbe60ead399078c1ae152af9a")
     version("1.0.3", sha256="10750207c1a9ad6f6e082d91dbff3920443bdaf1c344a782730489a9efa802f1")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-google-api-core@1.14:1", type=("build", "run"))
+    depends_on("py-google-api-core@1.31.6:1,2.3.1:2", when="@2:", type=("build", "run"))
+    depends_on("py-google-api-core@1.14:1", when="@:1", type=("build", "run"))
+    depends_on("py-google-auth@1.25:2", when="@2:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-cloud-storage/package.py
+++ b/var/spack/repos/builtin/packages/py-google-cloud-storage/package.py
@@ -12,10 +12,19 @@ class PyGoogleCloudStorage(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python"
     pypi = "google-cloud-storage/google-cloud-storage-1.18.0.tar.gz"
 
+    version("2.7.0", sha256="1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17")
     version("1.18.0", sha256="9fb3dc68948f4c893c2b16f5a3db3daea2d2f3b8e9d5c2d505fe1523758009b6")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-google-auth@1.2.0:", type=("build", "run"))
-    depends_on("py-google-cloud-core@1.0:1", type=("build", "run"))
-    depends_on("py-google-resumable-media@0.3.1:", type=("build", "run"))
+
+    with when("@2:"):
+        depends_on("py-google-auth@1.25:2", type=("build", "run"))
+        depends_on("py-google-api-core@1.31.5:1,2.3.1:2", type=("build", "run"))
+        depends_on("py-google-cloud-core@2.3:2", type=("build", "run"))
+        depends_on("py-google-resumable-media@2.3.2:", type=("build", "run"))
+        depends_on("py-requests@2.18:2", type=("build", "run"))
+
+    with when("@:1"):
+        depends_on("py-google-auth@1.2.0:", type=("build", "run"))
+        depends_on("py-google-cloud-core@1.0:1", type=("build", "run"))
+        depends_on("py-google-resumable-media@0.3.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-resumable-media/package.py
+++ b/var/spack/repos/builtin/packages/py-google-resumable-media/package.py
@@ -12,8 +12,9 @@ class PyGoogleResumableMedia(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-resumable-media-python"
     pypi = "google-resumable-media/google-resumable-media-0.3.2.tar.gz"
 
+    version("2.4.1", sha256="15b8a2e75df42dc6502d1306db0bce2647ba6013f9cd03b6e17368c0886ee90a")
     version("0.3.2", sha256="3e38923493ca0d7de0ad91c31acfefc393c78586db89364e91cb4f11990e51ba")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-google-crc32c@1:", when="@2:", type=("build", "run"))
+    depends_on("py-six", when="@0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-googleapis-common-protos/package.py
+++ b/var/spack/repos/builtin/packages/py-googleapis-common-protos/package.py
@@ -12,9 +12,13 @@ class PyGoogleapisCommonProtos(PythonPackage):
     homepage = "https://github.com/googleapis/googleapis"
     pypi = "googleapis-common-protos/googleapis-common-protos-1.6.0.tar.gz"
 
+    version("1.58.0", sha256="c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df")
     version("1.55.0", sha256="53eb313064738f45d5ac634155ae208e121c963659627b90dfcb61ef514c03e1")
     version("1.6.0", sha256="e61b8ed5e36b976b487c6e7b15f31bb10c7a0ca7bd5c0e837f4afab64b53a0c6")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-protobuf@3.6.0:3", type=("build", "run"))
-    depends_on("py-protobuf@3.12.0:3", type=("build", "run"), when="@1.55.0:")
+    depends_on(
+        "py-protobuf@3.19.5:3.19,3.20.2:4.21.0,4.21.6:4", when="@1.58:", type=("build", "run")
+    )
+    depends_on("py-protobuf@3.12.0:3", when="@1.55", type=("build", "run"))
+    depends_on("py-protobuf@3.6.0:3", when="@:1.6", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-uritemplate/package.py
+++ b/var/spack/repos/builtin/packages/py-uritemplate/package.py
@@ -12,6 +12,7 @@ class PyUritemplate(PythonPackage):
     homepage = "https://uritemplate.readthedocs.org/"
     pypi = "uritemplate/uritemplate-3.0.0.tar.gz"
 
+    version("4.1.1", sha256="4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0")
     version("3.0.0", sha256="c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Python 3.10.8 and Apple Clang 12.0.0.