### PR TITLE
r-hoardr: add v0.5.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-hoardr/package.py
+++ b/var/spack/repos/builtin/packages/r-hoardr/package.py
@@ -17,6 +17,7 @@ class RHoardr(RPackage):
 
     cran = "hoardr"
 
+    version("0.5.3", sha256="b9e4d1350e1fde7db922e55128306e3768ee46ff9532f05c96543dcae383647c")
     version("0.5.2", sha256="819113f0e25da105f120a676b5173872a4144f2f6f354cad14b35f898e76dc54")
 
     depends_on("r-r6@2.2.0:", type=("build", "run"))


### PR DESCRIPTION
Add r-hoardr v0.5.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.