### PR TITLE
r-loo: add v2.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/r-loo/package.py
+++ b/var/spack/repos/builtin/packages/r-loo/package.py
@@ -28,8 +28,9 @@ class RLoo(RPackage):
     version("2.3.1", sha256="d98de21b71d9d9386131ae5ba4da051362c3ad39e0305af4f33d830f299ae08b")
     version("2.1.0", sha256="1bf4a1ef85d151577ff96d4cf2a29c9ef24370b0b1eb08c70dcf45884350e87d")
 
-    depends_on("r+X", type=("build", "run"))
     depends_on("r@3.1.2:", type=("build", "run"))
+
+    depends_on("r+X", type=("build", "run"))
     depends_on("r-checkmate", type=("build", "run"))
     depends_on("r-matrixstats@0.52:", type=("build", "run"))
     depends_on("pandoc@1.12.3:")

--- a/var/spack/repos/builtin/packages/r-loo/package.py
+++ b/var/spack/repos/builtin/packages/r-loo/package.py
@@ -22,6 +22,7 @@ class RLoo(RPackage):
 
     cran = "loo"
 
+    version("2.6.0", sha256="66da60fdf53a62cbc93797fa696a4cc43bce77f1721dd4bc1a58d25b3f981210")
     version("2.5.1", sha256="866a2f54a4e8726cc3062e27daa8a073e6ac4aeb6719af7845284f7a668745f1")
     version("2.4.1", sha256="bc21fb6b4a93a7e95ee1be57e4e787d731895fb8b4743c26b30b43adee475b50")
     version("2.3.1", sha256="d98de21b71d9d9386131ae5ba4da051362c3ad39e0305af4f33d830f299ae08b")


### PR DESCRIPTION
Add r-loo v2.6.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.