### PR TITLE
codespell: config, workflow and some typo fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+# ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,
-ignore-words-list = bu,fo,nd,ot,te,pilon,namd
+ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub
-ignore-words-list = bu,fo,nd,ot,te
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,
+ignore-words-list = bu,fo,nd,ot,te,pilon,namd

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,
-ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile
+# precice - package
+ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther,precice

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*,spack.yaml
 # precice - package
 ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther,precice

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*,*.dat
 ignore-regex = \b(THIRDPARTY|ThirdParty)\b
 # precice - package
 ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther,precice

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*,spack.yaml
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*
+ignore-regex = \b(THIRDPARTY|ThirdParty)\b
 # precice - package
 ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther,precice

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg
-# ignore-words-list = 
+skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub
+ignore-words-list = bu,fo,nd,ot,te

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,7 @@
 [codespell]
 skip = .git,*.pdf,*.svg,*.patch,*.py,*.diff,*.pub,foamEtcFile,patch.*,*.dat
 ignore-regex = \b(THIRDPARTY|ThirdParty)\b
+# default (34) + do not spit out warnings about non-utf-8 encoding
+quiet-level = 35
 # precice - package
 ignore-words-list = bu,fo,nd,ot,te,pilon,namd,oce,ther,precice

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Codespell
-        uses: codespell-project/actions-codespell@v1
+        uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -631,7 +631,7 @@ Spack now supports Python 3.12 (#40155)
 
    Spack's traditional [package preferences](
      https://spack.readthedocs.io/en/latest/build_settings.html#package-preferences)
-   are soft, but we've added hard requriements to `packages.yaml` and `spack.yaml`
+   are soft, but we've added hard requirements to `packages.yaml` and `spack.yaml`
    (#32528, #32369). Package requirements use the same syntax as specs:
 
    ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1547,7 +1547,7 @@ This minor release includes two new features:
 
 This release also includes several important fixes:
 
-* MPICC and related variables are now cleand in the build environment (#17450)
+* MPICC and related variables are now cleaned in the build environment (#17450)
 * LLVM flang only builds CUDA offload components when +cuda (#17466)
 * CI pipelines no longer upload user environments that can contain secrets to the internet (#17545)
 * CI pipelines add bootstrapped compilers to the compiler config (#17536)

--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -6,7 +6,7 @@
 
 function Compare-CommonArgs {
     $CMDArgs = $args[0]
-    # These aruments take precedence and call for no futher parsing of arguments
+    # These arguments take precedence and call for no further parsing of arguments
     # invoke actual Spack entrypoint with that context and exit after
     "--help", "-h", "--version", "-V" | ForEach-Object {
         $arg_opt = $_

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -42,7 +42,7 @@ concretizer:
     # "minimal": allows the duplication of 'build-tools' nodes only (e.g. py-setuptools, cmake etc.)
     # "full" (experimental): allows separation of the entire build-tool stack (e.g. the entire "cmake" subDAG)
     strategy: minimal
-  # Option to specify compatiblity between operating systems for reuse of compilers and packages
+  # Option to specify compatibility between operating systems for reuse of compilers and packages
   # Specified as a key: [list] where the key is the os that is being targeted, and the list contains the OS's 
   # it can reuse. Note this is a directional compatibility so mutual compatibility between two OS's 
   # requires two entries i.e. os_compatible: {sonoma: [monterey], monterey: [sonoma]}

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -97,7 +97,7 @@ config:
 
 
   # If this is false, tools like curl that use SSL will not verify
-  # certifiates. (e.g., curl will use use the -k option)
+  # certificates. (e.g., curl will use use the -k option)
   verify_ssl: true
 
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -149,8 +149,8 @@ this can expose you to attacks.  Use at your own risk.
 ``ssl_certs``
 --------------------
 
-Path to custom certificats for SSL verification. The value can be a 
-filesytem path, or an environment variable that expands to an absolute file path.
+Path to custom certificates for SSL verification. The value can be a 
+filesystem path, or an environment variable that expands to an absolute file path.
 The default value is set to the environment variable ``SSL_CERT_FILE``
 to use the same syntax used by many other applications that automatically
 detect custom certificates.

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -134,7 +134,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spac
 
 .. code-block:: toml
 
-   [project.entry_points."spack.extenions"]
+   [project.entry_points."spack.extensions"]
    my_package = "my_package:get_extension_path"
 
 The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -287,7 +287,7 @@ variables for themselves, or need to have variables of their own dependencies se
 
 In practice however, ``run`` is often sufficient, and may make ``module load`` snappier.
 
-The ``all`` option is discouraged and seldomly used.
+The ``all`` option is discouraged and seldom used.
 
 A common complaint about autoloading is the large number of modules that are visible to the user.
 Spack has a solution for this as well: ``hide_implicits: true``. This ensures that only those

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -935,7 +935,7 @@ string is split into a list of components based on delimiters such as
 ``.`` and ``-`` and string boundaries. The components are split into
 the **release** and a possible **pre-release** (if the last component
 is numeric and the second to last is a string ``alpha``, ``beta`` or ``rc``).
-The release components are ordered lexicographically, with comparsion
+The release components are ordered lexicographically, with comparison
 between different types of components as follows:
 
 #. The following special strings are considered larger than any other

--- a/lib/spack/spack/cmd/installer/CMakeLists.txt
+++ b/lib/spack/spack/cmd/installer/CMakeLists.txt
@@ -11,7 +11,7 @@ if (SPACK_VERSION)
   set(SPACK_FILENAME "spack-${SPACK_VERSION}.tar.gz")
   set(SPACK_DIR "spack-${SPACK_VERSION}")
 
-  # SPACK DOWLOAD AND EXTRACTION-----------------------------------
+  # SPACK DOWNLOAD AND EXTRACTION-----------------------------------
   file(DOWNLOAD "${SPACK_DL}/${SPACK_FILENAME}"
     "${CMAKE_CURRENT_BINARY_DIR}/${SPACK_FILENAME}"
     STATUS download_status
@@ -54,7 +54,7 @@ endif()
 message(STATUS "Successfully downloaded ${GIT_FILENAME}")
 
 
-# PYTHON DOWLOAD AND EXTRACTION-----------------------------------
+# PYTHON DOWNLOAD AND EXTRACTION-----------------------------------
 file(DOWNLOAD "${PY_DOWNLOAD_LINK}/${PY_FILENAME}"
   "${CMAKE_CURRENT_BINARY_DIR}/${PY_FILENAME}"
   STATUS download_status

--- a/lib/spack/spack/cmd/installer/README.md
+++ b/lib/spack/spack/cmd/installer/README.md
@@ -73,7 +73,7 @@ install. When given the option of adjusting your ``PATH``, choose the
 ``Git from the command line and also from 3rd-party software`` option. This will
 automatically update your ``PATH`` variable to include the ``git`` command.
 Certain Spack commands expect ``git`` to be part of the ``PATH``. If this step
-is not performed properly, certain Spack comands will not work.
+is not performed properly, certain Spack commands will not work.
 
 If your Spack installation needs to be modified, repaired, or uninstalled,
 you can do any of these things by rerunning ``Spack.exe``.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1335,7 +1335,7 @@ build(PackageNode) :- not attr("hash", PackageNode, _), attr("node", PackageNode
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
-% because we want to reuse what is avaialble, but
+% because we want to reuse what is available, but
 % we also want things that are built to stick to *default preferences* from
 % the package and from the user. We therefore treat built specs differently and apply
 % a different set of optimization criteria to them. Spack's *first* priority is to

--- a/lib/spack/spack/test/data/directory_search/README.txt
+++ b/lib/spack/spack/test/data/directory_search/README.txt
@@ -1,1 +1,1 @@
-This directory tree is made up to test that search functions wil return a stable ordered sequence.
+This directory tree is made up to test that search functions will return a stable ordered sequence.

--- a/lib/spack/spack/test/data/filter_file/x86_cpuid_info.c
+++ b/lib/spack/spack/test/data/filter_file/x86_cpuid_info.c
@@ -350,7 +350,7 @@ init_amd( PAPI_mh_info_t * mh_info, int *num_levels )
     * Application Note, AP-485, Nov 2008, 241618-033
     * Updated to AP-485, Aug 2009, 241618-036
     *
-    * The following data structure and its instantiation trys to
+    * The following data structure and its instantiation tries to
     * capture all the information in Section 2.1.3 of the above
     * document. Not all of it is used by PAPI, but it could be.
     * As the above document is revised, this table should be
@@ -989,7 +989,7 @@ static struct _intel_cache_info intel_cache[] = {
 // 0xB1 NOTE: This is currently the only instance where .entries
 //      is dependent on .size. It's handled as a code exception.
 //      If other instances appear in the future, the structure
-//      should probably change to accomodate it.
+//      should probably change to accommodate it.
 	{.descriptor = 0xB1,
 	 .level = 1,
 	 .type = PAPI_MH_TYPE_TLB | PAPI_MH_TYPE_INST,

--- a/lib/spack/spack/test/data/unparse/amdfftw.txt
+++ b/lib/spack/spack/test/data/unparse/amdfftw.txt
@@ -58,9 +58,9 @@ class Amdfftw(FftwBase):
     variant(
         "amd-mpi-vader-limit", default=False, description="Build with amd-mpi-vader-limit support"
     )
-    variant("static", default=False, description="Build with static suppport")
-    variant("amd-trans", default=False, description="Build with amd-trans suppport")
-    variant("amd-app-opt", default=False, description="Build with amd-app-opt suppport")
+    variant("static", default=False, description="Build with static support")
+    variant("amd-trans", default=False, description="Build with amd-trans support")
+    variant("amd-app-opt", default=False, description="Build with amd-app-opt support")
 
     depends_on("texinfo")
 

--- a/lib/spack/spack/test/data/unparse/llvm.txt
+++ b/lib/spack/spack/test/data/unparse/llvm.txt
@@ -496,7 +496,7 @@ class Llvm(CMakePackage, CudaPackage):
 
             except ProcessError:
                 # Newer LLVM versions have a simple script that sets up
-                # automatically when run with sudo priviliges
+                # automatically when run with sudo privileges
                 setup = Executable("./lldb/scripts/macos-setup-codesign.sh")
                 try:
                     setup()
@@ -688,10 +688,10 @@ class Llvm(CMakePackage, CudaPackage):
         if self.spec.satisfies("~code_signing platform=darwin"):
             cmake_args.append(define("LLDB_USE_SYSTEM_DEBUGSERVER", True))
 
-        # Semicolon seperated list of projects to enable
+        # Semicolon separated list of projects to enable
         cmake_args.append(define("LLVM_ENABLE_PROJECTS", projects))
 
-        # Semicolon seperated list of runtimes to enable
+        # Semicolon separated list of runtimes to enable
         if runtimes:
             cmake_args.append(define("LLVM_ENABLE_RUNTIMES", runtimes))
 

--- a/lib/spack/spack/test/data/unparse/mfem.txt
+++ b/lib/spack/spack/test/data/unparse/mfem.txt
@@ -7,7 +7,7 @@
 
 ``mfem`` was chosen because it's one of the most complex packages in Spack, because it
 uses ``@when`` functions, because it has ``configure()`` calls with star-args in
-different locations, and beacuse it has a function with embedded unicode that needs to
+different locations, and because it has a function with embedded unicode that needs to
 be unparsed consistently between Python versions.
 
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ drop = [
   '^pygments/lexers/(?!python|__init__|_mapping).*\.py$',
   # trim rich's markdown support
   "rich/markdown.py",
-  # ruamel.yaml installs unneded files
+  # ruamel.yaml installs unneeded files
   "ruamel.*.pth",
   "pvectorc.*.so"
 ]

--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -103,7 +103,7 @@ _bash_completion_spack() {
     local COMP_CWORD_NO_FLAGS=$((${#COMP_WORDS_NO_FLAGS[@]} - 1))
 
     # There is no guarantee that the cursor is at the end of the command line
-    # when tab completion is envoked. For example, in the following situation:
+    # when tab completion is invoked. For example, in the following situation:
     #     `spack -d [] install`
     # if the user presses the TAB key, a list of valid flags should be listed.
     # Note that we cannot simply ignore everything after the cursor. In the
@@ -118,7 +118,7 @@ _bash_completion_spack() {
         list_options=true
     fi
 
-    # In general, when envoking tab completion, the user is not expecting to
+    # In general, when invoking tab completion, the user is not expecting to
     # see optional flags mixed in with subcommands or package names. Tab
     # completion is used by those who are either lazy or just bad at spelling.
     # If someone doesn't remember what flag to use, seeing single letter flags

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -248,7 +248,7 @@ spack:
   # - axom +cuda cuda_arch=75       # axom: https://github.com/spack/spack/issues/29520
   # - cusz +cuda cuda_arch=75       # cusz: https://github.com/spack/spack/issues/38787
   # - dealii +cuda cuda_arch=75     # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
-  # - paraview +cuda cuda_arch=75   # Error building some cuda componets in paraview
+  # - paraview +cuda cuda_arch=75   # Error building some cuda components in paraview
   # - ecp-data-vis-sdk +adios2 +hdf5 +vtkm +zfp +paraview +cuda cuda_arch=75  # embree: https://github.com/spack/spack/issues/39534
   # - lammps +cuda cuda_arch=75     # lammps: needs NVIDIA driver
   # - lbann +cuda cuda_arch=75      # lbann: https://github.com/spack/spack/issues/38788
@@ -295,7 +295,7 @@ spack:
   # - axom +cuda cuda_arch=80       # axom: https://github.com/spack/spack/issues/29520
   # - cusz +cuda cuda_arch=80       # cusz: https://github.com/spack/spack/issues/38787
   # - dealii +cuda cuda_arch=80     # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
-  # - paraview +cuda cuda_arch=80   # Error building some cuda componets in paraview
+  # - paraview +cuda cuda_arch=80   # Error building some cuda components in paraview
   # - ecp-data-vis-sdk +adios2 +hdf5 +vtkm +zfp +paraview +cuda cuda_arch=80 # embree: https://github.com/spack/spack/issues/39534
   # - lammps +cuda cuda_arch=80     # lammps: needs NVIDIA driver
   # - lbann +cuda cuda_arch=80      # lbann: https://github.com/spack/spack/issues/38788

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -57,7 +57,7 @@ if python -m pytest --trace-config 2>&1 | grep xdist; then
 fi
 
 # We are running pytest-cov after the addition of pytest-xdist, since it integrates
-# other pugins for pytest automatically. We still need to use "coverage" explicitly
+# other plugins for pytest automatically. We still need to use "coverage" explicitly
 # for the commands above.
 #
 # There is a need to pass the configuration file explicitly due to a bug:

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -227,7 +227,7 @@ function check_sp_flags -d "check spack flags for h/V flags"
     # Check if inputs contain h or V flags.
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -246,7 +246,7 @@ end
 
 
 
-function match_flag -d "checks all combinations of flags ocurring inside of a string"
+function match_flag -d "checks all combinations of flags occurring inside of a string"
 
     # Remove leading and trailing spaces -- but we need to insert a "guard" (x)
     # so that eg. `string trim -h` doesn't trigger the help string for `string trim`
@@ -288,7 +288,7 @@ function check_env_activate_flags -d "check spack env subcommand flags for -h, -
     # Check if inputs contain -h/--help, --sh, --csh, or --fish
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -336,7 +336,7 @@ function check_env_deactivate_flags -d "check spack env subcommand flags for --s
     # Check if inputs contain --sh, --csh, or --fish
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -456,7 +456,7 @@ function spack_runner -d "Runner function for the `spack` wrapper"
 
         # CASE: spack subcommand is `env`. Here we get the spack runtime to
         # supply the appropriate shell commands for setting the environment
-        # varibles. These commands are then run by fish (using the `capture_all`
+        # variables. These commands are then run by fish (using the `capture_all`
         # function, instead of a command substitution).
 
         case "env"
@@ -600,7 +600,7 @@ set -l stat $status
 
 
 #
-# Delete temporary global variabels allocated in `allocated_sp_shared`.
+# Delete temporary global variables allocated in `allocated_sp_shared`.
 #
 
 delete_sp_shared
@@ -644,7 +644,7 @@ function spack_pathadd -d "Add path to specified variable (defaults to PATH)"
     #  -> Notes: [1] (cf. EOF).
     if test -d "$pa_new_path"
 
-        # combine argument array into single string (space seperated), to be
+        # combine argument array into single string (space separated), to be
         # passed to regular expression matching (`string match -r`)
         set -l _a "$pa_oldvalue"
 

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -600,7 +600,7 @@ set -l stat $status
 
 
 #
-# Delete temprary global variabels allocated in `allocated_sp_shared`.
+# Delete temporary global variabels allocated in `allocated_sp_shared`.
 #
 
 delete_sp_shared

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -12,7 +12,7 @@ Pop-Location
 Set-Variable -Name python_pf_ver -Value (Get-Command -Name python -ErrorAction SilentlyContinue).Path
 
 # If python_pf_ver is not defined, we cannot find Python on the Path
-# We next look for Spack vendored copys
+# We next look for Spack vendored copies
 if ($null -eq $python_pf_ver)
 {
     $python_pf_ver_list = Resolve-Path -Path "$PWD\Python*"

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -120,7 +120,7 @@ _spack_shell_wrapper() {
                 case $_sp_arg in
                     activate)
                         # Get --sh, --csh, or -h/--help arguments.
-                        # Space needed here becauses regexes start with a space
+                        # Space needed here because regexes start with a space
                         # and `-h` may be the only argument.
                         _a=" $@"
                         # Space needed here to differentiate between `-h`
@@ -141,7 +141,7 @@ _spack_shell_wrapper() {
                         ;;
                     deactivate)
                         # Get --sh, --csh, or -h/--help arguments.
-                        # Space needed here becauses regexes start with a space
+                        # Space needed here because regexes start with a space
                         # and `-h` may be the only argument.
                         _a=" $@"
                         # Space needed here to differentiate between `--sh`
@@ -170,7 +170,7 @@ _spack_shell_wrapper() {
             ;;
         "load"|"unload")
             # Get --sh, --csh, -h, or --help arguments.
-            # Space needed here becauses regexes start with a space
+            # Space needed here because regexes start with a space
             # and `-h` may be the only argument.
             _a=" $@"
             # Space needed here to differentiate between `-h`

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -103,7 +103,7 @@ _bash_completion_spack() {
     local COMP_CWORD_NO_FLAGS=$((${#COMP_WORDS_NO_FLAGS[@]} - 1))
 
     # There is no guarantee that the cursor is at the end of the command line
-    # when tab completion is envoked. For example, in the following situation:
+    # when tab completion is invoked. For example, in the following situation:
     #     `spack -d [] install`
     # if the user presses the TAB key, a list of valid flags should be listed.
     # Note that we cannot simply ignore everything after the cursor. In the
@@ -118,7 +118,7 @@ _bash_completion_spack() {
         list_options=true
     fi
 
-    # In general, when envoking tab completion, the user is not expecting to
+    # In general, when invoking tab completion, the user is not expecting to
     # see optional flags mixed in with subcommands or package names. Tab
     # completion is used by those who are either lazy or just bad at spelling.
     # If someone doesn't remember what flag to use, seeing single letter flags

--- a/var/spack/repos/builtin/packages/legion/README.md
+++ b/var/spack/repos/builtin/packages/legion/README.md
@@ -73,11 +73,11 @@ Finally, to build the highest performing installation of Legion requires an appr
 
 * **`fortran`**: This variant supports `on` or `off` and enables building of Fortran language bindings for Legion. `default=off`
 
-[//]: <> (TOOD: More details here on Kokkos interop?)
+[//]: <> (TODO: More details here on Kokkos interop?)
 
 * **`kokkos`**: Enable support for interoperability with [Kokkos](https://github.com/kokkos) use in Legion tasks. `default=off`
 
-[//]: <> (TOOD: More details here on OpenMP interop?)
+[//]: <> (TODO: More details here on OpenMP interop?)
 
 * **`openmp`**: This variant enables OpenMP support within Legion tasks (and within the Realm runtime). Please note that the full OpenMP feature set (e.g. OpenMP 5.0) is not fully supported when enabling this feature.  `default=off`
 

--- a/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
+++ b/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
@@ -44,7 +44,7 @@ for arg in "$@"; do
             jvm_mem_opts="$jvm_mem_opts $arg"
             ;;
          *)
-            if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+            if [[ ${pass_args} == '' ]] #needed to avoid preceding space on first arg e.g. ' MarkDuplicates'
                 then
                     pass_args="$arg"
             else


### PR DESCRIPTION
Excluded .py files entirely for this initial pass. Someone can remove skipping them and improve there as well