### PR TITLE
libxaw3d: add v1.6.4

### DIFF
--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -13,6 +13,7 @@ class Libxaw3d(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXaw3d"
     xorg_mirror_path = "lib/libXaw3d-1.6.2.tar.gz"
 
+    version("1.6.4", sha256="09fecfdab9d7d5953567883e2074eb231bc7a122a06e5055f9c119090f1f76a7")
     version("1.6.2", sha256="847dab01aeac1448916e3b4edb4425594b3ac2896562d9c7141aa4ac6c898ba9")
 
     depends_on("libx11")


### PR DESCRIPTION
Add libxaw3d v1.6.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.