### PR TITLE
Add a vc version

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -282,7 +282,7 @@ class Root(CMakePackage):
     )
     # depends_on('intel-tbb@:2021.0', when='@:6.22 ^intel-tbb')
     depends_on("unuran", when="+unuran")
-    depends_on("vc", when="+vc")
+    depends_on("vc@1.3.0", when="+vc")
     depends_on("vdt", when="+vdt")
     depends_on("veccore", when="+veccore")
     depends_on("libxml2", when="+xml")


### PR DESCRIPTION
It seems ROOT searches for a specific version of Vc, see https://github.com/root-project/root/blob/fb891723bc2750754f0908bfa404421e0cb2211b/cmake/modules/SearchInstalledSoftware.cmake#L1437. When building with a newer version installed cmake would complain that it doesn't find 1.3.0, so I added a version in the dependency.