### PR TITLE
cpp-argparse: add v2.9

### DIFF
--- a/var/spack/repos/builtin/packages/cpp-argparse/package.py
+++ b/var/spack/repos/builtin/packages/cpp-argparse/package.py
@@ -14,4 +14,5 @@ class CppArgparse(CMakePackage):
 
     maintainers("qoelet")
 
+    version("2.9", sha256="cd563293580b9dc592254df35b49cf8a19b4870ff5f611c7584cf967d9e6031e")
     version("2.2", sha256="f0fc6ab7e70ac24856c160f44ebb0dd79dc1f7f4a614ee2810d42bb73799872b")


### PR DESCRIPTION
Add cpp-argparse v2.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.