### PR TITLE
Fix spack load only=package missing dependencies PATH

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -89,7 +89,10 @@ def environment_modifications_for_spec(spec, view=None, set_package_py_globals=T
     # before asking for package-specific modifications
     env.extend(
         spack.build_environment.modifications_from_dependencies(
-            spec, context="run", set_package_py_globals=set_package_py_globals
+            spec,
+            custom_mods_only=False,
+            context="run",
+            set_package_py_globals=set_package_py_globals,
         )
     )
 


### PR DESCRIPTION
This PR makes `spack load --only=package pkg` setup run-dependencies' `PATH`.

I think this is more consistent because it already did setup dependencies' `PYTHONPATH`.

Then `spack load --only=package` could become the new default: #25732

Before, you had:
- `spack load --only=package pkg` setups all the  `PYTHONPATH`s, but only pkg's `PATH`
- `spack load --only=package,dependencies pkg` setups all `PATH`s, and redundant `PYTHONPATH`s (see #25306)

Now:
- `spack load --only=package pkg` setups `pkg` and run-dependencies `PATH` and `PYTHONPATH` (once) etc.
-  `spack load --only=package,dependencies pkg` setups all dependencies (not just run), but you get redundant `PATH` and `PYTHONPATH`.

Note: This is a quick fix. I think the dependency env setup could be less confusing between when is called `setup_run_environment` vs `setup_dependent_run_environment`, `_make_runnable` vs `environment.inspect_path` etc.
