### PR TITLE
libpcap: add v1.10.3

### DIFF
--- a/var/spack/repos/builtin/packages/libpcap/package.py
+++ b/var/spack/repos/builtin/packages/libpcap/package.py
@@ -13,6 +13,7 @@ class Libpcap(AutotoolsPackage):
     list_url = "https://www.tcpdump.org/release/"
     url = "https://www.tcpdump.org/release/libpcap-1.8.1.tar.gz"
 
+    version("1.10.3", sha256="2a8885c403516cf7b0933ed4b14d6caa30e02052489ebd414dc75ac52e7559e6")
     version("1.10.0", sha256="8d12b42623eeefee872f123bd0dc85d535b00df4d42e865f993c40f7bfc92b1e")
     version("1.9.1", sha256="635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094")
     version("1.8.1", sha256="673dbc69fdc3f5a86fb5759ab19899039a8e5e6c631749e48dcd9c6f0c83541e")


### PR DESCRIPTION
Add libpcap v1.10.3.

**Changelog:**
https://github.com/the-tcpdump-group/tcpdump/blob/master/CHANGES

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.