### PR TITLE
deprecate buildcache create --rel, buildcache install --allow-root

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -200,7 +200,7 @@ class BuildcacheBootstrapper(Bootstrapper):
                 matches = spack.store.find([spec_str], multiple=False, query_fn=query)
                 for match in matches:
                     spack.binary_distribution.install_root_node(
-                        match, allow_root=True, unsigned=True, force=True, sha256=pkg_sha256
+                        match, unsigned=True, force=True, sha256=pkg_sha256
                     )
 
     def _install_and_test(

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -43,11 +43,12 @@ def setup_parser(subparser):
     subparsers = subparser.add_subparsers(help="buildcache sub-commands")
 
     create = subparsers.add_parser("create", help=create_fn.__doc__)
+    # TODO: remove from Spack 0.21
     create.add_argument(
         "-r",
         "--rel",
         action="store_true",
-        help="make all rpaths relative before creating tarballs.",
+        help="make all rpaths relative before creating tarballs. (deprecated)",
     )
     create.add_argument(
         "-f", "--force", action="store_true", help="overwrite tarball if it exists."
@@ -130,11 +131,12 @@ def setup_parser(subparser):
     install.add_argument(
         "-m", "--multiple", action="store_true", help="allow all matching packages "
     )
+    # TODO: remove from Spack 0.21
     install.add_argument(
         "-a",
         "--allow-root",
         action="store_true",
-        help="allow install root string in binary files after RPATH substitution",
+        help="allow install root string in binary files after RPATH substitution. (deprecated)",
     )
     install.add_argument(
         "-u",
@@ -449,6 +451,9 @@ def create_fn(args):
             "Spack 0.21, use positional arguments instead."
         )
 
+    if args.rel:
+        tty.warn("The --rel flag is deprecated and will be removed in Spack 0.21")
+
     # TODO: remove this in 0.21. If we have mirror_flag, the first
     # spec is in the positional mirror arg due to argparse limitations.
     input_specs = args.specs
@@ -521,12 +526,13 @@ def install_fn(args):
     if not args.specs:
         tty.die("a spec argument is required to install from a buildcache")
 
+    if args.allow_root:
+        tty.warn("The --allow-root flag is deprecated and will be removed in Spack 0.21")
+
     query = bindist.BinaryCacheQuery(all_architectures=args.otherarch)
     matches = spack.store.find(args.specs, multiple=args.multiple, query_fn=query)
     for match in matches:
-        bindist.install_single_spec(
-            match, allow_root=args.allow_root, unsigned=args.unsigned, force=args.force
-        )
+        bindist.install_single_spec(match, unsigned=args.unsigned, force=args.force)
 
 
 def list_fn(args):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -391,7 +391,7 @@ def _process_binary_cache_tarball(
 
     with timer.measure("install"), spack.util.path.filter_padding():
         binary_distribution.extract_tarball(
-            pkg.spec, download_result, allow_root=False, unsigned=unsigned, force=False
+            pkg.spec, download_result, unsigned=unsigned, force=False
         )
 
         pkg.installed_from_binary_cache = True


### PR DESCRIPTION
`buildcache create --rel`: deprecate this because there is no point in
making things relative before tarballing; on install you need to expand
`$ORIGIN` / `@loader_path` / relative symlinks anyways because some
dependencies may actually be in an upstream, or have different
projections.

`buildcache install --allow-root`: this flag was propagated through a
lot of functions but was ultimately unused.
