### PR TITLE
perl-compress-raw-bzip2: add v2.204

### DIFF
--- a/var/spack/repos/builtin/packages/perl-compress-raw-bzip2/package.py
+++ b/var/spack/repos/builtin/packages/perl-compress-raw-bzip2/package.py
@@ -12,6 +12,7 @@ class PerlCompressRawBzip2(PerlPackage):
     homepage = "https://metacpan.org/pod/Compress::Raw::Bzip2"
     url = "http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.081.tar.gz"
 
+    version("2.204", sha256="ee7b490e67e7e2a7a0e8c1e1aa29a9610066149f46b836921149ad1813f70c69")
     version("2.081", sha256="8692b5c9db91954408e24e805fbfda222879da80d89d9410791421e3e5bc3520")
 
     depends_on("bzip2")


### PR DESCRIPTION
Add perl-compress-raw-bzip2 v2.204.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.