### PR TITLE
sdl2-image: add v2.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/sdl2-image/package.py
+++ b/var/spack/repos/builtin/packages/sdl2-image/package.py
@@ -13,6 +13,7 @@ class Sdl2Image(AutotoolsPackage):
     homepage = "http://sdl.beuc.net/sdl.wiki/SDL_image"
     url = "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1.tar.gz"
 
+    version("2.6.3", sha256="931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c")
     version("2.0.1", sha256="3a3eafbceea5125c04be585373bfd8b3a18f259bd7eae3efc4e6d8e60e0d7f64")
 
     depends_on("sdl2")


### PR DESCRIPTION
Add sdl2-image v2.6.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.