### PR TITLE
gitlab ci: Better tagging of "service" jobs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -36,6 +36,27 @@ ci:
         - aws s3 sync --exclude "*" --include "*spec.json.sig*" /tmp ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache
         - aws s3 cp /tmp/public_keys ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/_pgp --recursive --exclude "*" --include "*.pub"
 
+  - reindex-job:
+      tags: ["service"]
+      variables:
+        CI_JOB_SIZE: "medium"
+        KUBERNETES_CPU_REQUEST: "4000m"
+        KUBERNETES_MEMORY_REQUEST: "16G"
+
+  - cleanup-job:
+      tags: ["service"]
+      variables:
+        CI_JOB_SIZE: "small"
+        KUBERNETES_CPU_REQUEST: "500m"
+        KUBERNETES_MEMORY_REQUEST: "500M"
+
+  - noop-job:
+      tags: ["service"]
+      variables:
+        CI_JOB_SIZE: "small"
+        KUBERNETES_CPU_REQUEST: "500m"
+        KUBERNETES_MEMORY_REQUEST: "500M"
+
   - any-job:
       image: "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18"
       tags: ["spack"]


### PR DESCRIPTION
Until now, gitlab ci relied on service jobs (noop, cleanup, and reindex) to have the "public" tag to avoid being run on the signing runner or the gpu runners at UO.  But after the ci boiler plate reduction PR, we can no longer use the reserved tags ("public", "protected", and "notary") in that way.  This is fine because that wasn't really a good approach anyway.

Now the "service" tag has been added to some of the cheaper or more highly available runners (see [here](https://github.com/spack/spack-infrastructure/pull/464)), and the goal of this PR is to use those runners for these jobs.

Here is an [example](https://gitlab.spack.io/spack/spack/-/jobs/6523533) of a reindex-job that ran on the signing runner and failed because that runner only allows the use of one particular image.

- [x] Tag non-rebuild jobs to target a cheaper (and more highly available) subset of runners.
- [x] Add missing resource requests to these jobs as well.
