### PR TITLE
perl-dbd-pg: add v3.16.1

### DIFF
--- a/var/spack/repos/builtin/packages/perl-dbd-pg/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-pg/package.py
@@ -13,6 +13,7 @@ class PerlDbdPg(PerlPackage):
     homepage = "https://metacpan.org/pod/DBD::Pg"
     url = "https://cpan.metacpan.org/authors/id/T/TU/TURNSTEP/DBD-Pg-3.10.0.tar.gz"
 
+    version("3.16.1", sha256="8e917a746dacb1edce5832d8911e5938cc4863aeac4a52820382e7d174e9c3b9")
     version("3.10.0", sha256="e103268a63e2828e3d43659bdba5f743446cbbe047a766f843112eedae105f80")
 
     depends_on("postgresql")


### PR DESCRIPTION
Add perl-dbd-pg v3.16.1.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.