### PR TITLE
pmix, openmpi, and prrte need to use the same `configure` to find the same deps

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -554,7 +554,6 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     depends_on("pmix@1.0:1", when="@2.0:2")
     depends_on("pmix@3.2:", when="@4.0:4")
     depends_on("pmix@5:", when="@5.0:5")
-    depends_on("munge", when="@5.0:5")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="@main")

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -554,6 +554,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     depends_on("pmix@1.0:1", when="@2.0:2")
     depends_on("pmix@3.2:", when="@4.0:4")
     depends_on("pmix@5:", when="@5.0:5")
+    depends_on("munge", when="@5.0:5")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="@main")

--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -80,6 +80,7 @@ class Pmix(AutotoolsPackage):
     depends_on("libtool", type="build", when="@master")
     depends_on("perl", type="build", when="@master")
     depends_on("pandoc", type="build", when="+docs")
+    depends_on("pkgconfig", type="build")
 
     depends_on("libevent@2.0.20:")
     depends_on("hwloc@1.0:1", when="@:2")

--- a/var/spack/repos/builtin/packages/prrte/package.py
+++ b/var/spack/repos/builtin/packages/prrte/package.py
@@ -33,6 +33,7 @@ class Prrte(AutotoolsPackage):
     depends_on("automake", type=("build"))
     depends_on("libtool", type=("build"))
     depends_on("flex", type=("build"))
+    depends_on("pkgconfig", type="build")
 
     def autoreconf(self, spec, prefix):
         # If configure exists nothing needs to be done


### PR DESCRIPTION
This is the error you will see when munge is missing from `PKG_CONFIG_PATH`:

```
configure:63942: checking for pmix pkg-config cflags
configure:63956: check_package_pkgconfig_run_results=Package munge was not found in the pkg-config search path.
Perhaps you should add the directory containing `munge.pc'
to the PKG_CONFIG_PATH environment variable
Package 'munge', required by 'pmix', not found
configure:63959: $? = 1
configure:63966: pkg-config output: Package munge was not found in the pkg-config search path.
Perhaps you should add the directory containing `munge.pc'
to the PKG_CONFIG_PATH environment variable
Package 'munge', required by 'pmix', not found
configure:63972: result: error
configure:63974: error: An error occurred retrieving pmix cppflags from pkg-config
```