### PR TITLE
globalarrays: add v5.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/globalarrays/package.py
+++ b/var/spack/repos/builtin/packages/globalarrays/package.py
@@ -21,6 +21,7 @@ class Globalarrays(AutotoolsPackage):
 
     tags = ["e4s"]
 
+    version("5.8.2", sha256="51599e4abfe36f05cecfaffa33be19efbe9e9fa42d035fd3f866469b663c22a2")
     version("5.8", sha256="64df7d1ea4053d24d84ca361e67a6f51c7b17ed7d626cb18a9fbc759f4a078ac")
     version("5.7.2", sha256="8cd0fcfd85bc7f9c168c831616f66f1e8b9b2ca31dc7dd93cc55b27cc7fe7069")
     version("5.7.1", sha256="aa4c6038d792cabf1766e264320da58a555da81a3a36be32b7c4d3e71c08ffa9")


### PR DESCRIPTION
Add globalarrays v5.8.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.