### PR TITLE
libmaxminddb: add v1.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/libmaxminddb/package.py
+++ b/var/spack/repos/builtin/packages/libmaxminddb/package.py
@@ -14,6 +14,7 @@ class Libmaxminddb(AutotoolsPackage):
         "https://github.com/maxmind/libmaxminddb/releases/download/1.3.2/libmaxminddb-1.3.2.tar.gz"
     )
 
+    version("1.7.1", sha256="e8414f0dedcecbc1f6c31cb65cd81650952ab0677a4d8c49cab603b3b8fb083e")
     version("1.3.2", sha256="e6f881aa6bd8cfa154a44d965450620df1f714c6dc9dd9971ad98f6e04f6c0f0")
 
     def configure_args(self):


### PR DESCRIPTION
Add libmaxminddb v1.7.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.