### PR TITLE
OpenMC: add v0.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -18,12 +18,13 @@ class Openmc(CMakePackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.2"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.3"
     git = "https://github.com/openmc-dev/openmc.git"
     maintainers("paulromano")
 
     version("develop", branch="develop", submodules=True)
     version("master", branch="master", submodules=True)
+    version("0.13.3", commit="27cb0dc97960fe6d750eb5a93584a9a0ca532ac8", submodules=True)
     version("0.13.2", commit="030f73a8690ed19e91806e46c8caf338d252e74a", submodules=True)
     version("0.13.1", commit="33bc948f4b855c037975f16d16091fe4ecd12de3", submodules=True)
     version("0.13.0", commit="cff247e35785e7236d67ccf64a3401f0fc50a469", submodules=True)

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -17,12 +17,13 @@ class PyOpenmc(PythonPackage):
     programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.2"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.3"
     git = "https://github.com/openmc-dev/openmc.git"
     maintainers("paulromano")
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("0.13.3", commit="27cb0dc97960fe6d750eb5a93584a9a0ca532ac8", submodules=True)
     version("0.13.2", commit="030f73a8690ed19e91806e46c8caf338d252e74a", submodules=True)
     version("0.13.1", commit="33bc948f4b855c037975f16d16091fe4ecd12de3", submodules=True)
     version("0.13.0", commit="cff247e35785e7236d67ccf64a3401f0fc50a469", submodules=True)

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -38,6 +38,7 @@ class PyOpenmc(PythonPackage):
     for ver in [
         "develop",
         "master",
+        "0.13.3",
         "0.13.2",
         "0.13.1",
         "0.13.0",


### PR DESCRIPTION
This PR adds version 0.13.3 for packages openmc and py-openmc.