### PR TITLE
xcb-proto: add v1.15.2

### DIFF
--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -13,6 +13,7 @@ class XcbProto(AutotoolsPackage):
     homepage = "https://xcb.freedesktop.org/"
     url = "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.14.1.tar.xz"
 
+    version("1.15.2", sha256="7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed")
     version("1.14.1", sha256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3")
     version("1.14", sha256="186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605")
     version("1.13", sha256="0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7")


### PR DESCRIPTION
Add xcb-proto v1.15.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.