### PR TITLE
code-server: add v4.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/code-server/package.py
+++ b/var/spack/repos/builtin/packages/code-server/package.py
@@ -13,6 +13,7 @@ class CodeServer(Package):
     homepage = "https://coder.com/docs/code-server/latest"
     url = "https://github.com/coder/code-server/releases/download/v4.4.0/code-server-4.4.0-linux-amd64.tar.gz"
 
+    version("4.11.0", sha256="4eb233054941ec298caec6fc84dfba0a72c1bc5fadc0fe4896b10f3f4a291d51")
     version("4.10.1", sha256="f34ce611a9c058982a5e9d200fdf009788e3a564e970b053f4145574bce21b09")
     version("4.4.0", sha256="e3dd265acb18c2230c72d19bbce619ac5c1bd800ebb26e5e169c4d613069500d")
     version("4.3.0", sha256="42c71e98de85270b164b023ef8eb0692cf7700c03081ba5a44eaca014a92eb57")


### PR DESCRIPTION
Add Code Server v4.11.0.

**Changelog:**
https://github.com/coder/code-server/releases/tag/v4.11.0

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.