### PR TITLE
homer: add v4.11.1

### DIFF
--- a/var/spack/repos/builtin/packages/homer/package.py
+++ b/var/spack/repos/builtin/packages/homer/package.py
@@ -14,6 +14,7 @@ class Homer(Package):
     homepage = "http://homer.ucsd.edu/homer"
     url = "http://homer.ucsd.edu/homer/data/software/homer.v4.9.1.zip"
 
+    version("4.11.1", sha256="80d1cd00616729894017b24a36a2ef81f9cde8bd364e875aead1e0cfb500c82b")
     version("4.9.1", sha256="ad1303b0b0400dc8a88dbeae1ee03a94631977b751a3d335326c4febf0eec3a9")
 
     depends_on("perl", type=("build", "run"))


### PR DESCRIPTION
Add homer v4.11.1.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.