### PR TITLE
Add `llnl.util.filesystem.find_first`

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2755,8 +2755,10 @@ def filesummary(path, print_bytes=16) -> Tuple[int, bytes]:
 
 class FindFirstFile:
     """Uses hybrid iterative deepening to locate the first matching
-    file. Up to depth 2 it is BFS with iterative deepening, then
-    it switches to normal DFS."""
+    file. Up to depth ``bfs_depth`` it uses iterative deepening, which
+    mimics breadth-first with the same memory footprint as depth-first
+    search, after which it switches to ordinary depth-first search using
+    ``os.walk``."""
 
     def __init__(self, root: str, *file_patterns: str, bfs_depth: int = 2):
         """Create a small summary of the given file. Does not error
@@ -2788,7 +2790,7 @@ class FindFirstFile:
         # Then fall back to depth-first search
         return self._find_dfs()
 
-    def _find_at_depth(self, path, max_depth, depth=0):
+    def _find_at_depth(self, path, max_depth, depth=0) -> bool:
         """Returns True when done. Notice search can be done
         either because a file was found, or because it recursed
         through all directories."""

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2740,18 +2740,27 @@ class FindFile:
         return self.results
 
     def find_first_file(self, rel_path, depth, max_depth):
+
+        try:
+            entries = os.scandir(os.path.join(self.root, rel_path))
+        except OSError:
+            return False
+
         found_dir = False
-        with os.scandir(os.path.join(self.root, rel_path)) as entries:
+        with entries:
             if depth == max_depth:
                 self.find_matches(rel_path, entries)
                 return True
 
             for f in entries:
-                if not f.is_symlink() and f.is_dir():
+                try:
+                    is_dir = not f.is_symlink() and f.is_dir()
+                except OSError:
+                    is_dir = False
+                if is_dir:
                     found_dir |= self.find_first_file(
                         os.path.join(rel_path, f.name), depth + 1, max_depth
                     )
-
         return found_dir
 
     def find_matches(self, rel_path, entries):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2740,7 +2740,6 @@ class FindFile:
         return self.results
 
     def find_first_file(self, rel_path, depth, max_depth):
-
         try:
             entries = os.scandir(os.path.join(self.root, rel_path))
         except OSError:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2730,7 +2730,7 @@ class FindFile:
 
     def __init__(self, root, name):
         self.root = root
-        self.regex = re.compile(fnmatch.translate(name)).match
+        self.match = re.compile(fnmatch.translate(name)).match
         self.results = []
 
     def run(self):
@@ -2756,5 +2756,5 @@ class FindFile:
 
     def find_matches(self, rel_path, entries):
         for f in entries:
-            if self.regex(f.name):
+            if self.match(f.name):
                 self.results.append(os.path.join(rel_path, f.name))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2781,7 +2781,7 @@ class FindFirstFile:
         self.file = None
 
         # First do iterative deepening (i.e. bfs through limited depth dfs)
-        for i in range(self.bfs_depth):
+        for i in range(self.bfs_depth + 1):
             if self._find_at_depth(self.root, i):
                 return self.file
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2777,12 +2777,10 @@ class FindFirstFile:
         # normcase is trivial on posix
         regex = re.compile("|".join(fnmatch.translate(os.path.normcase(p)) for p in file_patterns))
 
-        if os.path is posixpath:
-            # On posix use filenames as is.
-            self.match = regex.match
-        else:
-            # On case sensitive filesystems match against normcase'd paths.
-            self.match = lambda p: regex.match(os.path.normcase(p))
+        # On case sensitive filesystems match against normcase'd paths.
+        self.match = (
+            lambda p: regex.match(os.path.normcase(p)) if os.path is posixpath else regex.match
+        )
 
     def find(self) -> Optional[str]:
         """Run the file search

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2779,7 +2779,7 @@ class FindFirstFile:
 
         # On case sensitive filesystems match against normcase'd paths.
         self.match = (
-            lambda p: regex.match(os.path.normcase(p)) if os.path is posixpath else regex.match
+            regex.match if os.path is posixpath else lambda p: regex.match(os.path.normcase(p))
         )
 
     def find(self) -> Optional[str]:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2773,14 +2773,16 @@ class FindFirstFile:
         """
         self.root = root
         self.bfs_depth = bfs_depth
+        self.match: Callable
 
         # normcase is trivial on posix
         regex = re.compile("|".join(fnmatch.translate(os.path.normcase(p)) for p in file_patterns))
 
         # On case sensitive filesystems match against normcase'd paths.
-        self.match = (
-            regex.match if os.path is posixpath else lambda p: regex.match(os.path.normcase(p))
-        )
+        if os.path is posixpath:
+            self.match = regex.match
+        else:
+            self.match = lambda p: regex.match(os.path.normcase(p))
 
     def find(self) -> Optional[str]:
         """Run the file search

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2789,8 +2789,9 @@ class FindFirstFile:
         return self._find_dfs()
 
     def _find_at_depth(self, path, max_depth, depth=0):
-        """Returns True when done. Notice it can be done
-        without"""
+        """Returns True when done. Notice search can be done
+        either because a file was found, or because it recursed
+        through all directories."""
         try:
             entries = os.scandir(path)
         except OSError:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2756,5 +2756,5 @@ class FindFile:
 
     def find_matches(self, rel_path, entries):
         for f in entries:
-            if not f.is_dir() and self.regex(f.name):
+            if self.regex(f.name):
                 self.results.append(os.path.join(rel_path, f.name))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -18,7 +18,7 @@ import stat
 import sys
 import tempfile
 from contextlib import contextmanager
-from typing import Callable, List, Match, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Match, Optional, Tuple, Union
 
 from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
@@ -1673,7 +1673,7 @@ def fix_darwin_install_name(path):
                     break
 
 
-def find_first(root: str, *file_patterns: str, bfs_depth: int = 2) -> Optional[str]:
+def find_first(root: str, files: Union[Iterable[str], str], bfs_depth: int = 2) -> Optional[str]:
     """Find the first file matching a pattern.
 
     The following
@@ -1684,7 +1684,7 @@ def find_first(root: str, *file_patterns: str, bfs_depth: int = 2) -> Optional[s
 
     is equivalent to:
 
-    >>> find_first("/usr", "abc*", "def*")
+    >>> find_first("/usr", ["abc*", "def*"])
 
     Any glob pattern supported by fnmatch can be used.
 
@@ -1693,14 +1693,16 @@ def find_first(root: str, *file_patterns: str, bfs_depth: int = 2) -> Optional[s
 
     Parameters:
         root (str): The root directory to start searching from
-        files (str or Iterable): Library name(s) to search for
+        files (str or Iterable): File pattern(s) to search for
         bfs_depth (int): (advanced) parameter that specifies at which
             depth to switch to depth-first search.
 
     Returns:
         str or None: The matching file or None when no file is found.
     """
-    return FindFirstFile(root, *file_patterns, bfs_depth=bfs_depth).find()
+    if isinstance(files, str):
+        files = [files]
+    return FindFirstFile(root, *files, bfs_depth=bfs_depth).find()
 
 
 def find(root, files, recursive=True):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -871,3 +871,30 @@ def test_filesummary(tmpdir):
     assert fs.filesummary(p, print_bytes=8) == (26, b"abcdefgh...stuvwxyz")
     assert fs.filesummary(p, print_bytes=13) == (26, b"abcdefghijklmnopqrstuvwxyz")
     assert fs.filesummary(p, print_bytes=100) == (26, b"abcdefghijklmnopqrstuvwxyz")
+
+
+def test_find_first_file(tmpdir):
+    # Create a structure: a/b/c/d
+    tmpdir.join("a").ensure(dir=True).join("a").ensure(dir=True).join("a").ensure(dir=True)
+    tmpdir.join("b").ensure(dir=True).join("a").ensure(dir=True)
+    tmpdir.join("c").ensure(dir=True).join("a").ensure(dir=True)
+    tmpdir.join("d").ensure(dir=True).join("a").ensure(dir=True)
+
+    with open(tmpdir.join("a", "a", "a", "file1"), "w") as f:
+        f.write("contents")
+
+    with open(tmpdir.join("a", "a", "a", "file2"), "w") as f:
+        f.write("contents")
+
+    with open(tmpdir.join("d", "file1"), "w") as f:
+        f.write("contents")
+
+    root = str(tmpdir)
+
+    # Iterative deepening: should find low-depth file1.
+    assert os.path.samefile(fs.find_first(root, "file*"), os.path.join(root, "d", "file1"))
+
+    assert fs.find_first(root, "nonexisting") is None
+
+    # Should find first dir
+    assert os.path.samefile(fs.find_first(root, "a"), os.path.join(root, "a"))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -874,7 +874,7 @@ def test_filesummary(tmpdir):
 
 
 def test_find_first_file(tmpdir):
-    # Create a structure: a/b/c/d
+    # Create a structure: a/a/a/{file1,file2}, b/a, c/a, d/{a,file1}
     tmpdir.join("a").ensure(dir=True).join("a").ensure(dir=True).join("a").ensure(dir=True)
     tmpdir.join("b").ensure(dir=True).join("a").ensure(dir=True)
     tmpdir.join("c").ensure(dir=True).join("a").ensure(dir=True)
@@ -895,6 +895,10 @@ def test_find_first_file(tmpdir):
     assert os.path.samefile(fs.find_first(root, "file*"), os.path.join(root, "d", "file1"))
 
     assert fs.find_first(root, "nonexisting") is None
+
+    assert os.path.samefile(
+        fs.find_first(root, "nonexisting", "file2"), os.path.join(root, "a", "a", "a", "file2")
+    )
 
     # Should find first dir
     assert os.path.samefile(fs.find_first(root, "a"), os.path.join(root, "a"))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -875,19 +875,14 @@ def test_filesummary(tmpdir):
 
 def test_find_first_file(tmpdir):
     # Create a structure: a/a/a/{file1,file2}, b/a, c/a, d/{a,file1}
-    tmpdir.join("a").ensure(dir=True).join("a").ensure(dir=True).join("a").ensure(dir=True)
-    tmpdir.join("b").ensure(dir=True).join("a").ensure(dir=True)
-    tmpdir.join("c").ensure(dir=True).join("a").ensure(dir=True)
-    tmpdir.join("d").ensure(dir=True).join("a").ensure(dir=True)
+    tmpdir.join("a", "a", "a").ensure(dir=True)
+    tmpdir.join("b", "a").ensure(dir=True)
+    tmpdir.join("c", "a").ensure(dir=True)
+    tmpdir.join("d", "a").ensure(dir=True)
 
-    with open(tmpdir.join("a", "a", "a", "file1"), "w") as f:
-        f.write("contents")
-
-    with open(tmpdir.join("a", "a", "a", "file2"), "w") as f:
-        f.write("contents")
-
-    with open(tmpdir.join("d", "file1"), "w") as f:
-        f.write("contents")
+    fs.touch(tmpdir.join("a", "a", "a", "file1"))
+    fs.touch(tmpdir.join("a", "a", "a", "file2"))
+    fs.touch(tmpdir.join("d", "file1"))
 
     root = str(tmpdir)
 
@@ -897,7 +892,7 @@ def test_find_first_file(tmpdir):
     assert fs.find_first(root, "nonexisting") is None
 
     assert os.path.samefile(
-        fs.find_first(root, "nonexisting", "file2"), os.path.join(root, "a", "a", "a", "file2")
+        fs.find_first(root, ["nonexisting", "file2"]), os.path.join(root, "a", "a", "a", "file2")
     )
 
     # Should find first dir

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -873,13 +873,14 @@ def test_filesummary(tmpdir):
     assert fs.filesummary(p, print_bytes=100) == (26, b"abcdefghijklmnopqrstuvwxyz")
 
 
-@pytest.mark.parametrize("bfs_depth", [1, 10])
+@pytest.mark.parametrize("bfs_depth", [1, 2, 10])
 def test_find_first_file(tmpdir, bfs_depth):
     # Create a structure: a/a/a/{file1,file2}, b/a, c/a, d/{a,file1}
     tmpdir.join("a", "a", "a").ensure(dir=True)
     tmpdir.join("b", "a").ensure(dir=True)
     tmpdir.join("c", "a").ensure(dir=True)
     tmpdir.join("d", "a").ensure(dir=True)
+    tmpdir.join("e").ensure(dir=True)
 
     fs.touch(tmpdir.join("a", "a", "a", "file1"))
     fs.touch(tmpdir.join("a", "a", "a", "file2"))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -873,7 +873,8 @@ def test_filesummary(tmpdir):
     assert fs.filesummary(p, print_bytes=100) == (26, b"abcdefghijklmnopqrstuvwxyz")
 
 
-def test_find_first_file(tmpdir):
+@pytest.mark.parametrize("bfs_depth", [1, 10])
+def test_find_first_file(tmpdir, bfs_depth):
     # Create a structure: a/a/a/{file1,file2}, b/a, c/a, d/{a,file1}
     tmpdir.join("a", "a", "a").ensure(dir=True)
     tmpdir.join("b", "a").ensure(dir=True)
@@ -887,13 +888,16 @@ def test_find_first_file(tmpdir):
     root = str(tmpdir)
 
     # Iterative deepening: should find low-depth file1.
-    assert os.path.samefile(fs.find_first(root, "file*"), os.path.join(root, "d", "file1"))
+    assert os.path.samefile(
+        fs.find_first(root, "file*", bfs_depth=bfs_depth), os.path.join(root, "d", "file1")
+    )
 
-    assert fs.find_first(root, "nonexisting") is None
+    assert fs.find_first(root, "nonexisting", bfs_depth=bfs_depth) is None
 
     assert os.path.samefile(
-        fs.find_first(root, ["nonexisting", "file2"]), os.path.join(root, "a", "a", "a", "file2")
+        fs.find_first(root, ["nonexisting", "file2"], bfs_depth=bfs_depth),
+        os.path.join(root, "a", "a", "a", "file2"),
     )
 
     # Should find first dir
-    assert os.path.samefile(fs.find_first(root, "a"), os.path.join(root, "a"))
+    assert os.path.samefile(fs.find_first(root, "a", bfs_depth=bfs_depth), os.path.join(root, "a"))


### PR DESCRIPTION
When locating files for externals in say `/usr`, sometimes Spack is
stuck in a slow `os.walk("/usr")`. Typically the relevant files are at
low depth, so it makes sense to locate files through iterative deepening
until a cross-over point where depth-first search is cheaper. The
success path is faster, the failure path is a bit slower.

Why iterative deepening and not bfs? Basically to avoid keeping tons
of open file descriptors or large lists of paths. The cost of this is repeated
traversal of low-depth dirs, but that shouldn't be terribly expensive.

The user facing function is `find_first(root, patterns)`, which effectively
corresponds with
```
find -name "${patterns[0]}" -o -name "${patterns[1]}" -o ... -print -quit
```

The dfs implementation should also be faster than `llnl.util.filesystem.find`
since it doesn't use `glob` in a loop, but constructs the relevant regex once
ahead of time. Also one regex is constructed for all search patterns
together.

Ping @scheibelp, maybe you can try this on your favorite slow filesystem
