### PR TITLE
perl-http-message: add v6.44

### DIFF
--- a/var/spack/repos/builtin/packages/perl-http-message/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-message/package.py
@@ -12,6 +12,7 @@ class PerlHttpMessage(PerlPackage):
     homepage = "https://metacpan.org/pod/HTTP::Message"
     url = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/HTTP-Message-6.13.tar.gz"
 
+    version("6.44", sha256="398b647bf45aa972f432ec0111f6617742ba32fc773c6612d21f64ab4eacbca1")
     version("6.13", sha256="f25f38428de851e5661e72f124476494852eb30812358b07f1c3a289f6f5eded")
 
     depends_on("perl-lwp-mediatypes", type=("build", "run"))


### PR DESCRIPTION
Add perl-http-message v6.44.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.