### PR TITLE
pax-utils: add v1.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/pax-utils/package.py
+++ b/var/spack/repos/builtin/packages/pax-utils/package.py
@@ -13,4 +13,5 @@ class PaxUtils(AutotoolsPackage):
     homepage = "https://wiki.gentoo.org/index.php?title=Project:Hardened/PaX_Utilities"
     url = "https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.2.tar.xz"
 
+    version("1.3.3", sha256="eeca7fbd98bc66bead4a77000c2025d9f17ea8201b84245882406ce00b9b6b14")
     version("1.2.2", sha256="7f4a7f8db6b4743adde7582fa48992ad01776796fcde030683732f56221337d9")


### PR DESCRIPTION
Add pax-utils v1.3.3.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.