### PR TITLE
Update the PyTorch ecosystem

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -28,6 +28,7 @@ spack:
       - py-efficientnet-pytorch
       - py-gpytorch
       - py-kornia
+      - py-lightning
       - py-pytorch-gradual-warmup-lr
       - py-pytorch-lightning
       - py-segmentation-models-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -31,6 +31,7 @@ spack:
       - py-efficientnet-pytorch
       - py-gpytorch
       - py-kornia
+      - py-lightning
       - py-pytorch-gradual-warmup-lr
       - py-pytorch-lightning
       - py-segmentation-models-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -34,6 +34,7 @@ spack:
       # - py-efficientnet-pytorch
       # - py-gpytorch
       # - py-kornia
+      # - py-lightning
       # - py-pytorch-gradual-warmup-lr
       # - py-pytorch-lightning
       # - py-segmentation-models-pytorch

--- a/var/spack/repos/builtin/packages/py-lightning-utilities/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning-utilities/package.py
@@ -14,6 +14,7 @@ class PyLightningUtilities(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("0.8.0", sha256="8e5d95c7c57f026cdfed7c154303e88c93a7a5e868c9944cb02cf71f1db29720")
     version(
         "0.6.0.post0", sha256="6f02cfe59e6576487e709a0e66e07671563bde9e21b40e1c567918e4d753278c"
     )
@@ -24,7 +25,6 @@ class PyLightningUtilities(PythonPackage):
     version("0.3.0", sha256="d769ab9b76ebdee3243d1051d509aafee57d7947734ddc22977deef8a6427f2f")
 
     # setup.py
-    depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     # requirements/base.txt

--- a/var/spack/repos/builtin/packages/py-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning/package.py
@@ -1,0 +1,77 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLightning(PythonPackage):
+    """Use Lightning Apps to build everything from production-ready,
+    multi-cloud ML systems to simple research demos.
+    """
+
+    homepage = "https://github.com/Lightning-AI/lightning"
+    pypi = "lightning/lightning-2.0.0.tar.gz"
+
+    maintainers("adamjstewart")
+
+    version("2.0.0", sha256="dfe158aa91ac139d8bdfccc7cdb627072e0052076ae9c0459c8fa12a028dbe6c")
+    version("1.9.4", sha256="842d81c48ed0684d2e33b4d815794f9c3b2adb3916446ed12556dfeb3952e721")
+    version("1.9.3", sha256="1d594b756d619b65ed61cf2fc17511819565ec94f70a49e797bd9b8e435d7c0c")
+    version("1.9.2", sha256="056bef8c9a5f3cfa82d07a65798a524d3a90fbb9e07d155f8da3194b24151593")
+    version("1.9.1", sha256="d13e4b364361ddb8d0380b41f069f13e6f8f6b10d6ed3c34ceafa7e6007d6007")
+    version("1.9.0", sha256="d002270e2cd6bdf239d6605f8ec7f6f79bd2ec4eb5e7758b38ca36c57d4d1fdf")
+    version("1.8.6", sha256="4f56a390e58551cf40173c8c74684972c261185f3a92690888340b7209855f49")
+    version("1.8.5", sha256="c54b2369a51c613ab4324c61c56af2d6100b9431ac0d7ae31c8d646561873eb4")
+    version("1.8.4", sha256="4f7746b406276449bd91b46c71eaf8823781322e56dec860316c74560e7e8551")
+    version("1.8.3", sha256="61b03b7858848ac01aea3d76679104bc651271697c40f13cc078ad4365594874")
+    version("1.8.2", sha256="f30e30b9eaa8a0986fbaec61734775ba349185ed17bd7f02caa2af4ff75e273e")
+    version("1.8.1", sha256="c0a5dda56f62efd807ccf18a2943fbf8ca60511f8afa63ec3ab1ebe79e43575c")
+
+    variant(
+        "extra", default=False, description="Install extra dependencies for full functionality"
+    )
+
+    # src/pytorch_lightning/__setup__.py
+    depends_on("python@3.8:", when="@2:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    # requirements/pytorch/base.txt
+    depends_on("py-numpy@1.17.2:", type=("build", "run"))
+    depends_on("py-torch@1.11:", when="@2:", type=("build", "run"))
+    depends_on("py-torch@1.10:", when="@1.9:", type=("build", "run"))
+    depends_on("py-torch@1.9:", type=("build", "run"))
+    depends_on("py-tqdm@4.57.0:", type=("build", "run"))
+    depends_on("py-pyyaml@5.4:", type=("build", "run"))
+    depends_on("py-fsspec@2021.06.1:+http", type=("build", "run"))
+    depends_on("py-torchmetrics@0.7:", type=("build", "run"))
+    depends_on("py-packaging@17.1:", when="@1.9:", type=("build", "run"))
+    depends_on("py-packaging@17.0:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.7:", when="@2:", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.6.0.post0:", when="@1.9.1:", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.4.2:", when="@1.9.0", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.3,0.4.1:", when="@1.8.4:1.8", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.3:", when="@1.8.0:1.8.3", type=("build", "run"))
+
+    # requirements/pytorch/extra.txt
+    with when("+extra"):
+        depends_on("py-matplotlib@3.2:", type=("build", "run"))
+        depends_on("py-omegaconf@2.0.5:", type=("build", "run"))
+        depends_on("py-hydra-core@1.0.5:", type=("build", "run"))
+        depends_on("py-jsonargparse@4.18:+signatures", when="@1.9:", type=("build", "run"))
+        depends_on("py-jsonargparse@4.15.2:+signatures", type=("build", "run"))
+        depends_on("py-rich@12.3:", when="@2:", type=("build", "run"))
+        depends_on("py-rich@10.14:", type=("build", "run"))
+        depends_on("py-tensorboardx@2.2:", when="@1.9:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-lightning-lite@1.8.0", when="@1.8.0", type=("build", "run"))
+    depends_on("py-tensorboardx@2.2:", when="@1.8.3:1.8", type=("build", "run"))
+    depends_on("py-tensorboard@2.9.1:", when="@:1.8.2", type=("build", "run"))
+
+    # https://github.com/Lightning-AI/lightning/issues/16637
+    conflicts("^py-torch~distributed", when="@1.9.0")
+    # https://github.com/Lightning-AI/lightning/issues/15494
+    conflicts("^py-torch~distributed", when="@1.8.0")

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -14,6 +14,7 @@ class PyPytorchLightning(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("2.0.0", sha256="632dec9af8036f726904e691c505d7650658ef0f4054a062c9e6a940ca09dfd8")
     version("1.9.4", sha256="188a7f4468acf23512e7f4903253d86fc7929a49f0c09d699872e364162001e8")
     version("1.9.3", sha256="479164caea190d49ee2a218eef7e001888be56db912b417639b047e8f9ca8a07")
     version("1.9.2", sha256="e60303e258457ccf7ec37c46a616892691fe3fbb23ab12f5c02b8018f03bf223")
@@ -51,13 +52,13 @@ class PyPytorchLightning(PythonPackage):
     )
 
     # src/pytorch_lightning/__setup__.py
-    depends_on("python@3.7:", when="@1.6:", type=("build", "run"))
-    depends_on("python@3.6:", when="@:1.5", type=("build", "run"))
+    depends_on("python@3.8:", when="@2:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     # requirements/pytorch/base.txt
     depends_on("py-numpy@1.17.2:", when="@1.3:", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", when="@:1.2", type=("build", "run"))
+    depends_on("py-torch@1.11:", when="@2:", type=("build", "run"))
     depends_on("py-torch@1.10:", when="@1.9:", type=("build", "run"))
     depends_on("py-torch@1.9:", when="@1.7:", type=("build", "run"))
     depends_on("py-torch@1.8:", when="@1.6:", type=("build", "run"))
@@ -82,6 +83,7 @@ class PyPytorchLightning(PythonPackage):
     depends_on("py-packaging", when="@:1.2", type=("build", "run"))
     depends_on("py-typing-extensions@4.0.0:", when="@1.6:", type=("build", "run"))
     depends_on("py-typing-extensions", when="@1.4:1.5", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.7:", when="@2:", type=("build", "run"))
     depends_on("py-lightning-utilities@0.6.0.post0:", when="@1.9.1:", type=("build", "run"))
     depends_on("py-lightning-utilities@0.4.2:", when="@1.9.0", type=("build", "run"))
     depends_on("py-lightning-utilities@0.3,0.4.1:", when="@1.8.4:1.8", type=("build", "run"))
@@ -103,6 +105,7 @@ class PyPytorchLightning(PythonPackage):
         depends_on("py-jsonargparse@3.19.3:+signatures", when="@1.5:", type=("build", "run"))
         depends_on("py-jsonargparse@3.17:+signatures", when="@1.4:", type=("build", "run"))
         depends_on("py-jsonargparse@3.13.1:+signatures", when="@1.3:", type=("build", "run"))
+        depends_on("py-rich@12.3:", when="@2:", type=("build", "run"))
         depends_on("py-rich@10.14:", when="@1.7:", type=("build", "run"))
         depends_on("py-rich@10.2.2:", when="@1.5:", type=("build", "run"))
         depends_on("py-tensorboardx@2.2:", when="@1.9:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyPytorchLightning(PythonPackage):
     """PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers."""
 
-    homepage = "https://github.com/PyTorchLightning/pytorch-lightning"
+    homepage = "https://github.com/Lightning-AI/lightning"
     pypi = "pytorch-lightning/pytorch-lightning-1.2.10.tar.gz"
 
     maintainers("adamjstewart")

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -351,6 +351,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         sha256="a54db63640b90e5833cc1099c0935572f5297d2d8625f62f01ac1fda79ed4569",
         when="@1.13 arch=ppc64le:",
     )
+    conflicts("arch=ppc64le:", when="@:1.9,2:")
 
     # Cherry-pick a patch to allow earlier versions of PyTorch to work with CUDA 11.4
     patch(

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -24,6 +24,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     import_modules = ["torch", "torch.autograd", "torch.nn", "torch.utils"]
 
     version("master", branch="master", submodules=True)
+    version("2.0.0", tag="v2.0.0", submodules=True)
     version("1.13.1", tag="v1.13.1", submodules=True)
     version("1.13.0", tag="v1.13.0", submodules=True)
     version("1.12.1", tag="v1.12.1", submodules=True)
@@ -119,12 +120,20 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     # Required dependencies
     # See python_min_version in setup.py
-    depends_on("python@3.7:", when="@1.11:", type=("build", "link", "run"))
-    depends_on("python@3.6.2:", when="@1.7.1:", type=("build", "link", "run"))
-    depends_on("python@3.6.1:", when="@1.6:1.7.0", type=("build", "link", "run"))
-    depends_on("python@3.5:", when="@1.5", type=("build", "link", "run"))
-    depends_on("python@2.7:2,3.5:", when="@1.4", type=("build", "link", "run"))
+    # Upper bounds come from wheel availability on PyPI
+    depends_on("python@3.8:3.11", when="@2:", type=("build", "link", "run"))
+    depends_on("python@3.7:3.10", when="@1.11:1", type=("build", "link", "run"))
+    depends_on("python@3.6.2:3.9", when="@1.7.1:1.10", type=("build", "link", "run"))
+    depends_on("python@3.6.1:3.8", when="@1.6:1.7.0", type=("build", "link", "run"))
+    depends_on("python@3.5:3.8", when="@1.5", type=("build", "link", "run"))
+    depends_on("python@2.7:2,3.5:3.8", when="@1.4", type=("build", "link", "run"))
     depends_on("python@2.7:2,3.5:3.7", when="@:1.3", type=("build", "link", "run"))
+
+    # CMakelists.txt
+    depends_on("cmake@3.18:", when="@2:", type="build")
+    depends_on("cmake@3.13:", when="@1.11:", type="build")
+    depends_on("cmake@3.10:", when="@1.10:", type="build")
+    depends_on("cmake@3.5:", type="build")
 
     # pyproject.toml
     depends_on("py-setuptools", type=("build", "run"))
@@ -132,14 +141,17 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-numpy@1.16.6:", type=("build", "run"))
     depends_on("ninja@1.5:", when="@1.1:", type="build")
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("cmake@3.13:", when="@1.11:", type="build")
-    depends_on("cmake@3.10:", when="@1.10:", type="build")
-    depends_on("cmake@3.5:", type="build")
-    depends_on("py-cffi", type=("build", "run"))
-    depends_on("py-typing-extensions@3.6.2.1:", when="@1.7:", type=("build", "run"))
-    depends_on("py-future", when="@1.5:", type=("build", "run"))
-    depends_on("py-six", when="@1.13:", type=("build", "run"))
     depends_on("py-requests", when="@1.13:", type=("build", "run"))
+    depends_on("py-cffi", when="@:1", type=("build", "run"))
+    depends_on("py-future", when="@1.5:1", type=("build", "run"))
+    depends_on("py-six", when="@1.13:1", type=("build", "run"))
+
+    # setup.py
+    depends_on("py-filelock", when="@2:", type=("build", "run"))
+    depends_on("py-typing-extensions@3.6.2.1:", when="@1.7:", type=("build", "run"))
+    depends_on("py-sympy", when="@2:", type=("build", "run"))
+    depends_on("py-networkx", when="@2:", type=("build", "run"))
+    depends_on("py-jinja2", when="@2:", type=("build", "run"))
 
     # Undocumented dependencies
     depends_on("py-tqdm", type="run")
@@ -147,7 +159,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
 
     # third_party
-    depends_on("py-pybind11@2.10.0", when="@1.13:", type=("build", "link", "run"))
+    depends_on("py-pybind11@2.10.1", when="@2:", type=("build", "link", "run"))
+    depends_on("py-pybind11@2.10.0", when="@1.13:1", type=("build", "link", "run"))
     depends_on("py-pybind11@2.6.2", when="@1.8:1.12", type=("build", "link", "run"))
     depends_on("py-pybind11@2.3.0", when="@1.1:1.7", type=("build", "link", "run"))
     depends_on("py-pybind11@2.2.4", when="@:1.0", type=("build", "link", "run"))
@@ -178,14 +191,17 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("benchmark", when="@1.6:+test")
 
     # Optional dependencies
+    # https://github.com/pytorch/pytorch#prerequisites
+    depends_on("cuda@11:", when="@2:+cuda", type=("build", "link", "run"))
+    depends_on("cuda@10.2:", when="@1.11:1+cuda", type=("build", "link", "run"))
     # https://discuss.pytorch.org/t/compiling-1-10-1-from-source-with-gcc-11-and-cuda-11-5/140971
-    depends_on("cuda@9.2:", when="@1.11:+cuda", type=("build", "link", "run"))
-    depends_on("cuda@9.2:11.4", when="@1.6:1.10+cuda", type=("build", "link", "run"))
-    depends_on("cuda@9:11.4", when="@1.1:1.5+cuda", type=("build", "link", "run"))
-    depends_on("cuda@7.5:11.4", when="@:1.0+cuda", type=("build", "link", "run"))
-    depends_on("cudnn@6:7", when="@:1.0+cudnn")
-    depends_on("cudnn@7.0:7", when="@1.1:1.5+cudnn")
+    depends_on("cuda@10.2:11.4", when="@1.10+cuda", type=("build", "link", "run"))
+    depends_on("cuda@9.2:11.4", when="@1.6:1.9+cuda", type=("build", "link", "run"))
+    depends_on("cuda@9:11.4", when="@1.2:1.5+cuda", type=("build", "link", "run"))
+    depends_on("cuda@7.5:11.4", when="@:1.1+cuda", type=("build", "link", "run"))
     depends_on("cudnn@7:", when="@1.6:+cudnn")
+    depends_on("cudnn@7", when="@1.2:1.5+cudnn")
+    depends_on("cudnn@6.5:7", when="@:1.1+cudnn")
     depends_on("magma+cuda", when="+magma+cuda")
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("nccl", when="+nccl+cuda")
@@ -208,19 +224,22 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("miopen-hip")
         depends_on("rocminfo")
     # https://github.com/pytorch/pytorch/issues/60332
-    # depends_on("xnnpack@2022-02-16", when="@1.12:+xnnpack")
+    # depends_on("xnnpack@2022-12-21", when="@2:+xnnpack")
+    # depends_on("xnnpack@2022-02-16", when="@1.12:1+xnnpack")
     # depends_on("xnnpack@2021-06-21", when="@1.10:1.11+xnnpack")
     # depends_on("xnnpack@2021-02-22", when="@1.8:1.9+xnnpack")
     # depends_on("xnnpack@2020-03-23", when="@1.6:1.7+xnnpack")
     depends_on("mpi", when="+mpi")
     # https://github.com/pytorch/pytorch/issues/60270
-    # depends_on("gloo@2022-05-18", when="@1.13:+gloo")
+    # depends_on("gloo@2023-01-17", when="@2:+gloo")
+    # depends_on("gloo@2022-05-18", when="@1.13:1+gloo")
     # depends_on("gloo@2021-05-21", when="@1.10:1.12+gloo")
     # depends_on("gloo@2021-05-04", when="@1.9+gloo")
     # depends_on("gloo@2020-09-18", when="@1.7:1.8+gloo")
     # depends_on("gloo@2020-03-17", when="@1.6+gloo")
     # https://github.com/pytorch/pytorch/issues/60331
-    # depends_on("onnx!1.12.0", when="@1.13:+onnx_ml")
+    # depends_on("onnx@1.13.1", when="@2:+onnx_ml")
+    # depends_on("onnx@1.12.0", when="@1.13:1+onnx_ml")
     # depends_on("onnx@1.11.0", when="@1.12+onnx_ml")
     # depends_on("onnx@1.10.1_2021-10-08", when="@1.11+onnx_ml")
     # depends_on("onnx@1.10.1", when="@1.10+onnx_ml")
@@ -340,12 +359,12 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         when="@:1.9.1 ^cuda@11.4.100:",
     )
 
-    # PyTorch does not build with GCC 12 (fixed on master)
+    # PyTorch does not build with GCC 12 (fixed in 2.0)
     # See: https://github.com/pytorch/pytorch/issues/77614
     patch(
         "https://github.com/facebookincubator/gloo/commit/4a5e339b764261d20fc409071dc7a8b8989aa195.patch?full_index=1",
         sha256="dc8b3a9bea4693f32d6850ea2ce6ce75e1778538bfba464b50efca92bac425e3",
-        when="@:1.13 %gcc@12:",
+        when="@:1 %gcc@12:",
         working_dir="third_party/gloo",
     )
 

--- a/var/spack/repos/builtin/packages/py-torchaudio/package.py
+++ b/var/spack/repos/builtin/packages/py-torchaudio/package.py
@@ -23,6 +23,7 @@ class PyTorchaudio(PythonPackage):
     git = "https://github.com/pytorch/audio.git"
 
     version("main", branch="main", submodules=True)
+    version("2.0.1", tag="v2.0.1", submodules=True)
     version("0.13.1", tag="v0.13.1", submodules=True)
     version("0.13.0", tag="v0.13.0", submodules=True)
     version("0.12.1", tag="v0.12.1", submodules=True)
@@ -44,16 +45,20 @@ class PyTorchaudio(PythonPackage):
     version("0.4.0", tag="v0.4.0", submodules=True)
 
     # https://github.com/pytorch/audio#dependencies
-    depends_on("python@3.7:3.10", when="@0.12:", type=("build", "link", "run"))
+    depends_on("python@3.8:3.11", when="@2:", type=("build", "link", "run"))
+    depends_on("python@3.7:3.10", when="@0.12:0", type=("build", "link", "run"))
     depends_on("python@3.7:3.9", when="@0.11", type=("build", "link", "run"))
     depends_on("python@3.6:3.9", when="@0.7.2:0.10", type=("build", "link", "run"))
     depends_on("python@3.6:3.8", when="@0.6:0.7.0", type=("build", "link", "run"))
     depends_on("python@3.5:3.8", when="@0.5", type=("build", "link", "run"))
     depends_on("python@2.7,3.5:3.8", when="@0.4", type=("build", "link", "run"))
 
+    # CMakelists.txt
     depends_on("cmake@3.18:", when="@0.10:", type="build")
     depends_on("cmake@3.5:", when="@0.8:", type="build")
     depends_on("ninja", when="@0.8:", type="build")
+
+    # setup.py
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", when="@0.12:", type=("build", "link"))
     depends_on("pkgconfig", type="build")
@@ -61,6 +66,7 @@ class PyTorchaudio(PythonPackage):
 
     # https://github.com/pytorch/audio#dependencies
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.0", when="@2.0.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.13.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.13.0", type=("build", "link", "run"))
     depends_on("py-torch@1.12.1", when="@0.12.1", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -16,6 +16,7 @@ class PyTorchdata(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main")
+    version("0.6.0", sha256="048dea12ee96c0ea1525097959fee811d7b38c2ed05f44a90f35f8961895fb5b")
     version("0.5.1", sha256="69d80bd33ce8f08e7cfeeb71cefddfc29cede25a85881e33dbae47576b96ed29")
     version("0.5.0", sha256="b4e1a7015b34e3576111d495a00a675db238bfd136629fc443078bab9383ec36")
     version("0.4.1", sha256="71c0aa3aca3b04a986a2cd4cc2e0be114984ca836dc4def2c700bf1bd1ff087e")
@@ -23,8 +24,19 @@ class PyTorchdata(PythonPackage):
     version("0.3.0", sha256="ac36188bf133cf5f1041a28ccb3ee82ba52d4b5d99617be37d64d740acd6cfd4")
 
     # https://github.com/pytorch/data#version-compatibility
-    depends_on("python@3.7:3.10", type=("build", "run"))
+    depends_on("python@3.8:3.11", when="@0.6:", type=("build", "run"))
+    depends_on("python@3.7:3.10", when="@:0.5", type=("build", "run"))
+
+    # pyproject.toml
+    depends_on("py-setuptools", type="build")
+
+    # CMakeLists.txt
+    depends_on("cmake@3.13:", when="@0.4:", type="build")
+    depends_on("ninja", when="@0.4:", type="build")
+
+    # https://github.com/pytorch/data#version-compatibility
     depends_on("py-torch@master", when="@main", type=("build", "run"))
+    depends_on("py-torch@2.0.0", when="@0.6.0", type=("build", "run"))
     depends_on("py-torch@1.13.1", when="@0.5.1", type=("build", "run"))
     depends_on("py-torch@1.13.0", when="@0.5.0", type=("build", "run"))
     depends_on("py-torch@1.12.1", when="@0.4.1", type=("build", "run"))
@@ -32,10 +44,9 @@ class PyTorchdata(PythonPackage):
     depends_on("py-torch@1.11.0", when="@0.3.0", type=("build", "run"))
 
     # requirements.txt
-    depends_on("py-setuptools", type="build")
     depends_on("py-urllib3@1.25:", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
-    depends_on("py-portalocker@2:", when="@0.4:", type=("build", "run"))
+    depends_on("py-portalocker@2:", when="@0.4:0.5", type=("build", "run"))
 
     # third_party/CMakeLists.txt
     depends_on("py-pybind11", when="@0.4:")

--- a/var/spack/repos/builtin/packages/py-torchtext/package.py
+++ b/var/spack/repos/builtin/packages/py-torchtext/package.py
@@ -16,6 +16,7 @@ class PyTorchtext(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main", submodules=True)
+    version("0.15.1", tag="v0.15.1", submodules=True)
     version("0.14.1", tag="v0.14.1", submodules=True)
     version("0.14.0", tag="v0.14.0", submodules=True)
     version("0.13.1", tag="v0.13.1", submodules=True)
@@ -31,24 +32,30 @@ class PyTorchtext(PythonPackage):
     version("0.5.0", tag="0.5.0", submodules=True)
 
     # https://github.com/pytorch/text#installation
-    depends_on("python@3.7:3.10", when="@0.13:", type=("build", "link", "run"))
+    depends_on("python@3.8:3.11", when="@2:", type=("build", "link", "run"))
+    depends_on("python@3.7:3.10", when="@0.13:1", type=("build", "link", "run"))
     depends_on("python@3.6:3.9", when="@0.8.1:0.12", type=("build", "link", "run"))
     depends_on("python@3.6:3.8", when="@0.7:0.8.0", type=("build", "link", "run"))
     depends_on("python@3.5:3.8", when="@0.6", type=("build", "link", "run"))
     depends_on("python@2.7,3.5:3.8", when="@:0.5", type=("build", "link", "run"))
 
+    # CMakelists.txt
     depends_on("cmake@3.18:", when="@0.13:", type="build")
     depends_on("ninja", when="@0.13:", type="build")
-    depends_on("py-pybind11", when="@0.8:", type=("build", "link"))
+
+    # setup.py
     depends_on("py-setuptools", type="build")
     depends_on("py-tqdm", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-torchdata@0.6:", when="@0.15:", type=("build", "run"))
+    depends_on("py-pybind11", when="@0.8:", type=("build", "link"))
     depends_on("py-six", when="@:0.6", type=("build", "run"))
     depends_on("py-sentencepiece", when="@:0.7", type=("build", "run"))
 
     # https://github.com/pytorch/text#installation
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.0", when="@0.15.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.14.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.14.0", type=("build", "link", "run"))
     depends_on("py-torch@1.12.1", when="@0.13.1", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -18,6 +18,7 @@ class PyTorchvision(PythonPackage):
     maintainers("adamjstewart")
 
     version("main", branch="main")
+    version("0.15.1", sha256="689d23d4ebb0c7e54e8651c89b17155b64341c14ae4444a04ca7dc6f2b6a0a43")
     version("0.14.1", sha256="ced67e1cf1f97e168cdf271851a4d0b6d382ab7936e7bcbb39aaa87239c324b6")
     version("0.14.0", sha256="be1621c85c56eb40537cb74e6ec5d8e58ed8b69f8374a58bcb6ec413cb540c8b")
     version("0.13.1", sha256="c32fab734e62c7744dadeb82f7510ff58cc3bca1189d17b16aa99b08afc42249")
@@ -59,7 +60,8 @@ class PyTorchvision(PythonPackage):
     )
 
     # https://github.com/pytorch/vision#installation
-    depends_on("python@3.7:3.10", when="@0.12:", type=("build", "link", "run"))
+    depends_on("python@3.8:3.11", when="@0.15:", type=("build", "link", "run"))
+    depends_on("python@3.7:3.10", when="@0.12:0.14", type=("build", "link", "run"))
     depends_on("python@3.6:3.9", when="@0.8.2:0.11", type=("build", "link", "run"))
     depends_on("python@3.6:3.8", when="@0.7:0.8.1", type=("build", "link", "run"))
     depends_on("python@3.5:3.8", when="@0.6", type=("build", "link", "run"))
@@ -75,6 +77,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on("py-torch@master", when="@main", type=("build", "link", "run"))
+    depends_on("py-torch@2.0.0", when="@0.15.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.1", when="@0.14.1", type=("build", "link", "run"))
     depends_on("py-torch@1.13.0", when="@0.14.0", type=("build", "link", "run"))
     depends_on("py-torch@1.12.1", when="@0.13.1", type=("build", "link", "run"))
@@ -82,7 +85,8 @@ class PyTorchvision(PythonPackage):
     depends_on("py-torch@1.11.0", when="@0.12.0", type=("build", "link", "run"))
     depends_on("py-torch@1.10.2", when="@0.11.3", type=("build", "link", "run"))
     depends_on("py-torch@1.10.1", when="@0.11.2", type=("build", "link", "run"))
-    depends_on("py-torch@1.10.0", when="@0.11.0:0.11.1", type=("build", "link", "run"))
+    depends_on("py-torch@1.10.0", when="@0.11.1", type=("build", "link", "run"))
+    depends_on("py-torch@1.10.0", when="@0.11.0", type=("build", "link", "run"))
     depends_on("py-torch@1.9.1", when="@0.10.1", type=("build", "link", "run"))
     depends_on("py-torch@1.9.0", when="@0.10.0", type=("build", "link", "run"))
     depends_on("py-torch@1.8.2", when="@0.9.2", type=("build", "link", "run"))
@@ -101,20 +105,20 @@ class PyTorchvision(PythonPackage):
     depends_on("py-torch@1.1.0", when="@0.3.0", type=("build", "link", "run"))
     depends_on("py-torch@:1.0.1", when="@0.2.2", type=("build", "link", "run"))
 
-    # https://github.com/pytorch/vision/issues/1712
-    depends_on("pil@4.1.1:6", when="@:0.4 backend=pil", type=("build", "run"))
-    depends_on("pil@4.1.1:9", when="@0.5: backend=pil", type=("build", "run"))
+    # https://github.com/pytorch/vision/pull/5898
+    depends_on("pil@5.3:8.2,8.4:", when="@0.13: backend=pil", type=("build", "run"))
     # https://github.com/pytorch/vision/issues/4146
     # https://github.com/pytorch/vision/issues/4934
     depends_on("pil@5.3:8.2,8.4:9", when="@0.10:0.12 backend=pil", type=("build", "run"))
-    # https://github.com/pytorch/vision/pull/5898
-    depends_on("pil@5.3:8.2,8.4:", when="@0.13: backend=pil", type=("build", "run"))
+    depends_on("pil@4.1.1:9", when="@0.5: backend=pil", type=("build", "run"))
+    # https://github.com/pytorch/vision/issues/1712
+    depends_on("pil@4.1.1:6", when="@:0.4 backend=pil", type=("build", "run"))
     depends_on("py-accimage", when="backend=accimage", type=("build", "run"))
     depends_on("libpng@1.6.0:", when="backend=png")
     depends_on("jpeg")  # seems to be required for all backends
 
-    depends_on("ffmpeg@3.1:4.4", when="@0.4.2:0.12.0")
-    depends_on("ffmpeg@3.1:", when="@0.13.0:")
+    depends_on("ffmpeg@3.1:", when="@0.13:")
+    depends_on("ffmpeg@3.1:4.4", when="@0.4.2:0.12")
 
     # Many of the datasets require additional dependencies to use.
     # These can be installed after the fact.


### PR DESCRIPTION
All PyTorch libraries have the same release schedule, and are tightly coupled, so I updated all of them in the same PR.

* https://github.com/pytorch/pytorch/releases/tag/v2.0.0
* https://github.com/pytorch/vision/releases/tag/v0.15.1
* https://github.com/pytorch/text/releases/tag/v0.15.1
* https://github.com/pytorch/audio/releases/tag/v2.0.1
* https://github.com/pytorch/data/releases/tag/v0.6.0
* https://github.com/Lightning-AI/lightning/releases/tag/2.0.0

Note that pytorch-lightning was renamed to lightning in v1.8. The old package name is still updated for backwards compatibility, but the plan is to deprecate it someday: https://github.com/Lightning-AI/lightning/discussions/17095. We can't simply deprecate and remove the old package because it has a different package name, so imports won't work.