### PR TITLE
libverto: add v0.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/libverto/package.py
+++ b/var/spack/repos/builtin/packages/libverto/package.py
@@ -14,6 +14,7 @@ class Libverto(AutotoolsPackage):
     homepage = "https://github.com/latchset/libverto/"
     url = "https://github.com/latchset/libverto/archive/0.3.1.tar.gz"
 
+    version("0.3.2", sha256="b1005607e58961bf74945b87f36b8bdb94266a692685998b09a63190e3994dc1")
     version("0.3.1", sha256="02c7e679577ae7608ed35fe740bec2ef8c58142344cef247f2797ef788d41adc")
     version("0.3.0", sha256="fad201d9d0ac1abf1283d2d78bb3a615f72cfd2a2141673589d93c0cb762b3f1")
     version("0.2.7", sha256="0ef688a8a8690c24714834cc155b067b1c5d3f3194acceb333751deebd50de01")


### PR DESCRIPTION
Add libverto v0.3.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.