### PR TITLE
Fix regression on compiler constraint

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1773,10 +1773,8 @@ class SpackSolverSetup(object):
             # real_version from the compiler object to get more accurate
             # results.
             if not supported:
-                compiler_obj = spack.compilers.compilers_for_spec(compiler)
-                compiler_obj = compiler_obj[0]
                 supported = self._supported_targets(
-                    compiler.name, compiler_obj.real_version, candidate_targets
+                    compiler.name, compiler.real_version, candidate_targets
                 )
 
             if not supported:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -915,6 +915,12 @@ error(2, "No valid version for '{0}' compiler '{1}' satisfies '@{2}'", Package, 
      attr("node_compiler_version_satisfies", Package, Compiler, Constraint),
 		 not compiler_version_satisfies(Compiler, Constraint, _).
 
+error(2, "No valid version for '{0}' compiler '{1}' satisfies '@{2}'", Package, Compiler, Constraint)
+  :- attr("node", Package),
+     attr("node_compiler_version_satisfies", Package, Compiler, Constraint),
+     not compiler_version_satisfies(Compiler, Constraint, ID),
+     node_compiler(Package, ID).
+
 % If the node is associated with a compiler and the compiler satisfy a constraint, then
 % the compiler associated with the node satisfy the same constraint
 attr("node_compiler_version_satisfies", Package, Compiler, Constraint)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2136,3 +2136,24 @@ class TestConcretize(object):
         spack.config.set("compilers", compiler_configuration)
         s = spack.spec.Spec("a %gcc@:11").concretized()
         assert s.compiler.version == ver("11.1.0"), s
+
+    @pytest.mark.regression("36339")
+    def test_compiler_with_custom_non_numeric_version(self, mock_executable):
+        """Test that, when a compiler has a completely made up version, we can use its
+        'real version' to detect targets and don't raise during concretization.
+        """
+        gcc_path = mock_executable("gcc", output="echo 9")
+        compiler_configuration = [
+            {
+                "compiler": {
+                    "spec": "gcc@foo",
+                    "paths": {"cc": gcc_path, "cxx": gcc_path, "f77": None, "fc": None},
+                    "operating_system": "debian6",
+                    "target": "x86_64",
+                    "modules": [],
+                }
+            }
+        ]
+        spack.config.set("compilers", compiler_configuration)
+        s = spack.spec.Spec("a %gcc@foo").concretized()
+        assert s.compiler.version == ver("foo")

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2097,3 +2097,42 @@ class TestConcretize(object):
 
         assert result.specs
         assert not result.unsolved_specs
+
+    @pytest.mark.regression("36339")
+    def test_compiler_match_constraints_when_selected(self):
+        """Test that, when multiple compilers with the same name are in the configuration
+        we ensure that the selected one matches all the required constraints.
+        """
+        compiler_configuration = [
+            {
+                "compiler": {
+                    "spec": "gcc@11.1.0",
+                    "paths": {
+                        "cc": "/usr/bin/gcc",
+                        "cxx": "/usr/bin/g++",
+                        "f77": "/usr/bin/gfortran",
+                        "fc": "/usr/bin/gfortran",
+                    },
+                    "operating_system": "debian6",
+                    "target": "x86_64",
+                    "modules": [],
+                }
+            },
+            {
+                "compiler": {
+                    "spec": "gcc@12.1.0",
+                    "paths": {
+                        "cc": "/usr/bin/gcc",
+                        "cxx": "/usr/bin/g++",
+                        "f77": "/usr/bin/gfortran",
+                        "fc": "/usr/bin/gfortran",
+                    },
+                    "operating_system": "debian6",
+                    "target": "x86_64",
+                    "modules": [],
+                }
+            },
+        ]
+        spack.config.set("compilers", compiler_configuration)
+        s = spack.spec.Spec("a %gcc@:11").concretized()
+        assert s.compiler.version == ver("11.1.0"), s

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2138,6 +2138,7 @@ class TestConcretize(object):
         assert s.compiler.version == ver("11.1.0"), s
 
     @pytest.mark.regression("36339")
+    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows")
     def test_compiler_with_custom_non_numeric_version(self, mock_executable):
         """Test that, when a compiler has a completely made up version, we can use its
         'real version' to detect targets and don't raise during concretization.


### PR DESCRIPTION
fixes #36339
closes #36338

We were missing a rule that enforced a match between the `node_compiler` and the compiler used to satisfy a requirement.