### PR TITLE
bricks: Fix package to properly find spack opencl-clhpp (spack#37170)

### DIFF
--- a/var/spack/repos/builtin/packages/bricks/bricks-cmakelists-option-opencl.patch
+++ b/var/spack/repos/builtin/packages/bricks/bricks-cmakelists-option-opencl.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 58dcbd4..f0658eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,7 +43,11 @@ endif()
+ 
+ find_package(OpenMP REQUIRED)
+ find_package(MPI)
+-find_package(OpenCL 2.0)
++
++option(BRICK_USE_OPENCL "Use OpenCL targets" ON)
++if (BRICK_USE_OPENCL)
++    find_package(OpenCL 2.0)
++endif()
+ 
+ option(BRICK_USE_MEMFD "Using memfd instead of shm_open, supported on Linux >= 3.17 with \"CONFIG_MEMFD_CREATE\"" OFF)
+ if (BRICK_USE_MEMFD)

--- a/var/spack/repos/builtin/packages/bricks/package.py
+++ b/var/spack/repos/builtin/packages/bricks/package.py
@@ -35,10 +35,13 @@ class Bricks(CMakePackage):
     depends_on("cuda", when="+cuda")
     depends_on("mpi")
 
+    patch("bricks-cmakelists-option-opencl.patch")
+
     def cmake_args(self):
         """CMake arguments for configure stage"""
-        args = []
-
+        args = [self.define_from_variant("BRICK_USE_OPENCL", "cuda")]
+        if "+cuda" in self.spec:
+            args.append(f"-DOCL_ROOT:STRING={self.spec['opencl-clhpp'].prefix}")
         return args
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
The bricks package uses header from the opencl-clhpp package when built with the cuda variant activated. In order to find the header files, the bricks CMakeLists.txt uses the `find_package(OpenCL 2.0)` statement. The CMake FindOpenCL module searches several paths to find the header files. Eventually it will search for header files in the local /usr/include directories. If OpenCL headers are found, but CUDA is not installed locally, then the build will fail.

One of the CMake variables searched for a path to the OpenCL headers is OCL_ROOT. This fix utilizes the OCL_ROOT variable to identify the correct path to the install opencl-clhpp package within Spack. Also, if the cuda variant is not used, then the OpenCL build is disabled to prevent a build failure due to improperly-identified locally-installed OpenCL header files.

I am making this fix in Bricks as this is the package I am responsible for. The real problem is the incorrect identification of the opencl-clhpp header path. I would like to see a fix go into the opencl-clhpp package that creates a pkg-config file that would correctly identify the header path.

Fixes https://github.com/spack/spack/issues/37170