### PR TITLE
hunspell: add v1.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/hunspell/package.py
+++ b/var/spack/repos/builtin/packages/hunspell/package.py
@@ -12,6 +12,7 @@ class Hunspell(AutotoolsPackage):
     homepage = "https://hunspell.github.io/"
     url = "https://github.com/hunspell/hunspell/archive/v1.6.0.tar.gz"
 
+    version("1.7.2", sha256="69fa312d3586c988789266eaf7ffc9861d9f6396c31fc930a014d551b59bbd6e")
     version("1.7.0", sha256="bb27b86eb910a8285407cf3ca33b62643a02798cf2eef468c0a74f6c3ee6bc8a")
     version("1.6.0", sha256="512e7d2ee69dad0b35ca011076405e56e0f10963a02d4859dbcc4faf53ca68e2")
 


### PR DESCRIPTION
Add hunspell v1.7.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.