### PR TITLE
perl-parallel-forkmanager: add v2.02

### DIFF
--- a/var/spack/repos/builtin/packages/perl-parallel-forkmanager/package.py
+++ b/var/spack/repos/builtin/packages/perl-parallel-forkmanager/package.py
@@ -12,4 +12,5 @@ class PerlParallelForkmanager(PerlPackage):
     homepage = "https://metacpan.org/pod/Parallel::ForkManager"
     url = "http://search.cpan.org/CPAN/authors/id/Y/YA/YANICK/Parallel-ForkManager-1.19.tar.gz"
 
+    version("2.02", sha256="c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404")
     version("1.19", sha256="f1de2e9875eeb77d65f80338905dedd522f3913822502982f805aa71cde5a472")


### PR DESCRIPTION
Add perl-parallel-forkmanager v2.02.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.