### PR TITLE
New option "--first" for "spack location"

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -76,6 +76,14 @@ def setup_parser(subparser):
         help="location of the named or current environment",
     )
 
+    subparser.add_argument(
+        "--first",
+        action="store_true",
+        default=False,
+        dest="find_first",
+        help="use the first match if multiple packages match the spec",
+    )
+
     arguments.add_common_arguments(subparser, ["spec"])
 
 
@@ -121,7 +129,7 @@ def location(parser, args):
     # install_dir command matches against installed specs.
     if args.install_dir:
         env = ev.active_environment()
-        spec = spack.cmd.disambiguate_spec(specs[0], env)
+        spec = spack.cmd.disambiguate_spec(specs[0], env, first=args.find_first)
         print(spec.prefix)
         return
 

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -37,6 +37,13 @@ def mock_spec():
     shutil.rmtree(s.package.stage.path)
 
 
+def test_location_first(install_mockery, mock_fetch, mock_archive, mock_packages):
+    """Test with and without the --first option"""
+    install("libelf@0.8.12")
+    install("libelf@0.8.13")
+    """This would normally return an error without --first"""
+    assert location("--first --install-dir", "libelf")
+
 def test_location_build_dir(mock_spec):
     """Tests spack location --build-dir."""
     spec, pkg = mock_spec

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -42,7 +42,7 @@ def test_location_first(install_mockery, mock_fetch, mock_archive, mock_packages
     install = SpackCommand("install")
     install("libelf@0.8.12")
     install("libelf@0.8.13")
-    """This would normally return an error without --first"""
+    # This would normally return an error without --first
     assert location("--first", "--install-dir", "libelf")
 
 

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -43,7 +43,7 @@ def test_location_first(install_mockery, mock_fetch, mock_archive, mock_packages
     install("libelf@0.8.12")
     install("libelf@0.8.13")
     """This would normally return an error without --first"""
-    assert location("--first --install-dir", "libelf")
+    assert location("--first", "--install-dir", "libelf")
 
 
 def test_location_build_dir(mock_spec):

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -39,10 +39,12 @@ def mock_spec():
 
 def test_location_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
+    install = SpackCommand("install")
     install("libelf@0.8.12")
     install("libelf@0.8.13")
     """This would normally return an error without --first"""
     assert location("--first --install-dir", "libelf")
+
 
 def test_location_build_dir(mock_spec):
     """Tests spack location --build-dir."""

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -572,7 +572,7 @@ _spack_buildcache_update_index() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --first"
     else
         _all_packages
     fi
@@ -1225,7 +1225,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env --first"
     else
         _all_packages
     fi


### PR DESCRIPTION
This extends the options for "spack location -i" to replicate the functionality available with "spack load --first <spec>".  This is very useful in scripts that use spack when one doesn't care what version of a particular package is used.  Otherwise, this requires a cumbersome process of determining the available package hashes and loading one of the hashes explicitly.  Just as with "spack load --first", this option defaults to False to maintain the expected default behavior.