### PR TITLE
perl-file-sharedir-install: add v0.14

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-sharedir-install/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-sharedir-install/package.py
@@ -12,6 +12,7 @@ class PerlFileSharedirInstall(PerlPackage):
     homepage = "https://metacpan.org/pod/File::ShareDir::Install"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/File-ShareDir-Install-0.11.tar.gz"
 
+    version("0.14", sha256="8f9533b198f2d4a9a5288cbc7d224f7679ad05a7a8573745599789428bc5aea0")
     version("0.11", sha256="32bf8772e9fea60866074b27ff31ab5bc3f88972d61915e84cbbb98455e00cc8")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Add perl-file-sharedir-install v0.14.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.