### PR TITLE
whizard: add paths when building

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -43,17 +43,11 @@ class Whizard(AutotoolsPackage):
     )
 
     variant("pythia8", default=True, description="builds with pythia8")
-
     variant("fastjet", default=False, description="builds with fastjet")
-
     variant("lcio", default=False, description="builds with lcio")
-
     variant("lhapdf", default=False, description="builds with fastjet")
-
     variant("openmp", default=False, description="builds with openmp")
-
     variant("openloops", default=False, description="builds with openloops")
-
     variant("latex", default=False, description="data visualization with latex")
 
     depends_on("libtirpc")
@@ -99,6 +93,8 @@ class Whizard(AutotoolsPackage):
         env.set("CXX", self.compiler.cxx)
         env.set("FC", self.compiler.fc)
         env.set("F77", self.compiler.fc)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["libtirpc"].prefix.lib)
+        env.prepend_path("CPATH", self.spec["libtirpc"].prefix.include.tirpc)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -17,7 +17,7 @@ class Whizard(AutotoolsPackage):
 
     tags = ["hep"]
 
-    maintainers("vvolkl")
+    maintainers("vvolkl", "jmcarcell")
 
     version("master", branch="master")
     version("3.1.0", sha256="9dc5e6d1a25d2fc708625f85010cb81b63559ff02cceb9b35024cf9f426c0ad9")


### PR DESCRIPTION
For some reason I'm not able to build in Ubuntu 22.04. I checked the Makefile variables and everything looks good but when it's time to build there are issues that I didn't find for CentOS 7, Alma9 nor Arch Linux. After adding these paths it works and I don't think they break the build for other OSes