### PR TITLE
py-versioneer: new versions, depends_on py-tomli

### DIFF
--- a/var/spack/repos/builtin/packages/py-versioneer/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer/package.py
@@ -16,9 +16,12 @@ class PyVersioneer(PythonPackage):
 
     maintainers("scemama")
 
+    version("0.28", sha256="7175ca8e7bb4dd0e3c9779dd2745e5b4a6036304af3f5e50bd896f10196586d6")
+    version("0.27", sha256="452e0130658e9d3f0ba3e8a70cf34ef23c0ff6cbf743555b3e73a6c11d0161a3")
     version("0.26", sha256="84fc729aa296d1d26645a8f62f178019885ff6f9a1073b29a4a228270ac5257b")
     version("0.18", sha256="ead1f78168150011189521b479d3a0dd2f55c94f5b07747b484fd693c3fbf335")
 
     depends_on("python@3.7:", when="@0.23:", type=("build", "run"))
     depends_on("python@3.6:", when="@0.19:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-tomli", when="@0.28: ^python@:3.10", type="build")


### PR DESCRIPTION
py-versioneer-0.28 depends on tomli fro some python vresions: https://github.com/python-versioneer/python-versioneer/blob/0.28/pyproject.toml

```
==> py-versioneer: Successfully installed py-versioneer-0.28-m6ffkioc7zj4bucwgrmkiry4hk4huykg
```