### PR TITLE
py-torch: Update conflicts for +/~tensorpipe

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -104,7 +104,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     )
 
     conflicts("+cuda+rocm")
-    conflicts("+tensorpipe", when="+rocm", msg="TensorPipe doesn't yet support ROCm")
+    conflicts("+tensorpipe", when="+rocm ^hip@:5.1", msg="TensorPipe not supported until ROCm 5.2")
     conflicts("+breakpad", when="target=ppc64:")
     conflicts("+breakpad", when="target=ppc64le:")
 
@@ -113,6 +113,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     # https://github.com/pytorch/pytorch/issues/80805
     conflicts("+openmp", when="platform=darwin target=aarch64:")
+
+    #https://github.com/pytorch/pytorch/issues/97397
+    conflicts("~tensorpipe", when="+distributed", msg="TensorPipe must be enabled with +distributed")
 
     conflicts(
         "cuda_arch=none",

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -116,7 +116,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     # https://github.com/pytorch/pytorch/issues/97397
     conflicts(
-        "~tensorpipe", when="+distributed", msg="TensorPipe must be enabled with +distributed"
+        "~tensorpipe", when="@1.8: +distributed", msg="TensorPipe must be enabled with +distributed"
     )
 
     conflicts(

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -114,8 +114,10 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # https://github.com/pytorch/pytorch/issues/80805
     conflicts("+openmp", when="platform=darwin target=aarch64:")
 
-    #https://github.com/pytorch/pytorch/issues/97397
-    conflicts("~tensorpipe", when="+distributed", msg="TensorPipe must be enabled with +distributed")
+    # https://github.com/pytorch/pytorch/issues/97397
+    conflicts(
+        "~tensorpipe", when="+distributed", msg="TensorPipe must be enabled with +distributed"
+    )
 
     conflicts(
         "cuda_arch=none",

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -116,7 +116,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     # https://github.com/pytorch/pytorch/issues/97397
     conflicts(
-        "~tensorpipe", when="@1.8: +distributed", msg="TensorPipe must be enabled with +distributed"
+        "~tensorpipe",
+        when="@1.8: +distributed",
+        msg="TensorPipe must be enabled with +distributed",
     )
 
     conflicts(


### PR DESCRIPTION
Shamelessly stealing https://github.com/spack/spack/pull/36537.

Update a couple of `conflicts()` for the `tensorpipe` variant based on the following:
 - ROCm 5.2+ now supports TensorPipe. This PR disables the conflict for `+tensorpipe` when a new enough ROCM is used.
 - `+distributed` cannot be used without TensorPipe as per https://github.com/pytorch/pytorch/issues/97397. This PR adds a new conflict to ensure the `+distributed ~tensorpipe` case will not concretize.