### PR TITLE
r-ff: add v4.0.9

### DIFF
--- a/var/spack/repos/builtin/packages/r-ff/package.py
+++ b/var/spack/repos/builtin/packages/r-ff/package.py
@@ -54,6 +54,7 @@ class RFf(RPackage):
 
     cran = "ff"
 
+    version("4.0.9", sha256="722053271987a0c9673c3ff9e7968bbab47979d529a2fe6bb1a3179408ee3c4f")
     version("4.0.7", sha256="0a47333d31c7afc3f95387166e21a3e4c763cbef47d9b5927753aef4ff8d83fa")
     version("4.0.5", sha256="9aba9e271144ec224063ddba0d791e2fcdb9c912d48fdc49e204fce628355037")
     version("4.0.4", sha256="22ecf1811263f27c9fd9f7e13e77f97dcbc0b8ae6f59b76dbaed77569c13d2e5")


### PR DESCRIPTION
Add r-ff v4.0.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.