### PR TITLE
megadock: add v4.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/megadock/package.py
+++ b/var/spack/repos/builtin/packages/megadock/package.py
@@ -15,6 +15,7 @@ class Megadock(MakefilePackage, CudaPackage):
     homepage = "https://www.bi.cs.titech.ac.jp/megadock/"
     url = "https://www.bi.cs.titech.ac.jp/megadock/archives/megadock-4.0.3.tgz"
 
+    version("4.1.1", sha256="5e08416ea86169be9f0a998f081f53c04aa8696ef83b9fcc5bf685fe45d52087")
     version("4.0.3", sha256="c1409a411555f4f7b4eeeda81caf622d8a28259a599ea1d2181069c55f257664")
 
     variant("mpi", description="Enable MPI", default=False)


### PR DESCRIPTION
Add megadock v4.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.