### PR TITLE
Package Fix: cardioid: Removing .php from the cardioid homepage.

### DIFF
--- a/var/spack/repos/builtin/packages/cardioid/package.py
+++ b/var/spack/repos/builtin/packages/cardioid/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Cardioid(CMakePackage):
     """Cardiac simulation suite."""
 
-    homepage = "https://baasic.llnl.gov/comp-bio/cardioid-code.php"
+    homepage = "https://baasic.llnl.gov/comp-bio/cardioid-code"
     git = "https://github.com/LLNL/cardioid.git"
     maintainers("rblake-llnl")
 


### PR DESCRIPTION
Fixes #36043 .