### PR TITLE
Xorg docs: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -15,6 +15,7 @@ class XorgDocs(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-docs"
     xorg_mirror_path = "doc/xorg-docs-1.7.1.tar.gz"
 
+    version("1.7.2", sha256="0c1e018868a00cb5a5bc8622ffd87e706e119ffa0949edde00d0d0d912663677")
     version("1.7.1", sha256="360707db2ba48f6deeb53d570deca9fa98218af48ead4a726a67f63e3ef63816")
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -15,6 +15,8 @@ class XorgDocs(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-docs"
     xorg_mirror_path = "doc/xorg-docs-1.7.1.tar.gz"
 
+    maintainers("wdconinc")
+
     version("1.7.2", sha256="0c1e018868a00cb5a5bc8622ffd87e706e119ffa0949edde00d0d0d912663677")
     version("1.7.1", sha256="360707db2ba48f6deeb53d570deca9fa98218af48ead4a726a67f63e3ef63816")
 

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -14,6 +14,7 @@ class XorgSgmlDoctools(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-sgml-doctools"
     xorg_mirror_path = "doc/xorg-sgml-doctools-1.11.tar.gz"
 
+    version("1.12", sha256="985a0329e6a6dadd6ad517f8d54f8766ab4b52bb8da7b07d02ec466bec444bdb")
     version("1.11", sha256="986326d7b4dd2ad298f61d8d41fe3929ac6191c6000d6d7e47a8ffc0c34e7426")
 
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -14,6 +14,8 @@ class XorgSgmlDoctools(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-sgml-doctools"
     xorg_mirror_path = "doc/xorg-sgml-doctools-1.11.tar.gz"
 
+    maintainers("wdconinc")
+
     version("1.12", sha256="985a0329e6a6dadd6ad517f8d54f8766ab4b52bb8da7b07d02ec466bec444bdb")
     version("1.11", sha256="986326d7b4dd2ad298f61d8d41fe3929ac6191c6000d6d7e47a8ffc0c34e7426")
 


### PR DESCRIPTION
No significant changes in either package, just the chore of keeping the versions updated:
- https://gitlab.freedesktop.org/xorg/doc/xorg-docs/-/compare/xorg-docs-1.7.1...xorg-docs-1.7.2
- https://gitlab.freedesktop.org/xorg/doc/xorg-sgml-doctools/-/compare/xorg-sgml-doctools-1.11...xorg-sgml-doctools-1.12