### PR TITLE
poppler-data: new version 0.4.12

### DIFF
--- a/var/spack/repos/builtin/packages/poppler-data/package.py
+++ b/var/spack/repos/builtin/packages/poppler-data/package.py
@@ -17,6 +17,7 @@ class PopplerData(CMakePackage):
     homepage = "https://poppler.freedesktop.org/"
     url = "https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz"
 
+    version("0.4.12", sha256="c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74")
     version("0.4.9", sha256="1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012")
 
     depends_on("cmake@2.6:", type="build")


### PR DESCRIPTION
This release is best for poppler 23.04.0