### PR TITLE
allow repo to specify alternate packages subdirectory

### DIFF
--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -32,10 +32,15 @@ A package repository a directory structured like this::
           ...
 
 The top-level ``repo.yaml`` file contains configuration metadata for the
-repository, and the ``packages`` directory contains subdirectories for
-each package in the repository.  Each package directory contains a
-``package.py`` file and any patches or other files needed to build the
+repository. The packages subdirectory, typically ``packages``, contains
+subdirectories for each package in the repository.  Each package directory
+contains a ``package.py`` file and any patches or other files needed to build the
 package.
+
+The ``repo.yaml`` file may also contain a ``subdirectory`` key,
+which can modify the name of the subdirectory used for packages. As seen above,
+the default value is ``packages``. An empty string (``subdirectory: ''``) requires
+a flattened repo structure in which the package names are top-level subdirectories.
 
 Package repositories allow you to:
 
@@ -372,6 +377,24 @@ You can supply a custom namespace with a second argument, e.g.:
   $ cat myrepo/repo.yaml
   repo:
     namespace: 'llnl.comp'
+
+You can also create repositories with custom structure with the ``-d/--subdirectory``
+argument, e.g.:
+
+.. code-block:: console
+
+  $ spack repo create -d applications myrepo apps
+  ==> Created repo with namespace 'apps'.
+  ==> To register it with Spack, run this command:
+    spack repo add ~/myrepo
+
+  $ ls myrepo
+  applications/  repo.yaml
+
+  $ cat myrepo/repo.yaml
+  repo:
+    namespace: apps
+    subdirectory: applications
 
 ^^^^^^^^^^^^^^^^^^
 ``spack repo add``

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -38,7 +38,10 @@ def setup_parser(subparser):
         action="store",
         dest="subdir",
         default=spack.repo.packages_dir_name,
-        help="subdirectory to stroe packages in the repository. Default 'packages'. Use an empty string for no subdirectory."
+        help=(
+            "subdirectory to store packages in the repository."
+            " Default 'packages'. Use an empty string for no subdirectory."
+            ),
     )
 
     # List

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -41,7 +41,7 @@ def setup_parser(subparser):
         help=(
             "subdirectory to store packages in the repository."
             " Default 'packages'. Use an empty string for no subdirectory."
-            ),
+        ),
     )
 
     # List

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -32,6 +32,14 @@ def setup_parser(subparser):
         help="namespace to identify packages in the repository. " "defaults to the directory name",
         nargs="?",
     )
+    create_parser.add_argument(
+        "-d",
+        "--subdirectory",
+        action="store",
+        dest="subdir",
+        default=spack.repo.packages_dir_name,
+        help="subdirectory to stroe packages in the repository. Default 'packages'. Use an empty string for no subdirectory."
+    )
 
     # List
     list_parser = sp.add_parser("list", help=repo_list.__doc__)
@@ -70,7 +78,7 @@ def setup_parser(subparser):
 
 def repo_create(args):
     """Create a new package repository."""
-    full_path, namespace = spack.repo.create_repo(args.directory, args.namespace)
+    full_path, namespace = spack.repo.create_repo(args.directory, args.namespace, args.subdir)
     tty.msg("Created repo with namespace '%s'." % namespace)
     tty.msg("To register it with spack, run this command:", "spack repo add %s" % full_path)
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -936,12 +936,6 @@ class Repo(object):
         self.config_file = os.path.join(self.root, repo_config_name)
         check(os.path.isfile(self.config_file), "No %s found in '%s'" % (repo_config_name, root))
 
-        self.packages_path = os.path.join(self.root, packages_dir_name)
-        check(
-            os.path.isdir(self.packages_path),
-            "No directory '%s' found in '%s'" % (packages_dir_name, root),
-        )
-
         # Read configuration and validate namespace
         config = self._read_config()
         check(
@@ -961,6 +955,13 @@ class Repo(object):
 
         # Keep name components around for checking prefixes.
         self._names = self.full_namespace.split(".")
+
+        packages_dir = config.get("subdirectory", packages_dir_name)
+        self.packages_path = os.path.join(self.root, packages_dir)
+        check(
+            os.path.isdir(self.packages_path),
+            "No directory '%s' found in '%s'" % (packages_dir, root),
+        )
 
         # These are internal cache variables.
         self._modules = {}
@@ -1151,7 +1152,7 @@ class Repo(object):
 
     def package_path(self, name):
         """Get path to package.py file for this repo."""
-        return os.path.join(self.root, packages_dir_name, name, package_file_name)
+        return os.path.join(self.packages_path, name, package_file_name)
 
     def all_package_paths(self):
         for name in self.all_package_names():

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1289,7 +1289,7 @@ class Repo(object):
 RepoType = Union[Repo, RepoPath]
 
 
-def create_repo(root, namespace=None):
+def create_repo(root, namespace=None, subdir=packages_dir_name):
     """Create a new repository in root with the specified namespace.
 
     If the namespace is not provided, use basename of root.
@@ -1320,12 +1320,14 @@ def create_repo(root, namespace=None):
 
     try:
         config_path = os.path.join(root, repo_config_name)
-        packages_path = os.path.join(root, packages_dir_name)
+        packages_path = os.path.join(root, subdir)
 
         fs.mkdirp(packages_path)
         with open(config_path, "w") as config:
             config.write("repo:\n")
-            config.write("  namespace: '%s'\n" % namespace)
+            config.write(f"  namespace: '{namespace}'\n")
+            if subdir != packages_dir_name:
+                config.write(f"  subdirectory: '{subdir}'\n")
 
     except (IOError, OSError) as e:
         # try to clean up.

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1606,7 +1606,7 @@ _spack_repo() {
 _spack_repo_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -d --subdirectory"
     else
         _repos
     fi


### PR DESCRIPTION
Allow repo.yaml to specify packages subdirectory (default remains `packages`).

This is to improve interoperability with https://github.com/GoogleCloudPlatform/ramble.