### PR TITLE
Enable tcl module tests on windows

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -621,9 +621,7 @@ class BaseFileLayout(object):
             projection = self.conf.default_projections["all"]
 
         name = self.spec.format(projection)
-        # Not everybody is working on linux...
-        parts = name.split("/")
-        name = "/".join(parts)
+
         # Add optional suffixes based on constraints
         path_elements = [name] + self.conf.suffixes
         return "-".join(path_elements)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -623,7 +623,7 @@ class BaseFileLayout(object):
         name = self.spec.format(projection)
         # Not everybody is working on linux...
         parts = name.split("/")
-        name = os.path.join(*parts)
+        name = "/".join(parts)
         # Add optional suffixes based on constraints
         path_elements = [name] + self.conf.suffixes
         return "-".join(path_elements)

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 import spack.modules.common
@@ -17,8 +15,6 @@ libdwarf_spec_string = "libdwarf target=x86_64"
 
 #: Class of the writer tested in this module
 writer_cls = spack.modules.tcl.TclModulefileWriter
-
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "mock_module_filename")

--- a/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
+++ b/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
@@ -13,9 +13,9 @@ class ModulePathSeparator(Package):
     version(1.0, "0123456789abcdef0123456789abcdef")
 
     def setup_run_environment(self, env):
-        env.append_path("COLON", "foo")
-        env.prepend_path("COLON", "foo")
-        env.remove_path("COLON", "foo")
+        env.append_path("COLON", "foo", separator=":")
+        env.prepend_path("COLON", "foo", separator=":")
+        env.remove_path("COLON", "foo", separator=":")
 
         env.append_path("SEMICOLON", "bar", separator=";")
         env.prepend_path("SEMICOLON", "bar", separator=";")


### PR DESCRIPTION
Removes skips for tests and adds tweaks to mocked packages to enable functionality on windows.