### PR TITLE
coreutils: add v9.2

### DIFF
--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -22,6 +22,7 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
 
     executables = [r"^md5sum$"]
 
+    version("9.2", sha256="6885ff47b9cdb211de47d368c17853f406daaf98b148aaecdf10de29cc04b0b3")
     version("9.1", sha256="61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423")
     version("9.0", sha256="ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce")
     version("8.32", sha256="4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa")


### PR DESCRIPTION
Add coreutils v9.2.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.