### PR TITLE
perl-log-log4perl: add v1.49

### DIFF
--- a/var/spack/repos/builtin/packages/perl-log-log4perl/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-log4perl/package.py
@@ -12,4 +12,5 @@ class PerlLogLog4perl(PerlPackage):
     homepage = "https://metacpan.org/pod/Log::Log4perl"
     url = "https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI/Log-Log4perl-1.46.tar.gz"
 
+    version("1.49", sha256="b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16")
     version("1.46", sha256="31011a17c04e78016e73eaa4865d0481d2ffc3dc22813c61065d90ad73c64e6f")


### PR DESCRIPTION
Add perl-log4perl v1.49.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.