### PR TITLE
bugfix: don't fetch package metadata for unknown concrete specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2789,11 +2789,11 @@ class Spec(object):
         # Also record all patches required on dependencies by
         # depends_on(..., patch=...)
         for dspec in root.traverse_edges(deptype=all, cover="edges", root=False):
-            pkg_deps = dspec.parent.package_class.dependencies
-            if dspec.spec.name not in pkg_deps:
+            if dspec.spec.concrete:
                 continue
 
-            if dspec.spec.concrete:
+            pkg_deps = dspec.parent.package_class.dependencies
+            if dspec.spec.name not in pkg_deps:
                 continue
 
             patches = []


### PR DESCRIPTION
Fixes #36847.
Fixes #34108.

This fixes two issues:
1. The concretizer can fail with `reuse:true` if a buildcache or installation contains a package with a dependency that has been renamed or deleted in the main repo (e.g., `netcdf` was refactored to `netcdf-c`, `netcdf-fortran`, etc., but there are still binary packages with dependencies called `netcdf`).

    We should still be able to install things for which we are missing `package.py` files.

    `Spec.inject_patches_variant()` was failing this requirement by attempting to look up the package class for concrete specs.  This isn't needed -- we can skip it.

2. `spec_clauses()` attempts to look up package information for concrete specs in order to determine which virtuals they may provide. This fails for renamed/deleted dependencies of buildcaches and installed packages.

    This will eventually be fixed by https://github.com/spack/spack/pull/35258, but we need a workaround to make older buildcaches usable.

- [x] swap two conditions in `Spec.inject_patches_variant()`
- [x] make an exception for renamed packages and omit their virtual constraints
- [x] add a note that this will be solved by adding virtuals to edges
