### PR TITLE
Add "build" stage to many `go` packages

### DIFF
--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -24,5 +24,14 @@ class Direnv(Package):
     depends_on("go@1.16:", type="build", when="@2.28:")
     depends_on("go", type="build")
 
+    phases = ["build", "install"]
+
+    def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
+        env.prepend_path("GOPATH", self.stage.path)
+
+    def build(self, spec, prefix):
+        make()
+
     def install(self, spec, prefix):
         make("install", "PREFIX=%s" % prefix)

--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -30,6 +30,14 @@ class Gh(Package):
 
     depends_on("go@1.16:", type="build")
 
-    def install(self, spec, prefix):
+    phases = ["build", "install"]
+
+    def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
+        env.prepend_path("GOPATH", self.stage.path)
+
+    def build(self, spec, prefix):
         make()
+
+    def install(self, spec, prefix):
         make("install", "prefix=" + prefix)

--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -21,6 +21,15 @@ class Glab(Package):
 
     depends_on("go@1.13:", type="build")
 
-    def install(self, spec, prefix):
+    phases = ["build", "install"]
+
+    def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
+        env.prepend_path("GOPATH", self.stage.path)
+
+    def build(self, spec, prefix):
         make()
-        make("install", "prefix=" + prefix)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("bin/glab", prefix.bin)

--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -51,6 +51,8 @@ class Hugo(Package):
 
     variant("extended", default=False, description="Enable extended features")
 
+    phases = ["build", "install"]
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("version", output=str, error=str)
@@ -58,13 +60,16 @@ class Hugo(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
         env.prepend_path("GOPATH", self.stage.path)
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         go_args = ["build"]
         if self.spec.satisfies("+extended"):
             go_args.extend(["--tags", "extended"])
 
         go(*go_args)
+
+    def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("hugo", prefix.bin)

--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -66,11 +66,15 @@ class Rclone(Package):
 
     depends_on("go@1.15:", type="build")
 
+    phases = ["build", "install"]
+
     def setup_build_environment(self, env):
         # Point GOPATH at the top of the staging dir for the build step.
         env.prepend_path("GOPATH", self.stage.path)
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         go("build")
+
+    def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("rclone", prefix.bin)

--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -23,11 +23,15 @@ class Restic(Package):
     depends_on("go@1.15:", type="build", when="@0.14.0:")
     depends_on("go", type="build")
 
+    phases = ["build", "install"]
+
     def setup_build_environment(self, env):
         # Point GOPATH at the top of the staging dir for the build step.
         env.prepend_path("GOPATH", self.stage.path)
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         go("run", "build.go")
+
+    def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("restic", prefix.bin)


### PR DESCRIPTION
Although many go packages have district compile and install steps we've often just treated that process as a single `install` stage within Spack. This PR aims to break up two stages for increased visibility.