### PR TITLE
MSVC: Make all piped env vars upper case

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -164,7 +164,7 @@ class Msvc(Compiler):
             out = out.decode("utf-16le", errors="replace")  # novermin
 
         int_env = dict(
-            (key.lower(), value)
+            (key.upper(), value)
             for key, _, value in (line.partition("=") for line in out.splitlines())
             if key and value
         )

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -164,7 +164,7 @@ class Msvc(Compiler):
             out = out.decode("utf-16le", errors="replace")  # novermin
 
         int_env = dict(
-            (key.upper(), value)
+            (key, value)
             for key, _, value in (line.partition("=") for line in out.splitlines())
             if key and value
         )

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -90,6 +90,7 @@ def system_env_normalize(func):
         if sys.platform == "win32":
             name = name.upper()
         return func(self, name, *args, **kwargs)
+
     return marshall_env_var_name
 
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -96,6 +96,7 @@ def system_env_normalize(func):
     env modification operations on the env.
     Normalize all env names to all caps to prevent this collision from the
     Spack side."""
+
     @wraps(func)
     def case_insensitive_modification(self, name: str, *args, **kwargs):
         if sys.platform == "win32":


### PR DESCRIPTION
Previously we were lowering all vars processed by vcvars when we read them into Spack. This was fine when we were hardcoding the env sets for PATH, INCLUDE, and LIBS, but when we started making those env mods more programatically, the lower caused a disconnect with other env mods to PATH (as opposed to path) and resulted in the vcvars changes clobbering the other PATHs sets.

This PR casts all arguments to upper so as to not conflict with the rest of Spack.