### PR TITLE
CI: update Linux images in ML pipelines

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -906,7 +906,7 @@ tutorial-protected-build:
 
 .ml-linux-x86_64-cpu-generate:
   extends: [ .ml-linux-x86_64-cpu, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
 ml-linux-x86_64-cpu-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-cpu-generate" ]
@@ -946,7 +946,7 @@ ml-linux-x86_64-cpu-protected-build:
 
 .ml-linux-x86_64-cuda-generate:
   extends: [ .ml-linux-x86_64-cuda, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
 ml-linux-x86_64-cuda-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-cuda-generate" ]
@@ -986,7 +986,7 @@ ml-linux-x86_64-cuda-protected-build:
 
 .ml-linux-x86_64-rocm-generate:
   extends: [ .ml-linux-x86_64-rocm, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
 
 ml-linux-x86_64-rocm-pr-generate:
   extends: [ ".pr-generate", ".ml-linux-x86_64-rocm-generate" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -45,7 +45,6 @@ spack:
     - py-torchdata
     - py-torchfile
     - py-torchgeo
-    - py-torchmeta
     - py-torchmetrics
     - py-torchtext
     - py-torchvision
@@ -74,12 +73,15 @@ spack:
     # - r-xgboost
     - xgboost
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/ml-linux-x86_64-cpu" }
+  mirrors:
+    mirror: s3://spack-binaries/develop/ml-linux-x86_64-cpu
 
   ci:
     pipeline-gen:
     - build-job:
-        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09", "entrypoint": [""] }
+        image:
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
+          entrypoint: ['']
 
   cdash:
     build-group: Machine Learning

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -48,7 +48,6 @@ spack:
     - py-torchdata
     - py-torchfile
     - py-torchgeo
-    - py-torchmeta
     - py-torchmetrics
     - py-torchtext
     - py-torchvision
@@ -77,12 +76,15 @@ spack:
     # - r-xgboost
     - xgboost
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/ml-linux-x86_64-cuda" }
+  mirrors:
+    mirror: s3://spack-binaries/develop/ml-linux-x86_64-cpu
 
   ci:
     pipeline-gen:
     - build-job:
-        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09", "entrypoint": [""] }
+        image:
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
+          entrypoint: ['']
 
   cdash:
     build-group: Machine Learning

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -51,7 +51,6 @@ spack:
     # - py-torchdata
     # - py-torchfile
     # - py-torchgeo
-    # - py-torchmeta
     # - py-torchmetrics
     # - py-torchtext
     # - py-torchvision
@@ -80,12 +79,15 @@ spack:
     # - r-xgboost
     - xgboost
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/ml-linux-x86_64-rocm" }
+  mirrors:
+    mirror: s3://spack-binaries/develop/ml-linux-x86_64-cpu
 
   ci:
     pipeline-gen:
     - build-job:
-        image: { "name": "ghcr.io/spack/e4s-amazonlinux-2:v2023-03-09", "entrypoint": [""] }
+        image:
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:nightly
+          entrypoint: ['']
 
   cdash:
     build-group: Machine Learning

--- a/var/spack/repos/builtin/packages/py-tokenizers/package.py
+++ b/var/spack/repos/builtin/packages/py-tokenizers/package.py
@@ -27,3 +27,8 @@ class PyTokenizers(PythonPackage):
     depends_on("rust@nightly", when="@:0.10", type="build")
 
     # TODO: This package currently requires internet access to install.
+
+    # cargo resolves dependencies, which includes openssl-sys somewhere, which needs
+    # system pkgconfig and openssl.
+    depends_on("pkgconfig", type="build")
+    depends_on("openssl")


### PR DESCRIPTION
The latest version of TF requires a newer version of GCC than is provided in the old image. This PR updates the image used in CI to a newer OS with modern GCC. TorchMeta is removed as it doesn't build with newer GCC and seems to no longer be maintained.

Extracted from #36263