### PR TITLE
Run pylint in GitHub Action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/lib/spack/docs"
     schedule:
       interval: "daily"
+  # Requirements to run style checks
+  - package-ecosystem: "pip"
+    directory: "/.github/workflows/style"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/style/requirements.txt
+++ b/.github/workflows/style/requirements.txt
@@ -1,0 +1,8 @@
+black==23.1.0
+clingo==5.6.2
+flake8==6.1.0
+isort==5.12.0
+mypy==1.5.0
+pylint==2.17.5
+types-six==1.16.21.9
+vermin==1.5.2

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Run linting
       # Currently, check only some parts of Spack and extend linting incrementally
       run: | 
-        pylint lib/spack/spack/bootstrap
+        pylint lib/spack/spack/bootstrap lib/spack/spack/schema
   audit:
     uses: ./.github/workflows/audit.yaml
     with:

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -25,8 +25,8 @@ jobs:
         cache: 'pip'
     - name: Install Python Packages
       run: |
-        pip install --upgrade pip
-        pip install --upgrade vermin
+        pip install --upgrade pip setuptools
+        pip install -r .github/workflows/style/requirements.txt
     - name: vermin (Spack's Core)
       run: vermin --backport importlib --backport argparse --violations --backport typing -t=3.6- -vvv lib/spack/spack/ lib/spack/llnl/ bin/
     - name: vermin (Repositories)
@@ -44,7 +44,8 @@ jobs:
         cache: 'pip'
     - name: Install Python packages
       run: |
-        python3 -m pip install --upgrade pip setuptools types-six black==23.1.0 mypy isort clingo flake8
+        pip install --upgrade pip setuptools
+        pip install -r .github/workflows/style/requirements.txt
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.
@@ -65,7 +66,8 @@ jobs:
         cache: 'pip'
     - name: Install Python packages
       run: |
-        python3 -m pip install --upgrade pip setuptools pylint
+        pip install --upgrade pip setuptools
+        pip install -r .github/workflows/style/requirements.txt
     - name: Run linting
       # Currently, check only some parts of Spack and extend linting incrementally
       run: | 

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -18,8 +18,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # @v2
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # @v2
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -35,10 +35,10 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # @v2
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # @v2
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -53,6 +53,23 @@ jobs:
     - name: Run style tests
       run: |
           share/spack/qa/run-style-tests
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - name: Install Python packages
+      run: |
+        python3 -m pip install --upgrade pip setuptools pylint
+    - name: Run linting
+      # Currently, check only some parts of Spack and extend linting incrementally
+      run: | 
+        pylint lib/spack/spack/bootstrap
   audit:
     uses: ./.github/workflows/audit.yaml
     with:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -122,6 +122,7 @@ class Bootstrapper:
         Return:
             True if the Python module could be imported, False otherwise
         """
+        # pylint: disable=unused-argument
         return False
 
     def try_search_path(self, executables: Tuple[str], abstract_spec_str: str) -> bool:
@@ -135,6 +136,7 @@ class Bootstrapper:
         Return:
             True if the executables are found, False otherwise
         """
+        # pylint: disable=unused-argument
         return False
 
 

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -130,10 +130,12 @@ class BootstrapEnvironment(spack.environment.Environment):
         makefile = self.environment_root() / "Makefile"
         makefile.write_text(template.render(model.to_dict()))
         make = spack.util.executable.which("make")
+        if make is None:
+            raise RuntimeError("cannot find 'make' in the environment")
         kwargs = {}
         if not tty.is_debug():
             kwargs = {"output": os.devnull, "error": os.devnull}
-        make(
+        make(  # pylint: disable=not-callable
             "-C",
             str(self.environment_root()),
             "-j",

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -12,24 +12,24 @@ import llnl.util.tty
 # jsonschema is imported lazily as it is heavy to import
 # and increases the start-up time
 def _make_validator():
-    import jsonschema
+    import jsonschema  # pylint: disable=import-outside-toplevel
 
-    import spack.parser
+    import spack.parser  # pylint: disable=import-outside-toplevel
 
     def _validate_spec(validator, is_spec, instance, schema):
         """Check if the attributes on instance are valid specs."""
-        import jsonschema
-
+        # pylint: disable=unused-argument
         if not validator.is_type(instance, "object"):
             return
 
         for spec_str in instance:
             try:
                 spack.parser.parse(spec_str)
-            except spack.parser.SpecSyntaxError as e:
-                yield jsonschema.ValidationError(str(e))
+            except spack.parser.SpecSyntaxError as exc:
+                yield jsonschema.ValidationError(str(exc))
 
     def _deprecated_properties(validator, deprecated, instance, schema):
+        # pylint: disable=unused-argument
         if not (validator.is_type(instance, "object") or validator.is_type(instance, "array")):
             return
 
@@ -51,8 +51,6 @@ def _make_validator():
         if not is_error:
             warnings.warn(msg)
         else:
-            import jsonschema
-
             yield jsonschema.ValidationError(msg)
 
     return jsonschema.validators.extend(

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -10,10 +10,9 @@
 """
 from llnl.util.lang import union_dicts
 
-import spack.schema.gitlab_ci  # DEPRECATED
-import spack.schema.merged
-import spack.schema.packages
-import spack.schema.projections
+from .gitlab_ci import properties as gitlab_ci_properties  # DEPRECATED
+from .merged import properties as merged_properties
+from .projections import properties as projections_properties
 
 #: Top level key in a manifest file
 TOP_LEVEL_KEY = "spack"
@@ -40,7 +39,7 @@ spec_list_schema = {
     },
 }
 
-projections_scheme = spack.schema.projections.properties["projections"]
+projections_scheme = projections_properties["projections"]
 
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -54,13 +53,14 @@ schema = {
             "additionalProperties": False,
             "properties": union_dicts(
                 # Include deprecated "gitlab-ci" section
-                spack.schema.gitlab_ci.properties,
+                gitlab_ci_properties,
                 # merged configuration scope schemas
-                spack.schema.merged.properties,
+                merged_properties,
                 # extra environment schema properties
                 {
                     "include": {"type": "array", "default": [], "items": {"type": "string"}},
                     "develop": {
+                        # pylint: disable=duplicate-code
                         "type": "object",
                         "default": {},
                         "additionalProperties": False,
@@ -133,7 +133,7 @@ def update(data):
     Returns:
         True if data was changed, False otherwise
     """
-
+    # pylint: disable=import-outside-toplevel
     import spack.ci
 
     if "gitlab-ci" in data:

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -40,6 +40,7 @@ def parse(config_obj):
         config_obj: a configuration dictionary conforming to the
             schema definition for environment modifications
     """
+    # pylint: disable=import-outside-toplevel
     import spack.util.environment as ev
 
     env = ev.EnvironmentModifications()

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -70,6 +70,7 @@ core_shared_properties = union_dicts(
         },
         "match_behavior": {"type": "string", "enum": ["first", "merge"], "default": "first"},
         "mappings": {
+            # pylint: disable=duplicate-code
             "type": "array",
             "items": {
                 "type": "object",

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -12,6 +12,7 @@
 #: Common properties for connection specification
 connection = {
     "url": {"type": "string"},
+    # pylint: disable=fixme
     # todo: replace this with named keys "username" / "password" or "id" / "secret"
     "access_pair": {
         "type": "array",
@@ -51,6 +52,7 @@ mirror_entry = {
 #: Properties for inclusion in other schemas
 properties = {
     "mirrors": {
+        # pylint: disable=duplicate-code
         "type": "object",
         "default": {},
         "additionalProperties": False,

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -16,7 +16,7 @@ import spack.schema.projections
 #:
 #: THIS NEEDS TO BE UPDATED FOR EVERY NEW KEYWORD THAT
 #: IS ADDED IMMEDIATELY BELOW THE MODULE TYPE ATTRIBUTE
-spec_regex = (
+SPEC_REGEX = (
     r"(?!hierarchy|core_specs|verbose|hash_length|defaults|filter_hierarchy_specs|"
     r"whitelist|blacklist|"  # DEPRECATED: remove in 0.20.
     r"include|exclude|"  # use these more inclusive/consistent options
@@ -24,10 +24,10 @@ spec_regex = (
 )
 
 #: Matches a valid name for a module set
-valid_module_set_name = r"^(?!prefix_inspections$)\w[\w-]*$"
+VALID_MODULE_SET_NAME = r"^(?!prefix_inspections$)\w[\w-]*$"
 
 #: Matches an anonymous spec, i.e. a spec without a root name
-anonymous_spec_regex = r"^[\^@%+~]"
+ANONYMOUS_SPEC_REGEX = r"^[\^@%+~]"
 
 #: Definitions for parts of module schema
 array_of_strings = {"type": "array", "default": [], "items": {"type": "string"}}
@@ -97,8 +97,8 @@ module_type_configuration = {
         {
             "validate_spec": True,
             "patternProperties": {
-                spec_regex: module_file_configuration,
-                anonymous_spec_regex: module_file_configuration,
+                SPEC_REGEX: module_file_configuration,
+                ANONYMOUS_SPEC_REGEX: module_file_configuration,
             },
         },
     ],
@@ -129,7 +129,7 @@ module_config_properties = {
                     "core_specs": array_of_strings,
                     "filter_hierarchy_specs": {
                         "type": "object",
-                        "patternProperties": {spec_regex: array_of_strings},
+                        "patternProperties": {SPEC_REGEX: array_of_strings},
                     },
                 },
             },  # Specific lmod extensions
@@ -169,7 +169,7 @@ properties = {
             }
         },
         "patternProperties": {
-            valid_module_set_name: {
+            VALID_MODULE_SET_NAME: {
                 "type": "object",
                 "default": {},
                 "additionalProperties": False,

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -144,6 +144,7 @@ schema = {
 
 
 def update(data):
+    """Updates the 'version' section of the packages configuration, following #36273."""
     changed = False
     for key in data:
         version = data[key].get("version")

--- a/lib/spack/spack/schema/upstreams.py
+++ b/lib/spack/spack/schema/upstreams.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+"""Configuration for upstream DBs."""
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -10,6 +10,7 @@ properties = {
         "type": "object",
         "default": {},
         "patternProperties": {
+            # pylint: disable=duplicate-code
             r"\w[\w-]*": {
                 "type": "object",
                 "default": {},
@@ -29,7 +30,7 @@ properties = {
 #: Full schema with metadata
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Spack core configuration file schema",
+    "title": "Spack upstream configuration file schema",
     "type": "object",
     "additionalProperties": False,
     "properties": properties,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,3 +255,24 @@ setuptools = "pkg_resources"
 CacheControl = "https://raw.githubusercontent.com/ionrock/cachecontrol/v0.12.6/LICENSE.txt"
 distlib = "https://bitbucket.org/pypa/distlib/raw/master/LICENSE.txt"
 webencodings = "https://github.com/SimonSapin/python-webencodings/raw/master/LICENSE"
+
+[tool.pylint.main]
+init-hook = """
+import sys
+import os.path
+
+spack_lib_path = os.path.join(".", "lib", "spack")
+sys.path.insert(0, spack_lib_path)
+
+# Add external libs
+spack_external_libs = os.path.join(spack_lib_path, "external")
+sys.path.insert(0, os.path.join(spack_external_libs, "_vendoring"))
+sys.path.insert(0, spack_external_libs)
+"""
+py-version = "3.6"
+
+[tool.pylint.reports]
+output-format = "colorized"
+
+[tool.pylint.refactoring]
+max-nested = 5


### PR DESCRIPTION
This adds a job in CI running `pylint` for some part of the code in `spack`. The intent is to extend the amount of code linted in this way incrementally.

Linting `spack.schema` is done in https://github.com/spack/spack/pull/37041/commits/361023f23547ba864edb26c13dba9fb28dc3d67c

Modifications:
- [x] Run `pylint` on `spack.bootstrap` and `spack.schema` in CI
- [x] Pin the version of pylint used in CI
- [x] Use dependabot to update versions automatically