### PR TITLE
containerize: Ensure bootstrap images contain all system dependencies

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -165,6 +165,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip setuptools pytest coverage[toml] pytest-cov clingo pytest-xdist
+          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -32,9 +32,14 @@ can't be found. You can readily check if any prerequisite for using Spack is mis
 
    Spack will take care of bootstrapping any missing dependency marked as [B]. Dependencies marked as [-] are instead required to be found on the system.
 
+   % echo $?
+   1
+
 In the case of the output shown above Spack detected that both ``clingo`` and ``gnupg``
 are missing and it's giving detailed information on why they are needed and whether
-they can be bootstrapped. Running a command that concretize a spec, like:
+they can be bootstrapped. The return code of this command summarizes the results, if any
+dependencies are missing the return code is ``1``, otherwise ``0``. Running a command that
+concretizes a spec, like:
 
 .. code-block:: console
 
@@ -44,7 +49,7 @@ they can be bootstrapped. Running a command that concretize a spec, like:
    ==> Installing "clingo-bootstrap@spack%apple-clang@12.0.0~docs~ipo+python build_type=Release arch=darwin-catalina-x86_64" from a buildcache
    [ ... ]
 
-triggers the bootstrapping of clingo from pre-built binaries as expected.
+automatically triggers the bootstrapping of clingo from pre-built binaries as expected.
 
 Users can also bootstrap all the dependencies needed by Spack in a single command, which
 might be useful to setup containers or other similar environments:

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
 import shutil
+import sys
 import tempfile
 
 import llnl.util.filesystem
@@ -326,6 +327,7 @@ def _status(args):
     if missing:
         print(llnl.util.tty.color.colorize(legend))
         print()
+        sys.exit(1)
 
 
 def _add(args):

--- a/share/spack/templates/container/amazonlinux_2.dockerfile
+++ b/share/spack/templates/container/amazonlinux_2.dockerfile
@@ -10,6 +10,7 @@ RUN yum update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
@@ -18,6 +19,7 @@ RUN yum update -y \
         python3-pip \
         python3-setuptools \
         unzip \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/bootstrap-base.dockerfile
+++ b/share/spack/templates/container/bootstrap-base.dockerfile
@@ -39,7 +39,9 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # Creates the package cache
-RUN spack bootstrap now && spack spec hdf5+mpi
+RUN spack bootstrap now \
+    && spack bootstrap status --optional \
+    && spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]

--- a/share/spack/templates/container/centos_7.dockerfile
+++ b/share/spack/templates/container/centos_7.dockerfile
@@ -13,6 +13,7 @@ RUN yum update -y \
         git \
         gnupg2 \
         hostname \
+        hg \
         iproute \
         make \
         patch \
@@ -20,6 +21,7 @@ RUN yum update -y \
         python3-pip \
         python3-setuptools \
         unzip \
+        zstd \
  && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all

--- a/share/spack/templates/container/centos_stream.dockerfile
+++ b/share/spack/templates/container/centos_stream.dockerfile
@@ -15,13 +15,16 @@ RUN dnf update -y \
         gcc-gfortran \
         git \
         gnupg2 \
+        hg \
         hostname \
         iproute \
         make \
+        svn \
         patch \
         python3.11 \
         python3.11-setuptools \
         unzip \
+        zstd \
  && python3.11 -m ensurepip \
  && pip3.11 install boto3 \
  && rm -rf /var/cache/dnf \

--- a/share/spack/templates/container/leap-15.dockerfile
+++ b/share/spack/templates/container/leap-15.dockerfile
@@ -9,12 +9,16 @@ RUN zypper ref && \
     gcc-c++\
     gcc-fortran\
     make\
+    mercurial\
     git\
     gzip\
     patch\
     python3-base \
     python3-boto3\
+    subversion\
     tar\
+    unzip\
     xz\
+    zstd\
 &&  zypper clean
 {% endblock %}

--- a/share/spack/templates/container/ubuntu_2004.dockerfile
+++ b/share/spack/templates/container/ubuntu_2004.dockerfile
@@ -22,10 +22,13 @@ RUN apt-get -yqq update \
         iproute2 \
         locales \
         make \
+        mercurial \
+        subversion \
         python3 \
         python3-pip \
         python3-setuptools \
         unzip \
+        zstd \
  && locale-gen en_US.UTF-8 \
  && pip3 install boto3 \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Inspired by my [slip-up when proposing new images](https://github.com/spack/spack/pull/36713#issuecomment-1505336821).

This PR adds a check at the end of the "bootstrap" phase of `spack containerize`, that ensures that all Spack dependencies (including `--optional`) that cannot be automatically bootstrapped are included in the image. To assist with this, a new `--check` flag is added to `spack bootstrap status`: if given, the command will report an error code if any dependencies are reported as missing.

Most of the images are missing some system dependencies by this logic, so this PR also adds the missing packages accordingly.