### PR TITLE
r-intervals: add v0.15.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-intervals/package.py
+++ b/var/spack/repos/builtin/packages/r-intervals/package.py
@@ -11,6 +11,7 @@ class RIntervals(RPackage):
 
     cran = "intervals"
 
+    version("0.15.3", sha256="8501fef7c74b9be874e807839518aae85e79bf4a047cd52169b52c6d9b41dfc4")
     version("0.15.2", sha256="0bd23b0ce817ddd851238233d8a5420bf3a6d29e75fd361418cbc50118777c57")
     version("0.15.1", sha256="9a8b3854300f2055e1492c71932cc808b02feac8c4d3dbf6cba1c7dbd09f4ae4")
 


### PR DESCRIPTION
Add r-intervals v0.15.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.