### PR TITLE
perl-test-needs: add v0.002010

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-needs/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-needs/package.py
@@ -12,4 +12,5 @@ class PerlTestNeeds(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::Needs"
     url = "https://search.cpan.org/CPAN/authors/id/H/HA/HAARG/Test-Needs-0.002005.tar.gz"
 
+    version("0.002010", sha256="923ffdc78fcba96609753e4bae26b0ba0186893de4a63cd5236e012c7c90e208")
     version("0.002005", sha256="5a4f33983586edacdbe00a3b429a9834190140190dab28d0f873c394eb7df399")


### PR DESCRIPTION
Add perl-test-needs v0.002010. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.