### PR TITLE
py-pyshacl: patch dependency typo

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -26,4 +26,4 @@ class PyPyshacl(PythonPackage):
 
     def patch(self):
         if self.spec.satisfies("@0.17.2"):
-            filter_file(r"\^5.2.3,<7", ">=5.2.3,<7", "pyproject.toml")
+            filter_file("^5.2.3,<7", ">=5.2.3,<7", "pyproject.toml", string=True)

--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -26,4 +26,4 @@ class PyPyshacl(PythonPackage):
 
     def patch(self):
         if self.spec.satisfies("@0.17.2"):
-            filter_file("\^5.2.3,<7", ">=5.2.3,<7", "pyproject.toml")
+            filter_file(r"\^5.2.3,<7", ">=5.2.3,<7", "pyproject.toml")

--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -23,3 +23,7 @@ class PyPyshacl(PythonPackage):
     depends_on("py-owlrl@6.0.2:6", when="@0.20.0:", type=("build", "run"))
     depends_on("py-packaging@21.3:", when="@0.20.0:", type=("build", "run"))
     depends_on("py-prettytable@2.2.1:2", type=("build", "run"))
+
+    def patch(self):
+        if self.spec.satisfies("@0.17.2"):
+            filter_file("\^5.2.3,<7", ">=5.2.3,<7", "pyproject.toml")


### PR DESCRIPTION
In certain combinations, a typo in the owlrl dependency of py-pyshacl@0.17.2 might mess things up.

See https://github.com/RDFLib/pySHACL/issues/111#issuecomment-991989874 for confirmation that it is, indeed, a typo.