### PR TITLE
docs: update RHEL/CentOS system prerequisites

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -41,12 +41,9 @@ A build matrix showing which packages are working on which systems is shown belo
 
       .. code-block:: console
 
-         yum update -y
-         yum install -y epel-release
-         yum update -y
-         yum --enablerepo epel groupinstall -y "Development Tools"
-         yum --enablerepo epel install -y curl findutils gcc-c++ gcc gcc-gfortran git gnupg2 hostname iproute redhat-lsb-core make patch python3 python3-pip python3-setuptools unzip
-         python3 -m pip install boto3
+         dnf install epel-release
+         dnf group install "Development Tools"
+         dnf install curl findutils gcc-gfortran gnupg2 hostname iproute redhat-lsb-core python3 python3-pip python3-setuptools unzip python3-boto3
 
    .. tab-item:: macOS Brew
 


### PR DESCRIPTION
## Changes

I installed Spack on RHEL 8 recently (then later tested all of this against RHEL 8, 9 and CentOS Stream 8, 9) and there were a few things I noticed in the docs that I thought could use some cleaning up (changes I made in this pull request):

- Given that starting from RHEL 8 that `yum` is just an alias for `dnf`, I think it's better to reference `dnf` in the commands.
- I'm not sure why the `update` commands were there, but they're not needed (perhaps there was an assumption that `dnf update` was an equivalent for `apt update`, which is not needed anyway for `dnf`).
- I confirmed the packages `gcc-c++`, `gcc`, `git`, `make`, and `patch` are all included in the `Development Tools` group, so they can be dropped from the `dnf install` command (as was similarly done for Debian/Ubuntu[^1]).
- I added `python3-boto3` to the `dnf install` as it is available as a package and is better practice.

## Non-changes

Finally, some other comments about things that I hadn't changed (as I do recognise they may be considered nitpicks):

- Listing the commands in the docs as for RHEL is a little disingenuous, as it was seemingly written for CentOS, where the `epel-release` package doesn't exist in RHEL and instead you have to run two other commands instead (e.g. see below or the official docs[^2]).

```
$ subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
$ dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
```

- The package `redhat-lsb-core` (and therefore the command `lsb_release`) is not available in RHEL 9[^3][^4]. I'm not sure what the implications of this are, or if Spack even still needs it (I did see some other issues/pull requests mention about it), but I hadn't noticed any issues due to it absence after using Spack on RHEL 9 for a bit (installed several Spack packages).

[^1]: https://github.com/spack/spack/pull/32480#discussion_r962691249
[^2]: https://docs.fedoraproject.org/en-US/epel
[^3]: https://access.redhat.com/solutions/6960807
[^4]: https://bugzilla.redhat.com/show_bug.cgi?id=1964381