### PR TITLE
rsem: add v1.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/rsem/package.py
+++ b/var/spack/repos/builtin/packages/rsem/package.py
@@ -13,6 +13,7 @@ class Rsem(MakefilePackage):
     homepage = "https://deweylab.github.io/RSEM/"
     url = "https://github.com/deweylab/RSEM/archive/v1.3.0.tar.gz"
 
+    version("1.3.3", sha256="90e784dd9df8346caa2a7e3ad2ad07649608a51df1c69bfb6e16f45e611a40dc")
     version("1.3.1", sha256="93c749a03ac16e94b1aab94d032d4fd5687d3261316ce943ecb89d3ae3ec2e11")
     version("1.3.0", sha256="ecfbb79c23973e1c4134f05201f4bd89b0caf0ce4ae1ffd7c4ddc329ed4e05d2")
 


### PR DESCRIPTION
Add rsem v1.3.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.