### PR TITLE
harminv: add v1.4.2 and update URL to maintained git repository

### DIFF
--- a/var/spack/repos/builtin/packages/harminv/package.py
+++ b/var/spack/repos/builtin/packages/harminv/package.py
@@ -17,6 +17,7 @@ class Harminv(AutotoolsPackage):
     url = "http://ab-initio.mit.edu/harminv/harminv-1.4.tar.gz"
     list_url = "http://ab-initio.mit.edu/harminv/old"
 
+    version("1.4.1", sha256="e1b923c508a565f230aac04e3feea23b888b47d8e19b08816a97ee4444233670")
     version("1.4", sha256="e1b923c508a565f230aac04e3feea23b888b47d8e19b08816a97ee4444233670")
 
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/harminv/package.py
+++ b/var/spack/repos/builtin/packages/harminv/package.py
@@ -13,12 +13,11 @@ class Harminv(AutotoolsPackage):
     exponentially decaying) in a given bandwidth, it determines the
     frequencies, decay constants, amplitudes, and phases of those sinusoids."""
 
-    homepage = "http://ab-initio.mit.edu/wiki/index.php/Harminv"
-    url = "http://ab-initio.mit.edu/harminv/harminv-1.4.tar.gz"
-    list_url = "http://ab-initio.mit.edu/harminv/old"
+    homepage = "https://github.com/NanoComp/harminv"
+    url = "https://github.com/NanoComp/harminv/releases/download/v1.4.2/harminv-1.4.2.tar.gz"
 
+    version("1.4.2", sha256="5a9a1bf710972442f065d0d62c62d0c4ec3da4a3696d7160a35602c9470bc7a2")
     version("1.4.1", sha256="e1b923c508a565f230aac04e3feea23b888b47d8e19b08816a97ee4444233670")
-    version("1.4", sha256="e1b923c508a565f230aac04e3feea23b888b47d8e19b08816a97ee4444233670")
 
     depends_on("blas")
     depends_on("lapack")


### PR DESCRIPTION
Add harminv v1.4.2.

**Changelog:**
https://github.com/NanoComp/harminv/releases/tag/v1.4.2

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.