### PR TITLE
gfortran version fix

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -26,6 +26,7 @@ class Esmf(MakefilePackage):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with spack checksum esmf@x.y.z
+    version("8.4.1", sha256="1b54cee91aacaa9df400bd284614cbb0257e175f6f3ec9977a2d991ed8aa1af6")
     version("8.4.0", sha256="28531810bf1ae78646cda6494a53d455d194400f19dccd13d6361871de42ed0f")
     version("8.3.1", sha256="6c39261e55dcdf9781cdfa344417b9606f7f961889d5ec626150f992f04f146d")
     version("8.3.0", sha256="0ff43ede83d1ac6beabd3d5e2a646f7574174b28a48d1b9f2c318a054ba268fd")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -172,15 +172,25 @@ class Esmf(MakefilePackage):
 
         # ESMF_COMPILER must be set to select which Fortran and
         # C++ compilers are being used to build the ESMF library.
-        print(f"compiler is {self.compiler.name}")
+
         if self.compiler.name == "gcc":
             env.set("ESMF_COMPILER", "gfortran")
-            gfortran_major_version = self.compiler.real_version[0]
+            with self.compiler.compiler_environment():
+                gfortran_major_version = int(
+                    spack.compiler.get_compiler_version_output(
+                        self.compiler.fc, "-dumpversion"
+                    ).split(".")[0]
+                )
         elif self.compiler.name == "intel" or self.compiler.name == "oneapi":
             env.set("ESMF_COMPILER", "intel")
         elif self.compiler.name in ["clang", "apple-clang"]:
             env.set("ESMF_COMPILER", "gfortranclang")
-            gfortran_major_version = self.compiler.real_version[0]
+            with self.compiler.compiler_environment():
+                gfortran_major_version = int(
+                    spack.compiler.get_compiler_version_output(
+                        self.compiler.fc, "-dumpversion"
+                    ).split(".")[0]
+                )
         elif self.compiler.name == "nag":
             env.set("ESMF_COMPILER", "nag")
         elif self.compiler.name == "pgi":

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -172,22 +172,15 @@ class Esmf(MakefilePackage):
 
         # ESMF_COMPILER must be set to select which Fortran and
         # C++ compilers are being used to build the ESMF library.
+        print(f"compiler is {self.compiler.name}")
         if self.compiler.name == "gcc":
             env.set("ESMF_COMPILER", "gfortran")
-            gfortran_major_version = int(
-                spack.compiler.get_compiler_version_output(self.compiler.fc, "-dumpversion").split(
-                    "."
-                )[0]
-            )
+            gfortran_major_version = self.compiler.real_version[0]
         elif self.compiler.name == "intel" or self.compiler.name == "oneapi":
             env.set("ESMF_COMPILER", "intel")
         elif self.compiler.name in ["clang", "apple-clang"]:
             env.set("ESMF_COMPILER", "gfortranclang")
-            gfortran_major_version = int(
-                spack.compiler.get_compiler_version_output(self.compiler.fc, "-dumpversion").split(
-                    "."
-                )[0]
-            )
+            gfortran_major_version = self.compiler.real_version[0]
         elif self.compiler.name == "nag":
             env.set("ESMF_COMPILER", "nag")
         elif self.compiler.name == "pgi":


### PR DESCRIPTION
Apparently the function spack.compiler.get_compiler_version_output is evaluated before any modules are loaded and so if the machine defaulted to a different compiler than gfortran this method would fail.  Someone in the spack developer community must have been aware of this issue because we found that self.compiler.real_version[0] was provided and gave the correct information.