### PR TITLE
perl-yaml-libyaml: add v0.84

### DIFF
--- a/var/spack/repos/builtin/packages/perl-yaml-libyaml/package.py
+++ b/var/spack/repos/builtin/packages/perl-yaml-libyaml/package.py
@@ -12,4 +12,5 @@ class PerlYamlLibyaml(PerlPackage):
     homepage = "https://metacpan.org/pod/YAML::LibYAML"
     url = "http://search.cpan.org/CPAN/authors/id/T/TI/TINITA/YAML-LibYAML-0.67.tar.gz"
 
+    version("0.84", sha256="225bcb39be2d5e3d02df7888d5f99fd8712f048ba539b09232ca1481e70bfd05")
     version("0.67", sha256="e65a22abc912a46a10abddf3b88d806757f44f164ab3167c8f0ff6aa30648187")


### PR DESCRIPTION
Add perl-yaml-libyaml v0.84. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.