### PR TITLE
py-aiodns: add v3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-aiodns/package.py
+++ b/var/spack/repos/builtin/packages/py-aiodns/package.py
@@ -20,3 +20,4 @@ class PyAiodns(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-pycares@3.0.0:", type=("build", "run"))
+    depends_on("py-pycares@4.0.0:", type=("build", "run"), when="@3.0.0:")

--- a/var/spack/repos/builtin/packages/py-aiodns/package.py
+++ b/var/spack/repos/builtin/packages/py-aiodns/package.py
@@ -13,6 +13,7 @@ class PyAiodns(PythonPackage):
     homepage = "https://pypi.org/project/aiodns/"
     pypi = "aiodns/aiodns-2.0.0.tar.gz"
 
+    version("3.0.0", sha256="946bdfabe743fceeeb093c8a010f5d1645f708a241be849e17edfb0e49e08cd6")
     version("2.0.0", sha256="815fdef4607474295d68da46978a54481dd1e7be153c7d60f9e72773cd38d77d")
     version("1.2.0", sha256="d67e14b32176bcf3ff79b5d47c466011ce4adeadfa264f7949da1377332a0449")
     version("1.1.1", sha256="d8677adc679ce8d0ef706c14d9c3d2f27a0e0cc11d59730cdbaf218ad52dd9ea")

--- a/var/spack/repos/builtin/packages/py-pycares/package.py
+++ b/var/spack/repos/builtin/packages/py-pycares/package.py
@@ -14,6 +14,7 @@ class PyPycares(PythonPackage):
     homepage = "https://github.com/saghul/pycares"
     url = "https://github.com/saghul/pycares/archive/pycares-3.0.0.tar.gz"
 
+    version("4.0.0", sha256="c46316fa8e4b27795a1f7f0d7a6b313fc32a9664e7fd2e296b02ab2fe1e482a8")
     version("3.0.0", sha256="28dc2bd59cf20399a6af4383cc8f57970cfca8b808ca05d6493812862ef0ca9c")
 
     depends_on("python@2.6:", type=("build", "run"))


### PR DESCRIPTION
Add py-aiodns v3.0.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.