### PR TITLE
mvapich: add `pbs` support

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -64,8 +64,8 @@ class Mvapich(AutotoolsPackage):
         description="List of the process managers to activate",
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
-        .with_error("'slurm','pbs' or 'auto' cannot be activated along with " 
-        "other process managers")
+        .with_error(
+        　　"'slurm','pbs' or 'auto' cannot be activated along with " "other process managers")
         .with_default("auto")
         .with_non_feature_values("auto"),
     )

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -65,7 +65,7 @@ class Mvapich(AutotoolsPackage):
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
         .with_error(
-           "'slurm','pbs' or 'auto' cannot be activated along with other process managers"
+            "'slurm','pbs' or 'auto' cannot be activated along with other process managers"
         )
         .with_default("auto")
         .with_non_feature_values("auto"),

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -19,7 +19,7 @@ class Mvapich(AutotoolsPackage):
     url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-3.0a.tar.gz"
     list_url = "https://mvapich.cse.ohio-state.edu/downloads/"
 
-    maintainers("natshineman", "harisubramoni", "ndcontini")
+    maintainers("natshineman", "harisubramoni", "MatthewLieber"
 
     executables = ["^mpiname$", "^mpichversion$"]
 
@@ -62,9 +62,10 @@ class Mvapich(AutotoolsPackage):
     variant(
         "process_managers",
         description="List of the process managers to activate",
-        values=disjoint_sets(("auto",), ("slurm",),("pbs",), ("hydra", "gforker", "remshell"))
+        values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
-        .with_error("'slurm','pbs' or 'auto' cannot be activated along with " "other process managers")
+        .with_error("'slurm','pbs' or 'auto' cannot be activated along with " 
+        "other process managers")
         .with_default("auto")
         .with_non_feature_values("auto"),
     )

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -65,7 +65,7 @@ class Mvapich(AutotoolsPackage):
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
         .with_error(
-        　　"'slurm','pbs' or 'auto' cannot be activated along with other process managers"
+           "'slurm','pbs' or 'auto' cannot be activated along with other process managers"
         )
         .with_default("auto")
         .with_non_feature_values("auto"),

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -64,7 +64,9 @@ class Mvapich(AutotoolsPackage):
         description="List of the process managers to activate",
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
-        .with_error("'slurm','pbs' or 'auto' cannot be activated along with other process managers")
+        .with_error(
+        　　"'slurm','pbs' or 'auto' cannot be activated along with other process managers"
+        )
         .with_default("auto")
         .with_non_feature_values("auto"),
     )

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -65,7 +65,7 @@ class Mvapich(AutotoolsPackage):
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
         .with_error(
-        　　"'slurm','pbs' or 'auto' cannot be activated along with " "other process managers")
+        　　"'slurm','pbs' or 'auto' cannot be activated along with other process managers")
         .with_default("auto")
         .with_non_feature_values("auto"),
     )

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -66,7 +66,7 @@ class Mvapich(AutotoolsPackage):
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
         .with_error(
-            "'slurm','pbs' or 'auto' cannot be activated along with other process managers"
+            "'slurm' 'pbs' or 'auto' cannot be activated along with other process managers"
         )
         .with_default("auto")
         .with_non_feature_values("auto"),
@@ -101,8 +101,8 @@ class Mvapich(AutotoolsPackage):
     depends_on("libxml2")
     depends_on("cuda", when="+cuda")
     depends_on("libfabric", when="netmod=ofi")
-    depends_on("slurm", when="process_managers=slurm")
     depends_on("openpbs", when="process_managers=pbs")
+    depends_on("slurm", when="process_managers=slurm")
     depends_on("ucx", when="netmod=ucx")
 
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
@@ -150,6 +150,7 @@ class Mvapich(AutotoolsPackage):
             ]
         if "process_managers=pbs" in spec:
             opts = ["--with-pbs={0}".format(spec["pbs"].prefix)]
+
         return opts
 
     @property
@@ -288,6 +289,7 @@ class Mvapich(AutotoolsPackage):
             args.append("--enable-registration-cache")
         else:
             args.append("--disable-registration-cache")
+
         ld = ""
         for path in itertools.chain(self.compiler.extra_rpaths, self.compiler.implicit_rpaths()):
             ld += "-Wl,-rpath," + path + " "

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -147,7 +147,7 @@ class Mvapich(AutotoolsPackage):
                 "CFLAGS=-I{0}/include/slurm".format(spec["slurm"].prefix),
             ]
         if "process_managers=pbs" in spec:
-            opts = ["--with-pbs={0}".format(spec["pbs"].prefix),]
+            opts = ["--with-pbs={0}".format(spec["pbs"].prefix)]
         return opts
 
     @property

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import os.path
 import re
 import sys

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -19,7 +19,7 @@ class Mvapich(AutotoolsPackage):
     url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-3.0a.tar.gz"
     list_url = "https://mvapich.cse.ohio-state.edu/downloads/"
 
-    maintainers("natshineman", "harisubramoni", "MatthewLieber"
+    maintainers("natshineman", "harisubramoni", "MatthewLieber")
 
     executables = ["^mpiname$", "^mpichversion$"]
 

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -287,7 +287,12 @@ class Mvapich(AutotoolsPackage):
             args.append("--enable-registration-cache")
         else:
             args.append("--disable-registration-cache")
-
+            
+        ld = ""
+        for path in itertools.chain(self.compiler.extra_rpaths, self.compiler.implicit_rpaths()):
+            ld += "-Wl,-rpath," + path + " "
+        if ld != "":
+            args.append("LDFLAGS=" + ld)
         args.extend(self.process_manager_options)
         args.extend(self.network_options)
         args.extend(self.file_system_options)

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -147,9 +147,7 @@ class Mvapich(AutotoolsPackage):
                 "CFLAGS=-I{0}/include/slurm".format(spec["slurm"].prefix),
             ]
         if "process_managers=pbs" in spec:
-            opts = [
-                "--with-pbs={0}".format(spec["pbs"].prefix),
-            ]
+            opts = ["--with-pbs={0}".format(spec["pbs"].prefix),]
         return opts
 
     @property

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -64,8 +64,7 @@ class Mvapich(AutotoolsPackage):
         description="List of the process managers to activate",
         values=disjoint_sets(("auto",), ("slurm",), ("pbs",), ("hydra", "gforker", "remshell"))
         .prohibit_empty_set()
-        .with_error(
-        　　"'slurm','pbs' or 'auto' cannot be activated along with other process managers")
+        .with_error("'slurm','pbs' or 'auto' cannot be activated along with other process managers")
         .with_default("auto")
         .with_non_feature_values("auto"),
     )

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -287,7 +287,6 @@ class Mvapich(AutotoolsPackage):
             args.append("--enable-registration-cache")
         else:
             args.append("--disable-registration-cache")
-            
         ld = ""
         for path in itertools.chain(self.compiler.extra_rpaths, self.compiler.implicit_rpaths()):
             ld += "-Wl,-rpath," + path + " "


### PR DESCRIPTION
PBS support is added to "process_managers" so that users can implicitly use pbs_tmrsh to launch mpi processes.
The location of PBS is given with "–with-pbs=" through the "openpbs" package.
