### PR TITLE
msmc2: add v2.1.4

### DIFF
--- a/var/spack/repos/builtin/packages/msmc2/package.py
+++ b/var/spack/repos/builtin/packages/msmc2/package.py
@@ -17,6 +17,7 @@ class Msmc2(MakefilePackage):
 
     maintainers("robqiao")
 
+    version("2.1.4", sha256="e513723b9e956f01de8de89ff6d32c071f509512425185d12faa5bb76cf440d0")
     version("2.1.2", sha256="c8c2b6ed6ef1b5d6e6e15ec0d968288e5bdae2bea1f3b4ec790f599e96bb26cd")
     version("2.1.1", sha256="151dd75a8b0371ff94eed9504a7a73a2924e10466de30c230c1bb3c35a1a0913")
     version("2.0.2", sha256="91152b2494342148ff84a1e5c6d2f5f0d53acba12722cd68ff5807ba4e82af55")


### PR DESCRIPTION
Add msmc2 v2.1.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.