### PR TITLE
maeparser: add v1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/maeparser/package.py
+++ b/var/spack/repos/builtin/packages/maeparser/package.py
@@ -14,6 +14,7 @@ class Maeparser(CMakePackage):
 
     maintainers("RMeli")
 
+    version("1.3.1", sha256="a8d80f67d1b9be6e23b9651cb747f4a3200132e7d878a285119c86bf44568e36")
     version("1.3.0", sha256="fa8f9336de1e5d1cabec29a6da04547b1fb040bb32ba511ff30b4a14097c751c")
 
     variant(


### PR DESCRIPTION
Add maeparser v1.3.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.