### PR TITLE
py-flake8: add 6.0.0 and update dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -13,6 +13,7 @@ class PyFlake8(PythonPackage):
     homepage = "https://github.com/PyCQA/flake8"
     pypi = "flake8/flake8-4.0.1.tar.gz"
 
+    version("6.0.0", sha256="c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181")
     version("5.0.4", sha256="6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db")
     version("5.0.2", sha256="9cc32bc0c5d16eacc014c7ec6f0e9565fd81df66c2092c3c9df06e3c1ac95e5d")
     version("5.0.1", sha256="9c51d3d1426379fd444d3b79eabbeb887849368bd053039066439523d8486961")
@@ -27,6 +28,7 @@ class PyFlake8(PythonPackage):
     version("3.0.4", sha256="b4c210c998f07d6ff24325dd91fbc011f2c37bcd6bf576b188de01d8656e970d")
     version("2.5.4", sha256="cc1e58179f6cf10524c7bfdd378f5536d0a61497688517791639a5ecc867492f")
 
+    depends_on("python@3.8.1:", when="@6:", type=("build", "run"))
     depends_on("python@3.6.1:", when="@5:", type=("build", "run"))
     depends_on("python@3.6:", when="@4:", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@3.9.2:", type=("build", "run"))
@@ -40,6 +42,11 @@ class PyFlake8(PythonPackage):
     # error codes within each minor release:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
     # http://flake8.pycqa.org/en/latest/internal/releases.html#releasing-flake8
+
+    # Flake8 6.0.X
+    depends_on("py-mccabe@0.7", when="@6.0", type=("build", "run"))
+    depends_on("py-pycodestyle@2.10", when="@6.0", type=("build", "run"))
+    depends_on("py-pyflakes@3.0", when="@6.0", type=("build", "run"))
 
     # Flake8 5.0.X
     depends_on("py-mccabe@0.7", when="@5.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pycodestyle/package.py
+++ b/var/spack/repos/builtin/packages/py-pycodestyle/package.py
@@ -13,6 +13,7 @@ class PyPycodestyle(PythonPackage):
     homepage = "https://github.com/PyCQA/pycodestyle"
     pypi = "pycodestyle/pycodestyle-2.8.0.tar.gz"
 
+    version("2.10.0", sha256="347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053")
     version("2.9.1", sha256="2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785")
     version("2.9.0", sha256="beaba44501f89d785be791c9462553f06958a221d166c64e1f107320f839acc2")
     version("2.8.0", sha256="eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f")

--- a/var/spack/repos/builtin/packages/py-pyflakes/package.py
+++ b/var/spack/repos/builtin/packages/py-pyflakes/package.py
@@ -12,6 +12,7 @@ class PyPyflakes(PythonPackage):
     homepage = "https://github.com/PyCQA/pyflakes"
     pypi = "pyflakes/pyflakes-2.4.0.tar.gz"
 
+    version("3.0.1", sha256="ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd")
     version("2.5.0", sha256="491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3")
     version("2.4.0", sha256="05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c")
     version("2.3.0", sha256="e59fd8e750e588358f1b8885e5a4751203a0516e0ee6d34811089ac294c8806f")


### PR DESCRIPTION
https://github.com/PyCQA/flake8/tree/6.0.0
https://github.com/PyCQA/pycodestyle/tree/2.10.0
https://github.com/PyCQA/pyflakes/tree/3.0.1