### PR TITLE
Fix incorrect netcdf-c patch

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/netcdfc-mpi-win-support.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/netcdfc-mpi-win-support.patch
@@ -26,7 +26,7 @@ index e3eddc0f..0493cb9d 100644
  
  IF(MPI_C_INCLUDE_PATH)
      target_include_directories(netcdf PUBLIC ${MPI_C_INCLUDE_PATH})
-+    target_link_libraries(netcdf PUBLIC MPI::MPI_C)
++    target_link_libraries(netcdf MPI::MPI_C)
  ENDIF(MPI_C_INCLUDE_PATH)
  
  IF(MOD_NETCDF_NAME)


### PR DESCRIPTION
Patch included in netcdf-c package updates for Windows was part of a larger upstream patch that does not work without further changes included in the upstream PR but not in the patch. Pare down changes made in patch so it works for Spack.