### PR TITLE
interproscan: add version 5.61-93.0, fix build issue

### DIFF
--- a/var/spack/repos/builtin/packages/interproscan/web-pom.patch
+++ b/var/spack/repos/builtin/packages/interproscan/web-pom.patch
@@ -1,0 +1,12 @@
+diff --git a/core/web/pom.xml b/core/web/pom.xml
+index d595aea0e..362dd0326 100644
+--- a/core/web/pom.xml
++++ b/core/web/pom.xml
+@@ -247,6 +247,7 @@
+                         <artifactId>maven-war-plugin</artifactId>
+                         <version>${mvn.war.version}</version>
+                         <configuration>
++			    <classifier>interpo-protein-page</classifier>
+                             <warName>interpro-protein-page</warName>
+                             <webResources>
+                                 <resource>


### PR DESCRIPTION
This also reworks the directory layout a bit, installing only what should be required. 

I'm not sure if it's a newer maven thing or a newer java thing, but the module for the web bit doesn't build without having that classifier section in the pom.xml.