### PR TITLE
libxmu: add v1.1.4

### DIFF
--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -15,6 +15,7 @@ class Libxmu(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXmu"
     xorg_mirror_path = "lib/libXmu-1.1.2.tar.gz"
 
+    version("1.1.4", sha256="3091d711cdc1d8ea0f545a13b90d1464c3c3ab64778fd121f0d789b277a80289")
     version("1.1.2", sha256="e5fd4bacef068f9509b8226017205040e38d3fba8d2de55037200e7176c13dba")
 
     depends_on("libxt")


### PR DESCRIPTION
Add libxmu v1.1.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.