### PR TITLE
shortstack: add v4.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/shortstack/package.py
+++ b/var/spack/repos/builtin/packages/shortstack/package.py
@@ -14,6 +14,7 @@ class Shortstack(Package):
     homepage = "https://sites.psu.edu/axtell/software/shortstack/"
     url = "https://github.com/MikeAxtell/ShortStack/archive/v3.8.3.tar.gz"
 
+    version("4.0.1", sha256="d8ca2d5b245d13c9f2b2e6fa06bc34bc8f6bacbe07efebe3750b0178141cbeb6")
     version("3.8.3", sha256="7c76f51ed949ca95ec5df7cb54803ae2350658fd64c75909351d5a856abb0dbe")
 
     depends_on("perl", type=("build", "run"))


### PR DESCRIPTION
Add shortstack v4.0.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.