### PR TITLE
Prevent `spack install` from installing build deps of installed packages

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2420,7 +2420,9 @@ class BuildRequest(object):
         else:
             cache_only = self.install_args.get("dependencies_cache_only")
 
-        if not cache_only or include_build_deps:
+        # Only add build dependencies if dependency is not already installed
+        # and build depdencies are called for by install_args.
+        if (not cache_only or include_build_deps) and not pkg.spec.installed:
             deptypes.append("build")
         if self.run_tests(pkg):
             deptypes.append("test")

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2420,8 +2420,9 @@ class BuildRequest(object):
         else:
             cache_only = self.install_args.get("dependencies_cache_only")
 
-        # Only add build dependencies if pkg is not already installed
-        # and build depdencies are called for by install_args.
+        # Include build dependencies if pkg is not installed and cache_only
+        # is False, or if build depdencies are explicitly called for
+        # by include_build_deps.
         if include_build_deps or not (cache_only or pkg.spec.installed):
             deptypes.append("build")
         if self.run_tests(pkg):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2420,7 +2420,7 @@ class BuildRequest(object):
         else:
             cache_only = self.install_args.get("dependencies_cache_only")
 
-        # Only add build dependencies if dependency is not already installed
+        # Only add build dependencies if pkg is not already installed
         # and build depdencies are called for by install_args.
         if (not cache_only or include_build_deps) and not pkg.spec.installed:
             deptypes.append("build")

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2422,7 +2422,7 @@ class BuildRequest(object):
 
         # Only add build dependencies if pkg is not already installed
         # and build depdencies are called for by install_args.
-        if (not cache_only or include_build_deps) and not pkg.spec.installed:
+        if include_build_deps or not (cache_only or pkg.spec.installed):
             deptypes.append("build")
         if self.run_tests(pkg):
             deptypes.append("test")

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -253,28 +253,35 @@ def test_installer_str(install_mockery):
     assert "failed (0)" in istr
 
 
-def test_installer_prune_built_build_deps(install_mockery):
+def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     r"""
     Ensure that build dependencies of installed deps are pruned
     from installer package queues.
 
                 (a)
+                / \
                /   \
              (d)   (b) <-- is installed already so we should
-              |      \     prune (c) from this install since
-             (e)     (c)   it is *only* needed to build (b)
+               \   / \     prune (c) from this install since
+                \ /  (c)   it is *only* needed to build (b)
+                (e)
 
     Thus since (b) is already installed our build_pq dag should
     only include four packages. [(a), (b), (d), (e)]
     """
-    tmpdir = tempfile.mkdtemp()
-    builder = spack.repo.MockRepositoryBuilder(tmpdir)
+    @property
+    def _mock_installed(self):
+        return self.name in ["b"]
+
+    # Mock the installed property to say that (b) is installed
+    monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
+
+    # Create mock repository with packages (a), (b), (c), (d), and (e)
+    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
 
     builder.add_package("a", dependencies=[("b", "build", None), ("d", "build", None)])
-
-    builder.add_package("b", dependencies=[("c", "build", None)])
+    builder.add_package("b", dependencies=[("c", "build", None), ("e", "build", None)])
     builder.add_package("c")
-
     builder.add_package("d", dependencies=[("e", "build", None)])
     builder.add_package("e")
 
@@ -282,15 +289,11 @@ def test_installer_prune_built_build_deps(install_mockery):
         const_arg = installer_args(["a"], {})
         installer = create_installer(const_arg)
 
-        # Mark (b) as already installed locally
-        b_spec = spack.spec.Spec("b")
-        b_spec.concretize()
-        installer._flag_installed(b_spec.package)
-
         installer._init_queue()
 
         # Assert that (c) is not in the build_pq
-        assert len(installer.build_pq) == 4
+        for _, task in installer.build_pq:
+            assert "c-" not in task.pkg_id
 
 
 def test_check_before_phase_error(install_mockery):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -257,21 +257,21 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     Ensure that build dependencies of installed deps are pruned
     from installer package queues.
 
-                (a)
-                / \
-               /   \
-             (d)   (b) <-- is installed already so we should
-               \   / \     prune (c) from this install since
-                \ /  (c)   it is *only* needed to build (b)
-                (e)
+               (a)
+              /   \
+             /     \
+           (b)     (c) <--- is installed already so we should
+              \   / | \     prune (f) from this install since
+               \ /  |  \    it is *only* needed to build (b)
+               (d) (e) (f)
 
-    Thus since (b) is already installed our build_pq dag should
-    only include four packages. [(a), (b), (d), (e)]
+    Thus since (c) is already installed our build_pq dag should
+    only include four packages. [(a), (b), (c), (d), (e)]
     """
 
     @property
     def _mock_installed(self):
-        return self.name in ["b"]
+        return self.name in ["c"]
 
     # Mock the installed property to say that (b) is installed
     monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
@@ -279,11 +279,14 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     # Create mock repository with packages (a), (b), (c), (d), and (e)
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
 
-    builder.add_package("a", dependencies=[("b", "build", None), ("d", "build", None)])
-    builder.add_package("b", dependencies=[("c", "build", None), ("e", "build", None)])
-    builder.add_package("c")
-    builder.add_package("d", dependencies=[("e", "build", None)])
+    builder.add_package("a", dependencies=[("b", "build", None), ("c", "build", None)])
+    builder.add_package("b", dependencies=[("d", "build", None)])
+    builder.add_package(
+        "c", dependencies=[("d", "build", None), ("e", "all", None), ("f", "build", None)]
+    )
+    builder.add_package("d")
     builder.add_package("e")
+    builder.add_package("f")
 
     with spack.repo.use_repositories(builder.root):
         const_arg = installer_args(["a"], {})
@@ -292,8 +295,9 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
         installer._init_queue()
 
         # Assert that (c) is not in the build_pq
-        for _, task in installer.build_pq:
-            assert "c-" not in task.pkg_id
+        result = set([task.pkg_id[0] for _, task in installer.build_pq])
+        expected = set(["a", "b", "c", "d", "e"])
+        assert result == expected
 
 
 def test_check_before_phase_error(install_mockery):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -7,7 +7,6 @@ import glob
 import os
 import shutil
 import sys
-import tempfile
 
 import py
 import pytest
@@ -269,6 +268,7 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     Thus since (b) is already installed our build_pq dag should
     only include four packages. [(a), (b), (d), (e)]
     """
+
     @property
     def _mock_installed(self):
         return self.name in ["b"]


### PR DESCRIPTION
Currently if you ask Spack to install a spec it will enqueue all of the build dependencies in the spec's DAG **even if those build dependencies are only required for a package that is already built/installed on the host system.**

**Steps to Reproduce:**
```
$ spack install go
$ spack gc
$ spack install glab
```

This will suddenly begin rebuilding all of the build dependencies of Go since they were removed by `spack gc` even though Go is already installed.

This PR fixes the above behavior by restricting dependency types in the build queue staging to only include build dependencies of a pkg if that pkg is not currently installed. After making these changes you'll see that installing glab as in the above example only results in `glab` being built from source.