### PR TITLE
Xorg apps: updated versions to current latest

### DIFF
--- a/var/spack/repos/builtin/packages/constype/package.py
+++ b/var/spack/repos/builtin/packages/constype/package.py
@@ -16,6 +16,7 @@ class Constype(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/constype"
     xorg_mirror_path = "app/constype-1.0.4.tar.gz"
 
+    version("1.0.5", sha256="ec7d07204dd5abf8d21d0a89408be17ab316a017838c88b087b127082f02c051")
     version("1.0.4", sha256="ec09aff369cf1d527fd5b8075fb4dd0ecf89d905190cf1a0a0145d5e523f913d")
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/oclock/package.py
+++ b/var/spack/repos/builtin/packages/oclock/package.py
@@ -13,6 +13,8 @@ class Oclock(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/oclock"
     xorg_mirror_path = "app/oclock-1.0.3.tar.gz"
 
+    version("1.0.5", sha256="ddd93b48ab91222c071816083b7ff55248c63be9c4ae07cdcc3ffd82bf111ce6")
+    version("1.0.4", sha256="cffc414cd0cf0b0e4a9bec3b5e707d9c2e2bcd109629d74bd6dd61381563dd35")
     version("1.0.3", sha256="6628d1abe1612b87db9d0170cbe7f1cf4205cd764274f648c3c1bdb745bff877")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/rgb/package.py
+++ b/var/spack/repos/builtin/packages/rgb/package.py
@@ -18,6 +18,7 @@ class Rgb(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/rgb"
     xorg_mirror_path = "app/rgb-1.0.6.tar.gz"
 
+    version("1.1.0", sha256="77142e3d6f06cfbfbe440e29596765259988a22db40b1e706e14b8ba4c962aa5")
     version("1.0.6", sha256="cb998035e08b9f58ad3150cab60461c3225bdd075238cffc665e24da40718933")
 
     depends_on("xorg-server")

--- a/var/spack/repos/builtin/packages/rstart/package.py
+++ b/var/spack/repos/builtin/packages/rstart/package.py
@@ -17,6 +17,7 @@ class Rstart(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/rstart"
     xorg_mirror_path = "app/rstart-1.0.5.tar.gz"
 
+    version("1.0.6", sha256="28aa687437efeee70965a0878f9db79397cf691f4011268e16bc835627e23ec5")
     version("1.0.5", sha256="5271c0c2675b4ad09aace7edddfdd137af10fc754afa6260d8eb5d0bba7098c7")
 
     depends_on("xproto")

--- a/var/spack/repos/builtin/packages/sessreg/package.py
+++ b/var/spack/repos/builtin/packages/sessreg/package.py
@@ -14,6 +14,9 @@ class Sessreg(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/sessreg"
     xorg_mirror_path = "app/sessreg-1.1.0.tar.gz"
 
+    version("1.1.3", sha256="6e3e917e881132a7a9ccb181ddd83fe08a99668892455d808c911ad38beea215")
+    version("1.1.2", sha256="dbfe74c9af90696b2c6800bd58799e937a6a10eb48a49cc22053e3538fbe361a")
+    version("1.1.1", sha256="3e38f72ff690eaffc0f5eaff533a236bb5e93d4b91ed4fff60e9a2505347d009")
     version("1.1.0", sha256="e561edb48dfc3b0624554169c15f9dd2c3139e83084cb323b0c712724f2b6043")
 
     depends_on("xproto@7.0.25:")

--- a/var/spack/repos/builtin/packages/setxkbmap/package.py
+++ b/var/spack/repos/builtin/packages/setxkbmap/package.py
@@ -14,6 +14,8 @@ class Setxkbmap(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/setxkbmap"
     xorg_mirror_path = "app/setxkbmap-1.3.1.tar.gz"
 
+    version("1.3.3", sha256="51ba28edf93a464a7444b53b154fd5e93dedd1e9bbcc85b636f4cf56986c4842")
+    version("1.3.2", sha256="7e934afc55f161406f7dd99b5be8837e5d1478d8263776697b159d48461a1d3c")
     version("1.3.1", sha256="e24a73669007fa3b280eba4bdc7f75715aeb2e394bf2d63f5cc872502ddde264")
 
     depends_on("libxkbfile")

--- a/var/spack/repos/builtin/packages/setxkbmap/package.py
+++ b/var/spack/repos/builtin/packages/setxkbmap/package.py
@@ -20,6 +20,7 @@ class Setxkbmap(AutotoolsPackage, XorgPackage):
 
     depends_on("libxkbfile")
     depends_on("libx11")
+    depends_on("libxrandr", when="@1.3.3:")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/showfont/package.py
+++ b/var/spack/repos/builtin/packages/showfont/package.py
@@ -14,6 +14,7 @@ class Showfont(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/showfont"
     xorg_mirror_path = "app/showfont-1.0.5.tar.gz"
 
+    version("1.0.6", sha256="006c5cb931e33c8c073215cf106a9c7fe93b81ccb4268274bb33dd5697e1f425")
     version("1.0.5", sha256="566e34a145ea73397724d46e84f6a9b3691cf55d0fcb96ec7f917b2b39265ebb")
 
     depends_on("libfs")

--- a/var/spack/repos/builtin/packages/smproxy/package.py
+++ b/var/spack/repos/builtin/packages/smproxy/package.py
@@ -13,6 +13,7 @@ class Smproxy(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/smproxy"
     xorg_mirror_path = "app/smproxy-1.0.6.tar.gz"
 
+    version("1.0.7", sha256="aabd5e644512442da2bca1ce65ccee403b760a08e354b3474753ed36033e3d21")
     version("1.0.6", sha256="a01374763426a5fdcbc7a65edc54e2070cdbca4df41dddd3051c7586e4c814c9")
 
     depends_on("libsm")

--- a/var/spack/repos/builtin/packages/transset/package.py
+++ b/var/spack/repos/builtin/packages/transset/package.py
@@ -12,6 +12,8 @@ class Transset(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/transset"
     xorg_mirror_path = "app/transset-1.0.1.tar.gz"
 
+    version("1.0.3", sha256="adba0da81dacdebe5275ec0117dd08685e4f2f31afa0391f423e54906d0fb824")
+    version("1.0.2", sha256="5c7d7d1bac36137f41ac3db84d7ed9b9fdac868608572bcba0bc1de40510ca67")
     version("1.0.1", sha256="87c560e69e05ae8a5bad17ff62ac31cda43a5065508205b109c756c0ab857d55")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/twm/package.py
+++ b/var/spack/repos/builtin/packages/twm/package.py
@@ -15,6 +15,9 @@ class Twm(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/twm"
     xorg_mirror_path = "app/twm-1.0.9.tar.gz"
 
+    version("1.0.12", sha256="4150c9ec595520167ab8c4efcb5cf82641a4c4db78ce0a1cb4834e6aeb7c87fb")
+    version("1.0.11", sha256="410ecabac54e6db7afd5c20a78d89c0134f3c74b149bee71b1fec775e6e060cc")
+    version("1.0.10", sha256="679a1d07078c918fa32454498dc15573b299bbb0f001499e213c408e4b2170f5")
     version("1.0.9", sha256="1c325e8456a200693c816baa27ceca9c5e5e0f36af63d98f70a335853a0039e8")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/viewres/package.py
+++ b/var/spack/repos/builtin/packages/viewres/package.py
@@ -13,6 +13,9 @@ class Viewres(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/viewres"
     xorg_mirror_path = "app/viewres-1.0.4.tar.gz"
 
+    version("1.0.7", sha256="5dd63ee19575dd1d40360242ecc1ff96e222d9b80a2b7b8b89e6d1e0f2367d78")
+    version("1.0.6", sha256="2c9f1892dbb5563b704fd06f45cd9d263d8176027033d8438c79a2ceddac200f")
+    version("1.0.5", sha256="9dee5e6b0a18961bb5c33f3f654605d45912087b6ba781cb2277d1941fa35a4b")
     version("1.0.4", sha256="fd2aaec85c952fd6984fe14d0fcbda4d2ab9849a9183e4787b0ef552a10a87a1")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/x11perf/package.py
+++ b/var/spack/repos/builtin/packages/x11perf/package.py
@@ -12,6 +12,7 @@ class X11perf(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/x11perf"
     xorg_mirror_path = "app/x11perf-1.6.0.tar.gz"
 
+    version("1.6.1", sha256="a1874618df0e30ae1a9b2470fb50e77a40c4a6f6ddf87a5c154f7a3b913ac0b3")
     version("1.6.0", sha256="d33051c4e93100ab60609aee14ff889bb2460f28945063d793e21eda19381abb")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xauth/package.py
+++ b/var/spack/repos/builtin/packages/xauth/package.py
@@ -13,6 +13,10 @@ class Xauth(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xauth"
     xorg_mirror_path = "app/xauth-1.0.9.tar.gz"
 
+    version("1.1.2", sha256="84d27a1023d8da524c134f424b312e53cb96e08871f96868aa20316bfcbbc054")
+    version("1.1.1", sha256="0f558ef33e76843cf16a78cd3910ef8ec0809bea85d14e091c559dcec092c671")
+    version("1.1", sha256="e9fce796c8c5c9368594b9e8bbba237fb54b6615f5fd60e8d0a5b3c52a92c5ef")
+    version("1.0.10", sha256="5196821221d824b9bc278fa6505c595acee1d374518a52217d9b64d3c63dedd0")
     version("1.0.9", sha256="0709070caf23ba2fb99536907b75be1fe31853999c62d3e87a6a8d26ba8a8cdb")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xbacklight/package.py
+++ b/var/spack/repos/builtin/packages/xbacklight/package.py
@@ -15,6 +15,8 @@ class Xbacklight(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xbacklight"
     xorg_mirror_path = "app/xbacklight-1.2.1.tar.gz"
 
+    version("1.2.3", sha256="d2a8dd962454d8de3675286eab4edc4d1376ac7da040a3a8729ee250e6e798c1")
+    version("1.2.2", sha256="9812497b95b28776539808ba75e8b8a2d48a57416e172e04e9580e65c76a61bb")
     version("1.2.1", sha256="82c80cd851e3eb6d7a216d92465fcf6d5e456c2d5ac12c63cd2757b39fb65b10")
 
     depends_on("libxcb")

--- a/var/spack/repos/builtin/packages/xbiff/package.py
+++ b/var/spack/repos/builtin/packages/xbiff/package.py
@@ -14,6 +14,7 @@ class Xbiff(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xbiff"
     xorg_mirror_path = "app/xbiff-1.0.3.tar.gz"
 
+    version("1.0.4", sha256="8a0ca5628e6893340a2448b461a103b48a174ae777500beb9a9f56f99330ce62")
     version("1.0.3", sha256="b4b702348674985741685e3ec7fcb5640ffb7bf20e753fc2d708f70f2e4c304d")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xcalc/package.py
+++ b/var/spack/repos/builtin/packages/xcalc/package.py
@@ -13,6 +13,9 @@ class Xcalc(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xcalc"
     xorg_mirror_path = "app/xcalc-1.0.6.tar.gz"
 
+    version("1.1.1", sha256="9219c889bfb2d0e168ef9a14700662c5cde829b69b12875cb6d59b70d4b68f3b")
+    version("1.1.0", sha256="a86418d9af9d0e57e5253ba1c29e754480509c828d369aaaca48400b2045e630")
+    version("1.0.7", sha256="2b00129583f51a45acfcaaa461750169e530996e190b31f7a92891846380f1f5")
     version("1.0.6", sha256="7fd5cd9a35160925c41cbadfb1ea23599fa20fd26cd873dab20a650b24efe8d1")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xclipboard/package.py
+++ b/var/spack/repos/builtin/packages/xclipboard/package.py
@@ -15,6 +15,7 @@ class Xclipboard(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xclipboard"
     xorg_mirror_path = "app/xclipboard-1.1.3.tar.gz"
 
+    version("1.1.4", sha256="c40cb97f6c8597ba74a3de5c188d4429f686e4d395b85dac0ec8c7311bdf3d10")
     version("1.1.3", sha256="a8c335cf166cbb27ff86569503db7e639f85741ad199bfb3ba45dd0cfda3da7f")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xclock/package.py
+++ b/var/spack/repos/builtin/packages/xclock/package.py
@@ -14,6 +14,10 @@ class Xclock(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xclock"
     xorg_mirror_path = "app/xclock-1.0.7.tar.gz"
 
+    version("1.1.1", sha256="be0f90645b0fe21d2cbfdd77102cc3168f01cb794663fd8db2b305fed261e4c3")
+    version("1.1.0", sha256="2798db1a9e8bc6b417d813ac46f8e8326d59d4a00f10457609f9712debe58670")
+    version("1.0.9", sha256="4f0dd4d7d969b55c64f6e58242bca201d19e49eb8c9736dc099330bb0c5385b1")
+    version("1.0.8", sha256="bb6f2439e6037759dc1682d80a3fe0232e7b55aa9b38548203e746d290b246bd")
     version("1.0.7", sha256="e730bd575938d5628ef47003a9d4d41b882621798227f5d0c12f4a26365ed1b5")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xcmsdb/package.py
+++ b/var/spack/repos/builtin/packages/xcmsdb/package.py
@@ -15,6 +15,7 @@ class Xcmsdb(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xcmsdb"
     xorg_mirror_path = "app/xcmsdb-1.0.5.tar.gz"
 
+    version("1.0.6", sha256="640b42c746eb34bdd71ca2850f2bc9fb0ade194c9f152a8d002425a0684df077")
     version("1.0.5", sha256="8442352ee5eb3ea0d3a489c26d734e784ef6964150c2a173401d0dc6638ca236")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xcompmgr/package.py
+++ b/var/spack/repos/builtin/packages/xcompmgr/package.py
@@ -14,6 +14,8 @@ class Xcompmgr(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xcompmgr"
     xorg_mirror_path = "app/xcompmgr-1.1.7.tar.gz"
 
+    version("1.1.9", sha256="978294a31bf8decb90acae750c9630b986b78a98c3e0517bd63486a62fa10030")
+    version("1.1.8", sha256="ba10933678a5665d06fa7096bd08f37316add8ed84aaacd7ba26a97e8f2e0498")
     version("1.1.7", sha256="ef4b23c370f99403bbd9b6227f8aa4edc3bc83fc6d57ee71f6f442397cef505a")
 
     depends_on("libxcomposite")

--- a/var/spack/repos/builtin/packages/xconsole/package.py
+++ b/var/spack/repos/builtin/packages/xconsole/package.py
@@ -13,6 +13,8 @@ class Xconsole(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xconsole"
     xorg_mirror_path = "app/xconsole-1.0.6.tar.gz"
 
+    version("1.0.8", sha256="1897be35738489f92ef511caef189db8d5079469374021dc09b59e89992b7c29")
+    version("1.0.7", sha256="91bc7327643b1ca57800a37575930af16fbea485d426a96d8f465de570aa6eb3")
     version("1.0.6", sha256="28151453a0a687462516de133bac0287b488a2ff56da78331fee34bc1bf3e7d5")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xcursorgen/package.py
+++ b/var/spack/repos/builtin/packages/xcursorgen/package.py
@@ -12,6 +12,8 @@ class Xcursorgen(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xcursorgen"
     xorg_mirror_path = "app/xcursorgen-1.0.6.tar.gz"
 
+    version("1.0.8", sha256="b8bb2756918343b8bc15a4ce875e9efb6c4e7777adba088280e53dd09753b6ac")
+    version("1.0.7", sha256="6bc32d4977ffd60c00583bfd217f1d1245ca54dafbfbbcdbf14f696f9487b83e")
     version("1.0.6", sha256="4559f2b6eaa93de4cb6968679cf40e39bcbe969b62ebf3ff84f6780f8048ef8c")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xditview/package.py
+++ b/var/spack/repos/builtin/packages/xditview/package.py
@@ -12,6 +12,8 @@ class Xditview(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xditview"
     xorg_mirror_path = "app/xditview-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="2b158cdc3b3eb63a9ba2cc2c31908ab9bd3bc834b2f01f1792a30690229237dd")
+    version("1.0.5", sha256="67c4522a24dd7e8762ae458fe216c5bddc12101af295e78c19ff7313fa8cbfad")
     version("1.0.4", sha256="73ad88cfc879edcc6ede65999c11d670da27575388126795d71f3ad60286d379")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xdm/package.py
+++ b/var/spack/repos/builtin/packages/xdm/package.py
@@ -12,6 +12,9 @@ class Xdm(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xdm"
     xorg_mirror_path = "app/xdm-1.1.11.tar.gz"
 
+    version("1.1.14", sha256="bcc543c3c120094d58d9cc9837958d4303693c2116ba342ba3dd9440137b4026")
+    version("1.1.13", sha256="2f05aa58c205dcf10443ba414d27535b74ec11466dc95228343b0ce4f0c2a307")
+    version("1.1.12", sha256="8ea737945f69e172afbbc8b5060e4c7ea8079f402eb0a458572197c907020bb4")
     version("1.1.11", sha256="38c544a986143b1f24566c1a0111486b339b92224b927be78714eeeedca12a14")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xdpyinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdpyinfo/package.py
@@ -17,6 +17,7 @@ class Xdpyinfo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xdpyinfo"
     xorg_mirror_path = "app/xdpyinfo-1.3.2.tar.gz"
 
+    version("1.3.3", sha256="2ae7b8213ea839b8376843477496276e8d69550c48bff081e16376539fc27c5a")
     version("1.3.2", sha256="ef39935e8e9b328e54a85d6218d410d6939482da6058db1ee1b39749d98cbcf2")
 
     depends_on("libxext")

--- a/var/spack/repos/builtin/packages/xdriinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdriinfo/package.py
@@ -12,6 +12,8 @@ class Xdriinfo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xdriinfo"
     xorg_mirror_path = "app/xdriinfo-1.0.5.tar.gz"
 
+    version("1.0.7", sha256="9fab95510b1f67409632fb8af01369b128f4d12763fe1a2662f5666976a7d30c")
+    version("1.0.6", sha256="c59d1d97d8b1066ea470407237c87fb131ca9f6c4db4652a6e9461ae03c698ad")
     version("1.0.5", sha256="e4e6abaa4591c540ab63133927a6cebf0a5f4d27dcd978878ab4a422d62a838e")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xedit/package.py
+++ b/var/spack/repos/builtin/packages/xedit/package.py
@@ -12,6 +12,7 @@ class Xedit(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xedit"
     xorg_mirror_path = "app/xedit-1.2.2.tar.gz"
 
+    version("1.2.3", sha256="3c8be175613f72858b24d973b0d66ae2d3c9a48a5f0bd637920d85b283feede7")
     version("1.2.2", sha256="7e2dacbc2caed81d462ee028e108866893217d55e35e4b860b09be2b409ee18f")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xev/package.py
+++ b/var/spack/repos/builtin/packages/xev/package.py
@@ -18,6 +18,9 @@ class Xev(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xev"
     xorg_mirror_path = "app/xev-1.2.2.tar.gz"
 
+    version("1.2.5", sha256="a948974ede621a8402ed9ea64f1ec83992285aa4fbb9d40b52985156c61a358a")
+    version("1.2.4", sha256="6b1f94813f008a4ba45e0a2d4e1b64deaab1def56fabd7fac3621106cbaa3383")
+    version("1.2.3", sha256="a3c5fbf339f43ba625a6d84e52ab1a7170581505ef498be6aa4e7bdfbd8d5cef")
     version("1.2.2", sha256="e4c0c7b6f411e8b9731f2bb10d729d167bd00480d172c28b62607a6ea9e45c57")
 
     depends_on("libxrandr@1.2:")

--- a/var/spack/repos/builtin/packages/xeyes/package.py
+++ b/var/spack/repos/builtin/packages/xeyes/package.py
@@ -12,6 +12,8 @@ class Xeyes(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xeyes"
     xorg_mirror_path = "app/xeyes-1.1.1.tar.gz"
 
+    version("1.2.0", sha256="727e651fd4597f6aa131b67474372a081dccd28ea2cdd364f21dae6e59003ee8")
+    version("1.1.2", sha256="4a675b34854da362bd8dff4f21ff92e0c19798b128ea0af24b7fc7c5ac2feea3")
     version("1.1.1", sha256="3a1871a560ab87c72a2e2ecb7fd582474448faec3e254c9bd8bead428ab1bca3")
 
     depends_on("libx11")
@@ -19,6 +21,8 @@ class Xeyes(AutotoolsPackage, XorgPackage):
     depends_on("libxext")
     depends_on("libxmu")
     depends_on("libxrender@0.4:")
+    depends_on("libxi@1.7:", when="@1.2:")
+    depends_on("libxcb@1.9:", when="@1.2:")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -13,6 +13,7 @@ class Xfd(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xfd"
     xorg_mirror_path = "app/xfd-1.1.2.tar.gz"
 
+    version("1.1.4", sha256="58d3c4e1395a1d901529b1d80331d810836cb56b2db950c15444ea71d2af21fd")
     version("1.1.3", sha256="4a1bd18f324c239b1a807ed4ccaeb172ba771d65a7307fb492d8dd8d27f01527")
     version("1.1.2", sha256="4eff3e15b2526ceb48d0236d7ca126face399289eabc0ef67e6ed3b3fdcb60ad")
 

--- a/var/spack/repos/builtin/packages/xfontsel/package.py
+++ b/var/spack/repos/builtin/packages/xfontsel/package.py
@@ -14,6 +14,8 @@ class Xfontsel(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xfontsel"
     xorg_mirror_path = "app/xfontsel-1.0.5.tar.gz"
 
+    version("1.1.0", sha256="32938f671c706dc15644ceebf5daebbf0f2f1fe45afa2d06d2b905cc7d6c7de2")
+    version("1.0.6", sha256="a7b025cb96b678f03caeb61a2770890359bdab34dc37e09d447b30c54c4df35e")
     version("1.0.5", sha256="9b3ad0cc274398d22be9fa7efe930f4e3749fd4b1b61d9c31a7fb6c1f1ff766e")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xfs/package.py
+++ b/var/spack/repos/builtin/packages/xfs/package.py
@@ -12,9 +12,12 @@ class Xfs(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xfs"
     xorg_mirror_path = "app/xfs-1.1.4.tar.gz"
 
+    version("1.2.1", sha256="76df0106dbf845cb44534eb89f1ed7e9fb4d466125200baeb4719eb2586ded29")
+    version("1.2.0", sha256="56ebdc5ff85af332a0c5dc60c9b971551624bbc312bf6af3d13b925600ea367f")
     version("1.1.4", sha256="28f89b854d1ff14fa1efa5b408e5e1c4f6a145420310073c4e44705feeb6d23b")
 
-    depends_on("libxfont@1.4.5:")
+    depends_on("libxfont@1.4.5:", when="@:1.1")
+    depends_on("libxfont2@2.0.1:", when="@1.2:")
     depends_on("font-util")
 
     depends_on("xproto@7.0.17:")

--- a/var/spack/repos/builtin/packages/xfsinfo/package.py
+++ b/var/spack/repos/builtin/packages/xfsinfo/package.py
@@ -16,6 +16,8 @@ class Xfsinfo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xfsinfo"
     xorg_mirror_path = "app/xfsinfo-1.0.5.tar.gz"
 
+    version("1.0.7", sha256="df874933710c9c38640496a2121d73272501b9620bdb95784e9e67b913788151")
+    version("1.0.6", sha256="a817e553703748fe2d721b1fe8ea95687ee78f7aef25427ed72d9584494d91e1")
     version("1.0.5", sha256="56a0492ed2cde272dc8f4cff4ba0970ccb900e51c10bb8ec62747483d095fd69")
 
     depends_on("libfs")

--- a/var/spack/repos/builtin/packages/xgamma/package.py
+++ b/var/spack/repos/builtin/packages/xgamma/package.py
@@ -13,6 +13,7 @@ class Xgamma(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xgamma"
     xorg_mirror_path = "app/xgamma-1.0.6.tar.gz"
 
+    version("1.0.7", sha256="61f5ef02883d65ab464678ad3d8c5445a0ff727fe6255af90b1b842ddf77370d")
     version("1.0.6", sha256="66da1d67e84146518b69481c6283c5d8f1027ace9ff7e214d3f81954842e796a")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xgc/package.py
+++ b/var/spack/repos/builtin/packages/xgc/package.py
@@ -13,6 +13,7 @@ class Xgc(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xgc"
     xorg_mirror_path = "app/xgc-1.0.5.tar.gz"
 
+    version("1.0.6", sha256="8b5cfc547c04a2bd0807be700349522c0e717e34387019dd209eefa83cfa74f0")
     version("1.0.5", sha256="16645fb437699bad2360f36f54f42320e33fce5a0ab9a086f6e0965963205b02")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xhost/package.py
+++ b/var/spack/repos/builtin/packages/xhost/package.py
@@ -13,6 +13,8 @@ class Xhost(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xhost"
     xorg_mirror_path = "app/xhost-1.0.7.tar.gz"
 
+    version("1.0.9", sha256="ca850367593fcddc4bff16de7ea1598aa4f6817daf5a803a1258dff5e337f7c3")
+    version("1.0.8", sha256="e5aabce1533dc778ceb5bbc207105cf3770f710629caceaad64675b00c38c3f8")
     version("1.0.7", sha256="8dd1b6245dfbdef45a64a18ea618f233f77432c2f30881b1db9dc40d510d9490")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xinit/package.py
+++ b/var/spack/repos/builtin/packages/xinit/package.py
@@ -14,6 +14,9 @@ class Xinit(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xinit"
     xorg_mirror_path = "app/xinit-1.3.4.tar.gz"
 
+    version("1.4.2", sha256="9121c9162f6dedab1229a8c4ed4021c4d605699cb0da580ac2ee1b0c96b3f60e")
+    version("1.4.1", sha256="ca33ec3de6c39589c753620e5b3bcbc8277218b949bfa2df727779b03a8d2357")
+    version("1.4.0", sha256="17548a5df41621b87d395f1074dfb88b0dc6917f9127540b89c6de4a80f33776")
     version("1.3.4", sha256="754c284875defa588951c1d3d2b20897d3b84918d0a97cb5a4724b00c0da0746")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xinput/package.py
+++ b/var/spack/repos/builtin/packages/xinput/package.py
@@ -12,6 +12,7 @@ class Xinput(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xinput"
     xorg_mirror_path = "app/xinput-1.6.2.tar.gz"
 
+    version("1.6.3", sha256="9f29f9bfe387c5a3d582f9edc8c5a753510ecc6fdfb154c03b5cea5975b10ce4")
     version("1.6.2", sha256="2c8ca5ff2a8703cb7d898629a4311db720dbd30d0c162bfe37f18849a727bd42")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xkbevd/package.py
+++ b/var/spack/repos/builtin/packages/xkbevd/package.py
@@ -12,6 +12,7 @@ class Xkbevd(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xkbevd"
     xorg_mirror_path = "app/xkbevd-1.1.4.tar.gz"
 
+    version("1.1.5", sha256="5d6b65a417be57e19a76277601da83271b19de6e71cb0e8821441f6fb9973c47")
     version("1.1.4", sha256="97dc2c19617da115c3d1183807338fa78c3fd074d8355d10a484f7b1c5b18459")
 
     depends_on("libxkbfile")

--- a/var/spack/repos/builtin/packages/xkbprint/package.py
+++ b/var/spack/repos/builtin/packages/xkbprint/package.py
@@ -13,6 +13,8 @@ class Xkbprint(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xkbprint"
     xorg_mirror_path = "app/xkbprint-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="0d4602034cde190ca3d8f5c1051d34cebff5c0d92f7a32422a4de9d2313698ad")
+    version("1.0.5", sha256="af5d91b7e5b05f7d081b66e93fca0112cca049b7b6a644b2637b344d52054ac3")
     version("1.0.4", sha256="169ebbf57fc8b7685c577c73a435998a38c27e0d135ce0a55fccc64cbebec768")
 
     depends_on("libxkbfile")

--- a/var/spack/repos/builtin/packages/xkbutils/package.py
+++ b/var/spack/repos/builtin/packages/xkbutils/package.py
@@ -13,6 +13,7 @@ class Xkbutils(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xkbutils"
     xorg_mirror_path = "app/xkbutils-1.0.4.tar.gz"
 
+    version("1.0.5", sha256="b87072f0d7e75f56ee04455e1feab92bb5847aee4534b18c2e08b926150279ff")
     version("1.0.4", sha256="cf31303cbdd6a86c34cab46f4b6e0c7acd2e84578593b334a146142894529bca")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xkill/package.py
+++ b/var/spack/repos/builtin/packages/xkill/package.py
@@ -14,6 +14,8 @@ class Xkill(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xkill"
     xorg_mirror_path = "app/xkill-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="3b35a2f4b67dda1e98b6541488cd7f7343eb6e3dbe613aeff3d5a5a4c4c64b58")
+    version("1.0.5", sha256="98fab8a8af78d5aae4e1f284b580c60e3d25ed2a72daa4dbce419b28d8adaf8a")
     version("1.0.4", sha256="f80115f2dcca3d4b61f3c28188752c21ca7b2718b54b6e0274c0497a7f827da0")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xload/package.py
+++ b/var/spack/repos/builtin/packages/xload/package.py
@@ -13,6 +13,7 @@ class Xload(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xload"
     xorg_mirror_path = "app/xload-1.1.3.tar.gz"
 
+    version("1.1.4", sha256="4e3d240ab63e02f2ddac8182519d94bea82bda4887e3e364dd8832a04ca8436a")
     version("1.1.3", sha256="9952e841d25ab2fd0ce5e27ba91858331c3f97575d726481772d4deb89432483")
     version("1.1.2", sha256="4863ad339d22c41a0ca030dc5886404f5ae8b8c47cd5e09f0e36407edbdbe769")
 

--- a/var/spack/repos/builtin/packages/xlogo/package.py
+++ b/var/spack/repos/builtin/packages/xlogo/package.py
@@ -12,6 +12,8 @@ class Xlogo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xlogo"
     xorg_mirror_path = "app/xlogo-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="0b0dbd90f53103b9241cc3a68c232213cec5c1d9a839604e59d128e4d81d1a4d")
+    version("1.0.5", sha256="28f51b64e3bce6aa5ac0e35d0c12121e6e0311d3bd8b48664a57a74f6be651eb")
     version("1.0.4", sha256="0072eb3b41af77d5edfafb12998c7dd875f2795dc94735a998fd2ed8fc246e57")
 
     depends_on("libsm")

--- a/var/spack/repos/builtin/packages/xlsatoms/package.py
+++ b/var/spack/repos/builtin/packages/xlsatoms/package.py
@@ -12,6 +12,8 @@ class Xlsatoms(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xlsatoms"
     xorg_mirror_path = "app/xlsatoms-1.1.2.tar.gz"
 
+    version("1.1.4", sha256="e3b4dce0e6bf3b60bc308ed184d2dc201ea4af6ce03f0126aa303ccd1ccb1237")
+    version("1.1.3", sha256="2a5a3ac0ded207c31ac1c2e9b8ae0030bba7ff604fea87a92781186ba71cbffa")
     version("1.1.2", sha256="5400e22211795e40c4c4d28a048250f92bfb8c373004f0e654a2ad3138c2b36d")
 
     depends_on("libxcb", when="@1.1:")

--- a/var/spack/repos/builtin/packages/xlsclients/package.py
+++ b/var/spack/repos/builtin/packages/xlsclients/package.py
@@ -13,6 +13,8 @@ class Xlsclients(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xlsclients"
     xorg_mirror_path = "app/xlsclients-1.1.3.tar.gz"
 
+    version("1.1.5", sha256="225d75e4c0b0929f16f974e20931ab85204b40098d92a5479b0b9379120637e5")
+    version("1.1.4", sha256="0b46e8289413c3e7c437a95ecd6494f99d27406d3a0b724ef995a98cbd6c33e8")
     version("1.1.3", sha256="4670a4003aae01e9172efb969246c3d8f33481f290aa8726ff50398c838e6994")
 
     depends_on("libxcb@1.6:", when="@1.1:")

--- a/var/spack/repos/builtin/packages/xlsfonts/package.py
+++ b/var/spack/repos/builtin/packages/xlsfonts/package.py
@@ -13,6 +13,8 @@ class Xlsfonts(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xlsfonts"
     xorg_mirror_path = "app/xlsfonts-1.0.5.tar.gz"
 
+    version("1.0.7", sha256="b92d4954eaf525674ff83f7e85240ef166c240a774277f71c30674f9f7794171")
+    version("1.0.6", sha256="870bbcfb903e790e730ea8ee964c72ce4a4df60f7a4b39541b88193d1e8c9453")
     version("1.0.5", sha256="2a7aeca1023a3918ad2a1af2258ed63d8f8b6c48e53841b3a3f15fb9a0c008ce")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xmag/package.py
+++ b/var/spack/repos/builtin/packages/xmag/package.py
@@ -12,6 +12,7 @@ class Xmag(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xmag"
     xorg_mirror_path = "app/xmag-1.0.6.tar.gz"
 
+    version("1.0.7", sha256="bf94f5ac6ad0dd423b3ee8fb78710d1e47ad7e9fc8b4cf561851fba5370e38eb")
     version("1.0.6", sha256="07c5ec9114376dcd9a3303a38779e79b949d486f3b832d4a438550357d797aa5")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xman/package.py
+++ b/var/spack/repos/builtin/packages/xman/package.py
@@ -13,6 +13,7 @@ class Xman(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xman"
     xorg_mirror_path = "app/xman-1.1.4.tar.gz"
 
+    version("1.1.5", sha256="ff0aeb164fcb736b381bd7722c27aa0284cafb9a5d1b3940c3c3ee0af642f204")
     version("1.1.4", sha256="72fd0d479624a31d9a7330e5fdd220b7aa144744781f8e78aa12deece86e05c7")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xmessage/package.py
+++ b/var/spack/repos/builtin/packages/xmessage/package.py
@@ -14,6 +14,8 @@ class Xmessage(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xmessage"
     xorg_mirror_path = "app/xmessage-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="46acfb25c531f59a24abc85b14b956c9c03c870757dddae4d6d083833924a071")
+    version("1.0.5", sha256="99533a90ab66e268180a8400796950a7f560ea9421e2c3f32284cabc1858806b")
     version("1.0.4", sha256="883099c3952c8cace5bd11d3df2e9ca143fc07375997435d5ff4f2d50353acca")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xmh/package.py
+++ b/var/spack/repos/builtin/packages/xmh/package.py
@@ -14,6 +14,7 @@ class Xmh(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xmh"
     xorg_mirror_path = "app/xmh-1.0.3.tar.gz"
 
+    version("1.0.4", sha256="2034f24fb3181b6e07ebf7235d2845a7ebb18d533aa405dbc99235eec4ab410f")
     version("1.0.3", sha256="f90baf2615a4e1e01232c50cfd36ee4d50ad2fb2f76b8b5831fb796661f194d2")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xmodmap/package.py
+++ b/var/spack/repos/builtin/packages/xmodmap/package.py
@@ -16,6 +16,8 @@ class Xmodmap(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xmodmap"
     xorg_mirror_path = "app/xmodmap-1.0.9.tar.gz"
 
+    version("1.0.11", sha256="c4fac9df448b98ac5a1620f364e74ed5f7084baae0d09123700f34d4b63cb5d8")
+    version("1.0.10", sha256="d4e9dc4cb034d0d774d059498d05348869934c52b0f24b0f3913823090b88640")
     version("1.0.9", sha256="73427a996f0fcda2a2c7ac96cfc4edd5985aeb13b48053f55ae7f63a668fadef")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xmore/package.py
+++ b/var/spack/repos/builtin/packages/xmore/package.py
@@ -12,6 +12,7 @@ class Xmore(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xmore"
     xorg_mirror_path = "app/xmore-1.0.2.tar.gz"
 
+    version("1.0.3", sha256="00e2f55ce4d2699a97f70060d309898c92ed2a42b9e16f21047a3654432a92b6")
     version("1.0.2", sha256="7371631d05986f1111f2026a77e43e048519738cfcc493c6222b66e7b0f309c0")
 
     depends_on("libxaw")

--- a/var/spack/repos/builtin/packages/xpr/package.py
+++ b/var/spack/repos/builtin/packages/xpr/package.py
@@ -13,6 +13,8 @@ class Xpr(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xpr"
     xorg_mirror_path = "app/xpr-1.0.4.tar.gz"
 
+    version("1.1.0", sha256="fabd02fb1a52358d521f1be7422738bc8c9b511a8d82a163888f628db6f6cb18")
+    version("1.0.5", sha256="7a429478279a2b0f2363b24b8279ff132cc5e83762d3329341490838b0723757")
     version("1.0.4", sha256="9ec355388ae363fd40239a3fa56908bb2f3e53b5bfc872cf0182d14d730c6207")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xprop/package.py
+++ b/var/spack/repos/builtin/packages/xprop/package.py
@@ -13,6 +13,10 @@ class Xprop(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xprop"
     xorg_mirror_path = "app/xprop-1.2.2.tar.gz"
 
+    version("1.2.6", sha256="58ee5ee0c47fa454d3b16312e778c3f549605a8ad0fd0daafc70d2d6174b116d")
+    version("1.2.5", sha256="b7bf6b6be6cf23e7966a153fc84d5901c14f01ee952fbd9d930aa48e2385d670")
+    version("1.2.4", sha256="dddb6e208ffa515e68f001c22077a465f1365a4bcf91d9b37f336a6c0d15400d")
+    version("1.2.3", sha256="82c13f40577e10b6f3f0160a21b1e46c00a0c719aa560618b961c453e1b5c80d")
     version("1.2.2", sha256="3db78771ce8fb8954fb242ed9d4030372523649c5e9c1a9420340020dd0afbc2")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xrdb/package.py
+++ b/var/spack/repos/builtin/packages/xrdb/package.py
@@ -12,6 +12,9 @@ class Xrdb(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xrdb"
     xorg_mirror_path = "app/xrdb-1.1.0.tar.gz"
 
+    version("1.2.1", sha256="e674f5fb081a023e54878c0aac728dc30feb821207c989cff17a60f0c4a80ced")
+    version("1.2.0", sha256="7dec50e243d55c6a0623ff828355259b6a110de74a0c65c40529514324ef7938")
+    version("1.1.1", sha256="d19f856296c5f1742a703afc620654efc76fedfb86e1afe0bff9f1038b9e8a47")
     version("1.1.0", sha256="44b0b6b7b7eb80b83486dfea67c880f6b0059052386c7ddec4d58fd2ad9ae8e9")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xrefresh/package.py
+++ b/var/spack/repos/builtin/packages/xrefresh/package.py
@@ -12,6 +12,8 @@ class Xrefresh(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xrefresh"
     xorg_mirror_path = "app/xrefresh-1.0.5.tar.gz"
 
+    version("1.0.7", sha256="f2817920f119bd9146ed3cde223b8a4ab17cb72da4ece7bddde35e18b31aa337")
+    version("1.0.6", sha256="0dda726365d341c00aed0f9cfebf3d2cfaa0c661212c73c0114cbb4ce92f357e")
     version("1.0.5", sha256="b373cc1ecd37c3d787e7074ce89a8a06ea173d7ba9e73fa48de973c759fbcf38")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xscope/package.py
+++ b/var/spack/repos/builtin/packages/xscope/package.py
@@ -12,6 +12,8 @@ class Xscope(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xscope"
     xorg_mirror_path = "app/xscope-1.4.1.tar.gz"
 
+    version("1.4.3", sha256="86f9da3cf0422b5964191c9e8f792e107577818de094b38db0a6dbce403a9b54")
+    version("1.4.2", sha256="e12d634a69ce1ec36b0afd1d40814215e262801a030ddf83d7d0348cd046b381")
     version("1.4.1", sha256="f99558a64e828cd2c352091ed362ad2ef42b1c55ef5c01cbf782be9735bb6de3")
 
     depends_on("xproto@7.0.17:")

--- a/var/spack/repos/builtin/packages/xset/package.py
+++ b/var/spack/repos/builtin/packages/xset/package.py
@@ -12,6 +12,8 @@ class Xset(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xset"
     xorg_mirror_path = "app/xset-1.2.3.tar.gz"
 
+    version("1.2.5", sha256="2068d1356d80c29ce283f0fff5895667b38f24ea95df363d3dde7b8c8a92fffe")
+    version("1.2.4", sha256="3a05e8626298c7a79002ec5fb4949dcba8abc7a2b95c03ed5e0f5698c3b4dea0")
     version("1.2.3", sha256="5ecb2bb2cbf3c9349b735080b155a08c97b314dacedfc558c7f5a611ee1297f7")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xsetroot/package.py
+++ b/var/spack/repos/builtin/packages/xsetroot/package.py
@@ -12,6 +12,8 @@ class Xsetroot(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xsetroot"
     xorg_mirror_path = "app/xsetroot-1.1.1.tar.gz"
 
+    version("1.1.3", sha256="80dbb0d02807e89294a042298b8a62f9aa0c3a94d89244ccbc35e4cf80fcaaba")
+    version("1.1.2", sha256="9d007f5119be09924ac3a5d2bd506f32e6c164b82633c88d2aff26311e1a2a2b")
     version("1.1.1", sha256="6cdd48757d18835251124138b4a8e4008c3bbc51cf92533aa39c6ed03277168b")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xsm/package.py
+++ b/var/spack/repos/builtin/packages/xsm/package.py
@@ -12,6 +12,8 @@ class Xsm(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xsm"
     xorg_mirror_path = "app/xsm-1.0.3.tar.gz"
 
+    version("1.0.5", sha256="e8a2f64b5a37be39a81877cd4069745a226a31493080f03ae74b76fb3f17b7a6")
+    version("1.0.4", sha256="d12fb0071719de5845d41602963988e4b889f482427c13ce8e515f5ca51c0564")
     version("1.0.3", sha256="f70815139d62416dbec5915ec37db66f325932a69f6350bb1a74c0940cdc796a")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xstdcmap/package.py
+++ b/var/spack/repos/builtin/packages/xstdcmap/package.py
@@ -15,6 +15,8 @@ class Xstdcmap(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xstdcmap"
     xorg_mirror_path = "app/xstdcmap-1.0.3.tar.gz"
 
+    version("1.0.5", sha256="70bd5909d6f1b4d9b038593f72ce70b0095a6f773e1dd8059136bbeb021b8771")
+    version("1.0.4", sha256="7b1a23ba7ac623803101b6f9df37889fb1ef2f1bb53da25a415c8a88eebc8073")
     version("1.0.3", sha256="b97aaa883a9eedf9c3056ea1a7e818e3d93b63aa1f54193ef481d392bdef5711")
 
     depends_on("libxmu")

--- a/var/spack/repos/builtin/packages/xtrap/package.py
+++ b/var/spack/repos/builtin/packages/xtrap/package.py
@@ -12,6 +12,7 @@ class Xtrap(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xtrap"
     xorg_mirror_path = "app/xtrap-1.0.2.tar.gz"
 
+    version("1.0.3", sha256="c6b86b921a748acbf1d82590fbd9c4575f970220760088f0e0efac6fd93d6dc3")
     version("1.0.2", sha256="e8916e05bfb0d72a088aaaac0feaf4ad7671d0f509d1037fb3c0c9ea131b93d2")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xvidtune/package.py
+++ b/var/spack/repos/builtin/packages/xvidtune/package.py
@@ -13,6 +13,7 @@ class Xvidtune(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xvidtune"
     xorg_mirror_path = "app/xvidtune-1.0.3.tar.gz"
 
+    version("1.0.4", sha256="e5982c9e6c5009f0061c187a9cc82368215bd004cfa464a3d738c90e1d258668")
     version("1.0.3", sha256="c0e158388d60e1ce054ce462958a46894604bd95e13093f3476ec6d9bbd786d4")
 
     depends_on("libxxf86vm")

--- a/var/spack/repos/builtin/packages/xvinfo/package.py
+++ b/var/spack/repos/builtin/packages/xvinfo/package.py
@@ -13,6 +13,8 @@ class Xvinfo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xvinfo"
     xorg_mirror_path = "app/xvinfo-1.1.3.tar.gz"
 
+    version("1.1.5", sha256="76fdc89a4e4207d0069ae3e511b4e30a60fcf86b630d01ef56d32ba5856e76c4")
+    version("1.1.4", sha256="43d06be36fe10f247295fbe2edf1062740064343f2228d6a61b4f9feac4f7396")
     version("1.1.3", sha256="1c1c2f97abfe114389e94399cc7bf3dfd802ed30ad41ba23921d005bd8a6c39f")
 
     depends_on("libxv")

--- a/var/spack/repos/builtin/packages/xwd/package.py
+++ b/var/spack/repos/builtin/packages/xwd/package.py
@@ -12,6 +12,8 @@ class Xwd(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xwd"
     xorg_mirror_path = "app/xwd-1.0.6.tar.gz"
 
+    version("1.0.8", sha256="066d10a1b66a47efd7caa7d7aa670c0c26ff90c8408f0e30b4dfb29dcb39d4c4")
+    version("1.0.7", sha256="1c5e86806234a96a29c90be1872128293c6def5ba69ecb70e161efe325e2ba03")
     version("1.0.6", sha256="ff01f0a4b736f955aaf7c8c3942211bc52f9fb75d96f2b19777f33fff5dc5b83")
 
     depends_on("libx11")

--- a/var/spack/repos/builtin/packages/xwininfo/package.py
+++ b/var/spack/repos/builtin/packages/xwininfo/package.py
@@ -13,6 +13,8 @@ class Xwininfo(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xwininfo"
     xorg_mirror_path = "app/xwininfo-1.1.3.tar.gz"
 
+    version("1.1.5", sha256="aaa915909bb509320c3c775c79babaccc063fd3edc39e520a3c0352e265e9f58")
+    version("1.1.4", sha256="3561f6c37eec416ad306f41ff24172b86cbed00854dff8912915e97d2cc17c34")
     version("1.1.3", sha256="784f8b9c9ddab24ce4faa65fde6430a8d7cf3c0564573582452cc99c599bd941")
 
     depends_on("libxcb@1.6:")

--- a/var/spack/repos/builtin/packages/xwud/package.py
+++ b/var/spack/repos/builtin/packages/xwud/package.py
@@ -13,6 +13,8 @@ class Xwud(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/xwud"
     xorg_mirror_path = "app/xwud-1.0.4.tar.gz"
 
+    version("1.0.6", sha256="262171b0c434966ddbbe8a54afb9615567ad74d4cc2e823e14e51e099ec3ab0d")
+    version("1.0.5", sha256="24d51e236ec3d1dd57c73679136029a14808aee5a2edda152d61598ba018c697")
     version("1.0.4", sha256="b7c124ccd87f529daedb7ef01c670ce6049fe141fd9ba7f444361de34510cd6c")
 
     depends_on("libx11")


### PR DESCRIPTION
This updates all xorg apps to the latest versions, adding updated requirements where needed.

No major version increases in any packages.

Minor version increases in some packages (build changes, if any, are indicated below):
- rgb
- xauth
- xcalc
- xclock
- xeyes: xi >= 1.7, x11-xcb xcb-present >= 1.9 xcb-xfixes xcb-damage
- xfontsel
- xfs: xfont2 >= 2.0.1
- xinit
- xpr
- xrdb

Bugfix version increases in many packages, with no expected impact on dependencies or interfaces, except for:
- setxkbmap: xrandr

Summary of dependency changes:
- setxkbmap:
  - depends_on("libxrandr", when="@1.3.3:")
- xeyes:
  - depends_on("libxi@1.7:", when="@1.2:")
  - depends_on("libxcb@1.9:", when="@1.2:")
- xfs:
  - depends_on("libxfont@1.4.5:", when="@:1.1")
  - depends_on("libxfont2@2.0.1:", when="@1.2:")

All latest new versions (except for `rgb`) were successfully built (albeit on top of #36241 #36240 and #36238 with `xorg-proto +legacy`). `rgb` depends on `xorg-server` which has newer versions as well, and I'm still sorting that out.