### PR TITLE
console-bridge: add v1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/console-bridge/package.py
+++ b/var/spack/repos/builtin/packages/console-bridge/package.py
@@ -15,6 +15,7 @@ class ConsoleBridge(CMakePackage):
     homepage = "https://github.com/ros/console_bridge/"
     url = "https://github.com/ros/console_bridge/archive/1.0.1.tar.gz"
 
+    version("1.0.2", sha256="303a619c01a9e14a3c82eb9762b8a428ef5311a6d46353872ab9a904358be4a4")
     version("1.0.1", sha256="2ff175a9bb2b1849f12a6bf972ce7e4313d543a2bbc83b60fdae7db6e0ba353f")
     version("1.0.0", sha256="880bbded7fcdc71479e9b1efc3ba5353f08eed23f0009c93d6bea8ba3974d078")
     version("0.5.1", sha256="c4ad60c82cd510d4078273a9e210faed572bef6014322456afd14999d2daf130")


### PR DESCRIPTION
Add console-bridge v1.0.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.