### PR TITLE
perl-sub-install: add v0.929

### DIFF
--- a/var/spack/repos/builtin/packages/perl-sub-install/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-install/package.py
@@ -12,4 +12,5 @@ class PerlSubInstall(PerlPackage):
     homepage = "https://metacpan.org/pod/Sub::Install"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Sub-Install-0.928.tar.gz"
 
+    version("0.929", sha256="80b1e281d8cd3b2b31dac711f5c8a1657a87cd80bbe69af3924bcbeb4e5db077")
     version("0.928", sha256="61e567a7679588887b7b86d427bc476ea6d77fffe7e0d17d640f89007d98ef0f")


### PR DESCRIPTION
Add perl-sub-install v0.929. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.