### PR TITLE
perl-class-load: add v0.25

### DIFF
--- a/var/spack/repos/builtin/packages/perl-class-load/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-load/package.py
@@ -12,4 +12,5 @@ class PerlClassLoad(PerlPackage):
     homepage = "https://metacpan.org/pod/Class::Load"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Class-Load-0.24.tar.gz"
 
+    version("0.25", sha256="2a48fa779b5297e56156380e8b32637c6c58decb4f4a7f3c7350523e11275f8f")
     version("0.24", sha256="0bb983da46c146534fc77a556d6e40d925142f2eb43103534025ee545265ca36")


### PR DESCRIPTION
Add perl-class-load v0.25.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.