### PR TITLE
libpthread-stubs: adapt to XorgPackage

### DIFF
--- a/var/spack/repos/builtin/packages/libpthread-stubs/package.py
+++ b/var/spack/repos/builtin/packages/libpthread-stubs/package.py
@@ -13,6 +13,8 @@ class LibpthreadStubs(AutotoolsPackage, XorgPackage):
     homepage = "https://gitlab.freedesktop.org/xorg/lib/pthread-stubs"
     xorg_mirror_path = "xcb/libpthread-stubs-0.4.tar.gz"
 
+    maintainers("wdconinc")
+
     version(
         "0.4",
         sha256="50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9",

--- a/var/spack/repos/builtin/packages/libpthread-stubs/package.py
+++ b/var/spack/repos/builtin/packages/libpthread-stubs/package.py
@@ -6,12 +6,20 @@
 from spack.package import *
 
 
-class LibpthreadStubs(AutotoolsPackage):
+class LibpthreadStubs(AutotoolsPackage, XorgPackage):
     """The libpthread-stubs package provides weak aliases for pthread
     functions not provided in libc or otherwise available by default."""
 
-    homepage = "https://xcb.freedesktop.org/"
-    url = "https://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.gz"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/pthread-stubs"
+    xorg_mirror_path = "xcb/libpthread-stubs-0.4.tar.gz"
 
-    version("0.4", sha256="50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9")
-    version("0.3", sha256="3031f466cf0b06de6b3ccbf2019d15c4fcf75229b7d226a711bc1885b3a82cde")
+    version(
+        "0.4",
+        sha256="50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9",
+        url="https://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.gz",
+    )
+    version(
+        "0.3",
+        sha256="3031f466cf0b06de6b3ccbf2019d15c4fcf75229b7d226a711bc1885b3a82cde",
+        url="https://xcb.freedesktop.org/dist/libpthread-stubs-0.3.tar.gz",
+    )


### PR DESCRIPTION
This resolves a loose end from #36241 (missed due to package name). `libpthread-stubs` is another package from the xcb project that is now tracked through https://gitlab.freedesktop.org/xorg/ instead. No new versions; no changed hashes.