### PR TITLE
perl-class-inspector: add v1.36

### DIFF
--- a/var/spack/repos/builtin/packages/perl-class-inspector/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-inspector/package.py
@@ -12,4 +12,5 @@ class PerlClassInspector(PerlPackage):
     homepage = "https://metacpan.org/pod/Class::Inspector"
     url = "http://search.cpan.org/CPAN/authors/id/P/PL/PLICEASE/Class-Inspector-1.32.tar.gz"
 
+    version("1.36", sha256="cc295d23a472687c24489d58226ead23b9fdc2588e522f0b5f0747741700694e")
     version("1.32", sha256="cefadc8b5338e43e570bc43f583e7c98d535c17b196bcf9084bb41d561cc0535")


### PR DESCRIPTION
Add perl-class-inspector v1.36.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.