### PR TITLE
[SIRIUS] do not use device allocator in Umpire

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -234,8 +234,8 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     with when("@7.5: +memory_pool"):
         depends_on("umpire")
-        depends_on("umpire+cuda", when="+cuda")
-        depends_on("umpire+rocm", when="+rocm")
+        depends_on("umpire+cuda~device_alloc", when="+cuda")
+        depends_on("umpire+rocm~device_alloc", when="+rocm")
 
     patch("strip-spglib-include-subfolder.patch", when="@6.1.5")
     patch("link-libraries-fortran.patch", when="@6.1.5")


### PR DESCRIPTION
Rationale:
* Sirius doesn't need allocations from device
* `+device_alloc` causes linking errors
Decision: use `umpire~device_alloc`