### PR TITLE
Enable rocm support and gtest variant for ucx

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -142,14 +142,12 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     def patch(self):
         if self.spec.satisfies("+rocm"):
-            filter_file(
-                "$$with_rocm", "${with_rocm[@]}", "configure", string=True
-            )
+            filter_file("$$with_rocm", "${with_rocm[@]}", "configure", string=True)
             filter_file(
                 "-I$with_rocm/include/hip -I$with_rocm/include",
                 "$ROCM_CPPFLAGS",
                 "configure",
-                string=True
+                string=True,
             )
             filter_file(
                 "-L$with_rocm/hip/lib -L$with_rocm/lib", "$ROCM_LDFLAGS", "configure", string=True

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -175,7 +175,6 @@ class Ucx(AutotoolsPackage, CudaPackage):
         args += self.with_or_without("pic")
 
         args += self.with_or_without("cuda", activation_value="prefix")
-        args += self.with_or_without("rocm")  # todo, prefix, avoid /opt/rocm guess.
 
         args += self.with_or_without("cm")
         args += self.enable_or_disable("cma")

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -170,6 +170,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
         args += self.with_or_without("openmp")
         args += self.enable_or_disable("optimizations")
         args += self.enable_or_disable("params-check", variant="parameter_checking")
+        args += self.enable_or_disable("gtest")
         args += self.with_or_without("pic")
 
         args += self.with_or_without("cuda", activation_value="prefix")
@@ -246,8 +247,6 @@ class Ucx(AutotoolsPackage, CudaPackage):
             args.append("--with-rocm=" + rocm_flags)
         else:
             args.append("--without-rocm")
-        if "+gtest" in spec:
-            args.append("--enable-gtest")
 
         return args
 

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -115,6 +115,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     variant("ud", default=False, description="Compile with IB Unreliable Datagram support")
     variant("verbs", default=False, description="Build OpenFabrics support")
     variant("xpmem", default=False, description="Enable XPMEM support")
+    variant("gtest", default=False, description="Build and install Googletest")
 
     depends_on("binutils+ld", when="%aocc", type="build")
     depends_on("binutils", when="+backtrace_detail")
@@ -129,6 +130,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     depends_on("rdma-core", when="+rdmacm")
     depends_on("rdma-core", when="+verbs")
     depends_on("xpmem", when="+xpmem")
+    depends_on("hip", when="+rocm")
 
     conflicts("+gdrcopy", when="~cuda", msg="gdrcopy currently requires cuda support")
     conflicts("+rocm", when="+gdrcopy", msg="gdrcopy > 2.0 does not support rocm")
@@ -137,6 +139,21 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     # See https://github.com/openucx/ucx/pull/8629, wrong int type
     patch("commit-2523555.patch", when="@1.13.1")
+
+    def patch(self):
+        if self.spec.satisfies("+rocm"):
+            filter_file(
+                "$$with_rocm", "${with_rocm[@]}", "configure", string=True
+            )
+            filter_file(
+                "-I$with_rocm/include/hip -I$with_rocm/include",
+                "$ROCM_CPPFLAGS",
+                "configure",
+                string=True
+            )
+            filter_file(
+                "-L$with_rocm/hip/lib -L$with_rocm/lib", "$ROCM_LDFLAGS", "configure", string=True
+            )
 
     @when("@1.9-dev")
     def autoreconf(self, spec, prefix):
@@ -219,9 +236,30 @@ class Ucx(AutotoolsPackage, CudaPackage):
         if "%aocc" in spec:
             args.append("LDFLAGS=-fuse-ld=bfd")
 
+        if "+rocm" in spec:
+            rocm_flags = " ".join(
+                [
+                    "-I" + self.spec["hip"].prefix.include,
+                    "-I" + self.spec["hip"].prefix.include.hip,
+                    "-I" + self.spec["hsa-rocr-dev"].prefix.include.hsa,
+                    "-L" + self.spec["hip"].prefix.lib,
+                    "-L" + self.spec["hsa-rocr-dev"].prefix.lib,
+                ]
+            )
+            args.append("--with-rocm=" + rocm_flags)
+        else:
+            args.append("--without-rocm")
+        if "+gtest" in spec:
+            args.append("--enable-gtest")
+
         return args
 
     @run_after("install")
     def drop_examples(self):
         if self.spec.satisfies("~examples"):
             shutil.rmtree(join_path(self.spec.prefix, "share", "ucx", "examples"))
+
+    @run_after("install")
+    def install_gtest(self):
+        if self.spec.satisfies("+gtest"):
+            install_tree("test", self.spec.prefix.test)


### PR DESCRIPTION
Currently ucx is not building with ROCm support even with the `+rocm` option set. When adding `+rocm` to the ucx installation right now, the installation will guess the ROCm path to be `/opt/rocm`. One single path cannot be set to the ROCm path since the required lib and include files are in multiple directories. Instead, this change will set the `-L` and `-I` flags. A `+gtest` option is also added to build and install Google tests.

To build ucx with ROCm support and run ROCm gtests:
`spack install ucx@1.13.0 +rocm +gtest`
`spack load ucx@1.13.0 +rocm +gtest`
`cd /spack/opt/spack/linux-centos8-zen/gcc-8.5.0/ucx-1.13.0-mvq4w4pximjoymits5rznowtun2euecp` (cd to ucx prefix path)
`test/gtest/gtest --gtest_filter=*rocm*`

sample gtest output:
[gtest_output.txt](https://github.com/spack/spack/files/11174058/gtest_output.txt)
