### PR TITLE
glab: add v1.28.0

### DIFF
--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -14,6 +14,7 @@ class Glab(Package):
 
     maintainers("alecbcs")
 
+    version("1.28.0", sha256="9a0b433c02033cf3d257405d845592e2b7c2e38741027769bb97a8fd763aeeac")
     version("1.27.0", sha256="26bf5fe24eeaeb0f861c89b31129498f029441ae11cc9958e14ad96ec1356d51")
     version("1.26.0", sha256="af1820a7872d53c7119a23317d6c80497374ac9529fc2ab1ea8b1ca033a9b4da")
     version("1.22.0", sha256="4d9bceb6818c8bf9f681119dae3a65f1c895fa21e9da6b38e8f88d245f524e10")
@@ -21,6 +22,8 @@ class Glab(Package):
     version("1.20.0", sha256="6beb0186fa50d0dea3b05fcfe6e4bc1f9be0c07aa5fa15b37ca2047b16980412")
 
     depends_on("go@1.13:", type="build")
+    depends_on("go@1.17:", type="build", when="@1.22.0:")
+    depends_on("go@1.18:", type="build", when="@1.23.0:")
 
     def install(self, spec, prefix):
         make()


### PR DESCRIPTION
Add glab v1.28.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.