### PR TITLE
prepend compiler bindir to PATH lower priority than wrapper

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -423,6 +423,14 @@ def set_wrapper_variables(pkg, env):
     compiler = pkg.compiler
     env.extend(spack.schema.environment.parse(compiler.environment))
 
+    # Before setting up PATH to Spack compiler wrappers, make sure compiler is in PATH
+    # This ensures that non-wrapped executables from the compiler bin directory are available
+    bindirs = dedupe(
+        [os.path.dirname(c) for c in [compiler.cc, compiler.cxx, compiler.fc, compiler.f77]]
+    )
+    for bindir in bindirs:
+        env.prepend_path("PATH", bindir)
+
     if compiler.extra_rpaths:
         extra_rpaths = ":".join(compiler.extra_rpaths)
         env.set("SPACK_COMPILER_EXTRA_RPATHS", extra_rpaths)


### PR DESCRIPTION
This resolves an issue discovered by @nicholas-sly in which the RH gcc-toolset compilers do not behave properly with the system `as` executable. This PR ensures that executables that are "siblings" of the compiler are found in the compiler directory rather than from another implementation.

TODO:
- [ ] ensure that compiler siblings are at a lower priority than other dependencies
- [ ] test