### PR TITLE
Package requirements: allow single specs in requirement lists

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -32,11 +32,16 @@ properties = {
                             {
                                 "type": "array",
                                 "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "one_of": {"type": "array"},
-                                        "any_of": {"type": "array"},
-                                    },
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "one_of": {"type": "array"},
+                                                "any_of": {"type": "array"},
+                                            }
+                                        },
+                                        {"type": "string"}
+                                    ]
                                 },
                             },
                             # Shorthand for a single requirement group with

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -38,9 +38,9 @@ properties = {
                                             "properties": {
                                                 "one_of": {"type": "array"},
                                                 "any_of": {"type": "array"},
-                                            }
+                                            },
                                         },
-                                        {"type": "string"}
+                                        {"type": "string"},
                                     ]
                                 },
                             },

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1017,9 +1017,12 @@ class SpackSolverSetup(object):
         else:
             rules = []
             for requirement in requirements:
-                for policy in ("one_of", "any_of"):
-                    if policy in requirement:
-                        rules.append((pkg_name, policy, requirement[policy]))
+                if isinstance(requirement, str):
+                    rules.append((pkg_name, "one_of", [requirement]))
+                else:
+                    for policy in ("one_of", "any_of"):
+                        if policy in requirement:
+                            rules.append((pkg_name, policy, requirement[policy]))
         return rules
 
     def pkg_rules(self, pkg, tests):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1018,6 +1018,8 @@ class SpackSolverSetup(object):
             rules = []
             for requirement in requirements:
                 if isinstance(requirement, str):
+                    # A string represents a spec that must be satisfied. It is
+                    # equivalent to a one_of group with a single element
                     rules.append((pkg_name, "one_of", [requirement]))
                 else:
                     for policy in ("one_of", "any_of"):

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -107,12 +107,28 @@ def fake_installs(monkeypatch, tmpdir):
     )
 
 
+def test_one_package_multiple_reqs(concretize_scope, test_repo):
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration requirements")
+
+    conf_str = """\
+packages:
+  y:
+    require:
+    - "@2.4"
+    - "~shared"
+"""
+    update_packages_config(conf_str)
+    y_spec = Spec("y").concretized()
+    assert y_spec.satisfies("@2.4~shared")
+
+
 def test_requirement_isnt_optional(concretize_scope, test_repo):
     """If a user spec requests something that directly conflicts
     with a requirement, make sure we get an error.
     """
     if spack.config.get("config:concretizer") == "original":
-        pytest.skip("Original concretizer does not support configuration" " requirements")
+        pytest.skip("Original concretizer does not support configuration requirements")
 
     conf_str = """\
 packages:


### PR DESCRIPTION
Without this PR, if you have a list of package requirements like:

```yaml
packages:
  foo:
    require:
    - x
    - y
    ...
```

x and y must be `one_of` or `any_of` like `one_of: [+shared]`, even if there is just a single item in the `one_of` list. This PR allows specifying strings as the elements of the `require:` list like:

```yaml
packages:
  foo:
    require:
    - @version+shared
```

This is useful if you are combining `packages` config from multiple files (if there is only one configuration file, then generally you might as well use `require: @version+shared` rather than specifying the requirements as a list
