### PR TITLE
r-pkgmaker: add v0.32.8

### DIFF
--- a/var/spack/repos/builtin/packages/r-pkgmaker/package.py
+++ b/var/spack/repos/builtin/packages/r-pkgmaker/package.py
@@ -19,6 +19,7 @@ class RPkgmaker(RPackage):
 
     cran = "pkgmaker"
 
+    version("0.32.8", sha256="0ff3578d2c051b544c3f105cfe4801575aac1564add048f9e952c53a8ccd1745")
     version("0.32.2", sha256="ce45b22def771a9c90a414093823e6befe7e23489c500eeccee5154b44d3ef91")
     version("0.27", sha256="17a289d8f596ba5637b07077b3bff22411a2c2263c0b7de59fe848666555ec6a")
 


### PR DESCRIPTION
Add r-pkgmaker v0.32.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.