### PR TITLE
Fix pkgconfig dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -13,7 +13,7 @@ class Clp(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Clp"
     url = "https://github.com/coin-or/Clp/archive/releases/1.17.6.tar.gz"
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("coinutils")
     depends_on("osi")
 

--- a/var/spack/repos/builtin/packages/freesasa/package.py
+++ b/var/spack/repos/builtin/packages/freesasa/package.py
@@ -25,7 +25,7 @@ class Freesasa(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
     # https://github.com/mittinatten/freesasa/issues/88
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("json-c", when="+json")
     depends_on("libxml2", when="+xml")

--- a/var/spack/repos/builtin/packages/impalajit/package.py
+++ b/var/spack/repos/builtin/packages/impalajit/package.py
@@ -29,7 +29,7 @@ class Impalajit(CMakePackage):
 
     variant("shared", default=True, description="build as a shared library")
     depends_on("cmake", type="build")
-    depends_on("pkg-config", type="build", when="@main")
+    depends_on("pkgconfig", type="build", when="@main")
     depends_on("llvm@10.0.0:11.1.0", when="@llvm")
     depends_on("z3", when="@llvm")
     depends_on("llvm@10.0.0:11.1.0", when="@llvm-1.0.0")

--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -34,7 +34,7 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("python", type=("build",), when="@2022-11-18:")
     depends_on("sed", type=("build",), when="@2022-11-18:")
     depends_on("zlib")
-    depends_on("pkgconf", type=("build",), when="@2022-11-18:")
+    depends_on("pkgconfig", type=("build",), when="@2022-11-18:")
     depends_on("zstd")
     depends_on("protobuf@:3.21.12", when="@2022-11-18:")
     depends_on("libarchive", when="@2021-11-12:")

--- a/var/spack/repos/builtin/packages/ophidia-server/package.py
+++ b/var/spack/repos/builtin/packages/ophidia-server/package.py
@@ -18,7 +18,7 @@ class OphidiaServer(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("libmatheval")
     depends_on("jansson")

--- a/var/spack/repos/builtin/packages/osi/package.py
+++ b/var/spack/repos/builtin/packages/osi/package.py
@@ -20,7 +20,7 @@ class Osi(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Osi"
     url = "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz"
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("coinutils")
 
     version("0.108.7", sha256="f1bc53a498585f508d3f8d74792440a30a83c8bc934d0c8ecf8cd8bc0e486228")

--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -38,7 +38,7 @@ class Palace(CMakePackage):
 
     # Dependencies
     depends_on("cmake@3.13:", type="build")
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("zlib")
     depends_on("nlohmann-json")


### PR DESCRIPTION
Packages shouldn't typically depend on pkg-config or pkgconf but on the virtual provider pkgconfig.