### PR TITLE
gpu test ci stack: remove x86_64_v3 tags

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -62,17 +62,17 @@ spack:
       - match:
         - kokkos +rocm amdgpu_target=gfx90a
         build-job-remove:
-          tags: [ "x86_64" ]
+          tags: [ "x86_64", "x86_64_v3" ]
         build-job:
-          tags: [ "x86_64-rocm", "rocm-5.4.0", "mi210" ]
+          tags: [ "x86_64_v3-rocm", "rocm-5.4.0", "mi210" ]
 
       - match:
         - kokkos +cuda cuda_arch=80 ^cuda@12.0.0
         - raja +cuda cuda_arch=80 ^cuda@12.0.0
         build-job-remove:
-          tags: [ "x86_64" ]
+          tags: [ "x86_64", "x86_64_v3" ]
         build-job:
-          tags: [ "x86_64-cuda", "nvidia-525.85.12", "cuda-12.0", "a100" ]
+          tags: [ "x86_64_v3-cuda", "nvidia-525.85.12", "cuda-12.0", "a100" ]
 
   cdash:
     build-group: GPU Testing


### PR DESCRIPTION
We've removed all `x86_64_v*` and `x86_64` tags from the GPU runners, and are replacing them with `x86_64_v*-{cuda,rocm}` tags so that we can selectively direct only the gpu-requiring jobs to these nodes. CC @kwryankrattiger 