### PR TITLE
Xorg libs: updated versions to current latest

### DIFF
--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -14,6 +14,9 @@ class Libice(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    version("1.1.1", sha256="04fbd34a11ba08b9df2e3cdb2055c2e3c1c51b3257f683d7fcf42dabcf8e1210")
+    version("1.1.0", sha256="7a735ec530d7a437955747eabac06bbc0b695da77fd1b4d1df3b0a483d823875")
+    version("1.0.10", sha256="1116bc64c772fd127a0d0c0ffa2833479905e3d3d8197740b3abd5f292f22d2d")
     version("1.0.9", sha256="7812a824a66dd654c830d21982749b3b563d9c2dfe0b88b203cefc14a891edc0")
 
     depends_on("xproto")

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -14,6 +14,8 @@ class Libice(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    maintainers("wdconinc")
+
     version("1.1.1", sha256="04fbd34a11ba08b9df2e3cdb2055c2e3c1c51b3257f683d7fcf42dabcf8e1210")
     version("1.1.0", sha256="7a735ec530d7a437955747eabac06bbc0b695da77fd1b4d1df3b0a483d823875")
     version("1.0.10", sha256="1116bc64c772fd127a0d0c0ffa2833479905e3d3d8197740b3abd5f292f22d2d")

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -14,9 +14,11 @@ class Libsm(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.2.4", sha256="51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15")
     version("1.2.3", sha256="1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320")
     version("1.2.2", sha256="14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4")
 
+    depends_on("libice@1.1.0:", when="@1.2.4:")
     depends_on("libice@1.0.5:")
     depends_on("uuid")
 

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -14,6 +14,8 @@ class Libsm(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.2.4", sha256="51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15")
     version("1.2.3", sha256="1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320")
     version("1.2.2", sha256="14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4")

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -14,6 +14,8 @@ class Libx11(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    maintainers("wdconinc")
+
     version("1.8.4", sha256="efd3a3a43c1f177edc2c205bedb0719b6648203595e54c0b83a32576aeaca7cd")
     version("1.8.3", sha256="5a55945b7da86ce94733faf229342f75867e9c1090685f47f4d82b7f88602a14")
     version("1.8.2", sha256="f1bc56187bee0f830e1179ac5068ac93b78c51ace94eb27702ffb2efd116587b")

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -15,11 +15,22 @@ class Libx11(AutotoolsPackage, XorgPackage):
     license("X11")
 
     version("1.8.4", sha256="efd3a3a43c1f177edc2c205bedb0719b6648203595e54c0b83a32576aeaca7cd")
+    version("1.8.3", sha256="5a55945b7da86ce94733faf229342f75867e9c1090685f47f4d82b7f88602a14")
+    version("1.8.2", sha256="f1bc56187bee0f830e1179ac5068ac93b78c51ace94eb27702ffb2efd116587b")
+    version("1.8.1", sha256="d52f0a7c02a45449f37b0831d99ff936d92eb4ce8b4c97dc17a63cea79ce5a76")
+    version("1.8", sha256="68e0a30c4248b9f41492891a4b49672c3b0c59e84c4868144f03eef01ebc5eea")
+    version("1.7.5", sha256="78992abcd2bfdebe657699203ad8914e7ae77025175460e04a1045387192a978")
+    version("1.7.4", sha256="252fb028524caa878e6507729efc115d7434f867f6549fe087e7869a66adfa2c")
+    version("1.7.3.1", sha256="d9d2c45f89687cfc915a766aa91f01843ae97607baa1d1027fd208f8e014f71e")
+    version("1.7.3", sha256="029acf61e7e760a3150716b145a58ce5052ee953e8cccc8441d4f550c420debb")
+    version("1.7.2", sha256="2c26ccd08f43a6214de89110554fbe97c71692eeb7e7d4829f3004ae6fafd2c0")
+    version("1.7.1", sha256="7e6d4120696e90995e66ac24f1042d4f11c14fbefd7aab48de0ed1fe3c4b922b")
     version("1.7.0", sha256="c48ec61785ec68fc6a9a6aca0a9578393414fe2562e3cc9cca30234345c7b6ac")
     version("1.6.7", sha256="f62ab88c2a87b55e1dc338726a55bb6ed8048084fe6a3294a7ae324ca45159d1")
     version("1.6.5", sha256="3abce972ba62620611fab5b404dafb852da3da54e7c287831c30863011d28fb3")
     version("1.6.3", sha256="0b03b9d22f4c9e59b4ba498f294e297f013cae27050dfa0f3496640200db5376")
 
+    depends_on("libxcb@1.11.1:", when="@1.6.4:")
     depends_on("libxcb@1.1.92:")
 
     depends_on("xproto@7.0.25:", when="@1.7.0:")

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -16,6 +16,9 @@ class Libx11(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.7", sha256="793ebebf569f12c864b77401798d38814b51790fce206e01a431e5feb982e20b")
+    version("1.8.6", sha256="5ff0d26c94d82ebb94a944b9f1f55cd01b9713fd461fe93f62f3527ce14ad94e")
+    version("1.8.5", sha256="d84a35c324d5a1724692eafc1ed76f1689c833021e0062933773ec437f91a56b")
     version("1.8.4", sha256="efd3a3a43c1f177edc2c205bedb0719b6648203595e54c0b83a32576aeaca7cd")
     version("1.8.3", sha256="5a55945b7da86ce94733faf229342f75867e9c1090685f47f4d82b7f88602a14")
     version("1.8.2", sha256="f1bc56187bee0f830e1179ac5068ac93b78c51ace94eb27702ffb2efd116587b")

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -16,6 +16,8 @@ class Libxau(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.0.11", sha256="3a321aaceb803577a4776a5efe78836eb095a9e44bbc7a465d29463e1a14f189")
     version("1.0.10", sha256="51a54da42475d4572a0b59979ec107c27dacf6c687c2b7b04e5cf989a7c7e60c")
     version("1.0.9", sha256="1f123d8304b082ad63a9e89376400a3b1d4c29e67e3ea07b3f659cccca690eea")

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -16,6 +16,9 @@ class Libxau(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.0.11", sha256="3a321aaceb803577a4776a5efe78836eb095a9e44bbc7a465d29463e1a14f189")
+    version("1.0.10", sha256="51a54da42475d4572a0b59979ec107c27dacf6c687c2b7b04e5cf989a7c7e60c")
+    version("1.0.9", sha256="1f123d8304b082ad63a9e89376400a3b1d4c29e67e3ea07b3f659cccca690eea")
     version("1.0.8", sha256="c343b4ef66d66a6b3e0e27aa46b37ad5cab0f11a5c565eafb4a1c7590bc71d7b")
 
     depends_on("xproto")

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -15,6 +15,8 @@ class Libxaw(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.0.15", sha256="ca8a613884c922985202075b3cc8ee8821bfa83a5eb066189ae3cca131e63972")
     version("1.0.14", sha256="59cfed2712cc80bbfe62dd1aacf24f58d74a76dd08329a922077b134a8d8048f")
     version("1.0.13", sha256="7e74ac3e5f67def549722ff0333d6e6276b8becd9d89615cda011e71238ab694")

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -15,6 +15,8 @@ class Libxaw(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.0.15", sha256="ca8a613884c922985202075b3cc8ee8821bfa83a5eb066189ae3cca131e63972")
+    version("1.0.14", sha256="59cfed2712cc80bbfe62dd1aacf24f58d74a76dd08329a922077b134a8d8048f")
     version("1.0.13", sha256="7e74ac3e5f67def549722ff0333d6e6276b8becd9d89615cda011e71238ab694")
     version("1.0.12", sha256="e32abc68d759ffb643f842329838f8b6c157e31023cc91059aabf730e7222ad2")
 

--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -15,6 +15,8 @@ class Libxaw3d(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.6.4", sha256="09fecfdab9d7d5953567883e2074eb231bc7a122a06e5055f9c119090f1f76a7")
     version("1.6.2", sha256="847dab01aeac1448916e3b4edb4425594b3ac2896562d9c7141aa4ac6c898ba9")
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,6 +17,7 @@ class Libxcb(AutotoolsPackage):
 
     license("MIT")
 
+    version("1.15", sha256="cc38744f817cf6814c847e2df37fcb8997357d72fa4bcbc228ae0fe47219a059")
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
 
@@ -26,6 +27,7 @@ class Libxcb(AutotoolsPackage):
 
     # libxcb 1.X requires xcb-proto >= 1.X
     depends_on("xcb-proto")
+    depends_on("xcb-proto@1.15:", when="@1.15")
     depends_on("xcb-proto@1.14:", when="@1.14")
     depends_on("xcb-proto@1.13:", when="@1.13")
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,6 +17,8 @@ class Libxcb(AutotoolsPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.15", sha256="cc38744f817cf6814c847e2df37fcb8997357d72fa4bcbc228ae0fe47219a059")
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -19,6 +19,7 @@ class Libxcb(AutotoolsPackage):
 
     maintainers("wdconinc")
 
+    version("1.16", sha256="4348566aa0fbf196db5e0a576321c65966189210cb51328ea2bb2be39c711d71")
     version("1.15", sha256="cc38744f817cf6814c847e2df37fcb8997357d72fa4bcbc228ae0fe47219a059")
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -15,6 +15,8 @@ class Libxcomposite(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("0.4.6", sha256="3599dfcd96cd48d45e6aeb08578aa27636fa903f480f880c863622c2b352d076")
     version("0.4.4", sha256="83c04649819c6f52cda1b0ce8bcdcc48ad8618428ad803fb07f20b802f1bdad1")
 

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -22,5 +22,6 @@ class Libxcomposite(AutotoolsPackage, XorgPackage):
     depends_on("libxfixes")
     depends_on("fixesproto@0.4:")
     depends_on("compositeproto@0.4:")
+    depends_on("xproto@7.0.22:", when="@0.4.6")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -14,6 +14,8 @@ class Libxcursor(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.2.1", sha256="77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98")
     version("1.1.14", sha256="be0954faf274969ffa6d95b9606b9c0cfee28c13b6fc014f15606a0c8b05c17b")
 

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -14,6 +14,8 @@ class Libxdamage(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.6", sha256="2afcc139eb6eb926ffe344494b1fc023da25def42874496e6e6d3aa8acef8595")
+    version("1.1.5", sha256="630ec53abb8c2d6dac5cd9f06c1f73ffb4a3167f8118fdebd77afd639dbc2019")
     version("1.1.4", sha256="4bb3e9d917f5f593df2277d452926ee6ad96de7b7cd1017cbcf4579fe5d3442b")
 
     depends_on("libxfixes")

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -14,6 +14,8 @@ class Libxdamage(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.6", sha256="2afcc139eb6eb926ffe344494b1fc023da25def42874496e6e6d3aa8acef8595")
     version("1.1.5", sha256="630ec53abb8c2d6dac5cd9f06c1f73ffb4a3167f8118fdebd77afd639dbc2019")
     version("1.1.4", sha256="4bb3e9d917f5f593df2277d452926ee6ad96de7b7cd1017cbcf4579fe5d3442b")

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -14,6 +14,8 @@ class Libxdmcp(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.4", sha256="55041a8ff8992ab02777478c4b19c249c0f8399f05a752cb4a1a868a9a0ccb9a")
     version("1.1.3", sha256="2ef9653d32e09d1bf1b837d0e0311024979653fe755ad3aaada8db1aa6ea180c")
     version("1.1.2", sha256="6f7c7e491a23035a26284d247779174dedc67e34e93cc3548b648ffdb6fc57c0")

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -15,6 +15,7 @@ class Libxdmcp(AutotoolsPackage, XorgPackage):
     license("MIT")
 
     version("1.1.4", sha256="55041a8ff8992ab02777478c4b19c249c0f8399f05a752cb4a1a868a9a0ccb9a")
+    version("1.1.3", sha256="2ef9653d32e09d1bf1b837d0e0311024979653fe755ad3aaada8db1aa6ea180c")
     version("1.1.2", sha256="6f7c7e491a23035a26284d247779174dedc67e34e93cc3548b648ffdb6fc57c0")
 
     depends_on("xproto")

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -14,6 +14,8 @@ class Libxext(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.3.5", sha256="1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd")
+    version("1.3.4", sha256="8ef0789f282826661ff40a8eef22430378516ac580167da35cc948be9041aac1")
     version("1.3.3", sha256="eb0b88050491fef4716da4b06a4d92b4fc9e76f880d6310b2157df604342cfe5")
 
     depends_on("libx11@1.6:")

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -14,6 +14,8 @@ class Libxext(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.3.5", sha256="1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd")
     version("1.3.4", sha256="8ef0789f282826661ff40a8eef22430378516ac580167da35cc948be9041aac1")
     version("1.3.3", sha256="eb0b88050491fef4716da4b06a4d92b4fc9e76f880d6310b2157df604342cfe5")

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -17,6 +17,7 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    # Newer versions are blocked by https://github.com/spack/spack/issues/41688
     # version("6.0.1", sha256="e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec")
     # version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
     version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -17,8 +17,8 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
-    version("6.0.1", sha256="e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec")
-    version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
+    # version("6.0.1", sha256="e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec")
+    # version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
     version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")
     version("5.0.2", sha256="ad8df1ecf3324512b80ed12a9ca07556e561b14256d94216e67a68345b23c981")
 
@@ -26,7 +26,7 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     depends_on("xproto")
     depends_on("fixesproto@5.0:", when="@5")
-    depends_on("fixesproto@6.0:", when="@6")
+    # depends_on("fixesproto@6.0:", when="@6")
     depends_on("xextproto")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -15,12 +15,15 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
+    version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")
     version("5.0.2", sha256="ad8df1ecf3324512b80ed12a9ca07556e561b14256d94216e67a68345b23c981")
 
     depends_on("libx11@1.6:")
 
     depends_on("xproto")
-    depends_on("fixesproto@5.0:")
+    depends_on("fixesproto@5.0:", when="@5")
+    depends_on("fixesproto@6.0:", when="@6")
     depends_on("xextproto")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -15,6 +15,8 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
     version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")
     version("5.0.2", sha256="ad8df1ecf3324512b80ed12a9ca07556e561b14256d94216e67a68345b23c981")

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -17,6 +17,7 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("6.0.1", sha256="e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec")
     version("6.0.0", sha256="82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7")
     version("5.0.3", sha256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570")
     version("5.0.2", sha256="ad8df1ecf3324512b80ed12a9ca07556e561b14256d94216e67a68345b23c981")

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -18,6 +18,8 @@ class Libxft(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("2.3.7", sha256="75b4378644f5df3a15f684f8f0b5ff1324d37aacd5a381f3b830a2fbe985f660")
     version("2.3.6", sha256="b7e59f69e0bbabe9438088775f7e5a7c16a572e58b11f9722519385d38192df5")
     version("2.3.5", sha256="f7324aa0664115223672bae55086f3a9ae8f6ad4cdca87a8dd620295ee459e1a")

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -20,6 +20,7 @@ class Libxft(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("2.3.8", sha256="32e48fe2d844422e64809e4e99b9d8aed26c1b541a5acf837c5037b8d9f278a8")
     version("2.3.7", sha256="75b4378644f5df3a15f684f8f0b5ff1324d37aacd5a381f3b830a2fbe985f660")
     version("2.3.6", sha256="b7e59f69e0bbabe9438088775f7e5a7c16a572e58b11f9722519385d38192df5")
     version("2.3.5", sha256="f7324aa0664115223672bae55086f3a9ae8f6ad4cdca87a8dd620295ee459e1a")

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -18,6 +18,11 @@ class Libxft(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("2.3.7", sha256="75b4378644f5df3a15f684f8f0b5ff1324d37aacd5a381f3b830a2fbe985f660")
+    version("2.3.6", sha256="b7e59f69e0bbabe9438088775f7e5a7c16a572e58b11f9722519385d38192df5")
+    version("2.3.5", sha256="f7324aa0664115223672bae55086f3a9ae8f6ad4cdca87a8dd620295ee459e1a")
+    version("2.3.4", sha256="1eca71bec9cb483165ce1ab94f5cd3036269f5268651df6a2d99c4a7ab644d79")
+    version("2.3.3", sha256="3c3cf88b1a96e49a3d87d67d9452d34b6e25e96ae83959b8d0a980935014d701")
     version("2.3.2", sha256="26cdddcc70b187833cbe9dc54df1864ba4c03a7175b2ca9276de9f05dce74507")
 
     depends_on("freetype@2.1.6:")

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -14,6 +14,8 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     license("MIT AND X11")
 
+    maintainers("wdconinc")
+
     version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
     version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")
     version("1.7.9", sha256="463cc5370191404bc0f8a450fdbf6d9159efbbf274e5e0f427a60191fed9cf4b")

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -16,6 +16,7 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    # Newer versions are blocked by https://github.com/spack/spack/issues/41688
     # version("1.8.1", sha256="3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea")
     # version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
     version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -16,8 +16,8 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
-    version("1.8.1", sha256="3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea")
-    version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
+    # version("1.8.1", sha256="3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea")
+    # version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
     version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")
     version("1.7.9", sha256="463cc5370191404bc0f8a450fdbf6d9159efbbf274e5e0f427a60191fed9cf4b")
     version("1.7.8", sha256="7466d0c626a9cc2e53fd78c811815e82924cd7582236a82401df3d282a9c2889")
@@ -32,7 +32,7 @@ class Libxi(AutotoolsPackage, XorgPackage):
     depends_on("xproto@7.0.13:")
     depends_on("xextproto@7.0.3:")
     depends_on("inputproto@2.2.99.1:", when="@1.7:")
-    depends_on("inputproto@2.3.99.1:", when="@1.8:")
+    # depends_on("inputproto@2.3.99.1:", when="@1.8:")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -14,6 +14,11 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     license("MIT AND X11")
 
+    version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
+    version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")
+    version("1.7.9", sha256="463cc5370191404bc0f8a450fdbf6d9159efbbf274e5e0f427a60191fed9cf4b")
+    version("1.7.8", sha256="7466d0c626a9cc2e53fd78c811815e82924cd7582236a82401df3d282a9c2889")
+    version("1.7.7", sha256="501f49e9c85609da17614d711aa4931fd128011042ff1cae53a16ce03e51ff5e")
     version("1.7.6", sha256="4e88fa7decd287e58140ea72238f8d54e4791de302938c83695fc0c9ac102b7e")
 
     depends_on("pkgconfig", type="build")
@@ -23,7 +28,8 @@ class Libxi(AutotoolsPackage, XorgPackage):
     depends_on("fixesproto@5.0:")
     depends_on("xproto@7.0.13:")
     depends_on("xextproto@7.0.3:")
-    depends_on("inputproto@2.2.99.1:")
+    depends_on("inputproto@2.2.99.1:", when="@1.7:")
+    depends_on("inputproto@2.3.99.1:", when="@1.8:")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -16,6 +16,7 @@ class Libxi(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.1", sha256="3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea")
     version("1.8", sha256="c80fd200a1190e4406bb4cc6958839d9651638cb47fa546a595d4bebcd3b9e2d")
     version("1.7.10", sha256="b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3")
     version("1.7.9", sha256="463cc5370191404bc0f8a450fdbf6d9159efbbf274e5e0f427a60191fed9cf4b")

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -14,6 +14,8 @@ class Libxinerama(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.5", sha256="2efa855cb42dc620eff3b77700d8655695e09aaa318f791f201fa60afa72b95c")
+    version("1.1.4", sha256="64de45e18cc76b8e703cb09b3c9d28bd16e3d05d5cd99f2d630de2d62c3acc18")
     version("1.1.3", sha256="0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -14,6 +14,8 @@ class Libxinerama(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.5", sha256="2efa855cb42dc620eff3b77700d8655695e09aaa318f791f201fa60afa72b95c")
     version("1.1.4", sha256="64de45e18cc76b8e703cb09b3c9d28bd16e3d05d5cd99f2d630de2d62c3acc18")
     version("1.1.3", sha256="0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44")

--- a/var/spack/repos/builtin/packages/libxkbfile/package.py
+++ b/var/spack/repos/builtin/packages/libxkbfile/package.py
@@ -14,6 +14,8 @@ class Libxkbfile(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.2", sha256="d1a7e659bc7ae1aa1fc1ecced261c734df5ad5d86af1ef7a946be0e2d841e51d")
     version("1.1.1", sha256="87faee6d4873c5631e8bb53e85134084b862185da682de8617f08ca18d82e216")
     version("1.1.0", sha256="2a92adda3992aa7cbad758ef0b8dfeaedebb49338b772c64ddf369d78c1c51d3")

--- a/var/spack/repos/builtin/packages/libxkbfile/package.py
+++ b/var/spack/repos/builtin/packages/libxkbfile/package.py
@@ -14,6 +14,9 @@ class Libxkbfile(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="d1a7e659bc7ae1aa1fc1ecced261c734df5ad5d86af1ef7a946be0e2d841e51d")
+    version("1.1.1", sha256="87faee6d4873c5631e8bb53e85134084b862185da682de8617f08ca18d82e216")
+    version("1.1.0", sha256="2a92adda3992aa7cbad758ef0b8dfeaedebb49338b772c64ddf369d78c1c51d3")
     version("1.0.9", sha256="95df50570f38e720fb79976f603761ae6eff761613eb56f258c3cb6bab4fd5e3")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -17,6 +17,8 @@ class Libxmu(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.4", sha256="3091d711cdc1d8ea0f545a13b90d1464c3c3ab64778fd121f0d789b277a80289")
     version("1.1.2", sha256="e5fd4bacef068f9509b8226017205040e38d3fba8d2de55037200e7176c13dba")
 

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -12,6 +12,7 @@ class Libxp(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXp"
     xorg_mirror_path = "lib/libXp-1.0.3.tar.gz"
 
+    version("1.0.4", sha256="05e46af1ccb68f1752cca5879774a4fb9bf3b19fe088eb745034956e0c6fadba")
     version("1.0.3", sha256="f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c")
 
     depends_on("libx11@1.6:")

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -12,6 +12,8 @@ class Libxp(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXp"
     xorg_mirror_path = "lib/libXp-1.0.3.tar.gz"
 
+    maintainers("wdconinc")
+
     version("1.0.4", sha256="05e46af1ccb68f1752cca5879774a4fb9bf3b19fe088eb745034956e0c6fadba")
     version("1.0.3", sha256="f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c")
 

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -14,6 +14,9 @@ class Libxpm(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    version("3.5.15", sha256="2a9bd419e31270593e59e744136ee2375ae817322447928d2abb6225560776f9")
+    version("3.5.14", sha256="18861cc64dfffc0e7fe317b0eeb935adf64858fd5d82004894c4906d909dabf8")
+    version("3.5.13", sha256="e3dfb0fb8c1f127432f2a498c7856b37ce78a61e8da73f1aab165a73dd97ad00")
     version("3.5.12", sha256="2523acc780eac01db5163267b36f5b94374bfb0de26fc0b5a7bee76649fd8501")
     version("3.5.11", sha256="53ddf924441b7ed2de994d4934358c13d9abf4828b1b16e1255ade5032b31df7")
     version("3.5.10", sha256="f73f06928a140fd2090c439d1d55c6682095044495af6bf886f8e66cf21baee5")

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -16,6 +16,8 @@ class Libxpm(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("3.5.17", sha256="959466c7dfcfcaa8a65055bfc311f74d4c43d9257900f85ab042604d286df0c6")
+    version("3.5.16", sha256="43a70e6f9b67215fb223ca270d83bdcb868c513948441d5b781ea0765df6bfb4")
     version("3.5.15", sha256="2a9bd419e31270593e59e744136ee2375ae817322447928d2abb6225560776f9")
     version("3.5.14", sha256="18861cc64dfffc0e7fe317b0eeb935adf64858fd5d82004894c4906d909dabf8")
     version("3.5.13", sha256="e3dfb0fb8c1f127432f2a498c7856b37ce78a61e8da73f1aab165a73dd97ad00")

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -14,6 +14,8 @@ class Libxpm(AutotoolsPackage, XorgPackage):
 
     license("X11")
 
+    maintainers("wdconinc")
+
     version("3.5.15", sha256="2a9bd419e31270593e59e744136ee2375ae817322447928d2abb6225560776f9")
     version("3.5.14", sha256="18861cc64dfffc0e7fe317b0eeb935adf64858fd5d82004894c4906d909dabf8")
     version("3.5.13", sha256="e3dfb0fb8c1f127432f2a498c7856b37ce78a61e8da73f1aab165a73dd97ad00")

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -28,6 +28,7 @@ class Libxpm(AutotoolsPackage, XorgPackage):
     depends_on("libx11")
 
     depends_on("xproto")
+    depends_on("ncompress", when="@3.5.15")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 

--- a/var/spack/repos/builtin/packages/libxpresent/package.py
+++ b/var/spack/repos/builtin/packages/libxpresent/package.py
@@ -15,6 +15,7 @@ class Libxpresent(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.0.1", sha256="8ebf8567a8f6afe5a64275a2ecfd4c84e957970c27299d964350f60be9f3541d")
     version("1.0.0", sha256="92f1bdfb67ae2ffcdb25ad72c02cac5e4912dc9bc792858240df1d7f105946fa")
 
     depends_on("libx11", type="link")

--- a/var/spack/repos/builtin/packages/libxpresent/package.py
+++ b/var/spack/repos/builtin/packages/libxpresent/package.py
@@ -15,6 +15,8 @@ class Libxpresent(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.0.1", sha256="8ebf8567a8f6afe5a64275a2ecfd4c84e957970c27299d964350f60be9f3541d")
     version("1.0.0", sha256="92f1bdfb67ae2ffcdb25ad72c02cac5e4912dc9bc792858240df1d7f105946fa")
 

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -16,6 +16,7 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.5.4", sha256="c72c94dc3373512ceb67f578952c5d10915b38cc9ebb0fd176a49857b8048e22")
     version("1.5.3", sha256="3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f")
     version("1.5.0", sha256="1b594a149e6b124aab7149446f2fd886461e2935eca8dca43fe83a70cf8ec451")
 

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -14,6 +14,8 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.5.3", sha256="3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f")
     version("1.5.0", sha256="1b594a149e6b124aab7149446f2fd886461e2935eca8dca43fe83a70cf8ec451")
 

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -14,6 +14,8 @@ class Libxrender(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("0.9.11", sha256="6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667")
     version("0.9.10", sha256="770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf")
     version("0.9.9", sha256="beeac64ff8d225f775019eb7c688782dee9f4cc7b412a65538f8dde7be4e90fe")

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -14,6 +14,7 @@ class Libxrender(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("0.9.11", sha256="6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667")
     version("0.9.10", sha256="770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf")
     version("0.9.9", sha256="beeac64ff8d225f775019eb7c688782dee9f4cc7b412a65538f8dde7be4e90fe")
 

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -14,12 +14,17 @@ class Libxres(AutotoolsPackage, XorgPackage):
 
     license("custom")
 
+    version("1.2.2", sha256="8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950")
+    version("1.2.1", sha256="918fb33c3897b389a1fbb51571c5c04c6b297058df286d8b48faa5af85e88bcc")
+    version("1.2.0", sha256="5b62feee09f276d74054787df030fceb41034de84174abec6d81c591145e043a")
     version("1.0.7", sha256="488c9fa14b38f794d1f019fe62e6b06514a39f1a7538e55ece8faf22482fefcd")
 
     depends_on("libx11")
     depends_on("libxext")
 
     depends_on("xextproto")
-    depends_on("resourceproto@1.0:")
+    depends_on("resourceproto@1.0:", when="@1.0")
+    depends_on("resourceproto@1.2:", when="@1.2")
+
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -14,6 +14,8 @@ class Libxres(AutotoolsPackage, XorgPackage):
 
     license("custom")
 
+    maintainers("wdconinc")
+
     version("1.2.2", sha256="8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950")
     version("1.2.1", sha256="918fb33c3897b389a1fbb51571c5c04c6b297058df286d8b48faa5af85e88bcc")
     version("1.2.0", sha256="5b62feee09f276d74054787df030fceb41034de84174abec6d81c591145e043a")

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -14,6 +14,8 @@ class Libxscrnsaver(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.2.4", sha256="0656b2630475104d6df75d91ebb8e0153e61d14e9871ef1f403bcda4a62a838a")
     version("1.2.3", sha256="4f74e7e412144591d8e0616db27f433cfc9f45aae6669c6c4bb03e6bf9be809a")
     version("1.2.2", sha256="e12ba814d44f7b58534c0d8521e2d4574f7bf2787da405de4341c3b9f4cc8d96")

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -14,6 +14,8 @@ class Libxscrnsaver(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.2.4", sha256="0656b2630475104d6df75d91ebb8e0153e61d14e9871ef1f403bcda4a62a838a")
+    version("1.2.3", sha256="4f74e7e412144591d8e0616db27f433cfc9f45aae6669c6c4bb03e6bf9be809a")
     version("1.2.2", sha256="e12ba814d44f7b58534c0d8521e2d4574f7bf2787da405de4341c3b9f4cc8d96")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -16,6 +16,7 @@ class Libxt(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.3.0", sha256="de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77")
     version("1.2.1", sha256="6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33")
     version("1.2.0", sha256="d4bee88898fc5e1dc470e361430c72fbc529b9cdbbb6c0ed3affea3a39f97d8d")
     version("1.1.5", sha256="b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3")

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -14,6 +14,8 @@ class Libxt(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.2.1", sha256="6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33")
+    version("1.2.0", sha256="d4bee88898fc5e1dc470e361430c72fbc529b9cdbbb6c0ed3affea3a39f97d8d")
     version("1.1.5", sha256="b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3")
 
     depends_on("libsm")

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -14,6 +14,8 @@ class Libxt(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.2.1", sha256="6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33")
     version("1.2.0", sha256="d4bee88898fc5e1dc470e361430c72fbc529b9cdbbb6c0ed3affea3a39f97d8d")
     version("1.1.5", sha256="b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3")

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -23,6 +23,8 @@ class Libxtst(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.2.4", sha256="01366506aeb033f6dffca5326af85f670746b0cabbfd092aabefb046cf48c445")
+    version("1.2.3", sha256="a0c83acce02d4923018c744662cb28eb0dbbc33b4adc027726879ccf68fbc2c2")
     version("1.2.2", sha256="221838960c7b9058cd6795c1c3ee8e25bae1c68106be314bc3036a4f26be0e6c")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -23,6 +23,8 @@ class Libxtst(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.2.4", sha256="01366506aeb033f6dffca5326af85f670746b0cabbfd092aabefb046cf48c445")
     version("1.2.3", sha256="a0c83acce02d4923018c744662cb28eb0dbbc33b4adc027726879ccf68fbc2c2")
     version("1.2.2", sha256="221838960c7b9058cd6795c1c3ee8e25bae1c68106be314bc3036a4f26be0e6c")

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -15,6 +15,8 @@ class Libxv(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.0.12", sha256="ce706619a970a580a0e35e9b5c98bdd2af243ac6494c65f44608a89a86100126")
     version("1.0.11", sha256="c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1")
     version("1.0.10", sha256="89a664928b625558268de81c633e300948b3752b0593453d7815f8775bab5293")

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -15,6 +15,8 @@ class Libxv(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.0.12", sha256="ce706619a970a580a0e35e9b5c98bdd2af243ac6494c65f44608a89a86100126")
+    version("1.0.11", sha256="c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1")
     version("1.0.10", sha256="89a664928b625558268de81c633e300948b3752b0593453d7815f8775bab5293")
 
     depends_on("libx11@1.6:")

--- a/var/spack/repos/builtin/packages/libxvmc/package.py
+++ b/var/spack/repos/builtin/packages/libxvmc/package.py
@@ -14,6 +14,10 @@ class Libxvmc(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.0.13", sha256="e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e")
+    version("1.0.12", sha256="024c9ec4f001f037eeca501ee724c7e51cf287eb69ced8c6126e16e7fa9864b5")
+    version("1.0.11", sha256="0b931d216b23b95df87cc65f7bb7acef4120d9263adb0a4d90856ba1f7a390da")
+    version("1.0.10", sha256="d8306f71c798d10409bb181b747c2644e1d60c05773c742c12304ab5aa5c8436")
     version("1.0.9", sha256="090f087fe65b30b3edfb996c79ff6cf299e473fb25e955fff1c4e9cb624da2c2")
 
     depends_on("libx11@1.6:")

--- a/var/spack/repos/builtin/packages/libxvmc/package.py
+++ b/var/spack/repos/builtin/packages/libxvmc/package.py
@@ -14,6 +14,8 @@ class Libxvmc(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.0.13", sha256="e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e")
     version("1.0.12", sha256="024c9ec4f001f037eeca501ee724c7e51cf287eb69ced8c6126e16e7fa9864b5")
     version("1.0.11", sha256="0b931d216b23b95df87cc65f7bb7acef4120d9263adb0a4d90856ba1f7a390da")

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -14,6 +14,8 @@ class Libxxf86dga(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.6", sha256="87c7482b1e29b4eeb415815641c4f69c00545a8138e1b73ff1f361f7d9c22ac4")
+    version("1.1.5", sha256="715e2bf5caf6276f0858eb4b11a1aef1a26beeb40dce2942387339da395bef69")
     version("1.1.4", sha256="e6361620a15ceba666901ca8423e8be0c6ed0271a7088742009160349173766b")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -14,6 +14,8 @@ class Libxxf86dga(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.6", sha256="87c7482b1e29b4eeb415815641c4f69c00545a8138e1b73ff1f361f7d9c22ac4")
     version("1.1.5", sha256="715e2bf5caf6276f0858eb4b11a1aef1a26beeb40dce2942387339da395bef69")
     version("1.1.4", sha256="e6361620a15ceba666901ca8423e8be0c6ed0271a7088742009160349173766b")

--- a/var/spack/repos/builtin/packages/libxxf86misc/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86misc/package.py
@@ -12,6 +12,8 @@ class Libxxf86misc(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXxf86misc"
     xorg_mirror_path = "lib/libXxf86misc-1.0.3.tar.gz"
 
+    maintainers("wdconinc")
+
     version("1.0.4", sha256="63a68b2fafd03236f9b0135de21976e9194d6d811ca2fd774c13a6b4be576676")
     version("1.0.3", sha256="358f692f793af00f6ef4c7a8566c1bcaeeea37e417337db3f519522cc1df3946")
 

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -14,6 +14,8 @@ class Libxxf86vm(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.5", sha256="f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128")
     version("1.1.4", sha256="5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99")
 

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -14,6 +14,7 @@ class Libxxf86vm(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.5", sha256="f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128")
     version("1.1.4", sha256="5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99")
 
     depends_on("libx11@1.6:")

--- a/var/spack/repos/builtin/packages/xbitmaps/package.py
+++ b/var/spack/repos/builtin/packages/xbitmaps/package.py
@@ -15,6 +15,8 @@ class Xbitmaps(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.1.3", sha256="93b433b7ff223c4685fdba583b4bd30f2706be2413a670021084422d85b0269d")
     version("1.1.2", sha256="27e700e8ee02c43f7206f4eca8f1953ad15236cac95d7a0f08505c3f7d99c265")
     version("1.1.1", sha256="3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188")

--- a/var/spack/repos/builtin/packages/xbitmaps/package.py
+++ b/var/spack/repos/builtin/packages/xbitmaps/package.py
@@ -15,6 +15,8 @@ class Xbitmaps(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.1.3", sha256="93b433b7ff223c4685fdba583b4bd30f2706be2413a670021084422d85b0269d")
+    version("1.1.2", sha256="27e700e8ee02c43f7206f4eca8f1953ad15236cac95d7a0f08505c3f7d99c265")
     version("1.1.1", sha256="3bc89e05be4179ce4d3dbba1ae554da4591d41f7a489d9e2735a18cfd8378188")
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -15,6 +15,8 @@ class XcbProto(AutotoolsPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.15.2", sha256="7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed")
     version("1.14.1", sha256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3")
     version("1.14", sha256="186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605")

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -17,6 +17,7 @@ class XcbProto(AutotoolsPackage):
 
     maintainers("wdconinc")
 
+    version("1.16.0", sha256="a75a1848ad2a89a82d841a51be56ce988ff3c63a8d6bf4383ae3219d8d915119")
     version("1.15.2", sha256="7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed")
     version("1.14.1", sha256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3")
     version("1.14", sha256="186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605")

--- a/var/spack/repos/builtin/packages/xkbcomp/package.py
+++ b/var/spack/repos/builtin/packages/xkbcomp/package.py
@@ -14,11 +14,13 @@ class Xkbcomp(AutotoolsPackage, XorgPackage):
     keyboard. It also includes a number of keyboard controls designed to
     make keyboards more accessible to people with physical impairments."""
 
-    homepage = "https://www.x.org/wiki/XKB/"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xkbcomp"
     xorg_mirror_path = "app/xkbcomp-1.3.1.tar.gz"
 
     license("MIT")
 
+    version("1.4.6", sha256="b216a2c8c0eab83f3dc4a3d5ee2bdf7827b30e49c8907035d0f222138eca0987")
+    version("1.4.5", sha256="e88a4d86b9925ea1e8685dd5ea29c815abafb8ddf19bf5f1a1e0650839252c23")
     version("1.4.4", sha256="159fba6b62ef4a3fb16ef7fc4eb4fc26f3888652471ceb604c495783dda020bc")
     version("1.3.1", sha256="018e83a922430652d4bc3f3db610d2296e618c76c9b3fbcdccde975aeb655749")
 

--- a/var/spack/repos/builtin/packages/xkbcomp/package.py
+++ b/var/spack/repos/builtin/packages/xkbcomp/package.py
@@ -19,6 +19,8 @@ class Xkbcomp(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.4.6", sha256="b216a2c8c0eab83f3dc4a3d5ee2bdf7827b30e49c8907035d0f222138eca0987")
     version("1.4.5", sha256="e88a4d86b9925ea1e8685dd5ea29c815abafb8ddf19bf5f1a1e0650839252c23")
     version("1.4.4", sha256="159fba6b62ef4a3fb16ef7fc4eb4fc26f3888652471ceb604c495783dda020bc")

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -15,6 +15,8 @@ class Xrandr(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.5.2", sha256="efd062cd228dc18a7de26422c81bc4be6a7e62f7f0ad6f9bebdd9ff8385c5668")
+    version("1.5.1", sha256="7b99edb7970a1365eaf5bcaf552144e4dfc3ccf510c4abc08569849929fb366e")
     version("1.5.0", sha256="ddfe8e7866149c24ccce8e6aaa0623218ae19130c2859cadcaa4228d8bb4a46d")
 
     depends_on("libxrandr@1.5:")

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -15,6 +15,8 @@ class Xrandr(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.5.2", sha256="efd062cd228dc18a7de26422c81bc4be6a7e62f7f0ad6f9bebdd9ff8385c5668")
     version("1.5.1", sha256="7b99edb7970a1365eaf5bcaf552144e4dfc3ccf510c4abc08569849929fb366e")
     version("1.5.0", sha256="ddfe8e7866149c24ccce8e6aaa0623218ae19130c2859cadcaa4228d8bb4a46d")

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -19,6 +19,7 @@ class Xtrans(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.5.0", sha256="a806f8a92f879dcd0146f3f1153fdffe845f2fc0df9b1a26c19312b7b0a29c86")
     version("1.4.0", sha256="48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9")
     version("1.3.5", sha256="b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d")
 

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -17,6 +17,8 @@ class Xtrans(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    maintainers("wdconinc")
+
     version("1.4.0", sha256="48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9")
     version("1.3.5", sha256="b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d")
 


### PR DESCRIPTION
This updates the versions of multiple Xorg packages to their current latest version. Verified the requirements and version dependencies, and updated where needed. Modified one homepage (xkbcomp) in the interest of conformity with the other packages.

Summary of dependency changes:
- libsm:
  - depends_on("libice@1.1.0:", when="@1.2.4:")
- libx11:
  - depends_on("libxcb@1.11.1:", when="@1.6.4:")
- libxcomposite:
  - depends_on("xproto@7.0.22:", when="@0.4.6")
- libxfixes:
  - depends_on("fixesproto@5.0:", when="@5")
  - ~~depends_on("fixesproto@6.0:", when="@6")~~ (https://github.com/spack/spack/issues/41688)
- libxi:
  - depends_on("inputproto@2.2.99.1:", when="@1.7:")
  - ~~depends_on("inputproto@2.3.99.1:", when="@1.8:")~~ (https://github.com/spack/spack/issues/41688)
- libxpm:
  - depends_on("ncompress", when="@3.5.15")
    (they addressed a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-4883) but realized quickly that ncompress should be optional)
- libxres
  - depends_on("resourceproto@1.0:", when="@1.0")
  - depends_on("resourceproto@1.2:", when="@1.2")

All modified libraries build fine for the newest version with the updated xorg-proto in #36238.