### PR TITLE
suite-sparse: SPQR must be added after GPU targets, since it depends on them

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -244,7 +244,6 @@ class SuiteSparse(Package):
             "KLU",
             "UMFPACK",
             "RBio",
-            "SPQR",
         ]
         if spec.satisfies("+cuda"):
             targets.extend(["SuiteSparse_GPURuntime", "GPUQREngine"])


### PR DESCRIPTION
SPQR should not be in the first list, and it is already correctly added after the targets `SuiteSparse_GPURuntime` and `GPUQREngine`.

Reproducer for failing builds: `spack install suite-sparse@5.13.0+cuda`