### PR TITLE
perl-file-homedir: add v1.006

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-homedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-homedir/package.py
@@ -12,6 +12,7 @@ class PerlFileHomedir(PerlPackage):
     homepage = "https://metacpan.org/pod/File::HomeDir"
     url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-HomeDir-1.004.tar.gz"
 
+    version("1.006", sha256="593737c62df0f6dab5d4122e0b4476417945bb6262c33eedc009665ef1548852")
     version("1.004", sha256="45f67e2bb5e60a7970d080e8f02079732e5a8dfc0c7c3cbdb29abfb3f9f791ad")
 
     depends_on("perl-file-which", type=("build", "run"))


### PR DESCRIPTION
Add perl-file-homedir v1.006.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.