### PR TITLE
Enable installer test

### DIFF
--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -564,6 +564,8 @@ def test_clear_failures_success(install_mockery):
 
     # Ensure the core directory and failure lock file still exist
     assert os.path.isdir(spack.store.db._failure_dir)
+    if sys.platform != "win32":
+        assert os.path.isfile(spack.store.db.prefix_fail_path)
 
 
 def test_clear_failures_errs(install_mockery, monkeypatch, capsys):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -564,6 +564,7 @@ def test_clear_failures_success(install_mockery):
 
     # Ensure the core directory and failure lock file still exist
     assert os.path.isdir(spack.store.db._failure_dir)
+    # Locks on windows are a no-op
     if sys.platform != "win32":
         assert os.path.isfile(spack.store.db.prefix_fail_path)
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -539,7 +539,6 @@ def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
     assert "Couldn't copy in provenance for cmake" in out
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_clear_failures_success(install_mockery):
     """Test the clear_failures happy path."""
 
@@ -565,7 +564,6 @@ def test_clear_failures_success(install_mockery):
 
     # Ensure the core directory and failure lock file still exist
     assert os.path.isdir(spack.store.db._failure_dir)
-    assert os.path.isfile(spack.store.db.prefix_fail_path)
 
 
 def test_clear_failures_errs(install_mockery, monkeypatch, capsys):


### PR DESCRIPTION
Removes assertion verifying lock behavior in the installer test. This assertion doesn't hold up when locking is disabled and isn't core to the test meaning.