### PR TITLE
jsoncpp: add v1.9.5

### DIFF
--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -16,6 +16,7 @@ class Jsoncpp(CMakePackage):
     url = "https://github.com/open-source-parsers/jsoncpp/archive/1.7.3.tar.gz"
     tags = ["windows"]
 
+    version("1.9.5", sha256="f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2")
     version("1.9.4", sha256="e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999")
     version("1.9.3", sha256="8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d")
     version("1.9.2", sha256="77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0")


### PR DESCRIPTION
Add jsoncpp v1.9.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.