### PR TITLE
papyrus: disable tests

### DIFF
--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -103,5 +103,5 @@ class Papyrus(CMakePackage):
                 work_dir=test_dir,
             )
 
-    def test(self):
-        self.run_example_tests()
+    # def test(self):
+    #     self.run_example_tests()


### PR DESCRIPTION
Currently papyrus delays in Gitlab CI by 18h because Spack doesn't enforce a
timeout for tests, and papyrus's tests are stuck.