### PR TITLE
perl-inline-c: add v0.81

### DIFF
--- a/var/spack/repos/builtin/packages/perl-inline-c/package.py
+++ b/var/spack/repos/builtin/packages/perl-inline-c/package.py
@@ -12,6 +12,7 @@ class PerlInlineC(PerlPackage):
     homepage = "https://metacpan.org/pod/Inline::C"
     url = "http://search.cpan.org/CPAN/authors/id/T/TI/TINITA/Inline-C-0.78.tar.gz"
 
+    version("0.81", sha256="f185258d9050d7f79b4f00f12625cc469c2f700ff62d3e831cb18d80d2c87aac")
     version("0.78", sha256="9a7804d85c01a386073d2176582b0262b6374c5c0341049da3ef84c6f53efbc7")
 
     depends_on("perl-yaml-libyaml", type=("build", "run"))


### PR DESCRIPTION
Add perl-inline-c v0.81.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.