### PR TITLE
r-git2r: add v0.31.0

### DIFF
--- a/var/spack/repos/builtin/packages/r-git2r/package.py
+++ b/var/spack/repos/builtin/packages/r-git2r/package.py
@@ -15,6 +15,7 @@ class RGit2r(RPackage):
 
     cran = "git2r"
 
+    version("0.31.0", sha256="f1db9278fa4604600a64beaedcf86dda595d7c8a10cdb1f7300a6635e73cd66d")
     version("0.30.1", sha256="85d913ddc7659e32c1b98ebc247fa1cc1b7717a5bd413fa78ea84696986ca840")
     version("0.29.0", sha256="f8f7a181dc0ac761f2a0c4099bfd744ded01c0e0832cab32dc5b4da32accd48e")
     version("0.28.0", sha256="ce6d148d21d2c87757e98ef4474b2d09faded9b9b866f046bd26d4ca925e55f2")

--- a/var/spack/repos/builtin/packages/r-git2r/package.py
+++ b/var/spack/repos/builtin/packages/r-git2r/package.py
@@ -26,6 +26,7 @@ class RGit2r(RPackage):
     version("0.15.0", sha256="682ab9e7f71b2ed13a9ef95840df3c6b429eeea070edeb4d21d725cf0b72ede6")
 
     depends_on("r@3.1:", type=("build", "run"))
+    depends_on("r@3.4:", type=("build", "run"), when="@0.31.0:")
     depends_on("libgit2")
     depends_on("zlib")
     depends_on("openssl")


### PR DESCRIPTION
Add r-git2r v0.31.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.