### PR TITLE
CMake: Make CMAKE_INSTALL_PREFIX a posix path

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -5,6 +5,7 @@
 import collections.abc
 import inspect
 import os
+import pathlib
 import platform
 import re
 import sys
@@ -15,7 +16,6 @@ import llnl.util.filesystem as fs
 import spack.build_environment
 import spack.builder
 import spack.package_base
-import spack.util.path as sp
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 
@@ -267,7 +267,7 @@ class CMakeBuilder(BaseBuilder):
         args = [
             "-G",
             generator,
-            define("CMAKE_INSTALL_PREFIX", sp.convert_to_posix_path(pkg.prefix)),
+            define("CMAKE_INSTALL_PREFIX", pathlib.Path(pkg.prefix).as_posix()),
             define("CMAKE_BUILD_TYPE", build_type),
             define("BUILD_TESTING", pkg.run_tests),
         ]

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -15,7 +15,7 @@ import llnl.util.filesystem as fs
 import spack.build_environment
 import spack.builder
 import spack.package_base
-import spack.util.path
+import spack.util.path as sp
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 
@@ -267,7 +267,7 @@ class CMakeBuilder(BaseBuilder):
         args = [
             "-G",
             generator,
-            define("CMAKE_INSTALL_PREFIX", pkg.prefix),
+            define("CMAKE_INSTALL_PREFIX", sp.convert_to_posix_path(pkg.prefix)),
             define("CMAKE_BUILD_TYPE", build_type),
             define("BUILD_TESTING", pkg.run_tests),
         ]


### PR DESCRIPTION
CMake gives off a warning when passed Windows style paths as install prefixes as the resultant path often causes invalid escape sequences.