### PR TITLE
perl-compress-raw-zlib: add v2.204

### DIFF
--- a/var/spack/repos/builtin/packages/perl-compress-raw-zlib/package.py
+++ b/var/spack/repos/builtin/packages/perl-compress-raw-zlib/package.py
@@ -12,6 +12,7 @@ class PerlCompressRawZlib(PerlPackage):
     homepage = "https://metacpan.org/pod/Compress::Raw::Zlib"
     url = "https://cpan.metacpan.org/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.081.tar.gz"
 
+    version("2.204", sha256="f161f4297efadbed79c8b096a75951784fc5ccd3170bd32866a19e5c6876d13f")
     version("2.081", sha256="e156de345bd224bbdabfcab0eeb3f678a3099a4e86c9d1b6771d880b55aa3a1b")
 
     depends_on("zlib")


### PR DESCRIPTION
Add perl-compress-raw-zlib v2.204.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.