### PR TITLE
libpipeline: add v1.5.7

### DIFF
--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -14,6 +14,7 @@ class Libpipeline(AutotoolsPackage):
     git = "https://gitlab.com/cjwatson/libpipeline"
     url = "https://download.savannah.nongnu.org/releases/libpipeline/libpipeline-1.5.5.tar.gz"
 
+    version("1.5.7", sha256="b8b45194989022a79ec1317f64a2a75b1551b2a55bea06f67704cb2a2e4690b0")
     version("1.5.5", sha256="0c8367f8b82bb721b50647a647115b6e62a37e3b2e954a9685e4d933f30c00cc")
     version("1.4.2", sha256="fef1fc9aa40ce8796f18cd1aecd888a9484a9556c8b0f8d07c863578277679be")
 


### PR DESCRIPTION
Add libpipeline v1.5.7.

**Changelog:**
https://gitlab.com/libpipeline/libpipeline/-/blob/main/NEWS.md

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.