### PR TITLE
r-convevol: add v2.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/r-convevol/package.py
+++ b/var/spack/repos/builtin/packages/r-convevol/package.py
@@ -16,6 +16,7 @@ class RConvevol(RPackage):
 
     cran = "convevol"
 
+    version("2.0.0", sha256="690664b93c1f144a409e80b2ebfc20dc34f0eb9405607d15e066e8db573e84de")
     version("1.3", sha256="d6b24b9796a559f5280e277746189d141151ade4b14cc6b4c2d9d496d7f314ac")
 
     depends_on("r@3.5.0:", type=("build", "run"))


### PR DESCRIPTION
Add r-convevol v2.0.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.