### PR TITLE
r-data-table: add v1.14.8

### DIFF
--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -16,6 +16,7 @@ class RDataTable(RPackage):
 
     cran = "data.table"
 
+    version("1.14.8", sha256="14b2ce5367df9c9bb58f373555066f5dcb629c156149b5565de36d69557139fd")
     version("1.14.4", sha256="4862a7c26e8309108fd1f5296616407b9ff9e4e1be5cdedcb717f114c2e348f0")
     version("1.14.2", sha256="f741b951e5937440139514aedbae78dbd6862d825066848bdb006aa02c2f3d2b")
     version("1.13.6", sha256="d50cdd4c4f89cabf83baa9114e49a3b8179f403c499d6e0be7791a44ffcd3e9b")


### PR DESCRIPTION
Add r-data-table v1.14.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.