### PR TITLE
oniguruma: add v6.9.8

### DIFF
--- a/var/spack/repos/builtin/packages/oniguruma/package.py
+++ b/var/spack/repos/builtin/packages/oniguruma/package.py
@@ -12,6 +12,7 @@ class Oniguruma(AutotoolsPackage):
     homepage = "https://github.com/kkos/oniguruma"
     url = "https://github.com/kkos/oniguruma/releases/download/v6.9.4/onig-6.9.4.tar.gz"
 
+    version("6.9.8", sha256="28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e")
     version("6.9.4", sha256="4669d22ff7e0992a7e93e116161cac9c0949cd8960d1c562982026726f0e6d53")
     version("6.1.3", sha256="480c850cd7c7f2fcaad0942b4a488e2af01fbb8e65375d34908f558b432725cf")
 


### PR DESCRIPTION
Add oniguruma v6.9.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.