### PR TITLE
mkfontscale: add v1.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/mkfontscale/package.py
+++ b/var/spack/repos/builtin/packages/mkfontscale/package.py
@@ -13,6 +13,7 @@ class Mkfontscale(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/mkfontscale"
     xorg_mirror_path = "app/mkfontscale-1.1.2.tar.gz"
 
+    version("1.2.2", sha256="4a5af55e670713024639a7f7d10826d905d86faf574cd77e0f5aef2d00e70168")
     version("1.1.2", sha256="8bba59e60fbc4cb082092cf6b67e810b47b4fe64fbc77dbea1d7e7d55312b2e4")
 
     depends_on("libfontenc")


### PR DESCRIPTION
Add mkfontscale v1.2.2.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.