### PR TITLE
octopus: Add NFFT variant

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -46,6 +46,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("arpack", default=False, description="Compile with ARPACK")
     variant("cgal", default=False, description="Compile with CGAL library support")
     variant("pfft", default=False, when="+mpi", description="Compile with PFFT")
+    variant(
+        "nfft",
+        default=False,
+        description="Compile with NFFT - Nonequispaced Fast Fourier Transform library",
+    )
     # poke here refers to https://gitlab.e-cam2020.eu/esl/poke
     # variant('poke', default=False,
     #         description='Compile with poke (not available in spack yet)')
@@ -96,6 +101,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("scalapack", when="+scalapack")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
+    depends_on("nfft@3.2.4", when="+nfft")
     depends_on("likwid", when="+likwid")
     depends_on("libyaml", when="+libyaml")
     depends_on("nlopt", when="+nlopt")
@@ -179,6 +185,9 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
         if "+pfft" in spec:
             args.append("--with-pfft-prefix=%s" % spec["pfft"].prefix)
+
+        if "+nfft" in spec:
+            args.append("--with-nfft=%s" % spec["nfft"].prefix)
 
         # if '+poke' in spec:
         #     args.extend([


### PR DESCRIPTION
NFFT is an optional dependency of octopus.
This MR adds the right version of NFFT as a variant to the octopus spack package.
A variant of this MR has been tested at https://github.com/fangohr/octopus-in-spack/pull/74 to check that octopus does pick up the NFFT variant.