### PR TITLE
fixes #29350 

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -254,7 +254,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("py-six", when="+lldb+python")
 
     # gold support, required for some features
-    depends_on("binutils+gold+ld+plugins", when="+gold")
+    depends_on("binutils+gold+ld+plugins+headers", when="+gold")
 
     # Older LLVM do not build with newer compilers, and vice versa
     with when("@16:"):


### PR DESCRIPTION
By enabling headers variant in binutils when compiling llvm with gold.

This prevent the following error when building llvm:
```
     5503    /import/exception-dump/ulrich/spack/lib/spack/env/gcc/g++ -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/tmp/ulrich/spack-stage/spack-stage-llvm-16.0.2-bxs
             neviufwoceafy5sspbbi7j47xlaah/spack-build-bxsnevi/tools/gold -I/tmp/ulrich/spack-stage/spack-stage-llvm-16.0.2-bxsneviufwoceafy5sspbbi7j47xlaah/spack-src/llvm/tools/gold -I/tmp/ulrich/spack-stage
             /spack-stage-llvm-16.0.2-bxsneviufwoceafy5sspbbi7j47xlaah/spack-build-bxsnevi/include -I/tmp/ulrich/spack-stage/spack-stage-llvm-16.0.2-bxsneviufwoceafy5sspbbi7j47xlaah/spack-src/llvm/include -is
             ystem /import/heisenbug-dump/ulrich/myLibs/spack-packages/linux-debian11-zen2/gcc-12.2.0/zlib-1.2.13-5xkquqwlizzkiltffz62nmxcdaoov2me/include -std=c++11 -fPIC -fno-semantic-interposition -fvisibi
             lity-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-un
             initialized -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-misleading-indentation -Wctad-ma
             ybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -fPIC -std=c++17 -MD -MT tools/gold/CMakeFiles/LLVMgold.dir/gold-plugin.cpp.o -MF tools/gold/CMakeFiles/LLVMgo
             ld.dir/gold-plugin.cpp.o.d -o tools/gold/CMakeFiles/LLVMgold.dir/gold-plugin.cpp.o -c /tmp/ulrich/spack-stage/spack-stage-llvm-16.0.2-bxsneviufwoceafy5sspbbi7j47xlaah/spack-src/llvm/tools/gold/go
             ld-plugin.cpp
  >> 5504    /tmp/ulrich/spack-stage/spack-stage-llvm-16.0.2-bxsneviufwoceafy5sspbbi7j47xlaah/spack-src/llvm/tools/gold/gold-plugin.cpp:38:10: fatal error: plugin-api.h: No such file or directory
````