### PR TITLE
spack install: fail if --log-file and not --log-format

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -340,6 +340,10 @@ def install(parser, args):
     if args.deprecated:
         spack.config.set("config:deprecated", True, scope="command_line")
 
+    if args.log_file and not args.log_format:
+        msg = "the '--log-format' must be specified when using '--log-file'"
+        tty.die(msg)
+
     arguments.sanitize_reporter_options(args)
 
     def reporter_factory(specs):


### PR DESCRIPTION
fixes #34551

`spack install` now fails if a user passed the --logfile option without specifying a log format. 

Before, passing a `--log-file` without a `--log-format` was a no-op (and that was obviously confusing).