### PR TITLE
cernlib: depends_on openssl when platform=linux

### DIFF
--- a/var/spack/repos/builtin/packages/cernlib/package.py
+++ b/var/spack/repos/builtin/packages/cernlib/package.py
@@ -28,7 +28,7 @@ class Cernlib(CMakePackage):
     depends_on("libxt")
     depends_on("libxcrypt")
 
-    depends_on("openssl", when="os=linux")
+    depends_on("openssl", when="platform=linux")
 
     @when("@2022.11.08.0-free")
     def patch(self):


### PR DESCRIPTION
Fixes #36836. @haampie 

Testing with `openssl@3` to see if that should require `openssl@1 `... (EDIT: `cernlib` -> `openssl`)