### PR TITLE
perl-moose: add v2.2203

### DIFF
--- a/var/spack/repos/builtin/packages/perl-moose/package.py
+++ b/var/spack/repos/builtin/packages/perl-moose/package.py
@@ -12,6 +12,7 @@ class PerlMoose(PerlPackage):
     homepage = "https://metacpan.org/pod/Moose"
     url = "https://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Moose-2.2006.tar.gz"
 
+    version("2.2203", sha256="fa7814acf4073fa434c148d403cbbf8a7b62f73ad396fa8869f3036d6e3241a7")
     version("2.2010", sha256="af0905b69f18c27de1177c9bc7778ee495d4ec91be1f223e8ca8333af4de08c5")
     version("2.2009", sha256="63ba8a5e27dbcbdbac2cd8f4162fff50a31e9829d8955a196a5898240c02d194")
     version("2.2007", sha256="bc75a320b55ba26ac9e60e11a77b3471066cb615bf7097537ed22e20df88afe8")


### PR DESCRIPTION
Depends on #36411 

Add perl-moose v2.2203.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.