### PR TITLE
acfl: add compiler-package mapping and fix version number

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -48,6 +48,7 @@ _compiler_to_pkg = {
     "oneapi": "intel-oneapi-compilers",
     "rocmcc": "llvm-amdgpu",
     "intel@2020:": "intel-oneapi-compilers-classic",
+    "arm": "acfl",
 }
 
 # TODO: generating this from the previous dict causes docs errors
@@ -56,6 +57,7 @@ package_name_to_compiler_name = {
     "intel-oneapi-compilers": "oneapi",
     "llvm-amdgpu": "rocmcc",
     "intel-oneapi-compilers-classic": "intel",
+    "acfl": "arm",
 }
 
 

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import re
 
 import spack.compiler
 
@@ -40,19 +39,7 @@ class Arm(spack.compiler.Compiler):
     # InstalledDir:
     # /opt/arm/arm-hpc-compiler-19.0_Generic-AArch64_RHEL-7_aarch64-linux/bin
     version_argument = "--version"
-    version_regex = r"Arm C\/C\+\+\/Fortran Compiler version ([\d\.]+) " r"\(build number (\d+)\) "
-
-    @classmethod
-    def extract_version_from_output(cls, output):
-        """Extracts the version from compiler's output."""
-        match = re.search(cls.version_regex, output)
-        temp = "unknown"
-        if match:
-            if match.group(1).count(".") == 1:
-                temp = match.group(1) + ".0." + match.group(2)
-            else:
-                temp = match.group(1) + "." + match.group(2)
-        return temp
+    version_regex = r"Arm C\/C\+\+\/Fortran Compiler version ([\d\.]+) "
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -36,7 +36,7 @@ from spack.operating_systems.cray_frontend import CrayFrontend
             "Thread model: posix\n"
             "InstalledDir:\n"
             "/opt/arm/arm-hpc-compiler-19.0_Generic-AArch64_RHEL-7_aarch64-linux/bin\n",
-            "19.0.0.73",
+            "19.0",
         ),
         (
             "Arm C/C++/Fortran Compiler version 19.3.1 (build number 75) (based on LLVM 7.0.2)\n"
@@ -44,7 +44,7 @@ from spack.operating_systems.cray_frontend import CrayFrontend
             "Thread model: posix\n"
             "InstalledDir:\n"
             "/opt/arm/arm-hpc-compiler-19.0_Generic-AArch64_RHEL-7_aarch64-linux/bin\n",
-            "19.3.1.75",
+            "19.3.1",
         ),
     ],
 )


### PR DESCRIPTION
fixes #36545

- Add mapping between compiler and package name for arm compiler.
- Do not include build number in version number to resolve #36545.