### PR TITLE
kubernetes: add v1.27.0 and split off new package kubectl

### DIFF
--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Kubectl(Package):
+    """
+    Kubectl is a command-line interface for Kubernetes clusters.
+    """
+
+    homepage = "https://kubernetes.io"
+    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.26.3.tar.gz"
+
+    maintainers("alecbcs")
+
+    version("1.26.3", sha256="e9db7e0a2e8cb40e478564de22530c5e582ae7136558994130b3ae7d8828ab31")
+
+    depends_on("bash", type="build")
+    depends_on("go", type="build")
+
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        make("WHAT=cmd/kubectl")
+
+    def install(self, spec, prefix):
+        install_tree("_output/bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -12,11 +12,11 @@ class Kubectl(Package):
     """
 
     homepage = "https://kubernetes.io"
-    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.26.3.tar.gz"
+    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.27.0.tar.gz"
 
     maintainers("alecbcs")
 
-    version("1.26.3", sha256="e9db7e0a2e8cb40e478564de22530c5e582ae7136558994130b3ae7d8828ab31")
+    version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
 
     depends_on("bash", type="build")
     depends_on("go", type="build")
@@ -24,7 +24,7 @@ class Kubectl(Package):
     phases = ["build", "install"]
 
     def build(self, spec, prefix):
-        make("WHAT=cmd/kubectl")
+        make("-f", "build/root/Makefile", "WHAT=cmd/kubectl")
 
     def install(self, spec, prefix):
         install_tree("_output/bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/kubernetes/package.py
@@ -12,14 +12,46 @@ class Kubernetes(Package):
     for deployment, maintenance, and scaling of applications."""
 
     homepage = "https://kubernetes.io"
-    url = "https://github.com/kubernetes/kubernetes/archive/v1.19.0-alpha.0.tar.gz"
+    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.26.3.tar.gz"
 
-    version("1.18.1", sha256="33ca738f1f4e6ad453b80f231f71e62470b822f21d44dc5b8121b2964ae8e6f8")
-    version("1.18.0", sha256="6bd252b8b5401ad6f1fb34116cd5df59153beced3881b98464862a81c083f7ab")
-    version("1.17.4", sha256="b61a6eb3bd5251884f34853cc51aa31c6680e7e476268fe06eb33f3d95294f62")
+    maintainers("alecbcs")
 
+    version("1.26.3", sha256="e9db7e0a2e8cb40e478564de22530c5e582ae7136558994130b3ae7d8828ab31")
+
+    # Deprecated versions
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-3294
+    version(
+        "1.18.1",
+        sha256="33ca738f1f4e6ad453b80f231f71e62470b822f21d44dc5b8121b2964ae8e6f8",
+        deprecated=True,
+    )
+    version(
+        "1.18.0",
+        sha256="6bd252b8b5401ad6f1fb34116cd5df59153beced3881b98464862a81c083f7ab",
+        deprecated=True,
+    )
+    version(
+        "1.17.4",
+        sha256="b61a6eb3bd5251884f34853cc51aa31c6680e7e476268fe06eb33f3d95294f62",
+        deprecated=True,
+    )
+
+    depends_on("bash", type="build")
     depends_on("go", type="build")
 
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        components = [
+            "cmd/kubeadm",
+            "cmd/kubelet",
+            "cmd/kube-apiserver",
+            "cmd/kube-controller-manager",
+            "cmd/kube-proxy",
+            "cmd/kube-scheduler",
+        ]
+
+        make(f"WHAT={' '.join(components)}")
+
     def install(self, spec, prefix):
-        make()
         install_tree("_output/bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/kubernetes/package.py
@@ -12,11 +12,11 @@ class Kubernetes(Package):
     for deployment, maintenance, and scaling of applications."""
 
     homepage = "https://kubernetes.io"
-    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.26.3.tar.gz"
+    url = "https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.27.0.tar.gz"
 
     maintainers("alecbcs")
 
-    version("1.26.3", sha256="e9db7e0a2e8cb40e478564de22530c5e582ae7136558994130b3ae7d8828ab31")
+    version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
 
     # Deprecated versions
     # https://nvd.nist.gov/vuln/detail/CVE-2022-3294


### PR DESCRIPTION
Add kubernetes v1.27.0 and create new minimal cli package `kubectl`.