### PR TITLE
perl-net-http: add v6.22

### DIFF
--- a/var/spack/repos/builtin/packages/perl-net-http/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-http/package.py
@@ -12,6 +12,7 @@ class PerlNetHttp(PerlPackage):
     homepage = "https://metacpan.org/pod/Net::HTTP"
     url = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/Net-HTTP-6.17.tar.gz"
 
+    version("6.22", sha256="62faf9a5b84235443fe18f780e69cecf057dea3de271d7d8a0ba72724458a1a2")
     version("6.17", sha256="1e8624b1618dc6f7f605f5545643ebb9b833930f4d7485d4124aa2f2f26d1611")
 
     depends_on("perl-uri", type=("build", "run"))


### PR DESCRIPTION
Add perl-net-http v6.22.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.