### PR TITLE
Stop installing codecov from pip

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{inputs.python_version}}
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools pytest codecov coverage[toml]
+        pip install --upgrade pip six setuptools pytest coverage[toml]
     - name: Package audits (with coverage)
       if: ${{ inputs.with_coverage == 'true' }}
       run: |

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -107,7 +107,7 @@ jobs:
           sudo apt-get install -y coreutils kcov csh zsh tcsh fish dash bash
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml] pytest-xdist
+          pip install --upgrade pip six setuptools pytest coverage[toml] pytest-xdist
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -163,7 +163,7 @@ jobs:
           sudo apt-get -y install coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml] pytest-cov clingo pytest-xdist
+          pip install --upgrade pip six setuptools pytest coverage[toml] pytest-cov clingo pytest-xdist
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -194,7 +194,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
-          pip install --upgrade pytest codecov coverage[toml] pytest-xdist pytest-cov
+          pip install --upgrade pytest coverage[toml] pytest-xdist pytest-cov
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -62,7 +62,7 @@ jobs:
               cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov[toml] pytest-xdist pytest-cov
+          pip install --upgrade pip six setuptools pytest pytest-xdist pytest-cov
           pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Setup git configuration
       run: |

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip six pywin32 setuptools codecov pytest-cov clingo
+          python -m pip install --upgrade pip six pywin32 setuptools pytest-cov clingo
     - name: Create local develop
       run: |
         ./.github/workflows/setup_git.ps1
@@ -47,7 +47,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip six pywin32 setuptools codecov coverage pytest-cov clingo
+          python -m pip install --upgrade pip six pywin32 setuptools coverage pytest-cov clingo
     - name: Create local develop
       run: |
         ./.github/workflows/setup_git.ps1
@@ -71,7 +71,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip six pywin32 setuptools codecov coverage
+          python -m pip install --upgrade pip six pywin32 setuptools coverage
     - name: Build Test
       run: |
         spack compiler find


### PR DESCRIPTION
It shouldn't be needed since we use Codecov's Github action.

See here for more information https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

Thanks for the pointer in chat @wdconinc !