### PR TITLE
dropwatch: add v1.5.4

### DIFF
--- a/var/spack/repos/builtin/packages/dropwatch/package.py
+++ b/var/spack/repos/builtin/packages/dropwatch/package.py
@@ -15,6 +15,7 @@ class Dropwatch(AutotoolsPackage):
     homepage = "https://github.com/nhorman/dropwatch"
     url = "https://github.com/nhorman/dropwatch/archive/v1.5.3.tar.gz"
 
+    version("1.5.4", sha256="8c43d0c15d0cb9ce179fa1fb0610611723689a6f551b23c70a7ddc1cf068e8d2")
     version("1.5.3", sha256="b748b66a816c1f94531446c0451da5461a4a31b0949244bb867d741c6ac0148b")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
Add dropwatch v1.5.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.