### PR TITLE
Update build system for libgridxc

### DIFF
--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -8,15 +8,17 @@ import os
 from spack.package import *
 
 
-class Libgridxc(MakefilePackage):
+class Libgridxc(CMakePackage,MakefilePackage):
     """A library to compute the exchange and correlation energy and potential
     in spherical (i.e. an atom) or periodic systems.
     """
 
     homepage = "https://gitlab.com/siesta-project/libraries/libgridxc"
     git = "https://gitlab.com/siesta-project/libraries/libgridxc.git"
-    url = "https://gitlab.com/siesta-project/libraries/libgridxc/-/archive/libgridxc-0.9.6/libgridxc-libgridxc-0.9.6.tar.gz"
+    url = "https://gitlab.com/siesta-project/libraries/libgridxc/-/archive/1.1.0/libgridxc-1.1.0.tar.gz"
 
+    version("1.1.0", sha256="e7883e57a4db2438ee59437740291c06e0cfe1c8ae1901e4001f32312307e46a")
+    version("0.10.1", sha256="c6b74457e516cba32c334ae4d7b027b18022d16733e05da7570a1ba7f4e4ada2")
     version("0.9.6", sha256="3b89ccc02d65729ea2d7cb291ae1d9b53acd65c1fd144e8846362cffb71b114a")
     version("0.9.5", sha256="98aa34dbaffe360ff332606eebb7c842994244a3114015d89c5a3850298c40aa")
     version("0.9.1", sha256="346735e30dd3a4099532a985b7a491f6d2b882954a527bdac655d87232be5341")
@@ -26,15 +28,33 @@ class Libgridxc(MakefilePackage):
     version("0.8.0", sha256="ff89b3302f850d1d9f651951e4ade20dfa4c71c809a2d86382c6797392064c9c")
     version("0.7.6", sha256="058b80f40c85997eea0eae3f15b7cc8105f817e59564106308b22f57a03b216b")
 
-    depends_on("autoconf@2.69:", type="build")
-    depends_on("automake@1.14:", type="build")
-    depends_on("libtool@2.4.2:", type="build")
-    depends_on("m4", type="build")
+    build_system(
+        conditional("cmake", when="@1.1.0:"),
+        conditional("makefile", when="@:0.10.1"),
+        default="cmake",
+    )
+
+    with when("build_system=makefile"):
+        build_directory = "build"
+        depends_on("autoconf@2.69:", type="build")
+        depends_on("automake@1.14:", type="build")
+        depends_on("libtool@2.4.2:", type="build")
+        depends_on("m4", type="build")
+
+    with when("build_system=cmake"):
+        depends_on("cmake", type="build")
+        depends_on("mpi", type="build")
+
     depends_on("libxc@:4.3.4", when="@0.8.0:")
 
-    build_directory = "build"
-
     parallel = False
+    
+    def cmake_args(self):
+        args = [
+            '-DWITH_MPI=ON',
+            '-DWITH_LIBXC=ON',
+        ]
+        return args
 
     def edit(self, spec, prefix):
         sh = which("sh")
@@ -44,12 +64,18 @@ class Libgridxc(MakefilePackage):
 
     @property
     def build_targets(self):
-        args = ["PREFIX={0}".format(self.prefix), "FC=fc"]
-        if self.spec.satisfies("@0.8.0:"):
-            args += ["WITH_LIBXC=1", "LIBXC_ROOT={0}".format(self.spec["libxc"].prefix)]
+        args = []
+        with when("build_system=makefile"):
+            # Legacy build options
+            if self.spec.satisfies("@:0.10.1"):
+                args += ["PREFIX={0}".format(self.prefix)]
+                if self.spec.satisfies("@0.8.0:0.10.1"):
+                    args += ["WITH_LIBXC=1", "LIBXC_ROOT={0}".format(self.spec["libxc"].prefix)]
         return args
 
+    @when("build_system=makefile")
     def install(self, spec, prefix):
+        # Legacy install options
         mkdirp(join_path(self.prefix, "share", "org.siesta-project"))
         install(
             join_path(self.prefix, "gridxc.mk"),

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -63,14 +63,12 @@ class Libgridxc(CMakePackage,MakefilePackage):
             copy("../extra/fortran.mk", "fortran.mk")
 
     @property
+    @when("build_system=makefile")
     def build_targets(self):
-        args = []
-        with when("build_system=makefile"):
-            # Legacy build options
-            if self.spec.satisfies("@:0.10.1"):
-                args += ["PREFIX={0}".format(self.prefix)]
-                if self.spec.satisfies("@0.8.0:0.10.1"):
-                    args += ["WITH_LIBXC=1", "LIBXC_ROOT={0}".format(self.spec["libxc"].prefix)]
+        # Legacy build options
+        args += ["PREFIX={0}".format(self.prefix)]
+        if self.spec.satisfies("@0.8.0:"):
+            args += ["WITH_LIBXC=1", "LIBXC_ROOT={0}".format(self.spec["libxc"].prefix)]
         return args
 
     @when("build_system=makefile")

--- a/var/spack/repos/builtin/packages/libgridxc/package.py
+++ b/var/spack/repos/builtin/packages/libgridxc/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class Libgridxc(CMakePackage,MakefilePackage):
+class Libgridxc(CMakePackage, MakefilePackage):
     """A library to compute the exchange and correlation energy and potential
     in spherical (i.e. an atom) or periodic systems.
     """
@@ -48,12 +48,9 @@ class Libgridxc(CMakePackage,MakefilePackage):
     depends_on("libxc@:4.3.4", when="@0.8.0:")
 
     parallel = False
-    
+
     def cmake_args(self):
-        args = [
-            '-DWITH_MPI=ON',
-            '-DWITH_LIBXC=ON',
-        ]
+        args = ["-DWITH_MPI=ON", "-DWITH_LIBXC=ON"]
         return args
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libpsml/package.py
+++ b/var/spack/repos/builtin/packages/libpsml/package.py
@@ -12,8 +12,9 @@ class Libpsml(AutotoolsPackage):
 
     homepage = "https://gitlab.com/siesta-project/libraries/libpsml"
     git = "https://gitlab.com/siesta-project/libraries/libpsml.git"
-    url = "https://gitlab.com/siesta-project/libraries/libpsml/-/archive/libpsml-1.1.10/libpsml-libpsml-1.1.10.tar.gz"
+    url = "https://gitlab.com/siesta-project/libraries/libpsml/-/archive/1.1.12/libpsml-1.1.12.tar.gz"
 
+    version("1.1.12", sha256="c61503d5a5de119f970f1bf27aa0ac8059b87e81d1a8013bef1bb7993df44c56")
     version("1.1.10", sha256="ba87ece7d443a42a5db3a119c555a29a391a060dd6f3f5039a2c6ea248b7fe84")
     version("1.1.9", sha256="04b8de33c555ae94a790116cd3cf7b6c9e8ec9a018562edff544a2e04876cf0c")
     version("1.1.8", sha256="77498783be1bc7006819f36c42477b5913464b8c660203f7d6b7f7e25aa29145")

--- a/var/spack/repos/builtin/packages/xmlf90/package.py
+++ b/var/spack/repos/builtin/packages/xmlf90/package.py
@@ -10,12 +10,19 @@ from spack.package import *
 class Xmlf90(AutotoolsPackage):
     """xmlf90 is a suite of libraries to handle XML in Fortran."""
 
-    homepage = "https://launchpad.net/xmlf90"
-    url = "https://launchpad.net/xmlf90/trunk/1.5/+download/xmlf90-1.5.4.tar.gz"
+    homepage = "https://gitlab.com/siesta-project/libraries/xmlf90" 
+    git = "https://gitlab.com/siesta-project/libraries/xmlf90.git" 
+    url = "https://gitlab.com/siesta-project/libraries/xmlf90/-/archive/1.5.6/xmlf90-1.5.6.tar.gz"
 
-    version("1.5.4", sha256="a0b1324ff224d5b5ad1127a6ad4f90979f6b127f1a517f98253eea377237bbe4")
-    version("1.5.3", sha256="a5378a5d9df4b617f51382092999eb0f20fa1a90ab49afbccfd80aa51650d27c")
-    version("1.5.2", sha256="666694db793828d1d1e9aea665f75c75ee21772693465a88b43e6370862abfa6")
+    version("1.5.6", sha256="c4492596c911b668b94fee40a53453f06aef3bc41014b9e2f4b51e640ad20528")
+    version("1.5.4", sha256="6e5bfdd6764afd036a139ff7c084b60e1badcf77aaf3552030168e77aa4eb68b")
+
+    # Launchpad - versions (superceeded by gitlab versions)
+    # homepage = "https://launchpad.net/xmlf90"
+    # url = "https://launchpad.net/xmlf90/trunk/1.5/+download/xmlf90-1.5.4.tar.gz"
+    # version("1.5.4", sha256="a0b1324ff224d5b5ad1127a6ad4f90979f6b127f1a517f98253eea377237bbe4")
+    # version("1.5.3", sha256="a5378a5d9df4b617f51382092999eb0f20fa1a90ab49afbccfd80aa51650d27c")
+    # version("1.5.2", sha256="666694db793828d1d1e9aea665f75c75ee21772693465a88b43e6370862abfa6")
 
     depends_on("autoconf@2.69:", type="build")
     depends_on("automake@1.14:", type="build")

--- a/var/spack/repos/builtin/packages/xmlf90/package.py
+++ b/var/spack/repos/builtin/packages/xmlf90/package.py
@@ -10,8 +10,8 @@ from spack.package import *
 class Xmlf90(AutotoolsPackage):
     """xmlf90 is a suite of libraries to handle XML in Fortran."""
 
-    homepage = "https://gitlab.com/siesta-project/libraries/xmlf90" 
-    git = "https://gitlab.com/siesta-project/libraries/xmlf90.git" 
+    homepage = "https://gitlab.com/siesta-project/libraries/xmlf90"
+    git = "https://gitlab.com/siesta-project/libraries/xmlf90.git"
     url = "https://gitlab.com/siesta-project/libraries/xmlf90/-/archive/1.5.6/xmlf90-1.5.6.tar.gz"
 
     version("1.5.6", sha256="c4492596c911b668b94fee40a53453f06aef3bc41014b9e2f4b51e640ad20528")


### PR DESCRIPTION
Hello.

this updates libraries needed for the latest versions of [siesta](https://gitlab.com/siesta-project/siesta).

LibGridXC has added a new CMake-based build system that supersedes the old system. The package definition now switches build system depending on the version of LibGridXC.