### PR TITLE
patchelf: add v0.17.2

### DIFF
--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -18,6 +18,7 @@ class Patchelf(AutotoolsPackage):
 
     maintainers("haampie")
 
+    version("0.17.2", sha256="20427b718dd130e4b66d95072c2a2bd5e17232e20dad58c1bea9da81fae330e0")
     version("0.16.1", sha256="1a562ed28b16f8a00456b5f9ee573bb1af7c39c1beea01d94fc0c7b3256b0406")
     version("0.15.0", sha256="53a8d58ed4e060412b8fdcb6489562b3c62be6f65cee5af30eba60f4423bfa0f")
     version("0.14.5", sha256="113ada3f1ace08f0a7224aa8500f1fa6b08320d8f7df05ff58585286ec5faa6f")


### PR DESCRIPTION
Add patchelf v0.17.2.

**Changelog:**
https://github.com/NixOS/patchelf/releases.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.