### PR TITLE
Fix bigdft-suite compilation

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-chess/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-chess/package.py
@@ -25,6 +25,10 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
     variant("ntpoly", default=False, description="Option to use NTPoly")
     # variant('minpack', default=False,  description='Give the link-line for MINPACK')
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@3.0:", type=("build", "run"))
 
     depends_on("blas")
@@ -39,13 +43,7 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
         depends_on("bigdft-futile@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-atlab@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "chess"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "chess"
 
     def configure_args(self):
         spec = self.spec
@@ -61,12 +59,15 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
         linalg = []
         if "+scalapack" in spec:
             linalg.append(spec["scalapack"].libs.ld_flags)
+        linalg.append(spec["lapack"].libs.ld_flags)
+        linalg.append(spec["blas"].libs.ld_flags)
 
         args = [
             "FCFLAGS=%s" % " ".join(openmp_flag),
+            "LDFLAGS=%s" % " ".join(linalg),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -24,6 +24,10 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@3.0:", type=("build", "run"))
 
     depends_on("blas")
@@ -43,13 +47,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-libabinit@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "bigdft"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "bigdft"
 
     def configure_args(self):
         spec = self.spec
@@ -72,13 +70,13 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
-            "--with-chess-libs=%s" % spec["bigdft-chess"].prefix.lib,
+            "--with-chess-libs=%s" % spec["bigdft-chess"].libs.ld_flags,
             "--with-chess-incs=%s" % spec["bigdft-chess"].headers.include_flags,
-            "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
+            "--with-psolver-libs=%s" % spec["bigdft-psolver"].libs.ld_flags,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,
-            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].prefix.lib,
+            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].libs.ld_flags,
             "--with-libABINIT-incs=%s" % spec["bigdft-libabinit"].headers.include_flags,
             "--with-libgain-libs=%s" % spec["libgain"].libs.ld_flags,
             "--with-libgain-incs=%s" % spec["libgain"].headers.include_flags,

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -25,6 +25,10 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@3.0:", type=("build", "run"))
 
     depends_on("blas")
@@ -33,13 +37,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     depends_on("py-pyyaml")
     depends_on("mpi", when="+mpi")
 
-    build_directory = "futile"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "futile"
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -24,6 +24,10 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@3.0:", type=("build", "run"))
 
     depends_on("blas")
@@ -36,13 +40,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
         depends_on("bigdft-futile@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-atlab@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "psolver"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "psolver"
 
     def configure_args(self):
         spec = self.spec
@@ -65,7 +63,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -19,6 +19,10 @@ class BigdftSpred(AutotoolsPackage):
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
@@ -36,13 +40,7 @@ class BigdftSpred(AutotoolsPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-core@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "spred"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "spred"
 
     def configure_args(self):
         spec = self.spec
@@ -65,7 +63,7 @@ class BigdftSpred(AutotoolsPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,


### PR DESCRIPTION
This MR fixes Psolver compilation issue.
It fixes the issue addressed at https://github.com/spack/spack/issues/34351

Tested on spec `bigdft-psolver@1.9.2%gcc@10.3.0~cuda+mpi+openmp+scalapack`
This MR is cherry-picked from https://github.com/danielecesarini/spack/commit/d20f2841009eb037344e73516d38716769643e4b along with some modification to get `bigdft-atlab` to compile  (https://github.com/danielecesarini/spack/pull/43)