### PR TITLE
r-fastmap: add v1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-fastmap/package.py
+++ b/var/spack/repos/builtin/packages/r-fastmap/package.py
@@ -18,5 +18,6 @@ class RFastmap(RPackage):
 
     cran = "fastmap"
 
+    version("1.1.1", sha256="3623809dd016ae8abd235200ba7834effc4b916915a059deb76044137c5c7173")
     version("1.1.0", sha256="9113e526b4c096302cfeae660a06de2c4c82ae4e2d3d6ef53af6de812d4c822b")
     version("1.0.1", sha256="4778b05dfebd356f8df980dfeff3b973a72bca14898f870e5c40c1d84db9faec")


### PR DESCRIPTION
Add r-fastmap v1.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.