### PR TITLE
Cast spec target arch to string before 64 bit check

### DIFF
--- a/var/spack/repos/builtin/packages/7zip/package.py
+++ b/var/spack/repos/builtin/packages/7zip/package.py
@@ -70,7 +70,7 @@ class _7zip(SourceforgePackage, Package):
         return arch
 
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def build(self, spec, prefix):
         link_type = "1" if "static" in spec.variants["link_type"].value else "0"

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -39,7 +39,7 @@ class GenericBuilder(GenericBuilder):
     phases = ["build", "install"]
 
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def build(self, spec, prefix):
         if spec.satisfies("%msvc"):

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -69,7 +69,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
 
 class MSBuildBuilder(MSBuildBuilder):
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def setup_build_environment(self, env):
         spec = self.pkg.spec

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -57,7 +57,7 @@ class GenericBuilder(GenericBuilder):
         env.set("SPACK_IFORT", ifort_root)
 
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def build_command_line(self):
         args = ["-noLogo"]

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -231,7 +231,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         return args
 
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -97,7 +97,7 @@ class MSBuildBuilder(MSBuildBuilder):
         return os.path.join(win_dir, newest_compiler)
 
     def is_64bit(self):
-        return "64" in self.pkg.spec.target.family
+        return "64" in str(self.pkg.spec.target.family)
 
     def msbuild_args(self):
         plat = "x64" if self.is_64bit() else "x86"


### PR DESCRIPTION
64bit checks were refactored in #35797 to check spec target arch rather than host system platform arch, however this refactor did not properly cast the target arch to a string and the checks are now universally failing. Refactor to properly effect this comparison.