### PR TITLE
perl-xml-parser-lite: add v0.722

### DIFF
--- a/var/spack/repos/builtin/packages/perl-xml-parser-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser-lite/package.py
@@ -12,6 +12,7 @@ class PerlXmlParserLite(PerlPackage):
     homepage = "https://metacpan.org/pod/XML::Parser::Lite"
     url = "http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/XML-Parser-Lite-0.721.tar.gz"
 
+    version("0.722", sha256="6f90a027e1531a0e5406cf1de13c709b5216966df8f73d0bab9ab919209763ee")
     version("0.721", sha256="5862a36ecab9db9aad021839c847e8d2f4ab5a7796c61d0fb069bb69cf7908ba")
 
     depends_on("perl-test-requires", type=("build", "run"))


### PR DESCRIPTION
Add perl-xml-parser-lite v0.722. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.