### PR TITLE
boost: extend phoenix patch to 1.82.0

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -398,7 +398,7 @@ class Boost(Package):
     patch("intel-oneapi-linux-jam.patch", when="@1.76: %oneapi")
 
     # https://github.com/boostorg/phoenix/issues/111
-    patch("boost_phoenix_1.81.0.patch", level=2, when="@1.81.0")
+    patch("boost_phoenix_1.81.0.patch", level=2, when="@1.81.0:1.82.0")
 
     # https://github.com/boostorg/filesystem/issues/284
     patch(


### PR DESCRIPTION
When building packages that depend on boost 1.82.0 I'm finding the same issue that was found with 1.81 (https://github.com/boostorg/phoenix/issues/111). The patch fixes the issue again