### PR TITLE
perl-module-build: add v0.4232

### DIFF
--- a/var/spack/repos/builtin/packages/perl-module-build/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build/package.py
@@ -18,5 +18,6 @@ class PerlModuleBuild(PerlPackage):
     homepage = "https://metacpan.org/pod/Module::Build"
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/Module-Build-0.4224.tar.gz"
 
+    version("0.4232", sha256="67c82ee245d94ba06decfa25572ab75fdcd26a9009094289d8f45bc54041771b")
     version("0.4224", sha256="a6ca15d78244a7b50fdbf27f85c85f4035aa799ce7dd018a0d98b358ef7bc782")
     version("0.4220", sha256="fb1207c7e799366f7a8adda3f135bf8141c4d6068505650d4db2b2d3ce34b5a2")


### PR DESCRIPTION
Add perl-module-build v0.4232.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.