### PR TITLE
octopus: fix download links

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -16,7 +16,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     theory code."""
 
     homepage = "https://octopus-code.org/"
-    url = "https://octopus-code.org/down.php?file=6.0/octopus-6.0.tar.gz"
+    url = "https://octopus-code.org/download/6.0/octopus-6.0.tar.gz"
     git = "https://gitlab.com/octopus-code/octopus"
 
     maintainers("fangohr", "RemiLacroix-IDRIS")


### PR DESCRIPTION
 Octopus webpage doesn't use the PHP links (https://octopus-code.org/down.php?file=6.0/octopus-6.0.tar.gz) to download the tar balls anymore but rather link to the file directly (https://octopus-code.org/download/6.0/octopus-6.0.tar.gz). 

Currently all versions of ocotpus spack package wrongly download the PHP file instead of the actuall tar ball resulting in the same hash for all version  as reported in https://github.com/spack/spack/pull/35487#pullrequestreview-1394939010.

This MR fixes the links 
```shell
❯ spack checksum octopus 12.0 12.1 12.2
==> Found 3 versions of octopus:
  
  12.2  https://octopus-code.org/download/12.2/octopus-12.2.tar.gz
  12.1  https://octopus-code.org/download/12.1/octopus-12.1.tar.gz
  12.0  https://octopus-code.org/download/12.0/octopus-12.0.tar.gz

==> Fetching https://octopus-code.org/download/12.2/octopus-12.2.tar.gz
==> Fetching https://octopus-code.org/download/12.1/octopus-12.1.tar.gz
==> Fetching https://octopus-code.org/download/12.0/octopus-12.0.tar.gz

    version("12.2", sha256="e919e07703696eadb4ba59352d7a2678a9191b4586cb9da538661615e765a5a2")
    version("12.1", sha256="e2214e958f1e9631dbe6bf020c39f1fe4d71ab0b6118ea9bd8dc38f6d7a7959a")
    version("12.0", sha256="70beaf08573d394a766f10346a708219b355ad725642126065d12596afbc0dcc")

```