### PR TITLE
curl: Add version 8.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -27,7 +27,6 @@ class Curl(NMakePackage, AutotoolsPackage):
     maintainers("alecbcs")
 
     version("8.0.1", sha256="9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf")
-    version("8.0.0", sha256="dd6e792593dbd2253cc2da57265808427e3614e84ca86d424fbc75cf9baba08c")
     version("7.88.1", sha256="8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907")
 
     # Deprecated versions due to CVEs

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -26,6 +26,8 @@ class Curl(NMakePackage, AutotoolsPackage):
 
     maintainers("alecbcs")
 
+    version("8.0.1", sha256="9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf")
+    version("8.0.0", sha256="dd6e792593dbd2253cc2da57265808427e3614e84ca86d424fbc75cf9baba08c")
     version("7.88.1", sha256="8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907")
 
     # Deprecated versions due to CVEs

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -71,7 +71,9 @@ class R(AutotoolsPackage):
     depends_on("blas", when="+external-lapack")
     depends_on("lapack", when="+external-lapack")
     depends_on("bzip2")
-    depends_on("curl+libidn2")
+    # R didn't anticipate the celebratory
+    # non-breaking major version bump of curl 8.
+    depends_on("curl+libidn2@:7")
     depends_on("icu4c")
     depends_on("java")
     depends_on("ncurses")


### PR DESCRIPTION
I'm not sure, should 7.88.1 be deprecated?  8.0.0 [fixed multiple (non-high) security vulnerabilities](https://daniel.haxx.se/blog/2023/03/20/curl-8-0-0-is-here/).  Also, should 8.0.0 [be deprecated as well](https://daniel.haxx.se/blog/2023/03/20/curl-8-0-1-because-i-jinxed-it/)?