### PR TITLE
perl-inline: add v0.86

### DIFF
--- a/var/spack/repos/builtin/packages/perl-inline/package.py
+++ b/var/spack/repos/builtin/packages/perl-inline/package.py
@@ -12,6 +12,7 @@ class PerlInline(PerlPackage):
     homepage = "https://metacpan.org/pod/Inline"
     url = "http://search.cpan.org/CPAN/authors/id/I/IN/INGY/Inline-0.80.tar.gz"
 
+    version("0.86", sha256="510a7de2d011b0db80b0874e8c0f7390010991000ae135cff7474df1e6d51e3a")
     version("0.80", sha256="7e2bd984b1ebd43e336b937896463f2c6cb682c956cbd2c311a464363d2ccef6")
 
     depends_on("perl-test-warn", type=("build", "run"))


### PR DESCRIPTION
Add perl-inline v0.86.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.