### PR TITLE
py-gssapi: depends_on krb5

### DIFF
--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -21,3 +21,4 @@ class PyGssapi(PythonPackage):
     depends_on("py-setuptools@40.6.0:", type="build")
 
     depends_on("py-decorator", type=("build", "run"))
+    depends_on("krb5", type=("build", "link"))


### PR DESCRIPTION
This dependency was somehow overlooked (but is pretty crucial) because it doesn't appear in the python requirements...