### PR TITLE
Add missing deps for braker and bcftools

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -48,6 +48,7 @@ class Bcftools(AutotoolsPackage):
     depends_on("perl", when="@1.8:~perl-filters", type="run")
     depends_on("perl", when="@1.8:+perl-filters", type=("build", "run"))
 
+    depends_on("htslib@1.16", when="@1.16")
     depends_on("htslib@1.15", when="@1.15")
     depends_on("htslib@1.14", when="@1.14")
     depends_on("htslib@1.13", when="@1.13")

--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -32,6 +32,7 @@ class Braker(Package):
     depends_on("perl-hash-merge", type=("build", "run"))
     depends_on("perl-logger-simple", type=("build", "run"))
     depends_on("perl-file-homedir", when="@2.1.4:", type=("build", "run"))
+    depends_on("perl-list-moreutils", when="@2.1.6:", type=("build", "run"))
     depends_on("augustus")
     depends_on("augustus@3.2.3", when="@:2.1.0")
     depends_on("genemark-et")


### PR DESCRIPTION
Noticed a missing perl dep with braker. While testing that noticed that bcftools wouldn't build because there was no htslib in the spec for version 1.16.