### PR TITLE
kubernetes: add v1.27.1

### DIFF
--- a/var/spack/repos/builtin/packages/kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/kubernetes/package.py
@@ -16,6 +16,7 @@ class Kubernetes(Package):
 
     maintainers("alecbcs")
 
+    version("1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f")
     version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
 
     # Deprecated versions


### PR DESCRIPTION
Add kubernetes v1.27.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.