### PR TITLE
netdata: add v1.38.1

### DIFF
--- a/var/spack/repos/builtin/packages/netdata/package.py
+++ b/var/spack/repos/builtin/packages/netdata/package.py
@@ -12,6 +12,7 @@ class Netdata(AutotoolsPackage):
     homepage = "https://www.netdata.cloud/"
     url = "https://github.com/netdata/netdata/releases/download/v1.30.1/netdata-v1.30.1.tar.gz"
 
+    version("1.38.1", sha256="e32a5427f0c00550210dbbf0046c2621313955256edf836db686e2bc270b8d10")
     version("1.31.0", sha256="ca68f725224e8bbec041b493891376fbf41aedb47c4ac06161c2eda990089c9f")
     version("1.30.1", sha256="3df188ac04f17094cb929e2990841ba77f68aa6af484e0509b99db298fa206c9")
     version("1.22.1", sha256="f169c8615a6823448c2f1923c87c286d798132ea29d26f366e96d26e0aec3697")


### PR DESCRIPTION
Add netdata v1.38.1.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.