### PR TITLE
Silo: Add conflict for silo 4.11 and gcc 11.1.

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -67,7 +67,7 @@ class Silo(AutotoolsPackage):
     patch("H5FD_class_t-terminate.patch", when="@:4.10.2-bsd")
 
     # H5EPR_SEMI_COLON.patch was fixed in current dev
-    #patch("H5EPR_SEMI_COLON.patch", when="@:4.11-bsd")
+    # patch("H5EPR_SEMI_COLON.patch", when="@:4.11-bsd")
     patch("H5EPR_SEMI_COLON.patch")
 
     # Fix missing F77 init, fixed in 4.9

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -67,7 +67,8 @@ class Silo(AutotoolsPackage):
     patch("H5FD_class_t-terminate.patch", when="@:4.10.2-bsd")
 
     # H5EPR_SEMI_COLON.patch was fixed in current dev
-    patch("H5EPR_SEMI_COLON.patch", when="@:4.11")
+    #patch("H5EPR_SEMI_COLON.patch", when="@:4.11-bsd")
+    patch("H5EPR_SEMI_COLON.patch")
 
     # Fix missing F77 init, fixed in 4.9
     patch("48-configure-f77.patch", when="@:4.8")

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -85,6 +85,9 @@ class Silo(AutotoolsPackage):
     conflicts("+hzip", when="@4.10.2-bsd,4.11-bsd")
     conflicts("+fpzip", when="@4.10.2-bsd,4.11-bsd")
 
+    # silo 4.11 doesn't compile with gcc 11.1
+    conflicts("%gcc@11.1:", when="@4.11")
+
     # zfp include missing
     patch("zfp_error.patch", when="@4.11 +hdf5")
 

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -67,7 +67,7 @@ class Silo(AutotoolsPackage):
     patch("H5FD_class_t-terminate.patch", when="@:4.10.2-bsd")
 
     # H5EPR_SEMI_COLON.patch was fixed in current dev
-    patch("H5EPR_SEMI_COLON.patch", when="@:4.11-bsd")
+    patch("H5EPR_SEMI_COLON.patch", when="@:4.11")
 
     # Fix missing F77 init, fixed in 4.9
     patch("48-configure-f77.patch", when="@:4.8")
@@ -84,9 +84,6 @@ class Silo(AutotoolsPackage):
     # hzip and fpzip are not available in the BSD releases
     conflicts("+hzip", when="@4.10.2-bsd,4.11-bsd")
     conflicts("+fpzip", when="@4.10.2-bsd,4.11-bsd")
-
-    # silo 4.11 doesn't compile with gcc 11.1
-    conflicts("%gcc@11.1:", when="@4.11")
 
     # zfp include missing
     patch("zfp_error.patch", when="@4.11 +hdf5")


### PR DESCRIPTION
When I submitted a recent pull request for VisIt the CI launched a job on a system with gcc 11.1. The CI failed because of compile errors with silo 4.11.

This PR adds a conflict between silo 4.11 and gcc 11.1.