### PR TITLE
gobject-introspection: add v1.72.1

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -18,6 +18,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     maintainers("michaelkuhn")
 
+    version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
     version("1.72.0", sha256="02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc")
     version("1.56.1", sha256="5b2875ccff99ff7baab63a34b67f8c920def240e178ff50add809e267d9ea24b")
     version("1.49.2", sha256="73d59470ba1a546b293f54d023fd09cca03a951005745d86d586b9e3a8dde9ac")


### PR DESCRIPTION
Add gobject-introspection v1.72.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.