### PR TITLE
NWChem updates

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -13,10 +13,15 @@ class Nwchem(Package):
     """High-performance computational chemistry software"""
 
     homepage = "https://nwchemgit.github.io"
-    url = "https://github.com/nwchemgit/nwchem/releases/download/v7.0.2-release/nwchem-7.0.2-release.revision-b9985dfa-srconly.2020-10-12.tar.bz2"
+    url = "https://github.com/nwchemgit/nwchem/releases/download/v7.2.0-release/nwchem-7.2.0-release.revision-d0d141fd-srconly.2023-03-10.tar.bz2"
 
     tags = ["ecp", "ecp-apps"]
 
+    version(
+        "7.2.0",
+        sha256="28ea70947e77886337c84e6fae3bdf88f25f0acfdeaf95e722615779c19f7a7e",
+        url="https://github.com/nwchemgit/nwchem/releases/download/v7.2.0-release/nwchem-7.2.0-release.revision-d0d141fd-srconly.2023-03-10.tar.bz2",
+    )
     version(
         "7.0.2",
         sha256="9bf913b811b97c8ed51bc5a02bf1c8e18456d0719c0a82b2e71223a596d945a7",
@@ -81,9 +86,9 @@ class Nwchem(Package):
         use_32_bit_lin_alg = True
 
         if use_32_bit_lin_alg:
-            args.extend(["USE_64TO32=y", "BLAS_SIZE=4", "LAPACK_SIZE=4", "SCALAPACK_SIZE=4"])
+            args.extend(["USE_64TO32=y", "BLAS_SIZE=4", "SCALAPACK_SIZE=4"])
         else:
-            args.extend(["BLAS_SIZE=8", "LAPACK_SIZE=8" "SCALAPACK_SIZE=8"])
+            args.extend(["BLAS_SIZE=8", "SCALAPACK_SIZE=8"])
 
         if sys.platform == "darwin":
             target = "MACX64"
@@ -113,6 +118,7 @@ class Nwchem(Package):
 
             install_tree("data", share_path)
             install_tree(join_path("basis", "libraries"), join_path(share_path, "libraries"))
+            install_tree(join_path("basis", "libraries.bse"), join_path(share_path, "libraries"))
             install_tree(join_path("nwpw", "libraryps"), join_path(share_path, "libraryps"))
 
             b_path = join_path(self.stage.source_path, "bin", target, "nwchem")

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -69,7 +69,7 @@ class Nwchem(Package):
                 "EACCSD=y",  # TCE extra module
             ]
         )
-        if self.version >= Version("7.2.0"):
+        if self.spec.satisfies("@7.2.0:"):
             args.extend(["NWCHEM_MODULES=all python gwmol"])
         else:
             args.extend(["NWCHEM_MODULES=all python"])

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -27,11 +27,6 @@ class Nwchem(Package):
         sha256="9bf913b811b97c8ed51bc5a02bf1c8e18456d0719c0a82b2e71223a596d945a7",
         url="https://github.com/nwchemgit/nwchem/releases/download/v7.0.2-release/nwchem-7.0.2-release.revision-b9985dfa-srconly.2020-10-12.tar.bz2",
     )
-    version(
-        "7.0.0",
-        sha256="e3c6510627345be596f4079047e5e7b59e6c20599798ecfe122e3527f8ad6eb0",
-        url="https://github.com/nwchemgit/nwchem/releases/download/v7.0.0-release/nwchem-7.0.0-release.revision-2c9a1c7c-srconly.2020-02-26.tar.bz2",
-    )
 
     variant("openmp", default=False, description="Enables OpenMP support")
     variant("mpipr", default=False, description="Enables ARMCI with progress rank")
@@ -47,7 +42,7 @@ class Nwchem(Package):
     depends_on("mpi")
     depends_on("scalapack")
     depends_on("fftw-api")
-    depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")
+    depends_on("python@3", type=("build", "link", "run"))
 
     def install(self, spec, prefix):
         scalapack = spec["scalapack"].libs
@@ -64,19 +59,16 @@ class Nwchem(Package):
                 "CC=%s" % os.path.basename(spack_cc),
                 "FC=%s" % os.path.basename(spack_fc),
                 "USE_MPI=y",
-                "USE_BLAS=y",
-                "USE_FFTW3=y",
                 "PYTHONVERSION=%s" % spec["python"].version.up_to(2),
                 "BLASOPT=%s" % ((lapack + blas).ld_flags),
-                "BLAS_LIB=%s" % blas.ld_flags,
                 "LAPACK_LIB=%s" % lapack.ld_flags,
                 "SCALAPACK_LIB=%s" % scalapack.ld_flags,
-                "FFTW3_LIB=%s" % fftw.ld_flags,
-                "FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include),
-                "NWCHEM_MODULES=all python",
-                "NWCHEM_LONG_PATHS=Y",  # by default NWCHEM_TOP is 64 char max
+                "NWCHEM_MODULES=all python gwmol",
+#                "NWCHEM_MODULES=tinyqmpw python",# faster build for testing
                 "USE_NOIO=Y",  # skip I/O algorithms
-                "USE_NOFSCHECK=TRUE",  # FSCHECK, caused problems like code crashes
+                "MRCC_METHODS=y", # TCE extra module
+                "IPCCSD=y", # TCE extra module
+                "EACCSD=y" # TCE extra module
             ]
         )
 
@@ -103,6 +95,11 @@ class Nwchem(Package):
 
         if "+mpipr" in spec:
             args.extend(["ARMCI_NETWORK=MPI-PR"])
+
+        if "+fftw3" in spec:
+            args.extend(["USE_FFTW3=y"])
+            args.extend(["FFTW3_LIB=%s" % fftw.ld_flags])
+            args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         with working_dir("src"):
             make("nwchem_config", *args)

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -64,9 +64,9 @@ class Nwchem(Package):
                 "LAPACK_LIB=%s" % lapack.ld_flags,
                 "SCALAPACK_LIB=%s" % scalapack.ld_flags,
                 "USE_NOIO=Y",  # skip I/O algorithms
-                "MRCC_METHODS=y", # TCE extra module
-                "IPCCSD=y", # TCE extra module
-                "EACCSD=y" # TCE extra module
+                "MRCC_METHODS=y",  # TCE extra module
+                "IPCCSD=y",  # TCE extra module
+                "EACCSD=y",  # TCE extra module
             ]
         )
         if self.version >= Version("7.2.0"):

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -63,14 +63,16 @@ class Nwchem(Package):
                 "BLASOPT=%s" % ((lapack + blas).ld_flags),
                 "LAPACK_LIB=%s" % lapack.ld_flags,
                 "SCALAPACK_LIB=%s" % scalapack.ld_flags,
-                "NWCHEM_MODULES=all python gwmol",
-#                "NWCHEM_MODULES=tinyqmpw python",# faster build for testing
                 "USE_NOIO=Y",  # skip I/O algorithms
                 "MRCC_METHODS=y", # TCE extra module
                 "IPCCSD=y", # TCE extra module
                 "EACCSD=y" # TCE extra module
             ]
         )
+        if self.version >= Version("7.2.0"):
+            args.extend(["NWCHEM_MODULES=all python gwmol"])
+        else:
+            args.extend(["NWCHEM_MODULES=all python"])
 
         # TODO: query if blas/lapack/scalapack uses 64bit Ints
         # A flag to distinguish between 32bit and 64bit integers in linear


### PR DESCRIPTION
* removed obsolete version 7.0.0 (7.0.2 is a bug fix release for it)
* removed environment variables that are on by default in 7.0.0 and later: USE_NOFSCHECK, USE_BLAS, NWCHEM_LONG_PATHS
* BLAS_LIB removed since it is an alias for BLASOPT
* added fftw3 spec since FFTW is not recommended and the build fails when FFTW3 is linked out of MKL
* tweaked NWCHEM_MODULES environment variables based on version
* cleaned up python dependency
* added more functionality for TCE modules (MRCC_METHODS, IPCCSD, EACCSD)