### PR TITLE
OpenMPI: tell it where libcuda.so is

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1007,6 +1007,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
                 config_args.append(
                     "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0])
                 )
+            if spec.satisfies("@5.0:"):
+                # And then it returned
+                config_args.append(
+                    "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0] + "/stubs")
+                )
             if spec.satisfies("@1.7.2"):
                 # There was a bug in 1.7.2 when --enable-static is used
                 config_args.append("--enable-mca-no-build=pml-bfo")


### PR DESCRIPTION
starting with the 5.0.x release stream the cuda related configury items in Open MPI once again need --with-cuda-libdir so that libcuda.so can be found at configure time, otherwise no cuda support unless someone copies libcuda.so to
$CUDA_HOME/lib64

related to #36760