### PR TITLE
xyce: patch issue affecting MPICH

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/450-mpich-xyce.patch
+++ b/var/spack/repos/builtin/packages/xyce/450-mpich-xyce.patch
@@ -1,0 +1,34 @@
+From 8a622dd8204754733c769f0d13b685419e6607db Mon Sep 17 00:00:00 2001
+From: Paul Kuberry <pakuber@sandia.gov>
+Date: Wed, 12 Apr 2023 13:36:28 -0600
+Subject: [PATCH] Remove use of OpenMPI specific struct member
+
+MPITest/testBUG967 could not be built with MPICH because it used
+OpenMPI specific struct member variable `_ucount`.
+
+Replaced use of `_ucount` with call to MPI_Get_count, which is
+compatible with OpenMPI and MPICH.
+---
+ src/test/MPITest/testBUG967.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/test/MPITest/testBUG967.c b/src/test/MPITest/testBUG967.c
+index cdf7f918f..26e1b5311 100644
+--- a/src/test/MPITest/testBUG967.c
++++ b/src/test/MPITest/testBUG967.c
+@@ -45,8 +45,10 @@ int main(int narg, char**arg)
+   for (i=0; i < nrecvs; i++){
+     MPI_Wait(req + i, &status);
+     procs_from[i] = status.MPI_SOURCE;
+-    printf("%d wait source %d count %lu \n",
+-           my_proc, status.MPI_SOURCE, status._ucount);
++    int count;
++    MPI_Get_count(&status, MPI_INT, &count);
++    printf("%d wait source %d count %d \n",
++           my_proc, status.MPI_SOURCE, count);
+   }
+ 
+   for (i = 0; i < nrecvs; i++)
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -127,6 +127,13 @@ class Xyce(CMakePackage):
         # HDF5
         depends_on("hdf5~shared", when="^hdf5")
 
+    # fix MPI issue
+    patch(
+        "450-mpich-xyce.patch",
+        sha256="e91063d22afeeff01e6c572cef2ac2e3abea27b2fcb5a7e6ac5f41e4734a556d",
+        when="@:7.6,master",
+    )
+
     # fix RPATH issue on mac
     patch(
         "https://github.com/xyce/xyce/commit/40dbc0e0341a5cf9a7fa82a87313869dc284fdd9.patch?full_index=1",


### PR DESCRIPTION
Resolves #36527.

Patch file will be replaced with github commit location when the commits propagate to github.com and the affected version list for the patch will then remove `master`.