### PR TITLE
py-hatchling: new version 1.14.0; new pkgs py-calver, py-trove-classifiers

### DIFF
--- a/var/spack/repos/builtin/packages/py-calver/package.py
+++ b/var/spack/repos/builtin/packages/py-calver/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCalver(PythonPackage):
+    """The calver package is a setuptools extension for automatically
+    defining your Python package version as a calendar version."""
+
+    homepage = "https://github.com/di/calver"
+    pypi = "calver/calver-2022.6.26.tar.gz"
+
+    version("2022.6.26", sha256="e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-hatchling/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchling/package.py
@@ -13,6 +13,7 @@ class PyHatchling(PythonPackage):
     pypi = "hatchling/hatchling-1.4.1.tar.gz"
     git = "https://github.com/pypa/hatch"
 
+    version("1.14.0", sha256="462ea91df03ff5d52813b5613fec1313a1a2059d2e37343e572b3f979867c5da")
     version("1.13.0", sha256="f8d275a2cc720735286b7c2e2bc35da05761e6d3695c2fa416550395f10c53c7")
     version("1.10.0", sha256="5d31f43dffaf6265c808e1b5353662ffa5146d844278b55caa6c7f74f427ec50")
     version("1.8.1", sha256="448b04b23faed669b2b565b998ac955af4feea66c5deed3a1212ac9399d2e1cd")
@@ -25,3 +26,4 @@ class PyHatchling(PythonPackage):
     depends_on("py-pathspec@0.9:", type=("build", "run"))
     depends_on("py-pluggy@1:", type=("build", "run"))
     depends_on("py-tomli@1.2.2:", when="^python@:3.10", type=("build", "run"))
+    depends_on("py-trove-classifiers", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-hatchling/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchling/package.py
@@ -26,4 +26,4 @@ class PyHatchling(PythonPackage):
     depends_on("py-pathspec@0.9:", type=("build", "run"))
     depends_on("py-pluggy@1:", type=("build", "run"))
     depends_on("py-tomli@1.2.2:", when="^python@:3.10", type=("build", "run"))
-    depends_on("py-trove-classifiers", type=("build", "run"))
+    depends_on("py-trove-classifiers", when="@1.14:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
+++ b/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
@@ -16,4 +16,4 @@ class PyTroveClassifiers(PythonPackage):
     version("2023.3.9", sha256="ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-calver", type=("build", "run"))
+    depends_on("py-calver", type="build")

--- a/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
+++ b/var/spack/repos/builtin/packages/py-trove-classifiers/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyTroveClassifiers(PythonPackage):
+    """The trove-classifiers pacakge is the canonical source for classifiers
+    on PyPI. Classifiers categorize projects per PEP 301."""
+
+    homepage = "https://github.com/pypa/trove-classifiers"
+    pypi = "trove-classifiers/trove-classifiers-2023.3.9.tar.gz"
+
+    version("2023.3.9", sha256="ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-calver", type=("build", "run"))


### PR DESCRIPTION
Hatchling 1.14.0 adds a new dependency on trove-classifiers, which in turn depends on calver. So, those two packages needed to be added as well.

- https://github.com/pypa/hatch/commit/f8915309d31c418c62cf6aa57436fe2e8a83e25c
- https://github.com/pypa/trove-classifiers/blob/2023.3.9/pyproject.toml
- https://github.com/di/calver/blob/2022.06.26/pyproject.toml

Tested that this can still correctly install `py-black`:
```console
==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@12.2.0 -----------------------
oucxjnq py-black@23.3.0~colorama~d~jupyter~uvloop build_system=python_pip  ehgqd5n py-hatchling@1.14.0 build_system=python_pip
==> 2 installed packages
```