### PR TITLE
r-hms: add v1.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-hms/package.py
+++ b/var/spack/repos/builtin/packages/r-hms/package.py
@@ -14,6 +14,7 @@ class RHms(RPackage):
 
     cran = "hms"
 
+    version("1.1.3", sha256="e626f4c60af46efd53ea631b316a103e089470d8fd63c0e0c0efb99364990282")
     version("1.1.2", sha256="1ee6a9847336aaf58d3fcee5b56c290c2204e1213b6628862818419b2302bded")
     version("1.1.1", sha256="6b5f30db1845c70d27b5de33f31caa487cdd0787cd80a4073375e5f482269062")
     version("1.0.0", sha256="9704e903d724f0911d46e5ad18b469a7ed419c5b1f388bd064fd663cefa6c962")


### PR DESCRIPTION
Add r-hms v1.1.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.