### PR TITLE
mapserver: add v8.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/mapserver/package.py
+++ b/var/spack/repos/builtin/packages/mapserver/package.py
@@ -17,6 +17,7 @@ class Mapserver(CMakePackage):
     homepage = "https://www.mapserver.org/"
     url = "https://download.osgeo.org/mapserver/mapserver-7.2.1.tar.gz"
 
+    version("8.0.1", sha256="79d23595ef95d61d3d728ae5e60850a3dbfbf58a46953b4fdc8e6e0ffe5748ba")
     version("7.2.1", sha256="9459a7057d5a85be66a41096a5d804f74665381186c37077c94b56e784db6102")
 
     variant("python", default=False, description="Enable Python mapscript support")


### PR DESCRIPTION
Add mapserver v8.0.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.