### PR TITLE
libxfont: add v1.5.4

### DIFF
--- a/var/spack/repos/builtin/packages/libxfont/package.py
+++ b/var/spack/repos/builtin/packages/libxfont/package.py
@@ -17,6 +17,7 @@ class Libxfont(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXfont"
     xorg_mirror_path = "lib/libXfont-1.5.2.tar.gz"
 
+    version("1.5.4", sha256="59be6eab53f7b0feb6b7933c11d67d076ae2c0fd8921229c703fc7a4e9a80d6e")
     version("1.5.2", sha256="a7350c75171d03d06ae0d623e42240356d6d3e1ac7dfe606639bf20f0d653c93")
 
     depends_on("libfontenc")


### PR DESCRIPTION
Add libxfont v1.5.4.

**Changelog:**
https://cgit.freedesktop.org/xorg/lib/libXfont/log/

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.