### PR TITLE
speex: add v1.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/speex/package.py
+++ b/var/spack/repos/builtin/packages/speex/package.py
@@ -13,4 +13,5 @@ class Speex(AutotoolsPackage):
     homepage = "https://speex.org"
     url = "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
 
+    version("1.2.1", sha256="4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea")
     version("1.2.0", sha256="eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094")


### PR DESCRIPTION
Add speex v1.2.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.