### PR TITLE
perl-perl4-corelibs: add v0.005

### DIFF
--- a/var/spack/repos/builtin/packages/perl-perl4-corelibs/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl4-corelibs/package.py
@@ -13,6 +13,7 @@ class PerlPerl4Corelibs(PerlPackage):
     homepage = "https://metacpan.org/pod/release/ZEFRAM/Perl4-CoreLibs-0.003/lib/Perl4/CoreLibs.pm"
     url = "https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz"
 
+    version("0.005", sha256="0250aafd307e5d25670946a662bdd0a2a8cc6ed9d949a848753f0b26910923a8")
     version("0.004", sha256="78887e3365f8935ab00d528832e9b7a426fb684ffc5c03c20e67a217ca4ac64a")
     version("0.003", sha256="55c9b2b032944406dbaa2fd97aa3692a1ebce558effc457b4e800dabfaad9ade")
     version("0.002", sha256="c68272e8b0e37268d9fbb93f5ef5708e12e0a13bbb5a6123af3f493ea8852521")


### PR DESCRIPTION
Add perl-perl4-corelibs v0.005. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.