### PR TITLE
r-highr: add v0.10

### DIFF
--- a/var/spack/repos/builtin/packages/r-highr/package.py
+++ b/var/spack/repos/builtin/packages/r-highr/package.py
@@ -15,6 +15,7 @@ class RHighr(RPackage):
 
     cran = "highr"
 
+    version("0.10", sha256="ec55bc1ff66390ed66806dc2a7b6c17dbfd089b3d73fe2e369017f8cb4bc347b")
     version("0.9", sha256="beff11390d936c90fdcc00e7ed0eb72220f3de403a51b56659e3d3e0b6d8ed4d")
     version("0.8", sha256="4bd01fba995f68c947a99bdf9aca15327a5320151e10bd0326fad50a6d8bc657")
     version("0.7", sha256="cabba5b6f2ea82024a49c5ced5f1aa476f864bc52bc129038e319e4e26b6f3b7")

--- a/var/spack/repos/builtin/packages/r-highr/package.py
+++ b/var/spack/repos/builtin/packages/r-highr/package.py
@@ -23,4 +23,5 @@ class RHighr(RPackage):
 
     depends_on("r@3.0.2:", type=("build", "run"))
     depends_on("r@3.2.3:", type=("build", "run"), when="@0.8:")
+    depends_on("r@3.3.0:", type=("build", "run"), when="@0.10:")
     depends_on("r-xfun@0.18:", type=("build", "run"), when="@0.9:")


### PR DESCRIPTION
Add r-highr v0.10. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.