### PR TITLE
mosh: add v1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/mosh/package.py
+++ b/var/spack/repos/builtin/packages/mosh/package.py
@@ -16,6 +16,7 @@ class Mosh(AutotoolsPackage):
     homepage = "https://mosh.org/"
     url = "https://mosh.org/mosh-1.2.6.tar.gz"
 
+    version("1.4.0", sha256="872e4b134e5df29c8933dff12350785054d2fd2839b5ae6b5587b14db1465ddd")
     version("1.3.2", sha256="da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216")
     version("1.3.0", sha256="320e12f461e55d71566597976bd9440ba6c5265fa68fbf614c6f1c8401f93376")
     version("1.2.6", sha256="7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85")


### PR DESCRIPTION
Add most v1.4.0.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.