### PR TITLE
MXNet: add v1.9

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -24,6 +24,9 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
+    # MXNet
+    - mxnet
+
     # PyTorch
     - py-botorch
     - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -27,6 +27,9 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
+    # MXNet
+    - mxnet
+
     # PyTorch
     - py-botorch
     - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -28,7 +28,8 @@ spack:
     - py-keras2onnx
 
     # MXNet
-    - mxnet
+    # https://github.com/apache/mxnet/issues/21193
+    # - mxnet
 
     # PyTorch
     - py-botorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -28,8 +28,7 @@ spack:
     - py-keras2onnx
 
     # MXNet
-    # https://github.com/apache/mxnet/issues/21193
-    # - mxnet
+    - mxnet
 
     # PyTorch
     - py-botorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -29,6 +29,9 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
+    # MXNet
+    - mxnet
+
     # PyTorch
     # Does not yet support Spack-install ROCm
     # - py-botorch

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -109,7 +109,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define_from_variant("USE_NCCL", "nccl"))
 
             # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
-            args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
+            #args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
 
         return args
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -108,9 +108,6 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
             args.append(self.define_from_variant("USE_NCCL", "nccl"))
 
-            # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
-            # args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
-
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -108,8 +108,20 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
             args.append(self.define_from_variant("USE_NCCL", "nccl"))
 
-            # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
-            args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
+            args.append(
+                self.define(
+                    "CMAKE_CUDA_FLAGS",
+                    " ".join(
+                        [
+                            # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
+                            self.compiler.cxx11_flag,
+                            # https://github.com/apache/mxnet/issues/21193
+                            # https://github.com/spack/spack/issues/36922
+                            "-L" + join_path(self.spec["cuda"].libs.directories[0], "stubs"),
+                        ]
+                    ),
+                )
+            )
 
         return args
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -99,7 +99,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define("USE_CUTENSOR", False))
 
         if "+cuda" in self.spec:
-            args.append("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc)
+            args.append(self.define("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc))
             if "cuda_arch=none" not in self.spec:
                 cuda_arch = ";".join(
                     "{0:.1f}".format(float(i) / 10.0)

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -99,6 +99,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define("USE_CUTENSOR", False))
 
         if "+cuda" in self.spec:
+            args.append("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc
             if "cuda_arch=none" not in self.spec:
                 cuda_arch = ";".join(
                     "{0:.1f}".format(float(i) / 10.0)

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -106,21 +106,18 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
                 )
                 args.append(self.define("MXNET_CUDA_ARCH", cuda_arch))
 
-            args.append(self.define_from_variant("USE_NCCL", "nccl"))
-
-            args.append(
-                self.define(
-                    "CMAKE_CUDA_FLAGS",
-                    " ".join(
-                        [
-                            # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
-                            self.compiler.cxx11_flag,
-                            # https://github.com/apache/mxnet/issues/21193
-                            # https://github.com/spack/spack/issues/36922
-                            "-L" + join_path(self.spec["cuda"].libs.directories[0], "stubs"),
-                        ]
+            args.extend(
+                [
+                    self.define_from_variant("USE_NCCL", "nccl"),
+                    # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
+                    self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag),
+                    # https://github.com/apache/mxnet/issues/21193
+                    # https://github.com/spack/spack/issues/36922
+                    self.define(
+                        "CMAKE_CXX_FLAGS",
+                        "-L" + join_path(self.spec["cuda"].libs.directories[0], "stubs"),
                     ),
-                )
+                ]
             )
 
         return args

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -7,30 +7,21 @@ from spack.package import *
 
 
 class Mxnet(CMakePackage, CudaPackage, PythonExtension):
-    """MXNet is a deep learning framework
-    designed for both efficiency and flexibility."""
+    """MXNet is a deep learning framework designed for both efficiency and flexibility."""
 
     homepage = "https://mxnet.apache.org"
     url = "https://archive.apache.org/dist/incubator/mxnet/1.7.0/apache-mxnet-src-1.7.0-incubating.tar.gz"
     list_url = "https://mxnet.apache.org/get_started/download"
-    git = "https://github.com/apache/incubator-mxnet.git"
+    git = "https://github.com/apache/mxnet.git"
 
     maintainers("adamjstewart")
 
     version("master", branch="master", submodules=True)
-    version("1.master", branch="v1.x", submodules=True)
-    version(
-        "1.8.0",
-        sha256="95aff985895aba409c08d5514510ae38b88490cfb6281ab3a5ff0f5826c8db54",
-        preferred=True,
-    )
+    version("1.master", branch="v1.x", submodules=True, deprecated=True)
+    version("1.9.1", sha256="11ea61328174d8c29b96f341977e03deb0bf4b0c37ace658f93e38d9eb8c9322")
+    version("1.8.0", sha256="95aff985895aba409c08d5514510ae38b88490cfb6281ab3a5ff0f5826c8db54")
     version("1.7.0", sha256="1d20c9be7d16ccb4e830e9ee3406796efaf96b0d93414d676337b64bc59ced18")
     version("1.6.0", sha256="01eb06069c90f33469c7354946261b0a94824bbaf819fd5d5a7318e8ee596def")
-    version(
-        "1.3.0",
-        sha256="c00d6fbb2947144ce36c835308e603f002c1eb90a9f4c5a62f4d398154eed4d2",
-        deprecated=True,
-    )
 
     variant(
         "build_type",
@@ -51,8 +42,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
     depends_on("cmake@3.13:", type="build")
     depends_on("pkgconfig", when="@1.6.0", type="build")
     depends_on("blas")
-    depends_on("cuda@:10.2", when="@:1.8.0 +cuda")
-    depends_on("cuda@:11.3", when="@2.0.0: +cuda")
+    depends_on("cuda", when="+cuda")
     depends_on("cudnn", when="+cudnn")
     depends_on("nccl", when="+nccl")
     depends_on("opencv+highgui+imgproc+imgcodecs", when="+opencv")
@@ -61,8 +51,6 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
     # python/setup.py
     extends("python", when="+python")
-    depends_on("python@2.7:2.8,3.4:", when="@:1.8.0+python", type=("build", "run"))
-    depends_on("python@3.6:", when="@2.0.0:+python", type=("build", "run"))
     depends_on("py-pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
     depends_on("py-setuptools", when="+python", type="build")
@@ -76,6 +64,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
 
     conflicts("+cudnn", when="~cuda")
     conflicts("+nccl", when="~cuda")
+    conflicts("platform=darwin target=aarch64:", when="@:1")
 
     patch("openblas-1.7.0.patch", when="@1.7.0:1.master")
     patch("openblas-1.6.0.patch", when="@1.6.0")
@@ -99,10 +88,12 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             self.define_from_variant("USE_OPENCV", "opencv"),
             self.define_from_variant("USE_OPENMP", "openmp"),
             self.define_from_variant("USE_LAPACK", "lapack"),
+            self.define("BLAS_LIBRARIES", self.spec["blas"].libs[0]),
         ]
-        if self.spec.satisfies("@:1.8.0"):
+
+        if self.spec.satisfies("@:1.8"):
             args.append(self.define_from_variant("USE_MKLDNN", "mkldnn"))
-        if self.spec.satisfies("@2.0.0:"):
+        elif self.spec.satisfies("@1.9:"):
             args.append(self.define_from_variant("USE_ONEDNN", "mkldnn"))
             args.append(self.define("USE_CUTENSOR", False))
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -109,7 +109,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define_from_variant("USE_NCCL", "nccl"))
 
             # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
-            #args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
+            # args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
 
         return args
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -99,7 +99,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define("USE_CUTENSOR", False))
 
         if "+cuda" in self.spec:
-            args.append("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc
+            args.append("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc)
             if "cuda_arch=none" not in self.spec:
                 cuda_arch = ";".join(
                     "{0:.1f}".format(float(i) / 10.0)

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -99,7 +99,6 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
             args.append(self.define("USE_CUTENSOR", False))
 
         if "+cuda" in self.spec:
-            args.append(self.define("CMAKE_CUDA_COMPILER", self.spec["cuda"].prefix.bin.nvcc))
             if "cuda_arch=none" not in self.spec:
                 cuda_arch = ";".join(
                     "{0:.1f}".format(float(i) / 10.0)
@@ -108,6 +107,9 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
                 args.append(self.define("MXNET_CUDA_ARCH", cuda_arch))
 
             args.append(self.define_from_variant("USE_NCCL", "nccl"))
+
+            # Workaround for bug in GCC 8+ and CUDA 10 on PowerPC
+            args.append(self.define("CMAKE_CUDA_FLAGS", self.compiler.cxx11_flag))
 
         return args
 

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -19,6 +19,7 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
     version("master", branch="master", submodules=True)
     version("1.master", branch="v1.x", submodules=True, deprecated=True)
     version("1.9.1", sha256="11ea61328174d8c29b96f341977e03deb0bf4b0c37ace658f93e38d9eb8c9322")
+    version("1.9.0", sha256="a2a99cf604d57094269cacdfc4066492b2dc886593ee02b862e034f6180f712d")
     version("1.8.0", sha256="95aff985895aba409c08d5514510ae38b88490cfb6281ab3a5ff0f5826c8db54")
     version("1.7.0", sha256="1d20c9be7d16ccb4e830e9ee3406796efaf96b0d93414d676337b64bc59ced18")
     version("1.6.0", sha256="01eb06069c90f33469c7354946261b0a94824bbaf819fd5d5a7318e8ee596def")


### PR DESCRIPTION
Also adds MXNet to CI.

Still doesn't build on macOS arm64 yet:
```
Undefined symbols for architecture arm64:
  "_cblas_dgemm_batch", referenced from:
      mshadow::expr::BLASEngine<mshadow::cpu, double>::batched_gemm(mshadow::Stream<mshadow::cpu>*, bool, bool, long long, long long, long long, double, double const*, long long, double const*, long long, double, double*, long long, long long, double**) in np_matmul_op.cc.o
      mshadow::expr::BLASEngine<mshadow::cpu, double>::batched_gemm(mshadow::Stream<mshadow::cpu>*, bool, bool, long long, long long, long long, double, double const*, long long, double const*, long long, double, double*, long long, long long, double**) in dot.cc.o
...
```
Please help. Prob still safe to merge even if it doesn't fix macOS arm64 support.