### PR TITLE
Enable graph, mark, and info cmd tests on windows.

### DIFF
--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -3,15 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 from spack.main import SpackCommand, SpackCommandError
 
 graph = SpackCommand("graph")
-
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import sys
 
 import pytest
 
@@ -12,8 +11,6 @@ import spack.cmd.info
 from spack.main import SpackCommand
 
 info = SpackCommand("info")
-
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Not yet implemented on Windows")
 
 
 @pytest.fixture(scope="module")

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import pytest
 
 import spack.store

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -15,8 +15,6 @@ mark = SpackCommand("mark")
 install = SpackCommand("install")
 uninstall = SpackCommand("uninstall")
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-
 
 @pytest.mark.db
 def test_mark_mode_required(mutable_database):


### PR DESCRIPTION
Remove skips for passing tests on windows.