### PR TITLE
perl-mro-compat: add v0.15

### DIFF
--- a/var/spack/repos/builtin/packages/perl-mro-compat/package.py
+++ b/var/spack/repos/builtin/packages/perl-mro-compat/package.py
@@ -12,4 +12,5 @@ class PerlMroCompat(PerlPackage):
     homepage = "https://metacpan.org/pod/MRO::Compat"
     url = "http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/MRO-Compat-0.13.tar.gz"
 
+    version("0.15", sha256="0d4535f88e43babd84ab604866215fc4d04398bd4db7b21852d4a31b1c15ef61")
     version("0.13", sha256="8a2c3b6ccc19328d5579d02a7d91285e2afd85d801f49d423a8eb16f323da4f8")


### PR DESCRIPTION
Add perl-mro-compat v0.15.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.