### PR TITLE
perl-module-corelist: add v5.20230320

### DIFF
--- a/var/spack/repos/builtin/packages/perl-module-corelist/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-corelist/package.py
@@ -12,7 +12,9 @@ class PerlModuleCorelist(PerlPackage):
     homepage = "https://metacpan.org/pod/Module::CoreList"
     url = "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/Module-CoreList-5.20220820.tar.gz"
 
-    version("5.20230320", sha256="324a28f755bd10abc26e0e8b6564ae2623276ae99cbb28ee09ced647fa80f87b")
+    version(
+        "5.20230320", sha256="324a28f755bd10abc26e0e8b6564ae2623276ae99cbb28ee09ced647fa80f87b"
+    )
     version(
         "5.20220820", sha256="708effbbf04158b087d34d8acc707f35bdab9dccc61b41d432cb6d995d137f43"
     )

--- a/var/spack/repos/builtin/packages/perl-module-corelist/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-corelist/package.py
@@ -12,6 +12,7 @@ class PerlModuleCorelist(PerlPackage):
     homepage = "https://metacpan.org/pod/Module::CoreList"
     url = "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/Module-CoreList-5.20220820.tar.gz"
 
+    version("5.20230320", sha256="324a28f755bd10abc26e0e8b6564ae2623276ae99cbb28ee09ced647fa80f87b")
     version(
         "5.20220820", sha256="708effbbf04158b087d34d8acc707f35bdab9dccc61b41d432cb6d995d137f43"
     )


### PR DESCRIPTION
Add perl-module-corelist v5.20230320.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.