### PR TITLE
Make package build reproducible

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -558,6 +558,8 @@ def determine_number_of_jobs(
 
     if command_line is None and "command_line" in spack.config.scopes():
         command_line = spack.config.get("config:build_jobs", scope="command_line")
+        if command_line == 0:
+            command_line = min(16, cpus_available())
 
     if command_line is not None:
         return command_line
@@ -566,6 +568,8 @@ def determine_number_of_jobs(
 
     # in some rare cases _builtin config may not be set, so default to max 16
     config_default = config_default or spack.config.get("config:build_jobs", 16)
+    if config_default == 0:
+        config_default = min(16, cpus_available())
 
     return min(max_cpus, config_default)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -61,7 +61,6 @@ import spack.schema.upstreams
 import spack.util.spack_yaml as syaml
 import spack.util.web as web_util
 from spack.error import SpackError
-from spack.util.cpus import cpus_available
 
 #: Dict from section names -> schema for that section
 section_schemas = {
@@ -96,7 +95,7 @@ config_defaults = {
         "verify_ssl": True,
         "checksum": True,
         "dirty": False,
-        "build_jobs": min(16, cpus_available()),
+        "build_jobs": 0,
         "build_stage": "$tempdir/spack-stage",
         "concretizer": "clingo",
         "license_dir": spack.paths.default_license_dir,

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -79,7 +79,7 @@ properties = {
             "locks": {"type": "boolean"},
             "dirty": {"type": "boolean"},
             "build_language": {"type": "string"},
-            "build_jobs": {"type": "integer", "minimum": 1},
+            "build_jobs": {"type": "integer", "minimum": 0},
             "ccache": {"type": "boolean"},
             "concretizer": {"type": "string", "enum": ["original", "clingo"]},
             "db_lock_timeout": {"type": "integer", "minimum": 1},


### PR DESCRIPTION
without this patch, spack-0.19.0/lib/spack/docs/_build/texinfo/Spack.texi
varied in
@deffn {Data} spack.config.config_defaults = @{'config': @{'build_jobs': 4, 'build_stage': '$tempdir/spack@w{-}stage', 'checksum': True, 'concretizer': 'original', 'connect_timeout': 10, 'debug': False, 'dirty': False, 'verify_ssl': True@}@}

that caused resulting Spack.info and spack.1 files to differ as well.

See also https://reproducible-builds.org/ for why this matters.

This patch was done while working on reproducible builds for openSUSE.

Note: I only tested that our package builds.