### PR TITLE
intel-oneapi-mkl: include mpi libs when using +cluster

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -163,7 +163,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         lib_path = self.component_prefix.lib.intel64
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
-        return find_libraries(libs, lib_path, shared=shared)
+        resolved_libs = find_libraries(libs, lib_path, shared=shared)
+        if "+cluster" in self.spec:
+            resolved_libs = resolved_libs + self.spec["mpi"].libs
+        return resolved_libs
 
     def _xlp64_lib(self, lib):
         return lib + ("_ilp64" if "+ilp64" in self.spec else "_lp64")


### PR DESCRIPTION
When +cluster is enabled for intel-oneapi-mkl, include the mpi libs. This makes it more like the other scalapack providers which do not require the using package to link with mpi directly.

See #37374 

Fixes:
```
spack install latte%oneapi ^intel-oneapi-mkl+cluster ^intel-oneapi-mpi
```