### PR TITLE
Switch GROMACS build type to Release

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -91,7 +91,7 @@ class Gromacs(CMakePackage):
     variant("nosuffix", default=False, description="Disable default suffixes")
     variant(
         "build_type",
-        default="RelWithDebInfo",
+        default="Release",
         description="The build type to build",
         values=(
             "Debug",


### PR DESCRIPTION
The current default RelWithDebInfo gives significantly slower builds so it should not be the default.