### PR TITLE
Win: Fix external detection for service accounts

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -218,10 +218,8 @@ def update_configuration(detected_packages, scope=None, buildable=True):
 
 
 def _windows_drive():
-    """Return Windows drive string"""
-    # HOMEDRIVE is set by shell32!RegenerateUserEnvironment
-    # Which is only set when the user logs into a desktop session
-    # Secondary logins or service logins/accounts do not have this
+    """Return Windows drive string extracted from PROGRAMFILES
+    env var, which is garunteed to be defined for all logins"""
     drive = re.match(r"([a-zA-Z]:)", os.environ["PROGRAMFILES"]).group(1)
     return drive
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -219,7 +219,17 @@ def update_configuration(detected_packages, scope=None, buildable=True):
 
 def _windows_drive():
     """Return Windows drive string"""
-    return os.environ["HOMEDRIVE"]
+    # HOMEDRIVE is set by shell32!RegenerateUserEnvironment
+    # Which is only set when the user logs into a desktop session
+    # Secondary logins or service logins/accounts do not have this
+    # set. SYSTEMDRIVE is a fallback that may be set.
+    # If that's not set, parse the drive from %USERPROFILE%
+    home_drive = os.environ.get("HOMEDRIVE")
+    sys_drive = os.environ.get("SYSTEMDRIVE")
+    drive = home_drive if home_drive else sys_drive
+    if not drive:
+        drive = re.match(r"([a-zA-Z]:)", os.environ["USERPROFILE"]).group(1)
+    return drive
 
 
 class WindowsCompilerExternalPaths(object):

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -222,13 +222,7 @@ def _windows_drive():
     # HOMEDRIVE is set by shell32!RegenerateUserEnvironment
     # Which is only set when the user logs into a desktop session
     # Secondary logins or service logins/accounts do not have this
-    # set. SYSTEMDRIVE is a fallback that may be set.
-    # If that's not set, parse the drive from %USERPROFILE%
-    home_drive = os.environ.get("HOMEDRIVE")
-    sys_drive = os.environ.get("SYSTEMDRIVE")
-    drive = home_drive if home_drive else sys_drive
-    if not drive:
-        drive = re.match(r"([a-zA-Z]:)", os.environ["USERPROFILE"]).group(1)
+    drive = re.match(r"([a-zA-Z]:)", os.environ["PROGRAMFILES"]).group(1)
     return drive
 
 


### PR DESCRIPTION
I did not realize that HOMEDRIVE (the ENV variable we currently use to determine which drive we're operating in) is set by `shell32!RegenerateUserEnvironment`, which is never executed for service accounts. Not having this variable set causes the `_windows_drive` method in the detection module to fail on a KeyError. Normally this isn't an issue as most users are running either login or desktop sessions, however those users that use secondary logins or that are running will hit this failure, and Gitlab runners leverage service accounts, so in order to run a Windows Gitlab CI we'll need this PR.