### PR TITLE
perl-exporter-tiny: add v1.006001

### DIFF
--- a/var/spack/repos/builtin/packages/perl-exporter-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-exporter-tiny/package.py
@@ -13,5 +13,6 @@ class PerlExporterTiny(PerlPackage):
     homepage = "https://metacpan.org/pod/Exporter::Tiny"
     url = "http://search.cpan.org/CPAN/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.000000.tar.gz"
 
+    version("1.006001", sha256="8df2a7ee5a11bacb8166edd9ee8fc93172278a74d5abe2021a5f4a7d57915c50")
     version("1.006000", sha256="d95479ff085699d6422f7fc8306db085e34b626438deb82ec82d41df2295f400")
     version("1.000000", sha256="ffdd77d57de099e8f64dd942ef12a00a3f4313c2531f342339eeed2d366ad078")


### PR DESCRIPTION
Add perl-exporter-tiny v1.006001. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.