### PR TITLE
makedepend: add v1.0.8

### DIFF
--- a/var/spack/repos/builtin/packages/makedepend/package.py
+++ b/var/spack/repos/builtin/packages/makedepend/package.py
@@ -12,6 +12,7 @@ class Makedepend(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/util/makedepend"
     xorg_mirror_path = "util/makedepend-1.0.5.tar.gz"
 
+    version("1.0.8", sha256="275f0d2b196bfdc740aab9f02bb48cb7a97e4dfea011a7b468ed5648d0019e54")
     version("1.0.5", sha256="503903d41fb5badb73cb70d7b3740c8b30fe1cc68c504d3b6a85e6644c4e5004")
 
     depends_on("xproto@7.0.17:")


### PR DESCRIPTION
Add makedepend v1.0.8.

**Changelog:**
https://cgit.freedesktop.org/xorg/util/makedepend/log/

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.