### PR TITLE
veccore: new version 0.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -20,6 +20,7 @@ class Veccore(CMakePackage):
     maintainers("drbenmorgan", "sethrj")
 
     version("master", branch="master")
+    version("0.8.1", sha256="7d7983947c2c6faa55c908b3a968f19f96f4d5c909447c536de30c34b439e008")
     version("0.8.0", sha256="2f8e49f2b609bf15a776026fbec899b3d5d4ba30f033d4fdac4b07a5220a4fd3")
     version("0.7.0", sha256="61d9fc4be815c5c98088c2796763d3ed82ba4bad5a69b7892c1c2e7e1e53d311")
     version("0.6.0", sha256="db404d745906efec2a76175995e847af9174df5a8da1e5ccdb241c773d7c8df9")

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -56,16 +56,12 @@ class Vecgeom(CMakePackage, CudaPackage):
     variant("shared", default=True, description="Build shared libraries")
 
     depends_on("veccore")
-    depends_on("veccore@0.8.0", when="@1.1.18:")
+    depends_on("veccore@0.8.1:", when="+cuda")
+    depends_on("veccore@0.8.0:0.8", when="@1.1.18:")
     depends_on("veccore@0.5.2:", when="@1.1.0:")
     depends_on("veccore@0.4.2", when="@:1.0")
 
     conflicts("+cuda", when="@:1.1.5")
-    conflicts(
-        "%gcc@11.3:",
-        when="+cuda ^cuda@:11.6",
-        msg="vecgeom's CUDA support cannot be built with GCC >= 11.3 using CUDA < 11.7",
-    )
     conflicts("cxxstd=14", when="@1.2:")
     conflicts("cxxstd=11", when="@1.2:")
 


### PR DESCRIPTION
@helen-brooks Once this gets merged (or if you want to test this on your system by adding `https://github.com/sethrj/spack.git` as a remote) you should be able to build vecgeom on your CUDA system with GCC12.