### PR TITLE
r-lubridate: add v1.9.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-lubridate/package.py
+++ b/var/spack/repos/builtin/packages/r-lubridate/package.py
@@ -18,6 +18,7 @@ class RLubridate(RPackage):
 
     cran = "lubridate"
 
+    version("1.9.2", sha256="8976431a4affe989261cbaa5e09cd44bb42a3b16eed59a42c1698da34c6544a7")
     version("1.9.0", sha256="b936041f8a71894ef930cfff61b45833e0dd148b5b16697f4f541d25b31a903a")
     version("1.8.0", sha256="87d66efdb1f3d680db381d7e40a202d35645865a0542e2f270ef008a19002ba5")
     version("1.7.9.2", sha256="ee6a2d68faca51646477acd1898ba774bf2b6fd474a0abf351b16aa5e7a3db79")


### PR DESCRIPTION
Add r-lubridate v1.9.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.