### PR TITLE
perl-path-tiny: add v0.144

### DIFF
--- a/var/spack/repos/builtin/packages/perl-path-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-path-tiny/package.py
@@ -16,4 +16,5 @@ class PerlPathTiny(PerlPackage):
     homepage = "https://metacpan.org/pod/Path::Tiny"
     url = "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.108.tar.gz"
 
+    version("0.144", sha256="f6ea094ece845c952a02c2789332579354de8d410a707f9b7045bd241206487d")
     version("0.108", sha256="3c49482be2b3eb7ddd7e73a5b90cff648393f5d5de334ff126ce7a3632723ff5")


### PR DESCRIPTION
Add perl-path-tiny v0.144.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.