### PR TITLE
r-yulab-utils: add v0.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/r-yulab-utils/package.py
+++ b/var/spack/repos/builtin/packages/r-yulab-utils/package.py
@@ -13,5 +13,6 @@ class RYulabUtils(RPackage):
 
     cran = "yulab.utils"
 
+    version("0.0.6", sha256="973a51b8d1284060aec34e94849eea6783439dbcbf85083dd4f1a5df4f927b25")
     version("0.0.5", sha256="6ecd4dc5dae40e86b7a462fdac3ab8c0b276dcae5a284eb43390a05b01e3056b")
     version("0.0.4", sha256="38850663de53a9166b8e85deb85be1ccf1a5b310bbe4355f3b8bc823ed1b49ae")


### PR DESCRIPTION
Add r-yulab-utils v0.0.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.