### PR TITLE
update: h5bench VOL-ASYNC dependency

### DIFF
--- a/var/spack/repos/builtin/packages/h5bench/package.py
+++ b/var/spack/repos/builtin/packages/h5bench/package.py
@@ -39,7 +39,7 @@ class H5bench(CMakePackage):
     depends_on("cmake@3.10:", type="build")
     depends_on("mpi")
     depends_on("hdf5+mpi@1.12.0:1,develop-1.12:")
-    depends_on("hdf5-vol-async@1.3", when="+async")
+    depends_on("hdf5-vol-async@1.5", when="+async")
     depends_on("parallel-netcdf", when="+e3sm")
     depends_on("parallel-netcdf", when="+all")
 


### PR DESCRIPTION
Update h5bench dependency with fixes released in latest VOL-ASYNC.