### PR TITLE
xcb-util-*: new versions, migration to freedesktop.org

### DIFF
--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -14,9 +14,10 @@ class XcbUtilCursor(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.4.tar.xz"
 
+    version("0.1.4", sha256="28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb")
     version("0.1.3", sha256="a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8")
 
     depends_on("libxcb@1.4:")
@@ -25,3 +26,11 @@ class XcbUtilCursor(AutotoolsPackage):
 
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.1.4"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-cursor-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilCursor(AutotoolsPackage):
+class XcbUtilCursor(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,10 +15,14 @@ class XcbUtilCursor(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.4.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-cursor-0.1.4.tar.xz"
 
     version("0.1.4", sha256="28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb")
-    version("0.1.3", sha256="a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8")
+    version(
+        "0.1.3",
+        sha256="a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8",
+        url="https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.4.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
     depends_on("xcb-util-renderutil")
@@ -26,11 +30,3 @@ class XcbUtilCursor(AutotoolsPackage):
 
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.1.4"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-cursor-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-errors/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-errors/package.py
@@ -14,12 +14,21 @@ class XcbUtilErrors(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-errors"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-errors-1.0.1.tar.xz"
 
+    version("1.0.1", sha256="5628c87b984259ad927bacd8a42958319c36bdf4b065887803c9d820fb80f357")
     version("1.0", sha256="7752a722e580efdbada30632cb23aed35c18757399ac3b547b59fd7257cf5e33")
 
     depends_on("libxcb@1.4:")
 
     depends_on("xcb-proto")
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("1.0.1"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-errors-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-errors-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-errors/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-errors/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilErrors(AutotoolsPackage):
+class XcbUtilErrors(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,20 +15,16 @@ class XcbUtilErrors(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-errors"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-errors-1.0.1.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-errors-1.0.1.tar.xz"
 
     version("1.0.1", sha256="5628c87b984259ad927bacd8a42958319c36bdf4b065887803c9d820fb80f357")
-    version("1.0", sha256="7752a722e580efdbada30632cb23aed35c18757399ac3b547b59fd7257cf5e33")
+    version(
+        "1.0",
+        sha256="7752a722e580efdbada30632cb23aed35c18757399ac3b547b59fd7257cf5e33",
+        url="https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
 
     depends_on("xcb-proto")
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("1.0.1"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-errors-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-errors-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-image/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-image/package.py
@@ -14,9 +14,10 @@ class XcbUtilImage(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-image"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-image-0.4.1.tar.xz"
 
+    version("0.4.1", sha256="ccad8ee5dadb1271fd4727ad14d9bd77a64e505608766c4e98267d9aede40d3d")
     version("0.4.0", sha256="cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42")
 
     depends_on("libxcb@1.4:")
@@ -24,3 +25,11 @@ class XcbUtilImage(AutotoolsPackage):
 
     depends_on("xproto@7.0.8:")
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.4.1"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-image-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-image-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-image/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-image/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilImage(AutotoolsPackage):
+class XcbUtilImage(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,21 +15,17 @@ class XcbUtilImage(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-image"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-image-0.4.1.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-image-0.4.1.tar.xz"
 
     version("0.4.1", sha256="ccad8ee5dadb1271fd4727ad14d9bd77a64e505608766c4e98267d9aede40d3d")
-    version("0.4.0", sha256="cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42")
+    version(
+        "0.4.0",
+        sha256="cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42",
+        url="https://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
     depends_on("xcb-util")
 
     depends_on("xproto@7.0.8:")
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.4.1"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-image-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-image-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -14,12 +14,22 @@ class XcbUtilKeysyms(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-keysyms"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-keysyms-0.4.1.tar.xz"
 
+    version("0.4.1", sha256="7c260a5294412aed429df1da2f8afd3bd07b7cba3fec772fba15a613a6d5c638")
     version("0.4.0", sha256="0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96")
 
     depends_on("libxcb@1.4:")
 
     depends_on("xproto@7.0.8:")
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.4.1"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-keysyms-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-keysyms-{0}.tar.gz"
+
+        return url.format(version)
+

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -32,4 +32,3 @@ class XcbUtilKeysyms(AutotoolsPackage):
             url = "https://xcb.freedesktop.org/dist/xcb-util-keysyms-{0}.tar.gz"
 
         return url.format(version)
-

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilKeysyms(AutotoolsPackage):
+class XcbUtilKeysyms(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,20 +15,16 @@ class XcbUtilKeysyms(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-keysyms"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-keysyms-0.4.1.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-keysyms-0.4.1.tar.xz"
 
     version("0.4.1", sha256="7c260a5294412aed429df1da2f8afd3bd07b7cba3fec772fba15a613a6d5c638")
-    version("0.4.0", sha256="0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96")
+    version(
+        "0.4.0",
+        sha256="0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96",
+        url="https://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
 
     depends_on("xproto@7.0.8:")
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.4.1"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-keysyms-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-keysyms-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
@@ -14,11 +14,20 @@ class XcbUtilRenderutil(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-renderutil"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-renderutil-0.3.10.tar.xz"
 
+    version("0.3.10", sha256="3e15d4f0e22d8ddbfbb9f5d77db43eacd7a304029bf25a6166cc63caa96d04ba")
     version("0.3.9", sha256="55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5")
 
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.3.10"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-renderutil-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-renderutil-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilRenderutil(AutotoolsPackage):
+class XcbUtilRenderutil(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,19 +15,15 @@ class XcbUtilRenderutil(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-renderutil"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-renderutil-0.3.10.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-renderutil-0.3.10.tar.xz"
 
     version("0.3.10", sha256="3e15d4f0e22d8ddbfbb9f5d77db43eacd7a304029bf25a6166cc63caa96d04ba")
-    version("0.3.9", sha256="55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5")
+    version(
+        "0.3.9",
+        sha256="55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5",
+        url="https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.3.10"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-renderutil-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-renderutil-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -14,9 +14,10 @@ class XcbUtilWm(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-wm"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-wm-0.4.2.tar.xz"
 
+    version("0.4.2", sha256="62c34e21d06264687faea7edbf63632c9f04d55e72114aa4a57bb95e4f888a0b")
     version("0.4.1", sha256="038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334")
 
     depends_on("m4", type="build")
@@ -24,3 +25,11 @@ class XcbUtilWm(AutotoolsPackage):
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.4.2"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-wm-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-wm-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtilWm(AutotoolsPackage):
+class XcbUtilWm(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,21 +15,17 @@ class XcbUtilWm(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-wm"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-wm-0.4.2.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-wm-0.4.2.tar.xz"
 
     version("0.4.2", sha256="62c34e21d06264687faea7edbf63632c9f04d55e72114aa4a57bb95e4f888a0b")
-    version("0.4.1", sha256="038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334")
+    version(
+        "0.4.1",
+        sha256="038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334",
+        url="https://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.gz",
+    )
 
     depends_on("m4", type="build")
 
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.4.2"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-wm-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-wm-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util/package.py
@@ -14,11 +14,20 @@ class XcbUtil(AutotoolsPackage):
     libraries also provide client-side code which is not strictly part of
     the X protocol but which have traditionally been provided by Xlib."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-util"
+    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-0.4.1.tar.xz"
 
+    version("0.4.1", sha256="5abe3bbbd8e54f0fa3ec945291b7e8fa8cfd3cccc43718f8758430f94126e512")
     version("0.4.0", sha256="0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7")
 
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        if version >= Version("0.4.1"):
+            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-{0}.tar.xz"
+        else:
+            url = "https://xcb.freedesktop.org/dist/xcb-util-{0}.tar.gz"
+
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-util/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbUtil(AutotoolsPackage):
+class XcbUtil(AutotoolsPackage, XorgPackage):
     """The XCB util modules provides a number of libraries which sit on top
     of libxcb, the core X protocol library, and some of the extension
     libraries. These experimental libraries provide convenience functions
@@ -15,19 +15,15 @@ class XcbUtil(AutotoolsPackage):
     the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-util"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-0.4.1.tar.xz"
+    xorg_mirror_path = "lib/xcb-util-0.4.1.tar.xz"
 
     version("0.4.1", sha256="5abe3bbbd8e54f0fa3ec945291b7e8fa8cfd3cccc43718f8758430f94126e512")
-    version("0.4.0", sha256="0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7")
+    version(
+        "0.4.0",
+        sha256="0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7",
+        url="https://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.gz",
+    )
 
     depends_on("libxcb@1.4:")
 
     depends_on("pkgconfig", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("0.4.1"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/xcb-util-{0}.tar.gz"
-
-        return url.format(version)


### PR DESCRIPTION
The `xcb-utils` have been migrated to the gitlab.freedesktop.org, from the previous separate location. That means that a URL change is needed to pick up newer version (e.g. [ref](https://lists.freedesktop.org/archives/xcb/2022-October/011422.html)).

This replaces the `homepage` and `url` with the latest (to an `xz` file), adds a `url_for_version` function to resolve past versions, and add the latest versions. Because of the `url_for_version` I don't think we can use the `xorg_mirror_path` approach here.