### PR TITLE
libxrandr: add v1.5.3

### DIFF
--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -12,6 +12,7 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXrandr"
     xorg_mirror_path = "lib/libXrandr-1.5.0.tar.gz"
 
+    version("1.5.3", sha256="3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f")
     version("1.5.0", sha256="1b594a149e6b124aab7149446f2fd886461e2935eca8dca43fe83a70cf8ec451")
 
     depends_on("libx11@1.6:")


### PR DESCRIPTION
Add libxrandr v1.5.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.