### PR TITLE
r-bookdown: add v0.33

### DIFF
--- a/var/spack/repos/builtin/packages/r-bookdown/package.py
+++ b/var/spack/repos/builtin/packages/r-bookdown/package.py
@@ -14,6 +14,7 @@ class RBookdown(RPackage):
 
     cran = "bookdown"
 
+    version("0.33", sha256="2288e1d0c383e6ab49202a18db6cc1a04c3adc1b25da646cc46167bc6c2892c3")
     version("0.29", sha256="5b4e3dc44a5c6574e3d9e19ebe7897d3ddcf6eaffe8214e1d272b545929ff723")
     version("0.26", sha256="c6207288cb72ea7c555cbad449c61278e94b742cac1f610879fb3f2d60b2b185")
     version("0.24", sha256="8bead2a20542d05f643fe77a949689a17b0ae9ff23efbb918ddab47597db1be3")

--- a/var/spack/repos/builtin/packages/r-bookdown/package.py
+++ b/var/spack/repos/builtin/packages/r-bookdown/package.py
@@ -22,6 +22,8 @@ class RBookdown(RPackage):
     version("0.12", sha256="38eb4c5b877ccd85b16cfe74a48c3bc53de2f276da98e5515f37e7a06e065bb0")
     version("0.5", sha256="b7331fd56f64bd2bddc34e2a188fc491f9ff5308f44f7e3151721247f21ca67e")
 
+    depends_on("r@3.5.0:", type=("build", "run"), when="@0.33:")
+
     depends_on("r+X", type=("build", "run"))
     depends_on("r-htmltools@0.3.6:", type=("build", "run"))
     depends_on("r-knitr@1.22:", type=("build", "run"))


### PR DESCRIPTION
Add r-bookdown v0.33. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.