### PR TITLE
r-timedate: add v4022.108

### DIFF
--- a/var/spack/repos/builtin/packages/r-timedate/package.py
+++ b/var/spack/repos/builtin/packages/r-timedate/package.py
@@ -21,6 +21,7 @@ class RTimedate(RPackage):
 
     cran = "timeDate"
 
+    version("4022.108", sha256="a5949b4fe2f6bdff751fc0793df8e3150cc25c078d48a28c066c10a6c4bfceef")
     version("4021.106", sha256="14adf1ec6cbd80f11a243fa66ea943725a7a4c75923ae2d8e424235d500b10e2")
     version("3043.102", sha256="377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473")
     version("3042.101", sha256="6c8d4c7689b31c6a43555d9c7258516556ba03b132e5643691e3e317b89a8c6d")


### PR DESCRIPTION
Add r-timedate v4022.108. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.