### PR TITLE
libssh: add v0.8.9

### DIFF
--- a/var/spack/repos/builtin/packages/libssh/package.py
+++ b/var/spack/repos/builtin/packages/libssh/package.py
@@ -12,6 +12,7 @@ class Libssh(CMakePackage):
     homepage = "https://www.libssh.org"
     url = "https://www.libssh.org/files/0.8/libssh-0.8.5.tar.xz"
 
+    version("0.8.9", sha256="8559e19da0c40b6f93482b6160219ad77a4d9f1dc190bf174757455c6ae26825")
     version("0.8.5", sha256="07d2c431240fc88f6b06bcb36ae267f9afeedce2e32f6c42f8844b205ab5a335")
     version("0.7.5", sha256="54e86dd5dc20e5367e58f3caab337ce37675f863f80df85b6b1614966a337095")
 


### PR DESCRIPTION
Add libssh v0.8.9.

**Changelog:**
- Fixed possible infinite loop in known hosts checking.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.