### PR TITLE
perl-sub-exporter: add v0.989

### DIFF
--- a/var/spack/repos/builtin/packages/perl-sub-exporter/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-exporter/package.py
@@ -12,6 +12,7 @@ class PerlSubExporter(PerlPackage):
     homepage = "https://metacpan.org/pod/Sub::Exporter"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Sub-Exporter-0.987.tar.gz"
 
+    version("0.989", sha256="334896e0af5e0643fc3799cbbcf01f933d4ca6324cd644c0b6660e71cdbd01c9")
     version("0.987", sha256="543cb2e803ab913d44272c7da6a70bb62c19e467f3b12aaac4c9523259b083d6")
 
     depends_on("perl-params-util", type=("build", "run"))


### PR DESCRIPTION
Add perl-sub-exporter v0.989. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.