### PR TITLE
gitlab ci: request more memory for publish job

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -143,6 +143,8 @@ protected-publish:
   variables:
     AWS_ACCESS_KEY_ID: ${PROTECTED_MIRRORS_AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${PROTECTED_MIRRORS_AWS_SECRET_ACCESS_KEY}
+    KUBERNETES_CPU_REQUEST: 4000m
+    KUBERNETES_MEMORY_REQUEST: 16G
   script:
     - . "./share/spack/setup-env.sh"
     - spack --version


### PR DESCRIPTION
The protected publish job rebuilds the buildcache index of the target protected mirror, and until now just used default cpu/memory requets.  However, in this [case](https://gitlab.spack.io/spack/spack/-/jobs/6360497), the pod was using a little over 3GB of memory when it was evicted.   This PR requests more memory for the pod running this job.