### PR TITLE
glab: add v1.27.0

### DIFF
--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -14,6 +14,7 @@ class Glab(Package):
 
     maintainers("alecbcs")
 
+    version("1.27.0", sha256="26bf5fe24eeaeb0f861c89b31129498f029441ae11cc9958e14ad96ec1356d51")
     version("1.26.0", sha256="af1820a7872d53c7119a23317d6c80497374ac9529fc2ab1ea8b1ca033a9b4da")
     version("1.22.0", sha256="4d9bceb6818c8bf9f681119dae3a65f1c895fa21e9da6b38e8f88d245f524e10")
     version("1.21.1", sha256="8bb35c5cf6b011ff14d1eaa9ab70ec052d296978792984250e9063b006ee4d50")


### PR DESCRIPTION
Add glab v1.27.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.