### PR TITLE
CI: Use relative path in default script

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1088,7 +1088,7 @@ def generate_gitlab_ci_yaml(
                     raise AttributeError
 
                 def main_script_replacements(cmd):
-                    return cmd.replace("{env_dir}", concrete_env_dir)
+                    return cmd.replace("{env_dir}", rel_concrete_env_dir)
 
                 job_script = _unpack_script(runner_attribs["script"], op=main_script_replacements)
 


### PR DESCRIPTION
The default rebuild script was using an absolute path which was not compatible when running outside of a container in CI.

CC: @eugeneswalker 