### PR TITLE
whizard: Add another url for fetching

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -12,7 +12,10 @@ class Whizard(AutotoolsPackage):
     and simulated event samples."""
 
     homepage = "whizard.hepforge.org"
-    url = "https://whizard.hepforge.org/downloads/?f=whizard-2.8.3.tar.gz"
+    urls = [
+        "https://launchpad.net/whizard/3.1.x/3.1.2/+download/whizard-3.1.2.tar.gz",
+        "https://whizard.hepforge.org/downloads/?f=whizard-2.8.3.tar.gz",
+    ]
     git = "https://gitlab.tp.nt.uni-siegen.de/whizard/public.git"
 
     tags = ["hep"]


### PR DESCRIPTION
The hepforge mirror seems to be down often (like yesterday and today) and the launchpad one was proposed by the authors. This has been tested and works fine.