### PR TITLE
arborx: make explicit the need to specify cuda_arch when +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -73,6 +73,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
         rocm_dep = "+rocm amdgpu_target={0}".format(arch)
         depends_on("kokkos {0}".format(rocm_dep), when=rocm_dep)
 
+    conflicts("+cuda", when="cuda_arch=none")
     depends_on("kokkos+cuda_lambda", when="~trilinos+cuda")
 
     # Trilinos/Kokkos


### PR DESCRIPTION
In the Arborx build documentation, the simple example given for spack-based installation doesn't work (when you strip the version and compilers arguments), i.e. `spack install arborx +cuda`.

The error raised doesn't give much hint as to where the problem lies: `==> Error: Must enable CUDA to use cuda_lambda`

This is because the `kokkos` package needs to have `cuda_arch` specified when `+cuda`. And this is explicit when we try to do `spack install kokkos +cuda`. 

Another way of handling this might be to remove this `conflicts` from `kokkos` package altogether. 