### PR TITLE
perl-test-differences: add v0.69

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-differences/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-differences/package.py
@@ -12,6 +12,7 @@ class PerlTestDifferences(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::Differences"
     url = "http://search.cpan.org/CPAN/authors/id/D/DC/DCANTRELL/Test-Differences-0.64.tar.gz"
 
+    version("0.69", sha256="18f644fdd4a1fef93ef3f7f67df8e95b593d811899f34bcbbaba4d717222f58f")
     version("0.64", sha256="9f459dd9c2302a0a73e2f5528a0ce7d09d6766f073187ae2c69e603adf2eb276")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Add perl-test-differences v0.69. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.