### PR TITLE
perl-json: add v4.10

### DIFF
--- a/var/spack/repos/builtin/packages/perl-json/package.py
+++ b/var/spack/repos/builtin/packages/perl-json/package.py
@@ -12,4 +12,5 @@ class PerlJson(PerlPackage):
     homepage = "https://metacpan.org/pod/JSON"
     url = "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-2.97001.tar.gz"
 
+    version("4.10", sha256="df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35")
     version("2.97001", sha256="e277d9385633574923f48c297e1b8acad3170c69fa590e31fa466040fc6f8f5a")


### PR DESCRIPTION
Add perl-json v4.10.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.