### PR TITLE
Rename p2300 variant with stdexec for pika package

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -65,9 +65,9 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     variant("apex", default=False, description="Enable APEX support", when="@0.2:")
     variant("tracy", default=False, description="Enable Tracy support", when="@0.7:")
     variant(
-        "p2300",
+        "stdexec",
         default=False,
-        description="Use P2300 reference implementation for sender/receiver functionality",
+        description="Use stdexec for sender/receiver functionality",
         when="@0.9:",
     )
 
@@ -81,7 +81,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     # Pika is requiring the std::filesystem support starting from version 0.2.0
     conflicts("%gcc@:8", when="@0.2:")
     conflicts("%clang@:8", when="@0.2:")
-    conflicts("+p2300", when="cxxstd=17")
+    conflicts("+stdexec", when="cxxstd=17")
 
     # Other dependencies
     depends_on("boost@1.71:")
@@ -98,7 +98,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hip@5.2:", when="@0.8: +rocm")
     depends_on("hipblas", when="@:0.8 +rocm")
     depends_on("mpi", when="+mpi")
-    depends_on("stdexec", when="+p2300")
+    depends_on("stdexec", when="+stdexec")
     depends_on("rocblas", when="+rocm")
     depends_on("rocsolver", when="@0.5: +rocm")
     depends_on("tracy-client", when="+tracy")
@@ -171,7 +171,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("PIKA_WITH_TRACY", "tracy"),
             self.define("PIKA_WITH_TESTS", self.run_tests),
             self.define_from_variant("PIKA_WITH_GENERIC_CONTEXT_COROUTINES", "generic_coroutines"),
-            self.define_from_variant("PIKA_WITH_P2300_REFERENCE_IMPLEMENTATION", "p2300"),
+            self.define_from_variant("PIKA_WITH_P2300_REFERENCE_IMPLEMENTATION", "stdexec"),
             self.define("BOOST_ROOT", spec["boost"].prefix),
             self.define("HWLOC_ROOT", spec["hwloc"].prefix),
         ]


### PR DESCRIPTION
We now rename the variant in pika since the senders/receivers implementation moved from https://github.com/brycelelbach/wg21_p2300_execution to https://github.com/NVIDIA/stdexec.