### PR TITLE
.gitattributes: Ensure *.py *.yaml to be Unix text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-*.py diff=python
+*.py text eol=lf diff=python
+*.yaml text eol=lf
 *.lp linguist-language=Prolog
 lib/spack/external/* linguist-vendored
 *.bat text eol=crlf


### PR DESCRIPTION
In #36236, we discovered that two .py files have DOS CRLF eol style.

In it's review, @adamjstewart suggested that we probably want to ensure thru git that this can't happen again.
While at it, also ensure *.yaml to use Unix eol style.

Fix the remaining var/spack/repos/builtin/packages/cppcodec/package.py
The other file is already converted by merging #36236.