### PR TITLE
gh: add v2.25.1

### DIFF
--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -14,6 +14,7 @@ class Gh(Package):
 
     maintainers("lcnzg")
 
+    version("2.25.1", sha256="d3b28da03f49600697d2e80c2393425bd382e340040c34641bf3569593c7fbe8")
     version("2.25.0", sha256="b445dbb863643d30cc7991b134c694ea14492e7fac363a9e2648f245f67184f7")
     version("2.24.3", sha256="f5c8a273d3adabee9d4a07d38e738df589f1e9dcdae03f9c7b8e3d8aa4b58cf4")
     version("2.23.0", sha256="1e9f92a47caa92efedc06b22cfe9c951c5163c4a9bc60a45d477fd5d9b592e54")


### PR DESCRIPTION
Add gh v2.25.1.

**Changelog:**
https://github.com/cli/cli/releases/tag/v2.25.1

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.