### PR TITLE
GCC: add v 13.1 with Zen4 microarchitecture support

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2083,9 +2083,14 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "10.3:",
+            "versions": "10.3:13.0",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
+          },
+          {
+            "versions": "13.1:",
+            "name": "znver4",
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "clang": [

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -35,6 +35,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     version("master", branch="master")
 
+    version("13.1.0", sha256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86")
+
     version("12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff")
     version("12.1.0", sha256="62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b")
 


### PR DESCRIPTION
Add GCC version 13.1

This version includes full support for the AMD Zen4 CPU architecture and microarchitectures.json has been updated accordingly