### PR TITLE
libxres: add v1.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -12,6 +12,7 @@ class Libxres(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/lib/libXRes"
     xorg_mirror_path = "lib/libXres-1.0.7.tar.gz"
 
+    version("1.2.2", sha256="8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950")
     version("1.0.7", sha256="488c9fa14b38f794d1f019fe62e6b06514a39f1a7538e55ece8faf22482fefcd")
 
     depends_on("libx11")


### PR DESCRIPTION
Add libxres v1.2.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.