### PR TITLE
perl-app-cmd: add v0.335

### DIFF
--- a/var/spack/repos/builtin/packages/perl-app-cmd/package.py
+++ b/var/spack/repos/builtin/packages/perl-app-cmd/package.py
@@ -12,4 +12,5 @@ class PerlAppCmd(PerlPackage):
     homepage = "https://metacpan.org/pod/App::Cmd"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/App-Cmd-0.331.tar.gz"
 
+    version("0.335", sha256="f95517fc4df348d9e7ea01467aabd9725f0715662ee483b54b81d3f0b38c9874")
     version("0.331", sha256="4a5d3df0006bd278880d01f4957aaa652a8f91fe8f66e93adf70fba0c3ecb680")


### PR DESCRIPTION
Add perl-app-cmd v0.335.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.