### PR TITLE
ParaView: add latest release v5.11.1

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -28,10 +28,11 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master", submodules=True)
     version(
-        "5.11.0",
-        sha256="9a0b8fe8b1a2cdfd0ace9a87fa87e0ec21ee0f6f0bcb1fdde050f4f585a25165",
+        "5.11.1",
+        sha256="5cc2209f7fa37cd3155d199ff6c3590620c12ca4da732ef7698dec37fa8dbb34",
         preferred=True,
     )
+    version("5.11.0", sha256="9a0b8fe8b1a2cdfd0ace9a87fa87e0ec21ee0f6f0bcb1fdde050f4f585a25165")
     version("5.10.1", sha256="520e3cdfba4f8592be477314c2f6c37ec73fb1d5b25ac30bdbd1c5214758b9c2")
     version("5.10.0", sha256="86d85fcbec395cdbc8e1301208d7c76d8f48b15dc6b967ffbbaeee31242343a5")
     version("5.9.1", sha256="0d486cb6fbf55e428845c9650486f87466efcb3155e40489182a7ea85dfd4c8d")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -270,7 +270,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # Patch for paraview 5.10: +hdf5 ^hdf5@1.13.2:
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9690
     patch("vtk-xdmf2-hdf51.13.1.patch", when="@5.10.0:5.10")
-    patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.10:")
+    patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.10:5.11.0")
 
     # Fix VTK to work with external freetype using CONFIG mode for find_package
     patch("FindFreetype.cmake.patch", when="@5.10.1:")


### PR DESCRIPTION
:tada: :tada: :tada:

ParaView 5.11.1 is out

This PR updates the ParaView Spack package to include this new release ParaView v5.11.1 as the preferred version.

Let me know if we need to change anything else in the package.

:tada: :tada: :tada: