### PR TITLE
perl-params: add validate

### DIFF
--- a/var/spack/repos/builtin/packages/perl-params-validate/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-validate/package.py
@@ -12,6 +12,7 @@ class PerlParamsValidate(PerlPackage):
     homepage = "https://metacpan.org/pod/Params::Validate"
     url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Params-Validate-1.29.tar.gz"
 
+    version("1.31", sha256="1bf2518ef2c4869f91590e219f545c8ef12ed53cf313e0eb5704adf7f1b2961e")
     version("1.29", sha256="49a68dfb430bea028042479111d19068e08095e5a467e320b7ab7bde3d729733")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Add perl-params validate. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.