### PR TITLE
perl-class-method-modifiers: add v2.15

### DIFF
--- a/var/spack/repos/builtin/packages/perl-class-method-modifiers/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-method-modifiers/package.py
@@ -13,6 +13,7 @@ class PerlClassMethodModifiers(PerlPackage):
     homepage = "https://metacpan.org/pod/Class::Method::Modifiers"
     url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Class-Method-Modifiers-2.13.tar.gz"
 
+    version("2.15", sha256="65cd85bfe475d066e9186f7a8cc636070985b30b0ebb1cde8681cf062c2e15fc")
     version("2.13", sha256="ab5807f71018a842de6b7a4826d6c1f24b8d5b09fcce5005a3309cf6ea40fd63")
 
     depends_on("perl-carp", type=("build", "run"))


### PR DESCRIPTION
Add perl-class-method-modifiers v2.15.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.