### PR TITLE
Refactor LLNL/util to use pathlib over os.path

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1507,7 +1507,7 @@ def last_modification_time_recursive(path):
     path = path.resolve()
     times = [path.stat().st_mtime]
     times.extend(
-        os.lstat(root / name).st_mtime
+        os.lstat(Path(root) / name).st_mtime
         for root, dirs, files in os.walk(path)
         for name in dirs + files
     )

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -831,9 +831,9 @@ def copy_tree(
                         def escaped_path(path):
                             return path.replace("\\", r"\\")
 
-                        new_target = re.sub(
+                        new_target = Path(re.sub(
                             escaped_path(str(abs_src)), escaped_path(str(abs_dest)), str(target)
-                        )
+                        ))
                         if new_target != target:
                             tty.debug("Redirecting link {0} to {1}".format(target, new_target))
                             target = new_target
@@ -1289,7 +1289,7 @@ def traverse_tree(
     ignore = ignore or (lambda filename: False)
 
     # Don't descend into ignored directories
-    if ignore(rel_path):
+    if ignore(str(rel_path)):
         return
     source_path = source_root / rel_path  # type: ignore
     dest_path = dest_root / rel_path  # type: ignore

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -528,7 +528,7 @@ def exploding_archive_handler(tarball_container, stage):
     if len(non_hidden) == 1:
         src = non_hidden[0]
         if src.is_dir():
-            stage.srcdir = str(src)
+            stage.srcdir = str(src.name)
             shutil.move(src, stage.source_path)
             if len(files) > 1:
                 files.remove(non_hidden[0])

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -743,7 +743,7 @@ def resolve_link_target_relative_to_the_link(link):
     # as pathlib cannot handle invalid Windows directory links
     target = os.readlink(link)
     if PurePath(target).is_absolute():
-        return target
+        return PurePath(target)
 
     link_dir = link.parent
     return link_dir / target
@@ -820,16 +820,18 @@ def copy_tree(
             ignore=ignore,
             follow_nonexisting=True,
         ):
+            s = Path(s)
+            d = Path(d)
             if s.is_symlink():
-                link_target = resolve_link_target_relative_to_the_link(s)
+                link_target = Path(resolve_link_target_relative_to_the_link(s))
                 if symlinks:
-                    target = os.readlink(s)
+                    target = Path(os.readlink(s))
                     if target.is_absolute():
 
                         def escaped_path(path):
                             return path.replace("\\", r"\\")
 
-                        new_target = re.sub(escaped_path(abs_src), escaped_path(abs_dest), target)
+                        new_target = re.sub(escaped_path(str(abs_src)), escaped_path(str(abs_dest)), str(target))
                         if new_target != target:
                             tty.debug("Redirecting link {0} to {1}".format(target, new_target))
                             target = new_target
@@ -1277,6 +1279,7 @@ def traverse_tree(
             ``src`` that do not exit in ``dest``. Default is True
         follow_links (bool): Whether to descend into symlinks in ``src``
     """
+    rel_path = Path(rel_path) if rel_path is not Path else rel_path
     if order not in ("pre", "post"):
         raise ValueError("Order must be 'pre' or 'post'.")
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2545,7 +2545,7 @@ def files_in(*search_paths):
         files.extend(
             filter(
                 lambda x: x[1].is_file(),
-                [(f, d / f) for f in list(d.iterdir())],
+                [(f.name, f) for f in list(d.iterdir())],
             )
         )
     # prevent pathlib Path from leaking out into rest of codebase

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -831,7 +831,9 @@ def copy_tree(
                         def escaped_path(path):
                             return path.replace("\\", r"\\")
 
-                        new_target = re.sub(escaped_path(str(abs_src)), escaped_path(str(abs_dest)), str(target))
+                        new_target = re.sub(
+                            escaped_path(str(abs_src)), escaped_path(str(abs_dest)), str(target)
+                        )
                         if new_target != target:
                             tty.debug("Redirecting link {0} to {1}".format(target, new_target))
                             target = new_target

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -831,9 +831,13 @@ def copy_tree(
                         def escaped_path(path):
                             return path.replace("\\", r"\\")
 
-                        new_target = Path(re.sub(
-                            escaped_path(str(abs_src)), escaped_path(str(abs_dest)), str(target)
-                        ))
+                        new_target = Path(
+                            re.sub(
+                                escaped_path(str(abs_src)),
+                                escaped_path(str(abs_dest)),
+                                str(target),
+                            )
+                        )
                         if new_target != target:
                             tty.debug("Redirecting link {0} to {1}".format(target, new_target))
                             target = new_target

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -812,7 +812,6 @@ def copy_tree(
             )
 
         mkdirp(abs_dest)
-        # import pdb; pdb.set_trace()
         for s, d in traverse_tree(
             abs_src,
             abs_dest,
@@ -1479,14 +1478,14 @@ def visit_directory_tree(root, visitor, rel_path="", depth=0):
 
         if not isdir and not islink:
             # handle non-symlink files
-            visitor.visit_file(root, rel_child, depth)
+            visitor.visit_file(root, str(rel_child), depth)
         elif not isdir:
-            visitor.visit_symlinked_file(root, rel_child, depth)
-        elif not islink and visitor.before_visit_dir(root, rel_child, depth):
+            visitor.visit_symlinked_file(root, str(rel_child), depth)
+        elif not islink and visitor.before_visit_dir(root, str(rel_child), depth):
             # Handle ordinary directories
             visit_directory_tree(root, visitor, rel_child, depth + 1)
-            visitor.after_visit_dir(root, rel_child, depth)
-        elif islink and visitor.before_visit_symlinked_dir(root, rel_child, depth):
+            visitor.after_visit_dir(root, str(rel_child), depth)
+        elif islink and visitor.before_visit_symlinked_dir(root, str(rel_child), depth):
             # Handle symlinked directories
             visit_directory_tree(root, visitor, rel_child, depth + 1)
             visitor.after_visit_symlinked_dir(root, rel_child, depth)
@@ -2464,7 +2463,7 @@ class WindowsSimulatedRPath(object):
         perspective, and will cause an error when Developer
         mode is not enabled"""
         file_name = path.name
-        dest_file = PurePath(dest_dir, file_name)
+        dest_file = Path(dest_dir, file_name)
         if dest_dir.exists() and not dest_file == path:
             try:
                 symlink(path, dest_file)
@@ -2549,7 +2548,8 @@ def files_in(*search_paths):
                 [(f, d / f) for f in list(d.iterdir())],
             )
         )
-    return files
+    # prevent pathlib Path from leaking out into rest of codebase
+    return [(str(f[0]), str(f[1])) for f in files]
 
 
 @pathlib_filter
@@ -2577,11 +2577,11 @@ def search_paths_for_executables(*path_hints):
             continue
 
         path = path.resolve()
-        executable_paths.append(path)
+        executable_paths.append(str(path))
 
         bin_dir = path / "bin"
         if bin_dir.is_dir():
-            executable_paths.append(bin_dir)
+            executable_paths.append(str(bin_dir))
 
     return executable_paths
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -25,7 +25,7 @@ from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
 from llnl.util.symlink import islink, symlink
 
-from spack.util.executable import CommandNotFoundError, Executable, which
+from spack.util.executable import Executable, which
 from spack.util.path import pathlib_filter
 
 if sys.platform != "win32":
@@ -1239,7 +1239,7 @@ def can_access(file_name):
 def traverse_tree(
     source_root: str,
     dest_root: str,
-    rel_path: str = Path(""),
+    rel_path: str = "",
     *,
     order: str = "pre",
     ignore: Optional[Callable[[str], bool]] = None,
@@ -1286,8 +1286,8 @@ def traverse_tree(
     # Don't descend into ignored directories
     if ignore(rel_path):
         return
-    source_path = source_root / rel_path
-    dest_path = dest_root / rel_path
+    source_path = source_root / rel_path  # type: ignore
+    dest_path = dest_root / rel_path  # type: ignore
 
     # preorder yields directories before children
     if order == "pre":
@@ -1488,7 +1488,7 @@ def visit_directory_tree(root, visitor, rel_path="", depth=0):
         elif islink and visitor.before_visit_symlinked_dir(root, str(rel_child), depth):
             # Handle symlinked directories
             visit_directory_tree(root, visitor, rel_child, depth + 1)
-            visitor.after_visit_symlinked_dir(root, rel_child, depth)
+            visitor.after_visit_symlinked_dir(root, str(rel_child), depth)
 
 
 @pathlib_filter
@@ -2542,12 +2542,7 @@ def files_in(*search_paths):
     """
     files = []
     for d in filter(can_access_dir, search_paths):
-        files.extend(
-            filter(
-                lambda x: x[1].is_file(),
-                [(f.name, f) for f in list(d.iterdir())],
-            )
-        )
+        files.extend(filter(lambda x: x[1].is_file(), [(f.name, f) for f in list(d.iterdir())]))
     # prevent pathlib Path from leaking out into rest of codebase
     return [(str(f[0]), str(f[1])) for f in files]
 
@@ -2630,7 +2625,8 @@ def partition_path(path, entry=None):
     followed by an empty string and an empty list.
     """
     paths = prefixes(path)
-    # TODO: johnwparent - remove this once larger pathlib integration is complete and consuming methods
+    # TODO: johnwparent - remove this once larger pathlib
+    # integration is complete and consuming methods
     # can handle pathlib types
     paths = [str(x) for x in paths]
     if entry is not None:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1303,7 +1303,6 @@ def traverse_tree(
         # target is relative to the link, then that may not resolve properly
         # relative to our cwd - see resolve_link_target_relative_to_the_link
         if source_child.is_dir() and (follow_links or not source_child.is_symlink()):
-
             # When follow_nonexisting isn't set, don't descend into dirs
             # in source that do not exist in dest
             if follow_nonexisting or dest_child.exists():

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -221,9 +221,9 @@ def list_modules(directory, **kwargs):
             if init_py.is_file():
                 yield str(name.name)
 
-        elif name.endswith(".py"):
-            if not any(re.search(pattern, name) for pattern in ignore_modules):
-                yield re.sub(".py$", "", name)
+        elif name.suffix == ".py":
+            if not any(re.search(pattern, name.name) for pattern in ignore_modules):
+                yield re.sub(".py$", "", name.name)
 
 
 def decorator_with_or_without_args(decorator):

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -10,11 +10,11 @@ import contextlib
 import functools
 import inspect
 import itertools
-import os
 import re
 import sys
 import traceback
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Callable, Iterable, List, Tuple
 
 # Ignore emacs backups when listing modules
@@ -210,15 +210,16 @@ def list_modules(directory, **kwargs):
     order."""
     list_directories = kwargs.setdefault("directories", True)
 
-    for name in os.listdir(directory):
-        if name == "__init__.py":
+    directory = Path(directory)
+    for name in directory.iterdir():
+        if name.name == "__init__.py":
             continue
 
-        path = os.path.join(directory, name)
-        if list_directories and os.path.isdir(path):
-            init_py = os.path.join(path, "__init__.py")
-            if os.path.isfile(init_py):
-                yield name
+        path = directory / name
+        if list_directories and path.is_dir():
+            init_py = path / "__init__.py"
+            if init_py.is_file():
+                yield str(name.name)
 
         elif name.endswith(".py"):
             if not any(re.search(pattern, name) for pattern in ignore_modules):

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -5,11 +5,11 @@
 
 import errno
 import os
-from pathlib import Path
 import socket
 import sys
 import time
 from datetime import datetime
+from pathlib import Path
 
 import llnl.util.tty as tty
 from llnl.util.lang import pretty_seconds
@@ -288,7 +288,7 @@ class Lock(object):
 
     def __str__(self):
         """Readable string (with key fields) of the lock."""
-        location = "{0}[{1}:{2}]".format(str(self.path), self._start, self._length)
+        location = "{0}[{1}:{2}]".format(self.path, self._start, self._length)
         timeout = "timeout={0}".format(self.default_timeout)
         activity = "#reads={0}, #writes={1}".format(self._reads, self._writes)
         return "({0}, {1}, {2})".format(location, timeout, activity)

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -5,6 +5,7 @@
 
 import errno
 import os
+from pathlib import Path
 import socket
 import sys
 import time
@@ -92,6 +93,7 @@ class OpenFileTracker(object):
         Arguments:
           path (str): path to lock file we want a filehandle for
         """
+        path = Path(path)
         # Open writable files as 'r+' so we can upgrade to write later
         os_mode, fh_mode = (os.O_RDWR | os.O_CREAT), "r+"
 
@@ -110,7 +112,7 @@ class OpenFileTracker(object):
                 raise
 
             # path does not exist -- fail if we won't be able to create it
-            parent = os.path.dirname(path) or "."
+            parent = path.parent or "."
             if not os.access(parent, os.W_OK):
                 raise CantCreateLockError(path)
 
@@ -122,7 +124,7 @@ class OpenFileTracker(object):
                 # an exclusive (write) lock on it)
                 os_mode, fh_mode = os.O_RDONLY, "r"
 
-            fd = os.open(path, os_mode)
+            fd = os.open(str(path), os_mode)
             fh = os.fdopen(fd, fh_mode)
             open_file = OpenFile(fh)
 
@@ -229,7 +231,7 @@ class Lock(object):
             desc (str): optional debug message lock description, which is
                 helpful for distinguishing between different Spack locks.
         """
-        self.path = path
+        self.path = Path(path)
         self._file = None
         self._reads = 0
         self._writes = 0
@@ -286,7 +288,7 @@ class Lock(object):
 
     def __str__(self):
         """Readable string (with key fields) of the lock."""
-        location = "{0}[{1}:{2}]".format(self.path, self._start, self._length)
+        location = "{0}[{1}:{2}]".format(str(self.path), self._start, self._length)
         timeout = "timeout={0}".format(self.default_timeout)
         activity = "#reads={0}, #writes={1}".format(self._reads, self._writes)
         return "({0}, {1}, {2})".format(location, timeout, activity)
@@ -360,7 +362,7 @@ class Lock(object):
                 self._read_log_debug_data()
                 self._log_debug(
                     "{0} locked {1} [{2}:{3}] (owner={4})".format(
-                        LockType.to_str(op), self.path, self._start, self._length, self.pid
+                        LockType.to_str(op), str(self.path), self._start, self._length, self.pid
                     )
                 )
 
@@ -378,10 +380,10 @@ class Lock(object):
         return False
 
     def _ensure_parent_directory(self):
-        parent = os.path.dirname(self.path)
+        parent = self.path.parent
 
         # relative paths to lockfiles in the current directory have no parent
-        if not parent:
+        if parent == parent.parent:
             return "."
 
         try:
@@ -392,9 +394,9 @@ class Lock(object):
             # are fine if we ensure that the directory exists.
             # Python 3 allows an exist_ok parameter and ignores any OSError as long as
             # the directory exists.
-            if not (e.errno == errno.EISDIR or os.path.isdir(parent)):
+            if not (e.errno == errno.EISDIR or parent.is_dir()):
                 raise
-        return parent
+        return str(parent)
 
     def _read_log_debug_data(self):
         """Read PID and host data out of the file if it is there."""
@@ -625,7 +627,7 @@ class Lock(object):
 
     def cleanup(self):
         if self._reads == 0 and self._writes == 0:
-            os.unlink(self.path)
+            self.path.unlink()
         else:
             raise LockError("Attempting to cleanup active lock.")
 
@@ -797,7 +799,7 @@ class LockUpgradeError(LockError):
     """Raised when unable to upgrade from a read to a write lock."""
 
     def __init__(self, path):
-        msg = "Cannot upgrade lock from read to write on file: %s" % path
+        msg = "Cannot upgrade lock from read to write on file: %s" % str(path)
         super(LockUpgradeError, self).__init__(msg)
 
 
@@ -809,7 +811,7 @@ class LockROFileError(LockPermissionError):
     """Tried to take an exclusive lock on a read-only file."""
 
     def __init__(self, path):
-        msg = "Can't take write lock on read-only file: %s" % path
+        msg = "Can't take write lock on read-only file: %s" % str(path)
         super(LockROFileError, self).__init__(msg)
 
 
@@ -817,6 +819,6 @@ class CantCreateLockError(LockPermissionError):
     """Attempt to create a lock in an unwritable location."""
 
     def __init__(self, path):
-        msg = "cannot create lock '%s': " % path
+        msg = "cannot create lock '%s': " % str(path)
         msg += "file does not exist and location is not writable"
         super(LockError, self).__init__(msg)

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -51,17 +51,16 @@ def _win32_junction(path, link):
     path = Path(path)
     link = Path(link)
     # junctions require absolute paths
-    if not link.is_absolute():
-        link = link.absolute()
+    link = link.absolute()
 
     # os.symlink will fail if link exists, emulate the behavior here
     if link.exists():
         raise OSError(errno.EEXIST, "File  exists: %s -> %s" % (str(link), str(path)))
 
     if not path.is_absolute():
-        parent = os.path.join(link, os.pardir)
-        path = os.path.join(parent, path)
-        path = os.path.abspath(path)
+        parent = link / os.pardir
+        path = parent / path
+        path = path.absolute()
 
     CreateHardLink(link, path)
 
@@ -102,8 +101,7 @@ def _win32_is_junction(path):
     """
     Determines if a path is a win32 junction
     """
-    path = Path(path)
-    if path.is_symlink():
+    if Path(path).is_symlink():
         return False
 
     if sys.platform == "win32":

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -5,7 +5,6 @@
 import inspect
 import os
 import platform
-import posixpath
 import sys
 
 import pytest

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -337,9 +337,9 @@ def test_wrapper_variables(
         ]
     )
     cuda_include_dirs = cuda_headers.directories
-    assert posixpath.join("prefix", "include") in cuda_include_dirs
+    assert os.path.join("prefix", "include") in cuda_include_dirs
     assert (
-        posixpath.join("prefix", "include", "cuda", "std", "detail", "libcxx", "include")
+        os.path.join("prefix", "include", "cuda", "std", "detail", "libcxx", "include")
         not in cuda_include_dirs
     )
 

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -5,19 +5,16 @@
 
 import fnmatch
 import os.path
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 
 from llnl.util.filesystem import HeaderList, LibraryList, find, find_headers, find_libraries
 
 import spack.paths
+from spack.util.path import normalize_string_path
 
-if sys.platform == "win32":
-    from pathlib import WindowsPath
-else:
-    from pathlib import PosixPath
 
 @pytest.fixture()
 def library_list():
@@ -80,12 +77,14 @@ class TestLibraryList(object):
         s1 = library_list.joined()
         expected = " ".join(
             [
-                str(Path("/dir1/liblapack.%s" % plat_static_ext)),
-                str(Path("/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"))),
-                str(Path("/dir1/libblas.%s" % plat_static_ext)),
-                str(Path("/dir3/libz.%s" % plat_shared_ext)),
-                str(Path("libmpi.%s.20.10.1" % plat_shared_ext)),
+                normalize_string_path("/dir1/liblapack.%s" % plat_static_ext),
+                normalize_string_path(
+                    "/dir2/libpython3.6.%s"
+                    % (plat_apple_shared_ext if sys.platform != "win32" else "dll")
+                ),
+                normalize_string_path("/dir1/libblas.%s" % plat_static_ext),
+                normalize_string_path("/dir3/libz.%s" % plat_shared_ext),
+                "libmpi.%s.20.10.1" % plat_shared_ext,
             ]
         )
         assert s1 == expected
@@ -96,21 +95,25 @@ class TestLibraryList(object):
         s3 = library_list.joined(";")
         expected = ";".join(
             [
-                str(Path("/dir1/liblapack.%s" % plat_static_ext)),
-                str(Path("/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"))),
-                str(Path("/dir1/libblas.%s" % plat_static_ext)),
-                str(Path("/dir3/libz.%s" % plat_shared_ext)),
-                str(Path("libmpi.%s.20.10.1" % plat_shared_ext)),
+                normalize_string_path("/dir1/liblapack.%s" % plat_static_ext),
+                str(
+                    Path(
+                        "/dir2/libpython3.6.%s"
+                        % (plat_apple_shared_ext if sys.platform != "win32" else "dll")
+                    )
+                ),
+                normalize_string_path("/dir1/libblas.%s" % plat_static_ext),
+                normalize_string_path("/dir3/libz.%s" % plat_shared_ext),
+                normalize_string_path("libmpi.%s.20.10.1" % plat_shared_ext),
             ]
         )
         assert s3 == expected
 
     def test_flags(self, library_list):
         search_flags = library_list.search_flags
-        assert str(Path("-L/dir1")) in search_flags
-        assert str(Path("-L/dir2")) in search_flags
-        assert str(Path("-L/dir3")) in search_flags
+        assert normalize_string_path("-L/dir1") in search_flags
+        assert normalize_string_path("-L/dir2") in search_flags
+        assert normalize_string_path("-L/dir3") in search_flags
         assert isinstance(search_flags, str)
         assert search_flags == "-L{0}dir1 -L{0}dir2 -L{0}dir3".format(os.path.sep)
 
@@ -132,11 +135,15 @@ class TestLibraryList(object):
         assert names == ["lapack", "python3.6", "blas", "z", "mpi"]
 
         directories = library_list.directories
-        assert directories == [str(Path("/dir1")), str(Path("/dir2")), str(Path("/dir3"))]
+        assert directories == [
+            normalize_string_path("/dir1"),
+            normalize_string_path("/dir2"),
+            normalize_string_path("/dir3"),
+        ]
 
     def test_get_item(self, library_list):
         a = library_list[0]
-        assert a == str(Path("/dir1/liblapack.%s" % plat_static_ext))
+        assert a == normalize_string_path("/dir1/liblapack.%s" % plat_static_ext)
 
         b = library_list[:]
         assert type(b) == type(library_list)
@@ -170,11 +177,11 @@ class TestHeaderList(object):
         s1 = header_list.joined()
         expected = " ".join(
             [
-                str(Path("/dir1/Python.h")),
-                str(Path("/dir2/date.time.h")),
-                str(Path("/dir1/pyconfig.hpp")),
-                str(Path("/dir3/core.hh")),
-                str(Path("pymem.cuh")),
+                normalize_string_path("/dir1/Python.h"),
+                normalize_string_path("/dir2/date.time.h"),
+                normalize_string_path("/dir1/pyconfig.hpp"),
+                normalize_string_path("/dir3/core.hh"),
+                normalize_string_path("pymem.cuh"),
             ]
         )
         assert s1 == expected
@@ -185,20 +192,20 @@ class TestHeaderList(object):
         s3 = header_list.joined(";")
         expected = ";".join(
             [
-                str(Path("/dir1/Python.h")),
-                str(Path("/dir2/date.time.h")),
-                str(Path("/dir1/pyconfig.hpp")),
-                str(Path("/dir3/core.hh")),
-                str(Path("pymem.cuh")),
+                normalize_string_path("/dir1/Python.h"),
+                normalize_string_path("/dir2/date.time.h"),
+                normalize_string_path("/dir1/pyconfig.hpp"),
+                normalize_string_path("/dir3/core.hh"),
+                normalize_string_path("pymem.cuh"),
             ]
         )
         assert s3 == expected
 
     def test_flags(self, header_list):
         include_flags = header_list.include_flags
-        assert str(Path("-I/dir1")) in include_flags
-        assert str(Path("-I/dir2")) in include_flags
-        assert str(Path("-I/dir3")) in include_flags
+        assert normalize_string_path("-I/dir1") in include_flags
+        assert normalize_string_path("-I/dir2") in include_flags
+        assert normalize_string_path("-I/dir3") in include_flags
         assert isinstance(include_flags, str)
         assert include_flags == "-I{0}dir1 -I{0}dir2 -I{0}dir3".format(os.path.sep)
 
@@ -217,11 +224,15 @@ class TestHeaderList(object):
         assert names == ["Python", "date.time", "pyconfig", "core", "pymem"]
 
         directories = header_list.directories
-        assert directories == [str(Path("/dir1")), str(Path("/dir2")), str(Path("/dir3"))]
+        assert directories == [
+            normalize_string_path("/dir1"),
+            normalize_string_path("/dir2"),
+            normalize_string_path("/dir3"),
+        ]
 
     def test_get_item(self, header_list):
         a = header_list[0]
-        assert a == str(Path("/dir1/Python.h"))
+        assert a == normalize_string_path("/dir1/Python.h")
 
         b = header_list[:]
         assert type(b) == type(header_list)

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -5,6 +5,7 @@
 
 import fnmatch
 import os.path
+from pathlib import Path
 import sys
 
 import pytest
@@ -13,6 +14,10 @@ from llnl.util.filesystem import HeaderList, LibraryList, find, find_headers, fi
 
 import spack.paths
 
+if sys.platform == "win32":
+    from pathlib import WindowsPath
+else:
+    from pathlib import PosixPath
 
 @pytest.fixture()
 def library_list():
@@ -75,12 +80,12 @@ class TestLibraryList(object):
         s1 = library_list.joined()
         expected = " ".join(
             [
-                "/dir1/liblapack.%s" % plat_static_ext,
-                "/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
-                "/dir1/libblas.%s" % plat_static_ext,
-                "/dir3/libz.%s" % plat_shared_ext,
-                "libmpi.%s.20.10.1" % plat_shared_ext,
+                str(Path("/dir1/liblapack.%s" % plat_static_ext)),
+                str(Path("/dir2/libpython3.6.%s"
+                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"))),
+                str(Path("/dir1/libblas.%s" % plat_static_ext)),
+                str(Path("/dir3/libz.%s" % plat_shared_ext)),
+                str(Path("libmpi.%s.20.10.1" % plat_shared_ext)),
             ]
         )
         assert s1 == expected
@@ -91,23 +96,23 @@ class TestLibraryList(object):
         s3 = library_list.joined(";")
         expected = ";".join(
             [
-                "/dir1/liblapack.%s" % plat_static_ext,
-                "/dir2/libpython3.6.%s"
-                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
-                "/dir1/libblas.%s" % plat_static_ext,
-                "/dir3/libz.%s" % plat_shared_ext,
-                "libmpi.%s.20.10.1" % plat_shared_ext,
+                str(Path("/dir1/liblapack.%s" % plat_static_ext)),
+                str(Path("/dir2/libpython3.6.%s"
+                % (plat_apple_shared_ext if sys.platform != "win32" else "dll"))),
+                str(Path("/dir1/libblas.%s" % plat_static_ext)),
+                str(Path("/dir3/libz.%s" % plat_shared_ext)),
+                str(Path("libmpi.%s.20.10.1" % plat_shared_ext)),
             ]
         )
         assert s3 == expected
 
     def test_flags(self, library_list):
         search_flags = library_list.search_flags
-        assert "-L/dir1" in search_flags
-        assert "-L/dir2" in search_flags
-        assert "-L/dir3" in search_flags
+        assert str(Path("-L/dir1")) in search_flags
+        assert str(Path("-L/dir2")) in search_flags
+        assert str(Path("-L/dir3")) in search_flags
         assert isinstance(search_flags, str)
-        assert search_flags == "-L/dir1 -L/dir2 -L/dir3"
+        assert search_flags == "-L{0}dir1 -L{0}dir2 -L{0}dir3".format(os.path.sep)
 
         link_flags = library_list.link_flags
         assert "-llapack" in link_flags
@@ -127,11 +132,11 @@ class TestLibraryList(object):
         assert names == ["lapack", "python3.6", "blas", "z", "mpi"]
 
         directories = library_list.directories
-        assert directories == ["/dir1", "/dir2", "/dir3"]
+        assert directories == [str(Path("/dir1")), str(Path("/dir2")), str(Path("/dir3"))]
 
     def test_get_item(self, library_list):
         a = library_list[0]
-        assert a == "/dir1/liblapack.%s" % plat_static_ext
+        assert a == str(Path("/dir1/liblapack.%s" % plat_static_ext))
 
         b = library_list[:]
         assert type(b) == type(library_list)
@@ -140,9 +145,9 @@ class TestLibraryList(object):
 
     def test_add(self, library_list):
         pylist = [
-            "/dir1/liblapack.%s" % plat_static_ext,  # removed from the final list
-            "/dir2/libmpi.%s" % plat_shared_ext,
-            "/dir4/libnew.%s" % plat_static_ext,
+            Path("/dir1/liblapack.%s" % plat_static_ext),  # removed from the final list
+            Path("/dir2/libmpi.%s" % plat_shared_ext),
+            Path("/dir4/libnew.%s" % plat_static_ext),
         ]
         another = LibraryList(pylist)
         both = library_list + another
@@ -165,11 +170,11 @@ class TestHeaderList(object):
         s1 = header_list.joined()
         expected = " ".join(
             [
-                "/dir1/Python.h",
-                "/dir2/date.time.h",
-                "/dir1/pyconfig.hpp",
-                "/dir3/core.hh",
-                "pymem.cuh",
+                str(Path("/dir1/Python.h")),
+                str(Path("/dir2/date.time.h")),
+                str(Path("/dir1/pyconfig.hpp")),
+                str(Path("/dir3/core.hh")),
+                str(Path("pymem.cuh")),
             ]
         )
         assert s1 == expected
@@ -180,22 +185,22 @@ class TestHeaderList(object):
         s3 = header_list.joined(";")
         expected = ";".join(
             [
-                "/dir1/Python.h",
-                "/dir2/date.time.h",
-                "/dir1/pyconfig.hpp",
-                "/dir3/core.hh",
-                "pymem.cuh",
+                str(Path("/dir1/Python.h")),
+                str(Path("/dir2/date.time.h")),
+                str(Path("/dir1/pyconfig.hpp")),
+                str(Path("/dir3/core.hh")),
+                str(Path("pymem.cuh")),
             ]
         )
         assert s3 == expected
 
     def test_flags(self, header_list):
         include_flags = header_list.include_flags
-        assert "-I/dir1" in include_flags
-        assert "-I/dir2" in include_flags
-        assert "-I/dir3" in include_flags
+        assert str(Path("-I/dir1")) in include_flags
+        assert str(Path("-I/dir2")) in include_flags
+        assert str(Path("-I/dir3")) in include_flags
         assert isinstance(include_flags, str)
-        assert include_flags == "-I/dir1 -I/dir2 -I/dir3"
+        assert include_flags == "-I{0}dir1 -I{0}dir2 -I{0}dir3".format(os.path.sep)
 
         macros = header_list.macro_definitions
         assert "-DBOOST_LIB_NAME=boost_regex" in macros
@@ -212,11 +217,11 @@ class TestHeaderList(object):
         assert names == ["Python", "date.time", "pyconfig", "core", "pymem"]
 
         directories = header_list.directories
-        assert directories == ["/dir1", "/dir2", "/dir3"]
+        assert directories == [str(Path("/dir1")), str(Path("/dir2")), str(Path("/dir3"))]
 
     def test_get_item(self, header_list):
         a = header_list[0]
-        assert a == "/dir1/Python.h"
+        assert a == str(Path("/dir1/Python.h"))
 
         b = header_list[:]
         assert type(b) == type(header_list)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -6,6 +6,7 @@
 """Tests for ``llnl/util/filesystem.py``"""
 import filecmp
 import os
+from pathlib import Path
 import shutil
 import stat
 import sys
@@ -375,11 +376,11 @@ def test_recursive_search_of_headers_from_prefix(installation_dir_with_headers):
 
 if sys.platform == "win32":
     dir_list = [
-        (["C:/pfx/include/foo.h", "C:/pfx/include/subdir/foo.h"], ["C:/pfx/include"]),
-        (["C:/pfx/include/foo.h", "C:/pfx/subdir/foo.h"], ["C:/pfx/include", "C:/pfx/subdir"]),
+        (["C:/pfx/include/foo.h", "C:\\pfx\\include\\subdir\\foo.h"], ["C:\\pfx\\include"]),
+        (["C:/pfx/include/foo.h", "C:/pfx/subdir/foo.h"], ["C:\\pfx\\include", "C:\\pfx\\subdir"]),
         (
             ["C:/pfx/include/subdir/foo.h", "C:/pfx/subdir/foo.h"],
-            ["C:/pfx/include", "C:/pfx/subdir"],
+            ["C:\\pfx\\include", "C:\\pfx\\subdir"],
         ),
     ]
 else:
@@ -461,8 +462,8 @@ def test_partition_path(path, entry, expected):
 if sys.platform == "win32":
     path_list = [
         ("", []),
-        (r".\some\sub\dir", [r".\some", r".\some\sub", r".\some\sub\dir"]),
-        (r"another\sub\dir", [r"another", r"another\sub", r"another\sub\dir"]),
+        (r".\some\sub\dir", [Path(r".\some"), Path(r".\some\sub"), Path(r".\some\sub\dir")]),
+        (r"another\sub\dir", [Path(r"another"), Path(r"another\sub"), Path(r"another\sub\dir")]),
     ]
 else:
     path_list = [

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -6,10 +6,10 @@
 """Tests for ``llnl/util/filesystem.py``"""
 import filecmp
 import os
-from pathlib import Path
 import shutil
 import stat
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -377,9 +377,14 @@ def test_recursive_search_of_headers_from_prefix(installation_dir_with_headers):
 if sys.platform == "win32":
     dir_list = [
         (["C:/pfx/include/foo.h", "C:\\pfx\\include\\subdir\\foo.h"], ["C:\\pfx\\include"]),
-        (["C:/pfx/include/foo.h", "C:/pfx/subdir/foo.h"], ["C:\\pfx\\include", "C:\\pfx\\subdir"]),
+        (["C:\\pfx\\include\\foo.h", "C:\\pfx\\include\\subdir\\foo.h"], ["C:\\pfx\\include"]),
+        (["C:/pfx/include/foo.h", "C:/pfx/include/subdir/foo.h"], ["C:\\pfx\\include"]),
         (
-            ["C:/pfx/include/subdir/foo.h", "C:/pfx/subdir/foo.h"],
+            ["C:\\pfx\\include\\foo.h", "C:\\pfx\\subdir\\foo.h"],
+            ["C:\\pfx\\include", "C:\\pfx\\subdir"],
+        ),
+        (
+            ["C:\\pfx\\include\\subdir\\foo.h", "C:\\pfx\\subdir\\foo.h"],
             ["C:\\pfx\\include", "C:\\pfx\\subdir"],
         ),
     ]


### PR DESCRIPTION
With the introduction of Windows support, path handling and associated parsing/processing has become increasingly fraught, and in many places requires a lot of obtrusive, fragile, highly specific handling that often breaks and results in issues. The decorator ensuring consistent platform specific path useage over every single method in `llnl/util/filesystem.py` is a great example of this, as well as the custom url handling/parsing we do, particularly with regard to file urls. 

With the drop of Py2, we can now reasonably expect `pathlib` to be present for all users. `pathlib` offers (in most cases) much more robust and mature cross platform path handling than `os.path` or any custom work we implement, and in many cases can completely abstract away the issue of platform specific paths. 

This PR is intended to serve as an example of what a refactor to `pathlib` would look like and to motivate the conversion of the rest of the code base/get some general buy in. We convert all areas of `llnl/util` to use `pathlib` where appropriate and not too obtrusive. **At the moment, because these utilities cannot expect to be provided `pathlib.Path` objects by the rest of Spack, there is extra handling to deal with those cases, both in function arguments and returned values. This can all be removed once more of spack is converted.**

Note: a good portion of these changes were made with regex replacements so a finer pass to make more optimal choices with regard to design/`pathlib` use is warranted before a merge is seriously considered. 