### PR TITLE
Enable spack cmd clean tests on windows

### DIFF
--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 
 import pytest
 
@@ -16,8 +15,6 @@ import spack.package_base
 import spack.stage
 
 clean = spack.main.SpackCommand("clean")
-
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
 @pytest.fixture()


### PR DESCRIPTION
They work out out of the box on windows. Simply removing skips.