### PR TITLE
apachetop: add v0.23.2

### DIFF
--- a/var/spack/repos/builtin/packages/apachetop/package.py
+++ b/var/spack/repos/builtin/packages/apachetop/package.py
@@ -15,6 +15,7 @@ class Apachetop(AutotoolsPackage):
     homepage = "https://github.com/tessus/apachetop"
     url = "https://github.com/tessus/apachetop/archive/0.19.7.tar.gz"
 
+    version("0.23.2", sha256="4bce0120cb7b160256329f5d9253dc196b8690b33bdf410acc9c746bfa6d739d")
     version("0.19.7", sha256="88abf58ee5d7882e4cc3fa2462865ebbf0e8f872fdcec5186abe16e7bff3d4a5")
     version("0.18.4", sha256="1cbbfd1bf12275fb21e0cb6068b9050b2fee8c276887054a015bf103a1ae9cc6")
     version("0.17.4", sha256="892ed3b83b45eb38811e74d068089b1e8c34707787f240ce133d8c93198d7ff0")


### PR DESCRIPTION
Add apachetop v0.23.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.