### PR TITLE
shapeit4: add v4.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/shapeit4/package.py
+++ b/var/spack/repos/builtin/packages/shapeit4/package.py
@@ -13,6 +13,7 @@ class Shapeit4(MakefilePackage):
     homepage = "https://odelaneau.github.io/shapeit4/"
     url = "https://github.com/odelaneau/shapeit4/archive/v4.1.3.tar.gz"
 
+    version("4.2.2", sha256="9f109e307b5cc22ab68e7bf77de2429a9bbb2212d66303386e6a3dd81a5bc556")
     version("4.1.3", sha256="d209731277b00bca1e3478b7e0a0cbe40fbe23826c3d640ad12e0dd6033cbbb8")
 
     maintainers("ilbiondo")


### PR DESCRIPTION
Add shapeit4 v4.2.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.