### PR TITLE
r-renv: add v0.17.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-renv/package.py
+++ b/var/spack/repos/builtin/packages/r-renv/package.py
@@ -17,6 +17,7 @@ class RRenv(RPackage):
 
     cran = "renv"
 
+    version("0.17.3", sha256="1c4f28cd233e1f539a2a091f1d118de83eb8aea5d5780dbdfb6bb8dcc6e4f5f0")
     version("0.16.0", sha256="f3a13e6b71e9be460db73bd9e11a3cb8a1d9bc05c6b77423957cbc2a7f8ba016")
     version("0.15.5", sha256="b4f1a9a7daa82f0c3123ebd4eeba06e98d5485215518e5292b25bc56741d582e")
     version("0.15.2", sha256="d07effd329f6d653fec9cb517bc8adf3cd6b711758e439055b6d2f06c88765db")


### PR DESCRIPTION
Add r-renv v0.17.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.