### PR TITLE
perl-svg: add v2.87

### DIFF
--- a/var/spack/repos/builtin/packages/perl-svg/package.py
+++ b/var/spack/repos/builtin/packages/perl-svg/package.py
@@ -12,4 +12,5 @@ class PerlSvg(PerlPackage):
     homepage = "https://metacpan.org/pod/SVG"
     url = "http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/SVG-2.78.tar.gz"
 
+    version("2.87", sha256="b3fa58c1c59942b4ebef003da97c3e01e531480ca29e8efbe327ff0589c0bd3c")
     version("2.78", sha256="a665c1f18c0529f3da0f4b631976eb47e0f71f6d6784ef3f44d32fd76643d6bb")


### PR DESCRIPTION
Add perl-svg v2.87. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.