### PR TITLE
buildcache.py: show download url; use tty.msg/tty.debug consistently in fetch strategies

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1475,7 +1475,7 @@ def try_fetch(url_to_fetch):
     stage.create()
 
     try:
-        stage.fetch()
+        stage.fetch(verbose=False)
     except web_util.FetchError:
         stage.destroy()
         return None

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -24,7 +24,7 @@ import urllib.request
 import warnings
 from contextlib import closing, contextmanager
 from gzip import GzipFile
-from typing import Union
+from typing import NamedTuple, Optional, Union
 from urllib.error import HTTPError, URLError
 
 import ruamel.yaml as yaml
@@ -61,6 +61,15 @@ from spack.util.executable import which
 
 _build_cache_relative_path = "build_cache"
 _build_cache_keys_relative_path = "_pgp"
+
+
+class DownloadResult(NamedTuple):
+    """Result of a buildcache download."""
+
+    tarball_stage: Stage
+    specfile_stage: Stage
+    signature_verified: bool
+    url: str
 
 
 class FetchCacheError(Exception):
@@ -1474,13 +1483,13 @@ def try_fetch(url_to_fetch):
     return stage
 
 
-def _delete_staged_downloads(download_result):
+def _delete_staged_downloads(download_result: DownloadResult):
     """Clean up stages used to download tarball and specfile"""
-    download_result["tarball_stage"].destroy()
-    download_result["specfile_stage"].destroy()
+    download_result.tarball_stage.destroy()
+    download_result.specfile_stage.destroy()
 
 
-def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
+def download_tarball(spec, unsigned=False, mirrors_for_spec=None) -> Optional[DownloadResult]:
     """
     Download binary tarball for given package into stage area, returning
     path to downloaded tarball if successful, None otherwise.
@@ -1496,20 +1505,12 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
     Returns:
         ``None`` if the tarball could not be downloaded (maybe also verified,
         depending on whether new-style signed binary packages were found).
-        Otherwise, return an object indicating the path to the downloaded
-        tarball, the path to the downloaded specfile (in the case of new-style
-        buildcache), and whether or not the tarball is already verified.
-
-    .. code-block:: JSON
-
-       {
-           "tarball_path": "path-to-locally-saved-tarfile",
-           "specfile_path": "none-or-path-to-locally-saved-specfile",
-           "signature_verified": "true-if-binary-pkg-was-already-verified"
-       }
+        Otherwise, return a ``DownloadResult`` object indicating the path to the
+        downloaded tarball, the path to the downloaded specfile (in the case of
+        new-style buildcache), and whether or not the tarball is already verified.
     """
     if not spack.mirror.MirrorCollection():
-        tty.die("Please add a spack mirror to allow " + "download of pre-compiled packages.")
+        tty.die("Please add a spack mirror to allow download of pre-compiled packages.")
 
     tarball = tarball_path_name(spec, ".spack")
     specfile_prefix = tarball_name(spec, ".spec")
@@ -1582,11 +1583,9 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
                     #     the remaining mirrors, looking for one we can use.
                     tarball_stage = try_fetch(spackfile_url)
                     if tarball_stage:
-                        return {
-                            "tarball_stage": tarball_stage,
-                            "specfile_stage": local_specfile_stage,
-                            "signature_verified": signature_verified,
-                        }
+                        return DownloadResult(
+                            tarball_stage, local_specfile_stage, signature_verified, spackfile_url
+                        )
 
                 local_specfile_stage.destroy()
 
@@ -1864,7 +1863,9 @@ def _extract_inner_tarball(spec, filename, extract_to, unsigned, remote_checksum
     return tarfile_path
 
 
-def extract_tarball(spec, download_result, allow_root=False, unsigned=False, force=False):
+def extract_tarball(
+    spec, download_result: DownloadResult, allow_root=False, unsigned=False, force=False
+):
     """
     extract binary tarball for given package into install area
     """
@@ -1874,7 +1875,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         else:
             raise NoOverwriteException(str(spec.prefix))
 
-    specfile_path = download_result["specfile_stage"].save_filename
+    specfile_path = download_result.specfile_stage.save_filename
 
     with open(specfile_path, "r") as inputfile:
         content = inputfile.read()
@@ -1884,8 +1885,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
             spec_dict = sjson.load(content)
 
     bchecksum = spec_dict["binary_cache_checksum"]
-    filename = download_result["tarball_stage"].save_filename
-    signature_verified = download_result["signature_verified"]
+    filename = download_result.tarball_stage.save_filename
     tmpdir = None
 
     if (
@@ -1910,7 +1910,7 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False, for
         # the tarball.
         tarfile_path = filename
 
-        if not unsigned and not signature_verified:
+        if not unsigned and not download_result.signature_verified:
             raise UnsignedPackageException(
                 "To install unsigned packages, use the --no-check-signature option."
             )

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2012,7 +2012,7 @@ def install_root_node(spec, allow_root, unsigned=False, force=False, sha256=None
     if sha256:
         checker = spack.util.crypto.Checker(sha256)
         msg = 'cannot verify checksum for "{0}" [expected={1}]'
-        tarball_path = download_result["tarball_stage"].save_filename
+        tarball_path = download_result.tarball_stage.save_filename
         msg = msg.format(tarball_path, sha256)
         if not checker.check(tarball_path):
             size, contents = fsys.filesummary(tarball_path)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -387,7 +387,7 @@ def _process_binary_cache_tarball(
         if download_result is None:
             return False
 
-    tty.msg("Extracting {0} from binary cache".format(package_id(pkg)))
+    tty.msg(f"Extracting {package_id(pkg)} from {download_result.url}")
 
     with timer.measure("install"), spack.util.path.filter_padding():
         binary_distribution.extract_tarball(

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -387,7 +387,7 @@ def _process_binary_cache_tarball(
         if download_result is None:
             return False
 
-    tty.msg(f"Extracting {package_id(pkg)} from {download_result.url}")
+    tty.msg(f"Fetched {package_id(pkg)} from {download_result.url}")
 
     with timer.measure("install"), spack.util.path.filter_padding():
         binary_distribution.extract_tarball(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -431,7 +431,7 @@ class Stage(object):
         """Returns the well-known source directory path."""
         return os.path.join(self.path, _source_path_subdir)
 
-    def fetch(self, mirror_only=False, err_msg=None):
+    def fetch(self, mirror_only=False, err_msg=None, verbose=True):
         """Retrieves the code or archive
 
         Args:
@@ -523,7 +523,7 @@ class Stage(object):
             try:
                 fetcher.stage = self
                 self.fetcher = fetcher
-                self.fetcher.fetch()
+                self.fetcher.fetch(verbose=verbose)
                 break
             except spack.fetch_strategy.NoCacheError:
                 # Don't bother reporting when something is not cached.

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -587,9 +587,7 @@ def test_install_legacy_buildcache_layout(install_mockery_mutable_config):
     mirror_cmd("add", "--scope", "site", "test-legacy-layout", mirror_url)
     output = install_cmd("--no-check-signature", "--cache-only", "-f", spec_json_path, output=str)
     mirror_cmd("rm", "--scope=site", "test-legacy-layout")
-    expect_line = (
-        "Extracting archive-files-2.0-" "l3vdiqvbobmspwyb4q2b62fz6nitd4hk from binary cache"
-    )
+    expect_line = f"Fetched archive-files-2.0-l3vdiqvbobmspwyb4q2b62fz6nitd4hk from {mirror_url}"
     assert expect_line in output
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1099,10 +1099,10 @@ def test_install_use_buildcache(
 
     def validate(mode, out, pkg):
         def assert_auto(pkg, out):
-            assert "==> Extracting {0}".format(pkg) in out
+            assert "==> Fetched {0}".format(pkg) in out
 
         def assert_only(pkg, out):
-            assert "==> Extracting {0}".format(pkg) in out
+            assert "==> Fetched {0}".format(pkg) in out
 
         def assert_never(pkg, out):
             assert "==> {0}: Executing phase: 'install'".format(pkg) in out

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -471,7 +471,7 @@ class MockCache(object):
 
 
 class MockCacheFetcher(object):
-    def fetch(self):
+    def fetch(self, verbose=True):
         raise FetchError("Mock cache always fails for tests")
 
     def __str__(self):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -206,11 +206,11 @@ def test_process_external_package_module(install_mockery, monkeypatch, capfd):
 def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
     """Tests of _process_binary_cache_tarball with a tar file."""
 
-    def _spec(spec, unsigned=False, mirrors_for_spec=None):
-        return spec
+    def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
+        return spack.binary_distribution.DownloadResult(None, None, True, "http://url")
 
     # Skip binary distribution functionality since assume tested elsewhere
-    monkeypatch.setattr(spack.binary_distribution, "download_tarball", _spec)
+    monkeypatch.setattr(spack.binary_distribution, "download_tarball", download_tarball)
     monkeypatch.setattr(spack.binary_distribution, "extract_tarball", _noop)
 
     # Skip database updates
@@ -220,8 +220,8 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
     assert inst._process_binary_cache_tarball(spec.package, explicit=False, unsigned=False)
 
     out = capfd.readouterr()[0]
-    assert "Extracting a" in out
-    assert "from binary cache" in out
+    assert "Fetched" in out
+    assert "from http://url" in out
 
 
 def test_try_install_from_binary_cache(install_mockery, mock_packages, monkeypatch):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -215,7 +215,7 @@ def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
     def record_store(_class, fetcher, relative_dst, cosmetic_path=None):
         files_cached_in_mirror.add(os.path.basename(relative_dst))
 
-    def successful_fetch(_class):
+    def successful_fetch(_class, verbose=True):
         with open(_class.stage.save_filename, "w"):
             pass
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -548,7 +548,7 @@ def mock_download():
         def mirror_id(self):
             return None
 
-        def fetch(self):
+        def fetch(self, verbose=True):
             raise spack.fetch_strategy.FailedDownloadError(
                 "<non-existent URL>", "This FetchStrategy always fails"
             )
@@ -599,7 +599,7 @@ def fetching_not_allowed(monkeypatch):
         def mirror_id(self):
             return None
 
-        def fetch(self):
+        def fetch(self, verbose=True):
             raise Exception("Sources are fetched but shouldn't have been")
 
     fetcher = FetchStrategyComposite()

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -328,7 +328,7 @@ def failing_fetch_strategy():
     """Returns a fetch strategy that fails."""
 
     class FailingFetchStrategy(spack.fetch_strategy.FetchStrategy):
-        def fetch(self):
+        def fetch(self, verbose=True):
             raise spack.fetch_strategy.FailedDownloadError(
                 "<non-existent URL>", "This implementation of FetchStrategy always fails"
             )

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -215,6 +215,8 @@ class Boost(Package):
         description="Default symbol visibility in compiled libraries " "(1.69.0 or later)",
     )
 
+    variant("rebuild_me_please", default=True, description="test in ci")
+
     # Unicode support
     depends_on("icu4c", when="+icu")
     depends_on("icu4c cxxstd=11", when="+icu cxxstd=11")


### PR DESCRIPTION
- binary_distribution.py: print url the tarball is fetched from
- consistently use tty.msg/tty.debug, reduce verbosity for buildcache install

The goal is to be able to copy a link for a single tarball from CI log files
