### PR TITLE
openwsman: add v2.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/openwsman/package.py
+++ b/var/spack/repos/builtin/packages/openwsman/package.py
@@ -12,6 +12,7 @@ class Openwsman(CMakePackage):
     homepage = "https://github.com/Openwsman/openwsman"
     url = "https://github.com/Openwsman/openwsman/archive/v2.6.11.tar.gz"
 
+    version("2.7.2", sha256="f916b20956a64426c60a34fa2eaf2c8a13c7047ea2d2585329a6f33e00113be1")
     version("2.7.0", sha256="8870c4a21cbaba9387ad38c37667e2cee29008faacaaf7eb18ad2061e2fc89a1")
     version("2.6.11", sha256="895eaaae62925f9416766ea3e71a5368210e6cfe13b23e4e0422fa0e75c2541c")
     version("2.6.10", sha256="d3c624a03d7bc1835544ce1af56efd010f77cbee0c02b34e0755aa9c9b2c317b")


### PR DESCRIPTION
Add openwsman v2.7.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.