### PR TITLE
modules tcl: switch default all:autoload from none to direct

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -46,7 +46,7 @@ modules:
 
     tcl:
       all:
-        autoload: none
+        autoload: direct
 
     # Default configurations if lmod is enabled
     lmod:

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -629,8 +629,9 @@ by its dependency; when the dependency is autoloaded, the executable will be in 
 PATH. Similarly for scripting languages such as Python, packages and their dependencies
 have to be loaded together.
 
-Autoloading is enabled by default for Lmod, as it has great builtin support for through
-the ``depends_on`` function. For Environment Modules it is disabled by default.
+Autoloading is enabled by default for Lmod and Environment Modules. The former
+has builtin support for through the ``depends_on`` function. The latter uses
+``module load`` statement to load and track dependencies.
 
 Autoloading can also be enabled conditionally:
 
@@ -654,8 +655,10 @@ The allowed values for the ``autoload`` statement are either ``none``,
      In the ``tcl`` section of the configuration file it is possible to use
      the ``prerequisites`` directive that accepts the same values as
      ``autoload``. It will produce module files that have a ``prereq``
-     statement, which can be used to autoload dependencies in some versions
-     of Environment Modules.
+     statement, which autoloads dependencies on Environment Modules when its
+     ``auto_handling`` configuration option is enabled. If Environment Modules
+     is installed with Spack, ``auto_handling`` is enabled by default starting
+     version 4.2. Otherwise it is enabled by default since version 5.0.
 
 ------------------------
 Maintaining Module Files


### PR DESCRIPTION
Now that #36237 has fixed the *if-not-loaded-load logic* in `tcl` modulefiles, I am proposing to set `autoload: direct` as a default, like it was done for `lmod` on #28357.

Same behavior will be set by default on both module systems.