### PR TITLE
esmf: Fix post_install on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
 
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
@@ -348,12 +349,15 @@ class Esmf(MakefilePackage):
     @run_after("install")
     def post_install(self):
         install_tree("cmake", self.prefix.cmake)
-        # Several applications using ESMF are affected by CMake capitalization
-        # issue. The following fix allows all apps to use as-is.
-        for prefix in [dso_suffix, stat_suffix]:
-            library_path = os.path.join(self.prefix.lib, "libesmf.%s" % prefix)
-            if os.path.exists(library_path):
-                os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % prefix))
+        # Several applications using ESMF are affected by CMake
+        # capitalization issue. The following fix allows all apps
+        # to use as-is. Note that since the macOS file system is
+        # case-insensitive, this step is not allowed on macOS.
+        if sys.platform != "darwin":
+            for prefix in [dso_suffix, stat_suffix]:
+                library_path = os.path.join(self.prefix.lib, "libesmf.%s" % prefix)
+                if os.path.exists(library_path):
+                    os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % prefix))
 
     def check(self):
         make("check", parallel=False)


### PR DESCRIPTION
This PR fixes the `post_install` step from https://github.com/spack/spack/pull/35774 from @AlexanderRichert-NOAA to work on macOS. The issue is that since macOS is a case-insensitive filesystem, the symlink fails:
```
==> esmf: Executing phase: 'install'
==> Error: FileExistsError: [Errno 17] File exists: '/Users/mathomp4/spack/opt/spack/darwin-ventura-skylake/gcc-12.2.0/esmf-8.4.0-yeqvno4jilw3v5qtnqwz4odfz4uujygd/lib/libesmf.dylib' -> '/Users/mathomp4/spack/opt/spack/darwin-ventura-skylake/gcc-12.2.0/esmf-8.4.0-yeqvno4jilw3v5qtnqwz4odfz4uujygd/lib/libESMF.dylib'

/Users/mathomp4/spack/var/spack/repos/builtin/packages/esmf/package.py:356, in post_install:
        353        for prefix in [dso_suffix, stat_suffix]:
        354            library_path = os.path.join(self.prefix.lib, "libesmf.%s" % prefix)
        355            if os.path.exists(library_path):
  >>    356                os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % prefix))
```

So, this PR just says "do this if you aren't on Darwin". 