### PR TITLE
pugixml: add v1.13

### DIFF
--- a/var/spack/repos/builtin/packages/pugixml/package.py
+++ b/var/spack/repos/builtin/packages/pugixml/package.py
@@ -13,6 +13,7 @@ class Pugixml(CMakePackage):
     homepage = "https://pugixml.org/"
     url = "https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz"
 
+    version("1.13", sha256="40c0b3914ec131485640fa57e55bf1136446026b41db91c1bef678186a12abbe")
     version("1.11.4", sha256="8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716")
     version("1.11", sha256="26913d3e63b9c07431401cf826df17ed832a20d19333d043991e611d23beaa2c")
     version("1.10", sha256="55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a")


### PR DESCRIPTION
Add pugixml v1.13. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.