### PR TITLE
gpgme: add v1.20.0

### DIFF
--- a/var/spack/repos/builtin/packages/gpgme/package.py
+++ b/var/spack/repos/builtin/packages/gpgme/package.py
@@ -15,6 +15,7 @@ class Gpgme(AutotoolsPackage):
 
     executables = ["^gpgme-config$"]
 
+    version("1.20.0", sha256="25a5785a5da356689001440926b94e967d02e13c49eb7743e35ef0cf22e42750")
     version("1.19.0", sha256="cb58494dc415fba9eeb12b826550ad3190dc92e265c5bb2ae1a21c92841cfd38")
     version("1.18.0", sha256="361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e")
     version("1.16.0", sha256="6c8cc4aedb10d5d4c905894ba1d850544619ee765606ac43df7405865de29ed0")


### PR DESCRIPTION
Add gpgme v1.20.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.