### PR TITLE
modules: enhance help message

### DIFF
--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -88,7 +88,7 @@ class TestLmod(object):
         assert provides["compiler"] == spack.spec.CompilerSpec("oneapi@3.0")
 
     def test_simple_case(self, modulefile_content, module_configuration):
-        """Tests the generation of a simple Tcl module file."""
+        """Tests the generation of a simple Lua module file."""
 
         module_configuration("autoload_direct")
         content = modulefile_content(mpich_spec_string)
@@ -144,6 +144,31 @@ class TestLmod(object):
         assert len([x for x in content if 'append_path("SEMICOLON", "bar", ";")' in x]) == 1
         assert len([x for x in content if 'prepend_path("SEMICOLON", "bar", ";")' in x]) == 1
         assert len([x for x in content if 'remove_path("SEMICOLON", "bar", ";")' in x]) == 1
+
+    def test_help_message(self, modulefile_content, module_configuration):
+        """Tests the generation of module help message."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content("mpileaks target=core2")
+
+        help_msg = (
+            "help([[Name   : mpileaks]])"
+            "help([[Version: 2.3]])"
+            "help([[Target : core2]])"
+            "help()"
+            "help([[Mpileaks is a mock package that passes audits]])"
+        )
+        assert help_msg in "".join(content)
+
+        content = modulefile_content("libdwarf target=core2")
+
+        help_msg = (
+            "help([[Name   : libdwarf]])"
+            "help([[Version: 20130729]])"
+            "help([[Target : core2]])"
+            "depends_on("
+        )
+        assert help_msg in "".join(content)
 
     @pytest.mark.parametrize("config_name", ["exclude", "blacklist"])
     def test_exclude(self, modulefile_content, module_configuration, config_name):

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -121,6 +121,34 @@ class TestTcl(object):
         assert len([x for x in content if 'prepend-path --delim ";" SEMICOLON "bar"' in x]) == 1
         assert len([x for x in content if 'remove-path --delim ";" SEMICOLON "bar"' in x]) == 1
 
+    def test_help_message(self, modulefile_content, module_configuration):
+        """Tests the generation of module help message."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content("mpileaks target=core2")
+
+        help_msg = (
+            "proc ModulesHelp { } {"
+            '    puts stderr "Name   : mpileaks"'
+            '    puts stderr "Version: 2.3"'
+            '    puts stderr "Target : core2"'
+            '    puts stderr ""'
+            '    puts stderr "Mpileaks is a mock package that passes audits"'
+            "}"
+        )
+        assert help_msg in "".join(content)
+
+        content = modulefile_content("libdwarf target=core2")
+
+        help_msg = (
+            "proc ModulesHelp { } {"
+            '    puts stderr "Name   : libdwarf"'
+            '    puts stderr "Version: 20130729"'
+            '    puts stderr "Target : core2"'
+            "}"
+        )
+        assert help_msg in "".join(content)
+
     @pytest.mark.parametrize("config_name", ["exclude", "blacklist"])
     def test_exclude(self, modulefile_content, module_configuration, config_name):
         """Tests excluding the generation of selected modules."""

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -15,7 +15,11 @@ whatis([[Short description : {{ short_description }}]])
 whatis([[Configure options : {{ configure_options }}]])
 {% endif %}
 
+help([[Name   : {{ spec.name }}]])
+help([[Version: {{ spec.version }}]])
+help([[Target : {{ spec.target }}]])
 {% if long_description %}
+help()
 help([[{{ long_description| textwrap(72)| join() }}]])
 {% endif %}
 {% endblock %}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -14,11 +14,15 @@
 module-whatis "{{ short_description }}"
 {% endif %}
 
-{% if long_description %}
 proc ModulesHelp { } {
-{{ long_description| textwrap(72)| quote()| prepend_to_line('puts stderr ')| join() }}
-}
+    puts stderr "Name   : {{ spec.name }}"
+    puts stderr "Version: {{ spec.version }}"
+    puts stderr "Target : {{ spec.target }}"
+{% if long_description %}
+    puts stderr ""
+{{ long_description| textwrap(72)| quote()| prepend_to_line('    puts stderr ')| join() }}
 {% endif %}
+}
 {% endblock %}
 
 {% block autoloads %}


### PR DESCRIPTION
Update tcl and lmod modulefile template to provide more information on help message (name, version and target) like done on whatis for lmod modulefiles.