### PR TITLE
wayland: new versions, new build system (meson)

### DIFF
--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 
-class WaylandProtocols(AutotoolsPackage):
+class WaylandProtocols(MesonPackage, AutotoolsPackage):
     """wayland-protocols contains Wayland protocols that add functionality not
     available in the Wayland core protocol. Such protocols either add
     completely new functionality, or extend the functionality of some other
@@ -14,14 +16,37 @@ class WaylandProtocols(AutotoolsPackage):
     n wayland-protocols."""
 
     homepage = "https://wayland.freedesktop.org/"
-    url = "https://github.com/wayland-project/wayland-protocols/archive/1.20.tar.gz"
+    url = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.20/wayland-protocols-1.20.tar.gz"
+    list_url = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tags"
+    git = "https://gitlab.freedesktop.org/wayland/wayland-protocols"
 
+    build_system(
+        conditional("autotools", when="@:1.23"),
+        conditional("meson", when="@1.21:"),
+        default="meson"
+    )
+
+    version("1.31", sha256="04d3f66eca99d638ec8dbfdfdf79334290e22028f7d0b04c7034d9ef18a3248a")
+    version("1.30", sha256="1c02ce27d5267c904f2f0d31039265f3e4112f15bf274b1c72bdacd5322f243d")
+    version("1.29", sha256="4a85786ae69cd6d53bbe9278572f3c3d6ea342875ea444960edb6089237c3a18")
+    version("1.28", sha256="914dfa09e7e866e913b27d2d9bda0e20e728c7b1c831fd3db71538d9f99a4869")
+    version("1.27", sha256="6dd6ee86478adf4347f3b8b4f3da62dbe9e44912c9cef21cf99abfe692313df4")
+    version("1.26", sha256="fe56386f436a84e97c3b6a61b76306f205a64425900f247ad0048174b9c32d4d")
+    version("1.25", sha256="4326e2b5e04e459ab4522e83e19bff101a3faf9b085bcf46b6cabbd392cc4458")
+    version("1.24", sha256="71a171f964e4fe25cede281a2939ac5298ddaba9a5dd8a217db66843a532d064")
+    version("1.23", sha256="1ffd6f90eb247ff79de50ac10490ed03100572fb571cebef4df9ec74a271b2af")
+    version("1.22", sha256="92f3d88192bf5377300dee654a78e296aca20e2f8e1ed95024f0f91513760a94")
     version("1.20", sha256="b59cf0949aeb1f71f7db46b63b1c5a6705ffde8cb5bd194f843fbd9b41308dda")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    with when("build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+
+    with when("build_system=meson"):
+        depends_on("meson@0.55:")
+
     depends_on("pkgconfig", type="build")
     depends_on("doxygen", type="build")
     depends_on("xmlto", type="build")

--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -20,6 +20,8 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
     list_url = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tags"
     git = "https://gitlab.freedesktop.org/wayland/wayland-protocols"
 
+    maintainers("wdconinc")
+
     build_system(
         conditional("autotools", when="@:1.23"),
         conditional("meson", when="@1.21:"),

--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -23,7 +23,7 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
     build_system(
         conditional("autotools", when="@:1.23"),
         conditional("meson", when="@1.21:"),
-        default="meson"
+        default="meson",
     )
 
     version("1.31", sha256="04d3f66eca99d638ec8dbfdfdf79334290e22028f7d0b04c7034d9ef18a3248a")

--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.build_systems.autotools
-import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -21,6 +21,8 @@ class Wayland(MesonPackage, AutotoolsPackage):
     list_url = "https://gitlab.freedesktop.org/wayland/wayland/-/tags"
     git = "https://gitlab.freedesktop.org/wayland/wayland/"
 
+    maintainers("wdconinc")
+
     build_system(
         conditional("autotools", when="@:1.19"),
         conditional("meson", when="@1.18:"),

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -24,7 +24,7 @@ class Wayland(MesonPackage, AutotoolsPackage):
     build_system(
         conditional("autotools", when="@:1.19"),
         conditional("meson", when="@1.18:"),
-        default="meson"
+        default="meson",
     )
 
     version("1.21.0", sha256="53b7fa67142e653820030ec049971bcb5e84ac99e05cba5bcb9cb55f43fae4b3")

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -1,10 +1,8 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+so xxx# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.build_systems.autotools
-import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 
-class Wayland(AutotoolsPackage):
+class Wayland(MesonPackage, AutotoolsPackage):
     """Wayland is a project to define a protocol for a compositor to talk
     to its clients as well as a library implementation of the protocol.
     The compositor can be a standalone display server running on Linux
@@ -15,20 +17,37 @@ class Wayland(AutotoolsPackage):
     X servers(rootless or fullscreen) or other display servers."""
 
     homepage = "https://wayland.freedesktop.org/"
-    url = "https://github.com/wayland-project/wayland/archive/1.18.0.tar.gz"
+    url = "https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.18.0/wayland-1.18.0.tar.gz"
+    list_url = "https://gitlab.freedesktop.org/wayland/wayland/-/tags"
+    git = "https://gitlab.freedesktop.org/wayland/wayland/"
 
+    build_system(
+        conditional("autotools", when="@:1.19"),
+        conditional("meson", when="@1.18:"),
+        default="meson"
+    )
+
+    version("1.21.0", sha256="53b7fa67142e653820030ec049971bcb5e84ac99e05cba5bcb9cb55f43fae4b3")
+    version("1.20.0", sha256="20523cd6f2c18c3c86725467157c6221e19de76fbfad944042a2d494af3c7a92")
+    version("1.19.0", sha256="4e3b889468b9a4c2d16fc6489e28d000641e67c45dc97c4f6d9ecd3e261c895f")
     version("1.18.0", sha256="8d375719ebfa36b6f2968096fdf0bfa7d39ba110b7956c0032e395e7e012f332")
     version("1.17.93", sha256="293536ad23bfed15fc34e2a63bbb511167e8b096c0eba35e805cb64d46ad62ae")
     version("1.17.92", sha256="d944a7b999cfe6fee5327a2315c8e5891222c5a88a96e1ca73485978e4990512")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    with when("build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+
+    with when("build_system=meson"):
+        depends_on("meson@0.56.0:", type="build")
+
     depends_on("pkgconfig", type="build")
     depends_on("doxygen", type="build")
     depends_on("xmlto", type="build")
     depends_on("libxslt", type="build")
+    depends_on("docbook-xsl", type="build")
     depends_on("libxml2")
     depends_on("chrpath")
     depends_on("expat")

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -1,4 +1,4 @@
-so xxx# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
This adds a few new versions of wayland and wayland-protocols (I didn't go through all build combinations, but spot checked, earliest and last, and had no issues). This includes the URL change in #36216 but I left that PR smaller in scope so it can get merged earlier if there are changes requested here.

Added `docbook-xsl` as general dependency since it appears necessary and isn't picked up in a build of just wayland (but it didn't seem necessary in environments where that dependency gets installed for other reasons).