### PR TITLE
perl-text-format: add v0.62

### DIFF
--- a/var/spack/repos/builtin/packages/perl-text-format/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-format/package.py
@@ -12,6 +12,7 @@ class PerlTextFormat(PerlPackage):
     homepage = "https://metacpan.org/pod/Text::Format"
     url = "https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Text-Format-0.61.tar.gz"
 
+    version("0.62", sha256="7d429057319e123c590ba0765334f0ade4a5eb9ea8db7c0ec4d3902de5f90404")
     version("0.61", sha256="bb8a3b8ff515c85101baf553a769337f944a05cde81f111ae78aff416bf4ae2b")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Add perl-text-format v0.62. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.