### PR TITLE
modules: remove default symlink on uninstall

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -930,12 +930,21 @@ class BaseModuleFileWriter(object):
         if os.path.exists(mod_file):
             try:
                 os.remove(mod_file)  # Remove the module file
+                self.remove_module_defaults()  # Remove default targeting module file
                 os.removedirs(
                     os.path.dirname(mod_file)
                 )  # Remove all the empty directories from the leaf up
             except OSError:
                 # removedirs throws OSError on first non-empty directory found
                 pass
+
+    def remove_module_defaults(self):
+        if any(self.spec.satisfies(default) for default in self.conf.defaults):
+            # This spec matches a default, symlink needs to be removed as we
+            # remove the module file it targets.
+            default_symlink = os.path.join(os.path.dirname(self.layout.filename), "default")
+            if os.path.lexists(default_symlink):
+                os.remove(default_symlink)
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -939,12 +939,16 @@ class BaseModuleFileWriter(object):
                 pass
 
     def remove_module_defaults(self):
-        if any(self.spec.satisfies(default) for default in self.conf.defaults):
-            # This spec matches a default, symlink needs to be removed as we
-            # remove the module file it targets.
-            default_symlink = os.path.join(os.path.dirname(self.layout.filename), "default")
-            if os.path.lexists(default_symlink):
-                os.remove(default_symlink)
+        if not any(self.spec.satisfies(default) for default in self.conf.defaults):
+            return
+
+        # This spec matches a default, symlink needs to be removed as we remove the module
+        # file it targets.
+        default_symlink = os.path.join(os.path.dirname(self.layout.filename), "default")
+        try:
+            os.unlink(default_symlink)
+        except OSError:
+            pass
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -77,6 +77,9 @@ def test_modules_default_symlink(
     assert os.path.islink(link_path)
     assert os.readlink(link_path) == mock_module_filename
 
+    generator.remove()
+    assert not os.path.lexists(link_path)
+
 
 class MockDb(object):
     def __init__(self, db_ids, spec_hash_to_db):


### PR DESCRIPTION
When app is uninstalled, if it matches a default, then remove the default symlink targeting its modulefile.

Until now, when a default were uninstalled, the default symlink were left pointing to a nonexistent modulefile.