### PR TITLE
CP2K: bump down the supported version of elpa

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -58,7 +58,7 @@ class Cp2k(MakefilePackage, CudaPackage):
         "elpa",
         default=False,
         description="Enable optimised diagonalisation routines from ELPA",
-        when="@8.3:",
+        when="@7.1:",
     )
     variant(
         "sirius",


### PR DESCRIPTION
This PR bumps down the supported version of ELPA for CP2K, as it was found out that the lower versions of ELPA had no issues when building with python3. 