### PR TITLE
r-jsonlite: add v1.8.4

### DIFF
--- a/var/spack/repos/builtin/packages/r-jsonlite/package.py
+++ b/var/spack/repos/builtin/packages/r-jsonlite/package.py
@@ -22,6 +22,7 @@ class RJsonlite(RPackage):
 
     cran = "jsonlite"
 
+    version("1.8.4", sha256="79eaabe042226b0918aa828cc63d54fee8be67ae7c67f5e0d3010f468efb1278")
     version("1.8.3", sha256="c57f1daf681fc7d5db893693a65ac61a48ddd7aabf66b28647b0e30df92ac8f0")
     version("1.8.2", sha256="677b645c081a7e004b71f0c48a1d46c1be9715163ccb6b419fbb0342a6c9cc3a")
     version("1.8.0", sha256="7b1892efebcb4cf4628f716000accd4b43bbf82b3e6ba90b9529d4fa0e55cd4c")


### PR DESCRIPTION
Add r-jsonlite v1.8.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.