### PR TITLE
Keep -Werror to avoid issue #35235

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -14,6 +14,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     homepage = "http://www.openucx.org"
     url = "https://github.com/openucx/ucx/releases/download/v1.3.1/ucx-1.3.1.tar.gz"
     git = "https://github.com/openucx/ucx.git"
+    keep_werror = "all"
 
     maintainers("hppritcha")
 


### PR DESCRIPTION
Added `keep_werror` for `%nvhpc` to avoid issue #35235.
Ref: https://github.com/spack/spack/commit/0182603609f289ec43baa95b9e98998cbf268d04