### PR TITLE
qt-* (Qt6 pkgs): new version 6.4.3

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -89,6 +89,7 @@ class QtBase(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    version("6.4.3", sha256="e156692029a5503bad5f681bda856dd9df9dec17baa0ca7ee36b10178503ed40")
     version("6.4.2", sha256="c138ae734cfcde7a92a7efd97a902e53f3cd2c2f89606dfc482d0756f60cdc23")
     version("6.4.1", sha256="0ef6db6b3e1074e03dcae7e689144af66fd51b95a6efe949d40281cc43e6fecf")
     version("6.4.0", sha256="fbc462816bf5b87d521e9f69cebe0ce331de2258396e0932fa580283f07fce0c")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -14,6 +14,7 @@ class QtDeclarative(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    version("6.4.3", sha256="9549668f8ec28199ba19d73fb535855dc5bea690097f43c2f91954bc27ee0fa3")
     version("6.4.2", sha256="dec3599b55f75cff044cc6384fa2f7e9505f8a48af1b4c185c2789e2dafabda6")
     version("6.4.1", sha256="23b5c91e98ec2b8a4118a3d3ace0c2e61b355cc8f2ccb87d189708b69446f917")
     version("6.4.0", sha256="daf7b97be51451af5afa35e1c0421fb8964003852088b0293c144a12bd664cd1")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -14,6 +14,7 @@ class QtQuick3d(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    version("6.4.3", sha256="609f37efb97c9ef893630b5d29f1ad98a51a47700e260c604931285ac8521479")
     version("6.4.2", sha256="940145615fe3c4c8fb346c5bfc10f94fc7a4005c8c187886e0f3088ea0ce0778")
     version("6.4.1", sha256="67daeed69b9e7b3da516c6205e737fdba30a267978c1fb9d34723a6dc5588585")
     version("6.4.0", sha256="37987536da151b7c2cddabfde734759ebe6173708d32cb85aa008e151751270e")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -24,6 +24,8 @@ class QtQuick3d(QtPackage):
     version("6.2.4", sha256="7292ed4373a92913c6811f2faa5191f0426f84bd93a3f6eb7d54b62626b56db5")
     version("6.2.3", sha256="35d06edbdd83b7d781b70e0bada18911fa9b774b6403589d5b21813a73584d80")
 
+    depends_on("qt-base +network", when="@6.3.0:")
+
     depends_on("assimp@5.0.1:")
     depends_on("embree", when="@6.4:")
 

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -14,6 +14,7 @@ class QtQuicktimeline(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    version("6.4.3", sha256="e0f8f616a9c7d150dc73eccf7546ab4db041a05b85eafcb44b999cb41549dbed")
     version("6.4.2", sha256="af7449bf5954d2309081d6d65af7fd31cb11a5f8dc5f414163120d582f82353f")
     version("6.4.1", sha256="20450687941e6e12e1adf428114776c304d14447d61a4e8b08050c7c18463ee7")
     version("6.4.0", sha256="b5f88beaa726032141fab91b84bc3b268f6213518301c4ddcfa7d116fd08bdab")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -16,6 +16,7 @@ class QtShadertools(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    version("6.4.3", sha256="a018883e889540ab828db0b0b49a3c5d810dd7283bb84abf43d1622daf474f7d")
     version("6.4.2", sha256="7f29a78769f454fe529595acb693aa67812e80d894162ddad3f0444f65a22268")
     version("6.4.1", sha256="d325724c4ed79c759ac8cbbca5f9fd4b0e6e8d61a9ac58921cb1dac75c104687")
     version("6.4.0", sha256="51bf312965bd673193221cd49019f504feb79c0bf0ff01d6a6ca5c8d15f9d7c1")


### PR DESCRIPTION
New bugfix versions of Qt-6 packages currently in spack. Succesfully built locally without any issues, except for the additional of the `+network` requirement in `qt-quick3d` for `6.3.0:`, see commit description in https://github.com/spack/spack/pull/36235/commits/0fe65e6f890652073a8eadcdd029651740a55b40.