### PR TITLE
Setup extra rpaths for oneapi compiler automatically during `add` command

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -52,24 +52,26 @@ class Oneapi(Compiler):
         new_extra_rpaths = extra_rpaths or []
         temp_extra_rpaths = set()
         for path in paths:
-            extra_rpaths = [os.path.abspath(os.path.join(path, "..", "..", "lib")), os.path.abspath(os.path.join(path, "..", "..", "compiler", "lib"))]
+            extra_rpaths = [
+                os.path.abspath(os.path.join(path, "..", "..", "lib")),
+                os.path.abspath(os.path.join(path, "..", "..", "compiler", "lib")),
+            ]
             for extra_rpath in extra_rpaths:
                 if os.path.isdir(extra_rpath):
                     temp_extra_rpaths.add(extra_rpath)
         new_extra_rpaths.extend(temp_extra_rpaths)
         super(Oneapi, self).__init__(
-                cspec,
-                operating_system,
-                target,
-                paths,
-                modules,
-                alias,
-                environment,
-                new_extra_rpaths,
-                enable_implicit_rpaths,
-                **kwargs
-            )
-
+            cspec,
+            operating_system,
+            target,
+            paths,
+            modules,
+            alias,
+            environment,
+            new_extra_rpaths,
+            enable_implicit_rpaths,
+            **kwargs,
+        )
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -52,13 +52,15 @@ class Oneapi(Compiler):
         new_extra_rpaths = extra_rpaths or []
         temp_extra_rpaths = set()
         for path in paths:
-            extra_rpaths = [
-                os.path.abspath(os.path.join(path, "..", "..", "lib")),
-                os.path.abspath(os.path.join(path, "..", "..", "compiler", "lib")),
-            ]
-            for extra_rpath in extra_rpaths:
-                if os.path.isdir(extra_rpath):
-                    temp_extra_rpaths.add(extra_rpath)
+            if path and os.path.exists(path):
+                extra_rpaths = [
+                    os.path.abspath(os.path.join(path, "..", "..", "lib")),
+                    os.path.abspath(os.path.join(path, "..", "..", "compiler", "lib")),
+                ]
+            if extra_rpaths:
+                for extra_rpath in extra_rpaths:
+                    if os.path.isdir(extra_rpath):
+                        temp_extra_rpaths.add(extra_rpath)
         new_extra_rpaths.extend(temp_extra_rpaths)
         super(Oneapi, self).__init__(
             cspec,

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -36,6 +36,41 @@ class Oneapi(Compiler):
     version_argument = "--version"
     version_regex = r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))) (\S+)"
 
+    def __init__(
+        self,
+        cspec,
+        operating_system,
+        target,
+        paths,
+        modules=None,
+        alias=None,
+        environment=None,
+        extra_rpaths=None,
+        enable_implicit_rpaths=None,
+        **kwargs,
+    ):
+        new_extra_rpaths = extra_rpaths or []
+        temp_extra_rpaths = set()
+        for path in paths:
+            extra_rpaths = [os.path.abspath(os.path.join(path, "..", "..", "lib")), os.path.abspath(os.path.join(path, "..", "..", "compiler", "lib"))]
+            for extra_rpath in extra_rpaths:
+                if os.path.isdir(extra_rpath):
+                    temp_extra_rpaths.add(extra_rpath)
+        new_extra_rpaths.extend(temp_extra_rpaths)
+        super(Oneapi, self).__init__(
+                cspec,
+                operating_system,
+                target,
+                paths,
+                modules,
+                alias,
+                environment,
+                new_extra_rpaths,
+                enable_implicit_rpaths,
+                **kwargs
+            )
+
+
     @property
     def verbose_flag(self):
         return "-v"


### PR DESCRIPTION
Currently, after adding oneapi compiler using `spack compiler add` rpaths are not set for oneapi compiler. And users are required to add them manually to yaml files.  Example: https://spack-tutorial.readthedocs.io/en/latest/tutorial_configuration.html#advanced-compiler-configuration 

This patch automates this process