### PR TITLE
upcxx: Fixes for Cray targets

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 
 
 def is_CrayXC():
-    return (spack.platforms.host().name == "cray") and (
+    return (spack.platforms.host().name in ["linux", "cray"]) and (
         os.environ.get("CRAYPE_NETWORK_TARGET") == "aries"
     )
 
@@ -155,14 +155,6 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         else:
             options.append("--with-cross=" + spec.variants["cross"].value)
 
-        if is_CrayXC():
-            # Spack loads the cray-libsci module incorrectly on ALCF theta,
-            # breaking the Cray compiler wrappers
-            # cray-libsci is irrelevant to our build, so disable it
-            for var in ["PE_PKGCONFIG_PRODUCTS", "PE_PKGCONFIG_LIBS"]:
-                env[var] = ":".join(
-                    filter(lambda x: "libsci" not in x.lower(), env[var].split(":"))
-                )
         if (is_CrayXC() or is_CrayEX()) and env.get("CRAYPE_DIR"):
             # Undo spack compiler wrappers:
             # the C/C++ compilers must work post-install

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -187,9 +187,9 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             # This list can be pruned once the floor version reaches 2022.9.0
             options.append("--with-pmi-version=cray")
             if which("srun"):
-                options.append("--with-pmi-runcmd='srun -n %N -- %C'")
+                options.append("--with-pmi-runcmd=srun -n %N -- %C")
             elif which("aprun"):
-                options.append("--with-pmi-runcmd='aprun -n %N %C'")
+                options.append("--with-pmi-runcmd=aprun -n %N %C")
             options.append("--disable-ibv")
             options.append("--enable-ofi")
             options.append("--with-default-network=ofi")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -16,15 +16,16 @@ def is_CrayXC():
 
 
 def is_CrayEX():
-    if (spack.platforms.host().name in ["linux", "cray"]):
+    if spack.platforms.host().name in ["linux", "cray"]:
         target = os.environ.get("CRAYPE_NETWORK_TARGET")
-        if (target in ["ofi", "ucx"]): # normal case
+        if target in ["ofi", "ucx"]:  # normal case
             return True
-        elif (target is None): # but some systems lack Cray PrgEnv
+        elif target is None:  # but some systems lack Cray PrgEnv
             fi_info = which("fi_info")
             if fi_info and fi_info("-l", output=str).find("cxi") >= 0:
                 return True
     return False
+
 
 def cross_detect():
     if is_CrayXC():

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -287,4 +287,8 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             variants += "+rocm"
         else:
             variants += "~rocm"
+        if re.search(r"-DUPCXXI_ZE_ENABLED=1", output):
+            variants += "+level_zero"
+        else:
+            variants += "~level_zero"
         return variants


### PR DESCRIPTION
This PR improves automated default behavior for a few Cray XC/EX systems.

Successfully validated on ALCF Polaris and ALCF Theta