### PR TITLE
Upgrade exago's petsc dependency to v3.19.0

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -125,7 +125,8 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("petsc@3.13:3.14", when="@:1.2.99")
     depends_on("petsc@3.16.0:3.16", when="@1.3.0:1.4")
-    depends_on("petsc@3.18.0:3.18", when="@1.5.0:")
+    depends_on("petsc@3.18.0:3.18", when="@1.5.0")
+    depends_on("petsc@3.19.0", when="@develop")
 
     depends_on("petsc~mpi", when="~mpi")
 

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -125,8 +125,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("petsc@3.13:3.14", when="@:1.2.99")
     depends_on("petsc@3.16.0:3.16", when="@1.3.0:1.4")
-    depends_on("petsc@3.18.0:3.18", when="@1.5.0")
-    depends_on("petsc@3.19.0", when="@develop")
+    depends_on("petsc@3.18.0:3.19", when="@1.5.0:")
 
     depends_on("petsc~mpi", when="~mpi")
 


### PR DESCRIPTION
no major API changes, so exago can use petsc@3.19.0