### PR TITLE
r-plyr: add v1.8.8

### DIFF
--- a/var/spack/repos/builtin/packages/r-plyr/package.py
+++ b/var/spack/repos/builtin/packages/r-plyr/package.py
@@ -19,6 +19,7 @@ class RPlyr(RPackage):
 
     cran = "plyr"
 
+    version("1.8.8", sha256="a73211b4bbe13e4e5e764966a8dd90172c1cc311938dd464d142e1c7a701070c")
     version("1.8.7", sha256="7d9fdaf1157035a49c3661da3bbaa7bfcf782aafe1b98f7b5a68b0520046e87f")
     version("1.8.6", sha256="ea55d26f155443e9774769531daa5d4c20a0697bb53abd832e891b126c935287")
     version("1.8.4", sha256="60b522d75961007658c9806f8394db27989f1154727cb0bb970062c96ec9eac5")


### PR DESCRIPTION
Add r-plyr v1.8.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.