### PR TITLE
bamutil: fix filter_file invocation

### DIFF
--- a/var/spack/repos/builtin/packages/bamutil/package.py
+++ b/var/spack/repos/builtin/packages/bamutil/package.py
@@ -37,7 +37,7 @@ class Bamutil(MakefilePackage):
 
     @when("@1.0.15")
     def edit(self, spec, prefix):
-        filter_file("git://", "https://", "Makefile.inc", String=True)
+        filter_file("git://", "https://", "Makefile.inc", string=True)
 
     @when("@1.0.15:")
     def build(self, spec, prefix):


### PR DESCRIPTION
I don't know how this got past me. Encountered this while rebuilding our collection.