### PR TITLE
r-glmnet: add v4.1-7

### DIFF
--- a/var/spack/repos/builtin/packages/r-glmnet/package.py
+++ b/var/spack/repos/builtin/packages/r-glmnet/package.py
@@ -27,6 +27,7 @@ class RGlmnet(RPackage):
     version("2.0-5", sha256="2ca95352c8fbd93aa7800f3d972ee6c1a5fcfeabc6be8c10deee0cb457fd77b1")
 
     depends_on("r@3.6.0:", type=("build", "run"), when="@4.1:")
+
     depends_on("r-matrix@1.0-6:", type=("build", "run"))
     depends_on("r-foreach", type=("build", "run"))
     depends_on("r-shape", type=("build", "run"), when="@4.1:")

--- a/var/spack/repos/builtin/packages/r-glmnet/package.py
+++ b/var/spack/repos/builtin/packages/r-glmnet/package.py
@@ -18,6 +18,7 @@ class RGlmnet(RPackage):
 
     cran = "glmnet"
 
+    version("4.1-7", sha256="b3a0b606d99df0256eb68e6ebd271e071b246900a4379641af2e7d548c70eaa8")
     version("4.1-4", sha256="f6b0f70a0b3d81ff91c2b94f795a2a32e90dd458270f1a29e49e085dd65000f9")
     version("4.1-3", sha256="64bc35aa40b6e580cfb8a21e649eb103e996e8747a10c476b8bb9545c846325a")
     version("4.1", sha256="8f0af50919f488789ecf261f6e0907f367d89fca812baa2f814054fb2d0e40cb")


### PR DESCRIPTION
Add r-glmnet v4.1-7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.