### PR TITLE
buildcache: remove deprecated api

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1132,11 +1132,11 @@ index once every package is pushed. Note how this target uses the generated
    example/push/%: example/install/%
    	@mkdir -p $(dir $@)
    	$(info About to push $(SPEC) to a buildcache)
-   	$(SPACK) -e . buildcache create --allow-root --only=package --directory $(BUILDCACHE_DIR) /$(HASH)
+   	$(SPACK) -e . buildcache push --allow-root --only=package $(BUILDCACHE_DIR) /$(HASH)
    	@touch $@
 
    push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))
    	$(info Updating the buildcache index)
-   	$(SPACK) -e . buildcache update-index --directory $(BUILDCACHE_DIR)
+   	$(SPACK) -e . buildcache update-index $(BUILDCACHE_DIR)
    	$(info Done!)
    	@touch $@

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1277,7 +1277,6 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
         raise NoOverwriteException(url_util.format(remote_specfile_path))
 
     pkg_dir = os.path.basename(spec.prefix.rstrip(os.path.sep))
-    workdir = os.path.join(stage_dir, pkg_dir)
 
     binaries_dir = spec.prefix
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -760,13 +760,12 @@ def hashes_to_prefixes(spec):
     }
 
 
-def get_buildinfo_dict(spec, rel=False):
+def get_buildinfo_dict(spec):
     """Create metadata for a tarball"""
     manifest = get_buildfile_manifest(spec)
 
     return {
         "sbang_install_path": spack.hooks.sbang.sbang_install_path(),
-        "relative_rpaths": rel,
         "buildpath": spack.store.layout.root,
         "spackprefix": spack.paths.prefix,
         "relative_prefix": os.path.relpath(spec.prefix, spack.store.layout.root),
@@ -1209,9 +1208,6 @@ class PushOptions(NamedTuple):
     #: Overwrite existing tarball/metadata files in buildcache
     force: bool = False
 
-    #: Whether to use relative RPATHs
-    relative: bool = False
-
     #: Allow absolute paths to package prefixes when creating a tarball
     allow_root: bool = False
 
@@ -1283,38 +1279,15 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
     pkg_dir = os.path.basename(spec.prefix.rstrip(os.path.sep))
     workdir = os.path.join(stage_dir, pkg_dir)
 
-    # TODO: We generally don't want to mutate any files, but when using relative
-    # mode, Spack unfortunately *does* mutate rpaths and links ahead of time.
-    # For now, we only make a full copy of the spec prefix when in relative mode.
-
-    if options.relative:
-        # tarfile is used because it preserves hardlink etc best.
-        binaries_dir = workdir
-        temp_tarfile_name = tarball_name(spec, ".tar")
-        temp_tarfile_path = os.path.join(tarfile_dir, temp_tarfile_name)
-        with closing(tarfile.open(temp_tarfile_path, "w")) as tar:
-            tar.add(name="%s" % spec.prefix, arcname=".")
-        with closing(tarfile.open(temp_tarfile_path, "r")) as tar:
-            tar.extractall(workdir)
-        os.remove(temp_tarfile_path)
-    else:
-        binaries_dir = spec.prefix
+    binaries_dir = spec.prefix
 
     # create info for later relocation and create tar
-    buildinfo = get_buildinfo_dict(spec, options.relative)
+    buildinfo = get_buildinfo_dict(spec)
 
-    # optionally make the paths in the binaries relative to each other
-    # in the spack install tree before creating tarball
-    if options.relative:
-        make_package_relative(workdir, spec, buildinfo, options.allow_root)
-    elif not options.allow_root:
+    if not options.allow_root:
         ensure_package_relocatable(buildinfo, binaries_dir)
 
     _do_create_tarball(tarfile_path, binaries_dir, pkg_dir, buildinfo)
-
-    # remove copy of install directory
-    if options.relative:
-        shutil.rmtree(workdir)
 
     # get the sha256 checksum of the tarball
     checksum = checksum_tarball(tarfile_path)
@@ -1336,7 +1309,6 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
     # This will be used to determine is the directory layout has changed.
     buildinfo = {}
     buildinfo["relative_prefix"] = os.path.relpath(spec.prefix, spack.store.layout.root)
-    buildinfo["relative_rpaths"] = options.relative
     spec_dict["buildinfo"] = buildinfo
 
     with open(specfile_path, "w") as outfile:
@@ -1594,35 +1566,6 @@ def download_tarball(spec, unsigned=False, mirrors_for_spec=None):
         )
 
     return None
-
-
-def make_package_relative(workdir, spec, buildinfo, allow_root):
-    """
-    Change paths in binaries to relative paths. Change absolute symlinks
-    to relative symlinks.
-    """
-    prefix = spec.prefix
-    old_layout_root = buildinfo["buildpath"]
-    orig_path_names = list()
-    cur_path_names = list()
-    for filename in buildinfo["relocate_binaries"]:
-        orig_path_names.append(os.path.join(prefix, filename))
-        cur_path_names.append(os.path.join(workdir, filename))
-
-    platform = spack.platforms.by_name(spec.platform)
-    if "macho" in platform.binary_formats:
-        relocate.make_macho_binaries_relative(cur_path_names, orig_path_names, old_layout_root)
-
-    if "elf" in platform.binary_formats:
-        relocate.make_elf_binaries_relative(cur_path_names, orig_path_names, old_layout_root)
-
-    allow_root or relocate.ensure_binaries_are_relocatable(cur_path_names)
-    orig_path_names = list()
-    cur_path_names = list()
-    for linkname in buildinfo.get("relocate_links", []):
-        orig_path_names.append(os.path.join(prefix, linkname))
-        cur_path_names.append(os.path.join(workdir, linkname))
-    relocate.make_link_relative(cur_path_names, orig_path_names)
 
 
 def ensure_package_relocatable(buildinfo, binaries_dir):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -56,37 +56,7 @@ def setup_parser(subparser):
     push.add_argument(
         "-k", "--key", metavar="key", type=str, default=None, help="Key for signing."
     )
-    output = push.add_mutually_exclusive_group(required=False)
-    # TODO: remove from Spack 0.21
-    output.add_argument(
-        "-d",
-        "--directory",
-        metavar="directory",
-        dest="mirror_flag",
-        type=arguments.mirror_directory,
-        help="local directory where buildcaches will be written. (deprecated)",
-    )
-    # TODO: remove from Spack 0.21
-    output.add_argument(
-        "-m",
-        "--mirror-name",
-        metavar="mirror-name",
-        dest="mirror_flag",
-        type=arguments.mirror_name,
-        help="name of the mirror where buildcaches will be written. (deprecated)",
-    )
-    # TODO: remove from Spack 0.21
-    output.add_argument(
-        "--mirror-url",
-        metavar="mirror-url",
-        dest="mirror_flag",
-        type=arguments.mirror_url,
-        help="URL of the mirror where buildcaches will be written. (deprecated)",
-    )
-    # Unfortunately we cannot add this to the mutually exclusive group above,
-    # because we have further positional arguments.
-    # TODO: require from Spack 0.21
-    push.add_argument("mirror", type=str, help="Mirror name, path, or URL.", nargs="?")
+    push.add_argument("mirror", type=str, help="Mirror name, path, or URL.")
     push.add_argument(
         "--update-index",
         "--rebuild-index",
@@ -258,71 +228,17 @@ def setup_parser(subparser):
         default=None,
         help="A quoted glob pattern identifying copy manifest files",
     )
-    source = sync.add_mutually_exclusive_group(required=False)
-    # TODO: remove in Spack 0.21
-    source.add_argument(
-        "--src-directory",
-        metavar="DIRECTORY",
-        dest="src_mirror_flag",
-        type=arguments.mirror_directory,
-        help="Source mirror as a local file path (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    source.add_argument(
-        "--src-mirror-name",
-        metavar="MIRROR_NAME",
-        dest="src_mirror_flag",
-        type=arguments.mirror_name,
-        help="Name of the source mirror (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    source.add_argument(
-        "--src-mirror-url",
-        metavar="MIRROR_URL",
-        dest="src_mirror_flag",
-        type=arguments.mirror_url,
-        help="URL of the source mirror (deprecated)",
-    )
-    # TODO: only support this in 0.21
-    source.add_argument(
+    sync.add_argument(
         "src_mirror",
         metavar="source mirror",
         type=arguments.mirror_name_or_url,
         help="Source mirror name, path, or URL",
-        nargs="?",
     )
-    dest = sync.add_mutually_exclusive_group(required=False)
-    # TODO: remove in Spack 0.21
-    dest.add_argument(
-        "--dest-directory",
-        metavar="DIRECTORY",
-        dest="dest_mirror_flag",
-        type=arguments.mirror_directory,
-        help="Destination mirror as a local file path (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    dest.add_argument(
-        "--dest-mirror-name",
-        metavar="MIRROR_NAME",
-        type=arguments.mirror_name,
-        dest="dest_mirror_flag",
-        help="Name of the destination mirror (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    dest.add_argument(
-        "--dest-mirror-url",
-        metavar="MIRROR_URL",
-        dest="dest_mirror_flag",
-        type=arguments.mirror_url,
-        help="URL of the destination mirror (deprecated)",
-    )
-    # TODO: only support this in 0.21
-    dest.add_argument(
+    sync.add_argument(
         "dest_mirror",
         metavar="destination mirror",
         type=arguments.mirror_name_or_url,
         help="Destination mirror name, path, or URL",
-        nargs="?",
     )
     sync.set_defaults(func=sync_fn)
 
@@ -330,39 +246,8 @@ def setup_parser(subparser):
     update_index = subparsers.add_parser(
         "update-index", aliases=["rebuild-index"], help=update_index_fn.__doc__
     )
-    update_index_out = update_index.add_mutually_exclusive_group(required=True)
-    # TODO: remove in Spack 0.21
-    update_index_out.add_argument(
-        "-d",
-        "--directory",
-        metavar="directory",
-        dest="mirror_flag",
-        type=arguments.mirror_directory,
-        help="local directory where buildcaches will be written (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    update_index_out.add_argument(
-        "-m",
-        "--mirror-name",
-        metavar="mirror-name",
-        dest="mirror_flag",
-        type=arguments.mirror_name,
-        help="name of the mirror where buildcaches will be written (deprecated)",
-    )
-    # TODO: remove in Spack 0.21
-    update_index_out.add_argument(
-        "--mirror-url",
-        metavar="mirror-url",
-        dest="mirror_flag",
-        type=arguments.mirror_url,
-        help="URL of the mirror where buildcaches will be written (deprecated)",
-    )
-    # TODO: require from Spack 0.21
-    update_index_out.add_argument(
-        "mirror",
-        type=arguments.mirror_name_or_url,
-        help="Destination mirror name, path, or URL",
-        nargs="?",
+    update_index.add_argument(
+        "mirror", type=arguments.mirror_name_or_url, help="Destination mirror name, path, or URL"
     )
     update_index.add_argument(
         "-k",
@@ -422,29 +307,12 @@ def _concrete_spec_from_args(args):
 
 def push_fn(args):
     """create a binary package and push it to a mirror"""
-    if args.mirror_flag:
-        mirror = args.mirror_flag
-    elif not args.mirror:
-        raise ValueError("No mirror provided")
-    else:
-        mirror = arguments.mirror_name_or_url(args.mirror)
-
-    if args.mirror_flag:
-        tty.warn(
-            "Using flags to specify mirrors is deprecated and will be removed in "
-            "Spack 0.21, use positional arguments instead."
-        )
-
-    # TODO: remove this in 0.21. If we have mirror_flag, the first
-    # spec is in the positional mirror arg due to argparse limitations.
-    input_specs = args.specs
-    if args.mirror_flag and args.mirror:
-        input_specs.insert(0, args.mirror)
+    mirror = arguments.mirror_name_or_url(args.mirror)
 
     url = mirror.push_url
 
     specs = bindist.specs_to_be_packaged(
-        _matching_specs(input_specs, args.spec_file),
+        _matching_specs(args.specs, args.spec_file),
         root="package" in args.things_to_install,
         dependencies="dependencies" in args.things_to_install,
     )
@@ -689,21 +557,8 @@ def sync_fn(args):
         manifest_copy(glob.glob(args.manifest_glob))
         return 0
 
-    # If no manifest_glob, require a source and dest mirror.
-    # TODO: Simplify in Spack 0.21
-    if not (args.src_mirror_flag or args.src_mirror) or not (
-        args.dest_mirror_flag or args.dest_mirror
-    ):
-        raise ValueError("Source and destination mirror are required.")
-
-    if args.src_mirror_flag or args.dest_mirror_flag:
-        tty.warn(
-            "Using flags to specify mirrors is deprecated and will be removed in "
-            "Spack 0.21, use positional arguments instead."
-        )
-
-    src_mirror = args.src_mirror_flag if args.src_mirror_flag else args.src_mirror
-    dest_mirror = args.dest_mirror_flag if args.dest_mirror_flag else args.dest_mirror
+    src_mirror = args.src_mirror
+    dest_mirror = args.dest_mirror
 
     src_mirror_url = src_mirror.fetch_url
     dest_mirror_url = dest_mirror.push_url
@@ -782,13 +637,7 @@ def update_index(mirror: spack.mirror.Mirror, update_keys=False):
 
 def update_index_fn(args):
     """Update a buildcache index."""
-    if args.mirror_flag:
-        tty.warn(
-            "Using flags to specify mirrors is deprecated and will be removed in "
-            "Spack 0.21, use positional arguments instead."
-        )
-    mirror = args.mirror_flag if args.mirror_flag else args.mirror
-    update_index(mirror, update_keys=args.keys)
+    update_index(args.mirror, update_keys=args.keys)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -43,13 +43,6 @@ def setup_parser(subparser):
     subparsers = subparser.add_subparsers(help="buildcache sub-commands")
 
     push = subparsers.add_parser("push", aliases=["create"], help=push_fn.__doc__)
-    # TODO: remove from Spack 0.21
-    push.add_argument(
-        "-r",
-        "--rel",
-        action="store_true",
-        help="make all rpaths relative before creating tarballs. (deprecated)",
-    )
     push.add_argument("-f", "--force", action="store_true", help="overwrite tarball if it exists.")
     push.add_argument(
         "-u", "--unsigned", action="store_true", help="push unsigned buildcache tarballs"
@@ -126,13 +119,6 @@ def setup_parser(subparser):
     )
     install.add_argument(
         "-m", "--multiple", action="store_true", help="allow all matching packages "
-    )
-    # TODO: remove from Spack 0.21
-    install.add_argument(
-        "-a",
-        "--allow-root",
-        action="store_true",
-        help="allow install root string in binary files after RPATH substitution. (deprecated)",
     )
     install.add_argument(
         "-u",
@@ -449,9 +435,6 @@ def push_fn(args):
             "Spack 0.21, use positional arguments instead."
         )
 
-    if args.rel:
-        tty.warn("The --rel flag is deprecated and will be removed in Spack 0.21")
-
     # TODO: remove this in 0.21. If we have mirror_flag, the first
     # spec is in the positional mirror arg due to argparse limitations.
     input_specs = args.specs
@@ -522,9 +505,6 @@ def install_fn(args):
     """install from a binary package"""
     if not args.specs:
         tty.die("a spec argument is required to install from a buildcache")
-
-    if args.allow_root:
-        tty.warn("The --allow-root flag is deprecated and will be removed in Spack 0.21")
 
     query = bindist.BinaryCacheQuery(all_architectures=args.otherarch)
     matches = spack.store.find(args.specs, multiple=args.multiple, query_fn=query)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -486,7 +486,6 @@ def push_fn(args):
                 url,
                 bindist.PushOptions(
                     force=args.force,
-                    relative=args.rel,
                     unsigned=args.unsigned,
                     allow_root=args.allow_root,
                     key=args.key,

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -204,12 +204,12 @@ def test_default_rpaths_create_install_default_layout(mirror_dir):
     install_cmd("--no-cache", sy_spec.name)
 
     # Create a buildache
-    buildcache_cmd("push", "-au", "-d", mirror_dir, cspec.name, sy_spec.name)
+    buildcache_cmd("push", "-au", mirror_dir, cspec.name, sy_spec.name)
     # Test force overwrite create buildcache (-f option)
-    buildcache_cmd("push", "-auf", "-d", mirror_dir, cspec.name)
+    buildcache_cmd("push", "-auf", mirror_dir, cspec.name)
 
     # Create mirror index
-    buildcache_cmd("update-index", "-d", mirror_dir)
+    buildcache_cmd("update-index", mirror_dir)
     # List the buildcaches in the mirror
     buildcache_cmd("list", "-alv")
 
@@ -379,7 +379,7 @@ def test_spec_needs_rebuild(monkeypatch, tmpdir):
     install_cmd(s.name)
 
     # Put installed package in the buildcache
-    buildcache_cmd("push", "-u", "-a", "-d", mirror_dir.strpath, s.name)
+    buildcache_cmd("push", "-u", "-a", mirror_dir.strpath, s.name)
 
     rebuild = bindist.needs_rebuild(s, mirror_url)
 
@@ -408,8 +408,8 @@ def test_generate_index_missing(monkeypatch, tmpdir, mutable_config):
     install_cmd("--no-cache", s.name)
 
     # Create a buildcache and update index
-    buildcache_cmd("push", "-uad", mirror_dir.strpath, s.name)
-    buildcache_cmd("update-index", "-d", mirror_dir.strpath)
+    buildcache_cmd("push", "-ua", mirror_dir.strpath, s.name)
+    buildcache_cmd("update-index", mirror_dir.strpath)
 
     # Check package and dependency in buildcache
     cache_list = buildcache_cmd("list", "--allarch")
@@ -421,7 +421,7 @@ def test_generate_index_missing(monkeypatch, tmpdir, mutable_config):
     os.remove(*libelf_files)
 
     # Update index
-    buildcache_cmd("update-index", "-d", mirror_dir.strpath)
+    buildcache_cmd("update-index", mirror_dir.strpath)
 
     with spack.config.override("config:binary_index_ttl", 0):
         # Check dependency not in buildcache
@@ -497,10 +497,10 @@ def test_update_sbang(tmpdir, test_mirror):
     install_cmd("--no-cache", old_spec.name)
 
     # Create a buildcache with the installed spec.
-    buildcache_cmd("push", "-u", "-a", "-d", mirror_dir, old_spec_hash_str)
+    buildcache_cmd("push", "-u", "-a", mirror_dir, old_spec_hash_str)
 
     # Need to force an update of the buildcache index
-    buildcache_cmd("update-index", "-d", mirror_dir)
+    buildcache_cmd("update-index", mirror_dir)
 
     # Uninstall the original package.
     uninstall_cmd("-y", old_spec_hash_str)

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -258,31 +258,6 @@ def test_default_rpaths_install_nondefault_layout(mirror_dir):
 @pytest.mark.requires_executables(*args)
 @pytest.mark.maybeslow
 @pytest.mark.nomockstage
-@pytest.mark.usefixtures("default_config", "cache_directory", "install_dir_default_layout")
-def test_relative_rpaths_create_default_layout(mirror_dir):
-    """
-    Test the creation and installation of buildcaches with relative
-    rpaths into the default directory layout scheme.
-    """
-
-    gspec, cspec = Spec("garply").concretized(), Spec("corge").concretized()
-
-    # Install 'corge' without using a cache
-    install_cmd("--no-cache", cspec.name)
-
-    # Create build cache with relative rpaths
-    buildcache_cmd("push", "-aur", "-d", mirror_dir, cspec.name)
-
-    # Create mirror index
-    buildcache_cmd("update-index", "-d", mirror_dir)
-
-    # Uninstall the package and deps
-    uninstall_cmd("-y", "--dependents", gspec.name)
-
-
-@pytest.mark.requires_executables(*args)
-@pytest.mark.maybeslow
-@pytest.mark.nomockstage
 @pytest.mark.usefixtures(
     "default_config", "cache_directory", "install_dir_default_layout", "test_mirror"
 )

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -217,13 +217,13 @@ def test_default_rpaths_create_install_default_layout(mirror_dir):
     uninstall_cmd("-y", "--dependents", gspec.name)
 
     # Test installing from build caches
-    buildcache_cmd("install", "-au", cspec.name, sy_spec.name)
+    buildcache_cmd("install", "-u", cspec.name, sy_spec.name)
 
     # This gives warning that spec is already installed
-    buildcache_cmd("install", "-au", cspec.name)
+    buildcache_cmd("install", "-u", cspec.name)
 
     # Test overwrite install
-    buildcache_cmd("install", "-afu", cspec.name)
+    buildcache_cmd("install", "-fu", cspec.name)
 
     buildcache_cmd("keys", "-f")
     buildcache_cmd("list")
@@ -249,10 +249,10 @@ def test_default_rpaths_install_nondefault_layout(mirror_dir):
 
     # Install some packages with dependent packages
     # test install in non-default install path scheme
-    buildcache_cmd("install", "-au", cspec.name, sy_spec.name)
+    buildcache_cmd("install", "-u", cspec.name, sy_spec.name)
 
     # Test force install in non-default install path scheme
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
 
 @pytest.mark.requires_executables(*args)
@@ -269,19 +269,19 @@ def test_relative_rpaths_install_default_layout(mirror_dir):
     gspec, cspec = Spec("garply").concretized(), Spec("corge").concretized()
 
     # Install buildcache created with relativized rpaths
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
     # This gives warning that spec is already installed
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
     # Uninstall the package and deps
     uninstall_cmd("-y", "--dependents", gspec.name)
 
     # Install build cache
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
     # Test overwrite install
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
 
 @pytest.mark.requires_executables(*args)
@@ -298,7 +298,7 @@ def test_relative_rpaths_install_nondefault(mirror_dir):
     cspec = Spec("corge").concretized()
 
     # Test install in non-default install path scheme and relative path
-    buildcache_cmd("install", "-auf", cspec.name)
+    buildcache_cmd("install", "-uf", cspec.name)
 
 
 def test_push_and_fetch_keys(mock_gnupghome):
@@ -516,7 +516,7 @@ def test_update_sbang(tmpdir, test_mirror):
         assert new_spec.dag_hash() == old_spec.dag_hash()
 
         # Install package from buildcache
-        buildcache_cmd("install", "-a", "-u", "-f", new_spec.name)
+        buildcache_cmd("install", "-u", "-f", new_spec.name)
 
         # Continue blowing away caches
         bindist.clear_spec_cache()

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -291,7 +291,7 @@ def test_ci_workarounds():
     def make_rebuild_index_job(use_artifact_buildcache, optimize, use_dependencies):
         result = {
             "stage": "stage-rebuild-index",
-            "script": "spack buildcache update-index --mirror-url s3://mirror",
+            "script": "spack buildcache update-index s3://mirror",
             "tags": ["tag-0", "tag-1"],
             "image": {"name": "spack/centos7", "entrypoint": [""]},
             "after_script": ['rm -rf "./spack"'],

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -85,7 +85,7 @@ def tests_buildcache_create(install_mockery, mock_fetch, monkeypatch, tmpdir):
     pkg = "trivial-install-test-package"
     install(pkg)
 
-    buildcache("push", "-d", str(tmpdir), "--unsigned", pkg)
+    buildcache("push", "--unsigned", str(tmpdir), pkg)
 
     spec = Spec(pkg).concretized()
     tarball_path = spack.binary_distribution.tarball_path_name(spec, ".spack")
@@ -105,7 +105,7 @@ def tests_buildcache_create_env(
         add(pkg)
         install()
 
-        buildcache("push", "-d", str(tmpdir), "--unsigned")
+        buildcache("push", "--unsigned", str(tmpdir))
 
     spec = Spec(pkg).concretized()
     tarball_path = spack.binary_distribution.tarball_path_name(spec, ".spack")
@@ -118,7 +118,7 @@ def test_buildcache_create_fails_on_noargs(tmpdir):
     """Ensure that buildcache create fails when given no args or
     environment."""
     with pytest.raises(spack.main.SpackCommandError):
-        buildcache("push", "-d", str(tmpdir), "--unsigned")
+        buildcache("push", "--unsigned", str(tmpdir))
 
 
 def test_buildcache_create_fail_on_perm_denied(install_mockery, mock_fetch, monkeypatch, tmpdir):
@@ -127,7 +127,7 @@ def test_buildcache_create_fail_on_perm_denied(install_mockery, mock_fetch, monk
 
     tmpdir.chmod(0)
     with pytest.raises(OSError) as error:
-        buildcache("push", "-d", str(tmpdir), "--unsigned", "trivial-install-test-package")
+        buildcache("push", "--unsigned", str(tmpdir), "trivial-install-test-package")
     assert error.value.errno == errno.EACCES
     tmpdir.chmod(0o700)
 
@@ -159,11 +159,11 @@ def test_update_key_index(
     # Put installed package in the buildcache, which, because we're signing
     # it, should result in the public key getting pushed to the buildcache
     # as well.
-    buildcache("push", "-a", "-d", mirror_dir.strpath, s.name)
+    buildcache("push", "-a", mirror_dir.strpath, s.name)
 
     # Now make sure that when we pass the "--keys" argument to update-index
     # it causes the index to get update.
-    buildcache("update-index", "--keys", "-d", mirror_dir.strpath)
+    buildcache("update-index", "--keys", mirror_dir.strpath)
 
     key_dir_list = os.listdir(os.path.join(mirror_dir.strpath, "build_cache", "_pgp"))
 
@@ -213,27 +213,25 @@ def test_buildcache_sync(
     # Install a package and put it in the buildcache
     s = Spec(out_env_pkg).concretized()
     install(s.name)
-    buildcache("push", "-u", "-f", "-a", "--mirror-url", src_mirror_url, s.name)
+    buildcache("push", "-u", "-f", "-a", src_mirror_url, s.name)
 
     env("create", "test")
     with ev.read("test"):
         add(in_env_pkg)
         install()
-        buildcache("push", "-u", "-f", "-a", "--mirror-url", src_mirror_url, in_env_pkg)
+        buildcache("push", "-u", "-f", "-a", src_mirror_url, in_env_pkg)
 
         # Now run the spack buildcache sync command with all the various options
         # for specifying mirrors
 
         # Use urls to specify mirrors
-        buildcache(
-            "sync", "--src-mirror-url", src_mirror_url, "--dest-mirror-url", dest_mirror_url
-        )
+        buildcache("sync", src_mirror_url, dest_mirror_url)
 
         verify_mirror_contents()
         shutil.rmtree(dest_mirror_dir)
 
         # Use local directory paths to specify fs locations
-        buildcache("sync", "--src-directory", src_mirror_dir, "--dest-directory", dest_mirror_dir)
+        buildcache("sync", src_mirror_dir, dest_mirror_dir)
 
         verify_mirror_contents()
         shutil.rmtree(dest_mirror_dir)
@@ -242,7 +240,7 @@ def test_buildcache_sync(
         mirror("add", "src", src_mirror_url)
         mirror("add", "dest", dest_mirror_url)
 
-        buildcache("sync", "--src-mirror-name", "src", "--dest-mirror-name", "dest")
+        buildcache("sync", "src", "dest")
 
         verify_mirror_contents()
 
@@ -260,7 +258,7 @@ def test_buildcache_create_install(
     pkg = "trivial-install-test-package"
     install(pkg)
 
-    buildcache("push", "-d", str(tmpdir), "--unsigned", pkg)
+    buildcache("push", "--unsigned", str(tmpdir), pkg)
 
     spec = Spec(pkg).concretized()
     tarball_path = spack.binary_distribution.tarball_path_name(spec, ".spack")
@@ -324,12 +322,12 @@ def test_correct_specs_are_pushed(
 
     monkeypatch.setattr(spack.binary_distribution, "push_or_raise", fake_push)
 
-    buildcache_create_args = ["create", "-d", str(tmpdir), "--unsigned"]
+    buildcache_create_args = ["create", "--unsigned"]
 
     if things_to_install != "":
         buildcache_create_args.extend(["--only", things_to_install])
 
-    buildcache_create_args.extend([slash_hash])
+    buildcache_create_args.extend([str(tmpdir), slash_hash])
 
     buildcache(*buildcache_create_args)
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1647,7 +1647,7 @@ def test_ci_generate_bootstrap_prune_dag(
     install_cmd("gcc@=12.2.0%gcc@10.2.1")
 
     # Put installed compiler in the buildcache
-    buildcache_cmd("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, "gcc@12.2.0%gcc@10.2.1")
+    buildcache_cmd("push", "-u", "-a", "-f", mirror_dir.strpath, "gcc@12.2.0%gcc@10.2.1")
 
     # Now uninstall the compiler
     uninstall_cmd("-y", "gcc@12.2.0%gcc@10.2.1")
@@ -1662,7 +1662,7 @@ def test_ci_generate_bootstrap_prune_dag(
     install_cmd("--no-check-signature", "b%gcc@=12.2.0")
 
     # Put spec built with installed compiler in the buildcache
-    buildcache_cmd("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, "b%gcc@12.2.0")
+    buildcache_cmd("push", "-u", "-a", "-f", mirror_dir.strpath, "b%gcc@12.2.0")
 
     # Now uninstall the spec
     uninstall_cmd("-y", "b%gcc@12.2.0")

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1055,7 +1055,7 @@ spack:
     )
 
     install_cmd("archive-files")
-    buildcache_cmd("push", "-a", "-f", "-u", "--mirror-url", mirror_url, "archive-files")
+    buildcache_cmd("push", "-a", "-f", "-u", mirror_url, "archive-files")
 
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
@@ -1155,8 +1155,8 @@ spack:
         second_ci_yaml = str(tmpdir.join(".gitlab-ci-2.yml"))
         with ev.read("test"):
             install_cmd()
-            buildcache_cmd("push", "-u", "--mirror-url", mirror_url, "patchelf")
-            buildcache_cmd("update-index", "--mirror-url", mirror_url, output=str)
+            buildcache_cmd("push", "-u", mirror_url, "patchelf")
+            buildcache_cmd("update-index", mirror_url, output=str)
 
             # This generate should not trigger a rebuild of patchelf, since it's in
             # the main mirror referenced in the environment.
@@ -1297,7 +1297,7 @@ spack:
             mirror_cmd("rm", "test-ci")
 
             # Test generating buildcache index while we have bin mirror
-            buildcache_cmd("update-index", "--mirror-url", mirror_url)
+            buildcache_cmd("update-index", mirror_url)
             index_path = os.path.join(buildcache_path, "index.json")
             with open(index_path) as idx_fd:
                 index_object = json.load(idx_fd)
@@ -1613,7 +1613,7 @@ spack:
                 ypfd.write(spec_json)
 
             install_cmd("--add", "--keep-stage", "-f", json_path)
-            buildcache_cmd("push", "-u", "-a", "-f", "--mirror-url", mirror_url, "callpath")
+            buildcache_cmd("push", "-u", "-a", "-f", mirror_url, "callpath")
             ci_cmd("rebuild-index")
 
             buildcache_path = os.path.join(mirror_dir.strpath, "build_cache")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1138,7 +1138,7 @@ def test_install_use_buildcache(
 
     # Populate the buildcache
     install(package_name)
-    buildcache("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, package_name, dependency_name)
+    buildcache("push", "-u", "-a", "-f", mirror_dir.strpath, package_name, dependency_name)
 
     # Uninstall the all of the packages for clean slate
     uninstall("-y", "-a")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -966,7 +966,7 @@ def test_compiler_bootstrap_from_binary_mirror(
     install("gcc@=10.2.0")
 
     # Put installed compiler in the buildcache
-    buildcache("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, "gcc@10.2.0")
+    buildcache("push", "-u", "-a", "-f", mirror_dir.strpath, "gcc@10.2.0")
 
     # Now uninstall the compiler
     uninstall("-y", "gcc@10.2.0")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -235,7 +235,7 @@ def test_mirror_destroy(
 
     # Put a binary package in a buildcache
     install("--no-cache", spec_name)
-    buildcache("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, spec_name)
+    buildcache("push", "-u", "-a", "-f", mirror_dir.strpath, spec_name)
 
     contents = os.listdir(mirror_dir.strpath)
     assert "build_cache" in contents
@@ -245,7 +245,7 @@ def test_mirror_destroy(
 
     assert not os.path.exists(mirror_dir.strpath)
 
-    buildcache("push", "-u", "-a", "-f", "-d", mirror_dir.strpath, spec_name)
+    buildcache("push", "-u", "-a", "-f", mirror_dir.strpath, spec_name)
 
     contents = os.listdir(mirror_dir.strpath)
     assert "build_cache" in contents

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -100,7 +100,7 @@ echo $PATH"""
     parser = argparse.ArgumentParser()
     buildcache.setup_parser(parser)
 
-    create_args = ["create", "-a", "-f", "-d", mirror_path, pkghash]
+    create_args = ["create", "-a", "-f", mirror_path, pkghash]
     # Create a private key to sign package with if gpg2 available
     spack.util.gpg.create(
         name="test key 1", expires="0", email="spack@googlegroups.com", comment="Spack test key"
@@ -116,7 +116,7 @@ echo $PATH"""
     # Uninstall the package
     pkg.do_uninstall(force=True)
 
-    install_args = ["install", "-a", "-f", pkghash]
+    install_args = ["install", "-f", pkghash]
     args = parser.parse_args(install_args)
     # Test install
     buildcache.buildcache(parser, args)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -131,30 +131,6 @@ echo $PATH"""
     assert buildinfo["relocate_textfiles"] == ["dummy.txt"]
     assert buildinfo["relocate_links"] == ["link_to_dummy.txt"]
 
-    # create build cache with relative path
-    create_args.insert(create_args.index("-a"), "-f")
-    create_args.insert(create_args.index("-a"), "-r")
-    args = parser.parse_args(create_args)
-    buildcache.buildcache(parser, args)
-
-    # Uninstall the package
-    pkg.do_uninstall(force=True)
-
-    args = parser.parse_args(install_args)
-    buildcache.buildcache(parser, args)
-
-    # test overwrite install
-    install_args.insert(install_args.index("-a"), "-f")
-    args = parser.parse_args(install_args)
-    buildcache.buildcache(parser, args)
-
-    files = os.listdir(spec.prefix)
-    assert "link_to_dummy.txt" in files
-    assert "dummy.txt" in files
-    #    assert os.path.realpath(
-    #        os.path.join(spec.prefix, 'link_to_dummy.txt')
-    #    ) == os.path.realpath(os.path.join(spec.prefix, 'dummy.txt'))
-
     args = parser.parse_args(["keys"])
     buildcache.buildcache(parser, args)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -498,7 +498,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --rel -f --force -u --unsigned -a --allow-root -k --key -d --directory -m --mirror-name --mirror-url --update-index --rebuild-index --spec-file --only"
+        SPACK_COMPREPLY="-h --help -f --force -u --unsigned -a --allow-root -k --key --update-index --rebuild-index --spec-file --only"
     else
         _mirrors
     fi
@@ -507,7 +507,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --rel -f --force -u --unsigned -a --allow-root -k --key -d --directory -m --mirror-name --mirror-url --update-index --rebuild-index --spec-file --only"
+        SPACK_COMPREPLY="-h --help -f --force -u --unsigned -a --allow-root -k --key --update-index --rebuild-index --spec-file --only"
     else
         _mirrors
     fi
@@ -516,7 +516,7 @@ _spack_buildcache_create() {
 _spack_buildcache_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force -m --multiple -a --allow-root -u --unsigned -o --otherarch"
+        SPACK_COMPREPLY="-h --help -f --force -m --multiple -u --unsigned -o --otherarch"
     else
         _all_packages
     fi
@@ -563,7 +563,7 @@ _spack_buildcache_save_specfile() {
 _spack_buildcache_sync() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --manifest-glob --src-directory --src-mirror-name --src-mirror-url --dest-directory --dest-mirror-name --dest-mirror-url"
+        SPACK_COMPREPLY="-h --help --manifest-glob"
     else
         SPACK_COMPREPLY=""
     fi
@@ -572,7 +572,7 @@ _spack_buildcache_sync() {
 _spack_buildcache_update_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -m --mirror-name --mirror-url -k --keys"
+        SPACK_COMPREPLY="-h --help -k --keys"
     else
         _mirrors
     fi
@@ -581,7 +581,7 @@ _spack_buildcache_update_index() {
 _spack_buildcache_rebuild_index() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --directory -m --mirror-name --mirror-url -k --keys"
+        SPACK_COMPREPLY="-h --help -k --keys"
     else
         _mirrors
     fi


### PR DESCRIPTION
- remove `spack buildcache create --rel`
- remove `spack buildcache install --allow-root`
- remove `--mirror-url` / `--mirror-name` / `--directory` in favor of positional arguments