### PR TITLE
pika: Add patches for generic context coroutine stack allocation

### DIFF
--- a/var/spack/repos/builtin/packages/pika/generic_context_allocate_guard_0_10_12.patch
+++ b/var/spack/repos/builtin/packages/pika/generic_context_allocate_guard_0_10_12.patch
@@ -1,0 +1,15 @@
+diff --git a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+index a26314a0..38d4e7f1 100644
+--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
++++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+@@ -92,9 +92,7 @@ namespace pika::threads::coroutines {
+
+             void* allocate(std::size_t size) const
+             {
+-#if defined(_POSIX_VERSION) &&                                                 \
+-    !(defined(__APPLE__) &&                                                    \
+-        (defined(arm64) || defined(__arm64) || defined(__arm64__)))
++#if defined(_POSIX_VERSION)
+                 void* limit = posix::alloc_stack(size);
+                 posix::watermark_stack(limit, size);
+ #else

--- a/var/spack/repos/builtin/packages/pika/generic_context_allocate_guard_0_13_14.patch
+++ b/var/spack/repos/builtin/packages/pika/generic_context_allocate_guard_0_13_14.patch
@@ -1,0 +1,14 @@
+diff --git a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+index 79eabdb7a..0a6028ae8 100644
+--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
++++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+@@ -91,8 +91,7 @@ namespace pika::threads::coroutines {
+ 
+             void* allocate(std::size_t size) const
+             {
+-# if defined(_POSIX_VERSION) &&                                                                    \
+-     !(defined(__APPLE__) && (defined(arm64) || defined(__arm64) || defined(__arm64__)))
++# if defined(_POSIX_VERSION)
+                 void* limit = posix::alloc_stack(size);
+                 posix::watermark_stack(limit, size);
+ # else

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -144,6 +144,11 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     # Patches
     patch("transform_mpi_includes.patch", when="@0.3.0 +mpi")
     patch("mimalloc_no_version_requirement.patch", when="@:0.5 malloc=mimalloc")
+    patch("generic_context_allocate_guard_0_13_14.patch", when="@0.13:0.14 platform=darwin")
+    patch("generic_context_allocate_guard_0_10_12.patch", when="@0.10:0.12 platform=darwin")
+    patch("posix_stack_non_executable_0_13.patch", when="@0.13 platform=darwin")
+    patch("posix_stack_non_executable_0_6_0_12.patch", when="@0.6:0.12 platform=darwin")
+    patch("posix_stack_non_executable_0_1_0_5.patch", when="@:0.5 platform=darwin")
 
     # Fix missing template instantiation on macOS
     patch(

--- a/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_13.patch
+++ b/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_13.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+index 107fe781..be52d9c9 100644
+--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
++++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+@@ -77,7 +77,7 @@ namespace pika::threads::coroutines::detail::posix {
+
+     inline void* alloc_stack(std::size_t size)
+     {
+-        void* real_stack = ::mmap(nullptr, size + EXEC_PAGESIZE, PROT_EXEC | PROT_READ | PROT_WRITE,
++        void* real_stack = ::mmap(nullptr, size + EXEC_PAGESIZE, PROT_READ | PROT_WRITE,
+ #  if defined(__APPLE__)
+             MAP_PRIVATE | MAP_ANON | MAP_NORESERVE,
+ #  elif defined(__FreeBSD__)

--- a/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_1_0_5.patch
+++ b/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_1_0_5.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+index aba1863d..bdbddd2f 100644
+--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
++++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+@@ -80,7 +80,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
+         inline void* alloc_stack(std::size_t size)
+         {
+             void* real_stack = ::mmap(nullptr, size + EXEC_PAGESIZE,
+-                PROT_EXEC | PROT_READ | PROT_WRITE,
++                PROT_READ | PROT_WRITE,
+ #if defined(__APPLE__)
+                 MAP_PRIVATE | MAP_ANON | MAP_NORESERVE,
+ #elif defined(__FreeBSD__)

--- a/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_6_0_12.patch
+++ b/var/spack/repos/builtin/packages/pika/posix_stack_non_executable_0_6_0_12.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+index d53ac752..7c02f781 100644
+--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
++++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+@@ -79,7 +79,7 @@ namespace pika::threads::coroutines::detail::posix {
+     inline void* alloc_stack(std::size_t size)
+     {
+         void* real_stack = ::mmap(nullptr, size + EXEC_PAGESIZE,
+-            PROT_EXEC | PROT_READ | PROT_WRITE,
++            PROT_READ | PROT_WRITE,
+ #if defined(__APPLE__)
+             MAP_PRIVATE | MAP_ANON | MAP_NORESERVE,
+ #elif defined(__FreeBSD__)


### PR DESCRIPTION
This backports one patch that will be included in the upcoming 0.15.0 release and another that was included in 0.14.0 for macOS on M1/M2. The patches come in multiple variants because of formatting changes between versions. I'm backporting these all the way to 0.1.0 because pika is fundamentally broken without these on the M1/M2 chips.