### PR TITLE
feat: move -N/--namespace(s) to common args, allow in `buildcache list`

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -383,7 +383,7 @@ def display_specs(specs, args=None, **kwargs):
         deps (bool): Display dependencies with specs
         long (bool): Display short hashes with specs
         very_long (bool): Display full hashes with specs (supersedes ``long``)
-        namespace (bool): Print namespaces along with names
+        namespaces (bool): Print namespaces along with names
         show_flags (bool): Show compiler flags with specs
         variants (bool): Show variants with specs
         indent (int): indent each line this much
@@ -407,7 +407,7 @@ def display_specs(specs, args=None, **kwargs):
     paths = get_arg("paths", False)
     deps = get_arg("deps", False)
     hashes = get_arg("long", False)
-    namespace = get_arg("namespace", False)
+    namespaces = get_arg("namespaces", False)
     flags = get_arg("show_flags", False)
     full_compiler = get_arg("show_full_compiler", False)
     variants = get_arg("variants", False)
@@ -428,7 +428,7 @@ def display_specs(specs, args=None, **kwargs):
 
     format_string = get_arg("format", None)
     if format_string is None:
-        nfmt = "{fullname}" if namespace else "{name}"
+        nfmt = "{fullname}" if namespaces else "{name}"
         ffmt = ""
         if full_compiler or flags:
             ffmt += "{%compiler.name}"

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -105,7 +105,7 @@ def setup_parser(subparser):
     install.set_defaults(func=install_fn)
 
     listcache = subparsers.add_parser("list", help=list_fn.__doc__)
-    arguments.add_common_arguments(listcache, ["long", "very_long"])
+    arguments.add_common_arguments(listcache, ["long", "very_long", "namespaces"])
     listcache.add_argument(
         "-v",
         "--variants",

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -330,6 +330,15 @@ def tags():
         help="filter a package query by tag (multiple use allowed)",
     )
 
+@arg
+def namespaces():
+    return Args(
+        "-N",
+        "--namespaces",
+        action="store_true",
+        default=False,
+        help="show fully qualified package names",
+    )
 
 @arg
 def jobs():

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -330,6 +330,7 @@ def tags():
         help="filter a package query by tag (multiple use allowed)",
     )
 
+
 @arg
 def namespaces():
     return Args(
@@ -339,6 +340,7 @@ def namespaces():
         default=False,
         help="show fully qualified package names",
     )
+
 
 @arg
 def jobs():

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -227,7 +227,7 @@ def display_env(env, args, decorator, results):
             env.user_specs,
             root_args,
             decorator=lambda s, f: color.colorize("@*{%s}" % f),
-            namespace=True,
+            namespaces=True,
             show_flags=True,
             show_full_compiler=True,
             variants=True,

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -67,7 +67,7 @@ def setup_parser(subparser):
         help="do not group specs by arch/compiler",
     )
 
-    arguments.add_common_arguments(subparser, ["long", "very_long", "tags"])
+    arguments.add_common_arguments(subparser, ["long", "very_long", "tags", "namespaces"])
 
     subparser.add_argument(
         "-c",
@@ -139,9 +139,6 @@ def setup_parser(subparser):
     )
     subparser.add_argument(
         "--only-deprecated", action="store_true", help="show only deprecated packages"
-    )
-    subparser.add_argument(
-        "-N", "--namespace", action="store_true", help="show fully qualified package names"
     )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -42,7 +42,7 @@ def setup_parser(subparser):
     )
 
     # Below are arguments w.r.t. spec display (like spack spec)
-    arguments.add_common_arguments(subparser, ["long", "very_long"])
+    arguments.add_common_arguments(subparser, ["long", "very_long", "namespaces"])
 
     install_status_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
@@ -72,13 +72,6 @@ def setup_parser(subparser):
         default="nodes",
         choices=["nodes", "edges", "paths"],
         help="how extensively to traverse the DAG (default: nodes)",
-    )
-    subparser.add_argument(
-        "-N",
-        "--namespaces",
-        action="store_true",
-        default=False,
-        help="show fully qualified package names",
     )
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -29,7 +29,7 @@ specs are used instead
 for further documentation regarding the spec syntax, see:
     spack help --spec
 """
-    arguments.add_common_arguments(subparser, ["long", "very_long"])
+    arguments.add_common_arguments(subparser, ["long", "very_long", "namespaces"])
 
     install_status_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
@@ -66,13 +66,6 @@ for further documentation regarding the spec syntax, see:
         default="nodes",
         choices=["nodes", "edges", "paths"],
         help="how extensively to traverse the DAG (default: nodes)",
-    )
-    subparser.add_argument(
-        "-N",
-        "--namespaces",
-        action="store_true",
-        default=False,
-        help="show fully qualified package names",
     )
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -122,7 +122,7 @@ def test_namespaces_shown_correctly(database):
     out = find()
     assert "builtin.mock.zmpi" not in out
 
-    out = find("--namespace")
+    out = find("--namespaces")
     assert "builtin.mock.zmpi" in out
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -117,13 +117,13 @@ def test_tag2_tag3(parser, specs):
     assert len(specs) == 0
 
 
+@pytest.mark.parametrize(
+    "args,with_namespace", [([], False), (["--namespace"], True), (["--namespaces"], True)]
+)
 @pytest.mark.db
-def test_namespaces_shown_correctly(database):
-    out = find()
-    assert "builtin.mock.zmpi" not in out
-
-    out = find("--namespaces")
-    assert "builtin.mock.zmpi" in out
+def test_namespaces_shown_correctly(args, with_namespace, database):
+    """Test that --namespace(s) works. Old syntax is --namespace"""
+    assert ("builtin.mock.zmpi" in find(*args)) == with_namespace
 
 
 @pytest.mark.db

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -525,7 +525,7 @@ _spack_buildcache_install() {
 _spack_buildcache_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -a --allarch"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -v --variants -a --allarch"
     else
         _all_packages
     fi
@@ -1075,7 +1075,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --start-date --end-date"
     else
         _installed_packages
     fi
@@ -1704,7 +1704,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -I --install-status --no-install-status -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats -U --fresh --reuse --reuse-deps"
+        SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json -c --cover -t --types --timers --stats -U --fresh --reuse --reuse-deps"
     else
         _all_packages
     fi
@@ -1713,7 +1713,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -N --namespaces -t --types -U --fresh --reuse --reuse-deps"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types -U --fresh --reuse --reuse-deps"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -739,7 +739,7 @@ complete -c spack -n '__fish_spack_using_command buildcache install' -s o -l oth
 complete -c spack -n '__fish_spack_using_command buildcache install' -s o -l otherarch -d 'install specs from other architectures instead of default platform and OS'
 
 # spack buildcache list
-set -g __fish_spack_optspecs_spack_buildcache_list h/help l/long L/very-long v/variants a/allarch
+set -g __fish_spack_optspecs_spack_buildcache_list h/help l/long L/very-long N/namespaces v/variants a/allarch
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 buildcache list' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache list' -s h -l help -d 'show this help message and exit'
@@ -747,6 +747,8 @@ complete -c spack -n '__fish_spack_using_command buildcache list' -s l -l long -
 complete -c spack -n '__fish_spack_using_command buildcache list' -s l -l long -d 'show dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command buildcache list' -s L -l very-long -f -a very_long
 complete -c spack -n '__fish_spack_using_command buildcache list' -s L -l very-long -d 'show full dependency hashes as well as versions'
+complete -c spack -n '__fish_spack_using_command buildcache list' -s N -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command buildcache list' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command buildcache list' -s v -l variants -f -a variants
 complete -c spack -n '__fish_spack_using_command buildcache list' -s v -l variants -d 'show variants in output (can be long)'
 complete -c spack -n '__fish_spack_using_command buildcache list' -s a -l allarch -f -a allarch
@@ -1592,7 +1594,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -f 
 complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -d 'also fetch all dependencies'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated N/namespace start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1616,6 +1618,8 @@ complete -c spack -n '__fish_spack_using_command find' -s L -l very-long -f -a v
 complete -c spack -n '__fish_spack_using_command find' -s L -l very-long -d 'show full dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command find' -s t -l tag -r -f -a tags
 complete -c spack -n '__fish_spack_using_command find' -s t -l tag -r -d 'filter a package query by tag (multiple use allowed)'
+complete -c spack -n '__fish_spack_using_command find' -s N -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command find' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -f -a show_concretized
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -d 'show concretized specs in an environment'
 complete -c spack -n '__fish_spack_using_command find' -s f -l show-flags -f -a show_flags
@@ -1640,8 +1644,6 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a depre
 complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
-complete -c spack -n '__fish_spack_using_command find' -s N -l namespace -f -a namespace
-complete -c spack -n '__fish_spack_using_command find' -s N -l namespace -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date
@@ -2526,7 +2528,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= l/long L/very-long I/install-status no-install-status y/yaml j/json c/cover= N/namespaces t/types timers stats U/fresh reuse reuse-deps
+set -g __fish_spack_optspecs_spack_solve h/help show= l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json c/cover= t/types timers stats U/fresh reuse reuse-deps
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -2536,6 +2538,8 @@ complete -c spack -n '__fish_spack_using_command solve' -s l -l long -f -a long
 complete -c spack -n '__fish_spack_using_command solve' -s l -l long -d 'show dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command solve' -s L -l very-long -f -a very_long
 complete -c spack -n '__fish_spack_using_command solve' -s L -l very-long -d 'show full dependency hashes as well as versions'
+complete -c spack -n '__fish_spack_using_command solve' -s N -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command solve' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
@@ -2546,8 +2550,6 @@ complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a forma
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -d 'print concrete spec as json'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -f -a 'nodes edges paths'
 complete -c spack -n '__fish_spack_using_command solve' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
-complete -c spack -n '__fish_spack_using_command solve' -s N -l namespaces -f -a namespaces
-complete -c spack -n '__fish_spack_using_command solve' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command solve' -s t -l types -d 'show dependency types'
 complete -c spack -n '__fish_spack_using_command solve' -l timers -f -a timers
@@ -2562,7 +2564,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -f -a conc
 complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -d 'reuse installed dependencies only'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long I/install-status no-install-status y/yaml j/json format= c/cover= N/namespaces t/types U/fresh reuse reuse-deps
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse reuse-deps
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -2570,6 +2572,8 @@ complete -c spack -n '__fish_spack_using_command spec' -s l -l long -f -a long
 complete -c spack -n '__fish_spack_using_command spec' -s l -l long -d 'show dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command spec' -s L -l very-long -f -a very_long
 complete -c spack -n '__fish_spack_using_command spec' -s L -l very-long -d 'show full dependency hashes as well as versions'
+complete -c spack -n '__fish_spack_using_command spec' -s N -l namespaces -f -a namespaces
+complete -c spack -n '__fish_spack_using_command spec' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
@@ -2582,8 +2586,6 @@ complete -c spack -n '__fish_spack_using_command spec' -l format -r -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -l format -r -d 'print concrete spec with the specified format string'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -f -a 'nodes edges paths'
 complete -c spack -n '__fish_spack_using_command spec' -s c -l cover -r -d 'how extensively to traverse the DAG (default: nodes)'
-complete -c spack -n '__fish_spack_using_command spec' -s N -l namespaces -f -a namespaces
-complete -c spack -n '__fish_spack_using_command spec' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -f -a types
 complete -c spack -n '__fish_spack_using_command spec' -s t -l types -d 'show dependency types'
 complete -c spack -n '__fish_spack_using_command spec' -s U -l fresh -f -a concretizer_reuse


### PR DESCRIPTION
This PR adds the capability for `spack buildcache list` to display the namespace of packages in the buildcache. 

For consistency's sake, it also moves the `-N/--namespace` arg definition to the `common/arguments.py` and modifies `find`, `solve`, `spec` to use the common definition.

Previously, `find` was using `--namespace` (singular) to control whether to display the namespace (it doesn't restrict the search to that namespace). The other commands were using `--namespaces` (plural). For backwards compatibility and for consistency with `--deps`, `--tags`, etc, the plural `--namespaces` was chosen. The argument parser ensures that `find --namespace` will continue to behave as before.