### PR TITLE
py-iniconfig: new version 2.0.0 (-> hatchling)

### DIFF
--- a/var/spack/repos/builtin/packages/py-iniconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-iniconfig/package.py
@@ -13,6 +13,9 @@ class PyIniconfig(PythonPackage):
 
     pypi = "iniconfig/iniconfig-1.1.1.tar.gz"
 
+    version("2.0.0", sha256="2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3")
     version("1.1.1", sha256="bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-hatchling", when="@2", type="build")
+    depends_on("py-hatch-vcs", when="@2", type="build")
+    depends_on("py-setuptools", when="@1", type="build")

--- a/var/spack/repos/builtin/packages/py-iniconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-iniconfig/package.py
@@ -18,4 +18,5 @@ class PyIniconfig(PythonPackage):
 
     depends_on("py-hatchling", when="@2", type="build")
     depends_on("py-hatch-vcs", when="@2", type="build")
-    depends_on("py-setuptools", when="@1", type="build")
+    depends_on("py-setuptools@41.2:", when="@1", type="build")
+    depends_on("py-setuptools-scm@4:", when="@1", type="build")


### PR DESCRIPTION
py-iniconfig switched to hatchling with v2.0.0:
https://github.com/pytest-dev/iniconfig/blob/v2.0.0/pyproject.toml

```
==> py-iniconfig: Successfully installed py-iniconfig-2.0.0-ttoip2aalmxqqybv3vnozcabk47vg2yn
```