### PR TITLE
Fix compilation on Cray (target: any)

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -968,6 +968,9 @@ class SpackSolverSetup(object):
             if compiler.operating_system:
                 self.gen.fact(fn.compiler_os(compiler_id, compiler.operating_system))
 
+            if compiler.target == "any":
+                compiler.target = None
+
             if compiler.target is not None:
                 self.gen.fact(fn.compiler_target(compiler_id, compiler.target))
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2150,3 +2150,29 @@ class TestConcretize(object):
         spack.config.set("compilers", compiler_configuration)
         s = spack.spec.Spec("a %gcc@foo").concretized()
         assert s.compiler.version == ver("foo")
+
+    @pytest.mark.regression("36628")
+    def test_concretization_with_compilers_supporting_target_any(self):
+        """Tests that a compiler with 'target: any' can satisfy any target, and is a viable
+        candidate for concretization.
+        """
+        compiler_configuration = [
+            {
+                "compiler": {
+                    "spec": "gcc@12.1.0",
+                    "paths": {
+                        "cc": "/some/path/gcc",
+                        "cxx": "/some/path/g++",
+                        "f77": None,
+                        "fc": None,
+                    },
+                    "operating_system": "debian6",
+                    "target": "any",
+                    "modules": [],
+                }
+            }
+        ]
+
+        with spack.config.override("compilers", compiler_configuration):
+            s = spack.spec.Spec("a").concretized()
+        assert s.satisfies("%gcc@12.1.0")


### PR DESCRIPTION
fixes #36628

Fix using compilers that declare "target: any" in their configuration. This should happen only on Cray with the module based programming environment.