### PR TITLE
presentproto: add v1.1

### DIFF
--- a/var/spack/repos/builtin/packages/presentproto/package.py
+++ b/var/spack/repos/builtin/packages/presentproto/package.py
@@ -12,6 +12,7 @@ class Presentproto(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/proto/presentproto/"
     xorg_mirror_path = "proto/presentproto-1.0.tar.gz"
 
+    version("1.1", sha256="114252e97afb4dfae8b31e6b0d5e24e4babda26b364e2be57abc2f3c30248b87")
     version("1.0", sha256="02f8042cb351dd5c3699a0dbdb2ab25f86532efe3e1e3e97897e7f44b5c67040")
 
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
Add presentproto v1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.