### PR TITLE
py-torch: define property cmake_prefix_paths

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -606,3 +606,10 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     def install_test(self):
         with working_dir("test"):
             python("run_test.py")
+
+    @property
+    def cmake_prefix_paths(self):
+        cmake_prefix_paths = [
+            join_path(self.prefix, self.spec["python"].package.platlib, "torch/share/cmake")
+        ]
+        return cmake_prefix_paths

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -609,5 +609,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     @property
     def cmake_prefix_paths(self):
-        cmake_prefix_paths = [join_path(self.prefix, self.spec["python"].package.platlib, "torch", "share", "cmake")]
+        cmake_prefix_paths = [
+            join_path(self.prefix, self.spec["python"].package.platlib, "torch", "share", "cmake")
+        ]
         return cmake_prefix_paths

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -609,5 +609,5 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     @property
     def cmake_prefix_paths(self):
-        cmake_prefix_paths = [join_path(python_platlib, "torch", "share", "cmake")]
+        cmake_prefix_paths = [join_path(self.prefix, self.spec["python"].package.platlib, "torch", "share", "cmake")]
         return cmake_prefix_paths

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -610,6 +610,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     @property
     def cmake_prefix_paths(self):
         cmake_prefix_paths = [
-            join_path(self.prefix, self.spec["python"].package.platlib, "torch/share/cmake")
+            join_path(python_platlib, "torch", "share", "cmake")
         ]
         return cmake_prefix_paths

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -609,7 +609,5 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     @property
     def cmake_prefix_paths(self):
-        cmake_prefix_paths = [
-            join_path(python_platlib, "torch", "share", "cmake")
-        ]
+        cmake_prefix_paths = [join_path(python_platlib, "torch", "share", "cmake")]
         return cmake_prefix_paths


### PR DESCRIPTION
`py-torch` installs `libtorch` and a cmake config in a non-standard location. This points downstream code to the relevant location. From there it should pick up the correctly library and include paths for C++ projects.