### PR TITLE
cubelib, cubew, scorep: Add explicit configure args to fix instrumentation-time paths

### DIFF
--- a/var/spack/repos/builtin/packages/cubelib/package.py
+++ b/var/spack/repos/builtin/packages/cubelib/package.py
@@ -52,7 +52,7 @@ class Cubelib(AutotoolsPackage):
 
     def configure_args(self):
         configure_args = ["--enable-shared"]
-
+        configure_args.append("--with-frontend-zlib=%s" % self.spec["zlib"].prefix.lib)
         return configure_args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cubew/package.py
+++ b/var/spack/repos/builtin/packages/cubew/package.py
@@ -52,6 +52,8 @@ class Cubew(AutotoolsPackage):
 
     def configure_args(self):
         configure_args = ["--enable-shared"]
+        configure_args.append("--with-frontend-zlib=%s" % self.spec["zlib"].prefix.lib)
+        configure_args.append("--with-backend-zlib=%s" % self.spec["zlib"].prefix.lib)
 
         return configure_args
 

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -187,6 +187,9 @@ class Scorep(AutotoolsPackage):
         elif spec.satisfies("^openmpi"):
             config_args.append("--with-mpi=openmpi")
 
+        if spec.satisfies("^binutils"):
+            config_args.append("--with-libbfd=%s" % spec["binutils"].prefix)
+
         config_args.extend(
             [
                 "CFLAGS={0}".format(self.compiler.cc_pic_flag),


### PR DESCRIPTION
Score-P expects too much from libtool and gets very confused when its internal dependencies automatically appear and are automatically RPATHed. If we explicitly add these dependencies to our configure args, then their link paths will be provided at instrumentation time.

Note that this means anyone *not* using an external `zlib` with a Spack install of CubeLib/CubeW has at least in principle a broken install, and anyone who doesn't *have* a system-accessible `zlib` will not be able to link instrumented binaries cleanly without this patch.