### PR TITLE
ruby-rake: add v13.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/ruby-rake/package.py
+++ b/var/spack/repos/builtin/packages/ruby-rake/package.py
@@ -13,6 +13,7 @@ class RubyRake(RubyPackage):
     homepage = "https://github.com/ruby/rake"
     url = "https://github.com/ruby/rake/archive/v13.0.1.tar.gz"
 
+    version("13.0.6", sha256="a39d555a08a3cbd6961a98d0bf222a01018683760664ede3c1610af5ca5de0cc")
     version("13.0.1", sha256="d865329b5e0c38bd9d11ce70bd1ad6e0d5676c4eee74fd818671c55ec49d92fd")
 
     depends_on("ruby@2.2:", type=("build", "run"))


### PR DESCRIPTION
Add ruby-rake v13.0.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.