### PR TITLE
root: @loader_path fix for python packages

### DIFF
--- a/var/spack/repos/builtin/packages/apple-blas/package.py
+++ b/var/spack/repos/builtin/packages/apple-blas/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class AppleBlas(Package):
+
+    homepage = ""
+
+    has_code = False
+
+    version('4.0.0')
+
+    provides('blas')
+    provides('lapack')
+
+    # Only supported on 'platform=darwin' and compiler=apple-clang
+    conflicts('platform=linux')
+    conflicts('platform=cray')
+    conflicts('%gcc')
+    conflicts('%clang')
+
+    phases = []
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # we try to setup a build environment with enough hints
+        # for the build system to pick up on the Apple framework version
+        # of BLAS.
+        # - for a cmake build we actually needs nothing at all as
+        # find_package(BLAS) will do the right thing
+        # - for the rest of the build systems we'll assume that
+        # setting the C_INCLUDE_PATH will be enough for the compilation phase
+        # and *** for the link phase.
+        env.prepend_path("C_INCLUDE_PATH","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers")
+        env.set("SPACK_APPLE_BLAS","1")
+
+    @property
+    def headers(self):
+        return HeaderList('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers')
+
+    @property
+    def libs(self):
+        # OPENGL_glu_LIBRARY:FILEPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/OpenGL.framework
+        return LibraryList('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework')

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -44,6 +44,9 @@ class Lz4(CMakePackage, MakefilePackage):
     )
     variant("pic", default=True, description="Enable position-independent code (PIC)")
 
+    with when("build_system=cmake"):
+        depends_on("cmake@3:", type="build")
+
     def url_for_version(self, version):
         url = "https://github.com/lz4/lz4/archive"
 
@@ -77,6 +80,7 @@ class CMakeBuilder(CMakeBuilder):
             self.define("BUILD_STATIC_LIBS", True if "libs=static" in self.spec else False)
         )
         args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
+        args.append(self.define("CMAKE_POLICY_DEFAULT_CMP0042","NEW"))
         return args
 
 

--- a/var/spack/repos/builtin/packages/root/loader.patch
+++ b/var/spack/repos/builtin/packages/root/loader.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/modules/RootBuildOptions.cmake b/cmake/modules/RootBuildOptions.cmake
-index a3d9852567..926952a83b 100644
+index a3d9852567..8d81e139e3 100644
 --- a/cmake/modules/RootBuildOptions.cmake
 +++ b/cmake/modules/RootBuildOptions.cmake
-@@ -457,7 +457,8 @@ if(rpath)
+@@ -457,7 +457,7 @@ if(rpath)
    if(APPLE)
      set(CMAKE_MACOSX_RPATH TRUE)
      set(CMAKE_INSTALL_NAME_DIR "@rpath")

--- a/var/spack/repos/builtin/packages/root/loader.patch
+++ b/var/spack/repos/builtin/packages/root/loader.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/modules/RootBuildOptions.cmake b/cmake/modules/RootBuildOptions.cmake
+index a3d9852567..926952a83b 100644
+--- a/cmake/modules/RootBuildOptions.cmake
++++ b/cmake/modules/RootBuildOptions.cmake
+@@ -457,7 +457,8 @@ if(rpath)
+   if(APPLE)
+     set(CMAKE_MACOSX_RPATH TRUE)
+     set(CMAKE_INSTALL_NAME_DIR "@rpath")
+-    set(CMAKE_INSTALL_RPATH "@loader_path/${BINDIR_TO_LIBDIR}")
++    set(CMAKE_INSTALL_RPATH "@loader_path/${BINDIR_TO_LIBDIR};@loader_path")
+   else()
+     set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/${BINDIR_TO_LIBDIR}")
+   endif()

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -112,6 +112,8 @@ class Root(CMakePackage):
         # Resolve circular dependency, _cf_
         # https://sft.its.cern.ch/jira/browse/ROOT-8226.
         patch("root6-60606-mathmore.patch", when="@6.06.06")
+        # rpath correction
+        patch("loader.patch",when="@6.28.02 +python")
 
     # ###################### Variants ##########################
     # See README.md for specific notes about what ROOT configuration

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -30,6 +30,7 @@ class Root(CMakePackage):
 
     # Master branch
     version("master", branch="master")
+#    version("6-28-00-patches-may-03", url="https://github.com/root-project/root/tarball/f7adbd2b04e62a0660245d43f3d411367a8ebebc",sha256="488897e122782b75f24e92874b2868c6170578d94c7db68966c8ba7f1ec3bd81")
 
     # Development version (when more recent than production).
 
@@ -114,6 +115,8 @@ class Root(CMakePackage):
         patch("root6-60606-mathmore.patch", when="@6.06.06")
         # rpath correction
         patch("loader.patch",when="@6.28.02 +python")
+        patch("loader.patch",when="@6.28.04 +python")
+        patch("loader.patch",when="@6-28-00-patches-may-03 +python")
 
     # ###################### Variants ##########################
     # See README.md for specific notes about what ROOT configuration


### PR DESCRIPTION
@greenc-FNAL @HadrienG2 @drbenmorgan @vvolkl 

On a M1 Mac, I observe the following error when trying to do a simple "import ROOT" from Python. I believe the issue is the rpath used but I might of course be missing the real point here, hence this draft-only PR.

```
$ spack load root
$ python
Python 3.11.2 (main, Apr 18 2023, 17:13:26) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ROOT
Traceback (most recent call last):
  File "/Users/ci/spack/opt/spack/darwin-ventura-m1/apple-clang-14.0.0/root-6.28.02-g63l6epgs5vez77xvxk3mazbd6kxbn3i/lib/root/cppyy/__init__.py", line 60, in <module>
    importlib.import_module(libcppyy_mod_name)
  File "/Users/ci/spack/opt/spack/darwin-ventura-m1/apple-clang-14.0.0/python-3.11.2-u4plrgnzdyk7kad3nkl7u3wuaqd5pukj/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 676, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 573, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1233, in create_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
ImportError: dlopen(/Users/ci/spack/opt/spack/darwin-ventura-m1/apple-clang-14.0.0/root-6.28.02-g63l6epgs5vez77xvxk3mazbd6kxbn3i/lib/root/libcppyy3_11.so, 0x0002): Library not loaded: @rpath/libcppyy_backend3_11.6.28.so
  Referenced from: <5B8DA857-1270-3846-B182-4D3A5BD8B9DF> /Users/ci/spack/opt/spack/darwin-ventura-m1/apple-clang-14.0.0/root-6.28.02-g63l6epgs5vez77xvxk3mazbd6kxbn3i/lib/root/libcppyy3_11.6.28.02.so

...snip...

```
