### PR TITLE
tempestremap: add v2.1.6

### DIFF
--- a/var/spack/repos/builtin/packages/tempestremap/package.py
+++ b/var/spack/repos/builtin/packages/tempestremap/package.py
@@ -20,6 +20,7 @@ class Tempestremap(AutotoolsPackage):
 
     maintainers("iulian787", "vijaysm", "paullric")
 
+    version("2.1.6", sha256="d2208b5d6952eba5003ee7abcf22f46a254ba03f6b76dcc4d246068573d424e2")
     version("2.0.5", sha256="8618f5cbde450922efa1d77e67b062c557788b0cf4304adca30237afe3ade887")
     version("2.0.4", sha256="8349eeb604e97b13d2ecde8626a69e579a7af70ad0e8a6925a8bb4306a4963a4")
     version("2.0.3", sha256="b4578c2cb101ba091a10dc914e15ac968257f5db27ca78bc9fb5dbd70bce191f")


### PR DESCRIPTION
Add tempestremap v2.1.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.