### PR TITLE
xtrans: add v1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -15,6 +15,7 @@ class Xtrans(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libxtrans"
     xorg_mirror_path = "lib/xtrans-1.3.5.tar.gz"
 
+    version("1.4.0", sha256="48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9")
     version("1.3.5", sha256="b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d")
 
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
Add xtrans v1.4.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.