### PR TITLE
postgresql: add v15.2

### DIFF
--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -19,6 +19,7 @@ class Postgresql(AutotoolsPackage):
     list_url = "http://ftp.postgresql.org/pub/source"
     list_depth = 1
 
+    version("15.2", sha256="99a2171fc3d6b5b5f56b757a7a3cb85d509a38e4273805def23941ed2b8468c7")
     version("14.0", sha256="ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122")
     version("12.2", sha256="ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de")
     version("11.2", sha256="2676b9ce09c21978032070b6794696e0aa5a476e3d21d60afc036dc0a9c09405")


### PR DESCRIPTION
Add postgresql v15.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.