### PR TITLE
poppler: new version 23.04.0

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -15,6 +15,7 @@ class Poppler(CMakePackage):
     git = "https://gitlab.freedesktop.org/poppler/poppler.git"
 
     version("master", branch="master")
+    version("23.04.0", sha256="b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1")
     version("21.09.0", sha256="5a47fef738c2b99471f9b459a8bf8b40aefb7eed92caa4861c3798b2e126d05b")
     version("21.07.0", sha256="e26ab29f68065de4d6562f0a3e2b5435a83ca92be573b99a1c81998fa286a4d4")
     version("0.90.1", sha256="984d82e72e91418d280885298c8bdc855a2fd92665fd52a1345b27235e0c71c4")


### PR DESCRIPTION
The latest stable release is poppler-23.04.0.tar.xz, released on April 2, 2023:

        core:
         * Fix memory issue when signing fails. Issue #1372
         * Internal improvements of signature related code
         * CairoOutputDev: improve type3 font rendering
         * Fix memory leak in GlobalParams::findSystemFontFileForFamilyAndStyle

        utils:
         * pdftocairo: Fix crash in some special situations
         * pdfsig: allow holes in -dump signature list
         * pdfsig: Support --help
        