### PR TITLE
py-numpy: set openblas `symbol_suffix` in site.cfg

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -269,8 +269,10 @@ class PyNumpy(PythonPackage):
                 f.write("libraries = {0}\n".format(lapackblas_lib_names))
                 write_library_dirs(f, lapackblas_lib_dirs)
                 f.write("include_dirs = {0}\n".format(lapackblas_header_dirs))
-                f.write("symbol_suffix = {0}\n".format(
-                    spec["openblas"].variants["symbol_suffix"].value)
+                f.write(
+                    "symbol_suffix = {0}\n".format(
+                        spec["openblas"].variants["symbol_suffix"].value
+                    )
                 )
 
             if "^libflame" in spec or "^amdlibflame" in spec:

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -269,11 +269,9 @@ class PyNumpy(PythonPackage):
                 f.write("libraries = {0}\n".format(lapackblas_lib_names))
                 write_library_dirs(f, lapackblas_lib_dirs)
                 f.write("include_dirs = {0}\n".format(lapackblas_header_dirs))
-                f.write(
-                    "symbol_suffix = {0}\n".format(
-                        spec["openblas"].variants["symbol_suffix"].value
-                    )
-                )
+                symbol_suffix = spec["openblas"].variants["symbol_suffix"].value
+                if symbol_suffix != "none":
+                    f.write("symbol_suffix = {0}\n".format(symbol_suffix))
 
             if "^libflame" in spec or "^amdlibflame" in spec:
                 f.write("[flame]\n")

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -269,6 +269,9 @@ class PyNumpy(PythonPackage):
                 f.write("libraries = {0}\n".format(lapackblas_lib_names))
                 write_library_dirs(f, lapackblas_lib_dirs)
                 f.write("include_dirs = {0}\n".format(lapackblas_header_dirs))
+                f.write("symbol_suffix = {0}\n".format(
+                    spec["openblas"].variants["symbol_suffix"].value)
+                )
 
             if "^libflame" in spec or "^amdlibflame" in spec:
                 f.write("[flame]\n")


### PR DESCRIPTION
This writes the correct `symbol_suffix` variant value from the `openblas` in the spec into the `site.cfg`. Fixes #37133.

Correct suffix added with this fix:
```console
$ nm /opt/software/linux-ubuntu23.04-skylake/gcc-12.2.0/py-numpy-1.24.2-tcxvofpf3vvllzygdvymnkeyb5fcbtu2/lib/python3.10/site-packages/numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so | grep cblas_sgemm
                 U cblas_sgemm64_
```

And `py-numexpr` finds the correct symbols:
```console
==> Installing py-numexpr-2.8.4-zfvstvjck36pheyszwhtv72vkmp2znco
==> No binary for py-numexpr-2.8.4-zfvstvjck36pheyszwhtv72vkmp2znco found: installing from source
==> Using cached archive: /data/spack/cache/_source-cache/archive/0e/0e21addd25db5f62d60d97e4380339d9c1fb2de72c88b070c279776ee6455d10.tar.gz
==> No patches needed for py-numexpr
==> py-numexpr: Executing phase: 'install'
==> py-numexpr: Successfully installed py-numexpr-2.8.4-zfvstvjck36pheyszwhtv72vkmp2znco
  Stage: 0.01s.  Install: 10.81s.  Total: 10.88s
[+] /opt/software/linux-ubuntu23.04-skylake/gcc-12.2.0/py-numexpr-2.8.4-zfvstvjck36pheyszwhtv72vkmp2znco
```