### PR TITLE
MSVC: propagate all VCVARS changes to Spack env

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -170,11 +170,10 @@ class Msvc(Compiler):
         )
 
         for env_var in int_env:
-            if int_env[env_var] != os.environ.get(env_var, None):
-                if os.pathsep not in int_env[env_var]:
-                    env.set(env_var, int_env[env_var])
-                else:
-                    env.set_path(env_var, int_env[env_var].split(os.pathsep))
+            if os.pathsep not in int_env[env_var]:
+                env.set(env_var, int_env[env_var])
+            else:
+                env.set_path(env_var, int_env[env_var].split(os.pathsep))
 
         env.set("CC", self.cc)
         env.set("CXX", self.cxx)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -169,10 +169,12 @@ class Msvc(Compiler):
             if key and value
         )
 
-        if "path" in int_env:
-            env.set_path("PATH", int_env["path"].split(";"))
-        env.set_path("INCLUDE", int_env.get("include", "").split(";"))
-        env.set_path("LIB", int_env.get("lib", "").split(";"))
+        for env_var in int_env:
+            if int_env[env_var] != os.environ.get(env_var, None):
+                if os.pathsep not in int_env[env_var]:
+                    env.set(env_var, int_env[env_var])
+                else:
+                    env.set_path(env_var, int_env[env_var].split(os.pathsep))
 
         env.set("CC", self.cc)
         env.set("CXX", self.cxx)


### PR DESCRIPTION
MSVC compilers rely on vcvars environment setup scripts to establish build environment variables necessary for all projects to build successfully. Prior to this we were only piping LIB, INCLUDE, and PATH change through.
Instead we need to propagate all changes to the env variables made by VCVARs in order to establish robust support for the MSVC compiler. This most significantly impacts projects that need to be build with NMake and MSBuild