### PR TITLE
qt: new version 5.15.9

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -31,6 +31,7 @@ class Qt(Package):
 
     phases = ["configure", "build", "install"]
 
+    version("5.15.9", sha256="26d5f36134db03abe4a6db794c7570d729c92a3fc1b0bf9b1c8f86d0573cd02f")
     version("5.15.8", sha256="776a9302c336671f9406a53bd30b8e36f825742b2ec44a57c08217bff0fa86b9")
     version("5.15.7", sha256="8a71986676a3f37a198a9113acedbfd5bc5606a459b6b85816d951458adbe9a0")
     version("5.15.6", sha256="ebc77d27934b70b25b3dc34fbec7c4471eb451848e891c42b32409ea30fe309f")


### PR DESCRIPTION
This adds the new LTS version of Qt5. No build system changes needed.

The bundled libjpeg and sqlite versions were updated, but it is unclear if these are actual build requirements, and we have not been tracking these specific versions in the version dependencies (likely due to exactly this lack of clarity).

Compare: https://github.com/qt/qtbase/compare/v5.15.8-lts-lgpl...v5.15.9-lts-lgpl

Builds on my system:
```console
[+] /opt/software/linux-ubuntu23.04-skylake/gcc-12.2.0/qt-5.15.9-e643ajipydddydnc5kifonhdbexxgxxw
```