### PR TITLE
mpdecimal: add v2.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/mpdecimal/package.py
+++ b/var/spack/repos/builtin/packages/mpdecimal/package.py
@@ -14,6 +14,7 @@ class Mpdecimal(AutotoolsPackage):
     url = "https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.4.2.tar.gz"
     list_url = "https://www.bytereef.org/mpdecimal/download.html"
 
+    version("2.5.1", sha256="9f9cd4c041f99b5c49ffb7b59d9f12d95b683d88585608aa56a6307667b2b21f")
     version("2.4.2", sha256="83c628b90f009470981cf084c5418329c88b19835d8af3691b930afccb7d79c7")
 
     depends_on("gmake", type="build")


### PR DESCRIPTION
Add mpdecimal v2.5.1.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.