### PR TITLE
libzip: add version 1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/libzip/package.py
+++ b/var/spack/repos/builtin/packages/libzip/package.py
@@ -16,3 +16,10 @@ class Libzip(AutotoolsPackage):
     version("1.2.0", sha256="6cf9840e427db96ebf3936665430bab204c9ebbd0120c326459077ed9c907d9f")
 
     depends_on("zlib@1.1.2:")
+
+    @property
+    def headers(self):
+        # Up to version 1.3.0 zipconf.h was installed outside of self.prefix.include
+        return find_all_headers(
+            self.prefix if self.spec.satisfies("@:1.3.0") else self.prefix.include
+        )

--- a/var/spack/repos/builtin/packages/libzip/package.py
+++ b/var/spack/repos/builtin/packages/libzip/package.py
@@ -13,6 +13,7 @@ class Libzip(AutotoolsPackage):
     homepage = "https://nih.at/libzip/index.html"
     url = "https://nih.at/libzip/libzip-1.2.0.tar.gz"
 
+    version("1.3.2", sha256="ab4c34eb6c3a08b678cd0f2450a6c57a13e9618b1ba34ee45d00eb5327316457")
     version("1.2.0", sha256="6cf9840e427db96ebf3936665430bab204c9ebbd0120c326459077ed9c907d9f")
 
     depends_on("zlib@1.1.2:")


### PR DESCRIPTION
1. Add version `1.3.2`, which is the latest Autoconf-based version. More recent versions (up to the current latest release `1.9.2`) are CMake-based and will be added later together with the respective modifications of the package.
2. Up to version `1.3.0`, one of the headers, `zipconf.h`, is installed to `${libincludedir}` instead of `${includedir}` and the default `-I${includedir}` flag added by the compiler wrapper is not enough to make the package available. This PR adds property `headers`, which address the issue.