### PR TITLE
lammps: add missing hipfft dependency

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -533,6 +533,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     depends_on("mpi", when="+mpiio")
     depends_on("fftw-api@3", when="+kspace")
+    depends_on("hipfft", when="+kspace+kokkos+rocm")
     depends_on("voropp+pic", when="+voronoi")
     depends_on("netcdf-c+mpi", when="+user-netcdf")
     depends_on("netcdf-c+mpi", when="+netcdf")


### PR DESCRIPTION
Addresses #36696 in the `+kspace+kokkos+rocm` case.