### PR TITLE
perl-test-requires: add v0.11

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-requires/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-requires/package.py
@@ -12,4 +12,5 @@ class PerlTestRequires(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::Requires"
     url = "http://search.cpan.org/CPAN/authors/id/T/TO/TOKUHIROM/Test-Requires-0.10.tar.gz"
 
+    version("0.11", sha256="4b88de549597eecddf7c3c38a4d0204a16f59ad804577b671896ac04e24e040f")
     version("0.10", sha256="2768a391d50ab94b95cefe540b9232d7046c13ee86d01859e04c044903222eb5")


### PR DESCRIPTION
Add perl-test-requires v0.11. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.