### PR TITLE
py-agate-dbf: add v0.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-agate-dbf/package.py
+++ b/var/spack/repos/builtin/packages/py-agate-dbf/package.py
@@ -12,6 +12,7 @@ class PyAgateDbf(PythonPackage):
     homepage = "https://agate-dbf.readthedocs.io/en/latest/"
     pypi = "agate-dbf/agate-dbf-0.2.1.tar.gz"
 
+    version("0.2.2", sha256="589682b78c5c03f2dc8511e6e3edb659fb7336cd118e248896bb0b44c2f1917b")
     version("0.2.1", sha256="00c93c498ec9a04cc587bf63dd7340e67e2541f0df4c9a7259d7cb3dd4ce372f")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Add py-agate-dbf v0.2.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.