### PR TITLE
libdap4: add v3.20.6

### DIFF
--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -19,6 +19,7 @@ class Libdap4(AutotoolsPackage):
 
     maintainers("tjhei")
 
+    version("3.20.6", sha256="e44e83043c158d8c9d0a37a1821626ab0db4a1a6578b02182440170c0b060e6d")
     version("3.20.4", sha256="c39fa310985cc8963029ad0d0aba784e7dbf1f70c566bd7ae58242f1bb06d24a")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
Add libdap4 v3.20.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.