### PR TITLE
Changes to AOCC compiler spack recipe to use new compiler download URLs

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -22,7 +22,7 @@ class Aocc(Package):
     and tuning for x86 applications.
 
     Installation requires acceptance of the EULA by setting the +license-agreed variant.
-    https://developer.amd.com/wordpress/media/files/AOCC_EULA.pdf
+    https://www.amd.com/en/developer/aocc/aocc-compiler/eula.html
 
     Example for installation: \'spack install aocc +license-agreed\'
     """
@@ -36,36 +36,16 @@ class Aocc(Package):
     version(
         ver="4.0.0",
         sha256="2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-4.0.0.tar",
+        url="https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-4.0.0.tar",
     )
     version(
         ver="3.2.0",
         sha256="8493525b3df77f48ee16f3395a68ad4c42e18233a44b4d9282b25dbb95b113ec",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-3.2.0.tar",
-    )
-    version(
-        ver="3.1.0",
-        sha256="1948104a430506fe5e445c0c796d6956109e7cc9fc0a1e32c9f1285cfd566d0c",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-3.1.0.tar",
-    )
-    version(
-        ver="3.0.0",
-        sha256="4ff269b1693856b9920f57e3c85ce488c8b81123ddc88682a3ff283979362227",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-3.0.0.tar",
-    )
-    version(
-        ver="2.3.0",
-        sha256="9f8a1544a5268a7fb8cd21ac4bdb3f8d1571949d1de5ca48e2d3309928fc3d15",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-2.3.0.tar",
-    )
-    version(
-        ver="2.2.0",
-        sha256="500940ce36c19297dfba3aa56dcef33b6145867a1f34890945172ac2be83b286",
-        url="https://developer.amd.com/wordpress/media/files/aocc-compiler-2.2.0.tar",
+        url="https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-3.2.0.tar",
     )
 
     # Licensing
-    license_url = "https://developer.amd.com/wordpress/media/files/AOCC_EULA.pdf"
+    license_url = "https://www.amd.com/en/developer/aocc/aocc-compiler/eula.html"
 
     depends_on("libxml2")
     depends_on("zlib")


### PR DESCRIPTION
Fixes #36129 

No code changes, only the URL path for the 4.0.0 and 3.2.0 versions are changed.