### PR TITLE
Configurable stage package hash length

### DIFF
--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -3,5 +3,4 @@ config:
   concretizer: clingo
   build_stage::
     - '$spack/.staging'
-    - 'C:/spack'
   stage_name: '{name}-{version}-{hash:7}'

--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -2,4 +2,4 @@ config:
   locks: false
   concretizer: clingo
   build_stage::
-    - '$spack/.staging'
+    - 'C:/spack'

--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -2,4 +2,5 @@ config:
   locks: false
   concretizer: clingo
   build_stage::
+    - '$spack/.staging'
     - 'C:/spack'

--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -4,3 +4,4 @@ config:
   build_stage::
     - '$spack/.staging'
     - 'C:/spack'
+  stage_name: '{name}-{version}-{hash:7}'

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -57,7 +57,7 @@ import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import TestFailure, TestSuite
 from spack.installer import InstallError, PackageInstaller
-from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
+from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix, compute_stage_name
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix
@@ -1022,8 +1022,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         )
         # Construct a path where the stage should build..
         s = self.spec
-        stage_name = "{0}{1}-{2}-{3}".format(stage_prefix, s.name, s.version, s.dag_hash())
-
+        stage_name = compute_stage_name(stage_prefix, s)
         stage = Stage(
             fetcher,
             mirror_paths=mirror_paths,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1022,7 +1022,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         )
         # Construct a path where the stage should build..
         s = self.spec
-        stage_name = compute_stage_name(stage_prefix, s)
+        stage_name = compute_stage_name(s)
         stage = Stage(
             fetcher,
             mirror_paths=mirror_paths,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -57,7 +57,7 @@ import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import TestFailure, TestSuite
 from spack.installer import InstallError, PackageInstaller
-from spack.stage import ResourceStage, Stage, StageComposite, compute_stage_name, stage_prefix
+from spack.stage import ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -57,7 +57,7 @@ import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import TestFailure, TestSuite
 from spack.installer import InstallError, PackageInstaller
-from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix, compute_stage_name
+from spack.stage import ResourceStage, Stage, StageComposite, compute_stage_name, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -61,6 +61,7 @@ properties = {
             "build_stage": {
                 "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]
             },
+            "stage_hash_length": {"type": "integer", "minumum": 7},
             "test_stage": {"type": "string"},
             "extensions": {"type": "array", "items": {"type": "string"}},
             "template_dirs": {"type": "array", "items": {"type": "string"}},

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -61,7 +61,7 @@ properties = {
             "build_stage": {
                 "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]
             },
-            "stage_hash_length": {"type": "integer", "minumum": 7},
+            "stage_name": {"type": "string"},
             "test_stage": {"type": "string"},
             "extensions": {"type": "array", "items": {"type": "string"}},
             "template_dirs": {"type": "array", "items": {"type": "string"}},

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -51,6 +51,7 @@ stage_prefix = "spack-stage-"
 
 
 def compute_stage_name(prefix: str, spec):
+    """Determine stage name given a spec"""
     hash_len = spack.config.get("config:stage_hash_length", None)
     return f"{stage_prefix}{spec.name}-{spec.version}-{spec.dag_hash(hash_len)}"
 
@@ -156,7 +157,9 @@ def _resolve_paths(candidates):
 
         # Ensure the path is unique per user.
         can_path = sup.canonicalize_path(path)
-        if user not in can_path:
+        # Do not add per user path on Windows - currently only need to support
+        # single user stages
+        if user not in can_path and not sys.platform=="win32":
             can_path = os.path.join(can_path, user)
 
         paths.append(can_path)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -51,7 +51,7 @@ stage_prefix = "spack-stage-"
 
 
 def compute_stage_name(prefix: str, spec):
-    hash_len = spack.config.get("config:hash_length", None)
+    hash_len = spack.config.get("config:stage_hash_length", None)
     return f"{stage_prefix}{spec.name}-{spec.version}-{spec.dag_hash(hash_len)}"
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -52,8 +52,9 @@ stage_prefix = "spack-stage-"
 
 def compute_stage_name(prefix: str, spec):
     """Determine stage name given a spec"""
-    hash_len = spack.config.get("config:stage_hash_length", None)
-    return f"{stage_prefix}{spec.name}-{spec.version}-{spec.dag_hash(hash_len)}"
+    default_stage_structure = "spack-stage-{name}-{version}-{hash}"
+    stage_name_structure = spack.config.get("config:stage_name", default=default_stage_structure)
+    return spec.format(format_string=stage_name_structure)
 
 
 def create_stage_root(path: str) -> None:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -35,8 +35,8 @@ import spack.error
 import spack.fetch_strategy as fs
 import spack.mirror
 import spack.paths
-import spack.util.lock
 import spack.spec
+import spack.util.lock
 import spack.util.path as sup
 import spack.util.pattern as pattern
 import spack.util.url as url_util
@@ -159,7 +159,7 @@ def _resolve_paths(candidates):
         can_path = sup.canonicalize_path(path)
         # Do not add per user path on Windows - currently only need to support
         # single user stages
-        if user not in can_path and not sys.platform=="win32":
+        if user not in can_path and not sys.platform == "win32":
             can_path = os.path.join(can_path, user)
 
         paths.append(can_path)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -50,7 +50,7 @@ _source_path_subdir = "spack-src"
 stage_prefix = "spack-stage-"
 
 
-def compute_stage_name(prefix: str, spec):
+def compute_stage_name(spec):
     """Determine stage name given a spec"""
     default_stage_structure = "spack-stage-{name}-{version}-{hash}"
     stage_name_structure = spack.config.get("config:stage_name", default=default_stage_structure)
@@ -158,8 +158,9 @@ def _resolve_paths(candidates):
 
         # Ensure the path is unique per user.
         can_path = sup.canonicalize_path(path)
-        # Do not add per user path on Windows - currently only need to support
-        # single user stages
+        # When multiple users share a stage root, we can avoid conflicts between
+        # them by adding a per-user subdirectory.
+        # Avoid doing this on Windows to keep stage absolute path as short as possible.
         if user not in can_path and not sys.platform == "win32":
             can_path = os.path.join(can_path, user)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -36,6 +36,7 @@ import spack.fetch_strategy as fs
 import spack.mirror
 import spack.paths
 import spack.util.lock
+import spack.spec
 import spack.util.path as sup
 import spack.util.pattern as pattern
 import spack.util.url as url_util
@@ -47,6 +48,11 @@ _source_path_subdir = "spack-src"
 
 # The temporary stage name prefix.
 stage_prefix = "spack-stage-"
+
+
+def compute_stage_name(prefix: str, spec):
+    hash_len = spack.config.get("config:hash_length", None)
+    return f"{stage_prefix}{spec.name}-{spec.version}-{spec.dag_hash(hash_len)}"
 
 
 def create_stage_root(path: str) -> None:

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -765,8 +765,11 @@ class TestStage(object):
 
         # resolved path without user appends user
         paths = [os.path.join(os.path.sep, "a", "b", "c")]
+        can_paths = [paths[0]]
         user = getpass.getuser()
-        can_paths = [os.path.join(paths[0], user)]
+
+        if sys.platform != "win32":
+            can_paths = [os.path.join(paths[0], user)]
         assert spack.stage._resolve_paths(paths) == can_paths
 
         # resolved path with node including user does not append user
@@ -789,7 +792,7 @@ class TestStage(object):
             res_paths[1] = can_tempdir
             res_paths[2] = os.path.join(can_tempdir, user)
             res_paths[3] = os.path.join(can_tempdir, "stage", user)
-        else:
+        elif sys.platform != "win32":
             res_paths[0] = os.path.join(res_paths[0], user)
 
         assert spack.stage._resolve_paths(paths) == res_paths


### PR DESCRIPTION
Windows is unable to compile/link paths greater than 260 characters due to limitations in `cl.exe` and `link.exe`, the MSVC compiler and linker respectively. Spack's stage, particularly with a full 32 character hash, runs the risk of pushing packages over that limit (and does for Paraview). This PR adds support for a config option to reduce the size of the stage hash (with a lower limit of 7 characters to maintain uniqueness) and adds a shorter stage root to the default Windows config. 

This PR is designed to be an alternative to #35301 