### PR TITLE
minify spec.json in buildcache

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1343,7 +1343,7 @@ def _build_tarball_in_stage_dir(
     spec_dict["buildinfo"] = buildinfo
 
     with open(specfile_path, "w") as outfile:
-        outfile.write(sjson.dump(spec_dict))
+        outfile.write(json.dumps(spec_dict))
 
     # sign the tarball and spec file with gpg
     if not unsigned:


### PR DESCRIPTION
The `s` should go at the end, not at the front.

This saves about 40-50% of filesize, thanks to whitespace.