### PR TITLE
require: do not allow additional properties

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -35,6 +35,7 @@ properties = {
                                     "oneOf": [
                                         {
                                             "type": "object",
+                                            "additionalProperties": False,
                                             "properties": {
                                                 "one_of": {"type": "array"},
                                                 "any_of": {"type": "array"},


### PR DESCRIPTION
This avoids typos like `anyof`/`oneof`.
