### PR TITLE
r-svglite: add v2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-svglite/package.py
+++ b/var/spack/repos/builtin/packages/r-svglite/package.py
@@ -14,6 +14,7 @@ class RSvglite(RPackage):
 
     cran = "svglite"
 
+    version("2.1.1", sha256="48700169eec1b05dbee9e2bae000aa84c544617b018cb3ac431a128cfd8dac56")
     version("2.1.0", sha256="ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b")
     version("2.0.0", sha256="76e625fe172a5b7ce99a67b6d631b037b3f7f0021cfe15f2e15e8851b89defa5")
 


### PR DESCRIPTION
Add r-svglite v2.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.