### PR TITLE
Mostly fix concurrent install sbang

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -210,11 +210,14 @@ def install_sbang():
     if group_name and os.stat(sbang_bin_dir).st_gid != grp.getgrnam(group_name).gr_gid:
         os.chown(sbang_bin_dir, os.stat(sbang_bin_dir).st_uid, grp.getgrnam(group_name).gr_gid)
 
-    # copy over the fresh copy of `sbang`
-    sbang_tmp_path = os.path.join(
-        os.path.dirname(sbang_path), ".%s.%d.tmp" % (os.path.basename(sbang_path), os.getpid())
+    # safely create a temporary file
+    os_fd, sbang_tmp_path = tempfile.mkstemp(
+        prefix=".%s.tmp." % os.path.basename(sbang_path), dir=sbang_bin_dir
     )
-    shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
+    os.close(os_fd)
+
+    # copy over the fresh copy of `sbang`
+    shutil.copyfile(spack.paths.sbang_script, sbang_tmp_path)
 
     # set permissions on `sbang` (including group if set in configuration)
     os.chmod(sbang_tmp_path, config_mode)
@@ -225,6 +228,7 @@ def install_sbang():
     try:
         os.rename(sbang_tmp_path, sbang_path)
     except OSError as e:
+        # On windows, rename wont overwrite, so ignore races
         if e.errno != errno.EEXIST:
             raise e
 


### PR DESCRIPTION
Quick fix a race in `opt/spack/bin/sbang` file installation when running concurrent `spack install`.

There is still a possible race with multiple processes on different machines on a shared FS, but I think this fix is still better than nothing. There was an attempt at a proper fix #33549 but was reverted #33778.

Refers #33547 

--- 

Note: to reproduce, one can emulate concurrent install_sbang:

```sh
$ rm opt/spack/bin/sbang; seq 4 | xargs -I{} -n1 -P100 ./bin/spack python -c 'from spack.hooks.sbang import install_sbang; install_sbang()'
Traceback (most recent call last):
  File "/usr/lib/python3.10/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/.../github.com/spack/spack/lib/spack/spack/hooks/sbang.py", line 216, in install_sbang
    shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
  File "/usr/lib/python3.10/shutil.py", line 418, in copy
    copymode(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 307, in copymode
    chmod_func(dst, stat.S_IMODE(st.st_mode))
FileNotFoundError: [Errno 2] No such file or directory: '/.../github.com/spack/spack/opt/spack/bin/.sbang.tmp'
Traceback (most recent call last):
  File "/usr/lib/python3.10/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/.../github.com/spack/spack/lib/spack/spack/hooks/sbang.py", line 216, in install_sbang
    shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
  File "/usr/lib/python3.10/shutil.py", line 418, in copy
    copymode(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 307, in copymode
    chmod_func(dst, stat.S_IMODE(st.st_mode))
```

(As with all dataraces, try launching multiple times until it fails)
