### PR TITLE
e4s ci: use latest trilinos for +cuda variants

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -132,7 +132,7 @@ spack:
   - swig@4.0.2-fortran
   - tasmanian
   - tau +mpi +python
-  - trilinos@13.0.1 +belos +ifpack2 +stokhos
+  - trilinos +belos +ifpack2 +stokhos
   - turbine
   - umap
   - umpire
@@ -169,7 +169,7 @@ spack:
   - superlu-dist +cuda
   - tasmanian +cuda
   - tau +mpi +cuda
-  - trilinos@13.4.0 +belos +ifpack2 +stokhos +cuda
+  - "trilinos@13.4.0: +belos +ifpack2 +stokhos +cuda"
   - umpire ~shared +cuda
   - parsec +cuda
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -180,7 +180,7 @@ spack:
   - superlu-dist +cuda
   - tasmanian +cuda
   - tau +mpi +cuda
-  - trilinos@13.4.0 +belos +ifpack2 +stokhos +cuda
+  - "trilinos@13.4.0: +belos +ifpack2 +stokhos +cuda"
   - umpire ~shared +cuda
 
   # ROCm
@@ -209,7 +209,7 @@ spack:
   - superlu-dist +rocm
   - tasmanian ~openmp +rocm
   - tau +mpi +rocm
-  - trilinos@13.4.0 ~belos ~ifpack2 ~stokhos +rocm
+  - "trilinos@13.4.0: ~belos ~ifpack2 ~stokhos +rocm"
   - umpire +rocm
   - upcxx +rocm
 


### PR DESCRIPTION
Build `trilinos@13.4.0: +cuda` 