### PR TITLE
perl-test-warnings: add v0.031

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-warnings/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-warnings/package.py
@@ -12,4 +12,5 @@ class PerlTestWarnings(PerlPackage):
     homepage = "http://deps.cpantesters.org/?module=Test%3A%3ACleanNamespaces;perl=latest"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Test-Warnings-0.026.tar.gz"
 
+    version("0.031", sha256="1e542909fef305e45563e9878ea1c3b0c7cef1b28bb7ae07eba2e1efabec477b")
     version("0.026", sha256="ae2b68b1b5616704598ce07f5118efe42dc4605834453b7b2be14e26f9cc9a08")


### PR DESCRIPTION
Add perl-test-warnings v0.031. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.