### PR TITLE
perl-padwalker: add v2.5

### DIFF
--- a/var/spack/repos/builtin/packages/perl-padwalker/package.py
+++ b/var/spack/repos/builtin/packages/perl-padwalker/package.py
@@ -12,4 +12,5 @@ class PerlPadwalker(PerlPackage):
     homepage = "https://metacpan.org/pod/PadWalker"
     url = "http://search.cpan.org/CPAN/authors/id/R/RO/ROBIN/PadWalker-2.2.tar.gz"
 
+    version("2.5", sha256="07b26abb841146af32072a8d68cb90176ffb176fd9268e6f2f7d106f817a0cd0")
     version("2.2", sha256="fc1df2084522e29e892da393f3719d2c1be0da022fdd89cff4b814167aecfea3")


### PR DESCRIPTION
Add perl-padwalker v2.5.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.