### PR TITLE
apktool: add v2.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/apktool/package.py
+++ b/var/spack/repos/builtin/packages/apktool/package.py
@@ -13,6 +13,7 @@ class Apktool(Package):
     homepage = "https://ibotpeaches.github.io/Apktool/"
     url = "https://github.com/iBotPeaches/Apktool/archive/refs/tags/v2.6.0.tar.gz"
 
+    version("2.7.0", sha256="17d12a2955a46c48afb9b6855651016ac17626512216c91e8b2adab0013d3056")
     version("2.6.1", sha256="8932e77d963b9e0e07227422d82ed4a355e8aa268bad1361e5cfaffa8e4d52ee")
     version("2.6.0", sha256="74739cdb1434ca35ec34e51ca7272ad3f378ae3ed0a2d5805d9a2fab5016037f")
 


### PR DESCRIPTION
Add apktool v2.7.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.