### PR TITLE
VeloC/SCR component releases

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -25,6 +25,7 @@ class Axl(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.8.0", sha256="9fcd4eae143a67ff02622feda2a541b85e9a108749c039faeb473cbbc2330459")
     version("0.7.1", sha256="526a055c072c85cc989beca656717e06b128f148fda8eb19d1d9b43a3325b399")
     version("0.7.0", sha256="840ef61eadc9aa277d128df08db4cdf6cfa46b8fcf47b0eee0972582a61fbc50")
     version("0.6.0", sha256="86edb35f99b63c0ffb9dd644a019a63b062923b4efc95c377e92a1b13e79f537")
@@ -46,7 +47,9 @@ class Axl(CMakePackage):
     depends_on("zlib", type="link")
 
     depends_on("kvtree@main", when="@main")
-    depends_on("kvtree@1.3.0", when="@0.6.0:")
+    depends_on("kvtree@:1.2.0", when="@:0.5.0")
+    depends_on("kvtree@1.3.0", when="@0.6.0:0.7.1")
+    depends_on("kvtree@1.4.0:", when="@0.8.0:")
 
     variant(
         "async_api",

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -17,6 +17,7 @@ class Er(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.4.0", sha256="6cb5b6724ddac5c1f5ed6b326a5f3bf5d4eb1c6958a48218e6ca9bb7c02e48a8")
     version("0.3.0", sha256="01bc71bfb2ebb015ccb948f2bb9138b70972a3e8be0e53f9a4844e46b106a36c")
     version("0.2.0", sha256="9ddfe2b63682ed0e89685f9b7d5259ef82b802aba55c8ee78cc15a7adbad6bc0")
     version("0.1.0", sha256="543afc1c48bb2c67f48c32f6c9efcbf7bb27f2e622ff76f2c2ce5618c77aacfc")
@@ -30,7 +31,15 @@ class Er(CMakePackage):
     depends_on("shuffile")
     depends_on("zlib", type="link")
 
-    depends_on("kvtree@1.3", when="@0.2.0")
+    depends_on("kvtree@:1.2.0", when="@:0.1.0")
+    depends_on("kvtree@1.3.0", when="@0.2.0:0.3.0")
+    depends_on("kvtree@1.4.0:", when="@0.4.0:")
+    depends_on("rankstr@:0.2.0", when="@:0.3.0")
+    depends_on("rankstr@0.3.0:", when="@0.4.0:")
+    depends_on("redset@:0.2.0", when="@:0.3.0")
+    depends_on("redset@0.3.0:", when="@0.4.0:")
+    depends_on("shuffile@:0.2.0", when="@:0.3.0")
+    depends_on("shuffile@0.3.0:", when="@0.4.0:")
 
     deps = ["kvtree", "rankstr", "redset", "shuffile"]
     for dep in deps:

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -18,6 +18,7 @@ class Kvtree(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("1.4.0", sha256="48a36fd578f0d1198a9c1512d6446c830b915ace5bb97539eec615495bee5a51")
     version("1.3.0", sha256="8281e075772d3534183c46133553d5765455d79ed98a895743663db891755ca9")
     version("1.2.0", sha256="ecd4b8bc479c33ab4f23fc764445a3bb353a1d15c208d011f5577a32c182477f")
     version("1.1.1", sha256="4776bd55a559b7f9bb594454ae6b14ebff0087c93c3d59ac7d1ab27df4aa4d74")

--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -17,6 +17,7 @@ class Rankstr(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.3.0", sha256="5e6378a8fe155b4c6c5cf45db8aaf0562d88e93471d0e12c1e922252ffcce5e6")
     version("0.2.0", sha256="a3f7fd8015156c1b600946af759a03e099e05c83e7b2da6bac394fe7c0d4efae")
     version("0.1.0", sha256="b68239d67b2359ecc067cc354f86ccfbc8f02071e60d28ae0a2449f2e7f88001")
     version("0.0.3", sha256="d32052fbecd44299e13e69bf2dd7e5737c346404ccd784b8c2100ceed99d8cd3")

--- a/var/spack/repos/builtin/packages/redset/package.py
+++ b/var/spack/repos/builtin/packages/redset/package.py
@@ -17,6 +17,7 @@ class Redset(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.3.0", sha256="007ca5e7e5f4400e22ad7bca82e366cd51c73f28067c955cc16d7d0ff0c06a1b")
     version("0.2.0", sha256="0438b0ba56dafcd5694a8fceeb5a932901307353e056ab29817d30b8387f787f")
     version("0.1.0", sha256="baa75de0d0d6de64ade50cff3d38ee89fd136ce69869182bdaefccf5be5d286d")
     version("0.0.5", sha256="4db4ae59ab9d333a6d1d80678dedf917d23ad461c88b6d39466fc4bf6467d1ee")
@@ -27,6 +28,11 @@ class Redset(CMakePackage):
     depends_on("kvtree+mpi")
     depends_on("rankstr")
     depends_on("zlib", type="link")
+
+    depends_on("kvtree@:1.3.0", when="@:0.2.0")
+    depends_on("kvtree@1.4.0:", when="@0.3.0:")
+    depends_on("rankstr@:0.2.0", when="@:0.2.0")
+    depends_on("rankstr@0.3.0:", when="@0.3.0:")
 
     variant("shared", default=True, description="Build with shared libraries")
     depends_on("kvtree+shared", when="@0.1: +shared")

--- a/var/spack/repos/builtin/packages/shuffile/package.py
+++ b/var/spack/repos/builtin/packages/shuffile/package.py
@@ -17,6 +17,7 @@ class Shuffile(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.3.0", sha256="3463ad4a23fd31aa9a3426346ada04399fb9369dd1f40d22df9f19f9c0c1f8ae")
     version("0.2.0", sha256="467ffef72214c109b69f09d03e42be5e9254f13751b09c71168c14fa99117521")
     version("0.1.0", sha256="9e730cc8b7937517a9cffb08c031d9f5772306341c49d17b87b7f349d55a6d5e")
     version("0.0.4", sha256="f0249ab31fc6123103ad67b1eaf799277c72adcf0dfcddf8c3a18bad2d45031d")
@@ -25,6 +26,9 @@ class Shuffile(CMakePackage):
     depends_on("mpi")
     depends_on("kvtree+mpi")
     depends_on("zlib", type="link")
+
+    depends_on("kvtree@:1.3.0", when="@:0.2.0")
+    depends_on("kvtree@1.4.0:", when="@0.3.0:")
 
     variant("shared", default=True, description="Build with shared libraries")
     depends_on("kvtree+shared", when="@0.1: +shared")

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -17,6 +17,7 @@ class Spath(CMakePackage):
     maintainers("CamStan", "gonsie")
 
     version("main", branch="main")
+    version("0.3.0", sha256="cb155a31cebde8b7bf397123de3be290fd99d3863509b4ba9b0252caba660082")
     version("0.2.0", sha256="2de8a25547b53ef064664d79b543141bc3020219f40ff0e1076f676e13a9e77a")
     version("0.1.0", sha256="2cfc635b2384d3f92973c7aea173dabe47da112d308f5098e6636e4b2f4a704c")
     version("0.0.2", sha256="7a65be59c3d27e92ed4718fba1a97a4a1c68e0a552b54de13d58afe3d8199cf7")


### PR DESCRIPTION
VeloC/SCR component releases needed for upcoming VeloC release.

* AXL v0.8.0
* ER  v0.4.0
* KVTree v1.4.0
* Rankstr v0.3.0
* Redset v0.3.0
* Shuffile v0.3.0
* Spath v0.3.0

Added some dependency compatibility restraints as the new componenet versions have a change to how their cmake config works.