### PR TITLE
libibumad: add v44.1

### DIFF
--- a/var/spack/repos/builtin/packages/libibumad/package.py
+++ b/var/spack/repos/builtin/packages/libibumad/package.py
@@ -13,6 +13,7 @@ class Libibumad(CMakePackage):
     homepage = "https://github.com/linux-rdma/"
     url = "https://github.com/linux-rdma/rdma-core/archive/v25.0.tar.gz"
 
+    version("44.1", sha256="1dec7e25dd248f1ff4d262e5674297205ad9113a4ff25ab7ecbb75a824adac27")
     version("25.0", sha256="d735bd091d13e8a68ce650e432b5bdc934fc7f1d5fb42a6045278a5b3f7fe48b")
 
     depends_on("libnl")


### PR DESCRIPTION
Add libibumad v44.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.