### PR TITLE
lammps: backport fix for `+rocm+kokkos+kspace`

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -642,6 +642,14 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts("+intel", when="%aocc@:3.2.9999", msg="+intel with AOCC requires version 4 or newer")
 
+    # Backport of https://github.com/lammps/lammps/pull/3726
+    conflicts("+kokkos+rocm+kspace", when="@:20210929.3")
+    patch(
+        "https://github.com/lammps/lammps/commit/ebb8eee941e52c98054fdf96ea78ee4d5f606f47.patch?full_index=1",
+        sha256="3dedd807f63a21c543d1036439099f05c6031fd98e7cb1ea7825822fc074106e",
+        when="@20220623.3:20230208 +kokkos +rocm +kspace",
+    )
+
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
     patch("gtest_fix.patch", when="@:20210310 %aocc@3.2.0")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -650,6 +650,13 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
         when="@20220623.3:20230208 +kokkos +rocm +kspace",
     )
 
+    # Older LAMMPS does not compile with Kokkos 4.x
+    conflicts(
+        "^kokkos @4:",
+        when="@:20221222",
+        msg="LAMMPS is incompatible with Kokkos 4.x until @20230208",
+    )
+
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
     patch("gtest_fix.patch", when="@:20210310 %aocc@3.2.0")


### PR DESCRIPTION
Backport the LAMMPS patch that fixes https://github.com/spack/spack/issues/36696 into the latest stable versions, and add a conflict to prevent `+rocm +kokkos +kspace` from concretizing with old versions that do not have the fix.

CC @rbberger 