### PR TITLE
perl-file-which: add v1.27

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-which/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-which/package.py
@@ -12,4 +12,5 @@ class PerlFileWhich(PerlPackage):
     homepage = "http://cpansearch.perl.org/src/PLICEASE/File-Which-1.22/lib/File/Which.pm"
     url = "http://search.cpan.org/CPAN/authors/id/P/PL/PLICEASE/File-Which-1.22.tar.gz"
 
+    version("1.27", sha256="3201f1a60e3f16484082e6045c896842261fc345de9fb2e620fd2a2c7af3a93a")
     version("1.22", sha256="e8a8ffcf96868c6879e82645db4ff9ef00c2d8a286fed21971e7280f52cf0dd4")


### PR DESCRIPTION
Add perl-file-which v1.27.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.