### PR TITLE
go: add v1.20.2 and v1.19.7

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -84,7 +84,7 @@ class Go(Package):
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
 
     def url_for_version(self, version):
-        return f"https://dl.google.com/go/go{version}.src.tar.gz"
+        return f"https://go.dev/dl/go{version}.src.tar.gz"
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -30,8 +30,8 @@ from spack.package import *
 class Go(Package):
     """The golang compiler and build environment"""
 
-    homepage = "https://golang.org"
-    url = "https://dl.google.com/go/go1.16.6.src.tar.gz"
+    homepage = "https://go.dev"
+    url = "https://go.dev/dl/go1.20.2.src.tar.gz"
     git = "https://go.googlesource.com/go.git"
 
     extendable = True
@@ -39,21 +39,52 @@ class Go(Package):
 
     maintainers("alecbcs")
 
+    # 1.20
+    version("1.20.2", sha256="4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab")
     version("1.20.1", sha256="b5c1a3af52c385a6d1c76aed5361cf26459023980d0320de7658bae3915831a2")
-    version("1.20", sha256="3a29ff0421beaf6329292b8a46311c9fbf06c800077ceddef5fb7f8d5b1ace33")
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-41723
+    version(
+        "1.20",
+        sha256="3a29ff0421beaf6329292b8a46311c9fbf06c800077ceddef5fb7f8d5b1ace33",
+        deprecated=True,
+    )
 
+    # 1.19
+    version("1.19.7", sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633")
     version("1.19.6", sha256="d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767")
-    version("1.19.5", sha256="8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f")
-    version("1.19.4", sha256="eda74db4ac494800a3e66ee784e495bfbb9b8e535df924a8b01b1a8028b7f368")
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-41725
+    version(
+        "1.19.5",
+        sha256="8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f",
+        deprecated=True,
+    )
+    version(
+        "1.19.4",
+        sha256="eda74db4ac494800a3e66ee784e495bfbb9b8e535df924a8b01b1a8028b7f368",
+        deprecated=True,
+    )
 
-    version("1.18.10", sha256="9cedcca58845df0c9474ae00274c44a95c9dfaefb132fc59921c28c7c106f8e6")
-    version("1.18.9", sha256="fbe7f09b96aca3db6faeaf180da8bb632868ec049731e355ff61695197c0e3ea")
+    # 1.18
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-41724
+    version(
+        "1.18.10",
+        sha256="9cedcca58845df0c9474ae00274c44a95c9dfaefb132fc59921c28c7c106f8e6",
+        deprecated=True,
+    )
+    version(
+        "1.18.9",
+        sha256="fbe7f09b96aca3db6faeaf180da8bb632868ec049731e355ff61695197c0e3ea",
+        deprecated=True,
+    )
 
     provides("golang")
 
     depends_on("git", type=("build", "link", "run"))
     depends_on("go-or-gccgo-bootstrap", type="build")
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
+
+    def url_for_version(self, version):
+        return f"https://dl.google.com/go/go{version}.src.tar.gz"
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -39,19 +39,19 @@ class Go(Package):
 
     maintainers("alecbcs")
 
-    # 1.20
     version("1.20.2", sha256="4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab")
     version("1.20.1", sha256="b5c1a3af52c385a6d1c76aed5361cf26459023980d0320de7658bae3915831a2")
+
+    version("1.19.7", sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633")
+    version("1.19.6", sha256="d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767")
+
+    # Deprecated Versions
     # https://nvd.nist.gov/vuln/detail/CVE-2022-41723
     version(
         "1.20",
         sha256="3a29ff0421beaf6329292b8a46311c9fbf06c800077ceddef5fb7f8d5b1ace33",
         deprecated=True,
     )
-
-    # 1.19
-    version("1.19.7", sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633")
-    version("1.19.6", sha256="d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767")
     # https://nvd.nist.gov/vuln/detail/CVE-2022-41725
     version(
         "1.19.5",
@@ -63,8 +63,6 @@ class Go(Package):
         sha256="eda74db4ac494800a3e66ee784e495bfbb9b8e535df924a8b01b1a8028b7f368",
         deprecated=True,
     )
-
-    # 1.18
     # https://nvd.nist.gov/vuln/detail/CVE-2022-41724
     version(
         "1.18.10",


### PR DESCRIPTION
Add Go v1.20.2. 

**Changelog:**
- Add Go v1.20.2 and v1.19.7.
- Deprecate v1.20 due to CVE-2022-41723.
- Deprecate <= v1.19.5 due to CVE-2022-41725 and CVE-2022-41724.

**Test Plan:**
Built successfully using `go-bootstrap` on MacOS. Tested by building dependents such as direnv, hugo, and rclone.