### PR TITLE
Prevent spack from using spack installed python to run itself

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -10,33 +10,63 @@
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
 """:"
-# prefer SPACK_PYTHON environment variable, python3, python, then python2
+# prefer SPACK_PYTHON environment variable if set.
+if test ! -z "$SPACK_PYTHON"; then
+    if command -v "$SPACK_PYTHON" > /dev/null; then
+        export SPACK_PYTHON=`command -v "$cmd"`
+        exec "${SPACK_PYTHON}" "$0" "$@"
+    fi
+fi
+# We now must try to find a python in the path that is not one that Spack
+# itself has installed. Spack installed pythons can be elliminated by looking
+# if the parent directory of sys.prefix is '._view' while
+# sys.prefix != sys.base_prefix (from a python virtual environment).
 #
-# We will then include all executables found by whereis for these names
-# as fallbacks.
+# For the prefered pythons, we will first try each one till we find one
+# suitable. If none are found, we will use which or whereis on them in
+# order to find a fallback.
 SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
-SPACK_PYTHONS_TO_CHECK="${SPACK_PYTHON:-} ${SPACK_PREFERRED_PYTHONS}"
-# Collect the fallbacks with whereis
-for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
-    for path in $(whereis $cmd 2>/dev/null); do
-        if test "$path" != "$cmd:" -a -f "$path" -a -x "$path"; then
-            SPACK_PYTHONS_TO_CHECK="$SPACK_PYTHONS_TO_CHECK $path"
-        fi
-    done
-done
-# Check each possibility.
-for cmd in $SPACK_PYTHONS_TO_CHECK; do
+PYTHON_CHECK_CMD="import sys, os.path; print(sys.prefix != sys.base_prefix "\
+"or os.path.basename(os.path.dirname(sys.prefix)) != '._view')"
+
+for cmd in ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
-        # Skip it if it was installed by Spack itself (
-        # sys.prefix == sys.base_prefix "._view" is the parent directory of
-        # sys.prefix)
-        IS_NOT_FROM_SPACK=$($cmd -c "import sys, os.path; print(sys.prefix != sys.base_prefix or os.path.basename(os.path.dirname(sys.prefix)) != '._view')" 2>/dev/null)
+        IS_NOT_FROM_SPACK=`$cmd -c "$PYTHON_CHECK_CMD" 2>/dev/null`
         if test True = "$IS_NOT_FROM_SPACK"; then
-            export SPACK_PYTHON="$(command -v "$cmd")"
+            export SPACK_PYTHON=`command -v "$cmd"`
             exec "${SPACK_PYTHON}" "$0" "$@"
         fi
     fi
 done
+# Try finding fallbacks and trying them if the command 'which' is available.
+# Otherwise, we will try the same using whereis.
+if command -v which > /dev/null; then
+    for base_cmd in ${SPACK_PREFERRED_PYTHONS}; do
+        for cmd in `which -a $base_cmd 2>/dev/null`; do
+            if command -v > /dev/null "$cmd"; then
+                IS_NOT_FROM_SPACK=`$cmd -c "$PYTHON_CHECK_CMD" 2>/dev/null`
+                if test True = "$IS_NOT_FROM_SPACK"; then
+                    export SPACK_PYTHON=`command -v "$cmd"`
+                    exec "${SPACK_PYTHON}" "$0" "$@"
+                fi
+            fi
+        done
+    done
+elif command -v which > /dev/null; then
+    for base_cmd in ${SPACK_PREFERRED_PYTHONS}; do
+        for cmd in `whereis $base_cmd 2>/dev/null`; do
+            if test "$cmd" != "$base_cmd:" -a -f "$cmd" -a -x "$cmd"; then
+                if command -v > /dev/null "$cmd"; then
+                    IS_NOT_FROM_SPACK=`$cmd -c "$PYTHON_CHECK_CMD" 2>/dev/null`
+                    if test True = "$IS_NOT_FROM_SPACK"; then
+                        export SPACK_PYTHON=`command -v "$cmd"`
+                        exec "${SPACK_PYTHON}" "$0" "$@"
+                    fi
+                fi
+            fi
+        done
+    done
+fi
 
 echo "==> Error: spack could not find a python interpreter!" >&2
 exit 1

--- a/bin/spack
+++ b/bin/spack
@@ -69,7 +69,8 @@ elif command -v which > /dev/null; then
     done
 fi
 
-echo "==> Error: spack could not find a python interpreter!" >&2
+echo "==> Error: spack could not find a python interpreter! Adjust your "\
+"PATH or set SPACK_PYTHON to a python command/path to set one manually." >&2
 exit 1
 ":"""
 # Line above is a shell no-op, and ends a python multi-line comment.

--- a/bin/spack
+++ b/bin/spack
@@ -11,11 +11,30 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
+#
+# We will then include all executables found by whereis for these names
+# as fallbacks.
 SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+SPACK_PYTHONS_TO_CHECK="${SPACK_PYTHON:-} ${SPACK_PREFERRED_PYTHONS}"
+# Collect the fallbacks with whereis
 for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
+    for path in $(whereis $cmd 2>/dev/null); do
+        if test "$path" != "$cmd:" -a -f "$path" -a -x "$path"; then
+            SPACK_PYTHONS_TO_CHECK="$SPACK_PYTHONS_TO_CHECK $path"
+        fi
+    done
+done
+# Check each possibility.
+for cmd in $SPACK_PYTHONS_TO_CHECK; do
     if command -v > /dev/null "$cmd"; then
-        export SPACK_PYTHON="$(command -v "$cmd")"
-        exec "${SPACK_PYTHON}" "$0" "$@"
+        # Skip it if it was installed by Spack itself (
+        # sys.prefix == sys.base_prefix "._view" is the parent directory of
+        # sys.prefix)
+        IS_NOT_FROM_SPACK=$($cmd -c "import sys, os.path; print(sys.prefix != sys.base_prefix or os.path.basename(os.path.dirname(sys.prefix)) != '._view')" 2>/dev/null)
+        if test True = "$IS_NOT_FROM_SPACK"; then
+            export SPACK_PYTHON="$(command -v "$cmd")"
+            exec "${SPACK_PYTHON}" "$0" "$@"
+        fi
     fi
 done
 

--- a/bin/spack
+++ b/bin/spack
@@ -25,7 +25,8 @@ fi
 # For the prefered pythons, we will first try each one till we find one
 # suitable. If none are found, we will use which or whereis on them in
 # order to find a fallback.
-SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+SPACK_PREFERRED_PYTHONS="python3 python /usr/libexec/platform-python "\
+"/usr/bin/python3 /usr/bin/python"
 PYTHON_CHECK_CMD="import sys, os.path; print(sys.prefix != sys.base_prefix "\
 "or os.path.basename(os.path.dirname(sys.prefix)) != '._view')"
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -113,6 +113,13 @@ sourcing time, ensuring future invocations of the ``spack`` command will
 continue to use the same consistent python version regardless of changes in
 the environment.
 
+.. note::
+
+   The ``spack`` command will ignore any python interpreter installed by
+   spack found in a view, even if explicitly passed in ``SPACK_PYTHON``.
+   This is done so that it is impossible for ``spack uninstall`` to
+   to remove the python that ``spack`` is running on.
+
 ^^^^^^^^^^^^^^^^^^^^
 Bootstrapping clingo
 ^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -115,9 +115,9 @@ the environment.
 
 .. note::
 
-   The ``spack`` command will ignore any python interpreter installed by
-   spack found in a view, even if explicitly passed in ``SPACK_PYTHON``.
-   This is done so that it is impossible for ``spack uninstall`` to
+   When trying to find a suitable python interpreter, the ``spack`` command will
+   ignore any python interpreter installed by spack found in a view. This is
+   done so that it is impossible for ``spack uninstall`` or a re-concretization
    to remove the python that ``spack`` is running on.
 
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR is to fix #31502 

Essentially, if one has a spack environment where:

1. the python package has been installed
2. there is a view
3. the view is included in `PATH` before the first execution of `spack`

then, spack will be run on the python package it installed. This means that if a user does say `spack uninstall python` or if installing a package causes python to be rebuilt (different concretization), spack will remove the python it is running on part way through and will crash the first time it has to import a module after removing its own python (this happens when it tries to rebuild the view).

This PR changes how `bin/spack` looks for a python executable to run itself to prevent this situation where spack could pull the rug out from itself.

When looping over the python commands to try, it rejects any where the python's `sys.prefix` has `._view` as the parent directory except when it is part of a virtual environment in which case `sys.prefix != sys.base_prefix (this is so that if a user for whatever reason runs spack in a virtual environment with a directory name of `._view`, it will not be rejected).

Due to this rejection, it can sometimes happen that all the candidates it would previously try would (`python3 python python2 /usr/libexec/platform-python`) be rejected or not be found. To combat this, `bin/spack` has also been changed to go through the list of candidates and find fallback pythons using `whereis` on each candidate.

There are two potential issues with this PR.

1. Line 33 in the new `bin/spack` is very long and I am not entirely sure how to make it smaller and have it still work.
2. The added note to the Getting Started documentation, while accurate, may not be what is actually wanted there and might need some reworking.