### PR TITLE
perl-io-compress: add v2.204

### DIFF
--- a/var/spack/repos/builtin/packages/perl-io-compress/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-compress/package.py
@@ -13,6 +13,7 @@ class PerlIoCompress(PerlPackage):
     homepage = "https://metacpan.org/pod/IO::Uncompress::AnyUncompress"
     url = "http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/IO-Compress-2.081.tar.gz"
 
+    version("2.204", sha256="617784cb8543778681341b18fc67b74735e8b494f32f00814dd22f68ac6af018")
     version("2.081", sha256="5211c775544dc8c511af08edfb1c0c22734daa2789149c2a88d68e17b43546d9")
 
     depends_on("perl-compress-raw-zlib", type="run")


### PR DESCRIPTION
Add perl-io-compress v2.204.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.