### PR TITLE
pestpp: add v5.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/pestpp/package.py
+++ b/var/spack/repos/builtin/packages/pestpp/package.py
@@ -16,6 +16,7 @@ class Pestpp(CMakePackage):
     homepage = "https://pesthomepage.org"
     url = "https://github.com/usgs/pestpp/archive/5.0.5.tar.gz"
 
+    version("5.2.3", sha256="6b86a7db863a034e730480046a4b7b4a8dc7cc798658a5404a961be379c05dc3")
     version("5.0.5", sha256="b9695724758f69c1199371608b01419973bd1475b1788039a2fab6313f6ed67c")
 
     variant("mpi", default=True, description="Enable MPI support")


### PR DESCRIPTION
Add pestpp v5.2.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.