### PR TITLE
r-httr: add v1.4.5

### DIFF
--- a/var/spack/repos/builtin/packages/r-httr/package.py
+++ b/var/spack/repos/builtin/packages/r-httr/package.py
@@ -15,6 +15,7 @@ class RHttr(RPackage):
 
     cran = "httr"
 
+    version("1.4.5", sha256="f93bac7f882b0df099abca47dd5aae3686fb3cd2d3e9926fcd639bcddff76f6c")
     version("1.4.4", sha256="41d82523f3ee260d409a7b5ae4136190cbc5aecbc270b40ed7064f83e7f5435d")
     version("1.4.3", sha256="9a8613fa96173ac910c021391af1ced4d0609169049c802cf7cdfe1c40897c6a")
     version("1.4.2", sha256="462bed6ed0d92f811d5df4d294336025f1dbff357286999d9269bfd9c20b1ef9")


### PR DESCRIPTION
Add r-httr v1.4.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.