### PR TITLE
tree-sitter: add v0.20.8

### DIFF
--- a/var/spack/repos/builtin/packages/tree-sitter/package.py
+++ b/var/spack/repos/builtin/packages/tree-sitter/package.py
@@ -17,6 +17,7 @@ class TreeSitter(MakefilePackage):
 
     maintainers("albestro")
 
+    version("0.20.8", sha256="6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791")
     version("0.20.6", sha256="4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de")
     version("0.20.4", sha256="979ad0b36eb90975baf0c65d155d106276cac08afb1c2fe0ad54d4b7d498ce39")
     version("0.20.3", sha256="ab52fe93e0c658cff656b9d10d67cdd29084247052964eba13ed6f0e9fa3bd36")


### PR DESCRIPTION
Add tree-sitter v0.20.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.