### PR TITLE
perl-http-cookies: add v6.10

### DIFF
--- a/var/spack/repos/builtin/packages/perl-http-cookies/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-cookies/package.py
@@ -12,6 +12,7 @@ class PerlHttpCookies(PerlPackage):
     homepage = "https://metacpan.org/pod/HTTP::Cookies"
     url = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/HTTP-Cookies-6.04.tar.gz"
 
+    version("6.10", sha256="e36f36633c5ce6b5e4b876ffcf74787cc5efe0736dd7f487bdd73c14f0bd7007")
     version("6.04", sha256="0cc7f079079dcad8293fea36875ef58dd1bfd75ce1a6c244cd73ed9523eb13d4")
 
     depends_on("perl-uri", type=("build", "run"))


### PR DESCRIPTION
Add perl-http-cookies v6.10.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.