### PR TITLE
elfutils: unconditionally depend on zstd

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -48,7 +48,6 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     # Libraries for reading compressed DWARF sections.
     variant("bzip2", default=False, description="Support bzip2 compressed sections.")
     variant("xz", default=False, description="Support xz (lzma) compressed sections.")
-    variant("zstd", default=False, description="Support zstd compressed sections.", when="@0.182:")
 
     # Native language support from libintl.
     variant("nls", default=True, description="Enable Native Language Support.")
@@ -69,7 +68,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     depends_on("bzip2", type="link", when="+bzip2")
     depends_on("xz", type="link", when="+xz")
-    depends_on("zstd", type="link", when="+zstd")
+    depends_on("zstd", type="link", when="@0.182:")
     depends_on("zlib", type="link")
     depends_on("gettext", when="+nls")
     depends_on("m4", type="build")
@@ -121,10 +120,11 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         else:
             args.append("--without-lzma")
 
-        args.extend(self.with_or_without("zstd", activation_value="prefix"))
-
         # zlib is required
         args.append("--with-zlib=%s" % spec["zlib"].prefix)
+
+        if "@0.182:" in spec:
+            args.append(f"--with-zstd={prefix}")
 
         if "+nls" in spec:
             # configure doesn't use LIBS correctly

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -62,10 +62,11 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         sha256="d786d49c28d7f0c8fc27bab39ca8714e5f4d128c7f09bb18533a8ec99b38dbf8",
     )
 
-    depends_on("bzip2", type="link", when="+bzip2")
-    depends_on("xz", type="link", when="+xz")
-    depends_on("zstd", type="link", when="@0.182:")
+    depends_on("bzip2", type="link")
+    depends_on("xz", type="link")
     depends_on("zlib", type="link")
+    depends_on("zstd", type="link", when="@0.182:")
+
     depends_on("gettext", when="+nls")
     depends_on("m4", type="build")
     depends_on("pkgconfig@0.9.0:", type=("build", "link"))
@@ -105,9 +106,9 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     def configure_args(self):
         spec = self.spec
         args = [
-            "--with-zlib=%s" % spec["zlib"].prefix,
             "--with-bzlib=%s" % spec["bzip2"].prefix,
             "--with-lzma=%s" % spec["xz"].prefix,
+            "--with-zlib=%s" % spec["zlib"].prefix,
         ]
 
         if "@0.182:" in spec:

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -45,10 +45,6 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     version("0.168", sha256="b88d07893ba1373c7dd69a7855974706d05377766568a7d9002706d5de72c276")
     version("0.163", sha256="7c774f1eef329309f3b05e730bdac50013155d437518a2ec0e24871d312f2e23")
 
-    # Libraries for reading compressed DWARF sections.
-    variant("bzip2", default=False, description="Support bzip2 compressed sections.")
-    variant("xz", default=False, description="Support xz (lzma) compressed sections.")
-
     # Native language support from libintl.
     variant("nls", default=True, description="Enable Native Language Support.")
 
@@ -108,23 +104,14 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     def configure_args(self):
         spec = self.spec
-        args = []
-
-        if "+bzip2" in spec:
-            args.append("--with-bzlib=%s" % spec["bzip2"].prefix)
-        else:
-            args.append("--without-bzlib")
-
-        if "+xz" in spec:
-            args.append("--with-lzma=%s" % spec["xz"].prefix)
-        else:
-            args.append("--without-lzma")
-
-        # zlib is required
-        args.append("--with-zlib=%s" % spec["zlib"].prefix)
+        args = [
+            "--with-zlib=%s" % spec["zlib"].prefix,
+            "--with-bzlib=%s" % spec["bzip2"].prefix,
+            "--with-lzma=%s" % spec["xz"].prefix,
+        ]
 
         if "@0.182:" in spec:
-            args.append(f"--with-zstd={prefix}")
+            args.append("--with-zstd=%s" % spec["zstd"].prefix)
 
         if "+nls" in spec:
             # configure doesn't use LIBS correctly

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -120,7 +120,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on("dyninst@12.1.0:", when="@2022.0:")
     depends_on("dyninst@10.2.0:", when="@2021.0:2021.12")
     depends_on("dyninst@9.3.2:", when="@:2020")
-    depends_on("elfutils+bzip2+xz~nls", type="link")
+    depends_on("elfutils~nls", type="link")
     depends_on("gotcha@1.0.3:", when="@:2020.09")
     depends_on("intel-tbb+shared")
     depends_on("libdwarf", when="@:2022.06")


### PR DESCRIPTION
Given that zstd debug section compression is standard, I don't think elfutils
should only depend conditionally on zstd.

Also add xz / bzip2 unconditionally for consistency. Those schemes are not
supported by `ld` / `gold` / `as`, but are small dependencies, so it doesn't
hurt to add them, and they're probably pulled in through libarchive or
other dependencies anyways.

(Hm, I only now realize that `gdb` depends on zlib / zstd directly, I thought
that went through elfutils... well, whatever, this PR could still make sense)