### PR TITLE
trilinos: add version 14.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -41,6 +41,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("14.0.0", sha256="054d2fabdf70fce0dfaeb20eed265bd7894045d3e00c3d1ddb72d1c77c339ca1")
     version("13.4.1", sha256="5465cbff3de7ef4ac7d40eeff9d99342c00d9d20eee0a5f64f0a523093f5f1b3")
     version("13.4.0", sha256="39550006e059043b7e2177f10467ae2f77fe639901aee91cbc1e359516ff8d3e")
     version("13.2.0", sha256="0ddb47784ba7b8a6b9a07a4822b33be508feb4ccd54301b2a5d10c9e54524b90")


### PR DESCRIPTION
Develop GitLab CI pipelines are [currently failing in the E4S stack.](https://gitlab.spack.io/spack/spack/-/pipelines/355632) @sethrj helpfully pointed out that we are now building trilinos@develop because xyce requires 13.5.0 or newer (added in PR #36841).

I'm hoping this change will remove the "live at HEAD" dependency on Trilinos and fix our develop builds 🤞 

FYI @eugeneswalker @wspear 