### PR TITLE
r-rrblup: add v4.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-rrblup/package.py
+++ b/var/spack/repos/builtin/packages/r-rrblup/package.py
@@ -17,6 +17,7 @@ class RRrblup(RPackage):
 
     cran = "rrBLUP"
 
+    version("4.6.2", sha256="860f5e3f889593b6737f386743a2679322ec7d3557bea8e25482fd6cb745adff")
     version("4.6.1", sha256="e9230e74cc430a83ac5567071cb1c7f00b35c368f7d79bcc1cfde7225446c4db")
     version("4.6", sha256="28b475a1466fcdc1780caace75cf34155338fda496cebd5799315598a4bc84af")
 


### PR DESCRIPTION
Add r-rrblup v4.6.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.