### PR TITLE
Add Libint 2.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -43,7 +43,11 @@ class Libint(AutotoolsPackage, CMakePackage):
     version("1.1.6", sha256="f201b0c621df678cfe8bdf3990796b8976ff194aba357ae398f2f29b0e2985a6")
     version("1.1.5", sha256="ec8cd4a4ba1e1a98230165210c293632372f0e573acd878ed62e5ec6f8b6174b")
 
-    build_system(conditional("cmake", when="@2.7.0:"), conditional("autotools", when="@:2.6.0"))
+    build_system(
+        conditional("cmake", when="@2.7.0:"),
+        conditional("autotools", when="@:2.6.0"),
+        default="autotools",
+    )
 
     variant("debug", default=False, description="Enable building with debug symbols")
     variant("fortran", default=False, description="Build & install Fortran bindings")

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -70,6 +70,7 @@ class Libint(AutotoolsPackage, CMakePackage):
     depends_on("libtool", type="build")
     depends_on("python", type="build")
     depends_on("gnuconfig", type="build")  # macOS
+    depends_on("cmake", type="build", when="build_system=cmake")
 
     depends_on("eigen", when="@2.7.0: +cxx")
 

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -5,11 +5,10 @@
 
 import os
 
-from spack.package import *
-from spack.pkg.builtin.boost import Boost
-
 import spack.build_systems.autotools
 import spack.build_systems.cmake
+from spack.package import *
+from spack.pkg.builtin.boost import Boost
 
 TUNE_VARIANTS = (
     "none",


### PR DESCRIPTION
This PR adds Libint `2.7.2`. It also switches the build of the `libint` library from `autotools` to `cmake` (from this version onwards). It is an attempt at taking over #29428.

The old build system has been moved to `AutotoolsBuilder` while the new build system uses `CMakeBuilder` but also inherits from `AutotoolsBuilder` (so that the `libint` compiler can be built). **Are there better ways of doing this?**

I tested that `2.7.2` works by compiling the Hartree-Fock program provided with `libint`. I have _not_ tested the `fortran` bindings (hence why this is still a draft PR).

I tested the following on macOS (M1):
* `spack install libint@2.7.2` (new system)
* `spack install libint@2.6.0` (old system)
* `spack install libint@2.4.2` (old system)

I will do further tests on Ubuntu and with CP2K in the coming weeks (I'm about to go on holiday for a week).

@ltalirz @dev-zero I would appreciate some early feedback on the draft, since you have discussed this previously as part of #29428.