### PR TITLE
r-earth: add v5.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-earth/package.py
+++ b/var/spack/repos/builtin/packages/r-earth/package.py
@@ -15,6 +15,7 @@ class REarth(RPackage):
 
     cran = "earth"
 
+    version("5.3.2", sha256="c844d75edf9a2706a911bb05ed4287aad9acf6f3fed357e037763a300eac0bea")
     version("5.3.1", sha256="0bbe06ba974ceb8ec5de1d59cb53f9487d1828d7130fe2503c48b6cb449c4b03")
     version("5.3.0", sha256="05ace806271a74b3ddf8718a93237fe2a8550a8659ebd87f8079c0bda5e02437")
     version("5.1.2", sha256="326f98e8c29365ca3cd5584cf2bd6529358f5ef81664cbd494162f92b6c3488d")


### PR DESCRIPTION
Add r-earth v5.3.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.