### PR TITLE
py-html5lib, madgraph5amc: correct hashes of empty files

### DIFF
--- a/var/spack/repos/builtin/packages/madgraph5amc/package.py
+++ b/var/spack/repos/builtin/packages/madgraph5amc/package.py
@@ -26,11 +26,6 @@ class Madgraph5amc(MakefilePackage):
         sha256="acda34414beba201e529b8c03f87f4893fb3f99ed2956a131d60a387e76c5b8c",
         url="https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.1.tar.gz",
     )
-    version(
-        "2.8.0",
-        sha256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        url="https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.0.tar.gz",
-    )
     version("2.7.3.py3", sha256="400c26f9b15b07baaad9bd62091ceea785c2d3a59618fdc27cad213816bc7225")
 
     variant(

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -18,7 +18,7 @@ class PyHtml5lib(PythonPackage):
         preferred=True,
     )
     version("1.0.1", sha256="66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736")
-    version("0.99", sha256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    version("0.99", sha256="aff6fd3031c563883197e5a04b7df324086ff5f358278a0386808c463a077e59")
     version(
         "099",
         sha256="2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868",


### PR DESCRIPTION
Going through and fixing hashes that are due to empty string.
```console
$ grep -Ir $(echo -n | sha256sum | awk '{print$1}') $SPACK_ROOT/var/spack/repos/builtin
/home/wdconinc/git/spack/var/spack/repos/builtin/packages/madgraph5amc/package.py:        sha256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
/home/wdconinc/git/spack/var/spack/repos/builtin/packages/py-html5lib/package.py:    version("0.99", sha256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
```

```console
$ spack checksum py-html5lib 0.99
==> Found 1 version of py-html5lib:
  
  0.99  https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz

==> Fetching https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz

    version("0.99", sha256="aff6fd3031c563883197e5a04b7df324086ff5f358278a0386808c463a077e59")
```