### PR TITLE
libjwt: add v1.15.2

### DIFF
--- a/var/spack/repos/builtin/packages/libjwt/package.py
+++ b/var/spack/repos/builtin/packages/libjwt/package.py
@@ -15,6 +15,7 @@ class Libjwt(AutotoolsPackage):
 
     maintainers("bollig")
 
+    version("1.15.2", sha256="a366531ad7d5d559b1f8c982e7bc7cece7eaefacf7e91ec36d720609c01dc410")
     version("1.13.1", sha256="4df55ac89c6692adaf3badb43daf3241fd876612c9ab627e250dfc4bb59993d9")
     version("1.12.1", sha256="d29e4250d437340b076350e910e69fd5539ef8b92528d0306745cec0e343cc17")
     version("1.12.0", sha256="eaf5d8b31d867c02dde767efa2cf494840885a415a3c9a62680bf870a4511bee")


### PR DESCRIPTION
Add libjwt v1.15.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.