### PR TITLE
routino: add v3.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/routino/package.py
+++ b/var/spack/repos/builtin/packages/routino/package.py
@@ -14,6 +14,7 @@ class Routino(MakefilePackage):
     homepage = "https://www.routino.org"
     url = "https://www.routino.org/download/routino-3.2.tgz"
 
+    version("3.3.3", sha256="abd82b77c314048f45030f7219887ca241b46d40641db6ccb462202b97a047f5")
     version("3.2", sha256="e2a431eaffbafab630835966d342e4ae25d5edb94c8ed419200e1ffb50bc7552")
 
     depends_on("zlib")


### PR DESCRIPTION
Add routino v3.3.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.