### PR TITLE
perl-ffi-checklib: add v0.31

### DIFF
--- a/var/spack/repos/builtin/packages/perl-ffi-checklib/package.py
+++ b/var/spack/repos/builtin/packages/perl-ffi-checklib/package.py
@@ -17,4 +17,5 @@ class PerlFfiChecklib(PerlPackage):
     homepage = "https://metacpan.org/pod/FFI::CheckLib"
     url = "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/FFI-CheckLib-0.25.tar.gz"
 
+    version("0.31", sha256="04d885fc377d44896e5ea1c4ec310f979bb04f2f18658a7e7a4d509f7e80bb80")
     version("0.25", sha256="eb36b9a7cff1764a65b1b77e01e92c26207c558a3f986d0d17d2b110fa366ba4")


### PR DESCRIPTION
Add perl-ffi-checklib v0.31.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.