### PR TITLE
Perl: nmake args class attr to method

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -213,7 +213,6 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         perm = os.stat(filename).st_mode
         os.chmod(filename, perm | 0o200)
 
-    @property
     def nmake_arguments(self):
         args = []
         if self.spec.satisfies("%msvc"):
@@ -304,7 +303,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if sys.platform == "win32":
             win32_dir = os.path.join(self.stage.source_path, "win32")
             with working_dir(win32_dir):
-                nmake("install", *self.nmake_arguments, ignore_quotes=True)
+                nmake("install", *self.nmake_arguments(), ignore_quotes=True)
         else:
             make("install")
 


### PR DESCRIPTION
Class attribute defined in package class is inaccesible from install method due to builder. Refactor to class method.

error message produced when _not_ including these changes:
```
==> Error: AttributeError: 'super' object has no attribute 'nmake_arguments'

The 'perl' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure

C:\spack_win\spack\lib\spack\spack\builder.py:142, in __getattr__:
  >>    142        def __getattr__(self, item):
        143            result = getattr(super(type(self.root_builder), self.root_builder), item)
        144            if item in super(type(self.root_builder), self.root_builder).phases:
        145                result = _PhaseAdapter(self.root_builder, result)
```