### PR TITLE
tippecanoe: add v1.36.0

### DIFF
--- a/var/spack/repos/builtin/packages/tippecanoe/package.py
+++ b/var/spack/repos/builtin/packages/tippecanoe/package.py
@@ -13,6 +13,7 @@ class Tippecanoe(MakefilePackage):
     homepage = "https://github.com/mapbox/tippecanoe"
     url = "https://github.com/mapbox/tippecanoe/archive/1.34.3.tar.gz"
 
+    version("1.36.0", sha256="0e385d1244a0d836019f64039ea6a34463c3c2f49af35d02c3bf241aec41e71b")
     version("1.34.3", sha256="7a2dd2376a93d66a82c8253a46dbfcab3eaaaaca7bf503388167b9ee251bee54")
 
     depends_on("sqlite")


### PR DESCRIPTION
Add tippecanoe v1.36.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.