### PR TITLE
r-rcppparallel: add v5.1.7

### DIFF
--- a/var/spack/repos/builtin/packages/r-rcppparallel/package.py
+++ b/var/spack/repos/builtin/packages/r-rcppparallel/package.py
@@ -16,6 +16,7 @@ class RRcppparallel(RPackage):
 
     cran = "RcppParallel"
 
+    version("5.1.7", sha256="f9c30eb9ce1abffc590825d513d6d28dcbe970e36032dd7521febf04e905b29c")
     version("5.1.5", sha256="6396322b3b6d6f7019aac808ceb74707bc5c4ed01677fab408372c2a5508c2ea")
     version("5.0.2", sha256="8ca200908c6365aafb2063be1789f0894969adc03c0f523c6cc45434b8236f81")
     version("4.4.3", sha256="7a04929ecab97e46c0b09fe5cdbac9d7bfa17ad7d111f1a9787a9997f45fa0fa")


### PR DESCRIPTION
Add r-rcppparallel v5.1.7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.