### PR TITLE
libcap-ng: add v0.8.3

### DIFF
--- a/var/spack/repos/builtin/packages/libcap-ng/package.py
+++ b/var/spack/repos/builtin/packages/libcap-ng/package.py
@@ -12,6 +12,7 @@ class LibcapNg(AutotoolsPackage):
     homepage = "https://github.com/stevegrubb/libcap-ng/"
     url = "https://github.com/stevegrubb/libcap-ng/archive/v0.8.tar.gz"
 
+    version("0.8.3", sha256="e542e9139961f0915ab5878427890cdc7762949fbe216bd0cb4ceedb309bb854")
     version("0.8", sha256="836ea8188ae7c658cdf003e62a241509dd542f3dec5bc40c603f53a5aadaa93f")
     version("0.7.11", sha256="78f32ff282b49b7b91c56d317fb6669df26da332c6fc9462870cec2573352222")
     version("0.7.10", sha256="c3c156a215e5be5430b2f3b8717bbd1afdabe458b6068a8d163e71cefe98fc32")


### PR DESCRIPTION
Add libcap-ng v0.8.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.