### PR TITLE
intel-mpi-benchmarks: Open P2P variant for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -54,7 +54,7 @@ class IntelMpiBenchmarks(MakefilePackage):
     variant("ext", default=True, description="Build EXT benchmark")
     variant("io", default=True, description="Build IO benchmark")
     variant("nbc", default=True, description="Build NBC benchmark")
-    variant("p2p", default=True, description="Build P2P benchmark", when="@2018")
+    variant("p2p", default=True, description="Build P2P benchmark", when="@2018:")
     variant("rma", default=True, description="Build RMA benchmark")
     variant("mt", default=True, description="Build MT benchmark")
 


### PR DESCRIPTION
Intel MPI Benchmark `IMB-P2P` of point-to-point tests is available for versions newer than 2018.

With this change:
```
$ ls $(spack location -i intel-mpi-benchmarks@2021.3+p2p)/bin
IMB-EXT  IMB-IO  IMB-MPI1  IMB-MT  IMB-NBC  IMB-P2P  IMB-RMA
```

I believe the intention of 46828eff1b4e79a01dc7deb00b962d9f75b7a141 was to set the P2P variant as "2018 or later" -

> ...
>
> \* p2p benchmark is not included on older versions
>
> ...