### PR TITLE
E4S: Add sensei to the DaV SDK packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -77,7 +77,7 @@ spack:
   - conduit
   - datatransferkit
   - dyninst
-  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp
+  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sensei +sz +unifyfs +veloc +visit +vtkm +zfp
   - exaworks
   - flecsi
   - flit


### PR DESCRIPTION
Add SENSEI to the packages built in E4S under the Data and Vis SDK umbrella