### PR TITLE
r-lattice: add v0.21-8

### DIFF
--- a/var/spack/repos/builtin/packages/r-lattice/package.py
+++ b/var/spack/repos/builtin/packages/r-lattice/package.py
@@ -25,3 +25,4 @@ class RLattice(RPackage):
     version("0.20-34", sha256="4a1a1cafa9c6660fb9a433b3a51898b8ec8e83abf143c80f99e3e4cf92812518")
 
     depends_on("r@3.0.0:", type=("build", "run"))
+    depends_on("r@4.0.0:", type=("build", "run"), when="@0.21-8:")

--- a/var/spack/repos/builtin/packages/r-lattice/package.py
+++ b/var/spack/repos/builtin/packages/r-lattice/package.py
@@ -16,6 +16,7 @@ class RLattice(RPackage):
 
     cran = "lattice"
 
+    version("0.21-8", sha256="8ad3d6974262e6cab6cc8fec38aa279b5b2f2524adf6f3eab56f68302b60c329")
     version("0.20-45", sha256="22388d92bdb7d3959da84d7308d9026dd8226ef07580783729e8ad2f7d7507ad")
     version("0.20-44", sha256="57b908e3c7ada08a38ad857ee44f44fdf9cfa59d5d9500bda2ccc9c7e96cdb9b")
     version("0.20-41", sha256="54ca557f0cb33df60eb10b883c2ed2847e061ddd57ed9b5dd7695149609d57b5")


### PR DESCRIPTION
Add r-lattice v0.21-8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.