### PR TITLE
heaptrack: add v1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/heaptrack/package.py
+++ b/var/spack/repos/builtin/packages/heaptrack/package.py
@@ -13,6 +13,7 @@ class Heaptrack(CMakePackage):
     homepage = "https://github.com/KDE/heaptrack"
     url = "https://github.com/KDE/heaptrack/archive/v1.1.0.tar.gz"
 
+    version("1.3.0", sha256="794b067772f4e4219bb7b6ff1bc1b2134b1b242e748a2cc5c47626040c631956")
     version("1.1.0", sha256="bd247ac67d1ecf023ec7e2a2888764bfc03e2f8b24876928ca6aa0cdb3a07309")
 
     depends_on("boost@1.41: +program_options+exception+filesystem+system+iostreams+container")


### PR DESCRIPTION
Add heaptrack v1.3.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.