### PR TITLE
xkeyboard-config: add v2.34

### DIFF
--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -14,6 +14,7 @@ class XkeyboardConfig(AutotoolsPackage, XorgPackage):
     homepage = "https://www.freedesktop.org/wiki/Software/XKeyboardConfig/"
     xorg_mirror_path = "data/xkeyboard-config/xkeyboard-config-2.18.tar.gz"
 
+    version("2.34", sha256="a5882238b4199ca90428aea102790aaa847e6e214653d956bf2abba3027107ba")
     version("2.18", sha256="d5c511319a3bd89dc40622a33b51ba41a2c2caad33ee2bfe502363fcc4c3817d")
 
     depends_on("libx11@1.4.3:")


### PR DESCRIPTION
Add xkeyboard-config v2.34. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.