### PR TITLE
CI: Make Gitlab logs less verbose

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -29,8 +29,8 @@ from __future__ import print_function
 
 import os
 import os.path
-import sys
 import signal
+import sys
 
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 

--- a/bin/spack
+++ b/bin/spack
@@ -30,6 +30,9 @@ from __future__ import print_function
 import os
 import os.path
 import sys
+import signal
+
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 min_python3 = (3, 6)
 

--- a/bin/spack
+++ b/bin/spack
@@ -32,7 +32,8 @@ import os.path
 import signal
 import sys
 
-signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+if os.name == "posix":
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 min_python3 = (3, 6)
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -729,7 +729,7 @@ If this project does not have public pipelines, you will need to first:
             repro_job_url
         )
 
-        print(reproduce_msg)
+        tty.error(reproduce_msg)
 
     # Tie job success/failure to the success/failure of building the spec
     return install_exit_code

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -25,7 +25,7 @@ ci:
       - - cat /proc/loadavg || true
       variables:
         CI_JOB_SIZE: "default"
-        SPACK_CI_LOGGER_BYTES: 2000000
+        SPACK_CI_LOGGER_BYTES: "2000000"
         # SPACK_VERBOSE_SCRIPT: "1"
 
   - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -20,11 +20,12 @@ ci:
         # UO runners mount intermediate ci public key (verification), AWS runners mount public/private (signing/verification)
         - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
         - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-        - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2) | head -c ${SPACK_CI_LOGGER_BYTES}
       after_script:
       - - cat /proc/loadavg || true
       variables:
         CI_JOB_SIZE: "default"
+        SPACK_CI_LOGGER_BYTES: 2000000
         # SPACK_VERBOSE_SCRIPT: "1"
 
   - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -25,7 +25,7 @@ ci:
       - - cat /proc/loadavg || true
       variables:
         CI_JOB_SIZE: "default"
-        SPACK_CI_LOGGER_BYTES: "2000000"
+        SPACK_CI_LOGGER_BYTES: "3500000"
         # SPACK_VERBOSE_SCRIPT: "1"
 
   - signing-job:

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -114,6 +114,13 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder, SetupEnviron
                         "Makefile",
                     )
 
+    def build(self, pkg, spec, prefix):
+        n = 2 * 1024 * 1024  # 2mb
+        line_len = 128
+        for i in range(n // line_len):
+            print("x" * 127)
+        raise InstallError("Build failed")
+
 
 class GenericBuilder(spack.build_systems.generic.GenericBuilder, SetupEnvironment):
     def install(self, pkg, spec, prefix):

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -114,13 +114,6 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder, SetupEnviron
                         "Makefile",
                     )
 
-    def build(self, pkg, spec, prefix):
-        n = 2 * 1024 * 1024  # 2mb
-        line_len = 128
-        for i in range(n // line_len):
-            print("x" * 127)
-        raise InstallError("Build failed")
-
 
 class GenericBuilder(spack.build_systems.generic.GenericBuilder, SetupEnvironment):
     def install(self, pkg, spec, prefix):


### PR DESCRIPTION
Disable "--verbose" output in CI for improved taxonomy and usability of logs produced in Gitlab.