### PR TITLE
py-torch: OpenMP support doesn't work on Apple Silicon

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -111,6 +111,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # https://github.com/pytorch/pytorch/issues/77811
     conflicts("+qnnpack", when="platform=darwin target=aarch64:")
 
+    # https://github.com/pytorch/pytorch/issues/80805
+    conflicts("+openmp", when="platform=darwin target=aarch64:")
+
     conflicts(
         "cuda_arch=none",
         when="+cuda",


### PR DESCRIPTION
No idea how to tell where the bug is coming from and don't have the skills to debug this one, but figured it's better to add a conflict until we figure this one out since the resulting segfault is incredibly hard to track down.

https://github.com/pytorch/pytorch/issues/80805