### PR TITLE
perl-devel-overloadinfo: add v0.007

### DIFF
--- a/var/spack/repos/builtin/packages/perl-devel-overloadinfo/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-overloadinfo/package.py
@@ -12,6 +12,7 @@ class PerlDevelOverloadinfo(PerlPackage):
     homepage = "https://metacpan.org/pod/Devel::OverloadInfo"
     url = "http://search.cpan.org/CPAN/authors/id/I/IL/ILMARI/Devel-OverloadInfo-0.004.tar.gz"
 
+    version("0.007", sha256="21a184163b90f91f06ffc7f5de0b968356546ae9b400a9d75c573c958c246222")
     version("0.005", sha256="8bfde2ffa47c9946f8adc8cfc445c2f97b8d1cdd678111bee9f444e82f7aa6e7")
     version("0.004", sha256="83e88450064b0b0bbfd520cc9d7997fc7bed14ae257894eeadda28dc3e94937d")
 


### PR DESCRIPTION
Add perl-devel-overloadinfo v0.007.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.