### PR TITLE
faust: add v2.54.9

### DIFF
--- a/var/spack/repos/builtin/packages/faust/package.py
+++ b/var/spack/repos/builtin/packages/faust/package.py
@@ -14,6 +14,7 @@ class Faust(MakefilePackage):
     homepage = "https://faust.grame.fr/"
     url = "https://github.com/grame-cncm/faust/archive/2.27.2.tar.gz"
 
+    version("2.54.9", sha256="14648f020d77874e6f7411d7ff605820015645bbd4b891b24bee3d3a898e48d2")
     version("2.27.2", sha256="3367a868a93b63582bae29ab8783f1df7a10f4084a2bc1d2258ebf3d6a8c31d7")
     version("2.27.1", sha256="b3e93ca573025b231931e5eb92efc1a1e7f7720902aa3b285061519600a8c417")
 


### PR DESCRIPTION
Add faust v2.54.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.