### PR TITLE
r: fix building :3.6.1 with gcc 10:

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -177,6 +177,10 @@ class R(AutotoolsPackage):
         if self.compiler.name != "gcc":
             config_args.append("FPICFLAGS={0}".format(self.compiler.cc_pic_flag))
 
+        if self.spec.satisfies("@:3.6.1 %gcc@10:"):
+            config_args.append("CFLAGS=-fcommon")
+            config_args.append("FFLAGS=-fallow-argument-mismatch")
+
         return config_args
 
     @run_after("install")


### PR DESCRIPTION
I discovered that building versions of `r` `3.6.1` and earlier were failing on `gcc` `10` and later. I found I wasn't the only one who uncovered this[^1]. `-fcommon` is needed due to the flag default changing as of `gcc` `10`[^2], and `-fallow-argument-mismatch` is needed to resolve the rank mismatch error that occurs.

I tested this with `gcc` `10` and `11` and confirmed it resolves these build errors on those versions.

[^1]: https://bugs.gentoo.org/776781
[^2]: https://stat.ethz.ch/pipermail/r-announce/2019/000647.html