### PR TITLE
GNINA: add cuDNN variant and make RDKit optional

### DIFF
--- a/var/spack/repos/builtin/packages/gnina/package.py
+++ b/var/spack/repos/builtin/packages/gnina/package.py
@@ -18,6 +18,9 @@ class Gnina(CMakePackage, CudaPackage):
 
     version("1.0.3", sha256="4274429f38293d79c7d22ab08aca91109e327e9ce3f682cd329a8f9c6ef429da")
 
+    variant("cudnn", default=True, description="Build with cuDNN")
+    variant("gninavis", default=False, description="Build gninavis")
+
     _boost = "boost" + "".join(
         [
             "+atomic",
@@ -54,18 +57,21 @@ class Gnina(CMakePackage, CudaPackage):
     depends_on("libmolgrid")
 
     depends_on("openbabel@3:~gui~cairo~maeparser~coordgen")
-    depends_on("rdkit")
+    depends_on("rdkit", when="+gninavis")
 
     depends_on("python", type="build")
     depends_on("py-numpy", type="build")
     depends_on("py-pytest", type="build")
 
     depends_on("cuda@11")
+    depends_on("cudnn", when="+cudnn")
 
     def cmake_args(self):
         args = [
             "-DBLAS=Open",  # Use OpenBLAS instead of Atlas' BLAS
-            f"-DRDKIT_INCLUDE_DIR={self.spec['rdkit'].prefix.include}/rdkit",
         ]
+
+        if "+gninavis" in self.spec:
+            args.append(f"-DRDKIT_INCLUDE_DIR={self.spec['rdkit'].prefix.include.rdkit}")
 
         return args

--- a/var/spack/repos/builtin/packages/gnina/package.py
+++ b/var/spack/repos/builtin/packages/gnina/package.py
@@ -67,9 +67,7 @@ class Gnina(CMakePackage, CudaPackage):
     depends_on("cudnn", when="+cudnn")
 
     def cmake_args(self):
-        args = [
-            "-DBLAS=Open",  # Use OpenBLAS instead of Atlas' BLAS
-        ]
+        args = ["-DBLAS=Open"]  # Use OpenBLAS instead of Atlas' BLAS
 
         if "+gninavis" in self.spec:
             args.append(f"-DRDKIT_INCLUDE_DIR={self.spec['rdkit'].prefix.include.rdkit}")

--- a/var/spack/repos/builtin/packages/rdkit/package.py
+++ b/var/spack/repos/builtin/packages/rdkit/package.py
@@ -16,6 +16,7 @@ class Rdkit(CMakePackage):
 
     maintainers("bvanessen")
 
+    version("2022_09_5", sha256="2efe7ce3b527df529ed3e355e2aaaf14623e51876be460fa4ad2b7f7ad54c9b1")
     version("2021_09_5", sha256="f720b3f6292c4cd0a412a073d848ffac01a43960082e33ee54b68798de0cbfa1")
     version("2021_09_4", sha256="ce192e85bbdc1dcf24d327197229099c8625ee20ef022fcbd980791fdbfc7203")
     version("2021_09_3", sha256="3d9d47e9ea3f7563ca83bf24fc6d3419c3892ea77d831e1cf68d81f602ad1afc")


### PR DESCRIPTION
* Add `cudnn` variant
* Add `gninavis` variant
  * `rdkit` is only needed to build the `gninavis` executable 