### PR TITLE
PyTorch: fix ppc64le patching

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -350,7 +350,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         when="@1.12 arch=ppc64le:",
     )
     patch(
-        "https://github.com/open-ce/pytorch-feedstock/raw/main/pytorch-1.13/recipe/0302-cpp-extension.patch",
+        "https://github.com/open-ce/pytorch-feedstock/raw/open-ce-v1.8.0/pytorch-1.13/recipe/0302-cpp-extension.patch",
         sha256="a54db63640b90e5833cc1099c0935572f5297d2d8625f62f01ac1fda79ed4569",
         when="@1.13 arch=ppc64le:",
     )

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -354,7 +354,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         sha256="a54db63640b90e5833cc1099c0935572f5297d2d8625f62f01ac1fda79ed4569",
         when="@1.13 arch=ppc64le:",
     )
-    conflicts("arch=ppc64le:", when="@:1.9")
+    conflicts("arch=ppc64le:", when="@:1.9,2:")
 
     # Cherry-pick a patch to allow earlier versions of PyTorch to work with CUDA 11.4
     patch(

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -354,7 +354,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         sha256="a54db63640b90e5833cc1099c0935572f5297d2d8625f62f01ac1fda79ed4569",
         when="@1.13 arch=ppc64le:",
     )
-    conflicts("arch=ppc64le:", when="@:1.9,2:")
+    conflicts("arch=ppc64le:", when="@:1.9")
 
     # Cherry-pick a patch to allow earlier versions of PyTorch to work with CUDA 11.4
     patch(


### PR DESCRIPTION
File was moved when 2.0 support was added. 2.0 doesn't need any patches, so it should work out of the box.