### PR TITLE
libxfont2: add v2.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -17,6 +17,7 @@ class Libxfont2(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXfont"
     xorg_mirror_path = "lib/libXfont2-2.0.1.tar.gz"
 
+    version("2.0.6", sha256="a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc")
     version("2.0.1", sha256="381b6b385a69343df48a082523c856aed9042fbbc8ee0a6342fb502e4321230a")
 
     depends_on("libfontenc")


### PR DESCRIPTION
Add libxfont2 v2.0.6.

**Changelog:**
https://cgit.freedesktop.org/xorg/lib/libXfont/log/

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.