### PR TITLE
trident: add v23.01.1

### DIFF
--- a/var/spack/repos/builtin/packages/trident/package.py
+++ b/var/spack/repos/builtin/packages/trident/package.py
@@ -15,6 +15,7 @@ class Trident(Package):
     homepage = "https://netapp-trident.readthedocs.io"
     url = "https://github.com/NetApp/trident/archive/v20.01.1.tar.gz"
 
+    version("23.01.1", sha256="d0aedf2446e09b15abe9b0f052f42145c6acf23014a6e009e22cff5a2ad6c77d")
     version("20.01.1", sha256="02ba92e569916b98fb1b563c5ef03a94fd7981c3ac1ecb47e69ebb45471dc976")
     version("20.01.0", sha256="5de190579acf62f5e9945dfd45aeb21989272c4972e85cb10256b7ec605c29c7")
 


### PR DESCRIPTION
Add trident v23.01.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.