### PR TITLE
libxcursor: add v1.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -12,6 +12,7 @@ class Libxcursor(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXcursor"
     xorg_mirror_path = "lib/libXcursor-1.1.14.tar.gz"
 
+    version("1.2.1", sha256="77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98")
     version("1.1.14", sha256="be0954faf274969ffa6d95b9606b9c0cfee28c13b6fc014f15606a0c8b05c17b")
 
     depends_on("libxrender@0.8.2:")


### PR DESCRIPTION
Add libxcursor v1.2.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.