### PR TITLE
Cairo: add a dependency on which

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -57,7 +57,7 @@ class Cairo(AutotoolsPackage):
     depends_on("freetype", when="+ft")
     depends_on("pkgconfig", type="build")
     depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
-    depends_on("which")
+    depends_on("which", type="build")
 
     conflicts("+png", when="platform=darwin")
     conflicts("+svg", when="platform=darwin")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -57,6 +57,7 @@ class Cairo(AutotoolsPackage):
     depends_on("freetype", when="+ft")
     depends_on("pkgconfig", type="build")
     depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
+    depends_on("which")
 
     conflicts("+png", when="platform=darwin")
     conflicts("+svg", when="platform=darwin")


### PR DESCRIPTION
I happened to run on container without which and it fails in the autoreconf phase.