### PR TITLE
root: new version 6.28.02

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -32,6 +32,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
     version("6.28.00", sha256="afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084")
     version("6.26.10", sha256="8e56bec397104017aa54f9eb554de7a1a134474fe0b3bb0f43a70fc4fabd625f")
     version("6.26.08", sha256="4dda043e7918b40743ad0299ddd8d526b7078f0a3822fd06066df948af47940e")


### PR DESCRIPTION
Only bugfixes: https://root.cern/doc/v628/release-notes.html#release-6.2802.

Builds fine on my test system:
```
[+] /opt/software/linux-ubuntu23.04-skylake/gcc-12.2.0/root-6.28.02-zwzhoz6d4323lggrqi66y6prg4hlzwie
```