### PR TITLE
perl-sub-name: add v0.26

### DIFF
--- a/var/spack/repos/builtin/packages/perl-sub-name/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-name/package.py
@@ -12,4 +12,5 @@ class PerlSubName(PerlPackage):
     homepage = "https://metacpan.org/pod/Sub::Name"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Sub-Name-0.21.tar.gz"
 
+    version("0.26", sha256="2d2f2d697d516c89547e7c4307f1e79441641cae2c7395e7319b306d390df105")
     version("0.21", sha256="bd32e9dee07047c10ae474c9f17d458b6e9885a6db69474c7a494ccc34c27117")


### PR DESCRIPTION
Add perl-sub-name v0.26. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.