### PR TITLE
perl-list-moreutils and moreutils-xs: add v0.430

### DIFF
--- a/var/spack/repos/builtin/packages/perl-list-moreutils-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-moreutils-xs/package.py
@@ -15,4 +15,5 @@ class PerlListMoreutilsXs(PerlPackage):
     homepage = "https://metacpan.org/pod/List::MoreUtils::XS"
     url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-XS-0.428.tar.gz"
 
+    version("0.430", sha256="e8ce46d57c179eecd8758293e9400ff300aaf20fefe0a9d15b9fe2302b9cb242")
     version("0.428", sha256="9d9fe621429dfe7cf2eb1299c192699ddebf060953e5ebdc1b4e293c6d6dd62d")

--- a/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
@@ -12,6 +12,7 @@ class PerlListMoreutils(PerlPackage):
     homepage = "https://metacpan.org/pod/List::MoreUtils"
     url = "http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/List-MoreUtils-0.428.tar.gz"
 
+    version("0.430", sha256="63b1f7842cd42d9b538d1e34e0330de5ff1559e4c2737342506418276f646527")
     version("0.428", sha256="713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2")
 
     depends_on("perl-exporter-tiny", type=("build", "run"))


### PR DESCRIPTION
Add perl-list-moreutils and related moreutils-xs v0.430.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.