### PR TITLE
r-rstantools: add v2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-rstantools/package.py
+++ b/var/spack/repos/builtin/packages/r-rstantools/package.py
@@ -17,6 +17,7 @@ class RRstantools(RPackage):
 
     cran = "rstantools"
 
+    version("2.3.1", sha256="82d4f2e884ffc894463bd37765606d5a9bef2ee631758840ec58636acdca6975")
     version("2.2.0", sha256="cb810baeb90c67668361b666c6862df9917aff6aaec63d2c3a485f28407c4eb7")
     version("2.1.1", sha256="c95b15de8ec577eeb24bb5206e7b685d882f88b5e6902efda924b7217f463d2d")
     version("1.5.1", sha256="5cab16c132c12e84bd08e18cd6ef25ba39d67a04ce61015fc4490659c7cfb485")


### PR DESCRIPTION
Add r-rstantools v2.3.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.