### PR TITLE
restic: add v0.15.2

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -14,6 +14,7 @@ class Restic(Package):
 
     maintainers("alecbcs")
 
+    version("0.15.2", sha256="52aca841486eaf4fe6422b059aa05bbf20db94b957de1d3fca019ed2af8192b7")
     version("0.15.1", sha256="fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52")
     version("0.15.0", sha256="85a6408cfb0798dab52335bcb00ac32066376c32daaa75461d43081499bc7de8")
     version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")


### PR DESCRIPTION
Add restic v0.15.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.