### PR TITLE
octopus: set boost prefix

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -172,7 +172,10 @@ class Octopus(AutotoolsPackage, CudaPackage):
             )
 
         if "+cgal" in spec:
+            # Boost is a dependency of CGAL, and is not picked up by the configure script
+            # unless specified explicitly with `--with-boost` option.
             args.append("--with-cgal-prefix=%s" % spec["cgal"].prefix)
+            args.append("--with-boost=%s" % spec["boost"].prefix)
 
         if "+likwid" in spec:
             args.append("--with-likwid-prefix=%s" % spec["likwid"].prefix)


### PR DESCRIPTION
This MR sets explicitly the prefix for `boost` in octopus configure stage:
When octopus is installed with cgal, cgal pulls in boost as a dependency, for eg:
```shell
$ spack spec octopus+cgal
Input spec
--------------------------------
octopus+cgal

Concretized
--------------------------------
octopus@12.1%gcc@11.3.0~arpack+cgal~cuda~debug~elpa~libvdwxc~libyaml~likwid~metis+mpi~netcdf~nlopt~parmetis~pfft~python~scalapack build_system=autotools arch=linux-debian11-sandybridge
    ^cgal@5.0.3%gcc@11.3.0~core~demos+eigen~header_only~imageio~ipo+shared build_system=cmake build_type=Release arch=linux-debian11-sandybridge
        ^boost@1.80.0%gcc@11.3.0~atomic~chrono~clanglibcpp+container~context~contract~coroutine~date_time~debug+exception~fiber~filesystem~graph~graph_parallel~icu~iostreams~json~locale~log+math~mpi+multithreaded~nowide~numpy~pic~program_options~python+random~regex~serialization+shared~signals~singlethreaded~stacktrace+system~taggedlayout~test+thread~timer~type_erasure~versionedlayout~wave build_system=generic cxxstd=98 patches=a440f96 visibility=hidden arch=linux-debian11-sandybridge
        ^cmake@3.24.3%gcc@11.3.0~doc+ncurses+ownlibs~qt build_system=generic build_type=Release arch=linux-debian11-sandybridge 
            ^ncurses@6.3%gcc@11.3.0~symlinks+termlib abi=none build_system=autotools arch=linux-debian11-sandybridge
            
```
This MR explicitly passes the boost prefix as a configure argument and fixes https://github.com/fangohr/octopus-in-spack/issues/63
Boost is a dependency of CGAL, and is not picked up by the configure script  unless specified explicitly with `--with-boost` option. 