### PR TITLE
r-cachem: add v1.0.7

### DIFF
--- a/var/spack/repos/builtin/packages/r-cachem/package.py
+++ b/var/spack/repos/builtin/packages/r-cachem/package.py
@@ -15,6 +15,7 @@ class RCachem(RPackage):
 
     cran = "cachem"
 
+    version("1.0.7", sha256="234fad2a947d1e1fb87d3fa92abf9197877772e31bc81ae5991ae69689b6320a")
     version("1.0.6", sha256="9a9452f7bcf3f79436c418b3c3290449fb8fd338714d9b992153754d112f1864")
 
     depends_on("r-rlang", type=("build", "run"))


### PR DESCRIPTION
Add r-cachem v1.0.7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.