### PR TITLE
r-taxizedb: add v0.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-taxizedb/package.py
+++ b/var/spack/repos/builtin/packages/r-taxizedb/package.py
@@ -16,6 +16,7 @@ class RTaxizedb(RPackage):
 
     cran = "taxizedb"
 
+    version("0.3.1", sha256="452a1b8079e370c1f29a1ff40d731a5b04c935068b1d6b1c5d808e8bebbafd94")
     version("0.3.0", sha256="5f28338a233f0021097147e74c5f83107e5847de3413eceb308208e39af9fcb4")
     version("0.1.4", sha256="5a40569a2b5abe56201f112a10220150353412df39b7e8d21ea8698f424cf295")
 


### PR DESCRIPTION
Add r-taxizedb v0.3.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.