### PR TITLE
flibcpp: add v1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/flibcpp/package.py
+++ b/var/spack/repos/builtin/packages/flibcpp/package.py
@@ -13,6 +13,7 @@ class Flibcpp(CMakePackage):
     git = "https://github.com/swig-fortran/flibcpp.git"
     url = "https://github.com/swig-fortran/flibcpp/archive/v1.0.1.tar.gz"
 
+    version("1.0.2", sha256="e2c11c1f58ca830eb7ac7f25d66fc3502c4a8d994192ee30c63a1c3b51aac241")
     version("1.0.1", sha256="8569c71eab0257097a6aa666a6d86bdcb6cd6e31244d32cc5b2478d0e936ca7a")
     version("0.5.2", sha256="b9b4eb6431d5b56a54c37f658df7455eafd3d204a5534903b127e0c8a1c9b827")
     version("0.5.1", sha256="76db24ce7893f19ab97ea7260c39490ae1bd1e08a4cc5111ad7e70525a916993")


### PR DESCRIPTION
Add flibcpp v1.0.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.