### PR TITLE
Libfabric Enhancements

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -22,7 +22,11 @@ class Libfabric(AutotoolsPackage):
     executables = ["^fi_info$"]
 
     version("main", branch="main")
+    version("1.17.1", sha256="8b372ddb3f46784c53fdad50a701a6eb0e661239aee45a42169afbedf3644035")
+    version("1.17.0", sha256="579c0f5ef636c0c72f4d3d6bd4da91a5aed9ac3ac4ea387404c45dbbdee4745d")
     version("1.16.1", sha256="53f992d33f9afe94b8a4ea3d105504887f4311cf4b68cea99a24a85fcc39193f")
+    version("1.16.0", sha256="ac104b9d6e3ce8bda6116329e3f440b621d85602257b3015116ca590f65267d2")
+    version("1.15.2", sha256="8d050b88bee62e8512a88f5aa25f532f46bef587bc3f91022ecdb9b3b2676c7e")
     version("1.15.1", sha256="cafa3005a9dc86064de179b0af4798ad30b46b2f862fe0268db03d13943e10cd")
     version("1.15.0", sha256="70982c58eadeeb5b1ddb28413fd645e40b206618b56fbb2b18ab1e7f607c9bea")
     version("1.14.1", sha256="6cfabb94bca8e419d9015212506f5a367d077c5b11e94b9f57997ec6ca3d8aed")
@@ -107,6 +111,8 @@ class Libfabric(AutotoolsPackage):
     depends_on("psm", when="fabrics=psm")
     depends_on("ucx", when="fabrics=mlx")
     depends_on("uuid", when="fabrics=opx")
+    depends_on("numactl", when="fabrics=opx")
+    depends_on("linux-headers", when="fabrics=opx")
 
     depends_on("m4", when="@main", type="build")
     depends_on("autoconf", when="@main", type="build")
@@ -115,6 +121,8 @@ class Libfabric(AutotoolsPackage):
 
     conflicts("@1.9.0", when="platform=darwin", msg="This distribution is missing critical files")
     conflicts("fabrics=opx", when="@:1.14.99")
+
+    flag_handler = build_system_flags
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/linux-headers/package.py
+++ b/var/spack/repos/builtin/packages/linux-headers/package.py
@@ -14,6 +14,7 @@ class LinuxHeaders(Package):
     list_url = "https://www.kernel.org/pub/linux/kernel"
     list_depth = 2
 
+    version("6.2.8", sha256="fed0ad87d42f83a70ce019ff2800bc30a855e672e72bf6d54a014d98d344f665")
     version("4.9.10", sha256="bd6e05476fd8d9ea4945e11598d87bc97806bbc8d03556abbaaf809707661525")
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
* Add new libfabric versions 1.17.1, 1.17.0, 1.16.0, 1.15.2. This PR, if accepted, would supersede an older PR I have open https://github.com/spack/spack/pull/34644.

* Add dependencies on `numactl` and `linux-headers` when building libfabric with OPX provider support. (ref: [OPX provider configuration checks](https://github.com/ofiwg/libfabric/blob/091788a53c0e20e53c7444656914dfb4b47db708/prov/opx/configure.m4#L100-L122))

* Add new `linux-headers` version 6.2.8 to support the above. I'm not entirely sure what the minimum required version of `linux-headers` is here, but the existing 4.9.10 was too old. If I can identify proper version constraints, I will bound the dependency in a future contribution.

* Set libfabric `flag_handler` to pass compiler flags as arguments to configure (ref: [Spack Packaging Guide on Compiler Flags](https://spack.readthedocs.io/en/latest/packaging_guide.html#compiler-flags)). This allows for use of, for example, `cflags=-O3` in the spec for libfabric. Without this change, the default `flag_handler` of `inject_flags` passes the `-O3` option through to configuration where it is eclipsed by the libfabric defaults (`-O3 ... -g -O2` 👎 ). With this change, this is reversed, and user-specified options take precedence (`-g -O2 ... -O3` 👍 ).


Dropped after review:

* ~~The largest diff is due to new variant in support of [fabric direct](https://ofiwg.github.io/libfabric/v1.17.0/man/fi_direct.7.html). This is only valid when building support for a single libfabric provider. Any combination of 2 or more `fabrics` values when used with `+fabric_direct` raises an error~~:
```
$ spack spec libfabric+fabric_direct fabrics=psm2,tcp
==> Error: Fabric direct is only valid when supporting a single provider.
```