### PR TITLE
Automated deployment to update package flux-pmix 2023-04-07

### DIFF
--- a/var/spack/repos/builtin/packages/flux-pmix/package.py
+++ b/var/spack/repos/builtin/packages/flux-pmix/package.py
@@ -43,16 +43,18 @@ class FluxPmix(AutotoolsPackage):
         pluginpath = join_path(self.prefix.lib, "flux/shell/plugins/pmix.so")
         if spec.satisfies("@:0.3.0"):
             rcfile = join_path(self.prefix.etc, "flux/shell/lua.d/mpi/openmpi@5.lua")
-            filter_file( r"pmix/pmix.so", pluginpath)
+            filter_file(r"pmix/pmix.so", pluginpath)
         else:
             rcdir = join_path(self.prefix.etc, "flux/shell/lua.d")
             rcfile = join_path(rcdir, "pmix.lua")
             mkdirp(rcdir)
             with open(rcfile, "w") as fp:
-                fp.write("plugin.load(\"" + pluginpath + "\")")
- 
+                fp.write('plugin.load("' + pluginpath + '")')
+
     def setup_run_environment(self, env):
         spec = self.spec
         env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix, "etc/flux/shell/lua.d"))
         if spec.satisfies("@0.3.0:"):
-            env.prepend_path("FLUX_PMI_CLIENT_SEARCHPATH", join_path(self.prefix, "flux/upmi/plugins"))
+            env.prepend_path(
+                "FLUX_PMI_CLIENT_SEARCHPATH", join_path(self.prefix, "flux/upmi/plugins")
+            )

--- a/var/spack/repos/builtin/packages/flux-pmix/package.py
+++ b/var/spack/repos/builtin/packages/flux-pmix/package.py
@@ -18,8 +18,10 @@ class FluxPmix(AutotoolsPackage):
     maintainers("grondo")
 
     version("main", branch="main")
+    version("0.3.0", sha256="88edb2afaeb6058b56ff915105a36972acc0d83204cff7f4a4d2f65a5dee9d34")
     version("0.2.0", sha256="d09f1fe6ffe54f83be4677e1e727640521d8110090515d94013eba0f58216934")
 
+    depends_on("flux-core@0.49.0:", when="@0.3.0:")
     depends_on("flux-core@0.30.0:")
     depends_on("pmix@v4.1.0:")
     depends_on("openmpi")
@@ -37,10 +39,20 @@ class FluxPmix(AutotoolsPackage):
 
     @run_after("install")
     def add_pluginpath(self):
-        rcfile = join_path(self.prefix.etc, "flux/shell/lua.d/mpi/openmpi@5.lua")
-        filter_file(
-            r"pmix/pmix.so", join_path(self.prefix.lib, "flux/shell/plugins/pmix/pmix.so"), rcfile
-        )
-
+        spec = self.spec
+        pluginpath = join_path(self.prefix.lib, "flux/shell/plugins/pmix.so")
+        if spec.satisfies("@:0.3.0"):
+            rcfile = join_path(self.prefix.etc, "flux/shell/lua.d/mpi/openmpi@5.lua")
+            filter_file( r"pmix/pmix.so", pluginpath)
+        else:
+            rcdir = join_path(self.prefix.etc, "flux/shell/lua.d")
+            rcfile = join_path(rcdir, "pmix.lua")
+            mkdirp(rcdir)
+            with open(rcfile, "w") as fp:
+                fp.write("plugin.load(\"" + pluginpath + "\")")
+ 
     def setup_run_environment(self, env):
+        spec = self.spec
         env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix, "etc/flux/shell/lua.d"))
+        if spec.satisfies("@0.3.0:"):
+            env.prepend_path("FLUX_PMI_CLIENT_SEARCHPATH", join_path(self.prefix, "flux/upmi/plugins"))


### PR DESCRIPTION
This will update flux-pmix to use the new flux-core (recently merged). We had a few changes that are needed for the current recipe due to changes in flux-pmix:

 - changes to flux-pmix just went in that require flux-core 0.49.0 or later
 - `openmpi@5.lua` was dropped from the release, and also needs custom logic.

For provenance, our discussion is here https://github.com/flux-framework/flux-pmix/issues/83 and the successful build is here: https://github.com/flux-framework/spack/actions/runs/4634492203/jobs/8200744504

Thanks to @grondo and @garlick for the help in figuring out the additions below!