### PR TITLE
octopus: Add sparskit variant

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -233,7 +233,9 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append("--enable-python")
 
         if "+sparskit" in spec:
-            args.append("--with-sparskit=%s" % os.path.join(self.spec["sparskit"].prefix.lib, "libskit.a"))
+            args.append(
+                "--with-sparskit=%s" % os.path.join(self.spec["sparskit"].prefix.lib, "libskit.a")
+            )
         if "+etsf-io" in spec:
             args.append("--with-etsf-io-prefix=%s" % spec["etsf-io"].prefix)
         # --with-pfft-prefix=${prefix} --with-mpifftw-prefix=${prefix}

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -43,6 +43,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("metis", default=False, description="Compile with METIS")
     variant("parmetis", default=False, when="+mpi", description="Compile with ParMETIS")
     variant("netcdf", default=False, description="Compile with Netcdf")
+    variant(
+        "sparskit",
+        default=False,
+        description="Compile with Sparskit - A Basic Tool Kit for Sparse Matrix Computations",
+    )
     variant("arpack", default=False, description="Compile with ARPACK")
     variant("cgal", default=False, description="Compile with CGAL library support")
     variant("pfft", default=False, when="+mpi", description="Compile with PFFT")
@@ -94,6 +99,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("metis@5:+int64", when="+metis")
     depends_on("parmetis+int64", when="+parmetis")
     depends_on("scalapack", when="+scalapack")
+    depends_on("sparskit", when="+sparskit")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
     depends_on("likwid", when="+likwid")
@@ -205,6 +211,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
         # --with-etsf-io-prefix=
         # --with-sparskit=${prefix}/lib/libskit.a
+        if "+sparskit" in spec:
+            "--with-sparskit=%s" % os.path.join(self.spec["sparskit"].prefix.lib, "libskit.a")
         # --with-pfft-prefix=${prefix} --with-mpifftw-prefix=${prefix}
         # --with-berkeleygw-prefix=${prefix}
 

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -210,7 +210,6 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append("--enable-python")
 
         # --with-etsf-io-prefix=
-        # --with-sparskit=${prefix}/lib/libskit.a
         if "+sparskit" in spec:
             "--with-sparskit=%s" % os.path.join(self.spec["sparskit"].prefix.lib, "libskit.a")
         # --with-pfft-prefix=${prefix} --with-mpifftw-prefix=${prefix}


### PR DESCRIPTION
sparskit is an optional dependency of octopus.
This MR adds sparskit as a variant to the octopus spack package.
A variant of this MR has been tested at https://github.com/fangohr/octopus-in-spack/pull/80 to check that octopus does pick up the sparskit variant.