### PR TITLE
Add container images supporting RHEL alternatives

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -48,7 +48,7 @@ jobs:
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
                      [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
                      [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
-                     [rockylinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'rockylinux:8'],
+                     [rockylinux8, 'linux/amd64,linux/arm64', 'rockylinux:8'],
                      [rockylinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'rockylinux:9'],
                      [fedora37, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:37'],
                      [fedora38, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:38']]

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -45,7 +45,9 @@ jobs:
                      [leap15, 'linux/amd64,linux/arm64,linux/ppc64le', 'opensuse/leap:15'],
                      [ubuntu-bionic, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:18.04'],
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
-                     [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04']]
+                     [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
+                     [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
+                     [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9']]
     name: Build ${{ matrix.dockerfile[0] }}
     if: github.repository == 'spack/spack'
     steps:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -48,6 +48,8 @@ jobs:
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
                      [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
                      [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
+                     [rockylinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'rockylinux:8'],
+                     [rockylinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'rockylinux:9'],
                      [fedora37, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:37'],
                      [fedora38, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:38']]
     name: Build ${{ matrix.dockerfile[0] }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -47,7 +47,9 @@ jobs:
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
                      [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
-                     [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9']]
+                     [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
+                     [fedora37, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:37'],
+                     [fedora38, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:38']]
     name: Build ${{ matrix.dockerfile[0] }}
     if: github.repository == 'spack/spack'
     steps:

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -40,6 +40,34 @@
         "image": "docker.io/fedora:37"
       }
     },
+    "rockylinux:9": {
+      "bootstrap": {
+        "template": "container/rockylinux_9.dockerfile",
+        "image": "docker.io/rockylinux:9"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/rockylinux9",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "docker.io/rockylinux:9"
+      }
+    },
+    "rockylinux:8": {
+      "bootstrap": {
+        "template": "container/rockylinux_8.dockerfile",
+        "image": "docker.io/rockylinux:8"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/rockylinux8",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "docker.io/rockylinux:8"
+      }
+    },
     "almalinux:9": {
       "bootstrap": {
         "template": "container/almalinux_9.dockerfile",

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -12,6 +12,34 @@
       },
       "os_package_manager": "yum_amazon"
     },
+    "almalinux:9": {
+      "bootstrap": {
+        "template": "container/almalinux_9.dockerfile",
+        "image": "quay.io/almalinux/almalinux:9"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/almalinux9",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "quay.io/almalinux/almalinux:9"
+      }
+    },
+    "almalinux:8": {
+      "bootstrap": {
+        "template": "container/almalinux_8.dockerfile",
+        "image": "quay.io/almalinux/almalinux:8"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/almalinux8",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "quay.io/almalinux/almalinux:8"
+      }
+    },
     "centos:stream": {
       "bootstrap": {
         "template": "container/centos_stream.dockerfile",

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -12,6 +12,34 @@
       },
       "os_package_manager": "yum_amazon"
     },
+    "fedora:38": {
+      "bootstrap": {
+        "template": "container/fedora_38.dockerfile",
+        "image": "docker.io/fedora:38"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/fedora38",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "docker.io/fedora:38"
+      }
+    },
+    "fedora:37": {
+      "bootstrap": {
+        "template": "container/fedora_37.dockerfile",
+        "image": "docker.io/fedora:37"
+      },
+      "os_package_manager": "yum",
+      "build": "spack/fedora37",
+      "build_tags": {
+        "develop": "latest"
+      },
+      "final": {
+        "image": "docker.io/fedora:37"
+      }
+    },
     "almalinux:9": {
       "bootstrap": {
         "template": "container/almalinux_9.dockerfile",

--- a/share/spack/templates/container/almalinux_8.dockerfile
+++ b/share/spack/templates/container/almalinux_8.dockerfile
@@ -2,6 +2,7 @@
 {% block install_os_packages %}
 RUN yum update -y \
  && yum install -y \
+        bzip2 \
         curl \
         file \
         findutils \
@@ -10,6 +11,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +19,9 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/almalinux_8.dockerfile
+++ b/share/spack/templates/container/almalinux_8.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}

--- a/share/spack/templates/container/almalinux_9.dockerfile
+++ b/share/spack/templates/container/almalinux_9.dockerfile
@@ -1,7 +1,10 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
 RUN yum update -y \
- && yum install -y \
+ && yum install -y epel-release \
+ && yum update -y \
+ && yum --enablerepo epel install -y \
+        bzip2 \
         curl-minimal \
         file \
         findutils \
@@ -10,6 +13,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +21,9 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/almalinux_9.dockerfile
+++ b/share/spack/templates/container/almalinux_9.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl-minimal \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}

--- a/share/spack/templates/container/fedora_37.dockerfile
+++ b/share/spack/templates/container/fedora_37.dockerfile
@@ -2,6 +2,7 @@
 {% block install_os_packages %}
 RUN yum update -y \
  && yum install -y \
+        bzip2 \
         curl \
         file \
         findutils \
@@ -10,6 +11,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +19,10 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        zstd \
+        xz \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/fedora_37.dockerfile
+++ b/share/spack/templates/container/fedora_37.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}

--- a/share/spack/templates/container/fedora_38.dockerfile
+++ b/share/spack/templates/container/fedora_38.dockerfile
@@ -2,6 +2,7 @@
 {% block install_os_packages %}
 RUN yum update -y \
  && yum install -y \
+        bzip2 \
         curl \
         file \
         findutils \
@@ -10,6 +11,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +19,10 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        xz \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/fedora_38.dockerfile
+++ b/share/spack/templates/container/fedora_38.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}

--- a/share/spack/templates/container/rockylinux_8.dockerfile
+++ b/share/spack/templates/container/rockylinux_8.dockerfile
@@ -2,6 +2,7 @@
 {% block install_os_packages %}
 RUN yum update -y \
  && yum install -y \
+        bzip2 \
         curl \
         file \
         findutils \
@@ -10,6 +11,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +19,10 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        xz \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/rockylinux_8.dockerfile
+++ b/share/spack/templates/container/rockylinux_8.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}

--- a/share/spack/templates/container/rockylinux_9.dockerfile
+++ b/share/spack/templates/container/rockylinux_9.dockerfile
@@ -1,7 +1,10 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
 RUN yum update -y \
- && yum install -y \
+ && yum install -y epel-release \
+ && yum update -y \
+ && yum --enablerepo epel install -y \
+        bzip2 \
         curl-minimal \
         file \
         findutils \
@@ -10,6 +13,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -17,7 +21,10 @@ RUN yum update -y \
         python3 \
         python3-pip \
         python3-setuptools \
+        svn \
         unzip \
+        xz \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/rockylinux_9.dockerfile
+++ b/share/spack/templates/container/rockylinux_9.dockerfile
@@ -1,0 +1,24 @@
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block install_os_packages %}
+RUN yum update -y \
+ && yum install -y \
+        curl-minimal \
+        file \
+        findutils \
+        gcc-c++ \
+        gcc \
+        gcc-gfortran \
+        git \
+        gnupg2 \
+        hostname \
+        iproute \
+        make \
+        patch \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        unzip \
+ && pip3 install boto3 \
+ && rm -rf /var/cache/yum \
+ && yum clean all
+{% endblock %}


### PR DESCRIPTION
The official Spack container images are very handy for deploying (my use case, in CI). Unfortunately the set of easily available images for the RHEL family of distributions is limited to CentOS 7 and Stream.

This PR adds support for a series of distributions, both in `spack containerize` and in the [official images on GitHub](https://github.com/orgs/spack/packages?repo_name=spack). Namely:
 - Alma Linux 8 and 9 and Rocky Linux 8 and 9, 1:1 rebuilds of RHEL 8 and 9 respectively, and
 - Fedora 37 and 38, the latest and soon-to-be (at writing, next Tuesday) latest releases of Fedora.  (Fedora 36 is skipped here since it goes EOL next month.)