### PR TITLE
Improve wording of audit message

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -695,8 +695,9 @@ def _ensure_variant_defaults_are_parsable(pkgs, error_cls):
             try:
                 variant.validate_or_raise(vspec, pkg_cls=pkg_cls)
             except spack.variant.InvalidVariantValueError:
-                error_msg = "The variant '{}' default value in package '{}' cannot be validated"
-                errors.append(error_cls(error_msg.format(variant_name, pkg_name), []))
+                error_msg = "The default value of the variant '{}' in package '{}' failed validation"
+                question = "Is it among the allowed values?"
+                errors.append(error_cls(error_msg.format(variant_name, pkg_name), [question]))
 
     return errors
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -695,7 +695,9 @@ def _ensure_variant_defaults_are_parsable(pkgs, error_cls):
             try:
                 variant.validate_or_raise(vspec, pkg_cls=pkg_cls)
             except spack.variant.InvalidVariantValueError:
-                error_msg = "The default value of the variant '{}' in package '{}' failed validation"
+                error_msg = (
+                    "The default value of the variant '{}' in package '{}' failed validation"
+                )
                 question = "Is it among the allowed values?"
                 errors.append(error_cls(error_msg.format(variant_name, pkg_name), [question]))
 


### PR DESCRIPTION
On #36164 this would show:
```console
$ spack audit packages babelstream
PKG-DIRECTIVES: 1 issue found
1. The default value of the variant 'backend' in package 'babelstream' failed validation
    Is it among the allowed values?
```