### PR TITLE
Fix wrong computation of concrete specs due to a bug in intersects

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -501,7 +501,7 @@ class Result(object):
                 key = providers[0]
             candidate = answer.get(key)
 
-            if candidate and candidate.intersects(input_spec):
+            if candidate and candidate.satisfies(input_spec):
                 self._concrete_specs.append(answer[key])
                 self._concrete_specs_by_input[input_spec] = answer[key]
             else:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2076,3 +2076,24 @@ class TestConcretize(object):
         abstract_specs = [spack.spec.Spec(s) for s in ["py-extension1", "python"]]
         specs = spack.concretize.concretize_specs_together(*abstract_specs)
         assert specs[0]["python"] == specs[1]["python"]
+
+    @pytest.mark.regression("36190")
+    @pytest.mark.parametrize(
+        "specs",
+        [
+            ["mpileaks^ callpath ^dyninst@8.1.1:8 ^mpich2@1.3:1"],
+            ["multivalue-variant ^a@2:2"],
+            ["v1-consumer ^conditional-provider@1:1 +disable-v1"],
+        ],
+    )
+    def test_result_specs_is_not_empty(self, specs):
+        """Check that the implementation of "result.specs" is correct in cases where we
+        know a concretization exists.
+        """
+        specs = [spack.spec.Spec(s) for s in specs]
+        solver = spack.solver.asp.Solver()
+        setup = spack.solver.asp.SpackSolverSetup()
+        result, _, _ = solver.driver.solve(setup, specs, reuse=[])
+
+        assert result.specs
+        assert not result.unsolved_specs

--- a/var/spack/repos/builtin.mock/packages/v1-consumer/package.py
+++ b/var/spack/repos/builtin.mock/packages/v1-consumer/package.py
@@ -16,3 +16,5 @@ class V1Consumer(Package):
 
     depends_on("v2")
     depends_on("v1")
+
+    provides("somelang")


### PR DESCRIPTION
fixes #36190

There is still a bug in `Spec.intersects`, but that can be solved later without affecting users.