### PR TITLE
autodiff: add v1.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -16,6 +16,7 @@ class Autodiff(CMakePackage):
 
     maintainers("wdconinc", "HadrienG2")
 
+    version("1.0.1", sha256="63f2c8aaf940fbb1d1e7098b1d6c08794da0194eec3faf773f3123dc7233838c")
     version("1.0.0", sha256="112c6f5740071786b3f212c96896abc2089a74bca16b57bb46ebf4cec79dca43")
     version("0.6.12", sha256="3e9d667b81bba8e43bbe240a0321e25f4be248d1761097718664445306882dcc")
     version("0.6.11", sha256="ac7a52387a10ecb8ba77ce5385ffb23893ff9a623467b4392bd204422a3b5c09")


### PR DESCRIPTION
Add autodiff v1.0.1.

**Changelog:**
https://github.com/autodiff/autodiff/releases/tag/v1.0.1

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.