### PR TITLE
r-meta: add v6.2-1

### DIFF
--- a/var/spack/repos/builtin/packages/r-meta/package.py
+++ b/var/spack/repos/builtin/packages/r-meta/package.py
@@ -24,6 +24,7 @@ class RMeta(RPackage):
 
     cran = "meta"
 
+    version("6.2-1", sha256="2c2a0d4d8f3b07211120b232a155e3e1312164ce18817e0d5693c8da5da1d6cc")
     version("6.2-0", sha256="8ec8fb412996bbe17d3ca073f15c191a77bad486b08f39d7b8c2d07360ad5781")
 
     depends_on("r@4.0.0:", type=("build", "run"))


### PR DESCRIPTION
Add r-meta v6.2-1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.