### PR TITLE
erlang: add v25.3

### DIFF
--- a/var/spack/repos/builtin/packages/erlang/package.py
+++ b/var/spack/repos/builtin/packages/erlang/package.py
@@ -16,6 +16,7 @@ class Erlang(AutotoolsPackage):
     homepage = "https://erlang.org/"
     url = "https://erlang.org/download/otp_src_23.3.tar.gz"
 
+    version("25.3", sha256="aeaa546e0c38e338010d16348d8c67f7fc8c02df728a88d8499838d8c9131e1c")
     version("25.2", sha256="0df1243afde953647df95785f8e75541fd0ea8ac70c0f639c977513be1761f63")
     version("23.3", sha256="3c888d8f46124e134b75a9ba5d845f079020b7198ed2de64411e183d07e9002a")
     version("23.2", sha256="40e03428826c92e409e4f1510f9c0539eafb3ac49d6c2f607f4fa274d11a8928")


### PR DESCRIPTION
Add erlang v25.3.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.