### PR TITLE
libslirp: add v4.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/libslirp/package.py
+++ b/var/spack/repos/builtin/packages/libslirp/package.py
@@ -13,6 +13,7 @@ class Libslirp(MesonPackage):
     url = "https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.1/libslirp-v4.6.1.tar.gz"
     maintainers("bernhardkaindl")
 
+    version("4.7.0", sha256="9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3b")
     version("4.6.1", sha256="69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11")
 
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
Add libslirp v4.7.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.