### PR TITLE
perl-exporter-lite: add v0.09

### DIFF
--- a/var/spack/repos/builtin/packages/perl-exporter-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-exporter-lite/package.py
@@ -14,4 +14,5 @@ class PerlExporterLite(PerlPackage):
     homepage = "https://metacpan.org/pod/Exporter::Lite"
     url = "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
 
+    version("0.09", sha256="79d8b14fd5013922c63e850f15bf51059f2502404535eb6690ef23612c2a198d")
     version("0.08", sha256="c05b3909af4cb86f36495e94a599d23ebab42be7a18efd0d141fc1586309dac2")


### PR DESCRIPTION
Add perl-exporter-lite v0.09.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.