### PR TITLE
Fixup perl arch detection

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -230,7 +230,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         return args
 
     def is_64bit(self):
-        return "64" in str(self.pkg.spec.target.family)
+        return "64" in str(self.spec.target.family)
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Perl package references target arch by `self.pkg.spec.target.family` which raises an error as the perl package is not aware of a `pkg` attribute. Just reference the spec.