### PR TITLE
Fides 1.2

### DIFF
--- a/var/spack/repos/builtin/packages/fides/package.py
+++ b/var/spack/repos/builtin/packages/fides/package.py
@@ -16,6 +16,7 @@ class Fides(CMakePackage):
     maintainers("caitlinross", "dpugmire")
 
     version("master", branch="master")
+    version("1.2.0", sha256="12be939d75c765dab9241f9ed2b64af01cce2b10281de402f64fb685e6ccd7df")
     version("1.1.0", sha256="40d2e08b8d5cfdfc809eae6ed2ae0731108ce3b1383485f4934a5ec8aaa9425e")
     version("1.0.0", sha256="c355fdb4ca3790c1fa9a4491a0d294b8f883b6946c540ad9e5633c9fd8c8c3aa")
     variant("mpi", default=True, description="build mpi support")
@@ -24,7 +25,10 @@ class Fides(CMakePackage):
     depends_on("cmake@3.14.1:3.14,3.18.2:", type="build")
 
     depends_on("mpi", when="+mpi")
-    depends_on("adios2~zfp")
+    depends_on("adios2")
+    # Type check failures when using 32 bit IDs and ADIOS2 with ZFP in older
+    # versions of Fides
+    depends_on("adios2~zfp", when="@:1.1 ^vtk-m ~64bitids")
     depends_on("vtk-m")
 
     # Fix missing implicit includes

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -132,7 +132,9 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="cuda_arch=none", msg="vtk-m +cuda requires that cuda_arch be set")
 
-    conflicts("+ascent_types", when="+64bitids", msg="Ascent types requires 32 bit IDs for compatibility")
+    conflicts(
+        "+ascent_types", when="+64bitids", msg="Ascent types requires 32 bit IDs for compatibility"
+    )
 
     # Patch
     patch("diy-include-cstddef.patch", when="@1.5.3:1.8.0")

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -132,6 +132,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="cuda_arch=none", msg="vtk-m +cuda requires that cuda_arch be set")
 
+    conflicts("+ascent_types", when="+64bitids", msg="Ascent types requires 32 bit IDs for compatibility")
+
     # Patch
     patch("diy-include-cstddef.patch", when="@1.5.3:1.8.0")
 


### PR DESCRIPTION
Add Fides 1.2 and update constraints for older versions.

Add conflict to VTK-m to reflect build constraints around `acent_types` better.