### PR TITLE
perl-time-hires: add v1.9758

### DIFF
--- a/var/spack/repos/builtin/packages/perl-time-hires/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-hires/package.py
@@ -12,4 +12,5 @@ class PerlTimeHires(PerlPackage):
     homepage = "https://metacpan.org/pod/Time::HiRes"
     url = "http://search.cpan.org/CPAN/authors/id/J/JH/JHI/Time-HiRes-1.9746.tar.gz"
 
+    version("1.9758", sha256="5bfa145bc11e70a8e337543b1084a293743a690691b568493455dedf58f34b1e")
     version("1.9746", sha256="89408c81bb827bc908c98eec50071e6e1158f38fa462865ecc3dc03aebf5f596")


### PR DESCRIPTION
Add perl-time-hires v1.9758. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.