### PR TITLE
py-setuptools-scm: add a git dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -43,4 +43,4 @@ class PySetuptoolsScm(PythonPackage):
     depends_on("py-typing-extensions", when="@7:", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@7: ^python@:3.7", type=("build", "run"))
 
-    depends_on("git", type="build")
+    depends_on("git", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -43,4 +43,4 @@ class PySetuptoolsScm(PythonPackage):
     depends_on("py-typing-extensions", when="@7:", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@7: ^python@:3.7", type=("build", "run"))
 
-    depends_on("git")
+    depends_on("git", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -42,3 +42,5 @@ class PySetuptoolsScm(PythonPackage):
     depends_on("py-tomli@1:", when="@7.1: ^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions", when="@7:", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@7: ^python@:3.7", type=("build", "run"))
+
+    depends_on("git")


### PR DESCRIPTION
Currently it needs git but it doesn't depend on it, causing errors when an old git from the local system is used. Adding a dependency on git fixes this. We could add a version but probably all recent versions are fine (git-archive support is what is needed), I saw this problem when compiling on a Centos7 machine with git 1.8.