### PR TITLE
Remove dependency cmd test windows skips

### DIFF
--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
-import sys
 
 import pytest
 

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -18,8 +18,6 @@ dependencies = SpackCommand("dependencies")
 mpis = ["low-priority-provider", "mpich", "mpich2", "multi-provider-mpi", "zmpi"]
 mpi_deps = ["fake"]
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-
 
 def test_direct_dependencies(mock_packages):
     out = dependencies("mpileaks")

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
-import sys
 
 import pytest
 

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -15,8 +15,6 @@ from spack.main import SpackCommand
 
 dependents = SpackCommand("dependents")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-
 
 def test_immediate_dependents(mock_packages):
     out = dependents("libelf")


### PR DESCRIPTION
All the tests worked out of the box. Simply removing skips.