### PR TITLE
Mitigation for GitVersion bug when no `=reference` is given

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1880,8 +1880,9 @@ class SpackSolverSetup(object):
         """Define what version_satisfies(...) means in ASP logic."""
         for pkg_name, versions in sorted(self.version_constraints):
             # version must be *one* of the ones the spec allows.
+            # Also, "possible versions" contain only concrete versions, so satisfies is appropriate
             allowed_versions = [
-                v for v in sorted(self.possible_versions[pkg_name]) if v.intersects(versions)
+                v for v in sorted(self.possible_versions[pkg_name]) if v.satisfies(versions)
             ]
 
             # This is needed to account for a variable number of

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -788,6 +788,7 @@ def test_version_intersects_satisfies_semantic(lhs_str, rhs_str, expected):
         ),
     ],
 )
+@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_git_versions_without_explicit_reference(
     spec_str,
     tested_intersects,

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -771,3 +771,39 @@ def test_version_intersects_satisfies_semantic(lhs_str, rhs_str, expected):
     assert lhs.intersects(rhs) is rhs.intersects(lhs)
     assert lhs.satisfies(rhs) is lhs_sat_rhs
     assert rhs.satisfies(lhs) is rhs_sat_lhs
+
+
+@pytest.mark.parametrize(
+    "spec_str,tested_intersects,tested_satisfies",
+    [
+        (
+            "git-test-commit@git.1.x",
+            [("@:2", True), ("@:1", True), ("@:0", False), ("@1.3:", False)],
+            [("@:2", True), ("@:1", True), ("@:0", False), ("@1.3:", False)],
+        ),
+        (
+            "git-test-commit@git.v2.0",
+            [("@:2", True), ("@:1", False), ("@:0", False), ("@1.3:", True)],
+            [("@:2", True), ("@:1", False), ("@:0", False), ("@1.3:", True)],
+        ),
+    ],
+)
+def test_git_versions_without_explicit_reference(
+    spec_str,
+    tested_intersects,
+    tested_satisfies,
+    mock_git_version_info,
+    mock_packages,
+    monkeypatch,
+):
+    repo_path, filename, commits = mock_git_version_info
+    monkeypatch.setattr(
+        spack.package_base.PackageBase, "git", "file://%s" % repo_path, raising=False
+    )
+    spec = spack.spec.Spec(spec_str)
+
+    for test_str, expected in tested_intersects:
+        assert spec.intersects(test_str) is expected, test_str
+
+    for test_str, expected in tested_intersects:
+        assert spec.intersects(test_str) is expected, test_str


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/36134

This commit works around the issue in https://github.com/spack/spack/issues/36134, by using `GitVersion.satisfies` instead of `GitVersion.intersects`.

There are still underlying issues when trying to infer the "reference version" when no explicit one is given, but:

1. They are not reproducible with our synthetic repo
2. They occur only when the `git.<xxx>` form of Git version is used

Here we just work around the user facing issue and ensure the tests are correct with our synthetic repository.
