### PR TITLE
fix lhapdf package

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -43,12 +43,12 @@ class Lhapdf(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
-        if self.spec.satisfies("+python") and \
-           "gettext" in self.spec and \
-           "intl" in self.spec["gettext"].libs.names:
-            env.append_flags("LDFLAGS",
-                             "-L"
-                             + self.spec["gettext"].prefix.lib)
+        if (
+            self.spec.satisfies("+python")
+            and "gettext" in self.spec
+            and "intl" in self.spec["gettext"].libs.names
+        ):
+            env.append_flags("LDFLAGS", "-L" + self.spec["gettext"].prefix.lib)
 
     def configure_args(self):
         args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -41,6 +41,15 @@ class Lhapdf(AutotoolsPackage):
     depends_on("py-setuptools", type="build", when="+python")
     depends_on("gettext", type="build", when="+python")
 
+    def setup_build_environment(self, env):
+        # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
+        if self.spec.satisfies("+python") and \
+           "gettext" in self.spec and \
+           "intl" in self.spec["gettext"].libs.names:
+            env.append_flags("LDFLAGS",
+                             "-L"
+                             + self.spec["gettext"].prefix.lib)
+
     def configure_args(self):
         args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]
 


### PR DESCRIPTION
Add the the library path necessary for gettext.  Without this patch, lhapdf will attempt to link in intl library from python but will not get the LIBDIR containing the library.