### PR TITLE
ncio: add v1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/ncio/package.py
+++ b/var/spack/repos/builtin/packages/ncio/package.py
@@ -17,6 +17,7 @@ class Ncio(CMakePackage):
 
     maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
 
+    version("1.1.2", sha256="2e4506fe3176344f28e837f2f69bcbd3dda51a64cacf33af0e435b13abe094fc")
     version("1.1.0", sha256="9de05cf3b8b1291010197737666cede3d621605806379b528d2146c4f02d08f6")
     version("1.0.0", sha256="2e2630b26513bf7b0665619c6c3475fe171a9d8b930e9242f5546ddf54749bd4")
 


### PR DESCRIPTION
Add ncio v1.1.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.