### PR TITLE
Treat externals as concrete specs with missing information

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -38,8 +38,14 @@ def spec_for_current_python() -> str:
       https://www.python.org/dev/peps/pep-0513/
       https://stackoverflow.com/a/35801395/771663
     """
+    try:
+        __import__("ctypes")
+    except ImportError:
+        msg = "the current interpreter must support ctypes for bootstrapping Spack"
+        raise RuntimeError(msg)
+
     version_str = ".".join(str(x) for x in sys.version_info[:2])
-    return f"python@{version_str}"
+    return f"python@{version_str} +ctypes"
 
 
 def root_path() -> str:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -485,13 +485,8 @@ def _add_externals_if_missing() -> None:
     ]
     if IS_WINDOWS:
         search_list.append("winbison")
-    externals = spack.detection.by_path(search_list)
-    # System git is typically deprecated, so mark as non-buildable to force it as external
-    non_buildable_externals = {k: externals.pop(k) for k in ("git",) if k in externals}
-    spack.detection.update_configuration(externals, scope="bootstrap", buildable=True)
-    spack.detection.update_configuration(
-        non_buildable_externals, scope="bootstrap", buildable=False
-    )
+    detected_packages = spack.detection.by_path(search_list)
+    spack.detection.update_database(detected_packages)
 
 
 def clingo_root_spec() -> str:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -44,7 +44,7 @@ class BootstrapEnvironment(spack.environment.Environment):
     def environment_root(cls) -> pathlib.Path:
         """Environment root directory"""
         bootstrap_root_path = root_path()
-        python_part = spec_for_current_python().replace("@", "")
+        python_part = f"python{sys.version_info.major}.{sys.version_info.minor}"
         arch_part = archspec.cpu.host().family
         interpreter_part = hashlib.md5(sys.exec_prefix.encode()).hexdigest()[:5]
         environment_dir = f"{python_part}-{arch_part}-{interpreter_part}"

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -30,7 +30,9 @@ def setup_parser(subparser):
 
     scopes = spack.config.scopes()
 
-    find_parser = sp.add_parser("find", help="add external packages to packages.yaml")
+    find_parser = sp.add_parser(
+        "find", help="search for external packages and add them to the local DB"
+    )
     find_parser.add_argument(
         "--not-buildable",
         action="store_true",
@@ -139,13 +141,9 @@ def external_find(args):
         candidate_packages, path_hints=args.path, max_workers=args.jobs
     )
 
-    new_entries = spack.detection.update_configuration(
-        detected_packages, scope=args.scope, buildable=not args.not_buildable
-    )
+    new_entries = spack.detection.update_database(detected_packages)
     if new_entries:
-        path = spack.config.CONFIG.get_config_filename(args.scope, "packages")
-        msg = "The following specs have been detected on this system and added to {0}"
-        tty.msg(msg.format(path))
+        tty.msg("The following specs have been detected on this system and added to the local DB")
         spack.cmd.display_specs(new_entries)
     else:
         tty.msg("No new external packages detected")

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -233,7 +233,7 @@ def external_list(args):
     list(spack.repo.PATH.all_package_classes())
     # Print all the detectable packages
     tty.msg("Detectable packages per repository")
-    for namespace, pkgs in sorted(spack.package_base.detectable_packages.items()):
+    for namespace, pkgs in sorted(spack.package_base.DETECTABLE_PACKAGES.items()):
         print("Repository:", namespace)
         colify.colify(pkgs, indent=4, output=sys.stdout)
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -33,12 +33,6 @@ def setup_parser(subparser):
     find_parser = sp.add_parser(
         "find", help="search for external packages and add them to the local DB"
     )
-    find_parser.add_argument(
-        "--not-buildable",
-        action="store_true",
-        default=False,
-        help="packages with detected externals won't be built with Spack",
-    )
     find_parser.add_argument("--exclude", action="append", help="packages to exclude from search")
     find_parser.add_argument(
         "-p",

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -2,13 +2,21 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .common import DetectedPackage, executable_prefix, update_database
+from .common import (
+    DetectedPackage,
+    ensure_architecture_and_compiler,
+    executable_prefix,
+    update_database,
+)
+from .packages_yaml import import_externals
 from .path import by_path, executables_in_path
 
 __all__ = [
     "DetectedPackage",
     "by_path",
     "executables_in_path",
+    "ensure_architecture_and_compiler",
     "executable_prefix",
     "update_database",
+    "import_externals",
 ]

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .common import DetectedPackage, executable_prefix, update_configuration
+from .common import DetectedPackage, executable_prefix, update_database
 from .path import by_path, executables_in_path
 
 __all__ = [
@@ -10,5 +10,5 @@ __all__ = [
     "by_path",
     "executables_in_path",
     "executable_prefix",
-    "update_configuration",
+    "update_database",
 ]

--- a/lib/spack/spack/detection/packages_yaml.py
+++ b/lib/spack/spack/detection/packages_yaml.py
@@ -1,0 +1,108 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Import external packages from user configuration"""
+import collections
+import warnings
+
+import spack.concretize
+import spack.config
+import spack.error
+
+from .common import DetectedPackage, ensure_architecture_and_compiler
+
+
+def import_externals(scope=None):
+    """Return all the specs mentioned as externals in packages.yaml"""
+    packages_yaml = spack.config.CONFIG.get("packages", scope=scope)
+    result = collections.defaultdict(list)
+    for pkg_name, package_configuration in packages_yaml.items():
+        for item in package_configuration.get("externals", []):
+            # All these steps are needed to ensure "matching" external specs
+            # that are either detected or imported from config are hashed in
+            # the same way.
+
+            # Here it is essential that we pass a string, otherwise external_path would not be set
+            s = spack.spec.Spec(
+                str(spack.spec.parse_with_version_concrete(item["spec"])),
+                external_path=item.get("prefix"),
+                external_modules=item.get("modules"),
+            )
+            s = spack.spec.Spec.from_detection(
+                s, extra_attributes=item.get("extra_attributes", {})
+            )
+            ensure_architecture_and_compiler(s)
+            result[pkg_name].append(DetectedPackage(spec=s, prefix=item.get("prefix")))
+
+    # Try to reconstruct extensions for imported specs
+    for name, externals in result.items():
+        for candidate in externals:
+            s = candidate.spec
+            pkg = s.package_class(s)
+            if pkg.extendee_spec:
+                pkg.update_external_dependencies(result.get(pkg.extendee_spec.name, []))
+
+    return result
+
+
+def _pkg_config_dict(external_pkg_entries):
+    """Generate a package specific config dict according to the packages.yaml schema.
+
+    This does not generate the entire packages.yaml. For example, given some
+    external entries for the CMake package, this could return::
+
+        {
+            'externals': [{
+                'spec': 'cmake@3.17.1',
+                'prefix': '/opt/cmake-3.17.1/'
+            }, {
+                'spec': 'cmake@3.16.5',
+                'prefix': '/opt/cmake-3.16.5/'
+            }]
+       }
+    """
+    pkg_dict = spack.util.spack_yaml.syaml_dict()
+    pkg_dict["externals"] = []
+    for e in external_pkg_entries:
+        if not _spec_is_valid(e.spec):
+            continue
+
+        external_items = [("spec", str(e.spec)), ("prefix", e.prefix)]
+        if e.spec.external_modules:
+            external_items.append(("modules", e.spec.external_modules))
+
+        if e.spec.extra_attributes:
+            external_items.append(
+                (
+                    "extra_attributes",
+                    spack.util.spack_yaml.syaml_dict(e.spec.extra_attributes.items()),
+                )
+            )
+
+        # external_items.extend(e.spec.extra_attributes.items())
+        pkg_dict["externals"].append(spack.util.spack_yaml.syaml_dict(external_items))
+
+    return pkg_dict
+
+
+def _spec_is_valid(spec):
+    try:
+        str(spec)
+    except spack.error.SpackError:
+        # It is assumed here that we can at least extract the package name from
+        # the spec, so we can look up the implementation of determine_spec_details
+        msg = "Constructed spec for {0} does not have a string representation"
+        warnings.warn(msg.format(spec.name))
+        return False
+
+    try:
+        spack.spec.Spec(str(spec))
+    except spack.error.SpackError:
+        warnings.warn(
+            "Constructed spec has a string representation but the string"
+            " representation does not evaluate to a valid spec: {0}".format(str(spec))
+        )
+        return False
+
+    return True

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1598,58 +1598,23 @@ class SpackSolverSetup:
                 self.gen.newline()
                 requirement_weight += 1
 
-    def external_packages(self):
-        """Facts on external packages, as read from packages.yaml"""
-        # Read packages.yaml and normalize it, so that it
-        # will not contain entries referring to virtual
-        # packages.
+    def unbuildable_packages(self, possible_packages):
+        """Emit facts to prevent building certain packages from sources."""
+        # Read packages.yaml and normalize it, so that it will not contain entries
+        # referring to virtual packages.
         packages_yaml = spack.config.get("packages")
         packages_yaml = _normalize_packages_yaml(packages_yaml)
-
-        self.gen.h1("External packages")
+        self.gen.h1("Packages that cannot be built from sources (packages.yaml)")
         for pkg_name, data in packages_yaml.items():
             if pkg_name == "all":
                 continue
 
-            # This package does not appear in any repository
-            if pkg_name not in spack.repo.PATH:
+            if pkg_name not in possible_packages:
                 continue
 
-            self.gen.h2("External package: {0}".format(pkg_name))
-            # Check if the external package is buildable. If it is
-            # not then "external(<pkg>)" is a fact, unless we can
-            # reuse an already installed spec.
             external_buildable = data.get("buildable", True)
             if not external_buildable:
                 self.gen.fact(fn.buildable_false(pkg_name))
-
-            # Read a list of all the specs for this package
-            externals = data.get("externals", [])
-            external_specs = [spack.spec.parse_with_version_concrete(x["spec"]) for x in externals]
-
-            # Order the external versions to prefer more recent versions
-            # even if specs in packages.yaml are not ordered that way
-            external_versions = [
-                (x.version, external_id) for external_id, x in enumerate(external_specs)
-            ]
-            external_versions = [
-                (v, idx, external_id)
-                for idx, (v, external_id) in enumerate(sorted(external_versions, reverse=True))
-            ]
-            for version, idx, external_id in external_versions:
-                self.declared_versions[pkg_name].append(
-                    DeclaredVersion(version=version, idx=idx, origin=Provenance.EXTERNAL)
-                )
-
-            # Declare external conditions with a local index into packages.yaml
-            for local_idx, spec in enumerate(external_specs):
-                msg = "%s available as external when satisfying %s" % (spec.name, spec)
-                condition_id = self.condition(spec, msg=msg)
-                self.gen.fact(fn.pkg_fact(pkg_name, fn.possible_external(condition_id, local_idx)))
-                self.possible_versions[spec.name].add(spec.version)
-                self.gen.newline()
-
-            self.trigger_rules()
 
     def preferred_variants(self, pkg_name):
         """Facts on concretization preferences, as read from packages.yaml"""
@@ -2411,7 +2376,7 @@ class SpackSolverSetup:
         self.virtual_providers()
         self.provider_defaults()
         self.provider_requirements()
-        self.external_packages()
+        self.unbuildable_packages(self.pkgs)
 
         # TODO: make a config option for this undocumented feature
         require_checksum = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
@@ -2631,28 +2596,6 @@ class SpecBuilder:
 
     def no_flags(self, node, flag_type):
         self._specs[node].compiler_flags[flag_type] = []
-
-    def external_spec_selected(self, node, idx):
-        """This means that the external spec and index idx
-        has been selected for this package.
-        """
-
-        packages_yaml = spack.config.get("packages")
-        packages_yaml = _normalize_packages_yaml(packages_yaml)
-        spec_info = packages_yaml[node.pkg]["externals"][int(idx)]
-        self._specs[node].external_path = spec_info.get("prefix", None)
-        self._specs[node].external_modules = spack.spec.Spec._format_module_list(
-            spec_info.get("modules", None)
-        )
-        self._specs[node].extra_attributes = spec_info.get("extra_attributes", {})
-
-        # If this is an extension, update the dependencies to include the extendee
-        package = self._specs[node].package_class(self._specs[node])
-        extendee_spec = package.extendee_spec
-
-        if extendee_spec:
-            extendee_node = SpecBuilder.make_node(pkg=extendee_spec.name)
-            package.update_external_dependencies(self._specs.get(extendee_node, None))
 
     def depends_on(self, parent_node, dependency_node, type):
         dependency_spec = self._specs[dependency_node]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2845,7 +2845,10 @@ class Solver:
         return reusable
 
     def _reusable_specs(self, specs):
-        reusable_specs = []
+        # We always reuse unconditionally external specs that are is user config
+        externals = spack.detection.import_externals()
+        reusable_specs, _ = spack.detection.update_database(externals)
+
         if self.reuse:
             # Specs from the local Database
             with spack.store.STORE.db.read_transaction():
@@ -2870,7 +2873,9 @@ class Solver:
         # If we only want to reuse dependencies, remove the root specs
         if self.reuse == "dependencies":
             reusable_specs = [
-                spec for spec in reusable_specs if not any(root in spec for root in specs)
+                spec
+                for spec in reusable_specs
+                if spec.external or not any(root in spec for root in specs)
             ]
 
         return reusable_specs

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1066,13 +1066,18 @@ compiler_match(PackageNode, DependencyNode)
      node_compiler(PackageNode, CompilerID),
      node_compiler(DependencyNode, CompilerID).
 
-compiler_mismatch(PackageNode, DependencyNode)
+mismatch_candidates(PackageNode, DependencyNode)
   :- depends_on(PackageNode, DependencyNode),
+     unification_set(X, PackageNode),
+     unification_set(X, DependencyNode).
+
+compiler_mismatch(PackageNode, DependencyNode)
+  :- mismatch_candidates(PackageNode, DependencyNode),
      not attr("node_compiler_set", DependencyNode, _),
      not compiler_match(PackageNode, DependencyNode).
 
 compiler_mismatch_required(PackageNode, DependencyNode)
-  :- depends_on(PackageNode, DependencyNode),
+  :- mismatch_candidates(PackageNode, DependencyNode),
      attr("node_compiler_set", DependencyNode, _),
      not compiler_match(PackageNode, DependencyNode).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -158,7 +158,7 @@ error(100, multiple_values_error, Attribute, Package)
 %-----------------------------------------------------------------------------
 
 % Versions are declared with a weight and an origin, which indicates where the
-% version was declared (e.g. "package_py" or "external").
+% version was declared (e.g. "package_py" or "installed").
 pkg_fact(Package, version_declared(Version, Weight)) :- pkg_fact(Package, version_declared(Version, Weight, _)).
 
 % We can't emit the same version **with the same weight** from two different sources
@@ -199,14 +199,6 @@ attr("deprecated", node(ID, Package), Version) :-
 possible_version_weight(node(ID, Package), Weight)
  :- attr("version", node(ID, Package), Version),
     pkg_fact(Package, version_declared(Version, Weight)).
-
-% we can't use the weight for an external version if we don't use the
-% corresponding external spec.
-:- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "external")),
-   not external(node(ID, Package)),
-   internal_error("External weight used for built package").
 
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
@@ -424,10 +416,8 @@ dependency_holds(node(NodeID, Package), Dependency, Type) :-
   pkg_fact(Package, dependency_condition(ID, Dependency)),
   dependency_type(ID, Type),
   build(node(NodeID, Package)),
-  not external(node(NodeID, Package)),
   condition_holds(ID, node(NodeID, Package)).
 
-% We cut off dependencies of externals (as we don't really know them).
 % Don't impose constraints on dependencies that don't exist.
 do_not_impose(EffectID, node(NodeID, Package)) :-
   not dependency_holds(node(NodeID, Package), Dependency, _),
@@ -462,19 +452,17 @@ error(1, Msg)
      condition_holds(ConstraintID, node(ID2, Package)),
      unification_set(X, node(ID2, Package)),
      unification_set(X, node(ID1, TriggerPackage)),
-     not external(node(ID, Package)),  % ignore conflicts for externals
      not attr("hash", node(ID, Package), _).  % ignore conflicts for installed packages
 
 %-----------------------------------------------------------------------------
 % Virtual dependencies
 %-----------------------------------------------------------------------------
 
-% if a package depends on a virtual, it's not external and we have a
+% if a package depends on a virtual and we have a
 % provider for that virtual then it depends on the provider
 node_depends_on_virtual(PackageNode, Virtual, Type)
   :- dependency_holds(PackageNode, Virtual, Type),
-     virtual(Virtual),
-     not external(PackageNode).
+     virtual(Virtual).
 
 node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
@@ -484,8 +472,7 @@ node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(Package
 attr("virtual_on_edge", PackageNode, ProviderNode, Virtual)
   :- dependency_holds(PackageNode, Virtual, Type),
      attr("depends_on", PackageNode, ProviderNode, Type),
-     provider(ProviderNode, node(_, Virtual)),
-     not external(PackageNode).
+     provider(ProviderNode, node(_, Virtual)).
 
 % dependencies on virtuals also imply that the virtual is a virtual node
 1 { attr("virtual_node", node(0..X-1, Virtual)) : max_dupes(Virtual, X) }
@@ -565,11 +552,6 @@ do_not_impose(EffectID, node(X, Package))
     possible_provider_weight(DependencyNode, VirtualNode, Weight, _) } 1
  :- provider(DependencyNode, VirtualNode), internal_error("Package provider weights must be unique").
 
-% A provider that is an external can use a weight of 0
-possible_provider_weight(DependencyNode, VirtualNode, 0, "external")
-  :- provider(DependencyNode, VirtualNode),
-     external(DependencyNode).
-
 % A provider mentioned in packages.yaml can use a weight
 % according to its priority in the list of providers
 possible_provider_weight(node(DependencyID, Dependency), node(VirtualID, Virtual), Weight, "packages_yaml")
@@ -589,64 +571,15 @@ possible_provider_weight(node(DependencyID, Dependency), VirtualNode, 100, "fall
 % do not warn if generated program contains none of these.
 #defined virtual/1.
 #defined virtual_condition_holds/2.
-#defined external/1.
 #defined buildable_false/1.
 #defined default_provider_preference/3.
 
-%-----------------------------------------------------------------------------
-% External semantics
-%-----------------------------------------------------------------------------
-
-% if a package is external its version must be one of the external versions
-{ external_version(node(ID, Package), Version, Weight):
-    pkg_fact(Package, version_declared(Version, Weight, "external")) }
-    :- external(node(ID, Package)).
-
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
-  :- external(node(ID, Package)),
-     not external_version(node(ID, Package), _, _).
-
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
-  :- external(node(ID, Package)),
-     2 { external_version(node(ID, Package), Version, Weight) }.
-
-version_weight(PackageNode, Weight) :- external_version(PackageNode, Version, Weight).
-attr("version", PackageNode, Version) :- external_version(PackageNode, Version, Weight).
-
-% if a package is not buildable, only externals or hashed specs are allowed
-external(node(ID, Package))
+% If a package is not buildable, only hashed specs are allowed
+error(100, "Cannot build '{0}' from sources, since it is marked 'buildable:false' in packages.yaml", Package)
   :- buildable_false(Package),
      attr("node", node(ID, Package)),
      not attr("hash", node(ID, Package), _).
 
-% a package is a real_node if it is not external
-real_node(PackageNode) :- attr("node", PackageNode), not external(PackageNode).
-
-% a package is external if we are using an external spec for it
-external(PackageNode) :- attr("external_spec_selected", PackageNode, _).
-
-% we can't use the weight for an external version if we don't use the
-% corresponding external spec.
-:- attr("version",  node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
-   pkg_fact(Package, version_declared(Version, Weight, "external")),
-   not external(node(ID, Package)),
-   internal_error("External weight used for internal spec").
-
-% determine if an external spec has been selected
-attr("external_spec_selected", node(ID, Package), LocalIndex) :-
-    external_conditions_hold(node(ID, Package), LocalIndex),
-    attr("node", node(ID, Package)),
-    not attr("hash", node(ID, Package), _).
-
-external_conditions_hold(node(PackageID, Package), LocalIndex) :-
-    pkg_fact(Package, possible_external(ID, LocalIndex)), condition_holds(ID, node(PackageID, Package)).
-
-% it cannot happen that a spec is external, but none of the external specs
-% conditions hold.
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
- :- external(node(ID, Package)),
-    not external_conditions_hold(node(ID, Package), _).
 
 %-----------------------------------------------------------------------------
 % Config required semantics
@@ -835,8 +768,8 @@ attr("variant_value", PackageNode, Variant, Value)
     attr("variant_set", PackageNode, Variant, Value).
 
 % The rules below allow us to prefer default values for variants
-% whenever possible. If a variant is set in a spec, or if it is
-% specified in an external, we score it as if it was a default value.
+% whenever possible. If a variant is set in a spec we score it
+% as if it was a default value.
 variant_not_default(node(ID, Package), Variant, Value)
  :- attr("variant_value", node(ID, Package), Variant, Value),
     not variant_default_value(Package, Variant, Value),
@@ -844,10 +777,6 @@ variant_not_default(node(ID, Package), Variant, Value)
     not attr("variant_set", node(ID, Package), Variant, Value),
     % variant values forced by propagation don't count as non-default
     not attr("variant_propagate", node(ID, Package), Variant, Value, _),
-    % variants set on externals that we could use don't count as non-default
-    % this makes spack prefer to use an external over rebuilding with the
-    % default configuration
-    not external_with_variant_set(node(ID, Package), Variant, Value),
     attr("node", node(ID, Package)).
 
 
@@ -857,14 +786,6 @@ variant_default_not_used(node(ID, Package), Variant, Value)
      node_has_variant(node(ID, Package), Variant),
      not attr("variant_value", node(ID, Package), Variant, Value),
      attr("node", node(ID, Package)).
-
-% The variant is set in an external spec
-external_with_variant_set(node(NodeID, Package), Variant, Value)
- :- attr("variant_value", node(NodeID, Package), Variant, Value),
-    condition_requirement(ID, "variant_value", Package, Variant, Value),
-    pkg_fact(Package, possible_external(ID, _)),
-    external(node(NodeID, Package)),
-    attr("node", node(NodeID, Package)).
 
 % The default value for a variant in a package is what is prescribed:
 %

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -93,14 +93,14 @@ def test_raising_exception_if_bootstrap_disabled(mutable_config):
         spack.bootstrap.config.store_path()
 
 
-def test_raising_exception_module_importable():
+def test_raising_exception_module_importable(clean_store, mutable_config):
     with pytest.raises(ImportError, match='cannot bootstrap the "asdf" Python module'):
         spack.bootstrap.core.ensure_module_importable_or_raise("asdf")
 
 
-def test_raising_exception_executables_in_path():
+def test_raising_exception_executables_in_path(clean_store, mutable_config):
     with pytest.raises(RuntimeError, match="cannot bootstrap any of the asdf, fdsa executables"):
-        spack.bootstrap.core.ensure_executables_in_path_or_raise(["asdf", "fdsa"], "python")
+        spack.bootstrap.core.ensure_executables_in_path_or_raise(["asdf", "fdsa"], "doesnotexist")
 
 
 @pytest.mark.regression("25603")

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -556,8 +556,11 @@ def test_ci_generate_with_external_pkg(
     mock_packages,
     monkeypatch,
     ci_base_environment,
+    external_spec,
 ):
     """Make sure we do not generate jobs for external pkgs"""
+    external_spec("externaltool@1.0%gcc@10.2.1", prefix="/usr")
+    external_spec("externalvirtual@2.2%gcc@10.2.1", prefix="/usr")
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -26,9 +26,11 @@ env = SpackCommand("env")
 
 
 @pytest.fixture
-def mock_spec():
+def mock_spec(external_spec):
+    external_spec("externaltool@1.0%gcc@10.2.1", prefix="/usr")
     # Make it look like the source was actually expanded.
     s = spack.spec.Spec("externaltest").concretized()
+    s.package.do_install(fake=True)
     source_path = s.package.stage.source_path
     mkdirp(source_path)
     yield s, s.package

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -31,7 +31,7 @@ def test_mark_all_explicit(mutable_database):
     mark("-e", "-a")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 14
 
 
 @pytest.mark.db
@@ -48,15 +48,15 @@ def test_mark_one_explicit(mutable_database):
     uninstall("-y", "-a", "mpileaks")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 3
+    assert len(all_specs) == 2
 
 
 @pytest.mark.db
 def test_mark_one_implicit(mutable_database):
-    mark("-i", "externaltest")
+    mark("-i", "trivial-smoke-test")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 14
+    assert len(all_specs) == 13
 
 
 @pytest.mark.db
@@ -65,4 +65,4 @@ def test_mark_all_implicit_then_explicit(mutable_database):
     mark("-e", "-a")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 14

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -27,7 +27,8 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.regression("8083")
-def test_regression_8083(tmpdir, capfd, mock_packages, mock_fetch, config):
+def test_regression_8083(tmpdir, capfd, mock_fetch, external_spec):
+    external_spec("externaltool@1.0%gcc@10.2.1", prefix="/usr")
     with capfd.disabled():
         output = mirror("create", "-d", str(tmpdir), "externaltool")
     assert "Skipping" in output

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -78,7 +78,7 @@ def test_recursive_uninstall(mutable_database):
     uninstall("-y", "-a", "--dependents", "callpath")
 
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 9
+    assert len(all_specs) == 8
     # query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies("mpileaks")]
     callpath_specs = [s for s in all_specs if s.satisfies("callpath")]
@@ -91,7 +91,7 @@ def test_recursive_uninstall(mutable_database):
 
 @pytest.mark.db
 @pytest.mark.regression("3690")
-@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 8), ("libelf", 6)])
+@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 7), ("libelf", 5)])
 def test_uninstall_spec_with_multiple_roots(
     constraint, expected_number_of_specs, mutable_database
 ):
@@ -102,7 +102,7 @@ def test_uninstall_spec_with_multiple_roots(
 
 
 @pytest.mark.db
-@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 14), ("libelf", 14)])
+@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 13), ("libelf", 13)])
 def test_force_uninstall_spec_with_ref_count_not_zero(
     constraint, expected_number_of_specs, mutable_database
 ):
@@ -173,7 +173,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
 
     all_specs, mpileaks_specs, callpath_specs, mpi_specs = db_specs()
     total_specs = len(all_specs)
-    assert total_specs == 14
+    assert total_specs == 13
     assert len(mpileaks_specs) == 3
     assert len(callpath_specs) == 2
     assert len(mpi_specs) == 3

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -115,7 +115,10 @@ def test_view_multiple_projections_all_first(
     assert os.path.exists(extendee_prefix)
 
 
-def test_view_external(tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_view_external(
+    tmpdir, mock_packages, mock_archive, mock_fetch, external_spec, install_mockery
+):
+    external_spec("externaltool@1.0%gcc@10.2.1", prefix="/usr")
     install("externaltool")
     viewpath = str(tmpdir.mkdir("view"))
     output = view("symlink", viewpath, "externaltool")

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -6,47 +6,11 @@ packages:
       blas: [openblas]
   externaltool:
     buildable: False
-    externals:
-    - spec: externaltool@1.0%gcc@10.2.1
-      prefix: /path/to/external_tool
-    - spec: externaltool@0.9%gcc@10.2.1
-      prefix: /usr
-    - spec: externaltool@0_8%gcc@10.2.1
-      prefix: /usr
   externalvirtual:
     buildable: False
-    externals:
-    - spec: externalvirtual@2.0%clang@12.0.0
-      prefix: /path/to/external_virtual_clang
-    - spec: externalvirtual@1.0%gcc@10.2.1
-      prefix: /path/to/external_virtual_gcc
   externalmodule:
     buildable: False
-    externals:
-    - spec: externalmodule@1.0%gcc@4.5.0
-      modules:
-      - external-module
   'requires-virtual':
     buildable: False
-    externals:
-    - spec:  requires-virtual@2.0
-      prefix: /usr
-  'external-buildable-with-variant':
-    buildable: True
-    externals:
-      - spec: external-buildable-with-variant@1.1.special +baz
-        prefix: /usr
-      - spec: external-buildable-with-variant@0.9 +baz
-        prefix: /usr
-  'old-external':
-    buildable: True
-    externals:
-      - spec: old-external@1.0.0
-        prefix: /usr
-  'external-non-default-variant':
-    buildable: True
-    externals:
-      - spec: external-non-default-variant@3.8.7~foo~bar
-        prefix: /usr
   version-test-dependency-preferred:
     version: ['5.2.5']

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -723,21 +723,6 @@ def test_external_entries_in_db(mutable_database, external_spec):
     assert rec.explicit is True
 
 
-@pytest.mark.regression("8036")
-def test_regression_issue_8036(mutable_database, usr_folder_exists):
-    # The test ensures that the external package prefix is treated as
-    # existing. Even when the package prefix exists, the package should
-    # not be considered installed until it is added to the database with
-    # do_install.
-    s = spack.spec.Spec("externaltool@0.9")
-    s.concretize()
-    assert not s.installed
-
-    # Now install the external package and check again the `installed` property
-    s.package.do_install(fake=True)
-    assert s.installed
-
-
 @pytest.mark.regression("11118")
 def test_old_external_entries_prefix(clean_store, external_spec):
     external_spec("externaltool@1.0", prefix="/usr")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -454,7 +454,7 @@ def test_005_db_exists(database):
 def test_010_all_install_sanity(database):
     """Ensure that the install layout reflects what we think it does."""
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 14
 
     # Query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies("mpileaks")]
@@ -571,7 +571,7 @@ def test_050_basic_query(database):
     """Ensure querying database is consistent with what is installed."""
     # query everything
     total_specs = len(spack.store.STORE.db.query())
-    assert total_specs == 17
+    assert total_specs == 14
 
     # query specs with multiple configurations
     mpileaks_specs = database.query("mpileaks")
@@ -705,7 +705,8 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database, tmpdir):
         _check_db_sanity(mutable_database)
 
 
-def test_external_entries_in_db(mutable_database):
+def test_external_entries_in_db(mutable_database, external_spec):
+    external_spec("externaltool@1.0%gcc@10.2.1", prefix="/path/to/external_tool")
     rec = mutable_database.get_record("mpileaks ^zmpi")
     assert rec.spec.external_path is None
     assert not rec.spec.external_modules
@@ -738,7 +739,8 @@ def test_regression_issue_8036(mutable_database, usr_folder_exists):
 
 
 @pytest.mark.regression("11118")
-def test_old_external_entries_prefix(mutable_database):
+def test_old_external_entries_prefix(clean_store, external_spec):
+    external_spec("externaltool@1.0", prefix="/usr")
     with open(spack.store.STORE.db._index_path, "r") as f:
         db_obj = json.loads(f.read())
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -309,19 +309,13 @@ def test_installed_upstream_external(install_upstream, mock_fetch):
     """Check that when a dependency package is recorded as installed in
     an upstream database that it is not reinstalled.
     """
-    store_root, _ = install_upstream("externaltool")
-    with spack.store.use_store(store_root):
-        dependent = spack.spec.Spec("externaltest")
-        dependent.concretize()
-
-        new_dependency = dependent["externaltool"]
-        assert new_dependency.external
-        assert new_dependency.prefix == os.path.sep + os.path.join("path", "to", "external_tool")
-
+    s, _ = install_upstream("libelf")
+    with spack.store.use_store(s) as store:
+        dependent = spack.spec.Spec("libdwarf").concretized()
+        new_dependency = dependent["libelf"]
+        assert store.db.query(new_dependency) and not store.db.query_local(new_dependency)
         dependent.package.do_install()
-
-        assert not os.path.exists(new_dependency.prefix)
-        assert os.path.exists(dependent.prefix)
+        assert store.db.query(new_dependency) and not store.db.query_local(new_dependency)
 
 
 def test_installed_upstream(install_upstream, mock_fetch):

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -340,9 +340,10 @@ class TestLmod:
         assert "Override even better!" in content
 
     @pytest.mark.usefixtures("config")
-    def test_external_configure_args(self, factory):
+    def test_external_configure_args(self, factory, external_spec):
         # If this package is detected as an external, its configure option line
         # in the module file starts with 'unknown'
+        external_spec("externaltool@1.0%gcc@10.2.1", prefix="/usr")
         writer, spec = factory("externaltool")
 
         assert "unknown" in writer.context.configure_options

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -83,9 +83,6 @@ def test_invalid_json_spec(invalid_json, error_message):
 @pytest.mark.parametrize(
     "abstract_spec",
     [
-        # Externals
-        "externaltool",
-        "externaltest",
         # Ambiguous version spec
         "mpileaks@1.0:5.0,6.1,7.3+debug~opt",
         # Variants

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1114,14 +1114,23 @@ _spack_external() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find list read-cray-manifest"
+        SPACK_COMPREPLY="find import list read-cray-manifest"
     fi
 }
 
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --exclude -p --path --scope --all -t --tag -j --jobs"
+        SPACK_COMPREPLY="-h --help --exclude -p --path --all -t --tag -j --jobs"
+    else
+        _all_packages
+    fi
+}
+
+_spack_external_import() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope --exclude"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1121,7 +1121,7 @@ _spack_external() {
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --not-buildable --exclude -p --path --scope --all -t --tag -j --jobs"
+        SPACK_COMPREPLY="-h --help --exclude -p --path --scope --all -t --tag -j --jobs"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1579,31 +1579,38 @@ complete -c spack -n '__fish_spack_using_command extensions' -s s -l show -r -d 
 
 # spack external
 set -g __fish_spack_optspecs_spack_external h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a find -d 'add external packages to packages.yaml'
+complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a find -d 'search for external packages and add them to the local DB'
+complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a import -d 'import external packages from user configuration to the local DB'
 complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a list -d 'list detectable packages, by repository and name'
 complete -c spack -n '__fish_spack_using_command_pos 0 external' -f -a read-cray-manifest -d 'consume a Spack-compatible description of externally-installed packages, including dependency relationships'
 complete -c spack -n '__fish_spack_using_command external' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command external' -s h -l help -d 'show this help message and exit'
 
 # spack external find
-set -g __fish_spack_optspecs_spack_external_find h/help not-buildable exclude= p/path= scope= all t/tag= j/jobs=
+set -g __fish_spack_optspecs_spack_external_find h/help exclude= p/path= all t/tag= j/jobs=
 
 complete -c spack -n '__fish_spack_using_command external find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command external find' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command external find' -l not-buildable -f -a not_buildable
-complete -c spack -n '__fish_spack_using_command external find' -l not-buildable -d 'packages with detected externals won\'t be built with Spack'
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f -a exclude
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -d 'one or more alternative search paths for finding externals'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults system site user command_line'
-complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
 complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
 complete -c spack -n '__fish_spack_using_command external find' -s t -l tag -r -f -a tags
 complete -c spack -n '__fish_spack_using_command external find' -s t -l tag -r -d 'filter a package query by tag (multiple use allowed)'
 complete -c spack -n '__fish_spack_using_command external find' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command external find' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
+
+# spack external import
+set -g __fish_spack_optspecs_spack_external_import h/help scope= exclude=
+
+complete -c spack -n '__fish_spack_using_command external import' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command external import' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command external import' -l scope -r -f -a '_builtin defaults system site user command_line'
+complete -c spack -n '__fish_spack_using_command external import' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command external import' -l exclude -r -f -a exclude
+complete -c spack -n '__fish_spack_using_command external import' -l exclude -r -d 'packages to exclude from import'
 
 # spack external list
 set -g __fish_spack_optspecs_spack_external_list h/help

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -17,7 +17,7 @@ spack:
       root: {{ store_path }}
       padded_length: 0
 
-  packages:
+  packages::
     python:
       buildable: false
       externals:

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -21,7 +21,7 @@ spack:
     python:
       buildable: false
       externals:
-        - spec: "{{ python_spec }}"
+        - spec: "{{ python_spec }} target={{ architecture }}"
           prefix: "{{ python_prefix }}"
 
     py-typed-ast:


### PR DESCRIPTION
fixes #24498
fixes #24506
fixes #26034
fixes #28827
fixes #29930
fixes #30911

:warning: **Work in progress, many details missing (both in the implementation and in the description)** :warning: 

---

This draft PR reworks how externals are treated by Spack. The main change is that detecting an external writes directly into the DB:
![Screenshot from 2023-03-16 23-24-23](https://user-images.githubusercontent.com/4199709/225766688-c2fc44d7-266a-49ad-beac-8d586e7d7e2a.png)

Externals are inserted in the DB as they are detected, so any missing information stays missing by default. In the picture above, for instance, only `curl` was detected with some variants. They are also inserted as "implicit", so to make it easy to garbage collect them.

To deal with existing `packages.yaml` configurations there is another explicit command, called `import`:
![Screenshot from 2023-03-16 23-29-37](https://user-images.githubusercontent.com/4199709/225767334-44081527-f2c0-4da5-95a0-d9d3bd86def8.png)

## Concretization

Preferring externals over new builds is done through the "reuse" mechanism of our solver. Importing externals from `packages.yaml` is done automatically just before we concretize a spec, so to be sure we can reuse them. It is also done unconditionally, i.e. we'll reuse externals in `packages.yaml` even if `concretizer:reuse:false`. This gives us back a behavior that is very similar to the one in `develop`.




