### PR TITLE
gdb: add missing zstd, add system dep for zlib

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -79,6 +79,9 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     # https://bugzilla.redhat.com/show_bug.cgi?id=1829702
     depends_on("python@:3.8", when="@:9.2+python", type=("build", "link", "run"))
     depends_on("xz", when="+xz")
+    depends_on("zlib")
+    depends_on("zstd", when="@13.1:")
+    depends_on("readline")
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")
@@ -88,7 +91,9 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         args = [
-            "--with-system-gdbinit={0}".format(self.prefix.etc.gdbinit),
+            "--with-system-gdbinit={}".format(self.prefix.etc.gdbinit),
+            "--with-system-zlib={}".format(self.spec["zlib"].prefix),
+            "--with-system-readline={}".format(self.spec["readline"].prefix)
             *self.enable_or_disable("lto"),
             *self.with_or_without("quad"),
             *self.enable_or_disable("gold"),
@@ -97,12 +102,15 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
             *self.with_or_without("debuginfod"),
         ]
 
+        if self.spec.satisfies("@13.1:"):
+            args.append("--with-zstd={}".format(self.spec["zstd"].prefix))
+
         if self.spec.version >= Version("11.1"):
-            args.append("--with-gmp={0}".format(self.spec["gmp"].prefix))
+            args.append("--with-gmp={}".format(self.spec["gmp"].prefix))
 
         if "+python" in self.spec:
-            args.append("--with-python={0}".format(self.spec["python"].command))
-            args.append("LDFLAGS={0}".format(self.spec["python"].libs.ld_flags))
+            args.append("--with-python={}".format(self.spec["python"].command))
+            args.append("LDFLAGS={}".format(self.spec["python"].libs.ld_flags))
 
         return args
 

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -81,7 +81,6 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("xz", when="+xz")
     depends_on("zlib")
     depends_on("zstd", when="@13.1:")
-    depends_on("readline")
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")
@@ -92,8 +91,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         args = [
             "--with-system-gdbinit={}".format(self.prefix.etc.gdbinit),
-            "--with-system-zlib={}".format(self.spec["zlib"].prefix),
-            "--with-system-readline={}".format(self.spec["readline"].prefix),
+            "--with-system-zlib",
             *self.enable_or_disable("lto"),
             *self.with_or_without("quad"),
             *self.enable_or_disable("gold"),
@@ -103,7 +101,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
         ]
 
         if self.spec.satisfies("@13.1:"):
-            args.append("--with-zstd={}".format(self.spec["zstd"].prefix))
+            args.append("--with-zstd")
 
         if self.spec.version >= Version("11.1"):
             args.append("--with-gmp={}".format(self.spec["gmp"].prefix))

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -93,7 +93,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
         args = [
             "--with-system-gdbinit={}".format(self.prefix.etc.gdbinit),
             "--with-system-zlib={}".format(self.spec["zlib"].prefix),
-            "--with-system-readline={}".format(self.spec["readline"].prefix)
+            "--with-system-readline={}".format(self.spec["readline"].prefix),
             *self.enable_or_disable("lto"),
             *self.with_or_without("quad"),
             *self.enable_or_disable("gold"),


### PR DESCRIPTION
zstd is necessary for compressed debug sections

avoid that gdb builds its own version of zlib
