### PR TITLE
Harden Spack's powershell interface

### DIFF
--- a/share/spack/qa/windows_test_setup.ps1
+++ b/share/spack/qa/windows_test_setup.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = "SilentlyContinue"
-Write-Output F|xcopy .\share\spack\qa\configuration\windows_config.yaml $env:USERPROFILE\.spack\windows\config.yaml
+Write-Output F|xcopy .\share\spack\qa\configuration\windows_config.yaml "$env:USERPROFILE\.spack\windows\config.yaml"
 # The line below prevents the _spack_root symlink from causing issues with cyclic symlinks on Windows
 (Get-Item '.\lib\spack\docs\_spack_root').Delete()
 ./share/spack/setup-env.ps1

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -37,8 +37,7 @@ if (!$null -eq $py_path)
 
 if (!$null -eq $py_exe)
 {
-    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\haspywin.py"
-    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\spack external find python" | Out-Null
+    & "$py_exe" "$Env:SPACK_ROOT\bin\haspywin.py"
 }
 
 $Env:Path = "$Env:SPACK_ROOT\bin;$Env:Path"


### PR DESCRIPTION
Paths with spaces are an issue on Windows and our current powershell scripts are not sufficiently hardened against their use. This PR removes problematic commandlets that do not work well with paths with spaces and adds escape quotes in other areas where this could be an issue.

See https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/avoid-using-invoke-expression?view=powershell-7.3 for why `Invoke-Expression` should not be used, as written by the people who wrote `Invoke-Expression`.