### PR TITLE
lhapdf: Pass additional python lib dirs only if possible

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -46,7 +46,10 @@ class Lhapdf(AutotoolsPackage):
             "FCFLAGS=-O3",
             "CFLAGS=-O3",
             "CXXFLAGS=-O3",
-            "LIBS=-L" + self.spec["python"].prefix.lib + " -L" + self.spec["gettext"].prefix.lib,
         ]
+
+        if self.spec.satisfies("+python"):
+            args.extend("LIBS=-L" + self.spec["python"].prefix.lib + " -L" + self.spec["gettext"].prefix.lib)
+
         args.extend(self.enable_or_disable("python"))
         return args

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -42,14 +42,15 @@ class Lhapdf(AutotoolsPackage):
     depends_on("gettext", type="build", when="+python")
 
     def configure_args(self):
-        args = [
-            "FCFLAGS=-O3",
-            "CFLAGS=-O3",
-            "CXXFLAGS=-O3",
-        ]
+        args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]
 
         if self.spec.satisfies("+python"):
-            args.extend("LIBS=-L" + self.spec["python"].prefix.lib + " -L" + self.spec["gettext"].prefix.lib)
+            args.extend(
+                "LIBS=-L"
+                + self.spec["python"].prefix.lib
+                + " -L"
+                + self.spec["gettext"].prefix.lib
+            )
 
         args.extend(self.enable_or_disable("python"))
         return args


### PR DESCRIPTION
`lhapdf~python` does not have a `python` or `gettext` in its spec. This makes sure to only add them if the python variant is requested.