### PR TITLE
cmake build system: change default build type to "Release"

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -90,6 +90,10 @@ class CMakePackage(spack.package_base.PackageBase):
 
     with when("build_system=cmake"):
         # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
+        # See https://github.com/spack/spack/pull/36679 and related issues for a
+        # discussion of the trade-offs between Release and RelWithDebInfo for default
+        # builds. Release is chosen to maximize performance and reduce disk-space burden,
+        # at the cost of more difficulty in debugging.
         variant(
             "build_type",
             default="Release",

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -92,7 +92,7 @@ class CMakePackage(spack.package_base.PackageBase):
         # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
         variant(
             "build_type",
-            default="RelWithDebInfo",
+            default="Release",
             description="CMake build type",
             values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
         )

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -37,14 +37,6 @@ class Adios2(CMakePackage, CudaPackage):
     version("2.4.0", sha256="50ecea04b1e41c88835b4b3fd4e7bf0a0a2a3129855c9cc4ba6cf6a1575106e2")
     version("2.3.1", sha256="3bf81ccc20a7f2715935349336a76ba4c8402355e1dc3848fcd6f4c3c5931893")
 
-    # General build options
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     # There's not really any consistency about how static and shared libs are
     # implemented across spack.  What we're trying to support is specifically three
     # library build types:

--- a/var/spack/repos/builtin/packages/ccls/package.py
+++ b/var/spack/repos/builtin/packages/ccls/package.py
@@ -25,13 +25,6 @@ class Ccls(CMakePackage):
         "0.20201025", sha256="1470797b2c1a466e2d8a069efd807aac6fefdef8a556e1edf2d44f370c949221"
     )
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     depends_on("cmake@3.8:", type="build")
     depends_on("llvm@7:")
     depends_on("rapidjson")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -155,6 +155,13 @@ class Cmake(Package):
     version("3.0.2", sha256="6b4ea61eadbbd9bec0ccb383c29d1f4496eacc121ef7acf37c7a24777805693e")
     version("2.8.10.2", sha256="ce524fb39da06ee6d47534bbcec6e0b50422e18b62abc4781a4ba72ea2910eb1")
 
+    variant(
+        "build_type",
+        default="Release",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
+    )
+
     # Revert the change that introduced a regression when parsing mpi link
     # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516
     patch("cmake-revert-findmpi-link-flag-list.patch", when="@3.15.0")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -155,13 +155,6 @@ class Cmake(Package):
     version("3.0.2", sha256="6b4ea61eadbbd9bec0ccb383c29d1f4496eacc121ef7acf37c7a24777805693e")
     version("2.8.10.2", sha256="ce524fb39da06ee6d47534bbcec6e0b50422e18b62abc4781a4ba72ea2910eb1")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     # Revert the change that introduced a regression when parsing mpi link
     # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516
     patch("cmake-revert-findmpi-link-flag-list.patch", when="@3.15.0")

--- a/var/spack/repos/builtin/packages/compadre/package.py
+++ b/var/spack/repos/builtin/packages/compadre/package.py
@@ -28,13 +28,6 @@ class Compadre(CMakePackage):
     depends_on("kokkos-kernels@3.3.01:3.6")
     depends_on("cmake@3.13:", type="build")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     variant("mpi", default=False, description="Enable MPI support")
     depends_on("mpi", when="+mpi")
 

--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -24,14 +24,6 @@ class Embree(CMakePackage):
     version("3.8.0", sha256="40cbc90640f63c318e109365d29aea00003e4bd14aaba8bb654fc1010ea5753a")
     version("3.7.0", sha256="2b6300ebe30bb3d2c6e5f23112b4e21a25a384a49c5e3c35440aa6f3c8d9fe84")
 
-    # default to Release, as RelWithDebInfo creates a lot of overhead
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     variant("ispc", default=True, description="Enable ISPC support")
     depends_on("ispc", when="+ispc", type="build")
 

--- a/var/spack/repos/builtin/packages/enzyme/package.py
+++ b/var/spack/repos/builtin/packages/enzyme/package.py
@@ -30,13 +30,6 @@ class Enzyme(CMakePackage):
     version("0.0.14", sha256="740641eeeeadaf47942ac88cc52e62ddc0e8c25767a501bed36ec241cf258b8d")
     version("0.0.13", sha256="d4a53964ec1f763772db2c56e6734269b7656c8b2ecd41fa7a41315bcd896b5a")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     depends_on("llvm@7:12", when="@0.0.13:0.0.15")
     depends_on("llvm@7:14", when="@0.0.32:")  # TODO actual lower bound
     depends_on("llvm@7:14", when="@0.0.48:")

--- a/var/spack/repos/builtin/packages/fftx/package.py
+++ b/var/spack/repos/builtin/packages/fftx/package.py
@@ -21,13 +21,6 @@ class Fftx(CMakePackage, CudaPackage, ROCmPackage):
     version("main", branch="main")
     version("1.0.3", sha256="b5ff275facce4a2fbabd0aecc65dd55b744794f2e07cd8cfa91363001c664896")
 
-    variant(
-        "build_type",
-        default="Release",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        description="The build type to build",
-    )
-
     depends_on("spiral-software")
     depends_on("spiral-package-fftx")
     depends_on("spiral-package-simt")

--- a/var/spack/repos/builtin/packages/gpi-space/package.py
+++ b/var/spack/repos/builtin/packages/gpi-space/package.py
@@ -52,12 +52,6 @@ class GpiSpace(CMakePackage):
         description="GPI-2 fabric to enable",
         when="+iml",
     )
-    variant(
-        "build_type",
-        default="Release",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        description="CMake build type",
-    )
 
     depends_on("cmake@3.15.0:", type="build")
     depends_on("chrpath@0.13:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -44,12 +44,6 @@ class Helics(CMakePackage):
     version("2.4.2", sha256="957856f06ed6d622f05dfe53df7768bba8fe2336d841252f5fac8345070fa5cb")
     version("2.4.1", sha256="ac077e9efe466881ea366721cb31fb37ea0e72a881a717323ba4f3cdda338be4")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("apps", default=True, description="Install the HELICS apps executables")
     variant("apps_lib", default=True, description="Install the HELICS apps library")
     variant("benchmarks", default=False, description="Install the HELICS benchmarks")

--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -21,13 +21,6 @@ class Keepassxc(CMakePackage):
     version("2.6.6", sha256="3603b11ac39b289c47fac77fa150e05fd64b393d8cfdf5732dc3ef106650a4e2")
     version("2.6.4", sha256="e536e2a71c90fcf264eb831fb1a8b518ee1b03829828f862eeea748d3310f82b")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="The build type for the installation (only Debug or"
-        " ( Documentation indicates Release).",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("autotype", default=False, description="enable auto-type")
     variant("docs", default=True, description="Build documentation")
 

--- a/var/spack/repos/builtin/packages/libristra/package.py
+++ b/var/spack/repos/builtin/packages/libristra/package.py
@@ -20,13 +20,6 @@ class Libristra(CMakePackage):
     version("master", branch="master", submodules=False, preferred=True)
     version("1.0.0", commit="33235fe0334ca7f1f99b386a90932d9f8e1e71de")
 
-    variant(
-        "build_type",
-        default="Release",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        description="The build type to build",
-        multi=False,
-    )
     variant("paraview", default=False, description="Enable ParaView")
     variant("shared_lua", default=False, description="Build with shared lua")
 

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -89,12 +89,6 @@ class LlvmDoe(CMakePackage, CudaPackage):
         description="Build all supported targets, default targets "
         "<current arch>,NVPTX,AMDGPU,CppBackend",
     )
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("omp_tsan", default=False, description="Build with OpenMP capable thread sanitizer")
     variant(
         "omp_as_runtime",

--- a/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
@@ -34,13 +34,6 @@ class LlvmOpenmpOmpt(CMakePackage):
         "libomptarget", default=True, description="Enable building libomptarget for offloading"
     )
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     depends_on("cmake@2.8:", type="build")
     depends_on("llvm", when="~standalone")
     depends_on("ninja@1.5:", type="build")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -162,12 +162,6 @@ class Llvm(CMakePackage, CudaPackage):
         multi=True,
     )
     variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-    variant(
         "omp_tsan",
         default=False,
         when="@6:",

--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -121,12 +121,6 @@ class Mbedtls(MakefilePackage):
 
     variant("pic", default=False, description="Compile with position independent code.")
     variant(
-        "build_type",
-        default="Release",
-        description="Build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-    variant(
         "libs",
         default="static",
         values=("shared", "static"),

--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -121,6 +121,12 @@ class Mbedtls(MakefilePackage):
 
     variant("pic", default=False, description="Compile with position independent code.")
     variant(
+        "build_type",
+        default="Release",
+        description="Build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
+    )
+    variant(
         "libs",
         default="static",
         values=("shared", "static"),

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -13,13 +13,6 @@ class ScalapackBase(CMakePackage):
     of the library in the 'amdscalapack' package.
     """
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     variant("shared", default=True, description="Build the shared library version")
     variant("pic", default=False, description="Build position independent code")
 

--- a/var/spack/repos/builtin/packages/omnitrace/package.py
+++ b/var/spack/repos/builtin/packages/omnitrace/package.py
@@ -28,14 +28,6 @@ class Omnitrace(CMakePackage):
     version("1.3.0", commit="4dd144a32c8b83c44e132ef53f2b44fe4b4d5569", submodules=True)
     version("1.2.0", commit="f82845388aab108ed1d1fc404f433a0def391bb3", submodules=True)
 
-    # override build_type to default to Release because this has a significant
-    # impact on build-time and the size of the build
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant(
         "rocm",
         default=True,

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -30,13 +30,6 @@ class Opencarp(CMakePackage):
     variant("carputils", default=False, description="Installs the carputils framework")
     variant("meshtool", default=False, description="Installs the meshtool software")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     # Patch removing problematic steps in CMake process
     patch("opencarp7.patch", when="@7.0")
 

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -54,12 +54,6 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
 
     # build options
     extends("python")
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("cpptests", default=False, description="Build CPP tests")
     variant("native", default=False, description="Build natively for given hardware")
     variant("sanitize", default=False, description="Build with address sanitization")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -39,13 +39,6 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
     variant("cpptests", default=False, description="Build CPP tests")
     variant("cppbenchmarks", default=False, description="Build CPP benchmark examples")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     extends("python")
 
     # hard dependencies

--- a/var/spack/repos/builtin/packages/sleef/package.py
+++ b/var/spack/repos/builtin/packages/sleef/package.py
@@ -44,12 +44,6 @@ class Sleef(CMakePackage):
     # See https://github.com/shibatch/sleef/issues/234
     # See https://github.com/pytorch/pytorch/issues/26892
     # See https://github.com/pytorch/pytorch/pull/26993
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
 
     generator("ninja")
     depends_on("cmake@3.4.3:", type="build")

--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -53,12 +53,6 @@ class Sollve(CMakePackage):
         description="Build all supported targets, default targets "
         "<current arch>,NVPTX,AMDGPU,CppBackend",
     )
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("omp_tsan", default=False, description="Build with OpenMP capable thread sanitizer")
     variant("python", default=False, description="Install python bindings")
     variant("argobots", default=True, description="Use Argobots in BOLT")

--- a/var/spack/repos/builtin/packages/spiral-software/package.py
+++ b/var/spack/repos/builtin/packages/spiral-software/package.py
@@ -24,13 +24,6 @@ class SpiralSoftware(CMakePackage):
     version("8.2.1", sha256="78d7bb1c22a5b2d216eac7b6ddedd20b601ba40227e64f743cbb54d4e5a7794d")
     version("8.2.0", sha256="983f38d270ae2cb753c88cbce3f412e307c773807ad381acedeb9275afc0be32")
 
-    variant(
-        "build_type",
-        default="Release",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        description="Build the Release version by default",
-    )
-
     extendable = True
 
     # No dependencies.

--- a/var/spack/repos/builtin/packages/templight/package.py
+++ b/var/spack/repos/builtin/packages/templight/package.py
@@ -83,13 +83,6 @@ class Templight(CMakePackage):
 
     # Clang debug builds can be _huge_ (20+ GB), make sure you know what you
     # are doing before switching to them
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     # NOTE: LLVM has many configurable tweaks and optional tools/extensions.
     #       I did not think that  propagating all of these to a debugging and
     #       performance analysis tool was worth the maintenance burden. But

--- a/var/spack/repos/builtin/packages/templight/package.py
+++ b/var/spack/repos/builtin/packages/templight/package.py
@@ -81,8 +81,6 @@ class Templight(CMakePackage):
     )
     patch("develop-20180720.patch", when="@2018.07.20")
 
-    # Clang debug builds can be _huge_ (20+ GB), make sure you know what you
-    # are doing before switching to them
     # NOTE: LLVM has many configurable tweaks and optional tools/extensions.
     #       I did not think that  propagating all of these to a debugging and
     #       performance analysis tool was worth the maintenance burden. But

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -50,14 +50,6 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     version("1.2.0", sha256="607272992e05f8398d196f0acdcb4af025a4a96cd4f66614c6341f31d4561763")
     version("1.1.0", sha256="78618c81ca741b1fbba0853cb5d7af12c51973b514c268fc96dfb36b853cdb18")
 
-    # use release, instead of release with debug symbols b/c vtkm libs
-    # can overwhelm compilers with too many symbols
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("shared", default=False, description="build shared libs")
 
     variant("doubleprecision", default=True, description="enable double precision")

--- a/var/spack/repos/builtin/packages/winbison/package.py
+++ b/var/spack/repos/builtin/packages/winbison/package.py
@@ -37,13 +37,6 @@ class Winbison(CMakePackage):
     build_directory = "spack-build"
     cmake_dir = os.path.join(build_directory, "CMakeBuild")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -35,13 +35,6 @@ class Xyce(CMakePackage):
     depends_on("flex")
     depends_on("bison")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     variant("mpi", default=True, description="Enable MPI support")
     depends_on("mpi", when="+mpi")
 


### PR DESCRIPTION
fixes #22918
refers #36181

A point in favor of the switch, made by @ax3l : 
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/591#note_1165628

:warning: **This change is a one liner with a wide impact** :warning: 

In this PR the default build type of the CMake build system is changed from `RelWithDebInfo` to `Release`. Submitting this since the discussion pops up here and there, latest place being #36181. I think we should default to "Release", but curious what would be the point to avoid that choice.