### PR TITLE
opencascade: new version 7.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -20,6 +20,11 @@ class Opencascade(CMakePackage):
     maintainers("wdconinc")
 
     version(
+        "7.7.1",
+        extension="tar.gz",
+        sha256="f413d30a8a06d6164e94860a652cbc96ea58fe262df36ce4eaa92a9e3561fd12",
+    )
+    version(
         "7.7.0",
         extension="tar.gz",
         sha256="075ca1dddd9646fcf331a809904925055747a951a6afd07a463369b9b441b445",


### PR DESCRIPTION
No build system or dependency changes necessary.

New maintenance release announcement at https://www.opencascade.com/open-cascade-technology-7-7-1-maintenance-release/.

Full diff from 7.7.0 to 7.7.1 at https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=ffce0d66bbaafe3a95984d0e61804c201b9995d2;hp=185d29b92f6764ffa9fc195b7dbe7bba3c4ac855