### PR TITLE
libmmtf-cpp: add v1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/libmmtf-cpp/package.py
+++ b/var/spack/repos/builtin/packages/libmmtf-cpp/package.py
@@ -14,6 +14,7 @@ class LibmmtfCpp(CMakePackage):
     homepage = "https://github.com/rcsb/mmtf-cpp"
     url = "https://github.com/rcsb/mmtf-cpp/archive/v1.0.0.tar.gz"
 
+    version("1.1.0", sha256="021173bdc1814b1d0541c4426277d39df2b629af53151999b137e015418f76c0")
     version("1.0.0", sha256="881f69c4bb56605fa63fd5ca50842facc4947f686cbf678ad04930674d714f40")
 
     depends_on("msgpack-c")


### PR DESCRIPTION
Add libmmtf-cpp v1.1.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.