### PR TITLE
macOS: use Apple GL/GLU by default

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -50,4 +50,4 @@ packages:
     # Apple bundles libuuid in libsystem_c version 1353.100.2,
     # although the version number used here isn't critical
     - spec: apple-libuuid@1353.100.2
-      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+      prefix: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk

--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -50,4 +50,4 @@ packages:
     # Apple bundles libuuid in libsystem_c version 1353.100.2,
     # although the version number used here isn't critical
     - spec: apple-libuuid@1353.100.2
-      prefix: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk

--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -30,13 +30,13 @@ packages:
   apple-gl:
     buildable: false
     externals:
-    - spec: apple-gl@1.0.0
-      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current
+    - spec: apple-gl@4.1.0
+      prefix: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
   apple-glu:
     buildable: false
     externals:
-    - spec: apple-glu@1.0.0
-      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current
+    - spec: apple-glu@1.3.0
+      prefix: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
   apple-libunwind:
     buildable: false
     externals:

--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -23,8 +23,20 @@ packages:
     providers:
       elf: [libelf]
       fuse: [macfuse]
+      gl: [apple-gl]
+      glu: [apple-glu]
       unwind: [apple-libunwind]
       uuid: [apple-libuuid]
+  apple-gl:
+    buildable: false
+    externals:
+    - spec: apple-gl@1.0.0
+      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current
+  apple-glu:
+    buildable: false
+    externals:
+    - spec: apple-glu@1.0.0
+      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current
   apple-libunwind:
     buildable: false
     externals:

--- a/var/spack/repos/builtin/packages/apple-gl/package.py
+++ b/var/spack/repos/builtin/packages/apple-gl/package.py
@@ -30,11 +30,6 @@ class AppleGl(Package):
 
     phases = []
 
-    sdk_base = (
-        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
-        "Developer/SDKs/MacOSX"
-    )
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         # we try to setup a build environment with enough hints
         # for the build system to pick up on the Apple framework version
@@ -44,16 +39,14 @@ class AppleGl(Package):
         # - for the rest of the build systems we'll assume that
         # setting the C_INCLUDE_PATH will be enough for the compilation phase
         # and *** for the link phase.
-        env.prepend_path("C_INCLUDE_PATH", self.sdk_base)
+        env.prepend_path("C_INCLUDE_PATH", self.prefix[:-4])
 
     @property
     def headers(self):
         return HeaderList(
-            "{}.sdk/System/Library/Frameworks/OpenGL.framework/Headers".format(self.sdk_base)
+            join_path(self.prefix, "System/Library/Frameworks/OpenGL.framework/Headers")
         )
 
     @property
     def libs(self):
-        return LibraryList(
-            "{}.sdk/System/Library/Frameworks/OpenGL.framework".format(self.sdk_base)
-        )
+        return LibraryList(join_path(self.prefix, "System/Library/Frameworks/OpenGL.framework"))

--- a/var/spack/repos/builtin/packages/apple-glu/package.py
+++ b/var/spack/repos/builtin/packages/apple-glu/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class AppleGlu(Package):
     """Shim package for Apple implementation of OpenGL Utility Libray (GLU)"""
 
-    homepage = ""
+    homepage = "https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_intro/opengl_intro.html"
 
     maintainers("aphecetche")
 
@@ -28,11 +28,6 @@ class AppleGlu(Package):
 
     phases = []
 
-    sdk_base = (
-        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
-        "Developer/SDKs/MacOSX"
-    )
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         # we try to setup a build environment with enough hints
         # for the build system to pick up on the Apple framework version
@@ -42,16 +37,14 @@ class AppleGlu(Package):
         # - for the rest of the build systems we'll assume that
         # setting the C_INCLUDE_PATH will be enough for the compilation phase
         # and *** for the link phase.
-        env.prepend_path("C_INCLUDE_PATH", self.sdk_base)
+        env.prepend_path("C_INCLUDE_PATH", self.prefix[:-4])
 
     @property
     def headers(self):
         return HeaderList(
-            "{}.sdk/System/Library/Frameworks/OpenGL.framework/Headers".format(self.sdk_base)
+            join_path(self.prefix, "System/Library/Frameworks/OpenGL.framework/Headers")
         )
 
     @property
     def libs(self):
-        return LibraryList(
-            "{}.sdk/System/Library/Frameworks/OpenGL.framework".format(self.sdk_base)
-        )
+        return LibraryList(join_path(self.prefix, "System/Library/Frameworks/OpenGL.framework"))


### PR DESCRIPTION
Allowed me to successfully install glew. We should use these by default, I haven't found any other GL/GLU provider that works on macOS.

@aphecetche