### PR TITLE
octopus: Update compiler flags

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -236,10 +236,12 @@ class Octopus(AutotoolsPackage, CudaPackage):
             )
             # Add debug flag if needed
             if spec.satisfies("+debug"):
-                fcflags += f" -g"
-                cxxflags += f" -g"
-                cflags += f" -g"
-                gcc10_extra += "-fno-var-tracking-assignments" if spec.satisfies("%gcc@10:") else ""
+                fcflags += " -g"
+                cxxflags += " -g"
+                cflags += " -g"
+                gcc10_extra += (
+                    "-fno-var-tracking-assignments" if spec.satisfies("%gcc@10:") else ""
+                )
 
             args.append(f"{fcflags} {gcc10_extra}")
             args.append(f"{cxxflags} {gcc10_extra}")

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -219,16 +219,31 @@ class Octopus(AutotoolsPackage, CudaPackage):
             # In case of GCC version 10, we will have errors because of
             # argument mismatching. Need to provide a flag to turn this into a
             # warning and build sucessfully
+            # We can disable variable tracking at assignments introduced in GCC10
+            # for debug variant to decrease compile time.
 
-            fcflags = "FCFLAGS=-O2 -ffree-line-length-none"
-            fflags = "FFLAGS=O2 -ffree-line-length-none"
-            if spec.satisfies("%gcc@10:"):
-                gcc10_extra = "-fallow-argument-mismatch -fallow-invalid-boz"
-                args.append(fcflags + " " + gcc10_extra)
-                args.append(fflags + " " + gcc10_extra)
-            else:
-                args.append(fcflags)
-                args.append(fflags)
+            # Set optimization level for all flags
+            opt_level = "-O2"
+            fcflags = f"FCFLAGS={opt_level} -ffree-line-length-none"
+            cxxflags = f"CXXFLAGS={opt_level}"
+            cflags = f"CFLAGS={opt_level}"
+
+            # Add extra flags for gcc 10 or higher
+            gcc10_extra = (
+                "-fallow-argument-mismatch -fallow-invalid-boz"
+                if spec.satisfies("%gcc@10:")
+                else ""
+            )
+            # Add debug flag if needed
+            if spec.satisfies("+debug"):
+                fcflags += f" -g"
+                cxxflags += f" -g"
+                cflags += f" -g"
+                gcc10_extra += "-fno-var-tracking-assignments" if spec.satisfies("%gcc@10:") else ""
+
+            args.append(f"{fcflags} {gcc10_extra}")
+            args.append(f"{cxxflags} {gcc10_extra}")
+            args.append(f"{cflags} {gcc10_extra}")
 
         return args
 


### PR DESCRIPTION
This MR  tries to update the compiler flags set in the `octopus` spack package.
When octopus is compiled with spec `octopus@12.1%gcc@11.3.0+mpi+netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt`
The resulting binary has the following information printed during runs:
```shell
Version                : 12.1
Commit                 :
Build time             : Mon Feb 27 21:57:54 CET 2023
Configuration options  : maxdim3 openmp mpi sse2 avx libxc5 libxc_fxc
Optional libraries     : cgal metis netcdf parmetis pfft nlopt
Architecture           : x86_64
C compiler             : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/opt/spack/linux-debian11-sandybridge/gcc-11.3.0/openmpi-4.1.4-4lehnqllo3r6t45ix2wrdcew6lfwsdgw/bin/mpicc (/opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/gcc)
C compiler flags       : -g -O2
C++ compiler           : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/g++
C++ compiler flags     : -g -O2
Fortran compiler       : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/opt/spack/linux-debian11-sandybridge/gcc-11.3.0/openmpi-4.1.4-4lehnqllo3r6t45ix2wrdcew6lfwsdgw/bin/mpif90 (/opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/gfor
Fortran compiler flags : -O2 -ffree-line-length-none -fallow-argument-mismatch -fallow-invalid-boz -fopenmp
```

Which identifies the following issues that this MR tries to solve:
- Fixes https://github.com/fangohr/octopus-in-spack/issues/65 
Octopus configure script dosent use the FFLAGS at all which we are setting, we can hence remove it from here to reduce clutter.

- Fixes https://github.com/fangohr/octopus-in-spack/issues/64 and https://github.com/fangohr/octopus-in-spack/issues/69
In the octopus in spack  package, we do not set the `C flags` and `CXX flags` that  are used by octopus 
Such as `-O2` for compiler optimisation and `-g` for when the debug variant of the package is used.

- Fixes https://github.com/fangohr/octopus-in-spack/issues/61
We pass the no vartracking assignments flag to speed up compilation when debugging is required. gcc 10+ fortran does something called [Variable Tracking at Assignments](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/developer_guide/ch-debug-vta) This is enabled by default and to disable it we add `-fno-var-tracking-assignments`.
