### PR TITLE
perl-pegex: add v0.75

### DIFF
--- a/var/spack/repos/builtin/packages/perl-pegex/package.py
+++ b/var/spack/repos/builtin/packages/perl-pegex/package.py
@@ -12,6 +12,7 @@ class PerlPegex(PerlPackage):
     homepage = "https://metacpan.org/pod/Pegex"
     url = "http://search.cpan.org/CPAN/authors/id/I/IN/INGY/Pegex-0.64.tar.gz"
 
+    version("0.75", sha256="4dc8d335de80b25247cdb3f946f0d10d9ba0b3c34b0ed7d00316fd068fd05edc")
     version("0.64", sha256="27e00264bdafb9c2109212b9654542032617fecf7b7814915d2bdac198f067cd")
 
     depends_on("perl-file-sharedir-install", type=("build", "run"))


### PR DESCRIPTION
Add perl-pegex v0.75.

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.