### PR TITLE
External Detection for llvm-amdgpu

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -5,6 +5,7 @@
 
 
 import os
+import re
 
 from spack.package import *
 
@@ -17,6 +18,7 @@ class LlvmAmdgpu(CMakePackage):
     git = "https://github.com/RadeonOpenCompute/llvm-project.git"
     url = "https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
+    executables = [r"amdclang", r"amdclang\+\+", r"amdflang", r"clang.*", r"flang.*", "llvm-.*"]
     generator("ninja")
 
     maintainers("srekolam", "renjithravindrankannath", "haampie")
@@ -291,3 +293,16 @@ class LlvmAmdgpu(CMakePackage):
                 cmake_args.extend(self.cmake_args())
                 cmake(*cmake_args)
                 cmake("--build", ".")
+
+    @classmethod
+    def determine_version(cls, path):
+        match = re.search(r"amdclang", path)
+        ver = None
+        if match:
+            version_query = Executable(path)("--version", output=str)
+            match = re.search(r"roc-(\d)\.(\d).(\d)", version_query)
+            if match:
+                ver = "{0}.{1}.{2}".format(
+                    int(match.group(1)), int(match.group(2)), int(match.group(3))
+                )
+        return ver

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -297,12 +297,12 @@ class LlvmAmdgpu(CMakePackage):
     @classmethod
     def determine_version(cls, path):
         match = re.search(r"amdclang", path)
-        ver = None
+        detected_version = None
         if match:
             version_query = Executable(path)("--version", output=str)
             match = re.search(r"roc-(\d)\.(\d).(\d)", version_query)
             if match:
-                ver = "{0}.{1}.{2}".format(
+                detected_version = "{0}.{1}.{2}".format(
                     int(match.group(1)), int(match.group(2)), int(match.group(3))
                 )
-        return ver
+        return detected_version


### PR DESCRIPTION
This PR allows ```llvm-amdgpu``` to be externally detected. ```llvm-amdgpu``` is almost always a dependency for using and developing ROCm applications. Almost all other "fundamental" packages for ROCm can be externally detected except ```llvm-amdgpu```, forcing Spack users to build it from scratch.

Matin 