### PR TITLE
poke: add v3.0

### DIFF
--- a/var/spack/repos/builtin/packages/poke/package.py
+++ b/var/spack/repos/builtin/packages/poke/package.py
@@ -15,6 +15,7 @@ class Poke(AutotoolsPackage, GNUMirrorPackage):
 
     maintainers("ChristianTackeGSI")
 
+    version("3.0", sha256="79a9b2f33c9f8c327c499afadaeeabfeecf6ad4988924d2c6c6f317e50317add")
     version("1.0", sha256="de930b8700c0772b3c2cd0d0ca35f50fd3d77bdf82c6251eb516b49e8ca25b0a")
 
     depends_on("pkgconfig")


### PR DESCRIPTION
Add poke v3.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.