### PR TITLE
perl-alien-build: add v2.78

### DIFF
--- a/var/spack/repos/builtin/packages/perl-alien-build/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-build/package.py
@@ -14,6 +14,7 @@ class PerlAlienBuild(PerlPackage):
     homepage = "https://metacpan.org/pod/Alien::Build"
     url = "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-Build-1.86.tar.gz"
 
+    version("2.78", sha256="9140671790a0696920b0a97acd812ab4d0b93ac69306d20679f027dd0c7caa27")
     version("1.86", sha256="f856a46aea72fe77daea5b1788b4ea0dc215f5704f5a35fa063171be8523e4e9")
 
     depends_on("perl-capture-tiny", type=("build", "run"))


### PR DESCRIPTION
Add perl-alien-build v2.78.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.