### PR TITLE
mixcr: add v4.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/mixcr/package.py
+++ b/var/spack/repos/builtin/packages/mixcr/package.py
@@ -18,6 +18,7 @@ class Mixcr(Package):
     homepage = "https://mixcr.readthedocs.io/en/master/index.html"
     url = "https://github.com/milaboratory/mixcr/releases/download/v3.0.2/mixcr-3.0.2.zip"
 
+    version("4.3.2", sha256="8f67cda8e55eeee66b46db0f33308418b6ddb63ca8914623035809ccb5aae2c2")
     version("3.0.2", sha256="b4dcad985053438d5f5590555f399edfbd8cb514e1b9717620ee0ad0b5eb6b33")
 
     depends_on("java@8:")


### PR DESCRIPTION
Add mixcr v4.3.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.