### PR TITLE
py-torch build fixes for +rocm

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -104,7 +104,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     )
 
     conflicts("+cuda+rocm")
-    conflicts("+tensorpipe", when="+rocm", msg="TensorPipe doesn't yet support ROCm")
+    conflicts("+tensorpipe", when="+rocm@:5.1", msg="TensorPipe ROCm<5.2")
     conflicts("+breakpad", when="target=ppc64:")
     conflicts("+breakpad", when="target=ppc64le:")
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -104,9 +104,12 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     )
 
     conflicts("+cuda+rocm")
-    conflicts("+tensorpipe", when="+rocm@:5.1", msg="TensorPipe ROCm<5.2")
-    conflicts("+tensorpipe+distributed", when="@1.8:",
-              msg="TensorPipe and Distributed are incompatible for py-torch@1.8:")
+    conflicts("+tensorpipe", when="+rocm@:5.1")
+    conflicts(
+        "+tensorpipe+distributed",
+        when="@1.8:",
+        msg="TensorPipe and Distributed are incompatible for py-torch@1.8:",
+    )
     conflicts("+breakpad", when="target=ppc64:")
     conflicts("+breakpad", when="target=ppc64le:")
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -105,6 +105,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda+rocm")
     conflicts("+tensorpipe", when="+rocm@:5.1", msg="TensorPipe ROCm<5.2")
+    conflicts("+tensorpipe+distributed", when="@1.8:",
+              msg="TensorPipe and Distributed are incompatible for py-torch@1.8:")
     conflicts("+breakpad", when="target=ppc64:")
     conflicts("+breakpad", when="target=ppc64le:")
 


### PR DESCRIPTION
This change re-enables the +tensorpipe option to pytorch with newer rocm versions - since support exists in rocm5.2 and newer.
