### PR TITLE
bcache: Simplify check if -lintl shall be added to LDFLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -26,7 +26,7 @@ class Bcache(MakefilePackage):
 
     def setup_build_environment(self, env):
         # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
-        if any("libintl." in filename.split("/")[-1] for filename in self.spec["gettext"].libs):
+        if "gettext" in self.spec and "intl" in self.spec["gettext"].libs.names:
             env.append_flags("LDFLAGS", "-lintl")
 
     patch(


### PR DESCRIPTION
Replace my initial libintl check with the much nicer check for `"intl" in self.spec["gettext"].libs.names`.

Thanks to Chris Green @greenc-FNAL !