### PR TITLE
perl-config-general: add v2.65

### DIFF
--- a/var/spack/repos/builtin/packages/perl-config-general/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-general/package.py
@@ -12,4 +12,5 @@ class PerlConfigGeneral(PerlPackage):
     homepage = "https://metacpan.org/pod/Config::General"
     url = "https://cpan.metacpan.org/authors/id/T/TL/TLINDEN/Config-General-2.63.tar.gz"
 
+    version("2.65", sha256="4d6d5754be3a9f30906836f0cc10e554c8832e14e7a1341efb15b05d706fc58f")
     version("2.63", sha256="0a9bf977b8aabe76343e88095d2296c8a422410fd2a05a1901f2b20e2e1f6fad")


### PR DESCRIPTION
Add perl-config-general v2.65.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.