### PR TITLE
runc: add v1.1.6

### DIFF
--- a/var/spack/repos/builtin/packages/runc/package.py
+++ b/var/spack/repos/builtin/packages/runc/package.py
@@ -13,6 +13,7 @@ class Runc(MakefilePackage):
     url = "https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.tar.xz"
     maintainers("bernhardkaindl")
 
+    version("1.1.6", sha256="548506fc1de8f0a4790d8e937eeede17db4beb79c53d66acb4f7ec3edbc31668")
     version("1.1.4", sha256="9f5972715dffb0b2371e4d678c1206cc8c4ec5eb80f2d48755d150bac49be35b")
     version("1.0.2", sha256="740acb49e33eaf4958b5109c85363c1d3900f242d4cab47fbdbefa6f8f3c6909")
 


### PR DESCRIPTION
Add runc v1.1.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.