### PR TITLE
fairlogger: 1.9 and older are incompatible with fmt 9+

### DIFF
--- a/var/spack/repos/builtin/packages/fairlogger/package.py
+++ b/var/spack/repos/builtin/packages/fairlogger/package.py
@@ -60,6 +60,7 @@ class Fairlogger(CMakePackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants, when="+pretty")
     conflicts("^boost@1.70:", when="^cmake@:3.14")
+    depends_on("fmt@:8", when="@:1.9")
     depends_on("fmt@5.3.0:5", when="@1.6.0:1.6.1")
     depends_on("fmt@5.3.0:", when="@1.6.2:")
 


### PR DESCRIPTION
cc: @dennisklein 