### PR TITLE
root: add vdt to the run environment

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -662,6 +662,8 @@ class Root(CMakePackage):
         # the following vars are copied from thisroot.sh; silence a cppyy warning
         env.set("CLING_STANDARD_PCH", "none")
         env.set("CPPYY_API_PATH", "none")
+        if "+vdt" in self.spec:
+            env.prepend_path("CPATH", self.spec["vdt"].prefix.include)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set("ROOTSYS", self.prefix)
@@ -675,6 +677,8 @@ class Root(CMakePackage):
         if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
+        if "+vdt" in self.spec:
+            env.prepend_path("CPATH", self.spec["vdt"].prefix.include)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.set("ROOTSYS", self.prefix)
@@ -684,3 +688,5 @@ class Root(CMakePackage):
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib.root)
+        if "+vdt" in self.spec:
+            env.prepend_path("CPATH", self.spec["vdt"].prefix.include)


### PR DESCRIPTION
Something that depends on ROOT may depend on vdt implicitly since when compiling with vdt ROOT will include vdt headers, for example. But these headers won't be found as there is no direct dependency on vdt, so they should be added to the run environment when compiling with vdt. I didn't see this issue when building, so I don't think they are needed in the build enviroment