### PR TITLE
thrift: add v0.18.1

### DIFF
--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -24,6 +24,7 @@ class Thrift(Package):
 
     maintainers = ["thomas-bouvier"]
 
+    version("0.18.1", sha256="04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726")
     version("0.17.0", sha256="b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f")
     version("0.16.0", sha256="f460b5c1ca30d8918ff95ea3eb6291b3951cf518553566088f3f2be8981f6209")
     version("0.13.0", sha256="7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179")


### PR DESCRIPTION
Add thrift v0.18.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.