### PR TITLE
beakerlib: add v1.29.3

### DIFF
--- a/var/spack/repos/builtin/packages/beakerlib/package.py
+++ b/var/spack/repos/builtin/packages/beakerlib/package.py
@@ -14,6 +14,7 @@ class Beakerlib(MakefilePackage):
     homepage = "https://github.com/beakerlib/beakerlib"
     url = "https://github.com/beakerlib/beakerlib/archive/1.20.tar.gz"
 
+    version("1.29.3", sha256="f792b86bac8be1a4593dd096c32c1a061102c802c6f5760259a5753b13f6caa1")
     version("1.20", sha256="81f39a0b67adff4c3f4c051ffd26bcf45e19068dee7e81e3b00ee4698587f4e9")
     version("1.19", sha256="4dcaddf70a057ea5810c967cf5194d11850c8b5263ca25533e9e381067288460")
     version("1.18.1", sha256="65e6f81f17fd87f9db783d0b7a7216387a337f4692d3d9e1c40ef427d977c3d5")


### PR DESCRIPTION
Add beakerlib v1.29.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.