### PR TITLE
snap-berkeley: add v2.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/snap-berkeley/package.py
+++ b/var/spack/repos/builtin/packages/snap-berkeley/package.py
@@ -16,6 +16,7 @@ class SnapBerkeley(MakefilePackage):
     url = "https://github.com/amplab/snap/archive/v1.0beta.18.tar.gz"
     maintainers("snehring")
 
+    version("2.0.3", sha256="8a47cfa929827e60d45dbd436ba2d1119cb2161bd5b6be99eaedac01fb6fc33a")
     version("2.0.1", sha256="30f199c583e054c50ca6f3b61f27066640b7c829e5c5e8083841596a2869c064")
     version(
         "1.0beta.18", sha256="9e8a8dc3f17e3f533d34011afe98316c19cbd70cc8b4830375611e003697daee"


### PR DESCRIPTION
Add snap-berkeley v2.0.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.