### PR TITLE
perl-try-tiny: add v0.31

### DIFF
--- a/var/spack/repos/builtin/packages/perl-try-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-try-tiny/package.py
@@ -12,4 +12,5 @@ class PerlTryTiny(PerlPackage):
     homepage = "https://metacpan.org/pod/Try::Tiny"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz"
 
+    version("0.31", sha256="3300d31d8a4075b26d8f46ce864a1d913e0e8467ceeba6655d5d2b2e206c11be")
     version("0.28", sha256="f1d166be8aa19942c4504c9111dade7aacb981bc5b3a2a5c5f6019646db8c146")


### PR DESCRIPTION
Add perl-try-tiny v0.31. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.