### PR TITLE
octopus: Add berkeleygw variant

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -213,7 +213,6 @@ class Octopus(AutotoolsPackage, CudaPackage):
         if "+berkeleygw" in spec:
             args.append("--with-berkeleygw-prefix=%s" % spec["berkeleygw"].prefix)
 
-
         # When preprocessor expands macros (i.e. CFLAGS) defined as quoted
         # strings the result may be > 132 chars and is terminated.
         # This will look to a compiler as an Unterminated character constant

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -40,6 +40,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
     variant("mpi", default=True, description="Build with MPI support")
     variant("scalapack", default=False, when="+mpi", description="Compile with Scalapack")
+    variant("berkeleygw", default=False, description="Compile with BerkeleyGW")
     variant("metis", default=False, description="Compile with METIS")
     variant("parmetis", default=False, when="+mpi", description="Compile with ParMETIS")
     variant("netcdf", default=False, description="Compile with Netcdf")
@@ -80,6 +81,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
         depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+        depends_on("berkeleygw@2.1+mpi", when="+berkeleygw")
 
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
@@ -88,6 +90,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("arpack-ng~mpi", when="+arpack")
         depends_on("elpa~mpi", when="+elpa")
         depends_on("netcdf-fortran ^netcdf-c~~mpi", when="+netcdf")
+        depends_on("berkeleygw@2.1~mpi", when="+berkeleygw")
 
     depends_on("py-numpy", when="+python")
     depends_on("py-mpi4py", when="+python")
@@ -207,6 +210,9 @@ class Octopus(AutotoolsPackage, CudaPackage):
         # --with-sparskit=${prefix}/lib/libskit.a
         # --with-pfft-prefix=${prefix} --with-mpifftw-prefix=${prefix}
         # --with-berkeleygw-prefix=${prefix}
+        if "+berkeleygw" in spec:
+            args.append("--with-berkeleygw-prefix=%s" % spec["berkeleygw"].prefix)
+
 
         # When preprocessor expands macros (i.e. CFLAGS) defined as quoted
         # strings the result may be > 132 chars and is terminated.


### PR DESCRIPTION
berkeleygw is an optional dependency of octopus.
This MR adds the right version of berkeleygw as a variant to the octopus spack package.
A variant of this MR has been tested at https://github.com/fangohr/octopus-in-spack/pull/79 to check that octopus does pick up the berkeleygw variant.