### PR TITLE
perl-error: add v0.17029

### DIFF
--- a/var/spack/repos/builtin/packages/perl-error/package.py
+++ b/var/spack/repos/builtin/packages/perl-error/package.py
@@ -15,6 +15,7 @@ class PerlError(PerlPackage):
     homepage = "https://metacpan.org/pod/Error"
     url = "https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Error-0.17028.tar.gz"
 
+    version("0.17029", sha256="1a23f7913032aed6d4b68321373a3899ca66590f4727391a091ec19c95bf7adc")
     version("0.17028", sha256="3ad85c5e58b31c8903006298424a51bba39f1840e324f5ae612eabc8b935e960")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Add perl-error v0.17029.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.