### PR TITLE
openPMD-api: 0.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -11,7 +11,7 @@ class Catch2(CMakePackage):
     supports Objective-C (and maybe C)."""
 
     homepage = "https://github.com/catchorg/Catch2"
-    url = "https://github.com/catchorg/Catch2/archive/v2.9.1.tar.gz"
+    url = "https://github.com/catchorg/Catch2/archive/v2.13.10.tar.gz"
     git = "https://github.com/catchorg/Catch2.git"
     maintainers("ax3l", "AndrewGaspar")
 
@@ -26,6 +26,7 @@ class Catch2(CMakePackage):
     version(
         "3.0.0-preview3", sha256="06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975"
     )
+    version("2.13.10", sha256="d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943")
     version("2.13.8", sha256="b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a")
     version("2.13.7", sha256="3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae")
     version("2.13.6", sha256="48dfbb77b9193653e4e72df9633d2e0383b9b625a47060759668480fdf24fbd4")

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -10,7 +10,7 @@ class OpenpmdApi(CMakePackage):
     """C++ & Python API for Scientific I/O"""
 
     homepage = "https://www.openPMD.org"
-    url = "https://github.com/openPMD/openPMD-api/archive/0.14.2.tar.gz"
+    url = "https://github.com/openPMD/openPMD-api/archive/0.15.0.tar.gz"
     git = "https://github.com/openPMD/openPMD-api.git"
 
     maintainers("ax3l", "franzpoeschel")
@@ -19,6 +19,7 @@ class OpenpmdApi(CMakePackage):
 
     # C++17 up until here
     version("develop", branch="dev")
+    version("0.15.0", sha256="290e3a3c5814204ea6527d53423bfacf7a8dc490713227c9e0eaa3abf4756177")
     # C++14 up until here
     version("0.14.5", sha256="e3f509098e75014394877e0dc91f833e57ced5552b110c7339a69e9dbe49bf62")
     version("0.14.4", sha256="42b7bcd043e772d63f0fe0e5e70da411f001db10096d5b8be797ffc88e786379")
@@ -43,11 +44,12 @@ class OpenpmdApi(CMakePackage):
     variant("python", default=False, description="Enable Python bindings")
 
     depends_on("cmake@3.15.0:", type="build")
-    depends_on("catch2@2.6.1:", type="test")
-    depends_on("catch2@2.13.4:", type="test", when="@0.14.0:")
+    depends_on("catch2@2.6.1:2", type="test")
+    depends_on("catch2@2.13.4:2", type="test", when="@0.14.0:")
+    depends_on("catch2@2.13.10:2", type="test", when="@0.15.0:")
     depends_on("mpi@2.3:", when="+mpi")  # might become MPI 3.0+
     depends_on("nlohmann-json@3.9.1:")
-    depends_on("mpark-variant@1.4.0:", when="@:0.14.99")  # pre C++17 releases
+    depends_on("mpark-variant@1.4.0:", when="@:0.14")  # pre C++17 releases
     depends_on("toml11@3.7.1:", when="@0.15.0:")
     with when("+hdf5"):
         depends_on("hdf5@1.8.13:")
@@ -68,6 +70,7 @@ class OpenpmdApi(CMakePackage):
         depends_on("py-numpy@1.15.1:", type=["test", "run"])
         depends_on("py-mpi4py@2.1.0:", when="+mpi", type=["test", "run"])
         depends_on("python@3.6:", type=["link", "test", "run"])
+        depends_on("python@3.7:", when="@0.15.0:", type=["link", "test", "run"])
 
     conflicts("^hdf5 api=v16", msg="openPMD-api requires HDF5 APIs for 1.8+")
 

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -78,6 +78,20 @@ class OpenpmdApi(CMakePackage):
     # https://github.com/openPMD/openPMD-api/pull/1012
     patch("hdf5-1.12.0.patch", when="@:0.13 +hdf5")
 
+    # CMake: Fix Python Install Directory
+    patch(
+        "https://github.com/openPMD/openPMD-api/pull/1393.patch?full_index=1",
+        sha256="b5cecbdbe16d98c0ba352fa861fcdf9d7c7cc85f21226fa03effa7d62a7cb276",
+        when="@0.15.0",
+    )
+
+    # macOS AppleClang12 Fixes
+    patch(
+        "https://github.com/openPMD/openPMD-api/pull/1395.patch?full_index=1",
+        sha256="791c0a9d1dc09226beb26e8e67824b3337d95f4a2a6e7e64637ea8f0d95eee61",
+        when="@0.15.0",
+    )
+
     extends("python", when="+python")
 
     def cmake_args(self):


### PR DESCRIPTION
Add the latest release of openPMD-api.

Bumps Catch2 to also checksum the 2.13.10 release.