### PR TITLE
lhapdf: change extend to append

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -45,7 +45,7 @@ class Lhapdf(AutotoolsPackage):
         args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]
 
         if self.spec.satisfies("+python"):
-            args.extend(
+            args.append(
                 "LIBS=-L"
                 + self.spec["python"].prefix.lib
                 + " -L"


### PR DESCRIPTION
In this case we are adding a single element to the list so extend doesn't work because it will add each character of the string as an element to the list