### PR TITLE
tcpdump: add v4.99.4

### DIFF
--- a/var/spack/repos/builtin/packages/tcpdump/package.py
+++ b/var/spack/repos/builtin/packages/tcpdump/package.py
@@ -16,6 +16,7 @@ class Tcpdump(AutotoolsPackage):
     homepage = "https://www.tcpdump.org/"
     url = "https://www.tcpdump.org/release/tcpdump-4.9.3.tar.gz"
 
+    version("4.99.4", sha256="0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea")
     version("4.99.0", sha256="8cf2f17a9528774a7b41060323be8b73f76024f7778f59c34efa65d49d80b842")
     version("4.9.3", sha256="2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410")
     version("4.9.2", sha256="798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79")


### PR DESCRIPTION
Add tcpdump v4.99.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.