### PR TITLE
openldap: add v2.6.4

### DIFF
--- a/var/spack/repos/builtin/packages/openldap/package.py
+++ b/var/spack/repos/builtin/packages/openldap/package.py
@@ -19,6 +19,7 @@ class Openldap(AutotoolsPackage):
     homepage = "https://www.openldap.org/"
     url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.0.tgz"
 
+    version("2.6.4", sha256="d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991")
     version("2.6.0", sha256="b71c580eac573e9aba15d95f33dd4dd08f2ed4f0d7fc09e08ad4be7ed1e41a4f")
     version("2.4.49", sha256="e3b117944b4180f23befe87d0dcf47f29de775befbc469dcf4ac3dab3311e56e")
     version("2.4.48", sha256="d9523ffcab5cd14b709fcf3cb4d04e8bc76bb8970113255f372bc74954c6074d")


### PR DESCRIPTION
Add OpenLDAP v2.6.4.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.