### PR TITLE
bedtools2: add v2.31.0

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -15,6 +15,7 @@ class Bedtools2(Package):
     homepage = "https://github.com/arq5x/bedtools2"
     url = "https://github.com/arq5x/bedtools2/archive/v2.30.0.tar.gz"
 
+    version("2.31.0", sha256="183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec")
     version("2.30.0", sha256="c575861ec746322961cd15d8c0b532bb2a19333f1cf167bbff73230a7d67302f")
     version("2.29.2", sha256="bc2f36b5d4fc9890c69f607d54da873032628462e88c545dd633d2c787a544a5")
     version("2.27.1", sha256="edcac089d84e63a51f85c3c189469daa7d42180272130b046856faad3cf79112")


### PR DESCRIPTION
Add bedtools2 v2.31.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.