### PR TITLE
spot: add v2.11.4

### DIFF
--- a/var/spack/repos/builtin/packages/spot/package.py
+++ b/var/spack/repos/builtin/packages/spot/package.py
@@ -14,6 +14,7 @@ class Spot(AutotoolsPackage):
     homepage = "https://spot.lrde.epita.fr/"
     url = "https://www.lrde.epita.fr/dload/spot/spot-1.99.3.tar.gz"
 
+    version("2.11.4", sha256="91ecac6202819ea1de4534902ce457ec6eec0573d730584d6494d06b0bcaa0b4")
     version("2.9.4", sha256="e11208323baabe9b5f98098d4b9bb39803fb102a68abbbaf900f1fcd578f0f85")
     version("1.99.3", sha256="86964af559994af4451a8dca663a9e1db6e869ed60e747ab60ce72dddc31b61b")
     version("1.2.6", sha256="360678c75f6741f697e8e56cdbc9937f104eb723a839c3629f0dc5dc6de11bfc")


### PR DESCRIPTION
Add spot v2.11.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.