### PR TITLE
Bugfix: add perl-data-optlist 0.113 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/perl-data-optlist/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-optlist/package.py
@@ -16,3 +16,4 @@ class PerlDataOptlist(PerlPackage):
     version("0.110", sha256="366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3")
 
     depends_on("perl-sub-install", type=("build", "run"))
+    depends_on("perl-extutils-makemaker@6.78:", when="@0.113:", type=("build", "run"))


### PR DESCRIPTION
Resolves issue I detected with `perl-moose` build (#36368).

Checked both listed versions for dependencies at:
- 0.113  https://metacpan.org/release/RJBS/Data-OptList-0.113/source/Makefile.PL
- 0.110  https://metacpan.org/release/RJBS/Data-OptList-0.110/source/Makefile.PL