### PR TITLE
cgl: add v0.60.7

### DIFF
--- a/var/spack/repos/builtin/packages/cgl/package.py
+++ b/var/spack/repos/builtin/packages/cgl/package.py
@@ -21,6 +21,7 @@ class Cgl(AutotoolsPackage):
     depends_on("osi")
     depends_on("clp")
 
+    version("0.60.7", sha256="93b30a80b5d2880c2e72d5877c64bdeaf4d7c1928b3194ea2f88b1aa4517fb1b")
     version("0.60.6", sha256="9e2c51ffad816ab408763d6b931e2a3060482ee4bf1983148969de96d4b2c9ce")
     version("0.60.3", sha256="cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb")
 


### PR DESCRIPTION
Add cgl v0.60.7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.