### PR TITLE
Update sirius

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -236,9 +236,9 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     # versions below develop will simply ignore this dependency
     with when("+umpire"):
         depends_on("umpire")
-        depends_on("umpire+openmp", when("+openmp"))
-        depends_on("umpire+cuda", when("+cuda"))
-        depends_on("umpire+rocm", when("+rocm"))
+        depends_on("umpire+openmp", when=("+openmp"))
+        depends_on("umpire+cuda", when=("+cuda"))
+        depends_on("umpire+rocm", when=("+rocm"))
 
     patch("strip-spglib-include-subfolder.patch", when="@6.1.5")
     patch("link-libraries-fortran.patch", when="@6.1.5")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -145,6 +145,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant("fortran", default=False, description="Build Fortran bindings")
     variant("python", default=False, description="Build Python bindings")
+    variant("umpire", default=True, description="Build with umpire memory pool")
     variant("memory_pool", default=True, description="Build with memory pool")
     variant("elpa", default=False, description="Use ELPA")
     variant("vdwxc", default=False, description="Enable libvdwxc support")
@@ -232,6 +233,13 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("costa+shared", when="@7.3.2:")
 
+    # versions below develop will simply ignore this dependency
+    with when("+umpire"):
+        depends_on("umpire")
+        depends_on("umpire+openmp", when("+openmp"))
+        depends_on("umpire+cuda", when("+cuda"))
+        depends_on("umpire+rocm", when("+rocm"))
+
     patch("strip-spglib-include-subfolder.patch", when="@6.1.5")
     patch("link-libraries-fortran.patch", when="@6.1.5")
     patch("cmake-fix-shared-library-installation.patch", when="@6.1.5")
@@ -267,6 +275,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("USE_MAGMA", "magma"),
             self.define_from_variant("USE_NLCGLIB", "nlcglib"),
             self.define_from_variant("USE_VDWXC", "vdwxc"),
+            self.define_from_variant("USE_MEMORY_POOL", "umpire"),
             self.define_from_variant("USE_MEMORY_POOL", "memory_pool"),
             self.define_from_variant("USE_SCALAPACK", "scalapack"),
             self.define_from_variant("CREATE_FORTRAN_BINDINGS", "fortran"),

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -21,6 +21,8 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("master", branch="master")
 
+    version("7.4.3", sha256="015679a60a39fa750c5d1bd8fb1ce73945524bef561270d8a171ea2fd4687fec")
+    version("7.4.0", sha256="f9360a695a1e786d8cb9d6702c82dd95144a530c4fa7e8115791c7d1e92b020b")
     version("7.3.2", sha256="a256508de6b344345c295ad8642dbb260c4753cd87cc3dd192605c33542955d7")
     version("7.3.1", sha256="8bf9848b8ebf0b43797fd359adf8c84f00822de4eb677e3049f22baa72735e98")
     version("7.3.0", sha256="69b5cf356adbe181be6c919032859c4e0160901ff42a885d7e7ea0f38cc772e2")


### PR DESCRIPTION
- add umpire support to SIRIUS. The option will be ignored by previous versions of the package.