### PR TITLE
kmergenie: add v1.7051

### DIFF
--- a/var/spack/repos/builtin/packages/kmergenie/package.py
+++ b/var/spack/repos/builtin/packages/kmergenie/package.py
@@ -12,6 +12,7 @@ class Kmergenie(MakefilePackage):
     homepage = "http://kmergenie.bx.psu.edu/"
     url = "http://kmergenie.bx.psu.edu/kmergenie-1.7044.tar.gz"
 
+    version("1.7051", sha256="13148e5a2c700359cffca363b66ffa8f23c5db6af6eec03f739139ffdfee763f")
     version("1.7044", sha256="46f2a08a2d7b1885414143e436829dd7e61fcc31ec4e429433e516a168d2978e")
 
     depends_on("python", type=("build", "run"))


### PR DESCRIPTION
Add kmergenie v1.7051.

**Changelog:**
http://kmergenie.bx.psu.edu/CHANGELOG

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.