### PR TITLE
Environment/depfile: fix bug with Git hash versions

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -676,7 +676,7 @@ class MakeTargetVisitor(object):
         return ""
 
     def accept(self, node):
-        fmt = "{name}-{version}-{hash}"
+        fmt = "{name}-{hash}"
         tgt = node.edge.spec.format(fmt)
         spec_str = node.edge.spec.format(
             "{name}{@version}{%compiler}{variants}{arch=architecture}"
@@ -736,7 +736,7 @@ def env_depfile(args):
     )
 
     # Root specs without deps are the prereqs for the environment target
-    root_install_targets = [get_install_target(h.format("{name}-{version}-{hash}")) for h in roots]
+    root_install_targets = [get_install_target(h.format("{name}-{hash}")) for h in roots]
 
     all_pkg_identifiers = []
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -698,16 +698,14 @@ class MakeTargetVisitor(object):
         return True
 
 
-def _fmt_spec_make_target(spec):
+def _fmt_spec_make_target(spec: [spack.spec.Spec]) -> str:
     """Create a unique identifier string from a Spec to use as a make target.
 
     Many characters in a typical Spec formatted string trigger special
     behavior in `make`, including '=', and '%'. To avoid potential issues,
-    filter all characters except a small set which are guaranteed not to have
-    special meaning.
+    allow only a small set of characters which are known not to have any
+    special meaning (any other character is replaced with "_").
     """
-    if not isinstance(spec, spack.spec.Spec):
-        raise ValueError("Internal error: got non-spec object: {0}".format(spec))
     tgt = spec.format("{name}-{version}-{hash}")
     return re.sub(r"[^A-Za-z0-9_.-]", "_", tgt)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -698,6 +698,7 @@ class MakeTargetVisitor(object):
         return True
 
 
+_fmt_spec_make_target_pattern = re.compile(r"[^A-Za-z0-9_.-]")
 def _fmt_spec_make_target(spec: [spack.spec.Spec]) -> str:
     """Create a unique identifier string from a Spec to use as a make target.
 
@@ -707,7 +708,7 @@ def _fmt_spec_make_target(spec: [spack.spec.Spec]) -> str:
     special meaning (any other character is replaced with "_").
     """
     tgt = spec.format("{name}-{version}-{hash}")
-    return re.sub(r"[^A-Za-z0-9_.-]", "_", tgt)
+    return _fmt_spec_make_target_pattern.sub("_", tgt)
 
 
 def env_depfile(args):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -677,14 +677,21 @@ class MakeTargetVisitor(object):
         return ""
 
     def accept(self, node):
-        fmt = "{name}-{version}-{hash}"
         spec_str = node.edge.spec.format(
             "{name}{@version}{%compiler}{variants}{arch=architecture}"
         )
         buildcache_flag = self.build_cache_flag(node.depth)
-        prereqs = " ".join([self.target(_fmt_spec_make_target(dep.spec)) for dep in self.neighbors(node)])
+        prereqs = " ".join(
+            [self.target(_fmt_spec_make_target(dep.spec)) for dep in self.neighbors(node)]
+        )
         self.adjacency_list.append(
-            (_fmt_spec_make_target(node.edge.spec), prereqs, node.edge.spec.dag_hash(), spec_str, buildcache_flag)
+            (
+                _fmt_spec_make_target(node.edge.spec),
+                prereqs,
+                node.edge.spec.dag_hash(),
+                spec_str,
+                buildcache_flag,
+            )
         )
 
         # We already accepted this

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -699,13 +699,18 @@ class MakeTargetVisitor(object):
 
 
 def _fmt_spec_make_target(spec):
-    """According to https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Special-Chars-in-Names.html
-    a target should only consist of "ASCII letters and digits, `.', and `_'.".
+    """Create a unique identifier string from a Spec to use as a make target.
+
+    Many characters in a typical Spec formatted string trigger special
+    behavior in `make`, including '=', and '%'.
+
+    Note that '-' is an acceptable character but may cause confusion when
+    invoking make from the shell; it is allowed here though.
     """
     if not isinstance(spec, spack.spec.Spec):
         raise ValueError("Internal error: got non-spec object: {0}".format(spec))
     tgt = spec.format("{name}-{version}-{hash}")
-    return re.sub(r"[^A-Za-z0-9_.]", "_", tgt)
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", tgt)
 
 
 def env_depfile(args):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -709,6 +709,7 @@ class MakeTargetSpecComponentFormatter(object):
     allow only a small set of characters which are known not to have any
     special meaning (any other character is replaced with "_").
     """
+
     def __init__(self):
         self._pattern = None
 
@@ -718,7 +719,7 @@ class MakeTargetSpecComponentFormatter(object):
             self._pattern = re.compile(r"[^A-Za-z0-9_.-]")
         return self._pattern
 
-    def __call__(self, spec: [spack.spec.Spec]) -> str:
+    def __call__(self, spec: spack.spec.Spec) -> str:
         tgt = spec.format("{name}-{version}-{hash}")
         return self.pattern.sub("_", tgt)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -702,10 +702,9 @@ def _fmt_spec_make_target(spec):
     """Create a unique identifier string from a Spec to use as a make target.
 
     Many characters in a typical Spec formatted string trigger special
-    behavior in `make`, including '=', and '%'.
-
-    Note that '-' is an acceptable character but may cause confusion when
-    invoking make from the shell; it is allowed here though.
+    behavior in `make`, including '=', and '%'. To avoid potential issues,
+    filter all characters except a small set which are guaranteed not to have
+    special meaning.
     """
     if not isinstance(spec, spack.spec.Spec):
         raise ValueError("Internal error: got non-spec object: {0}".format(spec))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3120,7 +3120,7 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
     assert len(specs_that_make_would_install) == len(expected_installs)
 
 
-def test_environment_depfile_makefile(tmpdir, mock_packages, monkeypatch):
+def test_environment_depfile_spec_format_special_chars(tmpdir, mock_packages, monkeypatch):
     env("create", "test")
     make = Executable("make")
     makefile = str(tmpdir.join("Makefile"))
@@ -3146,7 +3146,7 @@ def test_environment_depfile_makefile(tmpdir, mock_packages, monkeypatch):
             makefile,
             "--make-disable-jobserver",
             "--make-prefix=prefix",
-            "--use-buildcache=never"
+            "--use-buildcache=never",
         )
 
     with open(makefile, "r") as f:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3122,7 +3122,6 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
 
 def test_environment_depfile_spec_format_special_chars(tmpdir, mock_packages, monkeypatch):
     env("create", "test")
-    make = Executable("make")
     makefile = str(tmpdir.join("Makefile"))
     with ev.read("test"):
         add("dttop")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3119,6 +3119,29 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
     assert len(specs_that_make_would_install) == len(expected_installs)
 
 
+def test_environment_depfile_makefile(tmpdir, mock_packages):
+    env("create", "test")
+    make = Executable("make")
+    makefile = str(tmpdir.join("Makefile"))
+    with ev.read("test"):
+        add("dttop")
+        concretize()
+
+    # Disable jobserver so we can do a dry run.
+    with ev.read("test"):
+        env(
+            "depfile",
+            "-o",
+            makefile,
+            "--make-disable-jobserver",
+            "--make-prefix=prefix",
+            "--use-buildcache=never"
+        )
+
+    # List all targets
+    out = make("-p", makefile, output=str)
+
+
 def test_environment_depfile_out(tmpdir, mock_packages):
     env("create", "test")
     makefile_path = str(tmpdir.join("Makefile"))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3158,7 +3158,7 @@ def test_environment_depfile_spec_format_special_chars(tmpdir, mock_packages, mo
         if "githash=version" in line:
             assert re.search("SPEC = dtlink1-githash=version-spackhash$", line)
 
-    assert "dtlink1_githash_version_spackhash" in makefile_contents
+    assert "dtlink1-githash_version-spackhash" in makefile_contents
 
 
 def test_environment_depfile_out(tmpdir, mock_packages):


### PR DESCRIPTION
If a spec contains a `hash=number` version, this was resulting in malformed Makefiles generated by `spack env depfile` (the target cannot include an un-escaped '=' character); for now just remove the version from these targets altogether