### PR TITLE
ci: remove job size tags

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -105,11 +105,11 @@ default:
 
 .generate:
   extends: [ ".generate-base" ]
-  tags: ["spack", "public", "medium", "x86_64"]
+  tags: ["spack", "public", "x86_64"]
 
 .generate-aarch64:
   extends: [ ".generate" ]
-  tags: ["spack", "public", "medium", "aarch64"]
+  tags: ["spack", "public", "aarch64"]
 
 .pr-generate:
   extends: [ ".pr", ".generate" ]
@@ -136,7 +136,7 @@ protected-publish:
   stage: publish
   extends: [ ".protected", ".aws-protected-creds" ]
   image: "ghcr.io/spack/python-aws-bash:0.0.1"
-  tags: ["spack", "public", "medium", "aws", "x86_64"]
+  tags: ["spack", "public", "aws", "x86_64"]
   retry:
     max: 2
     when: ["runner_system_failure", "stuck_or_timeout_failure"]
@@ -439,7 +439,7 @@ e4s-oneapi-protected-build:
 ########################################
 .e4s-power-generate-tags-and-image:
   image: { "name": "ecpe4s/ubuntu20.04-runner-ppc64le:2023-01-01", "entrypoint": [""] }
-  tags: ["spack", "public", "large", "ppc64le"]
+  tags: ["spack", "public", "ppc64le"]
 
 .e4s-power:
   extends: [".linux_power"]
@@ -553,7 +553,7 @@ radiuss-protected-build:
 ########################################
 
 .tags-x86_64_v4:
-  tags: ["spack", "public", "aws", "medium", "x86_64_v4"]
+  tags: ["spack", "public", "aws", "x86_64_v4"]
 
 # Include this AFTER .*-generate in "extends" list
 .radiuss-aws-overrides:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -14,7 +14,7 @@ ci:
       - rocblas
       - visit
       build-job:
-        tags: [ "spack", "huge" ]
+        tags: [ "spack" ]
         variables:
           CI_JOB_SIZE: huge
           SPACK_BUILD_JOBS: "12"
@@ -75,7 +75,7 @@ ci:
       - wrf
       - wxwidgets
       build-job:
-        tags: [ "spack", "large" ]
+        tags: [ "spack" ]
         variables:
           CI_JOB_SIZE: large
           SPACK_BUILD_JOBS: "8"
@@ -169,7 +169,7 @@ ci:
       - vtk-m
       - zfp
       build-job:
-        tags: [ "spack", "medium" ]
+        tags: [ "spack" ]
         variables:
           CI_JOB_SIZE: "medium"
           SPACK_BUILD_JOBS: "2"
@@ -286,7 +286,7 @@ ci:
       - zlib
       - zstd
       build-job:
-        tags: [ "spack", "small" ]
+        tags: [ "spack" ]
         variables:
           CI_JOB_SIZE: "small"
           SPACK_BUILD_JOBS: "1"


### PR DESCRIPTION
We recently noticed a GitLab CI job that failed to schedule because an otherwise appropriate runner did not carry the "medium" tag.

These size tags aren't actually used, so let's get them out of the way. For our cloud runners, we use the KUBERNETES_*_REQUEST variables to dictate job requirements.