### PR TITLE
write_install_manifest: 1 stat call please

### DIFF
--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -16,7 +16,7 @@ import spack.util.file_permissions as fp
 import spack.util.spack_json as sjson
 
 
-def compute_hash(path, block_size=1048576):
+def compute_hash(path: str, block_size: int = 1048576) -> str:
     # why is this not using spack.util.crypto.checksum...
     hasher = hashlib.sha1()
     with open(path, "rb") as file:

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -83,7 +83,7 @@ def check_entry(path, data):
     if s.st_gid != data["group"]:
         res.add_error(path, "group")
 
-    # Because this was poorly implemented in the past, `stat(...).st_mode` was stored
+    # In the past, `stat(...).st_mode` was stored
     # instead of `lstat(...).st_mode`. So, ignore mode errors for symlinks.
     if not stat.S_ISLNK(s.st_mode) and s.st_mode != data["mode"]:
         res.add_error(path, "mode")

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -27,11 +27,11 @@ def compute_hash(path, block_size=1048576):
     return base64.b32encode(hasher.digest()).decode()
 
 
-def create_manifest_entry(path):
+def create_manifest_entry(path) -> dict:
     try:
         s = os.lstat(path)
     except OSError:
-        return
+        return {}
 
     data = {"mode": s.st_mode, "owner": s.st_uid, "group": s.st_gid}
 

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import os
 import stat
+from typing import Any, Dict
 
 import llnl.util.tty as tty
 
@@ -27,13 +28,13 @@ def compute_hash(path, block_size=1048576):
     return base64.b32encode(hasher.digest()).decode()
 
 
-def create_manifest_entry(path) -> dict:
+def create_manifest_entry(path) -> Dict[str, Any]:
     try:
         s = os.lstat(path)
     except OSError:
         return {}
 
-    data = {"mode": s.st_mode, "owner": s.st_uid, "group": s.st_gid}
+    data: Dict[str, Any] = {"mode": s.st_mode, "owner": s.st_uid, "group": s.st_gid}
 
     if stat.S_ISLNK(s.st_mode):
         data["dest"] = os.readlink(path)

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -28,7 +28,7 @@ def compute_hash(path, block_size=1048576):
     return base64.b32encode(hasher.digest()).decode()
 
 
-def create_manifest_entry(path) -> Dict[str, Any]:
+def create_manifest_entry(path: str) -> Dict[str, Any]:
     try:
         s = os.lstat(path)
     except OSError:

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -5,6 +5,7 @@
 import base64
 import hashlib
 import os
+import stat
 
 import llnl.util.tty as tty
 
@@ -14,35 +15,33 @@ import spack.util.file_permissions as fp
 import spack.util.spack_json as sjson
 
 
-def compute_hash(path):
-    with open(path, "rb") as f:
-        sha1 = hashlib.sha1(f.read()).digest()
-        b32 = base64.b32encode(sha1)
-        return b32.decode()
+def compute_hash(path, block_size=1048576):
+    # why is this not using spack.util.crypto.checksum...
+    hasher = hashlib.sha1()
+    with open(path, "rb") as file:
+        while True:
+            data = file.read(block_size)
+            if not data:
+                break
+            hasher.update(data)
+    return base64.b32encode(hasher.digest()).decode()
 
 
 def create_manifest_entry(path):
-    data = {}
+    try:
+        s = os.lstat(path)
+    except OSError:
+        return
 
-    if os.path.exists(path):
-        stat = os.stat(path)
+    data = {"mode": s.st_mode, "owner": s.st_uid, "group": s.st_gid}
 
-        data["mode"] = stat.st_mode
-        data["owner"] = stat.st_uid
-        data["group"] = stat.st_gid
+    if stat.S_ISLNK(s.st_mode):
+        data["dest"] = os.readlink(path)
 
-        if os.path.islink(path):
-            data["type"] = "link"
-            data["dest"] = os.readlink(path)
-
-        elif os.path.isdir(path):
-            data["type"] = "dir"
-
-        else:
-            data["type"] = "file"
-            data["hash"] = compute_hash(path)
-            data["time"] = stat.st_mtime
-            data["size"] = stat.st_size
+    elif stat.S_ISREG(s.st_mode):
+        data["hash"] = compute_hash(path)
+        data["time"] = s.st_mtime
+        data["size"] = s.st_size
 
     return data
 
@@ -75,38 +74,28 @@ def check_entry(path, data):
         res.add_error(path, "added")
         return res
 
-    stat = os.stat(path)
+    s = os.lstat(path)
 
     # Check for all entries
-    if stat.st_mode != data["mode"]:
-        res.add_error(path, "mode")
-    if stat.st_uid != data["owner"]:
+    if s.st_uid != data["owner"]:
         res.add_error(path, "owner")
-    if stat.st_gid != data["group"]:
+    if s.st_gid != data["group"]:
         res.add_error(path, "group")
 
-    # Check for symlink targets  and listed as symlink
-    if os.path.islink(path):
-        if data["type"] != "link":
-            res.add_error(path, "type")
-        if os.readlink(path) != data.get("dest", ""):
-            res.add_error(path, "link")
-
-    # Check directories are listed as directory
-    elif os.path.isdir(path):
-        if data["type"] != "dir":
-            res.add_error(path, "type")
-
-    else:
+    # Because this was poorly implemented in the past, `stat(...).st_mode` was stored
+    # instead of `lstat(...).st_mode`. So, ignore mode errors for symlinks.
+    if not stat.S_ISLNK(s.st_mode) and s.st_mode != data["mode"]:
+        res.add_error(path, "mode")
+    elif stat.S_ISLNK(s.st_mode) and os.readlink(path) != data.get("dest"):
+        res.add_error(path, "link")
+    elif stat.S_ISREG(s.st_mode):
         # Check file contents against hash and listed as file
         # Check mtime and size as well
-        if stat.st_size != data["size"]:
+        if s.st_size != data["size"]:
             res.add_error(path, "size")
-        if stat.st_mtime != data["time"]:
+        if s.st_mtime != data["time"]:
             res.add_error(path, "mtime")
-        if data["type"] != "file":
-            res.add_error(path, "type")
-        if compute_hash(path) != data.get("hash", ""):
+        if compute_hash(path) != data.get("hash"):
             res.add_error(path, "hash")
 
     return res


### PR DESCRIPTION
Spack comes to a crawl post-install of nvhpc, which is partly thanks to
this post install hook which has a lot of redundancy, and isn't correct.

1. There's no need to store "type" because that is inferred from "mode".
2. There are more file types than "symlink", "dir", "file".
3. Don't checksum device type things
4. Don't run 3 stat calls (exists, stat, isdir/islink), but one lstat
   call
5. Don't store stat data of target of symlinks that may even
   point outside the prefix.
6. Do store an entry for dangling symlinks.
7. Don't read entire files into memory on checksum.

I also don't know why `spack.util.crypto` wasn't used for checksumming, but I
guess it's too late for that now.
