### PR TITLE
Enable windows stage tests

### DIFF
--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -876,11 +876,11 @@ def test_stage_create_replace_path(tmp_build_stage_dir):
     touch(nondir)
     path = url_util.path_to_file_url(str(nondir))
 
-    stage = Stage(path, name="")
+    stage = Stage(path, name="afile")
     stage.create()
 
     # Ensure the stage path is "converted" to a directory
-    assert os.path.isdir(stage.path)
+    assert os.path.isdir(nondir)
 
 
 def test_cannot_access(capsys):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -659,7 +659,7 @@ class TestStage:
         assert source_path.endswith(spack.stage._source_path_subdir)
         assert not os.path.exists(source_path)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_first_accessible_path(self, tmpdir):
         """Test _first_accessible_path names."""
@@ -691,7 +691,6 @@ class TestStage:
         # Cleanup
         shutil.rmtree(str(name))
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
     def test_create_stage_root(self, tmpdir, no_path_access):
         """Test create_stage_root permissions."""
         test_dir = tmpdir.join("path")
@@ -755,7 +754,7 @@ class TestStage:
 
         assert spack.stage._resolve_paths(paths) == res_paths
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_get_stage_root_bad_path(self, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""
@@ -864,7 +863,6 @@ class TestStage:
             _file.read() == _readme_contents
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_stage_create_replace_path(tmp_build_stage_dir):
     """Ensure stage creation replaces a non-directory path."""
     _, test_stage_path = tmp_build_stage_dir
@@ -872,7 +870,7 @@ def test_stage_create_replace_path(tmp_build_stage_dir):
 
     nondir = os.path.join(test_stage_path, "afile")
     touch(nondir)
-    path = str(nondir)
+    path = url_util.path_to_file_url(str(nondir))
 
     stage = Stage(path, name="")
     stage.create()
@@ -881,7 +879,6 @@ def test_stage_create_replace_path(tmp_build_stage_dir):
     assert os.path.isdir(stage.path)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
 def test_cannot_access(capsys):
     """Ensure can_access dies with the expected error."""
     with pytest.raises(SystemExit):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -659,7 +659,9 @@ class TestStage:
         assert source_path.endswith(spack.stage._source_path_subdir)
         assert not os.path.exists(source_path)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Windows file permission erroring is not yet supported")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows file permission erroring is not yet supported"
+    )
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_first_accessible_path(self, tmpdir):
         """Test _first_accessible_path names."""
@@ -754,7 +756,9 @@ class TestStage:
 
         assert spack.stage._resolve_paths(paths) == res_paths
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Windows file permission erroring is not yet supported")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows file permission erroring is not yet supported"
+    )
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
     def test_get_stage_root_bad_path(self, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""


### PR DESCRIPTION
A few more stage tests can be enabled on windows. 

The only remaining ones are failing due to windows file permissions not yet erroring on invalid directories. The tests that are skipped for this reason will still have to change because the current used directory of '\\no\\such\\path' will be a valid path as it currently appends it to the user space.