### PR TITLE
gl2ps: add support for ninja generator

### DIFF
--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -58,7 +58,7 @@ class Gl2ps(CMakePackage):
         if spec.satisfies("platform=darwin"):
             options.append(self.define("CMAKE_MACOSX_RPATH", True))
 
-        if spec.satisfies("generator=ninja"):
+        if spec.satisfies("platform=windows"):
             options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         if "~doc" in spec:

--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -31,6 +31,16 @@ class Gl2ps(CMakePackage):
     depends_on("zlib-api", when="+zlib")
     depends_on("texlive", type="build", when="+doc")
 
+    # gl2ps tries to build static and shared libs at once with the same
+    # target name. This causes ninja to fail the build
+    # This patch defines a new CL opt to toggle shared vs static
+    # and renames all lib target refs
+    # Patch derived from https://gitlab.onelab.info/gl2ps/gl2ps/-/issues/30
+    # and fixes a few additional places that solution misses.
+    with when("generator=ninja"):
+        variant("shared", default=True, description="Enable building shared libraries")
+        patch("prevent-ninja-target-clash.patch")
+
     def cmake_args(self):
         spec = self.spec
         options = [
@@ -47,6 +57,9 @@ class Gl2ps(CMakePackage):
         ]
         if spec.satisfies("platform=darwin"):
             options.append(self.define("CMAKE_MACOSX_RPATH", True))
+
+        if spec.satisfies("generator=ninja"):
+            options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         if "~doc" in spec:
             # Make sure we don't look.

--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -37,9 +37,9 @@ class Gl2ps(CMakePackage):
     # and renames all lib target refs
     # Patch derived from https://gitlab.onelab.info/gl2ps/gl2ps/-/issues/30
     # and fixes a few additional places that solution misses.
-    with when("generator=ninja"):
+    with when("platform=windows"):
         variant("shared", default=True, description="Enable building shared libraries")
-        patch("prevent-ninja-target-clash.patch")
+        patch("prevent-ninja-target-clash.patch", when="generator=ninja")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -39,7 +39,7 @@ class Gl2ps(CMakePackage):
     # and fixes a few additional places that solution misses.
     with when("platform=windows"):
         variant("shared", default=True, description="Enable building shared libraries")
-        patch("prevent-ninja-target-clash.patch", when="generator=ninja")
+        patch("prevent-ninja-target-clash.patch")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gl2ps/prevent-ninja-target-clash.patch
+++ b/var/spack/repos/builtin/packages/gl2ps/prevent-ninja-target-clash.patch
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0001c4f..a2133de 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,6 +49,7 @@ project(gl2ps C)
+ 
+ option(ENABLE_ZLIB "Enable compression using ZLIB" ON)
+ option(ENABLE_PNG "Enable PNG support" ON)
++option(BUILD_SHARED_LIBS "Enable building shared libs" ON)
+ 
+ set(GL2PS_MAJOR_VERSION 1)
+ set(GL2PS_MINOR_VERSION 4)
+@@ -139,19 +140,17 @@ if(APPLE)
+ endif()
+ 
+ if(OPENGL_FOUND)
+-  add_library(lib STATIC gl2ps.c gl2ps.h)
+-  set_target_properties(lib PROPERTIES OUTPUT_NAME gl2ps)
++  add_library(gl2ps gl2ps.c gl2ps.h)
+ 
+-  add_library(shared SHARED gl2ps.c gl2ps.h)
+-  target_link_libraries(shared ${EXTERNAL_LIBRARIES})
+-  set_target_properties(shared PROPERTIES OUTPUT_NAME gl2ps
++  target_link_libraries(gl2ps ${EXTERNAL_LIBRARIES})
++  set_target_properties(gl2ps PROPERTIES OUTPUT_NAME gl2ps
+     VERSION ${GL2PS_MAJOR_VERSION}.${GL2PS_MINOR_VERSION}.${GL2PS_PATCH_VERSION}
+     SOVERSION ${GL2PS_MAJOR_VERSION})
+   if(WIN32 OR CYGWIN)
+-    set_target_properties(shared PROPERTIES
++    set_target_properties(gl2ps PROPERTIES
+         COMPILE_FLAGS "-DGL2PSDLL -DGL2PSDLL_EXPORTS")
+   endif()
+-  install(TARGETS lib shared RUNTIME DESTINATION bin
++  install(TARGETS gl2ps RUNTIME DESTINATION bin
+                              LIBRARY DESTINATION lib${LIB_SUFFIX}
+                              ARCHIVE DESTINATION lib${LIB_SUFFIX})
+ endif()
+@@ -171,9 +170,9 @@ install(FILES ${CMAKE_SOURCE_DIR}/gl2psTestSimple.c DESTINATION ${GL2PS_DOC})
+ 
+ if(GLUT_FOUND)
+   add_executable(gl2psTest WIN32 gl2psTest.c)
+-  target_link_libraries(gl2psTest lib ${EXTERNAL_LIBRARIES})
++  target_link_libraries(gl2psTest gl2ps ${EXTERNAL_LIBRARIES})
+   add_executable(gl2psTestSimple WIN32 gl2psTestSimple.c)
+-  target_link_libraries(gl2psTestSimple lib ${EXTERNAL_LIBRARIES})
++  target_link_libraries(gl2psTestSimple gl2ps ${EXTERNAL_LIBRARIES})
+ endif()
+ 
+ find_package(LATEX)


### PR DESCRIPTION
gl2ps tries to build static and shared libs simultaneously with the same target name on the generator side. This causes problems for Ninja.
This PR only allows for building one lib at a time when Ninja is selected as the generator, behavior with Make remains consistent.