### PR TITLE
yambo: add v5.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/yambo/package.py
+++ b/var/spack/repos/builtin/packages/yambo/package.py
@@ -20,6 +20,7 @@ class Yambo(AutotoolsPackage):
     homepage = "http://www.yambo-code.org/index.php"
     url = "https://github.com/yambo-code/yambo/archive/4.2.2.tar.gz"
 
+    version("5.1.1", sha256="c85036ca60507e627c47b6c6aee8241830349e88110e1ce9132ef03ab2c4e9f6")
     version("4.2.2", sha256="86b4ebe679387233266aba49948246c85a32b1e6840d024f162962bd0112448c")
     version("4.2.1", sha256="8ccd0ca75cc32d9266d4a37edd2a7396cf5038f3a68be07c0f0f77d1afc72bdc")
     version("4.2.0", sha256="9f78c4237ff363ff4e9ea5eeea671b6fff783d9a6078cc31b0b1abeb1f040f4d")


### PR DESCRIPTION
Add yambo v5.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.