### PR TITLE
sandbox: add v2.25

### DIFF
--- a/var/spack/repos/builtin/packages/sandbox/package.py
+++ b/var/spack/repos/builtin/packages/sandbox/package.py
@@ -12,6 +12,7 @@ class Sandbox(AutotoolsPackage):
     homepage = "https://www.gentoo.org/proj/en/portage/sandbox/"
     url = "https://dev.gentoo.org/~mgorny/dist/sandbox-2.12.tar.xz"
 
+    version("2.25", sha256="24055986a1ed9b933da608e41e3284ee53c5a724f3c2457009f8e09e9c581ca8")
     version("2.12", sha256="265a490a8c528237c55ad26dfd7f62336fa5727c82358fc9cfbaa2e52c47fc50")
 
     depends_on("gawk", type="build")


### PR DESCRIPTION
Add sandbox v2.25. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.