### PR TITLE
Open MPI: fix pmix dependency for 5.0.x releases

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -554,7 +554,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     # depends_on('pmix@3.2.3', when='@4.1.2')
     depends_on("pmix@1.0:1", when="@2.0:2")
     depends_on("pmix@3.2:", when="@4.0:4")
-    depends_on("pmix@5:", when="@5.0:5")
+    depends_on("pmix@4.2:", when="@5.0:5")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="@main")


### PR DESCRIPTION
The Open MPI 5.0.x release stream needs PMIx 4.2(?).x  not 5 (which translates to pmix-master).