### PR TITLE
r-argparse: add v2.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-argparse/package.py
+++ b/var/spack/repos/builtin/packages/r-argparse/package.py
@@ -15,6 +15,7 @@ class RArgparse(RPackage):
 
     cran = "argparse"
 
+    version("2.2.2", sha256="b62c9bf5e6ca35fb7a2e614a916815c04cbf6c6db3f89f99b4df76470a4a856d")
     version("2.1.6", sha256="2ad7faad795878b88969ac5d91ba38f4e96deb85dfea7148c3510f0eaa3de592")
     version("2.1.5", sha256="83e112beb47733849980b286d93ac930f0cbe6ac78fcb94fc9f6b0eea882658d")
     version("2.1.3", sha256="aeda31a54a8d7a0a511cfbf7c5868637e129922671d43938165867437fb6a66e")


### PR DESCRIPTION
Add r-argparse v2.2.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.