### PR TITLE
libcyaml: add v1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/libcyaml/package.py
+++ b/var/spack/repos/builtin/packages/libcyaml/package.py
@@ -13,6 +13,7 @@ class Libcyaml(MakefilePackage):
     homepage = "https://github.com/tlsa/libcyaml"
     url = "https://github.com/tlsa/libcyaml/archive/v1.1.0.tar.gz"
 
+    version("1.4.0", sha256="e803fef0e254aa1f302c622c2d25cff989e04e9b2bebb7d22abd91386373122f")
     version("1.1.0", sha256="37a00ed8ec206b60a712acfd44196bef063b8f02e376d8e86f61a7007a81daea")
 
     depends_on("libyaml")


### PR DESCRIPTION
Add libcyaml v1.4.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.