### PR TITLE
liblouis: add v3.25.0

### DIFF
--- a/var/spack/repos/builtin/packages/liblouis/package.py
+++ b/var/spack/repos/builtin/packages/liblouis/package.py
@@ -13,6 +13,7 @@ class Liblouis(AutotoolsPackage):
     homepage = "http://liblouis.org/"
     url = "https://github.com/liblouis/liblouis/releases/download/v3.15.0/liblouis-3.15.0.tar.gz"
 
+    version("3.25.0", sha256="d720aa5fcd51de925a28ae801b8b2ca76ee67e2360b40055c679bce8e565f251")
     version("3.17.0", sha256="78c71476467850935d145010c8fcb26b513df1843505b3eb4c41888541a0113d")
     version("3.15.0", sha256="3a381b132b140747e5fcd47354da6cf43959da2167f8bc598430bbac51224467")
     version("3.14.0", sha256="f5b25f8059dd76595aeb419b1522dda78f281a75a7c56dceaaa443f8c437306a")


### PR DESCRIPTION
Add liblouis v3.25.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.