### PR TITLE
modules: add support for conflict in lua modulefile

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -400,28 +400,30 @@ that are already in the Lmod hierarchy.
 
 
 .. note::
-   Tcl modules
-     Tcl modules also allow for explicit conflicts between modulefiles.
+   Tcl and Lua modules also allow for explicit conflicts between modulefiles.
 
-     .. code-block:: yaml
+   .. code-block:: yaml
 
-        modules:
-          default:
-            enable:
-              - tcl
-            tcl:
-              projections:
-                all: '{name}/{version}-{compiler.name}-{compiler.version}'
-              all:
-                conflict:
-                  - '{name}'
-                  - 'intel/14.0.1'
+      modules:
+        default:
+          enable:
+            - tcl
+          tcl:
+            projections:
+              all: '{name}/{version}-{compiler.name}-{compiler.version}'
+            all:
+              conflict:
+                - '{name}'
+                - 'intel/14.0.1'
 
-     will create module files that will conflict with ``intel/14.0.1`` and with the
-     base directory of the same module, effectively preventing the possibility to
-     load two or more versions of the same software at the same time. The tokens
-     that are available for use in this directive are the same understood by
-     the :meth:`~spack.spec.Spec.format` method.
+   will create module files that will conflict with ``intel/14.0.1`` and with the
+   base directory of the same module, effectively preventing the possibility to
+   load two or more versions of the same software at the same time. The tokens
+   that are available for use in this directive are the same understood by the
+   :meth:`~spack.spec.Spec.format` method.
+
+   For Lmod and Environment Modules versions prior 4.2, it is important to
+   express the conflict on both modulefiles conflicting with each other.
 
 
 .. note::

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -796,7 +796,7 @@ class BaseContext(tengine.Context):
         if errors:
             raise ModulesError(
                 message="conflict scheme does not match naming scheme",
-                long_message="\n".join(errors),
+                long_message="\n    ".join(errors),
             )
 
     @tengine.context_property

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -788,7 +788,8 @@ class BaseContext(tengine.Context):
                 if naming_dir != conflict_dir:
                     errors.extend(
                         [
-                            f"spec={self.spec.cshort_spec}" f"conflict_scheme={item}",
+                            f"spec={self.spec.cshort_spec}",
+                            f"conflict_scheme={item}",
                             f"naming_scheme={projection}",
                         ]
                     )

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -7,13 +7,9 @@
 non-hierarchical modules.
 """
 import posixpath
-import string
 from typing import Any, Dict
 
-import llnl.util.tty as tty
-
 import spack.config
-import spack.projections as proj
 import spack.tengine as tengine
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
@@ -56,11 +52,6 @@ def make_context(spec, module_set_name, explicit):
 class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
-    @property
-    def conflicts(self):
-        """Conflicts for this module file"""
-        return self.conf.get("conflict", [])
-
 
 class TclFileLayout(BaseFileLayout):
     """File layout for tcl module files."""
@@ -73,29 +64,6 @@ class TclContext(BaseContext):
     def prerequisites(self):
         """List of modules that needs to be loaded automatically."""
         return self._create_module_list_of("specs_to_prereq")
-
-    @tengine.context_property
-    def conflicts(self):
-        """List of conflicts for the tcl module file."""
-        fmts = []
-        projection = proj.get_projection(self.conf.projections, self.spec)
-        f = string.Formatter()
-        for item in self.conf.conflicts:
-            if len([x for x in f.parse(item)]) > 1:
-                for naming_dir, conflict_dir in zip(projection.split("/"), item.split("/")):
-                    if naming_dir != conflict_dir:
-                        message = "conflict scheme does not match naming "
-                        message += "scheme [{spec}]\n\n"
-                        message += 'naming scheme   : "{nformat}"\n'
-                        message += 'conflict scheme : "{cformat}"\n\n'
-                        message += "** You may want to check your "
-                        message += "`modules.yaml` configuration file **\n"
-                        tty.error(message.format(spec=self.spec, nformat=projection, cformat=item))
-                        raise SystemExit("Module generation aborted.")
-                item = self.spec.format(item)
-            fmts.append(item)
-        # Substitute spec tokens if present
-        return [self.spec.format(x) for x in fmts]
 
 
 class TclModulefileWriter(BaseModuleFileWriter):

--- a/lib/spack/spack/test/data/modules/lmod/conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/conflicts.yaml
@@ -1,0 +1,10 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@3.3'
+  all:
+    autoload: none
+    conflict:
+      - '{name}'
+      - 'intel/14.0.1'

--- a/lib/spack/spack/test/data/modules/lmod/wrong_conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/wrong_conflicts.yaml
@@ -1,0 +1,11 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@3.3'
+  projections:
+    all: '{name}/{version}-{compiler.name}'
+  all:
+    autoload: none
+    conflict:
+      - '{name}/{compiler.name}'

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -307,7 +307,7 @@ class TestLmod:
 
         # This configuration is inconsistent, check an error is raised
         module_configuration("wrong_conflicts")
-        with pytest.raises(SystemExit):
+        with pytest.raises(spack.modules.common.ModulesError):
             modulefile_content("mpileaks")
 
     def test_override_template_in_package(self, modulefile_content, module_configuration):

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -290,6 +290,26 @@ class TestLmod:
         with pytest.raises(spack.modules.lmod.NonVirtualInHierarchyError):
             module.write()
 
+    def test_conflicts(self, modulefile_content, module_configuration):
+        """Tests adding conflicts to the module."""
+
+        # This configuration has no error, so check the conflicts directives
+        # are there
+        module_configuration("conflicts")
+        content = modulefile_content("mpileaks")
+
+        assert len([x for x in content if x.startswith("conflict")]) == 2
+        assert len([x for x in content if x == 'conflict("mpileaks")']) == 1
+        assert len([x for x in content if x == 'conflict("intel/14.0.1")']) == 1
+
+    def test_inconsistent_conflict_in_modules_yaml(self, modulefile_content, module_configuration):
+        """Tests inconsistent conflict definition in `modules.yaml`."""
+
+        # This configuration is inconsistent, check an error is raised
+        module_configuration("wrong_conflicts")
+        with pytest.raises(SystemExit):
+            modulefile_content("mpileaks")
+
     def test_override_template_in_package(self, modulefile_content, module_configuration):
         """Tests overriding a template from and attribute in the package."""
 

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -316,7 +316,7 @@ class TestTcl:
 
         # This configuration is inconsistent, check an error is raised
         module_configuration("wrong_conflicts")
-        with pytest.raises(SystemExit):
+        with pytest.raises(spack.modules.common.ModulesError):
             modulefile_content("mpileaks")
 
     def test_module_index(self, module_configuration, factory, tmpdir_factory):

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -311,6 +311,9 @@ class TestTcl:
         assert len([x for x in content if x == "conflict mpileaks"]) == 1
         assert len([x for x in content if x == "conflict intel/14.0.1"]) == 1
 
+    def test_inconsistent_conflict_in_modules_yaml(self, modulefile_content, module_configuration):
+        """Tests inconsistent conflict definition in `modules.yaml`."""
+
         # This configuration is inconsistent, check an error is raised
         module_configuration("wrong_conflicts")
         with pytest.raises(SystemExit):

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -69,6 +69,12 @@ setenv("LMOD_{{ name|upper() }}_VERSION", "{{ version_part }}")
 depends_on("{{ module }}")
 {% endfor %}
 {% endblock %}
+{#  #}
+{% block conflict %}
+{% for name in conflicts %}
+conflict("{{ name }}")
+{% endfor %}
+{% endblock %}
 
 {% block environment %}
 {% for command_name, cmd in environment_modifications %}


### PR DESCRIPTION
Add support for conflict directives in Lua modulefile like done for Tcl modulefile.

Note that conflicts are correctly honored on Lmod and Environment Modules <4.2 only if mutually expressed on both modulefiles that conflict with each other.

Fixes #21987.