### PR TITLE
rewrite `require: <string>` to more composable `require: [<string>]`

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -332,7 +332,7 @@ keyed by package name:
 
    packages:
      libfabric:
-       require: "@1.13.2"
+       require: ["@1.13.2"]
      openmpi:
        require:
        - any_of: ["~cuda", "%gcc"]
@@ -379,7 +379,7 @@ like this:
 
    packages:
      all:
-       require: '%clang'
+       require: ['%clang']
 
 which means every spec will be required to use ``clang`` as a compiler.
 
@@ -391,9 +391,9 @@ under ``all`` are disregarded. For example, with a configuration like this:
 
    packages:
      all:
-       require: '%clang'
+       require: ['%clang']
      cmake:
-       require: '%gcc'
+       require: ['%gcc']
 
 Spack requires ``cmake`` to use ``gcc`` and all other nodes (including ``cmake``
 dependencies) to use ``clang``.
@@ -409,7 +409,7 @@ This can be useful for fixing which virtual provider you want to use:
 
    packages:
      mpi:
-       require: 'mvapich2 %gcc'
+       require: ['mvapich2 %gcc']
 
 With the configuration above the only allowed ``mpi`` provider is ``mvapich2 %gcc``.
 
@@ -420,9 +420,9 @@ present. For instance with a configuration like:
 
    packages:
      mpi:
-       require: 'mvapich2 %gcc'
+       require: ['mvapich2 %gcc']
      mvapich2:
-       require: '~cuda'
+       require: ['~cuda']
 
 you will use ``mvapich2~cuda %gcc`` as an ``mpi`` provider.
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -130,3 +130,22 @@ schema = {
     "additionalProperties": False,
     "properties": properties,
 }
+
+
+def update(data):
+    """Update the data in place to remove deprecated properties.
+
+    Args:
+        data (dict): dictionary to be updated
+
+    Returns:
+        True if data was changed, False otherwise
+    """
+    changed = False
+    for item in data.values():
+        val = item.get("require")
+        if not isinstance(val, str):
+            continue
+        item["require"] = [val]
+        changed = True
+    return changed

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -133,7 +133,7 @@ schema = {
 
 
 def update(data):
-    """Update the data in place to remove deprecated properties.
+    """Update package config
 
     Args:
         data (dict): dictionary to be updated

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -134,7 +134,7 @@ def test_requirement_isnt_optional(concretize_scope, test_repo):
     conf_str = """\
 packages:
   x:
-    require: "@1.0"
+    require: ["@1.0"]
 """
     update_packages_config(conf_str)
     with pytest.raises(UnsatisfiableSpecError):
@@ -178,13 +178,11 @@ def test_requirement_adds_new_version(
     )
 
     a_commit_hash = commits[0]
-    conf_str = """\
+    conf_str = f"""\
 packages:
   v:
-    require: "@{0}=2.2"
-""".format(
-        a_commit_hash
-    )
+    require: ["@{a_commit_hash}=2.2"]
+"""
     update_packages_config(conf_str)
 
     s1 = Spec("v").concretized()
@@ -207,13 +205,11 @@ def test_requirement_adds_git_hash_version(
     )
 
     a_commit_hash = commits[0]
-    conf_str = """\
+    conf_str = f"""\
 packages:
   v:
-    require: "@{0}"
-""".format(
-        a_commit_hash
-    )
+    require: ["@{a_commit_hash}"]
+"""
     update_packages_config(conf_str)
 
     s1 = Spec("v").concretized()
@@ -300,7 +296,7 @@ def test_requirement_is_successfully_applied(concretize_scope, test_repo):
     conf_str = """\
 packages:
   x:
-    require: "@1.0"
+    require: ["@1.0"]
 """
     update_packages_config(conf_str)
     s2 = Spec("x").concretized()
@@ -318,9 +314,9 @@ def test_multiple_packages_requirements_are_respected(concretize_scope, test_rep
     conf_str = """\
 packages:
   x:
-    require: "@1.0"
+    require: ["@1.0"]
   y:
-    require: "@2.4"
+    require: ["@2.4"]
 """
     update_packages_config(conf_str)
     spec = Spec("x").concretized()
@@ -385,7 +381,7 @@ def test_requirements_for_package_that_is_not_needed(concretize_scope, test_repo
     conf_str = """\
 packages:
   x:
-    require: "@1.0"
+    require: ["@1.0"]
   y:
     require:
     - one_of: ["@2.4%gcc", "@2.5%clang"]
@@ -468,13 +464,11 @@ def test_default_requirements_with_all(spec_str, requirement_str, concretize_sco
     if spack.config.get("config:concretizer") == "original":
         pytest.skip("Original concretizer does not support configuration" " requirements")
 
-    conf_str = """\
+    conf_str = f"""\
 packages:
   all:
-    require: "{}"
-""".format(
-        requirement_str
-    )
+    require: ["{requirement_str}"]
+"""
     update_packages_config(conf_str)
 
     spec = Spec(spec_str).concretized()
@@ -497,15 +491,13 @@ def test_default_and_package_specific_requirements(
         pytest.skip("Original concretizer does not support configuration" " requirements")
     generic_req, specific_req = requirements
     generic_exp, specific_exp = expectations
-    conf_str = """\
+    conf_str = f"""\
 packages:
   all:
-    require: "{}"
+    require: ["{generic_req}"]
   x:
-    require: "{}"
-""".format(
-        generic_req, specific_req
-    )
+    require: ["{specific_req}"]
+"""
     update_packages_config(conf_str)
 
     spec = Spec("x").concretized()
@@ -518,13 +510,11 @@ packages:
 def test_requirements_on_virtual(mpi_requirement, concretize_scope, mock_packages):
     if spack.config.get("config:concretizer") == "original":
         pytest.skip("Original concretizer does not support configuration" " requirements")
-    conf_str = """\
+    conf_str = f"""\
 packages:
   mpi:
-    require: "{}"
-""".format(
-        mpi_requirement
-    )
+    require: ["{mpi_requirement}"]
+"""
     update_packages_config(conf_str)
 
     spec = Spec("callpath").concretized()
@@ -541,15 +531,13 @@ def test_requirements_on_virtual_and_on_package(
 ):
     if spack.config.get("config:concretizer") == "original":
         pytest.skip("Original concretizer does not support configuration" " requirements")
-    conf_str = """\
+    conf_str = f"""\
 packages:
   mpi:
-    require: "{0}"
-  {0}:
-    require: "{1}"
-""".format(
-        mpi_requirement, specific_requirement
-    )
+    require: "{mpi_requirement}"
+  {mpi_requirement}:
+    require: "{specific_requirement}"
+"""
     update_packages_config(conf_str)
 
     spec = Spec("callpath").concretized()
@@ -564,7 +552,7 @@ def test_incompatible_virtual_requirements_raise(concretize_scope, mock_packages
     conf_str = """\
     packages:
       mpi:
-        require: "mpich"
+        require: ["mpich"]
     """
     update_packages_config(conf_str)
 

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -10,6 +10,7 @@ import pytest
 import spack.directives
 import spack.fetch_strategy
 import spack.repo
+import spack.schema
 from spack.paths import mock_packages_path
 from spack.spec import Spec
 from spack.util.naming import mod_to_class
@@ -326,3 +327,18 @@ def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
 
     assert spack.package_base.deprecated_version(pkg_cls, "1.1.0")
     assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")
+
+
+def test_update_require():
+    # The require value type is now a list, such that it's composable.
+    packages_yaml = {
+        "all": {"require": "+x"},
+        "pkga": {"require": "+y"},
+        "pkgb": {"require": ["+z"]},
+    }
+    assert spack.schema.packages.update(packages_yaml)
+    assert packages_yaml == {
+        "all": {"require": ["+x"]},
+        "pkga": {"require": ["+y"]},
+        "pkgb": {"require": ["+z"]},
+    }


### PR DESCRIPTION
Having both string and list as value types for `require` makes
composability a bit painful, since the following:

```yaml
pkg:
  require:
  - +x

pkg:
  require:
  - +y
```

would merge to `[+x, +y]` as requirements for `pkg` in layered config,
but

```yaml
pkg:
  require: +x

pkg:
  require:
  - +y
```

would end up was `[+y]`, which is somewhat unexpected for the average
user, especially if person A sets global requirements in default/system/site
config and person B adds a new requirement in user config.

Opting out of this inheritance was already possible with `require::`, so
nothing is lost.
