### PR TITLE
scitokens-cpp: new versions 0.7.1, 1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -13,13 +13,18 @@ class ScitokensCpp(CMakePackage):
     homepage = "https://github.com/scitokens/scitokens-cpp"
     url = "https://github.com/scitokens/scitokens-cpp/archive/refs/tags/v0.7.0.tar.gz"
 
+    version("1.0.0", sha256="88376c5cd065aac8d92445184a02ccf5186dc4890ccd7518e88be436978675c0")
+    version("0.7.1", sha256="44a1bca188897b1e97645149d1f6bc187cd0e482ad36159ca376834f028ce5ef")
     version("0.7.0", sha256="72600cf32523b115ec7abf4ac33fa369e0a655b3d3b390e1f68363e6c4e961b6")
 
+    depends_on("cmake@2.6:")
+    depends_on("cmake@3.10:", when="@0.7.1:")
+    depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
     depends_on("uuid", type="build")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72
-    @when("^openssl@3:")
+    @when("@0.7.0 ^openssl@3:")
     def patch(self):
         filter_file(" -Werror", "", "CMakeLists.txt")


### PR DESCRIPTION
Two new versions were released since 0.7.0.

- https://github.com/scitokens/scitokens-cpp/releases/tag/v0.7.1
- https://github.com/scitokens/scitokens-cpp/releases/tag/v1.0.0

Some changes to dependencies:
- openssl always was an explicit requirement (but transitively satisfied by curl),
- `-Werror` was turned into a default false option in 0.7.1, then removed entirely in 1.0.0,
- cmake 3.10 required for both new versions.

Tested that all these new versions build fine:
```console
18:04:40 wdconinc@menelaos ~/git/spack (develop *$%>) $ spack find -lvx
==> In environment scitokens-cpp
==> Root specs
------- scitokens-cpp@0.7.0  ------- scitokens-cpp@0.7.1  ------- scitokens-cpp@1.0.0

==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@12.2.0 -----------------------
uvwdosd cmake@3.26.3~doc+ncurses+ownlibs~qt build_system=generic build_type=Release          5gqdlyl scitokens-cpp@0.7.1~ipo build_system=cmake build_type=RelWithDebInfo generator=make
r4bdoii scitokens-cpp@0.7.0~ipo build_system=cmake build_type=RelWithDebInfo generator=make  xnnvbsf scitokens-cpp@1.0.0~ipo build_system=cmake build_type=RelWithDebInfo generator=make
==> 4 installed packages
```