### PR TITLE
perl-file-pushd: add v1.016

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-pushd/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-pushd/package.py
@@ -12,4 +12,5 @@ class PerlFilePushd(PerlPackage):
     homepage = "https://metacpan.org/pod/File::pushd"
     url = "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/File-pushd-1.014.tar.gz"
 
+    version("1.016", sha256="d73a7f09442983b098260df3df7a832a5f660773a313ca273fa8b56665f97cdc")
     version("1.014", sha256="b5ab37ffe3acbec53efb7c77b4423a2c79afa30a48298e751b9ebee3fdc6340b")


### PR DESCRIPTION
Add perl-file-pushd v1.016.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.