### PR TITLE
spla: version 1.5.5

### DIFF
--- a/var/spack/repos/builtin/packages/spla/package.py
+++ b/var/spack/repos/builtin/packages/spla/package.py
@@ -17,6 +17,7 @@ class Spla(CMakePackage):
 
     maintainers("AdhocMan", "haampie")
 
+    version("1.5.5", sha256="bc0c366e228344b1b2df55b9ce750d73c1165380e512da5a04d471db126d66ce")
     version("1.5.4", sha256="de30e427d24c741e2e4fcae3d7668162056ac2574afed6522c0bb49d6f1d0f79")
     version("1.5.3", sha256="527c06e316ce46ec87309a16bfa4138b1abad23fd276fe789c78a2de84f05637")
     version("1.5.2", sha256="344c34986dfae182ec2e1eb539c9a57f75683aaa7a61a024fd0c594d81d97016")
@@ -39,6 +40,11 @@ class Spla(CMakePackage):
     variant("fortran", default=False, description="Build fortran module")
 
     conflicts("+cuda", when="+rocm", msg="+cuda and +rocm are mutually exclusive")
+    conflicts(
+        "%gcc@13.0:",
+        when="@1.5.0:1.5.4",
+        msg="Version 1.5.0 to 1.5.4 is not compatible with GCC 13 and later.",
+    )
 
     depends_on("mpi")
     depends_on("blas")


### PR DESCRIPTION
Add version 1.5.5 and conflict for some older versions that may fail to build with GCC 13.