### PR TITLE
perl-perlio-utf8-strict: add v0.010

### DIFF
--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -12,6 +12,7 @@ class PerlPerlioUtf8Strict(PerlPackage):
     homepage = "https://metacpan.org/pod/PerlIO::utf8_strict"
     url = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.002.tar.gz"
 
+    version("0.010", sha256="bcd2848b72df290b5e984fae8b1a6ca96f6d072003cf222389a8c9e8e1c570cd")
     version("0.009", sha256="ba82cf144820655d6d4836d12dde65f8895a3d905aeb4aa0b421249f43284c14")
     version("0.002", sha256="6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f")
 


### PR DESCRIPTION
Add perl-perlio-utf8-strict v0.010. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.