### PR TITLE
hugo: add v0.111.3

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -18,6 +18,7 @@ class Hugo(Package):
 
     maintainers("alecbcs")
 
+    version("0.111.3", sha256="b6eeb13d9ed2e5d5c6895bae56480bf0fec24a564ad9d17c90ede14a7b240999")
     version("0.111.2", sha256="66500ae3a03cbf51a6ccf7404d01f42fdc454aa1eaea599c934860bbf0aa2fc5")
     version("0.111.1", sha256="a71d4e1f49ca7156d3811c0b10957816b75ff2e01b35ef326e7af94dfa554ec0")
     version("0.110.0", sha256="eeb137cefcea1a47ca27dc5f6573df29a8fe0b7f1ed0362faf7f73899e313770")


### PR DESCRIPTION
Add hugo v0.111.3.

**Changelog:**
https://github.com/gohugoio/hugo/releases/tag/v0.111.3

**Test Plan:**
Built successfully using `go@1.20.1` on Debian 11.