### PR TITLE
Add double batched FFT library package

### DIFF
--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+import os
 
 
 class DoubleBatchedFftLibrary(CMakePackage):
@@ -32,6 +33,10 @@ class DoubleBatchedFftLibrary(CMakePackage):
     depends_on("opencl", when="+opencl")
 
     def cmake_args(self):
+        cxx_compiler = os.path.basename(self.compiler.cxx)
+        if self.spec.satisfies("+sycl") and cxx_compiler not in ["icpx", "dpcpp"]:
+            raise InstallError("The Double-Batched FFT Library requires the oneapi DPC++/C++ Compiler")
+
         return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_SYCL", "sycl"),

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -8,8 +8,8 @@ from spack.package import *
 
 class DoubleBatchedFftLibrary(CMakePackage):
     """A library for computing the Discrete Fourier Transform;
-       targeting Graphics Processing Units; supporting OpenCL,
-       Level Zero, and SYCL; with double-batching."""
+    targeting Graphics Processing Units; supporting OpenCL,
+    Level Zero, and SYCL; with double-batching."""
 
     homepage = "https://github.com/intel/double-batched-fft-library"
     url = "https://github.com/intel/double-batched-fft-library/archive/refs/tags/v0.3.6.tar.gz"
@@ -26,16 +26,18 @@ class DoubleBatchedFftLibrary(CMakePackage):
     variant("level-zero", default=True, when="~sycl", description="Build bbfft-level-zero")
     variant("opencl", default=True, when="~sycl", description="Build bbfft-opencl")
 
-    depends_on('cmake@3.23.0:', type='build')
-    depends_on('oneapi-level-zero', when='+sycl')
-    depends_on('oneapi-level-zero', when='+level-zero')
-    depends_on('opencl', when='+opencl')
+    depends_on("cmake@3.23.0:", type="build")
+    depends_on("oneapi-level-zero", when="+sycl")
+    depends_on("oneapi-level-zero", when="+level-zero")
+    depends_on("opencl", when="+opencl")
 
     def cmake_args(self):
-        return [self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-                self.define_from_variant('BUILD_SYCL', 'sycl'),
-                self.define_from_variant('BUILD_LEVEL_ZERO', 'level-zero'),
-                self.define_from_variant('BUILD_OPENCL', 'opencl'),
-                self.define('BUILD_BENCHMARK', False),
-                self.define('BUILD_EXAMPLE', False),
-                self.define('BUILD_TESTING', False)]
+        return [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("BUILD_SYCL", "sycl"),
+            self.define_from_variant("BUILD_LEVEL_ZERO", "level-zero"),
+            self.define_from_variant("BUILD_OPENCL", "opencl"),
+            self.define("BUILD_BENCHMARK", False),
+            self.define("BUILD_EXAMPLE", False),
+            self.define("BUILD_TESTING", False),
+        ]

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import os
+
+from spack.package import *
 
 
 class DoubleBatchedFftLibrary(CMakePackage):
@@ -35,7 +36,9 @@ class DoubleBatchedFftLibrary(CMakePackage):
     def cmake_args(self):
         cxx_compiler = os.path.basename(self.compiler.cxx)
         if self.spec.satisfies("+sycl") and cxx_compiler not in ["icpx", "dpcpp"]:
-            raise InstallError("The Double-Batched FFT Library requires the oneapi DPC++/C++ Compiler")
+            raise InstallError(
+                "The Double-Batched FFT Library requires the oneapi DPC++/C++ Compiler"
+            )
 
         return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class DoubleBatchedFftLibrary(CMakePackage):
+    """A library for computing the Discrete Fourier Transform;
+       targeting Graphics Processing Units; supporting OpenCL,
+       Level Zero, and SYCL; with double-batching."""
+
+    homepage = "https://github.com/intel/double-batched-fft-library"
+    url = "https://github.com/intel/double-batched-fft-library/archive/refs/tags/v0.3.6.tar.gz"
+    git = "https://github.com/intel/double-batched-fft-library.git"
+
+    maintainers = ["uphoffc"]
+
+    version("main", branch="main")
+    version("develop", branch="develop")
+    version("0.3.6", sha256="ff163251d77d3c686563141e871c702bf4997c0302d53616add55d6cf9b02d28")
+
+    variant("shared", default=True, description="Shared library")
+    variant("sycl", default=True, description="Build bbfft-sycl")
+    variant("level-zero", default=True, when="~sycl", description="Build bbfft-level-zero")
+    variant("opencl", default=True, when="~sycl", description="Build bbfft-opencl")
+
+    depends_on('cmake@3.23.0:', type='build')
+    depends_on('oneapi-level-zero', when='+sycl')
+    depends_on('oneapi-level-zero', when='+level-zero')
+    depends_on('opencl', when='+opencl')
+
+    def cmake_args(self):
+        return [self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+                self.define_from_variant('BUILD_SYCL', 'sycl'),
+                self.define_from_variant('BUILD_LEVEL_ZERO', 'level-zero'),
+                self.define_from_variant('BUILD_OPENCL', 'opencl'),
+                self.define('BUILD_BENCHMARK', False),
+                self.define('BUILD_EXAMPLE', False),
+                self.define('BUILD_TESTING', False)]


### PR DESCRIPTION
Adds a package for the double batched FFT library that provides FFT routines for Intel GPUs and supports the Level Zero, OpenCL, and SYCL run-time.