### PR TITLE
py-about-time: add v4.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-about-time/package.py
+++ b/var/spack/repos/builtin/packages/py-about-time/package.py
@@ -14,6 +14,7 @@ class PyAboutTime(PythonPackage):
     homepage = "https://github.com/rsalmei/about-time"
     pypi = "about-time/about-time-4.1.0.tar.gz"
 
+    version("4.2.1", sha256="6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece")
     version("4.1.0", sha256="963b1f3739b0c9732eb205031762b76f1291d89b5d0c8220a8d5b154e32ce650")
     version("3.1.1", sha256="586b329450c9387d1ae8c42d2db4f5b4c57a54508d0f1b7bb00322ffd5ce9f9b")
 


### PR DESCRIPTION
Add py-about-time v4.2.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.