### PR TITLE
nginx: add v1.23.4

### DIFF
--- a/var/spack/repos/builtin/packages/nginx/package.py
+++ b/var/spack/repos/builtin/packages/nginx/package.py
@@ -14,6 +14,7 @@ class Nginx(AutotoolsPackage):
     homepage = "https://nginx.org/en/"
     url = "https://nginx.org/download/nginx-1.12.0.tar.gz"
 
+    version("1.23.4", sha256="d43300e36bb249a7e6edc60bca1b0fc372a0bafce2f346d76acfb677a8790fc0")
     version("1.23.3", sha256="75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54")
     version("1.21.3", sha256="14774aae0d151da350417efc4afda5cce5035056e71894836797e1f6e2d1175a")
     version("1.15.6", sha256="a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6")


### PR DESCRIPTION
Add nginx v1.23.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.