### PR TITLE
perl-cpan-meta-check: add v0.017

### DIFF
--- a/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
+++ b/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
@@ -13,6 +13,7 @@ class PerlCpanMetaCheck(PerlPackage):
     homepage = "https://metacpan.org/pod/CPAN::Meta::Check"
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/CPAN-Meta-Check-0.014.tar.gz"
 
+    version("0.017", sha256="0454ab93f12780b1d579df15b5f939e09702e954be82028fadd40e8bc9b0f091")
     version("0.014", sha256="28a0572bfc1c0678d9ce7da48cf521097ada230f96eb3d063fcbae1cfe6a351f")
 
     depends_on("perl-test-deep", type=("build", "run"))


### PR DESCRIPTION
Add perl-cpan-meta-check v0.017.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.