### PR TITLE
mpc: add v1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -15,6 +15,7 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
     gnu_mirror_path = "mpc/mpc-1.1.0.tar.gz"
     list_url = "http://www.multiprecision.org/mpc/download.html"
 
+    version("1.3.1", sha256="ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8")
     version("1.2.1", sha256="17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459")
     version("1.1.0", sha256="6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e")
     version("1.0.3", sha256="617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3")


### PR DESCRIPTION
Add mpc v1.3.1.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.