### PR TITLE
Fix superlu-dist flag handling to not discard cflags from compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -132,9 +132,15 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
             flags.append(self.compiler.cxx11_flag)
         if name == "cflags" and "%pgi" not in self.spec:
             flags.append("-std=c99")
-        if name == "cflags" and (self.spec.satisfies("%xl") or self.spec.satisfies("%xl_r")) and self.spec.satisfies("@:6.1.1"):
+        if (
+            name == "cflags"
+            and (self.spec.satisfies("%xl") or self.spec.satisfies("%xl_r"))
+            and self.spec.satisfies("@:6.1.1")
+        ):
             flags.append("-DNoChange")
-        if name == "cflags" and (self.spec.satisfies("%oneapi") or self.spec.satisfies("%arm@23.04:")):
+        if name == "cflags" and (
+            self.spec.satisfies("%oneapi") or self.spec.satisfies("%arm@23.04:")
+        ):
             #
             # 2022 and later Intel OneAPI compilers and Arm compilers version 23.04 and later
             # throw errors compiling some of the non ISO C99 compliant code in this package

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -101,16 +101,6 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
             [spec["parmetis"].prefix.include, spec["metis"].prefix.include],
         )
 
-        if (spec.satisfies("%xl") or spec.satisfies("%xl_r")) and spec.satisfies("@:6.1.1"):
-            append_define("CMAKE_C_FLAGS", "-DNoChange")
-        if spec.satisfies("%oneapi") or spec.satisfies("%arm@23.04:"):
-            #
-            # 2022 and later Intel OneAPI compilers and Arm compilers version 23.04 and later
-            # throw errors compiling some of the non ISO C99 compliant code in this package
-            # see https://reviews.llvm.org/D122983
-            #
-            append_define("CMAKE_C_FLAGS", "-Wno-error=implicit-function-declaration")
-
         append_define("XSDK_INDEX_SIZE", "64" if "+int64" in spec else "32")
 
         append_from_variant("enable_openmp", "openmp")
@@ -142,7 +132,14 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
             flags.append(self.compiler.cxx11_flag)
         if name == "cflags" and "%pgi" not in self.spec:
             flags.append("-std=c99")
-        if name == "cflags" and self.spec.satisfies("%oneapi"):
+        if name == "cflags" and (self.spec.satisfies("%xl") or self.spec.satisfies("%xl_r")) and self.spec.satisfies("@:6.1.1"):
+            flags.append("-DNoChange")
+        if name == "cflags" and (self.spec.satisfies("%oneapi") or self.spec.satisfies("%arm@23.04:")):
+            #
+            # 2022 and later Intel OneAPI compilers and Arm compilers version 23.04 and later
+            # throw errors compiling some of the non ISO C99 compliant code in this package
+            # see https://reviews.llvm.org/D122983
+            #
             flags.append("-Wno-error=implicit-function-declaration")
         return (None, None, flags)
 


### PR DESCRIPTION
Make sure to append additional flags needed for specific compilers in the flag_handler instead of adding them as separate cmake define lines that override the main spack cflags.