### PR TITLE
detect ifx 2023.1, add test

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -34,7 +34,7 @@ class Oneapi(Compiler):
     PrgEnv_compiler = "oneapi"
 
     version_argument = "--version"
-    version_regex = r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))) (\S+)"
+    version_regex = r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -263,6 +263,11 @@ def test_intel_version_detection(version_str, expected_version):
             "Copyright (C) 1985-2021 Intel Corporation. All rights reserved.",
             "2022.0.0",
         ),
+        (  # IFX
+            "ifx (IFX) 2023.1.0 20230320\n"
+            "Copyright (C) 1985-2023 Intel Corporation. All rights reserved.",
+            "2023.1.0",
+        ),
     ],
 )
 def test_oneapi_version_detection(version_str, expected_version):


### PR DESCRIPTION
@prstrnn 

`spack compiler find` detected icx/icpx 2023.1.0, but did not find ifx because of a change in the version string. Support the new string and add a test.