### PR TITLE
r-blockmodeling: add v1.1.4

### DIFF
--- a/var/spack/repos/builtin/packages/r-blockmodeling/package.py
+++ b/var/spack/repos/builtin/packages/r-blockmodeling/package.py
@@ -14,6 +14,7 @@ class RBlockmodeling(RPackage):
 
     cran = "blockmodeling"
 
+    version("1.1.4", sha256="69ce17ed96ca754a6308edb62188e0040e357568b975ce8986f68ecb2fead2b8")
     version("1.1.3", sha256="5f705f92c9b96dcbdd6f109c6a99f88d70c576485369700b82391b6a75afbda6")
     version("1.0.5", sha256="18c227bb52f28aff4dae8929563474e3e006e238438c823b67dc6baa897f88ed")
     version("1.0.0", sha256="f10c41fff56dc7dc46dffbceacb8ff905eca06578d610a5a590fb408f0149cfc")


### PR DESCRIPTION
Add r-blockmodeling v1.1.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.