### PR TITLE
perl-clone: add v0.46

### DIFF
--- a/var/spack/repos/builtin/packages/perl-clone/package.py
+++ b/var/spack/repos/builtin/packages/perl-clone/package.py
@@ -12,4 +12,5 @@ class PerlClone(PerlPackage):
     homepage = "https://metacpan.org/pod/Clone"
     url = "https://cpan.metacpan.org/authors/id/G/GA/GARU/Clone-0.41.tar.gz"
 
+    version("0.46", sha256="aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b")
     version("0.41", sha256="e8c056dcf4bc8889079a09412af70194a54a269689ba72edcd91291a46a51518")


### PR DESCRIPTION
Add perl-clone v0.46.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.