### PR TITLE
simsipm: new version 2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/simsipm/package.py
+++ b/var/spack/repos/builtin/packages/simsipm/package.py
@@ -19,10 +19,11 @@ class Simsipm(CMakePackage):
 
     maintainers("vvolkl")
 
+    version("2.0.2", sha256="ba60ed88b54b1b29d089f583dbce93b3272b0b13d47772941339f1503ee3fa48")
     version("1.2.4", sha256="1c633bebb19c490b5e6dfa5ada4a6bc7ec36348237c2626d57843a25af923211")
 
     variant("python", default=False, description="Build pybind11-based python bindings")
-    variant("openmp", default=False, description="Use OpenMP")
+    variant("openmp", default=False, description="Use OpenMP", when="@:1")
 
     extends("python", when="+python")
     depends_on("python@3.6:", when="+python", type=("build", "run"))


### PR DESCRIPTION
New version of SimSiPM, 2.0.2, full changelog at https://github.com/EdoPro98/SimSiPM/compare/v1.2.4...v2.0.2.

Relevant change for this recipe is the removal of OpenMP in the version 2 series.

Built successfully:
```console
12:28:42 wdconinc@menelaos ~/git/spack (develop *$%>) $ spack find -lvx
==> In environment simsipm
==> Root specs
------- simsipm +python

==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@12.2.0 -----------------------
uvwdosd cmake@3.26.3~doc+ncurses+ownlibs~qt build_system=generic build_type=Release  ftarihu simsipm@2.0.2~ipo+python build_system=cmake build_type=RelWithDebInfo generator=make
==> 2 installed packages
```