### PR TITLE
perl-time-piece: add v1.3401

### DIFF
--- a/var/spack/repos/builtin/packages/perl-time-piece/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-piece/package.py
@@ -12,4 +12,5 @@ class PerlTimePiece(PerlPackage):
     homepage = "https://metacpan.org/pod/Time::Piece"
     url = "http://search.cpan.org/CPAN/authors/id/E/ES/ESAYM/Time-Piece-1.3203.tar.gz"
 
+    version("1.3401", sha256="4b55b7bb0eab45cf239a54dfead277dfa06121a43e63b3fce0853aecfdb04c27")
     version("1.3203", sha256="6971faf6476e4f715a5b5336f0a97317f36e7880fcca6c4db7c3e38e764a6f41")


### PR DESCRIPTION
Add perl-time-piece v1.3401. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.