### PR TITLE
pfunit: fix error with BUILD_SHARED_LIBS

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -147,7 +147,7 @@ class Pfunit(CMakePackage):
         spec = self.spec
         args = [
             self.define("Python_EXECUTABLE", spec["python"].command),
-            self.define_from_variant("BUILD_SHARED_LIBS", False),
+            self.define("BUILD_SHARED_LIBS", False),
             self.define("CMAKE_Fortran_MODULE_DIRECTORY", spec.prefix.include),
             self.define_from_variant("ENABLE_BUILD_DOXYGEN", "docs"),
             self.define("ENABLE_TESTS", self.run_tests),


### PR DESCRIPTION
In #35510, @haampie pointed out that pFUnit shared library builds are broken. And, yeah, they seem to be and @tclune and myself will work on fixing that.

But, I recently tried to build pFUnit and I got:
```
==> Error: KeyError: '"False" is not a variant of "pfunit"'

/Users/mathomp4/spack-mathomp4/lib/spack/spack/build_systems/cmake.py:158, in define_from_variant:
  >>    158    def define_from_variant(self, *args, **kwargs):
        159        return self.builder.define_from_variant(*args, **kwargs)

See build log for details:
  /var/folders/31/16x8_l1s72s2kw0w7byr03qm0000gp/T/mathomp4/spack-stage/spack-stage-pfunit-4.6.3-23xs5ykocttozsr6sbfqy6iicjxwtx5l/spack-build-out.txt
```

I think the issue is that "False" isn't a variant so this:
```python
            self.define_from_variant("BUILD_SHARED_LIBS", False),
```
fails. I think we need to use:
```python
            self.define("BUILD_SHARED_LIBS", False),
```
though I'll defer to @alalazo or whoever when they see this PR.