### PR TITLE
nano: add v7.2

### DIFF
--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -14,8 +14,9 @@ class Nano(AutotoolsPackage):
     list_url = "https://www.nano-editor.org/dist/"
     list_depth = 1
 
-    # 6.x
+    # 7.x
     version("7.2", sha256="86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526")
+    # 6.x
     version("6.3", sha256="eb532da4985672730b500f685dbaab885a466d08fbbf7415832b95805e6f8687")
     version("6.2", sha256="2bca1804bead6aaf4ad791f756e4749bb55ed860eec105a97fba864bc6a77cb3")
     version("6.1", sha256="3d57ec893fbfded12665b7f0d563d74431fc43abeaccacedea23b66af704db40")

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -15,6 +15,7 @@ class Nano(AutotoolsPackage):
     list_depth = 1
 
     # 6.x
+    version("7.2", sha256="86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526")
     version("6.3", sha256="eb532da4985672730b500f685dbaab885a466d08fbbf7415832b95805e6f8687")
     version("6.2", sha256="2bca1804bead6aaf4ad791f756e4749bb55ed860eec105a97fba864bc6a77cb3")
     version("6.1", sha256="3d57ec893fbfded12665b7f0d563d74431fc43abeaccacedea23b66af704db40")


### PR DESCRIPTION
Add nano v7.2.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.