### PR TITLE
perl-test-fatal: add v0.017

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-fatal/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-fatal/package.py
@@ -12,6 +12,7 @@ class PerlTestFatal(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::Fatal"
     url = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Fatal-0.014.tar.gz"
 
+    version("0.017", sha256="37dfffdafb84b762efe96b02fb2aa41f37026c73e6b83590db76229697f3c4a6")
     version("0.014", sha256="bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0")
 
     depends_on("perl-try-tiny", type=("build", "run"))


### PR DESCRIPTION
Add perl-test-fatal v0.017. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.