### PR TITLE
libxpm: Fix linking with libintl

### DIFF
--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -30,5 +30,5 @@ class Libxpm(AutotoolsPackage, XorgPackage):
         # If libxpm is installed as an external package, gettext won't
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
-        if "gettext" in self.spec:
-            env.append_flags("LDFLAGS", "-L{0} -lintl".format(self.spec["gettext"].prefix.lib))
+        if "gettext" in self.spec and "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS", "-lintl")


### PR DESCRIPTION
Original Author of this change: Chris Green  @greenc-FNAL 

Two changes:
- Remove adding the library path using -L: It is obsolete now that we have the library paths in before the system paths.
- Link with -linto only if the gettext recipe provides it: When we are on a glibc system, we can use external gettext, which means we use the libintl inside libc.so: no -lintl then.

This change was already submitted in #35450 and reviewed but is stuck in this big PR which is trying to do too in a single PR.