### PR TITLE
add openmp_max_threads variant and enable avx 512 optimizations for icelake

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -114,6 +114,10 @@ class Gromacs(CMakePackage, CudaPackage):
         "+mdrun_only", when="@2021:", msg="mdrun-only build option was removed for GROMACS 2021."
     )
     variant("openmp", default=True, description="Enables OpenMP at configure time")
+    variant("openmp_max_threads", default="none", description="Max number of OpenMP threads")
+    conflicts(
+        "+openmp_max_threads", when="~openmp", msg="OpenMP is off but OpenMP Max threads is set"
+    )
     variant(
         "sve",
         default=True,
@@ -522,6 +526,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         elif target == "mic_knl":
             # Intel KNL
             options.append("-DGMX_SIMD=AVX_512_KNL")
+        elif target == "icelake" or target == "cascadelake" or target == "skylake_avx512":
+            # Intel platforms with AVX512 support
+            options.append("-DGMX_SIMD=AVX_512")
         else:
             # Other architectures
             simd_features = [
@@ -568,6 +575,11 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append("-DGMX_CYCLE_SUBCOUNTERS:BOOL=ON")
         else:
             options.append("-DGMX_CYCLE_SUBCOUNTERS:BOOL=OFF")
+
+        if "+openmp" in self.spec and self.spec.variants["openmp_max_threads"].value != "none":
+            options.append(
+                "-DGMX_OPENMP_MAX_THREADS=%s" % self.spec.variants["openmp_max_threads"].value
+            )
 
         if "^mkl" in self.spec:
             # fftw-api@3 is provided by intel-mkl or intel-parllel-studio

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -526,9 +526,6 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         elif target == "mic_knl":
             # Intel KNL
             options.append("-DGMX_SIMD=AVX_512_KNL")
-        elif target == "icelake" or target == "cascadelake" or target == "skylake_avx512":
-            # Intel platforms with AVX512 support
-            options.append("-DGMX_SIMD=AVX_512")
         else:
             # Other architectures
             simd_features = [


### PR DESCRIPTION
Changes in this PR:

* add variant to control openmp_max_threads, tuning this parameter may lead to better performance on some architectures
* force AVX512 optimizations for cascadelake and icelake, currently its not enabled