### PR TITLE
intel-tbb: backport GCC 13 support patch

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/gcc_13-2021.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/gcc_13-2021.patch
@@ -1,0 +1,27 @@
+From b66c3b217f1954e31ea6f40a2416dd3264861c66 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Tue, 21 Feb 2023 09:36:33 +0000
+Subject: [PATCH] test: common: include <cstdlib> for abort() (fix build with
+ GCC 13)
+
+GCC 13 (as usual for new compiler releases) shuffles around some
+internal includes and so <cstdint> etc is no longer transitively included.
+
+See https://www.gnu.org/software/gcc/gcc-13/porting_to.html.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ test/common/utils_assert.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/test/common/utils_assert.h b/test/common/utils_assert.h
+index 1df8ae72acc49fe38dac4d9bed4e9f4f26affcf5..0123ab881e124a800a5ebf8507050148038747d5 100644
+@@ -20,6 +20,8 @@
+ #include "config.h"
+ #include "utils_report.h"
+ 
++#include <cstdlib>
++
+ #define REPORT_FATAL_ERROR REPORT
+ 
+ namespace utils {

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -122,6 +122,10 @@ class IntelTbb(CMakePackage, MakefilePackage):
     patch("gcc_generic-pedantic-2019.patch", level=1, when="@2019.1:2019.5")
     patch("gcc_generic-pedantic-4.4.patch", level=1, when="@:2019.0")
 
+    # Patch and conflicts for GCC 13 support (#1031).
+    patch("gcc_13-2021.patch", when="@2021.1:")
+    conflicts("%gcc@13", when="@:2021.3")
+
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.
     patch("tbb_cmakeConfig-2019.5.patch", level=0, when="@2019.5:2021.0")
     patch("tbb_cmakeConfig.patch", level=0, when="@2017.7:2019.4")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37290

This PR backports https://github.com/oneapi-src/oneTBB/pull/1031 into `intel-tbb @2021.1:` to support building on GCC 13.

There are other bugs that prevent a GCC 13 build from completing for `intel-tbb @:2021.3`, a `conflicts()` is added to disallow those cases.