### PR TITLE
bedtools2: add v2.21.0

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/fix-binary-variable.patch
+++ b/var/spack/repos/builtin/packages/bedtools2/fix-binary-variable.patch
@@ -1,0 +1,13 @@
+diff --git a/test/merge/test-merge.sh b/test/merge/test-merge.sh
+index 586940bf..d7e2cf51 100644
+--- a/test/merge/test-merge.sh
++++ b/test/merge/test-merge.sh
+@@ -444,7 +444,7 @@ chr1	30	100	.,.,.
+ chr2	10	20	.
+ chr2	30	40	.
+ chr2	42	100	.,." >exp
+-../../bin/bedtools merge -i a.full.bam  -c 7 -o collapse > obs
++$BT merge -i a.full.bam  -c 7 -o collapse > obs
+ check exp obs
+ rm obs exp
+ 

--- a/var/spack/repos/builtin/packages/bedtools2/fix-broken-test.patch
+++ b/var/spack/repos/builtin/packages/bedtools2/fix-broken-test.patch
@@ -1,0 +1,13 @@
+diff --git a/test/jaccard/test-jaccard.sh b/test/jaccard/test-jaccard.sh
+index b8d626bd..6aea03c6 100644
+--- a/test/jaccard/test-jaccard.sh
++++ b/test/jaccard/test-jaccard.sh
+@@ -119,7 +119,7 @@ rm obs exp
+ echo "    jaccard.t11...\c"
+ echo \
+ "intersection	union-intersection	jaccard	n_intersections
+-120	290	0.413793	4" >exp
++70	340	0.205882	3" >exp
+ $BT jaccard -a aMixedStrands.bed -b bMixedStrands.bed -s > obs
+ check obs exp
+ rm obs exp

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -3,10 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
+import os
+
 from spack.package import *
 
 
-class Bedtools2(Package):
+class Bedtools2(MakefilePackage):
     """Collectively, the bedtools utilities are a swiss-army knife of
     tools for a wide-range of genomics analysis tasks. The most
     widely-used tools enable genome arithmetic: that is, set theory
@@ -22,11 +25,53 @@ class Bedtools2(Package):
     version("2.26.0", sha256="15db784f60a11b104ccbc9f440282e5780e0522b8d55d359a8318a6b61897977")
     version("2.25.0", sha256="159122afb9978015f7ec85d7b17739b01415a5738086b20a48147eeefcf08cfb")
     version("2.23.0", sha256="9dacaa561d11ce9835d1d51e5aeb092bcbe117b7119663ec9a671abac6a36056")
+    version("2.21.0", sha256="51380b718cc5f2023d0738374a86a7d42fcca2385cf051a6f0c95d9c2624d78d")
 
     depends_on("zlib")
     depends_on("bzip2", when="@2.29:")
     depends_on("xz", when="@2.29:")
     depends_on("python", type="build")
+    depends_on("samtools", type="test")
 
+    conflicts(
+        "%gcc@11:",
+        when="@:2.26.0",
+        msg="bedtools2 2.26.0 and earlier requires GCC 10 or earlier to build",
+    )
+
+    # https://github.com/arq5x/bedtools2/commit/58e9973af1b3f5e3b26e5584aad7dc7b720f8765
+    patch("fix-binary-variable.patch", when="@:2.29.2")
+    # https://github.com/arq5x/bedtools2/commit/ed59faae0cdd9e1676f57666613ac372366227e9
+    patch("fix-broken-test.patch", when="@:2.24.0")
+    # https://github.com/arq5x/bedtools2/issues/84
+    # https://github.com/arq5x/bedtools2/issues/85
+    patch("remove-unreproducible-tests.patch", when="@:2.24.0")
+
+    @when("@2.22.1:")
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "install")
+
+    @when("@:2.22.0")
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install_tree("bin", prefix.bin)
+
+    @run_after("install")
+    def cache_test_sources(self):
+        self.cache_extra_test_sources(["test"])
+        self.cache_extra_test_sources(["data"])
+        self.cache_extra_test_sources(["genomes"])
+
+    def test(self):
+        test_dir = join_path(self.test_suite.current_test_cache_dir, "test")
+
+        if not os.path.exists(test_dir):
+            print("skipping all tests")
+            return
+
+        # BT=${BT-../../bin/bedtools}
+        os.environ["BT"] = "bedtools"
+
+        self.run_test(
+            "bash", options=["test.sh"], purpose="test: run all tests", work_dir=test_dir
+        )

--- a/var/spack/repos/builtin/packages/bedtools2/remove-unreproducible-tests.patch
+++ b/var/spack/repos/builtin/packages/bedtools2/remove-unreproducible-tests.patch
@@ -1,0 +1,60 @@
+diff --git a/test/reldist/test-reldist.sh b/test/reldist/test-reldist.sh
+index fc315127..ffbe2283 100644
+--- a/test/reldist/test-reldist.sh
++++ b/test/reldist/test-reldist.sh
+@@ -82,7 +82,7 @@ echo \
+ 0.49	937	43408	0.022" > exp
+ $BT reldist -a $DATA/refseq.chr1.exons.bed.gz \
+             -b $DATA/aluY.chr1.bed.gz > obs
+-check obs exp
++#check obs exp
+ rm obs exp
+ 
+ 
+@@ -146,5 +146,5 @@ echo \
+ 0.50	38	43422	0.001" > exp
+ $BT reldist -a $DATA/refseq.chr1.exons.bed.gz \
+             -b $DATA/gerp.chr1.bed.gz > obs
+-check obs exp
++#check obs exp
+ rm obs exp
+diff --git a/test/shuffle/test-shuffle.sh b/test/shuffle/test-shuffle.sh
+index 606d60ce..072cef64 100644
+--- a/test/shuffle/test-shuffle.sh
++++ b/test/shuffle/test-shuffle.sh
+@@ -28,7 +28,7 @@ chrX	105921488	105921585	trf	79
+ chrX	125331456	125331497	trf	73" > exp
+ $BT shuffle -seed 42 -i simrep.bed  \
+             -g ../../genomes/human.hg19.genome | head > obs
+-check obs exp
++#check obs exp
+ rm obs exp
+ 
+ 
+@@ -59,7 +59,7 @@ chr4	931201	931236	trf	52
+ chr1	4215777	4215954	trf	302" > exp
+ $BT shuffle -incl incl.bed -seed 42 -i simrep.bed  \
+             -g ../../genomes/human.hg19.genome | head -20 > obs
+-check obs exp
++#check obs exp
+ rm obs exp
+ 
+ ##############################################################
+@@ -89,7 +89,7 @@ chr2	428268	428303	trf	52
+ chr4	590632	590809	trf	302" > exp
+ $BT shuffle -incl incl.bed -chromFirst -seed 42 -i simrep.bed  \
+             -g ../../genomes/human.hg19.genome | head -20 > obs
+-check obs exp
++#check obs exp
+ rm obs exp
+ 
+ 
+@@ -123,5 +123,5 @@ chr2	2555287	2555330	trf	86" > exp
+ $BT shuffle -seed 42 -i simrep.bed  \
+             -g ../../genomes/human.hg19.genome \
+ | $BT intersect -a - -b excl.bed | head > obs
+-check obs exp
+-rm obs exp
+\ No newline at end of file
++#check obs exp
++rm obs exp


### PR DESCRIPTION
## Changes

This pull request adds version 2.21.0 including a number of other changes that fixes issues relating to later versions as well. These include:

- Making this a `MakefilePackage` instead of a `Package` (not sure why it wasn't already one).
- Adding `samtools` as a dependency that's required for tests.
- Adding a conflict for versions 2.26.0 and earlier as they can't be built with `gcc` versions later than 10.
- A number of patches that fix issues that cause tests to fail (and that are fixed in later versions, commits of which commented).
- Adding a function for installing versions 2.22.0 and earlier, as `install` isn't in those versions of the `Makefile`.
- Adding a function for running tests (only way I could get the tests to run and get it's complete output).

## Notes

I've tried to read over the docs, other issue comments and packages, as much as possible for this pull request, as this is my first commit on a package. Please forgive me though, if I've still made any mistakes.