### PR TITLE
bracken: add v2.8

### DIFF
--- a/var/spack/repos/builtin/packages/bracken/package.py
+++ b/var/spack/repos/builtin/packages/bracken/package.py
@@ -16,6 +16,7 @@ class Bracken(Package):
     homepage = "https://ccb.jhu.edu/software/bracken"
     url = "https://github.com/jenniferlu717/Bracken/archive/v2.7.tar.gz"
 
+    version("2.8", sha256="b0c8a803cc020b7d1cbca47b53e71e874d9688b836911e4a4b71b0e4b826b61a")
     version("2.7", sha256="1795ecd9f9e5582f37549795ba68854780936110a2f6f285c3e626d448cd1532")
 
     depends_on("python", type="run")


### PR DESCRIPTION
Add bracken v2.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.