### PR TITLE
wayland: change url from github (defunct) to freedesktop.org

### DIFF
--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -10,11 +10,11 @@ class WaylandProtocols(AutotoolsPackage):
     """wayland-protocols contains Wayland protocols that add functionality not
     available in the Wayland core protocol. Such protocols either add
     completely new functionality, or extend the functionality of some other
-    protocol either in Wayland core, or some other protocol i
-    n wayland-protocols."""
+    protocol either in Wayland core, or some other protocol in
+    wayland-protocols."""
 
     homepage = "https://wayland.freedesktop.org/"
-    url = "https://github.com/wayland-project/wayland-protocols/archive/1.20.tar.gz"
+    url = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.20/wayland-protocols-1.20.tar.gz"
 
     version("1.20", sha256="b59cf0949aeb1f71f7db46b63b1c5a6705ffde8cb5bd194f843fbd9b41308dda")
 

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -15,7 +15,7 @@ class Wayland(AutotoolsPackage):
     X servers(rootless or fullscreen) or other display servers."""
 
     homepage = "https://wayland.freedesktop.org/"
-    url = "https://github.com/wayland-project/wayland/archive/1.18.0.tar.gz"
+    url = "https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.18.0/wayland-1.18.0.tar.gz"
 
     version("1.18.0", sha256="8d375719ebfa36b6f2968096fdf0bfa7d39ba110b7956c0032e395e7e012f332")
     version("1.17.93", sha256="293536ad23bfed15fc34e2a63bbb511167e8b096c0eba35e805cb64d46ad62ae")


### PR DESCRIPTION
This resolves #36212, and addresses the fact that wayland is [not using the github mirror anymore](https://lists.freedesktop.org/archives/wayland-devel/2023-January/042598.html). I verified that the sha256sums (for both wayland and wayland-protocols) are the same for the archives at the new location compared with what is in the package.