### PR TITLE
cub: add v2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/cub/package.py
+++ b/var/spack/repos/builtin/packages/cub/package.py
@@ -14,6 +14,7 @@ class Cub(Package):
     url = "https://github.com/NVIDIA/cub/archive/1.12.0.zip"
     git = "https://github.com/NVIDIA/cub.git"
 
+    version("2.1.0", sha256="8ec47307f5e99379ac1cf6722cd5a24fc15b84b0f5361bebd453645a5e4bb34d")
     version("1.16.0", sha256="a9e327d46c82025d17ed3ab5a10da006bcdaef5dcbd294b332ef0a572f58445b")
     version("1.15.0", sha256="dcb75744650deb42e9123509482e0f84944c1dbd60d5cd909a416d953d3a6903")
     version("1.14.0", sha256="d83ac193b6acdb9281ca130fbe9590728c018c98f38916f903181b6f9410a829")


### PR DESCRIPTION
Add cub v2.1.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.