### PR TITLE
LULESH: fix space in rpath for +visual

### DIFF
--- a/var/spack/repos/builtin/packages/lulesh/package.py
+++ b/var/spack/repos/builtin/packages/lulesh/package.py
@@ -41,8 +41,7 @@ class Lulesh(MakefilePackage):
             targets.append("SILO_INCDIR = {0}".format(self.spec["silo"].prefix.include))
             targets.append("SILO_LIBDIR = {0}".format(self.spec["silo"].prefix.lib))
             cxxflag = " -g -DVIZ_MESH -I${SILO_INCDIR} "
-            ldflags = " -g -L${SILO_LIBDIR} -Wl,-rpath -Wl, "
-            ldflags += "${SILO_LIBDIR} -lsiloh5 -lhdf5 "
+            ldflags = " -g -L${SILO_LIBDIR} -Wl,-rpath=${SILO_LIBDIR} -lsiloh5 -lhdf5 "
 
         if "+openmp" in self.spec:
             cxxflag += self.compiler.openmp_flag


### PR DESCRIPTION
This fixes an error in lulesh's install when "+visual" is passed:

```sh
#space just after the second  -Wl, ; not sure of the initial intent
 -Wl,-rpath -Wl, /storage/users/XXXX/spack/linux-rhel8-zen/gcc-8.5.0/silo-4.9-2u5oxm4hae7a3rv6t
````