### PR TITLE
perl-text-csv: add v2.02

### DIFF
--- a/var/spack/repos/builtin/packages/perl-text-csv/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-csv/package.py
@@ -12,4 +12,5 @@ class PerlTextCsv(PerlPackage):
     homepage = "https://metacpan.org/pod/Text::CSV"
     url = "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/Text-CSV-1.95.tar.gz"
 
+    version("2.02", sha256="84120de3e10489ea8fbbb96411a340c32cafbe5cdff7dd9576b207081baa9d24")
     version("1.95", sha256="7e0a11d9c1129a55b68a26aa4b37c894279df255aa63ec8341d514ab848dbf61")


### PR DESCRIPTION
Add perl-text-csv v2.02. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.