### PR TITLE
henson: point Pybind11 to correct python

### DIFF
--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -28,7 +28,9 @@ class Henson(CMakePackage):
     def cmake_args(self):
         args = []
         if "+python" in self.spec:
-            args += ["-Dpython=on"]
+            python_executable = self.spec["python"].command.path
+            args += ["-Dpython=on",
+                     "-DPYTHON_EXECUTABLE={0}".format(python_executable)]
         else:
             args += ["-Dpython=off"]
 

--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -29,8 +29,7 @@ class Henson(CMakePackage):
         args = []
         if "+python" in self.spec:
             python_executable = self.spec["python"].command.path
-            args += ["-Dpython=on",
-                     "-DPYTHON_EXECUTABLE={0}".format(python_executable)]
+            args += ["-Dpython=on", "-DPYTHON_EXECUTABLE={0}".format(python_executable)]
         else:
             args += ["-Dpython=off"]
 


### PR DESCRIPTION
Explicitly set PYTHON_EXECUTABLE to correct python. Without that python bindings can be compiled against a wrong version of python.