### PR TITLE
lua-luafilesystem: update source URL and improve rockspec detection

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -27,6 +27,8 @@ class LuaLuafilesystem(LuaPackage):
     version("1.7.0-2", sha256="23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59")
     version("1.6.3", sha256="11c7b1fc2e560c0a521246b84e6257138d97dddde5a19e405714dbabcb9436ca")
 
+    depends_on("lua-lang@:5.3", when="@:1.7")
+
 class LuaBuilder(spack.build_systems.lua.LuaBuilder):
     def install(self, pkg, spec, prefix):
         rocks_args = self.luarocks_args()

--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import spack.build_systems.lua
 from spack.package import *
 
@@ -28,7 +29,13 @@ class LuaLuafilesystem(LuaPackage):
 
 class LuaBuilder(spack.build_systems.lua.LuaBuilder):
     def install(self, pkg, spec, prefix):
-        rock = "rockspecs/luafilesystem-{0}.rockspec".format(self.spec.version)
         rocks_args = self.luarocks_args()
-        rocks_args.append(rock)
+        if spec.satisfies("@:1.7.0-2"):
+            rock = "rockspecs/luafilesystem-{0}.rockspec".format(self.spec.version)
+            if not os.path.isfile(rock):
+                rock = "rockspecs/luafilesystem-{0}-1.rockspec".format(self.spec.version)
+            if not os.path.isfile(rock):
+                # fall back on default luarocks behavior for finding rockspec
+                rock = ""
+            rocks_args.append(rock)
         self.pkg.luarocks("--tree=" + prefix, "make", *rocks_args)

--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 import spack.build_systems.lua
 from spack.package import *
 
@@ -19,6 +20,7 @@ class LuaLuafilesystem(LuaPackage):
     """
 
     homepage = "https://lunarmodules.github.io/luafilesystem/"
+
     def url_for_version(self, version):
         url = "https://github.com/lunarmodules/luafilesystem/archive/refs/tags/v{0}.tar.gz"
         return url.format(version.underscored)
@@ -28,6 +30,7 @@ class LuaLuafilesystem(LuaPackage):
     version("1.6.3", sha256="11c7b1fc2e560c0a521246b84e6257138d97dddde5a19e405714dbabcb9436ca")
 
     depends_on("lua-lang@:5.3", when="@:1.7")
+
 
 class LuaBuilder(spack.build_systems.lua.LuaBuilder):
     def install(self, pkg, spec, prefix):

--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.lua
 from spack.package import *
 
 
@@ -24,3 +25,10 @@ class LuaLuafilesystem(LuaPackage):
     version("1.8.0", sha256="16d17c788b8093f2047325343f5e9b74cccb1ea96001e45914a58bbae8932495")
     version("1.7.0-2", sha256="23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59")
     version("1.6.3", sha256="11c7b1fc2e560c0a521246b84e6257138d97dddde5a19e405714dbabcb9436ca")
+
+class LuaBuilder(spack.build_systems.lua.LuaBuilder):
+    def install(self, pkg, spec, prefix):
+        rock = "rockspecs/luafilesystem-{0}.rockspec".format(self.spec.version)
+        rocks_args = self.luarocks_args()
+        rocks_args.append(rock)
+        self.pkg.luarocks("--tree=" + prefix, "make", *rocks_args)

--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -16,9 +16,11 @@ class LuaLuafilesystem(LuaPackage):
     LuaFileSystem is free software and uses the same license as Lua 5.1
     """
 
-    homepage = "http://keplerproject.github.io/luafilesystem"
-    url = "https://github.com/keplerproject/luafilesystem/archive/v1_6_3.tar.gz"
+    homepage = "https://lunarmodules.github.io/luafilesystem/"
+    def url_for_version(self, version):
+        url = "https://github.com/lunarmodules/luafilesystem/archive/refs/tags/v{0}.tar.gz"
+        return url.format(version.underscored)
 
-    version("1_8_0", sha256="16d17c788b8093f2047325343f5e9b74cccb1ea96001e45914a58bbae8932495")
-    version("1_7_0_2", sha256="23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59")
-    version("1_6_3", sha256="11c7b1fc2e560c0a521246b84e6257138d97dddde5a19e405714dbabcb9436ca")
+    version("1.8.0", sha256="16d17c788b8093f2047325343f5e9b74cccb1ea96001e45914a58bbae8932495")
+    version("1.7.0-2", sha256="23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59")
+    version("1.6.3", sha256="11c7b1fc2e560c0a521246b84e6257138d97dddde5a19e405714dbabcb9436ca")


### PR DESCRIPTION
`luafilesystem` has moved to a new git repo: https://github.com/lunarmodules/luafilesystem

This PR has changes to reflect the new location. In addition, I've changed the versioning to use standard dot-separated versions.

I was also running into build errors for older versions of luafilesystem because Spack's Lua build system only searches for rockspecs in the parent directory (i.e. the search is not recursive). I've added code to find the correct rockspec for those older versions.