### PR TITLE
bowtie: add v1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -13,6 +13,7 @@ class Bowtie(MakefilePackage):
     homepage = "https://sourceforge.net/projects/bowtie-bio/"
     url = "https://github.com/BenLangmead/bowtie/archive/v1.2.0.tar.gz"
 
+    version("1.3.1", sha256="147d9fe9652f7c5f351bfc0eb012e06981986fb43bd6bdfe88a95c02eabc6573")
     version("1.3.0", sha256="d7c2d982a67884909f284a0ff150b56b20127cd7a1ced461c3c4c03e6a6374c5")
     version("1.2.3", sha256="86402114caeacbb3a3030509cb59f0b7e96361c7b3ee2dd50e2cd68200898823")
     # The bowtie project git tagged and GitHub released a v1.2.2,


### PR DESCRIPTION
Add bowtie v1.3.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.