### PR TITLE
r-compositions: add v2.0-6

### DIFF
--- a/var/spack/repos/builtin/packages/r-compositions/package.py
+++ b/var/spack/repos/builtin/packages/r-compositions/package.py
@@ -22,6 +22,7 @@ class RCompositions(RPackage):
 
     depends_on("r@2.2.0:", type=("build", "run"))
     depends_on("r@3.6:", type=("build", "run"), when="@2.0-4:")
+
     depends_on("r-tensora", type=("build", "run"))
     depends_on("r-robustbase", type=("build", "run"))
     depends_on("r-bayesm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/r-compositions/package.py
+++ b/var/spack/repos/builtin/packages/r-compositions/package.py
@@ -15,6 +15,7 @@ class RCompositions(RPackage):
 
     cran = "compositions"
 
+    version("2.0-6", sha256="45d374ebfdcc2c9f6cc738d196caf83a2297ed2aefe2cc99007fcbeb78a61c34")
     version("2.0-4", sha256="7b9c7a3bf654fb02d9eb1b4a7566469b2f5232f3b2c1b324c02239fd31060faf")
     version("2.0-1", sha256="84a291308faf858e5a9d9570135c2da5e57b0887f407903485fa85d09da61a0f")
     version("1.40-2", sha256="110d71ae000561987cb73fc76cd953bd69d37562cb401ed3c36dca137d01b78a")


### PR DESCRIPTION
Add r-compositions v2.0-6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.