### PR TITLE
fdupes: add v2.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/fdupes/package.py
+++ b/var/spack/repos/builtin/packages/fdupes/package.py
@@ -15,6 +15,7 @@ class Fdupes(AutotoolsPackage):
 
     maintainers("michaelkuhn")
 
+    version("2.2.1", sha256="846bb79ca3f0157856aa93ed50b49217feb68e1b35226193b6bc578be0c5698d")
     version("2.1.2", sha256="cd5cb53b6d898cf20f19b57b81114a5b263cc1149cd0da3104578b083b2837bd")
 
     variant("ncurses", default=True, description="ncurses support")


### PR DESCRIPTION
Add fdupes v2.2.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.