### PR TITLE
gnupg: add v2.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -14,6 +14,7 @@ class Gnupg(AutotoolsPackage):
 
     maintainers("alalazo")
 
+    version("2.4.1", sha256="76b71e5aeb443bfd910ce9cbc8281b617c8341687afb67bae455877972b59de8")
     version("2.4.0", sha256="1d79158dd01d992431dd2e3facb89fdac97127f89784ea2cb610c600fb0c1483")
     version("2.3.8", sha256="540b7a40e57da261fb10ef521a282e0021532a80fd023e75fb71757e8a4969ed")
     version("2.3.7", sha256="ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669")


### PR DESCRIPTION
Add gnupg v2.4.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.