### PR TITLE
apfel: add v3.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -17,6 +17,7 @@ class Apfel(AutotoolsPackage):
 
     tags = ["hep"]
 
+    version("3.0.6", sha256="7063c9eee457e030b97926ac166cdaedd84625b31397e1dfd01ae47371fb9f61")
     version("3.0.4", sha256="c7bfae7fe2dc0185981850f2fe6ae4842749339d064c25bf525b4ef412bbb224")
 
     depends_on("swig", when="+python")


### PR DESCRIPTION
Add apfel v3.0.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.