### PR TITLE
glab: add v1.28.1

### DIFF
--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -14,6 +14,7 @@ class Glab(Package):
 
     maintainers("alecbcs")
 
+    version("1.28.1", sha256="243a0f15e4400aab7b4d27ec71c6ae650bf782473c47520ffccd57af8d939c90")
     version("1.28.0", sha256="9a0b433c02033cf3d257405d845592e2b7c2e38741027769bb97a8fd763aeeac")
     version("1.27.0", sha256="26bf5fe24eeaeb0f861c89b31129498f029441ae11cc9958e14ad96ec1356d51")
     version("1.26.0", sha256="af1820a7872d53c7119a23317d6c80497374ac9529fc2ab1ea8b1ca033a9b4da")


### PR DESCRIPTION
Add glab v1.28.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.