### PR TITLE
talloc: add v2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/talloc/package.py
+++ b/var/spack/repos/builtin/packages/talloc/package.py
@@ -13,6 +13,7 @@ class Talloc(AutotoolsPackage):
     homepage = "https://talloc.samba.org"
     url = "https://www.samba.org/ftp/talloc/talloc-2.1.9.tar.gz"
 
+    version("2.4.0", sha256="6df36862c42466ef88f360444513870ef46934f9016c84383cc4008a7d0c46ba")
     version("2.3.1", sha256="ef4822d2fdafd2be8e0cabc3ec3c806ae29b8268e932c5e9a4cd5585f37f9f77")
     version("2.3.0", sha256="75d5bcb34482545a82ffb06da8f6c797f963a0da450d0830c669267b14992fc6")
     version("2.1.9", sha256="f0aad4cb88a3322207c82136ddc07bed48a37c2c21f82962d6c5ccb422711062")


### PR DESCRIPTION
Add talloc v2.4.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.