### PR TITLE
perl-uri: add v5.08

### DIFF
--- a/var/spack/repos/builtin/packages/perl-uri/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri/package.py
@@ -12,6 +12,7 @@ class PerlUri(PerlPackage):
     homepage = "https://metacpan.org/pod/URI"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/URI-1.72.tar.gz"
 
+    version("5.08", sha256="7e2c6fe3b1d5947da334fa558a96e748aaa619213b85bcdce5b5347d4d26c46e")
     version("1.72", sha256="35f14431d4b300de4be1163b0b5332de2d7fbda4f05ff1ed198a8e9330d40a32")
     version("1.71", sha256="9c8eca0d7f39e74bbc14706293e653b699238eeb1a7690cc9c136fb8c2644115")
 


### PR DESCRIPTION
Add perl-uri v5.08. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.