### PR TITLE
(py-)codecov: not on pypi anymore, replace by static binary

### DIFF
--- a/var/spack/repos/builtin/packages/codecov/package.py
+++ b/var/spack/repos/builtin/packages/codecov/package.py
@@ -13,16 +13,16 @@ class Codecov(Package):
 
     homepage = "https://codecov.io"
 
-    versions = {
+    _versions = {
         "0.4.1": {
             "linux": {
-                "x86_64": "32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c",
+                "x86_64": "32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c"
             },
             "darwin": {
-                "x86_64": "4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af",
+                "x86_64": "4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af"
             },
             "windows": {
-                "x86_64": "e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8",
+                "x86_64": "e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8"
             },
         }
     }
@@ -30,9 +30,9 @@ class Codecov(Package):
     system = platform.system().lower()
     machine = platform.machine().lower()
 
-    for ver in versions:
-        if system in versions[ver] and machine in versions[ver][system]:
-            version(ver, sha256=versions[ver][system][machine], expand=False)
+    for ver in _versions:
+        if system in _versions[ver] and machine in _versions[ver][system]:
+            version(ver, sha256=_versions[ver][system][machine], expand=False)
 
     def url_for_version(self, version):
         _url_base = f"https://github.com/codecov/uploader/releases/download/v{version}/codecov"

--- a/var/spack/repos/builtin/packages/codecov/package.py
+++ b/var/spack/repos/builtin/packages/codecov/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack.package import *
 
 
@@ -10,16 +12,33 @@ class Codecov(Package):
     """Codecov uploads coverage reports to Codecov for processing."""
 
     homepage = "https://codecov.io"
-    url = "https://uploader.codecov.io/v0.4.0/linux/codecov"
+    _url_base = "https://github.com/codecov/uploader/releases/download/v0.4.1/codecov"
 
-    version(
-        "0.4.0",
-        sha256="671cf0d89d1c149f57e1a9a31f3fb567ab4209e4d5829f13ff7b8c104db7131f",
-        expand=False,
-    )
+    if platform.system() == "Linux" and platform.machine() == "x86_64":
+        version(
+            "0.4.1",
+            sha256="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c",
+            url=_url_base + "-linux",
+            expand=False,
+        )
+    elif platform.system() == "Darwin":
+        version(
+            "0.4.1",
+            sha256="4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af",
+            url=_url_base + "-macos",
+            expand=False,
+        )
+    elif platform.system() == "Windows":
+        version(
+            "0.4.1",
+            sha256="e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8",
+            url=_url_base + ".exe",
+            expand=False,
+        )
 
     def install(self, spec, prefix):
+        codecov = self.stage.archive_file
         chmod = which("chmod")
-        chmod("+x", "codecov")
+        chmod("+x", codecov)
         mkdirp(prefix.bin)
-        install("codecov", prefix.bin)
+        install(codecov, join_path(prefix.bin, "codecov"))

--- a/var/spack/repos/builtin/packages/codecov/package.py
+++ b/var/spack/repos/builtin/packages/codecov/package.py
@@ -41,4 +41,4 @@ class Codecov(Package):
         chmod = which("chmod")
         chmod("+x", codecov)
         mkdirp(prefix.bin)
-        install(codecov, join_path(prefix.bin, "codecov"))
+        install(codecov, prefix.bin.codecov)

--- a/var/spack/repos/builtin/packages/codecov/package.py
+++ b/var/spack/repos/builtin/packages/codecov/package.py
@@ -12,29 +12,31 @@ class Codecov(Package):
     """Codecov uploads coverage reports to Codecov for processing."""
 
     homepage = "https://codecov.io"
-    _url_base = "https://github.com/codecov/uploader/releases/download/v0.4.1/codecov"
 
-    if platform.system() == "Linux" and platform.machine() == "x86_64":
-        version(
-            "0.4.1",
-            sha256="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c",
-            url=_url_base + "-linux",
-            expand=False,
-        )
-    elif platform.system() == "Darwin":
-        version(
-            "0.4.1",
-            sha256="4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af",
-            url=_url_base + "-macos",
-            expand=False,
-        )
-    elif platform.system() == "Windows":
-        version(
-            "0.4.1",
-            sha256="e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8",
-            url=_url_base + ".exe",
-            expand=False,
-        )
+    versions = {
+        "0.4.1": {
+            "linux": {
+                "x86_64": "32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c",
+            },
+            "darwin": {
+                "x86_64": "4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af",
+            },
+            "windows": {
+                "x86_64": "e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8",
+            },
+        }
+    }
+
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    for ver in versions:
+        if system in versions[ver] and machine in versions[ver][system]:
+            version(ver, sha256=versions[ver][system][machine], expand=False)
+
+    def url_for_version(self, version):
+        _url_base = f"https://github.com/codecov/uploader/releases/download/v{version}/codecov"
+        return _url_base + ".exe" if self.system == "windows" else _url_base + f"-{self.system}"
 
     def install(self, spec, prefix):
         codecov = self.stage.archive_file

--- a/var/spack/repos/builtin/packages/codecov/package.py
+++ b/var/spack/repos/builtin/packages/codecov/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Codecov(Package):
+    """Codecov uploads coverage reports to Codecov for processing."""
+
+    homepage = "https://codecov.io"
+    url = "https://uploader.codecov.io/v0.4.0/linux/codecov"
+
+    version(
+        "0.4.0",
+        sha256="671cf0d89d1c149f57e1a9a31f3fb567ab4209e4d5829f13ff7b8c104db7131f",
+        expand=False,
+    )
+
+    def install(self, spec, prefix):
+        chmod = which("chmod")
+        chmod("+x", "codecov")
+        mkdirp(prefix.bin)
+        install("codecov", prefix.bin)

--- a/var/spack/repos/builtin/packages/py-codecov/package.py
+++ b/var/spack/repos/builtin/packages/py-codecov/package.py
@@ -12,7 +12,9 @@ class PyCodecov(PythonPackage):
     homepage = "https://github.com/codecov/codecov-python"
     pypi = "codecov/codecov-2.0.15.tar.gz"
 
-    version("2.0.15", sha256="8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788")
+    # Since codecov has been removed from PyPI, py-codecov is deprecated.
+    # The new codecov uploader can be installed with the package codecov. 
+    version("2.0.15", sha256="8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788", deprecated=True)
 
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-requests@2.7.9:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-codecov/package.py
+++ b/var/spack/repos/builtin/packages/py-codecov/package.py
@@ -13,8 +13,12 @@ class PyCodecov(PythonPackage):
     pypi = "codecov/codecov-2.0.15.tar.gz"
 
     # Since codecov has been removed from PyPI, py-codecov is deprecated.
-    # The new codecov uploader can be installed with the package codecov. 
-    version("2.0.15", sha256="8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788", deprecated=True)
+    # The new codecov uploader can be installed with the package codecov.
+    version(
+        "2.0.15",
+        sha256="8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
+        deprecated=True,
+    )
 
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-requests@2.7.9:", type=("build", "run"))


### PR DESCRIPTION
`py-codecov` still installs because the archive is still on the spack mirror, but this adds the new static binary distribution at https://uploader.codecov.io/linux.