### PR TITLE
perl-capture-tiny: add v0.48

### DIFF
--- a/var/spack/repos/builtin/packages/perl-capture-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-capture-tiny/package.py
@@ -12,4 +12,5 @@ class PerlCaptureTiny(PerlPackage):
     homepage = "https://metacpan.org/pod/Capture::Tiny"
     url = "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.46.tar.gz"
 
+    version("0.48", sha256="6c23113e87bad393308c90a207013e505f659274736638d8c79bac9c67cc3e19")
     version("0.46", sha256="5d7a6a830cf7f2b2960bf8b8afaac16a537ede64f3023827acea5bd24ca77015")


### PR DESCRIPTION
Add perl-capture-tiny v0.48.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.