### PR TITLE
stdexec: Bump required CMake version

### DIFF
--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -15,7 +15,7 @@ class Stdexec(CMakePackage):
 
     version("main", branch="main")
 
-    depends_on("cmake@3.22.1:", type="build")
+    depends_on("cmake@3.23.1:", type="build")
 
     conflicts("%gcc@:10")
     conflicts("%clang@:13")


### PR DESCRIPTION
Despite the minimum being 3.22.1 in stdexec's own CMakeLists.txt (https://github.com/NVIDIA/stdexec/blob/21f92767af4cb3d38cb70e019c9aceb668cbe2bd/CMakeLists.txt#L1), stdexec uses rapids-cmake which requires 3.23.1 (https://github.com/rapidsai/rapids-cmake/blob/c7a28304639a2ed460181b4753f3280c7833c718/CMakeLists.txt#L28), so I'm bumping the requirement.