### PR TITLE
py-esmpy: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyEsmpy(PythonPackage):
+    """ESMPy is a Python interface to the Earth System Modeling Framework (ESMF)"""
+
+    homepage = "https://earthsystemmodeling.org/"
+    git = "https://github.com/esmf-org/esmf.git"
+
+    # because it relies on py-setuptools-git-versioning, we need to install from git
+    version("develop", branch="develop")
+    version("8.4.0", tag="v8.4.0")
+    version("8.3.1", tag="v8.3.1")
+    version("8.3.0", tag="v8.3.0")
+    version("8.2.0", tag="v8.2.0")
+    version("8.1.1", tag="v8.1.1")
+    version("8.0.1", tag="v8.0.1")
+    version("8.0.0", tag="v8.0.0")
+
+    maintainers("angus-g")
+
+    # require an in-sync version of ESMF
+    for v in ["develop", "8.4.0", "8.3.1", "8.3.0", "8.2.0", "8.1.1", "8.0.1", "8.0.0"]:
+        depends_on(f"esmf@{v}", when=f"@{v}", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-git-versioning", type="build")
+
+    build_directory = "src/addon/esmpy"

--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -33,6 +33,7 @@ class PyEsmpy(PythonPackage):
     depends_on("py-setuptools-git-versioning", when="@8.4.0: ^python@3.10:", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@8.4.0: ^python@:3.7")
+    depends_on("py-pytest-json-report")
 
     patch("setuppy.patch", when="@:8.3.1")
 

--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -28,7 +28,7 @@ class PyEsmpy(PythonPackage):
     for v in ["develop", "8.4.0", "8.3.1", "8.3.0", "8.2.0", "8.1.1", "8.0.1", "8.0.0"]:
         depends_on(f"esmf@{v}", when=f"@{v}", type=("build", "run"))
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@41:", type="build")
     depends_on("py-build", when="@:8.3.1", type="build")
     depends_on("py-setuptools-git-versioning", when="@8.4.0:", type="build")
     depends_on("py-numpy", type="run")

--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -30,8 +30,9 @@ class PyEsmpy(PythonPackage):
 
     depends_on("py-setuptools@41:", type="build")
     depends_on("py-build", when="@:8.3.1", type="build")
-    depends_on("py-setuptools-git-versioning", when="@8.4.0:", type="build")
-    depends_on("py-numpy", type="run")
+    depends_on("py-setuptools-git-versioning", when="@8.4.0: ^python@3.10:", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-importlib-metadata", when="@8.4.0: ^python@:3.7")
 
     patch("setuppy.patch", when="@:8.3.1")
 

--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -10,9 +10,9 @@ class PyEsmpy(PythonPackage):
     """ESMPy is a Python interface to the Earth System Modeling Framework (ESMF)"""
 
     homepage = "https://earthsystemmodeling.org/"
+    url = "https://github.com/esmf-org/esmf/archive/refs/tags/v8.4.0.tar.gz"
     git = "https://github.com/esmf-org/esmf.git"
 
-    # because it relies on py-setuptools-git-versioning, we need to install from git
     version("develop", branch="develop")
     version("8.4.0", sha256="28531810bf1ae78646cda6494a53d455d194400f19dccd13d6361871de42ed0f")
     version("8.3.1", sha256="6c39261e55dcdf9781cdfa344417b9606f7f961889d5ec626150f992f04f146d")

--- a/var/spack/repos/builtin/packages/py-esmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-esmpy/package.py
@@ -14,13 +14,13 @@ class PyEsmpy(PythonPackage):
 
     # because it relies on py-setuptools-git-versioning, we need to install from git
     version("develop", branch="develop")
-    version("8.4.0", tag="v8.4.0")
-    version("8.3.1", tag="v8.3.1")
-    version("8.3.0", tag="v8.3.0")
-    version("8.2.0", tag="v8.2.0")
-    version("8.1.1", tag="v8.1.1")
-    version("8.0.1", tag="v8.0.1")
-    version("8.0.0", tag="v8.0.0")
+    version("8.4.0", sha256="28531810bf1ae78646cda6494a53d455d194400f19dccd13d6361871de42ed0f")
+    version("8.3.1", sha256="6c39261e55dcdf9781cdfa344417b9606f7f961889d5ec626150f992f04f146d")
+    version("8.3.0", sha256="0ff43ede83d1ac6beabd3d5e2a646f7574174b28a48d1b9f2c318a054ba268fd")
+    version("8.2.0", sha256="3693987aba2c8ae8af67a0e222bea4099a48afe09b8d3d334106f9d7fc311485")
+    version("8.1.1", sha256="58c2e739356f21a1b32673aa17a713d3c4af9d45d572f4ba9168c357d586dc75")
+    version("8.0.1", sha256="9172fb73f3fe95c8188d889ee72fdadb4f978b1d969e1d8e401e8d106def1d84")
+    version("8.0.0", sha256="051dca45f9803d7e415c0ea146df15ce487fb55f0fce18ca61d96d4dba0c8774")
 
     maintainers("angus-g")
 
@@ -29,6 +29,26 @@ class PyEsmpy(PythonPackage):
         depends_on(f"esmf@{v}", when=f"@{v}", type=("build", "run"))
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-git-versioning", type="build")
+    depends_on("py-build", when="@:8.3.1", type="build")
+    depends_on("py-setuptools-git-versioning", when="@8.4.0:", type="build")
+    depends_on("py-numpy", type="run")
 
-    build_directory = "src/addon/esmpy"
+    patch("setuppy.patch", when="@:8.3.1")
+
+    @property
+    def build_directory(self):
+        if self.version < Version("8.4.0"):
+            return join_path("src", "addon", "ESMPy")
+
+        return join_path("src", "addon", "esmpy")
+
+    def url_for_version(self, version):
+        if version < Version("8.2.1"):
+            return "https://github.com/esmf-org/esmf/archive/ESMF_{0}.tar.gz".format(
+                version.underscored
+            )
+        else:
+            # Starting with ESMF 8.2.1 releases are now in the form vx.y.z
+            return "https://github.com/esmf-org/esmf/archive/refs/tags/v{0}.tar.gz".format(
+                version.dotted
+            )

--- a/var/spack/repos/builtin/packages/py-esmpy/setuppy.patch
+++ b/var/spack/repos/builtin/packages/py-esmpy/setuppy.patch
@@ -1,0 +1,10 @@
+--- old/src/addon/ESMPy/setup.py	2023-03-20 13:16:31.735670768 +1100
++++ new/src/addon/ESMPy/setup.py	2023-03-20 13:17:02.563922021 +1100
+@@ -88,6 +88,7 @@
+         self.build_base = 'build'
+         self.build_lib = None
+         self.plat_name = None
++        self.build_scripts = []
+ 
+     def finalize_options(self):
+         self.cwd = os.getcwd()

--- a/var/spack/repos/builtin/packages/py-pytest-json-report/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-json-report/package.py
@@ -16,5 +16,6 @@ class PyPytestJsonReport(PythonPackage):
 
     version("1.5.0", sha256="2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de")
 
-    depends_on("py-pytest@3.8.0:")
-    depends_on("py-pytest-metadata")
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pytest@3.8:", type=("build", "run"))
+    depends_on("py-pytest-metadata", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-json-report/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-json-report/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestJsonReport(PythonPackage):
+    """A pytest plugin to create test reports as JSON"""
+
+    homepage = "https://github.com/numirias/pytest-json-report"
+    pypi = "pytest-json-report/pytest-json-report-1.5.0.tar.gz"
+
+    maintainers("angus-g")
+
+    version("1.5.0", sha256="2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de")
+
+    depends_on("py-pytest@3.8.0:")
+    depends_on("py-pytest-metadata")


### PR DESCRIPTION
This is the Python interface to ESMF. I'm not sure whether this is the best approach, or if it should be added as a variant to ESMF? This seemed like the most straightforward method, given it's a simple Python package, bundled with the ESMF repository.

This depends on py-setuptools-git-versioning #36123 