### PR TITLE
libxdmcp: add v1.1.4

### DIFF
--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -12,6 +12,7 @@ class Libxdmcp(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXdmcp"
     xorg_mirror_path = "lib/libXdmcp-1.1.2.tar.gz"
 
+    version("1.1.4", sha256="55041a8ff8992ab02777478c4b19c249c0f8399f05a752cb4a1a868a9a0ccb9a")
     version("1.1.2", sha256="6f7c7e491a23035a26284d247779174dedc67e34e93cc3548b648ffdb6fc57c0")
 
     depends_on("xproto")


### PR DESCRIPTION
Add libxdmcp v1.1.4.

**Changelog:**
https://cgit.freedesktop.org/xorg/lib/libXdmcp/log/

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.