### PR TITLE
gdb: turn debuginfod variant off by default

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -46,7 +46,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     variant("gold", default=False, description="Enable gold linker")
     variant("ld", default=False, description="Enable ld")
     variant("tui", default=False, description="Enable tui")
-    variant("debuginfod", default=True, description="Enable debuginfod support", when="@10.1:")
+    variant("debuginfod", default=False, description="Enable debuginfod support", when="@10.1:")
 
     # Resolves the undefined references to libintl_gettext while linking gdbserver
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined


### PR DESCRIPTION
https://github.com/spack/spack/pull/35769 introduced a `debuginfod` variant for `gdb` which causes `elfutils+debuginfod` to be enabled, which is missing a dependency I haven't been able to figure out. It's missing a `gzdirect` symbol, which appears to be either `zlib` or `gzip` but adding either as a dependency hasn't solved it for me, so I think this variant should be off by default.