### PR TITLE
containerize: strip binaries in a less aggressive way

### DIFF
--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -116,3 +116,14 @@ def test_error_message_invalid_os(minimal_configuration):
     minimal_configuration["spack"]["container"]["images"]["os"] = "invalid:1"
     with pytest.raises(ValueError, match="invalid operating system"):
         writers.create(minimal_configuration)
+
+
+@pytest.mark.regression("34629,18030")
+def test_not_stripping_all_symbols(minimal_configuration):
+    """Tests that we are not stripping all symbols, so that libraries can still be
+    used for linking.
+    """
+    minimal_configuration["spack"]["container"]["strip"] = True
+    content = writers.create(minimal_configuration)()
+    assert "xargs strip" in content
+    assert "xargs strip -s" not in content

--- a/lib/spack/spack/test/container/singularity.py
+++ b/lib/spack/spack/test/container/singularity.py
@@ -40,3 +40,14 @@ def test_singularity_specific_properties(properties, expected, singularity_confi
     writer = writers.create(singularity_configuration)
     for name, value in expected.items():
         assert getattr(writer, name) == value
+
+
+@pytest.mark.regression("34629,18030")
+def test_not_stripping_all_symbols(singularity_configuration):
+    """Tests that we are not stripping all symbols, so that libraries can still be
+    used for linking.
+    """
+    singularity_configuration["spack"]["container"]["strip"] = True
+    content = writers.create(singularity_configuration)()
+    assert "xargs strip" in content
+    assert "xargs strip -s" not in content

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -32,7 +32,7 @@ RUN find -L {{ paths.view }}/* -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip -s
+    awk -F: '{print $1}' | xargs strip
 {% endif %}
 
 # Modifications to the environment that are necessary to run

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -37,7 +37,7 @@ EOF
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip -s
+    awk -F: '{print $1}' | xargs strip
 {% endif %}
 {% if extra_instructions.build %}
 {{ extra_instructions.build }}


### PR DESCRIPTION
fixes #34629
fixes #18030

Substitute "strip -s" with just "strip", so that libraries can be used to link against.