### PR TITLE
Update archspec to latest release

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.0-dev (commit f3667f95030c6573842fb5f6df0d647285597509)
+* Version: 0.2.0-dev (commit d02dadbac4fa8f3a60293c4fbfd59feadaf546dc)
 
 astunparse
 ----------------

--- a/lib/spack/external/archspec/__main__.py
+++ b/lib/spack/external/archspec/__main__.py
@@ -1,0 +1,8 @@
+"""
+Run the `archspec` CLI as a module.
+"""
+
+import sys
+from .cli import main
+
+sys.exit(main())

--- a/lib/spack/external/archspec/cpu/microarchitecture.py
+++ b/lib/spack/external/archspec/cpu/microarchitecture.py
@@ -268,15 +268,14 @@ class Microarchitecture:
                 return flags
 
         msg = (
-            "cannot produce optimized binary for micro-architecture '{0}'"
-            " with {1}@{2} [supported compiler versions are {3}]"
+            "cannot produce optimized binary for micro-architecture '{0}' with {1}@{2}"
         )
-        msg = msg.format(
-            self.name,
-            compiler,
-            version,
-            ", ".join([x["versions"] for x in compiler_info]),
-        )
+        if compiler_info:
+            versions = [x["versions"] for x in compiler_info]
+            msg += f' [supported compiler versions are {", ".join(versions)}]'
+        else:
+            msg += " [no supported compiler versions]"
+        msg = msg.format(self.name, compiler, version)
         raise UnsupportedMicroarchitecture(msg)
 
 

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -102,7 +102,8 @@
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "x86_64_v2": {
@@ -157,7 +158,8 @@
             "name": "x86-64-v2",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "x86_64_v3": {
@@ -227,6 +229,13 @@
             "versions": "2021.2.0:",
             "name": "x86-64-v3",
             "flags": "-march={name} -mtune=generic"
+          }
+        ],
+        "nvhpc" : [
+          {
+            "versions": ":",
+            "name": "px",
+            "flags": "-tp {name} -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mxsave"
           }
         ]
       }
@@ -304,6 +313,13 @@
             "name": "x86-64-v4",
             "flags": "-march={name} -mtune=generic"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "px",
+            "flags": "-tp {name} -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
         ]
       }
     },
@@ -358,7 +374,8 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "core2": {
@@ -412,7 +429,8 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "nehalem": {
@@ -477,7 +495,8 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "westmere": {
@@ -539,7 +558,8 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "sandybridge": {
@@ -608,6 +628,12 @@
           {
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -680,6 +706,12 @@
           {
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -758,6 +790,12 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -826,6 +864,13 @@
           {
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "haswell",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -898,6 +943,13 @@
           {
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "haswell",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1063,6 +1115,13 @@
             "name": "skylake-avx512",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "skylake",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1143,6 +1202,13 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "skylake",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1221,6 +1287,13 @@
           {
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "skylake",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1329,6 +1402,13 @@
             "name": "icelake-client",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "skylake",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1387,7 +1467,8 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse2"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "bulldozer": {
@@ -1450,6 +1531,12 @@
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1519,6 +1606,12 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1587,6 +1680,13 @@
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse4.2"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "piledriver",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1662,6 +1762,13 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "name": "piledriver",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1741,6 +1848,12 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": ":",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1819,6 +1932,12 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "nvhpc": [
+          {
+            "versions": "20.5:",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -1902,6 +2021,12 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "nvhpc": [
+          {
+            "versions": "21.11:",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -1982,7 +2107,15 @@
             "name": "znver4",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
+        "nvhpc": [
+          {
+            "versions": "21.11:",
+	    "name": "zen3",
+            "flags": "-tp {name}",
+	    "warnings": "zen4 is not fully supported by nvhpc yet, falling back to zen3"
+          }
+	]
       }
     },
     "ppc64": {
@@ -2087,7 +2220,8 @@
             "versions": ":",
             "flags": "-mcpu={name} -mtune={name}"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "power8le": {
@@ -2116,6 +2250,13 @@
             "name": "power8",
             "flags": "-mcpu={name} -mtune={name}"
           }
+        ],
+	"nvhpc": [
+          {
+            "versions": ":",
+            "name": "pwr8",
+            "flags": "-tp {name}"
+          }
         ]
       }
     },
@@ -2138,6 +2279,13 @@
             "family": "ppc64le",
             "name": "power9",
             "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+	"nvhpc": [
+          {
+            "versions": ":",
+            "name": "pwr9",
+            "flags": "-tp {name}"
           }
         ]
       }
@@ -2170,7 +2318,8 @@
             "versions": ":",
             "flags": "-march=armv8-a -mtune=generic"
           }
-        ]
+        ],
+	"nvhpc": []
       }
     },
     "armv8.1a": {
@@ -2552,6 +2701,13 @@
                   "versions": "20:",
                   "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
               }
+          ],
+          "nvhpc" : [
+              {
+                  "versions": "22.5:",
+                  "name": "neoverse-n1",
+                  "flags": "-tp {name}"
+              }
           ]
       }
     },
@@ -2617,15 +2773,31 @@
                   "flags" : "-march=armv8.2-a+crypto+fp16 -mtune=cortex-a72"
               },
               {
-                  "versions": "8.0:8.9",
+                  "versions": "8.0:8.4",
                   "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
               },
               {
-                  "versions": "9.0:9.9",
+                  "versions": "8.5:8.9",
                   "flags" : "-mcpu=neoverse-v1"
               },
-	            {
-                  "versions": "10.0:",
+              {
+                  "versions": "9.0:9.3",
+                  "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
+              },
+              {
+                  "versions": "9.4:9.9",
+                  "flags" : "-mcpu=neoverse-v1"
+              },
+              {
+                  "versions": "10.0:10.1",
+                  "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
+              },
+              {
+                  "versions": "10.2",
+                  "flags" : "-mcpu=zeus"
+              },
+              {
+                  "versions": "10.3:",
                   "flags" : "-mcpu=neoverse-v1"
               }
 
@@ -2656,6 +2828,13 @@
 	            {
                   "versions": "22:",
                   "flags" : "-march=armv8.4-a+sve+ssbs+fp16+bf16+crypto+i8mm+rng"
+              }
+          ],
+          "nvhpc" : [
+              {
+                  "versions": "22.5:",
+                  "name": "neoverse-n1",
+                  "flags": "-tp {name}"
               }
           ]
       }


### PR DESCRIPTION
fixes #30004 
closes #36277

Modifications:
- [x] Fix -mcpu flags for gcc on neoverse-v1
- [x] Add support for NVHPC flags