### PR TITLE
exa: add v0.10.1

### DIFF
--- a/var/spack/repos/builtin/packages/exa/package.py
+++ b/var/spack/repos/builtin/packages/exa/package.py
@@ -12,6 +12,7 @@ class Exa(Package):
     homepage = "https://the.exa.website"
     url = "https://github.com/ogham/exa/archive/v0.9.0.tar.gz"
 
+    version("0.10.1", sha256="ff0fa0bfc4edef8bdbbb3cabe6fdbd5481a71abbbcc2159f402dea515353ae7c")
     version("0.9.0", sha256="96e743ffac0512a278de9ca3277183536ee8b691a46ff200ec27e28108fef783")
 
     depends_on("rust")


### PR DESCRIPTION
Add exa v0.10.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.