### PR TITLE
gapbs: add v1.4

### DIFF
--- a/var/spack/repos/builtin/packages/gapbs/package.py
+++ b/var/spack/repos/builtin/packages/gapbs/package.py
@@ -20,6 +20,7 @@ class Gapbs(MakefilePackage):
     homepage = "http://gap.cs.berkeley.edu/benchmark.html"
     url = "https://github.com/sbeamer/gapbs/archive/v1.0.tar.gz"
 
+    version("1.4", sha256="d91ecfe364e8c307e9e5535d730ef8ef8554b71d33891b70d0c4665cc11178bb")
     version("1.0", sha256="a7516998c4994592053c7aa0c76282760a8e009865a6b7a1c7c40968be1ca55d")
 
     variant("serial", default=False, description="Version with no parallelism")


### PR DESCRIPTION
Add gapbs v1.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.