### PR TITLE
Fix buildcache install "==> Error: 'NoneType' object has no attribute 'encode'"

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -511,7 +511,7 @@ def new_relocate_elf_binaries(binaries, prefix_to_prefix):
 
     # Transform to binary string
     prefix_to_prefix = OrderedDict(
-        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items()
+        (k.encode("utf-8"), v.encode("utf-8")) for (k, v) in prefix_to_prefix.items() if k and v
     )
 
     for path in binaries:

--- a/lib/spack/spack/relocate_text.py
+++ b/lib/spack/spack/relocate_text.py
@@ -20,7 +20,9 @@ def encode_path(p: Prefix) -> bytes:
 
 
 def _prefix_to_prefix_as_bytes(prefix_to_prefix) -> Dict[bytes, bytes]:
-    return OrderedDict((encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items())
+    return OrderedDict(
+        (encode_path(k), encode_path(v)) for (k, v) in prefix_to_prefix.items() if k and v
+    )
 
 
 def utf8_path_to_binary_regex(prefix: str):


### PR DESCRIPTION

Installing one of our local packages from a buildcache was causing an error:
==> Error: 'NoneType' object has no attribute 'encode'
which turned out to crop up in a second place once the first was fixed.  This is a suite of packages initially put in a buildcache in Spack 0.16, then pulled out and re-added from Spack 0.19. 

How to reproduce:
```
git clone https://github.com/spack/spack.git tst 
. tst/share/spack/setup-env.sh
git clone https://github.com/FNALssi/fnal_art.git $SPACK_ROOT/var/spack/repos/fnal_art
spack repo add --scope=site $SPACK_ROOT/var/spack/repos/fnal_art
spack mirror add --scope site fnal https://spack-cache-1.fnal.gov/binaries/
spack buildcache keys --install --force
spack buildcache keys --trust
spack buildcache install  -uoa  /32uzk6v
```