### PR TITLE
perl-xml-simple: add v2.25

### DIFF
--- a/var/spack/repos/builtin/packages/perl-xml-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-simple/package.py
@@ -12,6 +12,7 @@ class PerlXmlSimple(PerlPackage):
     homepage = "https://metacpan.org/pod/XML::Simple"
     url = "http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/XML-Simple-2.24.tar.gz"
 
+    version("2.25", sha256="531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8")
     version("2.24", sha256="9a14819fd17c75fbb90adcec0446ceab356cab0ccaff870f2e1659205dc2424f")
 
     depends_on("perl-xml-parser", type=("build", "run"))


### PR DESCRIPTION
Add perl-xml-simple v2.25. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.