### PR TITLE
Prevent usage of compiler wrappers for hdf5+mpi with MSVC

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -580,7 +580,10 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        if "+mpi" in spec and "%msvc" not in spec:
+        # MSMPI does not vendor compiler wrappers
+        # and pointing these varibles at the msvc compilers
+        # breaks CMake's mpi detection for MSMPI.
+        if "+mpi" in spec and "msmpi" not in spec:
             args.extend(
                 [
                     "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -343,9 +343,11 @@ class Hdf5(CMakePackage):
 
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
-    filter_compiler_wrappers(
-        "h5cc", "h5hlcc", "h5fc", "h5hlfc", "h5c++", "h5hlc++", relative_root="bin"
-    )
+    # These do not appear to exist on Windows, only enable for supported platforms
+    for plat in ["linux", "darwin", "cray"]:
+        filter_compiler_wrappers(
+            "h5cc", "h5hlcc", "h5fc", "h5hlfc", "h5c++", "h5hlc++", relative_root="bin", when=f"platform={plat}"
+        )
 
     def url_for_version(self, version):
         url = (

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -343,8 +343,8 @@ class Hdf5(CMakePackage):
 
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
-    # These do not exist on Windows
-    # Enable only for supported platforms
+    # These do not exist on Windows.
+    # Enable only for supported platforms.
     for p in ["linux", "darwin", "cray"]:
         filter_compiler_wrappers(
             "h5cc",

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -204,8 +204,8 @@ class Hdf5(CMakePackage):
 
     # The compiler wrappers (h5cc, h5fc, etc.) run 'pkg-config'.
     # Skip this on Windows since pkgconfig is autotools
-    for p in ["cray", "darwin", "linux"]:
-        depends_on("pkgconfig", when=f"platform={p}", type="run")
+    for plat in ["cray", "darwin", "linux"]:
+        depends_on("pkgconfig", when=f"platform={plat}", type="run")
 
     conflicts("+mpi", "^mpich@4.0:4.0.3")
     conflicts("api=v116", when="@1.6:1.14", msg="v116 is not compatible with this release")
@@ -345,7 +345,7 @@ class Hdf5(CMakePackage):
     # compiler wrappers and do not need to be changed.
     # These do not exist on Windows.
     # Enable only for supported platforms.
-    for p in ["linux", "darwin", "cray"]:
+    for plat in ["linux", "darwin", "cray"]:
         filter_compiler_wrappers(
             "h5cc",
             "h5hlcc",
@@ -354,7 +354,7 @@ class Hdf5(CMakePackage):
             "h5c++",
             "h5hlc++",
             relative_root="bin",
-            when=f"platform={p}",
+            when=f"platform={plat}",
         )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -581,7 +581,7 @@ class Hdf5(CMakePackage):
             args.append(self.define("DEFAULT_API_VERSION", api))
 
         # MSMPI does not vendor compiler wrappers
-        # and pointing these varibles at the msvc compilers
+        # and pointing these variables at the msvc compilers
         # breaks CMake's mpi detection for MSMPI.
         if "+mpi" in spec and "msmpi" not in spec:
             args.extend(

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -346,7 +346,14 @@ class Hdf5(CMakePackage):
     # These do not appear to exist on Windows, only enable for supported platforms
     for plat in ["linux", "darwin", "cray"]:
         filter_compiler_wrappers(
-            "h5cc", "h5hlcc", "h5fc", "h5hlfc", "h5c++", "h5hlc++", relative_root="bin", when=f"platform={plat}"
+            "h5cc",
+            "h5hlcc",
+            "h5fc",
+            "h5hlfc",
+            "h5c++",
+            "h5hlc++",
+            relative_root="bin",
+            when=f"platform={plat}",
         )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -580,8 +580,8 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        # MSMPI does not vendor compiler wrappers
-        # and pointing these variables at the msvc compilers
+        # MSMPI does not provide compiler wrappers
+        # and pointing these variables at the MSVC compilers
         # breaks CMake's mpi detection for MSMPI.
         if "+mpi" in spec and "msmpi" not in spec:
             args.extend(

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -580,7 +580,7 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        if "+mpi" in spec and "platform=windows" not in spec:
+        if "+mpi" in spec and "%msvc" not in spec:
             args.extend(
                 [
                     "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
@@ -645,7 +645,7 @@ class Hdf5(CMakePackage):
         if not pc_files:
             # This also tells us that the pkgconfig directory does not exist.
             return
-        import pdb; pdb.set_trace()
+
         # Replace versioned references in all pkg-config files:
         filter_file(
             r"(Requires(?:\.private)?:.*)(hdf5[^\s,]*)(?:-[^\s,]*)(.*)",

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -204,8 +204,8 @@ class Hdf5(CMakePackage):
 
     # The compiler wrappers (h5cc, h5fc, etc.) run 'pkg-config'.
     # Skip this on Windows since pkgconfig is autotools
-    for plat in ["cray", "darwin", "linux"]:
-        depends_on("pkgconfig", when="platform=%s" % plat, type="run")
+    for p in ["cray", "darwin", "linux"]:
+        depends_on("pkgconfig", when=f"platform={p}", type="run")
 
     conflicts("+mpi", "^mpich@4.0:4.0.3")
     conflicts("api=v116", when="@1.6:1.14", msg="v116 is not compatible with this release")
@@ -343,8 +343,9 @@ class Hdf5(CMakePackage):
 
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
-    # These do not appear to exist on Windows, only enable for supported platforms
-    for plat in ["linux", "darwin", "cray"]:
+    # These do not exist on Windows
+    # Enable only for supported platforms
+    for p in ["linux", "darwin", "cray"]:
         filter_compiler_wrappers(
             "h5cc",
             "h5hlcc",
@@ -353,7 +354,7 @@ class Hdf5(CMakePackage):
             "h5c++",
             "h5hlc++",
             relative_root="bin",
-            when=f"platform={plat}",
+            when=f"platform={p}",
         )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -344,8 +344,8 @@ class Hdf5(CMakePackage):
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
     # These do not exist on Windows.
-    # Enable only for supported platforms.
-    for plat in ["linux", "darwin", "cray"]:
+    # Enable only for supported target platforms.
+    for spack_spec_target_platform in ["linux", "darwin", "cray"]:
         filter_compiler_wrappers(
             "h5cc",
             "h5hlcc",
@@ -354,7 +354,7 @@ class Hdf5(CMakePackage):
             "h5c++",
             "h5hlc++",
             relative_root="bin",
-            when=f"platform={plat}",
+            when=f"platform={spack_spec_target_platform}",
         )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -580,7 +580,7 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        if "+mpi" in spec:
+        if "+mpi" in spec and "platform=windows" not in spec:
             args.extend(
                 [
                     "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
@@ -645,7 +645,7 @@ class Hdf5(CMakePackage):
         if not pc_files:
             # This also tells us that the pkgconfig directory does not exist.
             return
-
+        import pdb; pdb.set_trace()
         # Replace versioned references in all pkg-config files:
         filter_file(
             r"(Requires(?:\.private)?:.*)(hdf5[^\s,]*)(?:-[^\s,]*)(.*)",


### PR DESCRIPTION
Currently only MSMPI is supported with MSVC compiler. MSMPI does not provide compiler wrappers, nor does the Spack package define them. Skip this entirely when compiling with MSVC, otherwise CMake will struggle to find MSMPI.