### PR TITLE
mgard: ^protobuf@:3.21.12

### DIFF
--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -36,7 +36,7 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("zlib")
     depends_on("pkgconf", type=("build",), when="@2022-11-18:")
     depends_on("zstd")
-    depends_on("protobuf", when="@2022-11-18:")
+    depends_on("protobuf@:3.21.12", when="@2022-11-18:")
     depends_on("libarchive", when="@2021-11-12:")
     depends_on("tclap", when="@2021-11-12")
     depends_on("yaml-cpp", when="@2021-11-12:")


### PR DESCRIPTION
There are issues building mgard with protobuf 3.22:
* https://gitlab.spack.io/spack/spack/-/jobs/6548822
```
  >> 1143    /home/software/spack/__spack_path_placeholder__/__spack_path_place
             holder__/__spack_path_placeholder__/__spack_path_placeholder__/__s
             pack_path_placeholder__/__spack_path_placeholder__/__spack_path_pl
             aceholder__/__spack_path_placeholder__/__spack_path_placeh/linux-u
             buntu20.04-ppc64le/gcc-11.1.0/protobuf-3.22.2-iadvg7hfzgtwtwztbcam
             gcfzs6lkfdoo/include/google/protobuf/stubs/common.h:44:10: fatal e
             rror: absl/strings/string_view.h: No such file or directory
     1144       44 | #include "absl/strings/string_view.h"
     1145          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1146    compilation terminated.
  >> 1147    make[2]: *** [CMakeFiles/mgard-library.dir/build.make:7654: CMakeF
             iles/mgard-library.dir/src/mgard-x/CompressionHighLevel/Compress_C
             UDA.cpp.o] Error 1
```

CC @robertu94