### PR TITLE
barrnap: add v0.9

### DIFF
--- a/var/spack/repos/builtin/packages/barrnap/package.py
+++ b/var/spack/repos/builtin/packages/barrnap/package.py
@@ -12,6 +12,7 @@ class Barrnap(Package):
     homepage = "https://github.com/tseemann/barrnap"
     url = "https://github.com/tseemann/barrnap/archive/0.8.tar.gz"
 
+    version("0.9", sha256="36c27cd4350531d98b3b2fb7d294a2d35c15b7365771476456d7873ba33cce15")
     version("0.8", sha256="82004930767e92b61539c0de27ff837b8b7af01236e565f1473c63668cf0370f")
     version("0.7", sha256="ef2173e250f06cca7569c03404c9d4ab6a908ef7643e28901fbe9a732d20c09b")
     version("0.6", sha256="272642a41634623bda34dccdce487ab791925fa769e3e575d53014956a1f9dce")


### PR DESCRIPTION
Add barrnap v0.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.