### PR TITLE
rust: depend on curl+nghttp2

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -60,6 +60,9 @@ class Rust(Package):
     depends_on("pkgconfig", type="build")
     # TODO: openssl@3.x should be supported in later versions
     depends_on("openssl@:1")
+    # Cargo itself needs libcurl with nghttp2. If not found with pkg-config
+    # it will build vendored versions of libcurl, nghttp2, and openssl.
+    depends_on("curl+nghttp2")
     depends_on("libssh2")
     # https://github.com/rust-lang/cargo/issues/10446
     depends_on("libgit2@:1.3", when="@0:1.60")


### PR DESCRIPTION
Cargo's dependencies include curl, which if not found on the system is built
from vendored sources and statically linked, including even openssl, which
caused failures if certificates weren't in system dirs, like Spack's mozilla certs.

Before:

```
$ bwrap --dev-bind / / --tmpfs /etc/ssl cargo install x
    Updating crates.io index
error: failed to download from `https://crates.io/api/v1/crates/x/0.0.0/download`

Caused by:
  [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)
```

After:

```
$ bwrap --dev-bind / / --tmpfs /etc/ssl cargo install x
    Updating crates.io index
  Downloaded x v0.0.0
  Downloaded 1 crate (350 B) in 0.94s
  Installing x v0.0.0
   Compiling x v0.0.0
    Finished release [optimized] target(s) in 1.85s
  Installing /path/.cargo/bin/x
   Installed package `x v0.0.0` (executable `x`)
```