### PR TITLE
spack ci: preserve custom attributes in build jobs

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1249,15 +1249,18 @@ def generate_gitlab_ci_yaml(
                     build_stamp = cdash_handler.build_stamp
                     job_vars["SPACK_CDASH_BUILD_STAMP"] = build_stamp
 
-                job_object["artifacts"] = spack.config.merge_yaml(job_object.get("artifacts", {}), {
-                    "when": "always",
-                    "paths": [
-                        rel_job_log_dir,
-                        rel_job_repro_dir,
-                        rel_job_test_dir,
-                        rel_user_artifacts_dir,
-                    ],
-                })
+                job_object["artifacts"] = spack.config.merge_yaml(
+                    job_object.get("artifacts", {}),
+                    {
+                        "when": "always",
+                        "paths": [
+                            rel_job_log_dir,
+                            rel_job_repro_dir,
+                            rel_job_test_dir,
+                            rel_user_artifacts_dir,
+                        ],
+                    },
+                )
 
                 if enable_artifacts_buildcache:
                     bc_root = os.path.join(local_mirror_dir, "build_cache")

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1026,7 +1026,6 @@ def generate_gitlab_ci_yaml(
     spack_ci = SpackCI(ci_config, phases, staged_phases)
     spack_ci_ir = spack_ci.generate_ir()
 
-    before_script, after_script = None, None
     for phase in phases:
         phase_name = phase["name"]
         strip_compilers = phase["strip-compilers"]
@@ -1053,52 +1052,35 @@ def generate_gitlab_ci_yaml(
                         spec_record["needs_rebuild"] = False
                         continue
 
-                runner_attribs = spack_ci_ir["jobs"][release_spec_dag_hash]["attributes"]
+                job_object = spack_ci_ir["jobs"][release_spec_dag_hash]["attributes"]
 
-                if not runner_attribs:
+                if not job_object:
                     tty.warn("No match found for {0}, skipping it".format(release_spec))
                     continue
 
-                tags = [tag for tag in runner_attribs["tags"]]
-
                 if spack_pipeline_type is not None:
                     # For spack pipelines "public" and "protected" are reserved tags
-                    tags = _remove_reserved_tags(tags)
+                    job_object["tags"] = _remove_reserved_tags(job_object.get("tags", []))
                     if spack_pipeline_type == "spack_protected_branch":
-                        tags.extend(["protected"])
+                        job_object["tags"].extend(["protected"])
                     elif spack_pipeline_type == "spack_pull_request":
-                        tags.extend(["public"])
+                        job_object["tags"].extend(["public"])
 
-                variables = {}
-                if "variables" in runner_attribs:
-                    variables.update(runner_attribs["variables"])
-
-                image_name = None
-                image_entry = None
-                if "image" in runner_attribs:
-                    build_image = runner_attribs["image"]
-                    try:
-                        image_name = build_image.get("name")
-                        entrypoint = build_image.get("entrypoint")
-                        image_entry = [p for p in entrypoint]
-                    except AttributeError:
-                        image_name = build_image
-
-                if "script" not in runner_attribs:
+                if "script" not in job_object:
                     raise AttributeError
 
                 def main_script_replacements(cmd):
                     return cmd.replace("{env_dir}", concrete_env_dir)
 
-                job_script = _unpack_script(runner_attribs["script"], op=main_script_replacements)
+                job_object["script"] = _unpack_script(
+                    job_object["script"], op=main_script_replacements
+                )
 
-                before_script = None
-                if "before_script" in runner_attribs:
-                    before_script = _unpack_script(runner_attribs["before_script"])
+                if "before_script" in job_object:
+                    job_object["before_script"] = _unpack_script(job_object["before_script"])
 
-                after_script = None
-                if "after_script" in runner_attribs:
-                    after_script = _unpack_script(runner_attribs["after_script"])
+                if "after_script" in job_object:
+                    job_object["after_script"] = _unpack_script(job_object["after_script"])
 
                 osname = str(release_spec.architecture)
                 job_name = get_job_name(
@@ -1111,13 +1093,12 @@ def generate_gitlab_ci_yaml(
                     if _is_main_phase(phase_name):
                         compiler_action = "INSTALL_MISSING"
 
-                job_vars = {
-                    "SPACK_JOB_SPEC_DAG_HASH": release_spec_dag_hash,
-                    "SPACK_JOB_SPEC_PKG_NAME": release_spec.name,
-                    "SPACK_COMPILER_ACTION": compiler_action,
-                }
+                job_vars = job_object.setdefault("variables", {})
+                job_vars["SPACK_JOB_SPEC_DAG_HASH"] = release_spec_dag_hash
+                job_vars["SPACK_JOB_SPEC_PKG_NAME"] = release_spec.name
+                job_vars["SPACK_COMPILER_ACTION"] = compiler_action
 
-                job_dependencies = []
+                job_object["needs"] = []
                 if spec_label in dependencies:
                     if enable_artifacts_buildcache:
                         # Get dependencies transitively, so they're all
@@ -1130,7 +1111,7 @@ def generate_gitlab_ci_yaml(
                         for dep_label in dependencies[spec_label]:
                             dep_jobs.append(spec_labels[dep_label]["spec"])
 
-                    job_dependencies.extend(
+                    job_object["needs"].extend(
                         _format_job_needs(
                             phase_name,
                             strip_compilers,
@@ -1187,7 +1168,7 @@ def generate_gitlab_ci_yaml(
                             if enable_artifacts_buildcache:
                                 dep_jobs = [d for d in c_spec.traverse(deptype=all)]
 
-                            job_dependencies.extend(
+                            job_object["needs"].extend(
                                 _format_job_needs(
                                     bs["phase-name"],
                                     bs["strip-compilers"],
@@ -1253,7 +1234,7 @@ def generate_gitlab_ci_yaml(
                     ]
 
                 if artifacts_root:
-                    job_dependencies.append(
+                    job_object["needs"].append(
                         {"job": generate_job_name, "pipeline": "{0}".format(parent_pipeline_id)}
                     )
 
@@ -1268,18 +1249,19 @@ def generate_gitlab_ci_yaml(
                     build_stamp = cdash_handler.build_stamp
                     job_vars["SPACK_CDASH_BUILD_STAMP"] = build_stamp
 
-                variables.update(job_vars)
-
-                artifact_paths = [
-                    rel_job_log_dir,
-                    rel_job_repro_dir,
-                    rel_job_test_dir,
-                    rel_user_artifacts_dir,
-                ]
+                job_object["artifacts"] = {
+                    "when": "always",
+                    "paths": [
+                        rel_job_log_dir,
+                        rel_job_repro_dir,
+                        rel_job_test_dir,
+                        rel_user_artifacts_dir,
+                    ],
+                }
 
                 if enable_artifacts_buildcache:
                     bc_root = os.path.join(local_mirror_dir, "build_cache")
-                    artifact_paths.extend(
+                    job_object["artifacts"]["paths"].extend(
                         [
                             os.path.join(bc_root, p)
                             for p in [
@@ -1289,32 +1271,34 @@ def generate_gitlab_ci_yaml(
                         ]
                     )
 
+                job_object["stage"] = stage_name
+                job_object["needs"] = sorted(job_object["needs"], key=lambda d: d["job"])
+                job_object["retry"] = {"max": 2, "when": JOB_RETRY_CONDITIONS}
+                job_object["interruptible"] = True
+
                 job_object = {
-                    "stage": stage_name,
-                    "variables": variables,
-                    "script": job_script,
-                    "tags": tags,
-                    "artifacts": {"paths": artifact_paths, "when": "always"},
-                    "needs": sorted(job_dependencies, key=lambda d: d["job"]),
-                    "retry": {"max": 2, "when": JOB_RETRY_CONDITIONS},
-                    "interruptible": True,
+                    k: v
+                    for k, v in job_object.items()
+                    if k
+                    in (
+                        "stage",
+                        "script",
+                        "before_script",
+                        "after_script",
+                        "tags",
+                        "artifacts",
+                        "needs",
+                        "retry",
+                        "interruptible",
+                        "variables",
+                        "image",
+                    )
                 }
 
-                length_needs = len(job_dependencies)
+                length_needs = len(job_object["needs"])
                 if length_needs > max_length_needs:
                     max_length_needs = length_needs
                     max_needs_job = job_name
-
-                if before_script:
-                    job_object["before_script"] = before_script
-
-                if after_script:
-                    job_object["after_script"] = after_script
-
-                if image_name:
-                    job_object["image"] = image_name
-                    if image_entry is not None:
-                        job_object["image"] = {"name": image_name, "entrypoint": image_entry}
 
                 output_object[job_name] = job_object
                 job_id += 1

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1275,7 +1275,6 @@ def generate_gitlab_ci_yaml(
                     )
 
                 job_object["stage"] = stage_name
-                job_object["needs"] = sorted(job_object["needs"], key=lambda d: d["job"])
                 job_object["retry"] = {"max": 2, "when": JOB_RETRY_CONDITIONS}
                 job_object["interruptible"] = True
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1249,7 +1249,7 @@ def generate_gitlab_ci_yaml(
                     build_stamp = cdash_handler.build_stamp
                     job_vars["SPACK_CDASH_BUILD_STAMP"] = build_stamp
 
-                job_object["artifacts"] = {
+                job_object["artifacts"] = spack.config.merge_yaml(job_object.get("artifacts", {}), {
                     "when": "always",
                     "paths": [
                         rel_job_log_dir,
@@ -1257,7 +1257,7 @@ def generate_gitlab_ci_yaml(
                         rel_job_test_dir,
                         rel_user_artifacts_dir,
                     ],
-                }
+                })
 
                 if enable_artifacts_buildcache:
                     bc_root = os.path.join(local_mirror_dir, "build_cache")

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1276,25 +1276,6 @@ def generate_gitlab_ci_yaml(
                 job_object["retry"] = {"max": 2, "when": JOB_RETRY_CONDITIONS}
                 job_object["interruptible"] = True
 
-                job_object = {
-                    k: v
-                    for k, v in job_object.items()
-                    if k
-                    in (
-                        "stage",
-                        "script",
-                        "before_script",
-                        "after_script",
-                        "tags",
-                        "artifacts",
-                        "needs",
-                        "retry",
-                        "interruptible",
-                        "variables",
-                        "image",
-                    )
-                }
-
                 length_needs = len(job_object["needs"])
                 if length_needs > max_length_needs:
                     max_length_needs = length_needs

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -25,6 +25,7 @@ script_schema = {
 # CI target YAML for each job.
 attributes_schema = {
     "type": "object",
+    "additionalProperties": True,
     "properties": {
         "image": {
             "oneOf": [
@@ -51,7 +52,7 @@ attributes_schema = {
 
 submapping_schema = {
     "type": "object",
-    "additinoalProperties": False,
+    "additionalProperties": False,
     "required": ["submapping"],
     "properties": {
         "match_behavior": {"type": "string", "enum": ["first", "merge"], "default": "first"},

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -480,7 +480,7 @@ spack:
             assert filecmp.cmp(orig_file, copy_to_file) is True
 
 
-def test_ci_generate_with_custom_scripts(
+def test_ci_generate_with_custom_settings(
     tmpdir,
     working_env,
     mutable_mock_env_path,
@@ -490,7 +490,7 @@ def test_ci_generate_with_custom_scripts(
     ci_base_environment,
     mock_binary_index,
 ):
-    """Test use of user-provided scripts"""
+    """Test use of user-provided scripts and attributes"""
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
@@ -522,6 +522,7 @@ spack:
             - spack -d ci rebuild
           after_script:
             - rm -rf /some/path/spack
+          custom_attribute: custom!
 """
         )
 
@@ -569,6 +570,9 @@ spack:
                             "spack ci rebuild",
                         ]
                         assert ci_obj["after_script"] == ["rm -rf /some/path/spack"]
+
+                        # Ensure we have the custom attributes
+                        assert ci_obj["custom_attribute"] == "custom!"
 
                         found_it = True
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -200,6 +200,7 @@ spack:
         tags: [donotcare]
     - reindex-job:
         script:: [hello, world]
+        custom_attribute: custom!
   cdash:
     build-group: Not important
     url: https://my.fake.cdash
@@ -234,6 +235,7 @@ spack:
             rebuild_job = yaml_contents["rebuild-index"]
             expected = "spack buildcache update-index --keys --mirror-url {0}".format(mirror_url)
             assert rebuild_job["script"][0] == expected
+            assert rebuild_job["custom_attribute"] == "custom!"
 
             assert "variables" in yaml_contents
             assert "SPACK_ARTIFACTS_ROOT" in yaml_contents["variables"]
@@ -1222,6 +1224,7 @@ spack:
        tags:
          - nonbuildtag
        image: basicimage
+       custom_attribute: custom!
 """.format(
         mirror_url
     )
@@ -1263,6 +1266,7 @@ spack:
                 assert "nonbuildtag" in the_elt["tags"]
                 assert "image" in the_elt
                 assert the_elt["image"] == "basicimage"
+                assert the_elt["custom_attribute"] == "custom!"
 
             outputfile_not_pruned = str(tmpdir.join("unpruned_pipeline.yml"))
             ci_cmd("generate", "--no-prune-dag", "--output-file", outputfile_not_pruned)
@@ -1281,6 +1285,7 @@ spack:
                         job_vars = the_elt["variables"]
                         assert "SPACK_SPEC_NEEDS_REBUILD" in job_vars
                         assert job_vars["SPACK_SPEC_NEEDS_REBUILD"] == "False"
+                        assert the_elt["custom_attribute"] == "custom!"
                         found_spec_job = True
 
                 assert found_spec_job
@@ -2005,6 +2010,8 @@ spack:
           tags:
             - donotcare
           image: donotcare
+    - cleanup-job:
+        custom_attribute: custom!
 """
         )
 
@@ -2020,6 +2027,8 @@ spack:
 
                 assert "cleanup" in pipeline_doc
                 cleanup_job = pipeline_doc["cleanup"]
+
+                assert cleanup_job["custom_attribute"] == "custom!"
 
                 assert "script" in cleanup_job
                 cleanup_task = cleanup_job["script"][0]
@@ -2138,6 +2147,7 @@ spack:
           IMPORTANT_INFO: avalue
         script::
           - echo hello
+        custom_attribute: custom!
 """
         )
 
@@ -2157,6 +2167,7 @@ spack:
             signing_job_tags = signing_job["tags"]
             for expected_tag in ["notary", "protected", "aws"]:
                 assert expected_tag in signing_job_tags
+            assert signing_job["custom_attribute"] == "custom!"
 
 
 def test_ci_reproduce(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -525,6 +525,9 @@ spack:
           after_script:
             - rm -rf /some/path/spack
           custom_attribute: custom!
+          artifacts:
+            paths:
+            - some/custom/artifact
 """
         )
 
@@ -574,6 +577,7 @@ spack:
                         assert ci_obj["after_script"] == ["rm -rf /some/path/spack"]
 
                         # Ensure we have the custom attributes
+                        assert "some/custom/artifact" in ci_obj["artifacts"]["paths"]
                         assert ci_obj["custom_attribute"] == "custom!"
 
                         found_it = True


### PR DESCRIPTION
The `ci.yaml` schema allows for any attribute to be specified, however build jobs would only have a selected set of attributes preserved. This means attributes like `cache:` will silently be elided from the generated pipeline. Only build jobs have this issue, other job types correctly preserve extra attributes.

Rewrite the generation of build jobs to preserve any configured extra attributes, and adjust the tests to check for this feature across all job types.

CC @kwryankrattiger 