### PR TITLE
umpire: add conflict for `camp+cuda` for `~cuda`

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -98,6 +98,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp@main", when="@main")
     depends_on("camp@main", when="@develop")
     depends_on("camp+openmp", when="+openmp")
+    depends_on("camp~cuda", when="~cuda")
 
     with when("@5.0.0:"):
         with when("+cuda"):


### PR DESCRIPTION
`spack install "umpire~cuda ^camp+cuda"` concretizes but fails during install with
```
1 error found in build log:
     80    -- Checking for std::filesystem
     81    -- Performing Test UMPIRE_ENABLE_FILESYSTEM
     82    -- Performing Test UMPIRE_ENABLE_FILESYSTEM - Failed
     83    -- std::filesystem NOT found, using POSIX
     84    -- Host Shared Memory Disabled
     85    -- Configuring done (0.6s)
  >> 86    CMake Error at /scratch/local/spack-binaries/linux-arch-skylake/gcc-12.2.1/camp/2022.03.2/fal3fh6pw4sj7p35fvtfza4lymxa3du7/lib/cmake/camp/bltTargets.cmake:73 (set_target
           _properties):
     87      The link interface of target "blt::cuda_runtime" contains:
     88    
     89        Threads::Threads
     90    
     91      but the target was not found.  Possible reasons include:
     92    
```

Add a `conflict("camp+cuda", when="~cuda")` to umpire recipe.

Ping @davidbeckingsale 