### PR TITLE
silo: loosen hdf5 version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -52,7 +52,7 @@ class Silo(AutotoolsPackage):
     depends_on("automake", type="build", when="+shared")
     depends_on("libtool", type="build", when="+shared")
     depends_on("mpi", when="+mpi")
-    depends_on("hdf5@1.8", when="@:4.10+hdf5")
+    depends_on("hdf5@1.8:1.10", when="@:4.10+hdf5")
     depends_on("hdf5@1.12:", when="@4.11:+hdf5")
     depends_on("qt+gui~framework@4.8:4.9", when="+silex")
     depends_on("libx11", when="+silex")


### PR DESCRIPTION
We have successfully been building silo@4.10.2 against hdf5@1.10.4 from some time. Refinement of #34275 (which was concerned with 4.11 but unnecessarily restricted 4.10).

@tmdelellis