### PR TITLE
cc: deal with -Wl,-rpath= without value, deal with NAG

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -448,7 +448,9 @@ parse_Wl() {
         case "$1" in
             -rpath=*)
                 arg="${1#-rpath=}"
-                if system_dir "$arg"; then
+                if [ -z "$arg" ]; then
+                    shift; continue
+                elif system_dir "$arg"; then
                     append system_rpath_dirs_list "$arg"
                 else
                     append rpath_dirs_list "$arg"
@@ -456,7 +458,9 @@ parse_Wl() {
                 ;;
             --rpath=*)
                 arg="${1#--rpath=}"
-                if system_dir "$arg"; then
+                if [ -z "$arg" ]; then
+                    shift; continue
+                elif system_dir "$arg"; then
                     append system_rpath_dirs_list "$arg"
                 else
                     append rpath_dirs_list "$arg"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -433,6 +433,8 @@ wl_expect_rpath=no
 # Same, but for -Xlinker -rpath -Xlinker /path
 xlinker_expect_rpath=no
 
+wl_prefix=-Wl,
+
 parse_Wl() {
     while [ $# -ne 0 ]; do
     if [ "$wl_expect_rpath" = yes ]; then
@@ -470,12 +472,19 @@ parse_Wl() {
             "$dtags_to_strip")
                 ;;
             *)
-                append other_args_list "-Wl,$1"
+                append other_args_list "$wl_prefix$1"
                 ;;
         esac
     fi
     shift
     done
+}
+
+parse_Wl_NAG() {
+    # For -Wl,-Wl,,x,,y,,z; we receive $@ = [x, '', y, '', z]
+    # so dropping empty arguments with unset IFS gives 'parse_Wl x y z'
+    unset IFS
+    parse_Wl $@
 }
 
 
@@ -577,10 +586,17 @@ while [ $# -ne 0 ]; do
             append other_args_list "-l$arg"
             ;;
         -Wl,-Wl,,*)
-            # We never dealt with the NAG compiler -Wl,-Wl,,-rpath,,/path construct
-            append other_args_list "$1"
+            # NAG Fortran compiler linker flags are of the form -Wl,-Wl,,x,,y,,z
+            # Here we split on comma, and let parse_Wl_NAG drop empty arguments.
+            # This is still buggy, since '-Wl,-Wl,,-rpath,,/path with spaces' fails,
+            # but it's better than nothing.
+            wl_prefix=-Wl,-Wl,,
+            IFS=,
+            parse_Wl_NAG ${1#-Wl,-Wl,,}
+            unset IFS
             ;;
         -Wl,*)
+            wl_prefix=-Wl,
             IFS=,
             parse_Wl ${1#-Wl,}
             unset IFS

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -577,8 +577,7 @@ while [ $# -ne 0 ]; do
             append other_args_list "-l$arg"
             ;;
         -Wl,-Wl,,*)
-            # We never dealt with NAG compiler -Wl,-Wl,,-rpath,,/path construct; they are
-            # ignored here, and instead we hope that the linker gets intercepted.
+            # We never dealt with the NAG compiler -Wl,-Wl,,-rpath,,/path construct
             append other_args_list "$1"
             ;;
         -Wl,*)

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -434,8 +434,6 @@ wl_expect_rpath=no
 xlinker_expect_rpath=no
 
 parse_Wl() {
-    # drop -Wl
-    shift
     while [ $# -ne 0 ]; do
     if [ "$wl_expect_rpath" = yes ]; then
         if system_dir "$1"; then
@@ -580,7 +578,7 @@ while [ $# -ne 0 ]; do
             ;;
         -Wl,*)
             IFS=,
-            parse_Wl $1
+            parse_Wl ${1#-Wl,}
             unset IFS
             ;;
         -Xlinker)

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -471,6 +471,11 @@ parse_Wl() {
                 ;;
             "$dtags_to_strip")
                 ;;
+            -Wl)
+                # Nested -Wl,-Wl means we're in NAG compiler territory, we don't support
+                # it.
+                return 1
+                ;;
             *)
                 append other_args_list "$wl_prefix$1"
                 ;;
@@ -478,13 +483,6 @@ parse_Wl() {
     fi
     shift
     done
-}
-
-parse_Wl_NAG() {
-    # For -Wl,-Wl,,x,,y,,z; we receive $@ = [x, '', y, '', z]
-    # so dropping empty arguments with unset IFS gives 'parse_Wl x y z'
-    unset IFS
-    parse_Wl $@
 }
 
 
@@ -585,20 +583,12 @@ while [ $# -ne 0 ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             append other_args_list "-l$arg"
             ;;
-        -Wl,-Wl,,*)
-            # NAG Fortran compiler linker flags are of the form -Wl,-Wl,,x,,y,,z
-            # Here we split on comma, and let parse_Wl_NAG drop empty arguments.
-            # This is still buggy, since '-Wl,-Wl,,-rpath,,/path with spaces' fails,
-            # but it's better than nothing.
-            wl_prefix=-Wl,-Wl,,
-            IFS=,
-            parse_Wl_NAG ${1#-Wl,-Wl,,}
-            unset IFS
-            ;;
         -Wl,*)
             wl_prefix=-Wl,
             IFS=,
-            parse_Wl ${1#-Wl,}
+            if ! parse_Wl ${1#-Wl,}; then
+                append other_args_list "$1"
+            fi
             unset IFS
             ;;
         -Xlinker)

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -433,8 +433,6 @@ wl_expect_rpath=no
 # Same, but for -Xlinker -rpath -Xlinker /path
 xlinker_expect_rpath=no
 
-wl_prefix=-Wl,
-
 parse_Wl() {
     while [ $# -ne 0 ]; do
     if [ "$wl_expect_rpath" = yes ]; then
@@ -477,7 +475,7 @@ parse_Wl() {
                 return 1
                 ;;
             *)
-                append other_args_list "$wl_prefix$1"
+                append other_args_list "-Wl,$1"
                 ;;
         esac
     fi
@@ -584,7 +582,6 @@ while [ $# -ne 0 ]; do
             append other_args_list "-l$arg"
             ;;
         -Wl,*)
-            wl_prefix=-Wl,
             IFS=,
             if ! parse_Wl ${1#-Wl,}; then
                 append other_args_list "$1"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -576,6 +576,11 @@ while [ $# -ne 0 ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             append other_args_list "-l$arg"
             ;;
+        -Wl,-Wl,,*)
+            # We never dealt with NAG compiler -Wl,-Wl,,-rpath,,/path construct; they are
+            # ignored here, and instead we hope that the linker gets intercepted.
+            append other_args_list "$1"
+            ;;
         -Wl,*)
             IFS=,
             parse_Wl ${1#-Wl,}

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -352,6 +352,7 @@ def test_Wl_parsing(wrapper_environment):
     )
 
 
+@pytest.mark.regression("37179")
 def test_Wl_parsing_with_missing_value(wrapper_environment):
     check_args(
         cc,
@@ -360,6 +361,7 @@ def test_Wl_parsing_with_missing_value(wrapper_environment):
     )
 
 
+@pytest.mark.regression("37179")
 def test_Wl_parsing_NAG_is_ignored(wrapper_environment):
     check_args(
         fc,

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -351,13 +351,12 @@ def test_Wl_parsing(wrapper_environment):
         + ["-Wl,--disable-new-dtags", "-Wl,-rpath,/a", "-Wl,-rpath,/b", "-Wl,-rpath,/c"],
     )
 
+
 def test_Wl_parsing_with_missing_value(wrapper_environment):
     check_args(
         cc,
         ["-Wl,-rpath=/a,-rpath=", "-Wl,--rpath="],
-        [real_cc]
-        + target_args
-        + ["-Wl,--disable-new-dtags", "-Wl,-rpath,/a"],
+        [real_cc] + target_args + ["-Wl,--disable-new-dtags", "-Wl,-rpath,/a"],
     )
 
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -360,6 +360,14 @@ def test_Wl_parsing_with_missing_value(wrapper_environment):
     )
 
 
+def test_Wl_parsing_NAG_is_ignored(wrapper_environment):
+    check_args(
+        fc,
+        ["-Wl,-Wl,,x,,y,,z"],
+        [real_cc] + target_args + ["-Wl,--disable-new-dtags", "-Wl,-Wl,,x,,y,,z"],
+    )
+
+
 def test_Xlinker_parsing(wrapper_environment):
     # -Xlinker <x> ... -Xlinker <y> may have compiler flags inbetween, like -O3 in this
     # example. Also check that a trailing -Xlinker (which is a compiler error) is not

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -351,6 +351,15 @@ def test_Wl_parsing(wrapper_environment):
         + ["-Wl,--disable-new-dtags", "-Wl,-rpath,/a", "-Wl,-rpath,/b", "-Wl,-rpath,/c"],
     )
 
+def test_Wl_parsing_with_missing_value(wrapper_environment):
+    check_args(
+        cc,
+        ["-Wl,-rpath=/a,-rpath=", "-Wl,--rpath="],
+        [real_cc]
+        + target_args
+        + ["-Wl,--disable-new-dtags", "-Wl,-rpath,/a"],
+    )
+
 
 def test_Xlinker_parsing(wrapper_environment):
     # -Xlinker <x> ... -Xlinker <y> may have compiler flags inbetween, like -O3 in this


### PR DESCRIPTION
fixes #37179

The changes in #35912 and #35929 are causing two issues:

1. Empty `-Wl,-rpath=` were no longer dropped -- this is not an
   issue for GCC/Clang, but when we rewrite it to `-Wl,-rpath,`
   ICC doesn't forward the empty string argument. So, better to
   drop it then.
2. The `parse_Wl` stuff started parsing NAG's weird construct
   `-Wl,-Wl,,x,,y,,z` too, whereas in the past we never parsed
   NAG linker flags. I don't think it's worth supporting this.
