### PR TITLE
dealii: add support for 9.4.1 and 9.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -26,6 +26,8 @@ class Dealii(CMakePackage, CudaPackage):
     generator("ninja")
 
     version("master", branch="master")
+    version("9.4.2", sha256="45a76cb400bfcff25cc2d9093d9a5c91545c8367985e6798811c5e9d2a6a6fd4")
+    version("9.4.1", sha256="bfe5e4bf069159f93feb0f78529498bfee3da35baf5a9c6852aa59d7ea7c7a48")
     version("9.4.0", sha256="238677006cd9173658e5b69cdd1861f800556982db6005a3cc5eb8329cc1e36c")
     version("9.3.3", sha256="5dfb59174b341589e92b434398a1b7cc11ad053ce2315cf673f5efc5ba271a29")
     version("9.3.2", sha256="5341d76bfd75d3402fc6907a875513efb5fe8a8b99af688d94443c492d5713e8")

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -61,6 +61,14 @@ class Dealii(CMakePackage, CudaPackage):
         description="Compile using the specified C++ standard",
         values=("default", "11", "14", "17"),
     )
+    variant(
+        "cxxstd",
+        default="17",
+        when="@9.4:",
+        multi=False,
+        description="Compile using the specified C++ standard",
+        values=("default", "11", "14", "17"),
+    )
     variant("doc", default=False, description="Compile with documentation")
     variant("examples", default=True, description="Compile tutorial programs")
     variant("int64", default=False, description="Compile with 64 bit indices support")
@@ -279,6 +287,12 @@ class Dealii(CMakePackage, CudaPackage):
         "cxxstd=14",
         when="@9.4:+cgal",
         msg="CGAL requires the C++ standard to be set to 17 or later.",
+    )
+
+    conflicts(
+        "cxxstd=default",
+        when="@9.4:+cgal",
+        msg="CGAL requires the C++ standard to be set explicitly to 17 or later.",
     )
 
     # Interfaces added in 8.5.0:

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -264,12 +264,12 @@ class Dealii(CMakePackage, CudaPackage):
     patch(
         "https://github.com/dealii/dealii/commit/06bb9dc07efb6fea9912ee0d66264af548c552c8.patch?full_index=1",
         sha256="8a1f7b9a155c8c496ce08b2abb1ba5d329b3b29169f36c11678aa4e3cebf97a2",
-        when="@9.4.0 ^hdf5",
+        when="@9.4 ^hdf5",
     )
     patch(
         "https://github.com/dealii/dealii/commit/40076ac1a013cd7d221f9dda913b4d0e6452c21e.patch?full_index=1",
         sha256="7869dfab1116b6e862279bb6642c2c8fe49d87c42cfc6f031e03330f9f26a6c3",
-        when="@9.4.0 ^python",
+        when="@9.4 ^python",
     )
 
     # Fix issues with the FIND_GINKGO module for the newer Ginkgo versions
@@ -277,7 +277,7 @@ class Dealii(CMakePackage, CudaPackage):
     patch(
         "https://github.com/dealii/dealii/commit/df6c5de8d6785fce701c10575982858f3aeb4cbd.patch?full_index=1",
         sha256="c9884ebb0fe379c539012a225d8bcdcfe288edec8dc9d319fbfd64d8fbafba8e",
-        when="@:9.4.0+ginkgo ^ginkgo@1.5.0:",
+        when="@:9.4 +ginkgo ^ginkgo@1.5.0:",
     )
 
     # Check for sufficiently modern versions


### PR DESCRIPTION
We forgot to bump the versions for the last two minor releases. No other changes are needed.