### PR TITLE
r-curl: add v5.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/r-curl/package.py
+++ b/var/spack/repos/builtin/packages/r-curl/package.py
@@ -21,6 +21,7 @@ class RCurl(RPackage):
 
     cran = "curl"
 
+    version("5.0.0", sha256="d7f3cac9b513914ffa8f6f64e6fa5dd96c8273378ace6b0c16b71bc6ba59c9b2")
     version("4.3.3", sha256="3567b6acad40dad68acfe07511c853824839d451a50219a96dd6d125ed617c9e")
     version("4.3.2", sha256="90b1facb4be8b6315bb3d272ba2dd90b88973f6ea1ab7f439550230f8500a568")
     version("4.3", sha256="7406d485bb50a6190e3ed201e3489063fd249b8b3b1b4f049167ac405a352edb")


### PR DESCRIPTION
Add r-curl v5.0.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.