### PR TITLE
grep: add v3.10

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -12,6 +12,7 @@ class Grep(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/grep/"
     url = "https://ftp.gnu.org/gnu/grep/grep-3.3.tar.xz"
 
+    version("3.10", sha256="24efa5b595fb5a7100879b51b8868a0bb87a71c183d02c4c602633b88af6855b")
     version("3.9", sha256="abcd11409ee23d4caf35feb422e53bbac867014cfeed313bb5f488aca170b599")
     version("3.7", sha256="5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c")
     version("3.3", sha256="b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514")


### PR DESCRIPTION
Add grep v3.10. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.