### PR TITLE
perl-file-slurper: add v0.014

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-slurper/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-slurper/package.py
@@ -12,4 +12,5 @@ class PerlFileSlurper(PerlPackage):
     homepage = "https://metacpan.org/pod/File::Slurper"
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/File-Slurper-0.011.tar.gz"
 
+    version("0.014", sha256="d5a36487339888c3cd758e648160ee1d70eb4153cacbaff57846dbcefb344b0c")
     version("0.011", sha256="f6494844b9759b3d1dd8fc4ffa790f8e6e493c4eb58e88831a51e085f2e76010")


### PR DESCRIPTION
Add perl-file-slurper v0.014.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.