### PR TITLE
Ascent: Drop VTK-h dependency for 0.9

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -187,7 +187,7 @@ class Ascent(CMakePackage, CudaPackage):
     # Ascent 0.9.0 includes VTK-h, prior to 0.9.0
     # VTK-h was developed externally
     depends_on("vtk-h@:0.7", when="@:0.7 +vtkh")
-    depends_on("vtk-h@0.8.1:", when="@0.8: +vtkh")
+    depends_on("vtk-h@0.8.1:", when="@0.8:0.8 +vtkh")
     # propagate relevent variants to vtk-h
     depends_on("vtk-h+openmp", when="@:0.8.0 +vtkh+openmp")
     depends_on("vtk-h~openmp", when="@:0.8.0 +vtkh~openmp")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -174,8 +174,6 @@ class Ascent(CMakePackage, CudaPackage):
     depends_on("vtk-m~tbb", when="@0.9.0: +vtkh")
     depends_on("vtk-m+openmp", when="@0.9.0: +vtkh+openmp")
     depends_on("vtk-m~openmp", when="@0.9.0: +vtkh~openmp")
-    depends_on("vtk-m+openmp", when="@0.9.0: +vtkh+openmp")
-    depends_on("vtk-m~openmp", when="@0.9.0: +vtkh~openmp")
     depends_on("vtk-m~cuda", when="@0.9.0: +vtkh~cuda")
     depends_on("vtk-m+cuda", when="@0.9.0: +vtkh+cuda")
     depends_on("vtk-m+fpic", when="@0.8.0: +vtkh")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -254,6 +254,9 @@ class Ascent(CMakePackage, CudaPackage):
     conflicts(
         "+shared", when="@:0.7 +cuda", msg="Ascent needs to be built with ~shared for CUDA builds."
     )
+    conflicts(
+        "~fides", when="@0.9: +adios2", msg="Ascent >= 0.9 assumes FIDES when building ADIOS2"
+    )
 
     def setup_build_environment(self, env):
         env.set("CTEST_OUTPUT_ON_FAILURE", "1")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -169,7 +169,7 @@ class Ascent(CMakePackage, CudaPackage):
     # VTK-m
     #######################
 
-    depends_on("vtk-m@1.9:", when="@0.9.0:")
+    depends_on("vtk-m@1.9:1.9", when="@0.9.0:")
 
     depends_on("vtk-m~tbb", when="@0.9.0: +vtkh")
     depends_on("vtk-m+openmp", when="@0.9.0: +vtkh+openmp")

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -169,7 +169,7 @@ class Ascent(CMakePackage, CudaPackage):
     # VTK-m
     #######################
 
-    depends_on("vtk-m@1.9:1.9", when="@0.9.0:")
+    depends_on("vtk-m@1.9:1.9", when="@0.9.0: +vtkh")
 
     depends_on("vtk-m~tbb", when="@0.9.0: +vtkh")
     depends_on("vtk-m+openmp", when="@0.9.0: +vtkh+openmp")


### PR DESCRIPTION
VTK-h is now embedded in Ascent after 0.9, but the VTK-h dep still exists in a missed dep.