### PR TITLE
xrootd: new version 5.5.2, 5.5.3

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -15,6 +15,8 @@ class Xrootd(CMakePackage):
     url = "https://xrootd.slac.stanford.edu/download/v5.5.1/xrootd-5.5.1.tar.gz"
     list_url = "https://xrootd.slac.stanford.edu/dload.html"
 
+    version("5.5.3", sha256="703829c2460204bd3c7ba8eaa23911c3c9a310f6d436211ba0af487ef7f6a980")
+    version("5.5.2", sha256="ec4e0490b8ee6a3254a4ea4449342aa364bc95b78dc9a8669151be30353863c6")
     version("5.5.1", sha256="3556d5afcae20ed9a12c89229d515492f6c6f94f829a3d537f5880fcd2fa77e4")
     version("5.3.2", sha256="e8371fb9e86769bece74b9b9d67cb695023cd6a20a1199386fddd9ed840b0875")
     version("5.3.1", sha256="7ea3a112ae9d8915eb3a06616141e5a0ee366ce9a5e4d92407b846b37704ee98")


### PR DESCRIPTION
Only bugfixes, no build system changes, https://github.com/xrootd/xrootd/compare/v5.5.1...v5.5.3