### PR TITLE
scitokens-cpp: depends_on pkgconfig

### DIFF
--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -22,6 +22,7 @@ class ScitokensCpp(CMakePackage):
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
+    depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72


### PR DESCRIPTION
A missing dependency, showing up as:
```console
#24 1113.1 3 errors found in build log:
#24 1113.1      20    -- Check for working CXX compiler: /opt/spack/lib/spack/env/gcc/g++ 
#24 1113.1            - skipped
#24 1113.1      21    -- Detecting CXX compile features
#24 1113.1      22    -- Detecting CXX compile features - done
#24 1113.1      23    -- Found CURL: /opt/software/linux-debian-x86_64_v3/gcc-12.2.0/curl-
#24 1113.1            7.85.0-ca5zznsdkp2hwbnikha6sgqzcpuw74sc/lib/libcurl.so (found versio
#24 1113.1            n "7.85.0")
#24 1113.1      24    -- Found UUID : /opt/software/linux-debian-x86_64_v3/gcc-12.2.0/util
#24 1113.1            -linux-uuid-2.38.1-45xrjgjjauvev5qarwji7xgmlnhqlzkh/lib/libuuid.so
#24 1113.1      25    -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
#24 1113.1   >> 26    CMake Error at /opt/software/linux-debian-x86_64_v3/gcc-12.2.0/cmake
#24 1113.1            -3.24.3-6doi3daa6ihw6mk4zbk5oiiuiaahsny7/share/cmake-3.24/Modules/Fi
#24 1113.1            ndPkgConfig.cmake:663 (message):
#24 1113.1      27      pkg-config tool not found
#24 1113.1      28    Call Stack (most recent call first):
#24 1113.1      29      /opt/software/linux-debian-x86_64_v3/gcc-12.2.0/cmake-3.24.3-6doi3
#24 1113.1            daa6ihw6mk4zbk5oiiuiaahsny7/share/cmake-3.24/Modules/FindPkgConfig.c
#24 1113.1            make:829 (_pkg_check_modules_internal)
#24 1113.1      30      CMakeLists.txt:39 (pkg_check_modules)
#24 1113.1      31    
#24 1113.1      32    
```

Ref: https://github.com/scitokens/scitokens-cpp/blob/v1.0.0/CMakeLists.txt#L32