### PR TITLE
Add a "requires" directive, extend functionality of package requirements

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -393,7 +393,19 @@ We could express a similar requirement using the ``when`` attribute:
          message: "in this example only 4.1.5 can build with other compilers"
 
 In the example above, if the version turns out to be 4.1.4 or less, we require the compiler to be GCC.
+For readability, Spack also allows a ``spec`` key accepting a string when there is only a single
+constraint:
 
+.. code-block:: yaml
+
+   packages:
+     openmpi:
+       require:
+       - spec: "%gcc"
+         when: "@:4.1.4"
+         message: "in this example only 4.1.5 can build with other compilers"
+
+This code snippet and the one before it are semantically equivalent.
 
 Finally, instead of ``any_of`` you can use ``one_of`` which also takes a list of specs. The final
 concretized spec must match one and only one of them:

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -325,42 +325,87 @@ on the command line, because it can specify constraints on packages
 is not possible to specify constraints on dependencies while also keeping
 those dependencies optional.
 
-The package requirements configuration is specified in ``packages.yaml``
-keyed by package name:
+^^^^^^^^^^^^^^^^^^^
+Requirements syntax
+^^^^^^^^^^^^^^^^^^^
+
+The package requirements configuration is specified in ``packages.yaml``,
+keyed by package name and expressed using the Spec syntax. In the simplest
+case you can specify attributes that you always want the package to have
+by providing a single spec string to ``require``:
 
 .. code-block:: yaml
 
    packages:
      libfabric:
        require: "@1.13.2"
+
+In the above example, ``libfabric`` will always build with version 1.13.2. If you
+need to compose multiple configuration scopes ``require`` accepts a list of
+strings:
+
+.. code-block:: yaml
+
+   packages:
+     libfabric:
+       require:
+       - "@1.13.2"
+       - "%gcc"
+
+In this case ``libfabric`` will always build with version 1.13.2 **and** using GCC
+as a compiler.
+
+For more complex use cases, require accepts also a list of objects. These objects
+must have either a ``any_of`` or a ``one_of`` field, containing a list of spec strings,
+and they can optionally have a ``when`` and a ``message`` attribute:
+
+.. code-block:: yaml
+
+   packages:
      openmpi:
        require:
-       - any_of: ["~cuda", "%gcc"]
+       - any_of: ["@4.1.5", "%gcc"]
+         message: "in this example only 4.1.5 can build with other compilers"
+
+``any_of`` is a list of specs. One of those specs must be satisfied
+and it is also allowed for the concretized spec to match more than one.
+In the above example, that means you could build ``openmpi@4.1.5%gcc``,
+``openmpi@4.1.5%clang`` or ``openmpi@3.9%gcc``, but
+not ``openmpi@3.9%clang``.
+
+If a custom message is provided, and the requirement is not satisfiable,
+Spack will print the custom error message:
+
+.. code-block:: console
+
+   $ spack spec openmpi@3.9%clang
+   ==> Error: in this example only 4.1.5 can build with other compilers
+
+We could express a similar requirement using the ``when`` attribute:
+
+.. code-block:: yaml
+
+   packages:
+     openmpi:
+       require:
+       - any_of: ["%gcc"]
+         when: "@:4.1.4"
+         message: "in this example only 4.1.5 can build with other compilers"
+
+In the example above, if the version turns out to be 4.1.4 or less, we require the compiler to be GCC.
+
+
+Finally, instead of ``any_of`` you can use ``one_of`` which also takes a list of specs. The final
+concretized spec must match one and only one of them:
+
+.. code-block:: yaml
+
+   packages:
      mpich:
-      require:
-      - one_of: ["+cuda", "+rocm"]
+       require:
+       - one_of: ["+cuda", "+rocm"]
 
-Requirements are expressed using Spec syntax (the same as what is provided
-to ``spack install``). In the simplest case, you can specify attributes
-that you always want the package to have by providing a single spec to
-``require``; in the above example, ``libfabric`` will always build
-with version 1.13.2.
-
-You can provide a more-relaxed constraint and allow the concretizer to
-choose between a set of options using ``any_of`` or ``one_of``:
-
-* ``any_of`` is a list of specs. One of those specs must be satisfied
-  and it is also allowed for the concretized spec to match more than one.
-  In the above example, that means you could build ``openmpi+cuda%gcc``,
-  ``openmpi~cuda%clang`` or ``openmpi~cuda%gcc`` (in the last case,
-  note that both specs in the ``any_of`` for ``openmpi`` are
-  satisfied).
-* ``one_of`` is also a list of specs, and the final concretized spec
-  must match exactly one of them.  In the above example, that means
-  you could build ``mpich+cuda`` or ``mpich+rocm`` but not
-  ``mpich+cuda+rocm`` (note the current package definition for
-  ``mpich`` already includes a conflict, so this is redundant but
-  still demonstrates the concept).
+In the example above, that means you could build ``mpich+cuda`` or ``mpich+rocm`` but not ``mpich+cuda+rocm``.
 
 .. note::
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -413,6 +413,13 @@ In the example above, that means you could build ``mpich+cuda`` or ``mpich+rocm`
    preference: items that appear earlier in the list are preferred
    (note that these preferences can be ignored in favor of others).
 
+.. note::
+
+   When using a conditional requirement, Spack is allowed to actively avoid the triggering
+   condition (the ``when=...`` spec) if that leads to a concrete spec with better scores in
+   the optimization criteria. To check the current optimization criteria and their
+   priorities you can run ``spack solve zlib``.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Setting default requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2669,9 +2669,9 @@ to allow dependencies to run correctly:
 
 .. _packaging_conflicts:
 
----------
-Conflicts
----------
+--------------------------
+Conflicts and requirements
+--------------------------
 
 Sometimes packages have known bugs, or limitations, that would prevent them
 to build e.g. against other dependencies or with certain compilers. Spack
@@ -2681,26 +2681,35 @@ Adding the following to a package:
 
 .. code-block:: python
 
-    conflicts("%intel", when="@:1.2",
-              msg="<myNicePackage> <= v1.2 cannot be built with Intel ICC, "
-                  "please use a newer release.")
+    conflicts(
+        "%intel",
+         when="@:1.2",
+         msg="<myNicePackage> <= v1.2 cannot be built with Intel ICC, "
+             "please use a newer release."
+    )
 
 we express the fact that the current package *cannot be built* with the Intel
-compiler when we are trying to install a version "<=1.2". The ``when`` argument
-can be omitted, in which case the conflict will always be active.
-Conflicts are always evaluated after the concretization step has been performed,
-and if any match is found a detailed error message is shown to the user.
-You can add an additional message via the ``msg=`` parameter to a conflict that
-provideds more specific instructions for users.
+compiler when we are trying to install a version "<=1.2".
 
-Similarly, packages that only build on a subset of platforms can use the
-``conflicts`` directive to express that limitation, for example:
+The ``when`` argument can be omitted, in which case the conflict will always be active.
+
+An optional custom error message can be added via the ``msg=`` parameter, and will be printed
+by Spack in case the conflict cannot be avoided and leads to a concretization error.
+
+Sometimes, packages allow only very specific choices and they can't use the rest. In those cases
+the ``requires`` directive can be used:
 
 .. code-block:: python
 
-    for platform in ["cray", "darwin", "windows"]:
-        conflicts("platform={0}".format(platform), msg="Only 'linux' is supported")
+    requires(
+        "%apple-clang",
+        when="platform=darwin",
+        msg="<myNicePackage> builds only with Apple-Clang on Darwin"
+    )
 
+In the example above, our package can only be built with Apple-Clang on Darwin.
+The ``requires`` directive is effectively the opposite of the ``conflicts`` directive, and takes
+the same optional ``when`` and ``msg`` arguments.
 
 
 .. _packaging_extensions:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2711,6 +2711,21 @@ In the example above, our package can only be built with Apple-Clang on Darwin.
 The ``requires`` directive is effectively the opposite of the ``conflicts`` directive, and takes
 the same optional ``when`` and ``msg`` arguments.
 
+If a package needs to express more complex requirements, involving more than a single spec,
+that can also be done using the ``requires`` directive. To express that a package can be built
+either with GCC or with Clang we can write:
+
+.. code-block:: python
+
+    requires(
+        "%gcc", "%clang",
+        policy="one_of"
+        msg="<myNicePackage> builds only with GCC or Clang"
+    )
+
+When using multiple specs in a ``requires`` directive, it is advised to set the ``policy=``
+argument explicitly. That argument can take either the value ``any_of`` or the value ``one_of``,
+and the semantic is the same as for :ref:`package-requirements`.
 
 .. _packaging_extensions:
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -66,6 +66,7 @@ __all__ = [
     "variant",
     "resource",
     "build_system",
+    "requires",
 ]
 
 #: These are variant names used by Spack internally; packages can't use them
@@ -862,6 +863,24 @@ def maintainers(*names: str):
         pkg.maintainers = list(sorted(set(maintainers_from_base + list(names))))
 
     return _execute_maintainer
+
+
+@directive("requirements")
+def requires(requirement_spec):
+    """Allows a package to request a configuration to be present in all valid solutions.
+
+    For instance, a package that is known to compile only with GCC can declare:
+
+        requires("%gcc")
+
+    Args:
+        requirement_spec: spec expressing the requirement
+    """
+
+    def _execute_requires(pkg):
+        pkg.requirements.setdefault(requirement_spec, None)
+
+    return _execute_requires
 
 
 class DirectiveError(spack.error.SpackError):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -26,6 +26,7 @@ The available directives are:
   * ``resource``
   * ``variant``
   * ``version``
+  * ``requires``
 
 """
 import collections.abc
@@ -866,7 +867,7 @@ def maintainers(*names: str):
 
 
 @directive("requirements")
-def requires(requirement_spec, when=None, msg=None):
+def requires(*requirement_specs, policy="one_of", when=None, msg=None):
     """Allows a package to request a configuration to be present in all valid solutions.
 
     For instance, a package that is known to compile only with GCC can declare:
@@ -878,20 +879,28 @@ def requires(requirement_spec, when=None, msg=None):
         requires("%apple-clang", when="platform=darwin", msg="Apple Clang is required on Darwin")
 
     Args:
-        requirement_spec: spec expressing the requirement
+        requirement_specs: spec expressing the requirement
         when: optional constraint that triggers the requirement. If None the requirement
             is applied unconditionally.
+
         msg: optional user defined message
     """
 
     def _execute_requires(pkg):
+        if policy not in ("one_of", "any_of"):
+            err_msg = (
+                f"the 'policy' argument of the 'requires' directive in {pkg.name} is set "
+                f"to a wrong value (only 'one_of' or 'any_of' are allowed)"
+            )
+            raise DirectiveError(err_msg)
+
         when_spec = make_when_spec(when)
         if not when_spec:
             return
 
         # Save in a list the requirements and the associated custom messages
-        when_spec_list = pkg.requirements.setdefault(requirement_spec, [])
-        when_spec_list.append((when_spec, msg))
+        when_spec_list = pkg.requirements.setdefault(tuple(requirement_specs), [])
+        when_spec_list.append((when_spec, policy, msg))
 
     return _execute_requires
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -879,19 +879,17 @@ def requires(requirement_spec, when=None, msg=None):
 
     Args:
         requirement_spec: spec expressing the requirement
-        when: optional constraint that triggers the conflict
+        when: optional constraint that triggers the requirement. If None the requirement
+            is applied unconditionally.
         msg: optional user defined message
     """
 
     def _execute_requires(pkg):
-        # Note that when=None corresponds to when_spec = Spec(), which is always True.
-        # when=False, instead, is a statically evaluated condition that return False
-        # and get discarded.
         when_spec = make_when_spec(when)
         if not when_spec:
             return
 
-        # Save in a list the conflicts and the associated custom messages
+        # Save in a list the requirements and the associated custom messages
         when_spec_list = pkg.requirements.setdefault(requirement_spec, [])
         when_spec_list.append((when_spec, msg))
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -45,6 +45,7 @@ properties = {
                                                     "type": "array",
                                                     "items": {"type": "string"},
                                                 },
+                                                "spec": {"type": "string"},
                                                 "message": {"type": "string"},
                                                 "when": {"type": "string"},
                                             },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -37,8 +37,16 @@ properties = {
                                             "type": "object",
                                             "additionalProperties": False,
                                             "properties": {
-                                                "one_of": {"type": "array"},
-                                                "any_of": {"type": "array"},
+                                                "one_of": {
+                                                    "type": "array",
+                                                    "items": {"type": "string"},
+                                                },
+                                                "any_of": {
+                                                    "type": "array",
+                                                    "items": {"type": "string"},
+                                                },
+                                                "message": {"type": "string"},
+                                                "when": {"type": "string"},
                                             },
                                         },
                                         {"type": "string"},

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1346,7 +1346,7 @@ class SpackSolverSetup(object):
             if when_spec is False:
                 continue
 
-            if rule.condition:
+            if rule.condition and when_spec != spack.spec.Spec():
                 self.gen.fact(fn.requirement_conditional(pkg_name, requirement_grp_id))
 
             for spec_str in requirement_grp:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -102,7 +102,7 @@ ast_sym = ast_getter("symbol", "term")
 
 
 class Provenance(enum.IntEnum):
-    """Enumeration of the possible provenances of a fact."""
+    """Enumeration of the possible provenances of a version."""
 
     # A spec literal
     SPEC = enum.auto()
@@ -905,8 +905,7 @@ class SpackSolverSetup(object):
         """
 
         def key_fn(version):
-            # Origins are sorted by precedence defined in `version_origin_str`,
-            # then by order added.
+            # Origins are sorted by "provenance" first, see the Provenance enumeration above
             return version.origin, version.idx
 
         pkg = packagize(pkg)
@@ -1356,7 +1355,7 @@ class SpackSolverSetup(object):
                 continue
 
             # Write explicitly if a requirement is conditional or not
-            if rule.condition and main_requirement_condition != spack.spec.Spec():
+            if main_requirement_condition != spack.spec.Spec():
                 msg = f"condition to activate requirement {requirement_grp_id}"
                 try:
                     main_condition_id = self.condition(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -127,7 +127,6 @@ class Provenance(enum.IntEnum):
         return f"{self._name_.lower()}"
 
 
-
 DeclaredVersion = collections.namedtuple("DeclaredVersion", ["version", "idx", "origin"])
 
 
@@ -2152,9 +2151,7 @@ class SpackSolverSetup(object):
         self.add_concrete_versions_from_specs(dev_specs, Provenance.DEV_SPEC)
 
         req_version_specs = _get_versioned_specs_from_pkg_requirements()
-        self.add_concrete_versions_from_specs(
-            req_version_specs, Provenance.PACKAGE_REQUIREMENT
-        )
+        self.add_concrete_versions_from_specs(req_version_specs, Provenance.PACKAGE_REQUIREMENT)
 
         self.gen.h1("Concrete input spec definitions")
         self.define_concrete_input_specs(specs, possible)
@@ -2258,8 +2255,8 @@ def _specs_from_requires(pkg_name, section):
                 spec_strs.append(spec_group)
             else:
                 # Otherwise it is a one_of or any_of: get the values
-                (x,) = spec_group.values()
-                spec_strs.extend(x)
+                key = "one_of" if "one_of" in spec_group else "any_of"
+                spec_strs.extend(spec_group[key])
 
         extracted_specs = []
         for spec_str in spec_strs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -646,7 +646,7 @@ class ErrorHandler:
 
 #: Data class to collect information on a requirement
 RequirementRule = collections.namedtuple(
-    "RequirementRule", ["name", "policy", "requirements", "condition", "provenance", "message"]
+    "RequirementRule", ["pkg_name", "policy", "requirements", "condition", "provenance", "message"]
 )
 
 
@@ -1034,7 +1034,7 @@ class SpackSolverSetup(object):
             for when_spec, message in conditions:
                 rules.append(
                     RequirementRule(
-                        name=pkg.name,
+                        pkg_name=pkg.name,
                         policy="one_of",
                         requirements=[requirement],
                         provenance=Provenance.PACKAGE_PY,
@@ -1072,7 +1072,7 @@ class SpackSolverSetup(object):
                         if policy in requirement:
                             rules.append(
                                 RequirementRule(
-                                    name=pkg_name,
+                                    pkg_name=pkg_name,
                                     policy=policy,
                                     requirements=requirement[policy],
                                     provenance=provenance,
@@ -1086,7 +1086,7 @@ class SpackSolverSetup(object):
         self, pkg_name: str, requirements: str, provenance: Provenance
     ) -> RequirementRule:
         return RequirementRule(
-            name=pkg_name,
+            pkg_name=pkg_name,
             policy="one_of",
             requirements=[requirements],
             provenance=provenance,
@@ -1334,7 +1334,7 @@ class SpackSolverSetup(object):
         for requirement_grp_id, rule in enumerate(rules):
             virtual = rule.provenance == Provenance.PACKAGES_YAML_VIRTUAL
 
-            pkg_name, policy, requirement_grp = rule.name, rule.policy, rule.requirements
+            pkg_name, policy, requirement_grp = rule.pkg_name, rule.policy, rule.requirements
             self.gen.fact(fn.requirement_group(pkg_name, requirement_grp_id))
             self.gen.fact(fn.requirement_policy(pkg_name, requirement_grp_id, policy))
             if rule.message:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1037,13 +1037,13 @@ class SpackSolverSetup(object):
 
     def requirement_rules_from_package_py(self, pkg):
         rules = []
-        for requirement, conditions in pkg.requirements.items():
-            for when_spec, message in conditions:
+        for requirements, conditions in pkg.requirements.items():
+            for when_spec, policy, message in conditions:
                 rules.append(
                     RequirementRule(
                         pkg_name=pkg.name,
-                        policy="one_of",
-                        requirements=[requirement],
+                        policy=policy,
+                        requirements=requirements,
                         kind=Provenance.PACKAGE_PY,
                         condition=when_spec,
                         message=message,

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1044,7 +1044,7 @@ class SpackSolverSetup(object):
                         pkg_name=pkg.name,
                         policy=policy,
                         requirements=requirements,
-                        kind=Provenance.PACKAGE_PY,
+                        kind=RequirementKind.PACKAGE,
                         condition=when_spec,
                         message=message,
                     )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1755,6 +1755,7 @@ class SpackSolverSetup(object):
         self.gen.h2("Default platform")
         platform = spack.platforms.host()
         self.gen.fact(fn.node_platform_default(platform))
+        self.gen.fact(fn.allowed_platform(platform))
 
     def os_defaults(self, specs):
         self.gen.h2("Possible operating systems")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -461,13 +461,49 @@ error(100, "Attempted to use external for '{0}' which does not satisfy any confi
 % Config required semantics
 %-----------------------------------------------------------------------------
 
-activate_requirement_rules(Package) :- attr("node", Package).
-activate_requirement_rules(Package) :- attr("virtual_node", Package).
+activate_requirement(Package, X) :-
+  attr("node", Package),
+  requirement_group(Package, X),
+  not requirement_conditional(Package, X).
+
+activate_requirement(Package, X) :-
+  attr("virtual_node", Package),
+  requirement_group(Package, X),
+  not requirement_conditional(Package, X).
+
+activate_requirement(Package, X) :-
+  attr("node", Package),
+  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) },
+  requirement_group(Package, X),
+  requirement_conditional(Package, X).
+
+activate_requirement(Package, X) :-
+  attr("virtual_node", Package),
+  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) },
+  requirement_group(Package, X),
+  requirement_conditional(Package, X).
+
+1 { activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } 1 :-
+  requirement_policy(Package, X, "one_of"),
+  activate_requirement(Package, X).
+
+1 { activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } :-
+  requirement_policy(Package, X, "any_of"),
+  activate_requirement(Package, X).
+
+impose(Y) :- activate_requirement_rule(Y, Package, X).
+do_not_impose(Y) :-
+  not activate_requirement_rule(Y, Package, X),
+  requirement_conditional(Package, X),
+  requirement_group_member(Y, Package, X).
+
+% Avoid impose(Y) to be derived by other rules when it is part of a requirement
+:- impose(Y),
+   not activate_requirement_rule(Y, Package, X),
+   requirement_group_member(Y, Package, X).
 
 requirement_group_satisfied(Package, X) :-
-  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) } 1,
-  activate_requirement_rules(Package),
-  requirement_policy(Package, X, "one_of"),
+  activate_requirement_rule(_, Package, X),
   requirement_group(Package, X).
 
 requirement_weight(Package, Group, W) :-
@@ -476,12 +512,6 @@ requirement_weight(Package, Group, W) :-
   requirement_group_member(Y, Package, Group),
   requirement_policy(Package, Group, "one_of"),
   requirement_group_satisfied(Package, Group).
-
-requirement_group_satisfied(Package, X) :-
-  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) } ,
-  activate_requirement_rules(Package),
-  requirement_policy(Package, X, "any_of"),
-  requirement_group(Package, X).
 
 requirement_weight(Package, Group, W) :-
   W = #min {
@@ -495,20 +525,21 @@ requirement_weight(Package, Group, W) :-
   requirement_group_satisfied(Package, Group).
 
 error(100, "cannot satisfy a requirement for package '{0}'.", Package) :-
-  activate_requirement_rules(Package),
+  activate_requirement(Package, X),
   requirement_group(Package, X),
   not requirement_message(Package, X, _),
   not requirement_group_satisfied(Package, X).
 
 
 error(2, Message) :-
-  activate_requirement_rules(Package),
+  activate_requirement(Package, X),
   requirement_group(Package, X),
   requirement_message(Package, X, Message),
   not requirement_group_satisfied(Package, X).
 
 
 #defined requirement_group/2.
+#defined requirement_conditional/2.
 #defined requirement_message/3.
 #defined requirement_group_member/3.
 #defined requirement_has_weight/2.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -497,9 +497,19 @@ requirement_weight(Package, Group, W) :-
 error(100, "cannot satisfy a requirement for package '{0}'.", Package) :-
   activate_requirement_rules(Package),
   requirement_group(Package, X),
+  not requirement_message(Package, X, _),
   not requirement_group_satisfied(Package, X).
 
+
+error(2, Message) :-
+  activate_requirement_rules(Package),
+  requirement_group(Package, X),
+  requirement_message(Package, X, Message),
+  not requirement_group_satisfied(Package, X).
+
+
 #defined requirement_group/2.
+#defined requirement_message/3.
 #defined requirement_group_member/3.
 #defined requirement_has_weight/2.
 #defined requirement_policy/3.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -483,12 +483,7 @@ activate_requirement(Package, X) :-
   requirement_group(Package, X),
   requirement_conditional(Package, X).
 
-1 { activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } 1 :-
-  requirement_policy(Package, X, "one_of"),
-  activate_requirement(Package, X).
-
-1 { activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } :-
-  requirement_policy(Package, X, "any_of"),
+{ activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } :-
   activate_requirement(Package, X).
 
 impose(Y) :- activate_requirement_rule(Y, Package, X).
@@ -503,7 +498,15 @@ do_not_impose(Y) :-
    requirement_group_member(Y, Package, X).
 
 requirement_group_satisfied(Package, X) :-
-  activate_requirement_rule(_, Package, X),
+  1 { activate_requirement_rule(_, Package, X) },
+  requirement_policy(Package, X, "any_of"),
+  activate_requirement(Package, X),
+  requirement_group(Package, X).
+
+requirement_group_satisfied(Package, X) :-
+  1 { activate_requirement_rule(_, Package, X) } 1,
+  requirement_policy(Package, X, "one_of"),
+  activate_requirement(Package, X),
   requirement_group(Package, X).
 
 requirement_weight(Package, Group, W) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -732,6 +732,8 @@ variant_single_value(Package, "dev_path")
 %-----------------------------------------------------------------------------
 
 % if no platform is set, fall back to the default
+:- attr("node_platform", _, Platform), not allowed_platform(Platform).
+
 attr("node_platform", Package, Platform)
  :- attr("node", Package),
     not attr("node_platform_set", Package),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -494,7 +494,7 @@ requirement_weight(Package, Group, W) :-
   requirement_policy(Package, Group, "any_of"),
   requirement_group_satisfied(Package, Group).
 
-error(100, "Cannot satisfy the requirements in packages.yaml for package '{0}'. You may want to delete them to proceed with concretization. To check where the requirements are defined run 'spack config blame packages'", Package) :-
+error(100, "cannot satisfy a requirement for package '{0}'.", Package) :-
   activate_requirement_rules(Package),
   requirement_group(Package, X),
   not requirement_group_satisfied(Package, X).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -461,28 +461,19 @@ error(100, "Attempted to use external for '{0}' which does not satisfy any confi
 % Config required semantics
 %-----------------------------------------------------------------------------
 
+package_in_dag(Package) :-  attr("node", Package).
+package_in_dag(Package) :-  attr("virtual_node", Package).
+
 activate_requirement(Package, X) :-
-  attr("node", Package),
+  package_in_dag(Package),
   requirement_group(Package, X),
   not requirement_conditional(Package, X, _).
 
 activate_requirement(Package, X) :-
-  attr("virtual_node", Package),
+  package_in_dag(Package),
   requirement_group(Package, X),
-  not requirement_conditional(Package, X, _).
-
-activate_requirement(Package, X) :-
-  attr("node", Package),
   condition_holds(Y),
-  requirement_group(Package, X),
   requirement_conditional(Package, X, Y).
-
-activate_requirement(Package, X) :-
-  attr("virtual_node", Package),
-  condition_holds(Y),
-  requirement_group(Package, X),
-  requirement_conditional(Package, X, Y).
-
 
 requirement_group_satisfied(Package, X) :-
   1 { condition_holds(Y) : requirement_group_member(Y, Package, X) } 1,
@@ -521,7 +512,7 @@ error(100, "cannot satisfy a requirement for package '{0}'.", Package) :-
   not requirement_group_satisfied(Package, X).
 
 
-error(2, Message) :-
+error(10, Message) :-
   activate_requirement(Package, X),
   requirement_group(Package, X),
   requirement_message(Package, X, Message),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -489,8 +489,14 @@ activate_requirement(Package, X) :-
 impose(Y) :- activate_requirement_rule(Y, Package, X).
 do_not_impose(Y) :-
   not activate_requirement_rule(Y, Package, X),
-  requirement_conditional(Package, X),
   requirement_group_member(Y, Package, X).
+
+
+error(2, "cannot impose all the requirements for package '{0}'", Package)
+  :-  do_not_impose(Y),
+      condition_holds(Y),
+      not requirement_conditional(Package, X),
+      requirement_group_member(Y, Package, X).
 
 % Avoid impose(Y) to be derived by other rules when it is part of a requirement
 :- impose(Y),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -464,53 +464,28 @@ error(100, "Attempted to use external for '{0}' which does not satisfy any confi
 activate_requirement(Package, X) :-
   attr("node", Package),
   requirement_group(Package, X),
-  not requirement_conditional(Package, X).
+  not requirement_conditional(Package, X, _).
 
 activate_requirement(Package, X) :-
   attr("virtual_node", Package),
   requirement_group(Package, X),
-  not requirement_conditional(Package, X).
+  not requirement_conditional(Package, X, _).
 
 activate_requirement(Package, X) :-
   attr("node", Package),
-  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) },
+  condition_holds(Y),
   requirement_group(Package, X),
-  requirement_conditional(Package, X).
+  requirement_conditional(Package, X, Y).
 
 activate_requirement(Package, X) :-
   attr("virtual_node", Package),
-  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) },
+  condition_holds(Y),
   requirement_group(Package, X),
-  requirement_conditional(Package, X).
+  requirement_conditional(Package, X, Y).
 
-{ activate_requirement_rule(Y, Package, X) : requirement_group_member(Y, Package, X) } :-
-  activate_requirement(Package, X).
-
-impose(Y) :- activate_requirement_rule(Y, Package, X).
-do_not_impose(Y) :-
-  not activate_requirement_rule(Y, Package, X),
-  requirement_group_member(Y, Package, X).
-
-
-error(2, "cannot impose all the requirements for package '{0}'", Package)
-  :-  do_not_impose(Y),
-      condition_holds(Y),
-      not requirement_conditional(Package, X),
-      requirement_group_member(Y, Package, X).
-
-% Avoid impose(Y) to be derived by other rules when it is part of a requirement
-:- impose(Y),
-   not activate_requirement_rule(Y, Package, X),
-   requirement_group_member(Y, Package, X).
 
 requirement_group_satisfied(Package, X) :-
-  1 { activate_requirement_rule(_, Package, X) },
-  requirement_policy(Package, X, "any_of"),
-  activate_requirement(Package, X),
-  requirement_group(Package, X).
-
-requirement_group_satisfied(Package, X) :-
-  1 { activate_requirement_rule(_, Package, X) } 1,
+  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) } 1,
   requirement_policy(Package, X, "one_of"),
   activate_requirement(Package, X),
   requirement_group(Package, X).
@@ -521,6 +496,12 @@ requirement_weight(Package, Group, W) :-
   requirement_group_member(Y, Package, Group),
   requirement_policy(Package, Group, "one_of"),
   requirement_group_satisfied(Package, Group).
+
+requirement_group_satisfied(Package, X) :-
+  1 { condition_holds(Y) : requirement_group_member(Y, Package, X) } ,
+  requirement_policy(Package, X, "any_of"),
+  activate_requirement(Package, X),
+  requirement_group(Package, X).
 
 requirement_weight(Package, Group, W) :-
   W = #min {
@@ -548,7 +529,7 @@ error(2, Message) :-
 
 
 #defined requirement_group/2.
-#defined requirement_conditional/2.
+#defined requirement_conditional/3.
 #defined requirement_message/3.
 #defined requirement_group_member/3.
 #defined requirement_has_weight/2.

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -626,6 +626,20 @@ def test_non_existing_variants_under_all(concretize_scope, mock_packages):
             "libelf@0.8.12",
             [("%clang", False), ("%gcc", True)],
         ),
+        (
+            """\
+    packages:
+      all:
+        compiler: ["gcc", "clang"]
+
+      libelf:
+        require:
+        - spec: "%clang"
+          when: "@0.8.13"
+""",
+            "libelf@0.8.12",
+            [("%clang", False), ("%gcc", True)],
+        ),
     ],
 )
 def test_conditional_requirements_from_packages_yaml(
@@ -677,6 +691,18 @@ def test_conditional_requirements_from_packages_yaml(
               when: platform=test
               message: "can only be compiled with clang on the test platform"
     """,
+            "libelf%gcc",
+            "can only be compiled with clang on ",
+        ),
+        (
+            """\
+            packages:
+              libelf:
+                require:
+                - spec: "%clang"
+                  when: platform=test
+                  message: "can only be compiled with clang on the test platform"
+        """,
             "libelf%gcc",
             "can only be compiled with clang on ",
         ),

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -680,6 +680,18 @@ def test_conditional_requirements_from_packages_yaml(
             "libelf%gcc",
             "can only be compiled with clang on ",
         ),
+        (
+            """\
+        packages:
+          libelf:
+            require:
+            - one_of: ["%clang", "%intel"]
+              when: platform=test
+              message: "can only be compiled with clang or intel on the test platform"
+    """,
+            "libelf%gcc",
+            "can only be compiled with clang or intel",
+        ),
     ],
 )
 def test_requirements_fail_with_custom_message(

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -656,8 +656,30 @@ def test_requirements_from_packages_yaml(
 """,
             "mpileaks+debug",
             "debug is not allowed",
-        )
-        # TODO: improve error handling for compilers
+        ),
+        (
+            """\
+    packages:
+      libelf:
+        require:
+        - one_of: ["%clang"]
+          message: "can only be compiled with clang"
+""",
+            "libelf%gcc",
+            "can only be compiled with clang",
+        ),
+        (
+            """\
+        packages:
+          libelf:
+            require:
+            - one_of: ["%clang"]
+              when: platform=test
+              message: "can only be compiled with clang on the test platform"
+    """,
+            "libelf%gcc",
+            "can only be compiled with clang on ",
+        ),
     ],
 )
 def test_requirements_fail_with_custom_message(

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -628,7 +628,7 @@ def test_non_existing_variants_under_all(concretize_scope, mock_packages):
         ),
     ],
 )
-def test_requirements_from_packages_yaml(
+def test_conditional_requirements_from_packages_yaml(
     packages_yaml, spec_str, expected_satisfies, concretize_scope, mock_packages
 ):
     """Test that a few properties of specs that are concretized with requirements

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -770,7 +770,7 @@ def concretize_scope(mutable_config, tmpdir):
         spack.config.ConfigScope("concretize", str(tmpdir.join("concretize")))
     )
 
-    yield
+    yield str(tmpdir.join("concretize"))
 
     mutable_config.pop_scope()
     spack.repo.path._provider_index = None

--- a/var/spack/repos/builtin.mock/packages/requires_clang/package.py
+++ b/var/spack/repos/builtin.mock/packages/requires_clang/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RequiresClang(Package):
+    """Simple package with no dependencies"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/b-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("0.9", md5="abcd456789abcdef0123456789abcdef")
+
+    requires("%clang", msg="can only be compiled with Clang")

--- a/var/spack/repos/builtin.mock/packages/requires_clang_or_gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/requires_clang_or_gcc/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RequiresClangOrGcc(Package):
+    """Simple package with no dependencies"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/b-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("0.9", md5="abcd456789abcdef0123456789abcdef")
+
+    requires("%gcc", "%clang", policy="one_of")

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -18,13 +18,7 @@ class Bucky(MakefilePackage):
 
     version("1.4.4", sha256="1621fee0d42314d9aa45d0082b358d4531e7d1d1a0089c807c1b21fbdc4e4592")
 
-    # Compilation requires gcc
-    conflicts("%cce")
-    conflicts("%apple-clang")
-    conflicts("%nag")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
+    requires("%gcc")
 
     build_directory = "src"
 

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -18,7 +18,7 @@ class Bucky(MakefilePackage):
 
     version("1.4.4", sha256="1621fee0d42314d9aa45d0082b358d4531e7d1d1a0089c807c1b21fbdc4e4592")
 
-    requires("%gcc")
+    requires("%gcc", msg="bucky can only be compiled with GCC")
 
     build_directory = "src"
 

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -18,7 +18,7 @@ class Bucky(MakefilePackage):
 
     version("1.4.4", sha256="1621fee0d42314d9aa45d0082b358d4531e7d1d1a0089c807c1b21fbdc4e4592")
 
-    requires("%gcc", msg="bucky can only be compiled with GCC")
+    requires("%gcc", when="platform=linux", msg="bucky can only be compiled with GCC")
 
     build_directory = "src"
 

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -18,7 +18,7 @@ class Bucky(MakefilePackage):
 
     version("1.4.4", sha256="1621fee0d42314d9aa45d0082b358d4531e7d1d1a0089c807c1b21fbdc4e4592")
 
-    requires("%gcc", when="platform=linux", msg="bucky can only be compiled with GCC")
+    requires("%gcc", msg="bucky can only be compiled with GCC")
 
     build_directory = "src"
 

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -87,18 +87,10 @@ class Dyninst(CMakePackage):
     patch("v9.3.2-auto.patch", when="@9.3.2 %gcc@:4.7")
     patch("tribool.patch", when="@9.3.0:10.0.0 ^boost@1.69:")
 
+    requires("%gcc", msg="dyninst builds only with GCC")
+
     # No Mac support (including apple-clang)
     conflicts("platform=darwin", msg="macOS is not supported")
-
-    # We currently only build with gcc
-    conflicts("%clang")
-    conflicts("%arm")
-    conflicts("%cce")
-    conflicts("%fj")
-    conflicts("%intel")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
 
     # Version 11.0 requires a C++11-compliant ABI
     conflicts("%gcc@:5", when="@11.0.0:")

--- a/var/spack/repos/builtin/packages/ffte/package.py
+++ b/var/spack/repos/builtin/packages/ffte/package.py
@@ -32,12 +32,7 @@ class Ffte(Package):
 
     depends_on("mpi", when="+mpi")
 
-    conflicts("%cce", when="+cuda", msg="Must use NVHPC compiler")
-    conflicts("%clang", when="+cuda", msg="Must use NVHPC compiler")
-    conflicts("%gcc", when="+cuda", msg="Must use NVHPC compiler")
-    conflicts("%llvm", when="+cuda", msg="Must use NVHPC compiler")
-    conflicts("%nag", when="+cuda", msg="Must use NVHPC compiler")
-    conflicts("%intel", when="+cuda", msg="Must use NVHPC compiler")
+    requires("%nvhpc", when="+cuda", msg="ffte+cuda must use NVHPC compiler")
 
     def edit(self, spec, prefix):
         "No make-file, must create one from scratch."

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -273,9 +273,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # See https://gcc.gnu.org/install/prerequisites.html#GDC-prerequisite
         with when("@12:"):
             # All versions starting 12 have to be built GCC:
-            for c in spack.compilers.supported_compilers():
-                if c != "gcc":
-                    conflicts("%{0}".format(c))
+            requires("%gcc")
 
             # And it has to be GCC older than the version we build:
             vv = ["11", "12.1.0", "12.2.0"]


### PR DESCRIPTION
closes #17344
closes #21765

This PR adds a new directive:
```python
requires("%gcc", when=..., msg=...)
```
which behaves the opposite of `conflicts`. The directive uses the same mechanism as requirements in `packages.yaml`, so these have been extended to support a `when` and a `message` attribute too in the configuration file. 

Modifications:
- [x] Add a `requires` directive
- [x] Allow for conditional requirements using a `when=` argument
- [x] Allow for custom error messages
- [x] Add unit tests and docs