### PR TITLE
Disable module file generation by default

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -40,9 +40,8 @@ modules:
     roots:
      tcl:    $spack/share/spack/modules
      lmod:   $spack/share/spack/lmod
-    # What type of modules to use
-    enable:
-      - tcl
+    # What type of modules to use ("tcl" and/or "lmod")
+    enable: []
 
     tcl:
       all:

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -13,21 +13,14 @@ import spack.modules.common
 def _for_each_enabled(spec, method_name, explicit=None):
     """Calls a method for each enabled module"""
     set_names = set(spack.config.get("modules", {}).keys())
-    # If we have old-style modules enabled, we put those in the default set
-    old_default_enabled = spack.config.get("modules:enable")
-    if old_default_enabled:
-        set_names.add("default")
     for name in set_names:
         enabled = spack.config.get("modules:%s:enable" % name)
-        if name == "default":
-            # combine enabled modules from default and old format
-            enabled = spack.config.merge_yaml(old_default_enabled, enabled)
         if not enabled:
             tty.debug("NO MODULE WRITTEN: list of enabled module files is empty")
             continue
 
-        for type in enabled:
-            generator = spack.modules.module_types[type](spec, name, explicit)
+        for module_type in enabled:
+            generator = spack.modules.module_types[module_type](spec, name, explicit)
             try:
                 getattr(generator, method_name)()
             except RuntimeError as e:

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -3,15 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import spack.config
 import spack.modules
-import spack.modules.common
 
 
 def _for_each_enabled(spec, method_name, explicit=None):
     """Calls a method for each enabled module"""
+    spack.modules.ensure_modules_are_enabled_or_warn()
     set_names = set(spack.config.get("modules", {}).keys())
     for name in set_names:
         enabled = spack.config.get("modules:%s:enable" % name)

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -9,10 +9,15 @@ include Tcl non-hierarchical modules, Lua hierarchical modules, and others.
 
 from __future__ import absolute_import
 
-from .common import disable_modules
+from .common import disable_modules, ensure_modules_are_enabled_or_warn
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
-__all__ = ["TclModulefileWriter", "LmodModulefileWriter", "disable_modules"]
+__all__ = [
+    "TclModulefileWriter",
+    "LmodModulefileWriter",
+    "disable_modules",
+    "ensure_modules_are_enabled_or_warn",
+]
 
 module_types = {"tcl": TclModulefileWriter, "lmod": LmodModulefileWriter}


### PR DESCRIPTION
This follows a poll done in Slack over a month ago. 

Modifications:
- [x] Restore #35564
- [x] Add a warning if custom module file is detected, and module generation is disabled
- [x] Remove a leftover from old module schema in the generation hook

This is an example of a custom `modules.yaml` triggering a warning + an example of "normal" working mode:
![Screenshot from 2023-04-27 21-02-59](https://user-images.githubusercontent.com/4199709/234967469-37f327bb-766a-461c-9777-c015521b144a.png)
