### PR TITLE
r-tigris: add v2.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-tigris/package.py
+++ b/var/spack/repos/builtin/packages/r-tigris/package.py
@@ -14,6 +14,7 @@ class RTigris(RPackage):
 
     cran = "tigris"
 
+    version("2.0.1", sha256="d87c6b0c11ffb967699d345c6bfcfa82581a0753e1130bf0c927b2960b074d8c")
     version("1.6.1", sha256="927e8da3f7120bcc10f0b4ded95687512693e069f082eea7aea6302a2f1b2db2")
     version("1.6", sha256="fa14fbbaf44f5ade1cc92e6e4e4ed2e775bc7c106310711d16b0135a948a1661")
     version("1.5", sha256="5ef71ca83817ad6b97ee86d1e560e8e86ee21bdcb1807ce40c945b3213c04472")


### PR DESCRIPTION
Add r-tigris v2.0.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.