### PR TITLE
py-aiobotocore: add v2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-aiobotocore/package.py
+++ b/var/spack/repos/builtin/packages/py-aiobotocore/package.py
@@ -19,6 +19,7 @@ class PyAiobotocore(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-botocore@1.27.59", when="@2.4.2", type=("build", "run"))
     depends_on("py-botocore@1.19.52", when="@1.2.1", type=("build", "run"))
+    depends_on("py-botocore@1.29.76", when="@2.5.0", type=("build", "run"))
     depends_on("py-aiohttp@3.3.1:", type=("build", "run"))
     depends_on("py-wrapt@1.10.10:", type=("build", "run"))
     depends_on("py-aioitertools@0.5.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-aiobotocore/package.py
+++ b/var/spack/repos/builtin/packages/py-aiobotocore/package.py
@@ -12,6 +12,7 @@ class PyAiobotocore(PythonPackage):
     homepage = "https://aiobotocore.readthedocs.io/en/latest/"
     pypi = "aiobotocore/aiobotocore-1.2.1.tar.gz"
 
+    version("2.5.0", sha256="6a5b397cddd4f81026aa91a14c7dd2650727425740a5af8ba75127ff663faf67")
     version("2.4.2", sha256="0603b74a582dffa7511ce7548d07dc9b10ec87bc5fb657eb0b34f9bd490958bf")
     version("1.2.1", sha256="58cc422e65fc89f7cb78eca740d241ac8e15f39f6b308cc23152711e8a987d45")
 

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -13,6 +13,7 @@ class PyBotocore(PythonPackage):
     pypi = "botocore/botocore-1.13.44.tar.gz"
 
     version("1.29.84", sha256="a36f7f6f8eae5dbd4a1cc8cb6fc747f6315500541181eff2093ee0529fc8e4bc")
+    version("1.29.76", sha256="c2f67b6b3f8acf2968eafca06526f07b9fb0d27bac4c68a635d51abb675134a7")
     version("1.29.56", sha256="ca4d6403d745218270a20d9ca3ca9a33e3ad2fabb59a96ed8d6e1a824b274c86")
     version("1.29.26", sha256="f71220fe5a5d393c391ed81a291c0d0985f147568c56da236453043f93727a34")
     version("1.28.5", sha256="f322d7b62163219ffeb787a116d318273dfb7243c3b49d95f5bfff8daa1df4e0")


### PR DESCRIPTION
Add py-aiobotocore v2.5.0. 

**Changelog:**
https://github.com/aio-libs/aiobotocore/releases/tag/2.5.0

**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.