### PR TITLE
py-aioitertools: add v0.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-aioitertools/package.py
+++ b/var/spack/repos/builtin/packages/py-aioitertools/package.py
@@ -20,5 +20,5 @@ class PyAioitertools(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.6:3.9", type=("build", "run"), when="@0.11.0:")
     depends_on("py-flit-core@2:3", type="build")
-    depends_on("py-typing-extensions@3.7:", type=("build", "run"))
-    depends_on("py-typing-extensions@4:", type=("build", "run"), when="@0.11.0")
+    depends_on("py-typing-extensions@3.7:", when="@0.7.1", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", when="@0.11.0: ^python@:3.9", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-aioitertools/package.py
+++ b/var/spack/repos/builtin/packages/py-aioitertools/package.py
@@ -14,8 +14,11 @@ class PyAioitertools(PythonPackage):
     homepage = "https://aioitertools.omnilib.dev/en/stable/"
     pypi = "aioitertools/aioitertools-0.7.1.tar.gz"
 
+    version("0.11.0", sha256="42c68b8dd3a69c2bf7f2233bf7df4bb58b557bca5252ac02ed5187bbc67d6831")
     version("0.7.1", sha256="54a56c7cf3b5290d1cb5e8974353c9f52c677612b5d69a859369a020c53414a3")
 
     depends_on("python@3.6:", type=("build", "run"))
+    depends_on("python@3.6:3.9", type=("build", "run"), when="@0.11.0:")
     depends_on("py-flit-core@2:3", type="build")
     depends_on("py-typing-extensions@3.7:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"), when="@0.11.0")

--- a/var/spack/repos/builtin/packages/py-aioitertools/package.py
+++ b/var/spack/repos/builtin/packages/py-aioitertools/package.py
@@ -18,7 +18,6 @@ class PyAioitertools(PythonPackage):
     version("0.7.1", sha256="54a56c7cf3b5290d1cb5e8974353c9f52c677612b5d69a859369a020c53414a3")
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("python@3.6:3.9", type=("build", "run"), when="@0.11.0:")
     depends_on("py-flit-core@2:3", type="build")
     depends_on("py-typing-extensions@3.7:", when="@0.7.1", type=("build", "run"))
     depends_on("py-typing-extensions@4:", when="@0.11.0: ^python@:3.9", type=("build", "run"))


### PR DESCRIPTION
Add py-aioitertools v0.11.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.