### PR TITLE
perl-scalar-list-utils: add v1.63

### DIFF
--- a/var/spack/repos/builtin/packages/perl-scalar-list-utils/package.py
+++ b/var/spack/repos/builtin/packages/perl-scalar-list-utils/package.py
@@ -12,4 +12,5 @@ class PerlScalarListUtils(PerlPackage):
     homepage = "https://metacpan.org/pod/Scalar::Util"
     url = "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.50.tar.gz"
 
+    version("1.63", sha256="cafbdf212f6827dc9a0dd3b57b6ee50e860586d7198228a33262d55c559eb2a9")
     version("1.50", sha256="06aab9c693380190e53be09be7daed20c5d6278f71956989c24cca7782013675")


### PR DESCRIPTION
Add perl-scalar-list-utils v1.63. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.