### PR TITLE
perl-text-simpletable: add v2.07

### DIFF
--- a/var/spack/repos/builtin/packages/perl-text-simpletable/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-simpletable/package.py
@@ -12,4 +12,5 @@ class PerlTextSimpletable(PerlPackage):
     homepage = "https://metacpan.org/pod/Text::SimpleTable"
     url = "http://search.cpan.org/CPAN/authors/id/M/MR/MRAMBERG/Text-SimpleTable-2.04.tar.gz"
 
+    version("2.07", sha256="256d3f38764e96333158b14ab18257b92f3155c60d658cafb80389f72f4619ed")
     version("2.04", sha256="8d82f3140b1453b962956b7855ba288d435e7f656c3c40ced4e3e8e359ab5293")


### PR DESCRIPTION
Add perl-text-simpletable v2.07. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.