### PR TITLE
perl-data-optlist: add v0.113

### DIFF
--- a/var/spack/repos/builtin/packages/perl-data-optlist/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-optlist/package.py
@@ -12,6 +12,7 @@ class PerlDataOptlist(PerlPackage):
     homepage = "https://metacpan.org/pod/Data::OptList"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Data-OptList-0.110.tar.gz"
 
+    version("0.113", sha256="36aebc5817b7d4686b649434c2ee41f45c8bf97d4ca5a99f607cc40f695a4285")
     version("0.110", sha256="366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3")
 
     depends_on("perl-sub-install", type=("build", "run"))


### PR DESCRIPTION
Add perl-data-optlist v0.113.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.