### PR TITLE
emacs: default to +tls true

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -35,7 +35,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         values=("gtk", "athena"),
         description="Select an X toolkit (gtk, athena)",
     )
-    variant("tls", default=False, description="Build Emacs with gnutls")
+    variant("tls", default=True, description="Build Emacs with gnutls")
     variant("native", default=False, when="@28:", description="enable native compilation of elisp")
     variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
     variant("json", default=False, when="@27:", description="Build with json support")

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -15,6 +15,8 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     git = "git://git.savannah.gnu.org/emacs.git"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
 
+    maintainers("alecbcs")
+
     version("master", branch="master")
     version("28.2", sha256="a6912b14ef4abb1edab7f88191bfd61c3edd7085e084de960a4f86485cb7cad8")
     version("28.1", sha256="1439bf7f24e5769f35601dbf332e74dfc07634da6b1e9500af67188a92340a28")


### PR DESCRIPTION
Now that both elpa and melpa provide (and encourage) users to connect over https to prevent man in the middle attacks from injecting malicious emacs plugins into a users setup, it seems apt that we enable `+tls` by default. Without gnutils users will receive a vague "package not found" error when using emacs + melpa through spack due to the missing gnutls dependency.