### PR TITLE
ADOL-C: Fix libs property

### DIFF
--- a/var/spack/repos/builtin/packages/adol-c/package.py
+++ b/var/spack/repos/builtin/packages/adol-c/package.py
@@ -153,3 +153,8 @@ class AdolC(AutotoolsPackage):
                     join_path(source_directory, "ADOL-C", "examples", "additional_examples")
                 ):
                     Executable("./checkpointing/checkpointing")()
+
+    @property
+    def libs(self):
+        """The name of the library differs from the package name => own libs handling."""
+        return find_libraries(["libadolc"], root=self.prefix, shared=True, recursive=True)


### PR DESCRIPTION
- The default libs handler results in libadol-c being searched.
- The installed lib is called libadolc, so it fails.
- The property has been overriden, eliminating the bug.