### PR TITLE
perl-package-deprecationmanager: add v0.18

### DIFF
--- a/var/spack/repos/builtin/packages/perl-package-deprecationmanager/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-deprecationmanager/package.py
@@ -12,4 +12,5 @@ class PerlPackageDeprecationmanager(PerlPackage):
     homepage = "https://metacpan.org/pod/Package::DeprecationManager"
     url = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Package-DeprecationManager-0.17.tar.gz"
 
+    version("0.18", sha256="b68d3f0ced55b7615fddbb6029b89f92a34fe0dd8c6fd6bceffc157d56834fe8")
     version("0.17", sha256="1d743ada482b5c9871d894966e87d4c20edc96931bb949fb2638b000ddd6684b")


### PR DESCRIPTION
Add perl-package-deprecationmanager v0.18.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.