### PR TITLE
modules: add support for append_flags/remove_flags

### DIFF
--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -144,6 +144,8 @@ class TestLmod(object):
         assert len([x for x in content if 'append_path("SEMICOLON", "bar", ";")' in x]) == 1
         assert len([x for x in content if 'prepend_path("SEMICOLON", "bar", ";")' in x]) == 1
         assert len([x for x in content if 'remove_path("SEMICOLON", "bar", ";")' in x]) == 1
+        assert len([x for x in content if 'append_path("SPACE", "qux", " ")' in x]) == 1
+        assert len([x for x in content if 'remove_path("SPACE", "qux", " ")' in x]) == 1
 
     @pytest.mark.parametrize("config_name", ["exclude", "blacklist"])
     def test_exclude(self, modulefile_content, module_configuration, config_name):

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -120,6 +120,8 @@ class TestTcl(object):
         assert len([x for x in content if 'append-path --delim ";" SEMICOLON "bar"' in x]) == 1
         assert len([x for x in content if 'prepend-path --delim ";" SEMICOLON "bar"' in x]) == 1
         assert len([x for x in content if 'remove-path --delim ";" SEMICOLON "bar"' in x]) == 1
+        assert len([x for x in content if 'append-path --delim " " SPACE "qux"' in x]) == 1
+        assert len([x for x in content if 'remove-path --delim " " SPACE "qux"' in x]) == 1
 
     @pytest.mark.parametrize("config_name", ["exclude", "blacklist"])
     def test_exclude(self, modulefile_content, module_configuration, config_name):

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -70,9 +70,9 @@ depends_on("{{ module }}")
 {% for command_name, cmd in environment_modifications %}
 {% if command_name == 'PrependPath' %}
 prepend_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
-{% elif command_name == 'AppendPath' %}
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
 append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
-{% elif command_name == 'RemovePath' %}
+{% elif command_name in ('RemovePath', 'RemoveFlagsEnv') %}
 remove_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'SetEnv' %}
 setenv("{{ cmd.name }}", "{{ cmd.value }}")

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -43,9 +43,9 @@ conflict {{ name }}
 {% for command_name, cmd in environment_modifications %}
 {% if command_name == 'PrependPath' %}
 prepend-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'AppendPath' %}
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
 append-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'RemovePath' %}
+{% elif command_name in ('RemovePath', 'RemoveFlagsEnv') %}
 remove-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'SetEnv' %}
 setenv {{ cmd.name }} "{{ cmd.value }}"

--- a/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
+++ b/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
@@ -20,3 +20,6 @@ class ModulePathSeparator(Package):
         env.append_path("SEMICOLON", "bar", separator=";")
         env.prepend_path("SEMICOLON", "bar", separator=";")
         env.remove_path("SEMICOLON", "bar", separator=";")
+
+        env.append_flags("SPACE", "qux")
+        env.remove_flags("SPACE", "qux")


### PR DESCRIPTION
Adapt tcl and lmod modulefile templates to generate append-path or remove-path commands in modulefile when respectively append_flags or remove_flags commands are defined in package for run environment.

Fixes #10299.
closes #19577