### PR TITLE
Enable package-specific dependency directives

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -438,7 +438,7 @@ def _execute_version(pkg, ver, **kwargs):
     pkg.versions[version] = kwargs
 
 
-def _depends_on(pkg, spec, when=None, type=default_deptype, patches=None):
+def pkg_depends_on(pkg, spec, when=None, type=default_deptype, patches=None):
     when_spec = make_when_spec(when)
     if not when_spec:
         return
@@ -544,7 +544,7 @@ def depends_on(spec, when=None, type=default_deptype, patches=None):
     """
 
     def _execute_depends_on(pkg):
-        _depends_on(pkg, spec, when=when, type=type, patches=patches)
+        pkg_depends_on(pkg, spec, when=when, type=type, patches=patches)
 
     return _execute_depends_on
 
@@ -565,7 +565,7 @@ def extends(spec, type=("build", "run"), **kwargs):
         if not when_spec:
             return
 
-        _depends_on(pkg, spec, when=when, type=type)
+        pkg_depends_on(pkg, spec, when=when, type=type)
         spec_obj = spack.spec.Spec(spec)
         pkg.extendees[spec_obj.name] = (spec_obj, kwargs)
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -70,7 +70,7 @@ def test_extends_spec(config, mock_packages):
 def test_error_on_anonymous_dependency(config, mock_packages):
     pkg = spack.repo.path.get_pkg_class("a")
     with pytest.raises(spack.directives.DependencyError):
-        spack.directives._depends_on(pkg, "@4.5")
+        spack.directives.pkg_depends_on(pkg, "@4.5")
 
 
 @pytest.mark.regression("34879")


### PR DESCRIPTION
The bulk of the work of the `depends_on(...)` directive is done by the function `_depends_on(pkg, ...)` This function is already used by `directives.extends()` in addition to `directives.depends_on()`. We change its name here to `pkg_depends_on` to allow for its use in recipe-specific directives to enable registration of formulaic dependencies (e.g. `A@N.n.u` -> `B@N.n.u`).