### PR TITLE
perl-devel-stacktrace: add v2.04

### DIFF
--- a/var/spack/repos/builtin/packages/perl-devel-stacktrace/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-stacktrace/package.py
@@ -12,4 +12,5 @@ class PerlDevelStacktrace(PerlPackage):
     homepage = "https://metacpan.org/pod/Devel::StackTrace"
     url = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.02.tar.gz"
 
+    version("2.04", sha256="cd3c03ed547d3d42c61fa5814c98296139392e7971c092e09a431f2c9f5d6855")
     version("2.02", sha256="cbbd96db0ecf194ed140198090eaea0e327d9a378a4aa15f9a34b3138a91931f")


### PR DESCRIPTION
Add perl-devel-stacktrace v2.04.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.