### PR TITLE
libxcomposite: add v0.4.6

### DIFF
--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -13,6 +13,7 @@ class Libxcomposite(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXcomposite"
     xorg_mirror_path = "lib/libXcomposite-0.4.4.tar.gz"
 
+    version("0.4.6", sha256="3599dfcd96cd48d45e6aeb08578aa27636fa903f480f880c863622c2b352d076")
     version("0.4.4", sha256="83c04649819c6f52cda1b0ce8bcdcc48ad8618428ad803fb07f20b802f1bdad1")
 
     depends_on("libx11")


### PR DESCRIPTION
Add libxcomposite v0.4.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.