### PR TITLE
py-uproot, py-awkward, py-awkward-cpp: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-awkward-cpp/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward-cpp/package.py
@@ -16,6 +16,9 @@ class PyAwkwardCpp(PythonPackage):
 
     maintainers("vvolkl", "wdconinc")
 
+    version("12", sha256="429f7fcc37a671afa67fe9680f2edc3a123d1c74d399e5889c654f9529f9f8f2")
+    version("11", sha256="02d719a4da7487564b29b8e8b78925a32ac818b6f5572c2f55912b4e0e59c7a4")
+    version("10", sha256="d1c856cb6ef5cf3d4f67506a7efc59239f595635865cc9f4ab18440b8bfb11c6")
     version("9", sha256="db1c91c21f88b89a39b46176edc67a08b37f7283c16a2ed5159e3c874613c61a")
     version("8", sha256="a51b554490b3197fc5433822becb2e8208bf78fca82ffa314d839b72b3cc4169")
     version("7", sha256="dde733575b2a5ae5b946fe8667b4ae842d937d3b36ebb383d53dc53ea86ea65d")
@@ -26,6 +29,10 @@ class PyAwkwardCpp(PythonPackage):
     version("2", sha256="5e63f43e3135f76db81e0924a74ecf4870f585c11a9f432568b377c04028868c")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-scikit-build-core@0.1.3:+pyproject", type="build")
+    depends_on("py-scikit-build-core@0.2.0:+pyproject", when="@11:", type="build")
     depends_on("py-pybind11", type=("build", "link"))
-    depends_on("py-numpy@1.14.5:", type=("build", "run"))
+    depends_on("py-numpy@1.17.0:", when="@12:", type=("build", "run"))
+
+    # older versions
+    depends_on("py-numpy@1.14.5:", when="@:11", type=("build", "run"))
+    depends_on("py-scikit-build-core@0.1.3:+pyproject", when="@:9", type="build")

--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -30,6 +30,7 @@ class PyAwkward(PythonPackage):
     version("2.0.2", sha256="c7b8194be5f9b1f19ed64c2a4b01d96b1b5a9a357e5a96186c6692d6b4cf439b")
     version("2.0.1", sha256="97fa7e119cc31f479b660a8213df5ba8c938b66f76aadf90b8bdb956c5b5654b")
     version("2.0.0", sha256="3782b34643083d6ee7644e9fdb3daeafc4b6030a667f219fd61cb7b234976b68")
+    version("1.10.3", sha256="7e669b1d29da300ed4c4f0d3a14119356037e7cfa8c3aa9d130bf1be6e38f03b")
     version("1.10.2", sha256="303bc0919f0932db3e78a9254c17fcdeb125e4be65cd894b40dfbc3bfddfc054")
     version("1.10.1", sha256="c6394ed25fb14a086d63621d9d84fdc228f5d42a64586f215731b36fde17034b")
     version("1.10.0", sha256="1d89c7244e6184b35f4bce6bd08ff82eb2ef60be67f572923bc6aaee35dab544")

--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -17,6 +17,10 @@ class PyAwkward(PythonPackage):
 
     version("main", branch="main")
     version("master", branch="main", deprecated=True)
+    version("2.1.1", sha256="fda8e1634161b8b46b151c074ff0fc631fc0feaec2ec277c4b40a2095110b0dd")
+    version("2.1.0", sha256="73f7a76a1fb43e2557befee54b1381f3e6d90636983cdc54da1c2bcb9ad4c1a8")
+    version("2.0.10", sha256="8dae67afe50f5cf1677b4062f9b29dc7e6893420d0af5a0649364b117a3502af")
+    version("2.0.9", sha256="498e09e85894a952fa8ec4495a7865d2d7a57ab5c522c9e5dcc54419e2793ff2")
     version("2.0.8", sha256="32a57c29e13a2ae3bc1e6ac53637825bbd22c4286696163bd41a1dec284a8ee5")
     version("2.0.7", sha256="05397d659a5a8889c8afae193c0ea51585683038ecc7f666f3da9835ba2f6492")
     version("2.0.6", sha256="9e5133ba6be89ff1210d862edf83824fe0c1f21dccfe1d52161329760ffac821")
@@ -58,6 +62,9 @@ class PyAwkward(PythonPackage):
         ("@2.0.6", "@7"),
         ("@2.0.7", "@8"),
         ("@2.0.8", "@9"),
+        ("@2.0.9", "@10"),
+        ("@2.0.10", "@11"),
+        ("@2.1.0:", "@12"),
     ]
     for _awkward, _awkward_cpp in _awkward_to_awkward_cpp_map:
         depends_on("py-awkward-cpp{}".format(_awkward_cpp), when=_awkward, type=("build", "run"))
@@ -66,7 +73,8 @@ class PyAwkward(PythonPackage):
     depends_on("python@3.6:", when="@1.9:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.10:", type=("build", "run"))
     depends_on("py-numpy@1.13.1:", when="@:1", type=("build", "run"))
-    depends_on("py-numpy@1.14.5:", when="@2:", type=("build", "run"))
+    depends_on("py-numpy@1.14.5:", when="@2.0", type=("build", "run"))
+    depends_on("py-numpy@1.17.0:", when="@2.1:", type=("build", "run"))
     depends_on("py-pybind11", type=("build", "link"))
     depends_on("py-importlib-resources", when="@2: ^python@:3.8", type=("build", "run"))
     depends_on("py-typing-extensions@4.1:", when="@2: ^python@:3.10", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -23,6 +23,8 @@ class PyUproot(PythonPackage):
 
     tags = ["hep"]
 
+    version("5.0.5", sha256="1a2ac98d595bde7c83c7d5b716d33bb74abd44df6e8d84af62c638edb6c9abab")
+    version("5.0.4", sha256="c4ea1af198e3292a4649e3fe789d11b038c1ed57c10f167fc3f52100300c2eea")
     version("5.0.3", sha256="a4ab3f2ea0b98746f601d43115a64b36f9c2145e9793da1e1cd9aaca72f311ab")
     version("5.0.2", sha256="734f70d9e44f964d84bbe3de581aa4a96585be09049b3ad104623390d10ac828")
     version("5.0.1", sha256="0ee6790df1df1cd0125b636d7fc8bddc3517d5b665c84246148fe83c79b336aa")


### PR DESCRIPTION
- py-uproot: no build or run dependency version changes
- py-awkward-cpp: depends_on numpy@1.17.0: as of @12
- py-awkward: depends_on numpy@1.17.0: as of @2.1.0, along with py-awkward-cpp version progression

All versions were successfully built on my test system:
```console
$ spack find -lvx
==> In environment py-uproot
==> Root specs
------- py-awkward@1.10.3  ------- py-awkward@2.0.10  ------- py-awkward@2.1.1   ------- py-awkward-cpp@11  ------- py-uproot@5.0.4
------- py-awkward@2.0.9   ------- py-awkward@2.1.0   ------- py-awkward-cpp@10  ------- py-awkward-cpp@12  ------- py-uproot@5.0.5

==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@12.2.0 -----------------------
s7lrfec cmake@3.26.0~doc+ncurses+ownlibs~qt build_system=generic build_type=Release  k7bj3fb py-awkward@2.1.0 build_system=python_pip   vnrp75s py-awkward-cpp@12 build_system=python_pip
tsrih7v py-awkward@1.10.3 build_system=python_pip                                    rtvegko py-awkward@2.1.1 build_system=python_pip   73crblo py-uproot@5.0.4+lz4+xrootd+zstd build_system=python_pip
yjfgvwh py-awkward@2.0.9 build_system=python_pip                                     ldjcvgw py-awkward-cpp@10 build_system=python_pip  rdxlr4b py-uproot@5.0.5+lz4+xrootd+zstd build_system=python_pip
6l6isjn py-awkward@2.0.10 build_system=python_pip                                    7uvie6a py-awkward-cpp@11 build_system=python_pip
==> 11 installed packages
```