### PR TITLE
r-jomo: add v2.7-6

### DIFF
--- a/var/spack/repos/builtin/packages/r-jomo/package.py
+++ b/var/spack/repos/builtin/packages/r-jomo/package.py
@@ -18,6 +18,7 @@ class RJomo(RPackage):
 
     cran = "jomo"
 
+    version("2.7-6", sha256="3ffa2a5521d4969fe77b23cd3ab201afdf8db3f8f708b1276c33083c01d7e2da")
     version("2.7-4", sha256="2d25bc248dc1b931e6c19636197cd6f58fb00f5e1102ed3c04084c71d03d93fd")
     version("2.7-3", sha256="9d3987f3a73d305f3ab6fc66efc04a196a7eb8b65e20c411131dc17af51f0063")
     version("2.7-2", sha256="3962d5cbecc60e72670329dbef0dd74303080f5ea2a79c91e27f75db99ba6ce9")


### PR DESCRIPTION
Add r-jomo v2.7-6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.