### PR TITLE
Enabling py-torch+tensorpipe with rocm 5.2+

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -89,12 +89,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     variant("distributed", default=not is_darwin, description="Use distributed")
     variant("mpi", default=not is_darwin, description="Use MPI for Caffe2", when="+distributed")
     variant("gloo", default=not is_darwin, description="Use Gloo", when="+distributed")
-    variant(
-        "tensorpipe",
-        default=not is_darwin,
-        description="Use TensorPipe",
-        when="@1.6: +distributed",
-    )
+    variant("tensorpipe", default=not is_darwin, description="Use TensorPipe", when="@1.6:")
     variant("onnx_ml", default=True, description="Enable traditional ONNX ML API", when="@1.5:")
     variant(
         "breakpad",
@@ -104,7 +99,17 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     )
 
     conflicts("+cuda+rocm")
-    conflicts("+tensorpipe", when="+rocm", msg="TensorPipe doesn't yet support ROCm")
+    conflicts("+tensorpipe", when="^hip@:5.1")
+    conflicts(
+        "~tensorpipe",
+        when="@1.8: +distributed",
+        msg="Distributed requires TensorPipe for py-torch@1.8:",
+    )
+    conflicts(
+        "+tensorpipe",
+        when="~distributed",
+        msg="TensorPipe requires Distributed.",  # super-Oxford comma
+    )
     conflicts("+breakpad", when="target=ppc64:")
     conflicts("+breakpad", when="target=ppc64le:")
 


### PR DESCRIPTION
This also required noting a +distributed~tensorpipe conflict that originated with py-torch@1.8.

Issue description filed on pytorch:
https://github.com/pytorch/pytorch/issues/97397
At present, pytorch develop has not resolved it.

---
## Long description

These fixes update distributed and tensorpipe options, which were a source of difficulty compiling with rocm.

Py-torch itself is now implicitly requiring tensorpipe when distributed is turned on (since 1.8, https://github.com/pytorch/pytorch/issues/97397).  
AMD claims ROCM 5.2+ works with TensorPipe.

When adding `conflicts('~tensorpipe', when='@1.8: +distributed')`, spack can't resolve `~distributed~tensorpipe` unless tensorpipe exists as an option independently of +distributed.

Relaxing the condition on `variant('tensorpipe')` is fine though, since pytorch defines tensorpipe as a `cmake use_dependent_option`, which always defines `USE_TENSORPIPE=OFF` when `USE_DISTRIBUTED=OFF`.

https://github.com/pytorch/pytorch/blob/master/CMakeLists.txt
```
cmake_dependent_option(
    USE_TENSORPIPE "Use TensorPipe. Only available if USE_DISTRIBUTED is on." ON
    "USE_DISTRIBUTED" OFF)
```

So, the updated dependency specs here accomplish:
```
# latest version, defaults to +tensorpipe
$ spack spec py-torch%clang+rocm+distributed amdgpu_target=gfx90a
Input spec
--------------------------------
py-torch%clang+distributed+rocm amdgpu_target=gfx90a

Concretized
--------------------------------
py-torch@2.0.0%clang@14.0.2~caffe2~cuda~debug+distributed+fbgemm+gloo+kineto~metal+mkldnn+mpi+nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack+rocm+tensorpipe~test+valgrind+xnnpack amdgpu_target=gfx90a build_system=python_pip arch=linux-sles15-zen

# requires pre-1.8 version
$ spack spec py-torch%clang+rocm+distributed~tensorpipe amdgpu_target=gfx90a
Input spec
--------------------------------
py-torch%clang+distributed+rocm~tensorpipe amdgpu_target=gfx90a

Concretized
--------------------------------
py-torch@1.7.1%clang@14.0.2~caffe2~cuda~debug+distributed+fbgemm+gloo~metal+mkldnn+mpi+nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack+rocm~tensorpipe~test+xnnpack amdgpu_target=gfx90a build_system=python_pip patches=2229bcb,6d57172 arch=linux-sles15-zen

# any version here
$ spack spec py-torch%clang~distributed~tensorpipe
Input spec
--------------------------------
py-torch%clang~distributed~tensorpipe

Concretized
--------------------------------
py-torch@2.0.0%clang@14.0.2~caffe2~cuda~debug~distributed+fbgemm+kineto~metal+mkldnn+nnpack+numa+numpy+onnx_ml+openmp+qnnpack~rocm~tensorpipe~test+valgrind+xnnpack build_system=python_pip arch=linux-sles15-zen3

# any version here
$ spack spec py-torch%clang~distributed~tensorpipe+rocm amdgpu_target=gfx90a
Input spec
--------------------------------
py-torch%clang~distributed+rocm~tensorpipe amdgpu_target=gfx90a

# error
$ spack spec py-torch%clang~distributed+tensorpipe
==> Error: TensorPipe requires Distributed.
```