### PR TITLE
pharokka: add v1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/pharokka/package.py
+++ b/var/spack/repos/builtin/packages/pharokka/package.py
@@ -14,6 +14,7 @@ class Pharokka(Package):
     homepage = "https://github.com/gbouras13/pharokka"
     url = "https://github.com/gbouras13/pharokka/archive/refs/tags/v1.1.0.tar.gz"
 
+    version("1.3.2", sha256="e12b20beada9c261f51dd37a9aa7afe83291363035dc53478c42fb67882900e1")
     version("1.1.0", sha256="57d546f501f201117f5d8037ac47c0d83ccd1ec518080145e8f28d3e9843fba6")
 
     depends_on("py-bcbio-gff", type="run")


### PR DESCRIPTION
Add pharokka v1.3.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.