### PR TITLE
gpgme: add v1.19.0

### DIFF
--- a/var/spack/repos/builtin/packages/gpgme/package.py
+++ b/var/spack/repos/builtin/packages/gpgme/package.py
@@ -15,6 +15,7 @@ class Gpgme(AutotoolsPackage):
 
     executables = ["^gpgme-config$"]
 
+    version("1.19.0", sha256="cb58494dc415fba9eeb12b826550ad3190dc92e265c5bb2ae1a21c92841cfd38")
     version("1.18.0", sha256="361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e")
     version("1.16.0", sha256="6c8cc4aedb10d5d4c905894ba1d850544619ee765606ac43df7405865de29ed0")
     version("1.12.0", sha256="b4dc951c3743a60e2e120a77892e9e864fb936b2e58e7c77e8581f4d050e8cd8")


### PR DESCRIPTION
Add gpgme v1.19.0.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.