### PR TITLE
Update Qthreads recipe to support latest package versions

### DIFF
--- a/var/spack/repos/builtin/packages/qthreads/package.py
+++ b/var/spack/repos/builtin/packages/qthreads/package.py
@@ -29,20 +29,23 @@ class Qthreads(AutotoolsPackage):
 
     homepage = "http://www.cs.sandia.gov/qthreads/"
 
-    url = "https://github.com/Qthreads/qthreads/releases/download/1.10/qthread-1.10.tar.bz2"
+    url = "https://github.com/Qthreads/qthreads/releases/download/1.18/qthread-1.18.tar.gz"
     test_requires_compiler = True
     test_base_path = "test/basics/"
     test_list = ["hello_world_multi", "hello_world"]
 
     tags = ["e4s"]
 
+   
+    version("1.18", sha256="d1a808b35d3af0012194a8f3afe72241dfcffca7e88a7104fa02a46c73022880")
+    version("1.17", sha256="b17efb3c94c2027b8edd759584f4b1fa1e2725f1878a7a098d7bc58ad38d82f1")
     version("1.16", sha256="0a95e20b08cb486de6c33bff16590f41e444ca64ab738aee697ef982fbb021d8")
     version("1.15", sha256="3ac2dc24debff004a2998933de5724b1e14e1ae262fa9942acbb01f77819a23b")
     version("1.14", sha256="16f15e5b2e35b6329a857d24c283a1e43cd49921ee49a1446d4f31bf9c6f5cf9")
     version("1.12", sha256="2c13a5f6f45bc2f22038d272be2e748e027649d3343a9f824da9e86a88b594c9")
     version("1.11", sha256="dbde6c7cb7de7e89921e47363d09cecaebf775c9d090496c2be8350355055571")
     version("1.10", sha256="29fbc2e54bcbc814c1be13049790ee98c505f22f22ccee34b7c29a4295475656")
-
+    
     patch("restrict.patch", when="@:1.10")
     patch("trap.patch", when="@:1.10")
 
@@ -58,13 +61,15 @@ class Qthreads(AutotoolsPackage):
     variant("static", default=True, description="Build static library")
     variant(
         "stack_size",
-        default=4096,
+        default=16384,
         description="Specify number of bytes to use in a stack",
         values=is_integer,
     )
 
     depends_on("hwloc@1.0:1", when="@:1.15 +hwloc")
-    depends_on("hwloc@1.5:2", when="@1.16: +hwloc")
+    depends_on("hwloc@1.5:2", when="@:1.16 +hwloc")
+    depends_on("hwloc@2", when="@:1.17 +hwloc")
+    depends_on("hwloc@2", when="@:1.18 +hwloc")
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/qthreads/package.py
+++ b/var/spack/repos/builtin/packages/qthreads/package.py
@@ -5,6 +5,8 @@
 
 from spack.package import *
 
+maintainers("janciesko")
+
 
 def is_integer(x):
     """Any integer value"""
@@ -36,7 +38,6 @@ class Qthreads(AutotoolsPackage):
 
     tags = ["e4s"]
 
-   
     version("1.18", sha256="d1a808b35d3af0012194a8f3afe72241dfcffca7e88a7104fa02a46c73022880")
     version("1.17", sha256="b17efb3c94c2027b8edd759584f4b1fa1e2725f1878a7a098d7bc58ad38d82f1")
     version("1.16", sha256="0a95e20b08cb486de6c33bff16590f41e444ca64ab738aee697ef982fbb021d8")
@@ -45,7 +46,7 @@ class Qthreads(AutotoolsPackage):
     version("1.12", sha256="2c13a5f6f45bc2f22038d272be2e748e027649d3343a9f824da9e86a88b594c9")
     version("1.11", sha256="dbde6c7cb7de7e89921e47363d09cecaebf775c9d090496c2be8350355055571")
     version("1.10", sha256="29fbc2e54bcbc814c1be13049790ee98c505f22f22ccee34b7c29a4295475656")
-    
+
     patch("restrict.patch", when="@:1.10")
     patch("trap.patch", when="@:1.10")
 


### PR DESCRIPTION
Updates the `Qthreads` recipe to support versions `1.17` and `1.18`. Bumps requirement for `hwloc` to `2.x`.
