### PR TITLE
libmypaint: change extend to append

### DIFF
--- a/var/spack/repos/builtin/packages/libmypaint/package.py
+++ b/var/spack/repos/builtin/packages/libmypaint/package.py
@@ -37,7 +37,7 @@ class Libmypaint(AutotoolsPackage):
         args = []
 
         if "+gegl" in self.spec:
-            args.extend("--enable-gegl=yes")
+            args.append("--enable-gegl=yes")
 
         if "+introspection" in self.spec:
             args.extend(

--- a/var/spack/repos/builtin/packages/libmypaint/package.py
+++ b/var/spack/repos/builtin/packages/libmypaint/package.py
@@ -25,6 +25,7 @@ class Libmypaint(AutotoolsPackage):
     variant("gegl", default=False, description="Enable GEGL based code in build")
     variant("introspection", default=True, description="Enable introspection for this build")
 
+    depends_on("intltool")
     depends_on("json-c")
     depends_on("perl@5.8.1:")
     depends_on("perl-xml-parser")


### PR DESCRIPTION
For same reason as #36939, `extend` takes a list as argument, while `append` takes list entry. Here `append` should be used.