### PR TITLE
perl-test-deep: add v1.204

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-deep/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-deep/package.py
@@ -12,4 +12,5 @@ class PerlTestDeep(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::Deep"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Deep-1.127.tar.gz"
 
+    version("1.204", sha256="b6591f6ccdd853c7efc9ff3c5756370403211cffe46047f082b1cd1611a84e5f")
     version("1.127", sha256="b78cfc59c41ba91f47281e2c1d2bfc4b3b1b42bfb76b4378bc88cc37b7af7268")


### PR DESCRIPTION
Add perl-test-deep v1.204. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.