### PR TITLE
intel-mpi-benchmarks: Add MPI implementation check variant

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -57,7 +57,9 @@ class IntelMpiBenchmarks(MakefilePackage):
     variant("p2p", default=True, description="Build P2P benchmark", when="@2018")
     variant("rma", default=True, description="Build RMA benchmark")
     variant("mt", default=True, description="Build MT benchmark")
-    variant("check", default=False, description="Build with MPI implementation verification checks")
+    variant(
+        "check", default=False, description="Build with MPI implementation verification checks"
+    )
 
     # Handle missing variants in previous versions
     conflicts("+p2p", when="@:2019")

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -57,6 +57,7 @@ class IntelMpiBenchmarks(MakefilePackage):
     variant("p2p", default=True, description="Build P2P benchmark", when="@2018")
     variant("rma", default=True, description="Build RMA benchmark")
     variant("mt", default=True, description="Build MT benchmark")
+    variant("check", default=False, description="Build with MPI implementation verification checks")
 
     # Handle missing variants in previous versions
     conflicts("+p2p", when="@:2019")
@@ -101,8 +102,11 @@ class IntelMpiBenchmarks(MakefilePackage):
         if "+mt" in spec:
             targets.append("MT")
 
-        if self.spec.satisfies("@2019:"):
+        if spec.satisfies("@2019:"):
             targets = ["TARGET=" + target for target in targets]
+
+        if "+check" in spec:
+            targets.append("CPPFLAGS=-DCHECK")
 
         return targets
 


### PR DESCRIPTION
* Adds MPI implementation checks as described in the documentation: [Intel MPI Library/Overview/Checking Results ](https://www.intel.com/content/www/us/en/docs/mpi-library/user-guide-benchmarks/2021-2/checking-results.html)

Default value is `False` as this is recommended disabled for actual benchmarking. 

* I've also included a very small edit to drop `self.` where it's unnecessary due to already being defined above.


(@carsonwoods sorry for the double PRs today!)