### PR TITLE
py-onnxruntime: new version 1.1[1234].1

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -38,7 +38,9 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
 
     variant("cuda", default=False, description="Build with CUDA support")
 
-    depends_on("cmake@3.1:", type="build")
+    depends_on("cmake@3.13:", type="build")
+    depends_on("cmake@3.18:", type="build", when="@1.9:")
+    depends_on("cmake@3.24:", type="build", when="@1.14:")
     depends_on("python", type=("build", "run"))
     depends_on("py-pip", type="build")
     depends_on("protobuf")

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -21,12 +21,20 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
 
     license("MIT")
 
+    version("1.14.1", tag="v1.14.1", submodules=True)
+    version("1.13.1", tag="v1.13.1", submodules=True)
+    version("1.12.1", tag="v1.12.1", submodules=True)
+    version("1.11.1", tag="v1.11.1", submodules=True)
     version(
         "1.10.0", tag="v1.10.0", commit="0d9030e79888d1d5828730b254fedc53c7b640c1", submodules=True
     )
     version(
         "1.7.2", tag="v1.7.2", commit="5bc92dff16b0ddd5063b717fb8522ca2ad023cb0", submodules=True
     )
+    version("1.14.1", tag="v1.14.1", submodules=True)
+    version("1.13.1", tag="v1.13.1", submodules=True)
+    version("1.12.1", tag="v1.12.1", submodules=True)
+    version("1.11.1", tag="v1.11.1", submodules=True)
 
     variant("cuda", default=False, description="Build with CUDA support")
 


### PR DESCRIPTION
Needed for `acts@23.3:` #37055.

I suspect the statement "supports all ONNX releases with both future and backwards compatibility" isn't going to result in this being a matter of simply adding the new versions, but it's a start... (hence draft).

Already noticed `patch("cms_1_10.patch", whe="@1.10")` with typo.