### PR TITLE
r-utf8: add v1.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-utf8/package.py
+++ b/var/spack/repos/builtin/packages/r-utf8/package.py
@@ -14,6 +14,7 @@ class RUtf8(RPackage):
 
     cran = "utf8"
 
+    version("1.2.3", sha256="c0a88686591f4ad43b52917d0964e9df4c62d8858fe25135a1bf357dfcbd6347")
     version("1.2.2", sha256="a71aee87d43a9bcf29249c7a5a2e9ca1d2a836e8d5ee3a264d3062f25378d8f4")
     version("1.1.4", sha256="f6da9cadfc683057d45f54b43312a359cf96ec2731c0dda18a8eae31d1e31e54")
     version("1.1.3", sha256="43b394c3274ba0f66719d28dc4a7babeb87187e766de8d8ca716e0548091440f")


### PR DESCRIPTION
Add r-utf8 v1.2.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.