### PR TITLE
CI: Expand E4S ROCm stack to include missing DaV packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -199,7 +199,7 @@ spack:
   - cabana +rocm
   - caliper +rocm
   - chai ~benchmarks +rocm
-  - ecp-data-vis-sdk +paraview +vtkm +rocm
+  - ecp-data-vis-sdk +ascent +adios2 +hdf5 +paraview +pnetcdf +sz +vtkm +zfp +rocm
   - gasnet +rocm
   - ginkgo +rocm
   - heffte +rocm

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - conduit
   - datatransferkit
   - dyninst
-  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp
+  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp ^hdf5@1.14
   - exaworks
   - flecsi
   - flit
@@ -165,7 +165,7 @@ spack:
   - chai ~benchmarks ~tests +cuda ^umpire ~shared
   - cusz +cuda
   - dealii +cuda
-  - ecp-data-vis-sdk +cuda +adios2 +hdf5 +paraview +vtkm +zfp # Removing ascent because Dray is hung in CI. +ascent
+  - ecp-data-vis-sdk +cuda +ascent +adios2 +hdf5 +paraview +sz +vtkm +zfp  ^hdf5@1.14 # Removing ascent because Dray is hung in CI. +ascent
   - flecsi +cuda
   - flux-core +cuda
   - ginkgo +cuda
@@ -199,7 +199,7 @@ spack:
   - cabana +rocm
   - caliper +rocm
   - chai ~benchmarks +rocm
-  - ecp-data-vis-sdk +ascent +adios2 +hdf5 +paraview +pnetcdf +sz +vtkm +zfp +rocm
+  - ecp-data-vis-sdk +adios2 +hdf5 +paraview +pnetcdf +sz +vtkm +zfp +rocm ^hdf5@1.14 # Excludes ascent for now due to C++ standard issues
   - gasnet +rocm
   - ginkgo +rocm
   - heffte +rocm

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -165,7 +165,7 @@ spack:
   - chai ~benchmarks ~tests +cuda ^umpire ~shared
   - cusz +cuda
   - dealii +cuda
-  - ecp-data-vis-sdk +cuda +ascent +adios2 +hdf5 +paraview +sz +vtkm +zfp  ^hdf5@1.14 # Removing ascent because Dray is hung in CI. +ascent
+  - ecp-data-vis-sdk +cuda ~ascent +adios2 +hdf5 +paraview +sz +vtkm +zfp  ^hdf5@1.14 # Removing ascent because RAJA build failure
   - flecsi +cuda
   - flux-core +cuda
   - ginkgo +cuda

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -183,6 +183,8 @@ class Ascent(CMakePackage, CudaPackage):
     depends_on("vtk-m+cuda", when="@0.9.0: +vtkh+cuda")
     depends_on("vtk-m+fpic", when="@0.8.0: +vtkh")
     depends_on("vtk-m~shared+fpic", when="@0.8.0: +vtkh~shared")
+    # Ascent defaults to C++11
+    depends_on("kokkos std=11", when="+vtkh ^vtk-m +kokkos")
 
     #######################
     # VTK-h

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -152,7 +152,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     # Fortran support with ascent is problematic on some Cray platforms so the
     # SDK is explicitly disabling it until the issues are resolved.
     dav_sdk_depends_on(
-        "ascent+mpi~fortran+openmp+python+shared+vtkh+dray~test",
+        "ascent+mpi~fortran+python+shared+vtkh+dray~test",
         when="+ascent",
         propagate=["adios2", "cuda"] + cuda_arch_variants,
     )

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -207,6 +207,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant("std", default="17", values=stds, multi=False)
     variant("pic", default=False, description="Build position independent code")
 
+    conflicts("std=11", when="@3.7:")
+
     conflicts("+cuda", when="std=17 ^cuda@:10")
     conflicts("+cuda", when="std=20 ^cuda@:12")
 


### PR DESCRIPTION
Ascent: Fixup for VTK-m with Kokkos backend