### PR TITLE
perl-b-hooks-endofscope: add v0.26

### DIFF
--- a/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
@@ -12,6 +12,7 @@ class PerlBHooksEndofscope(PerlPackage):
     homepage = "https://metacpan.org/pod/B::Hooks::EndOfScope"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.21.tar.gz"
 
+    version("0.26", sha256="39df2f8c007a754672075f95b90797baebe97ada6d944b197a6352709cb30671")
     version("0.21", sha256="90f3580880f1d68b843c142cc86f58bead1f3e03634c63868ac9eba5eedae02c")
 
     depends_on("perl-sub-exporter-progressive", type=("build", "run"))


### PR DESCRIPTION
Add perl-b-hooks-endofscope v0.26.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.