### PR TITLE
openblas: fix build for Apple M2

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -295,6 +295,12 @@ class Openblas(MakefilePackage):
         skylake = set(["skylake", "skylake_avx512"])
         available_targets = set(available_targets) | skylake | openblas_arch
 
+        # Apple M2
+        # https://github.com/xianyi/OpenBLAS/issues/3995#issuecomment-1503592445
+        if microarch.name == "m2":
+            args.append("TARGET=VORTEX")
+            return args
+
         # Find closest ancestor that is known to build in blas
         if microarch.name not in available_targets:
             for microarch in microarch.ancestors:


### PR DESCRIPTION
Making OpenBLAS work on Apple M2 required fixes that are introduced in `develop` and will be available in the next `0.3.24` release (see https://github.com/xianyi/OpenBLAS/issues/3995)

Moreover, current microarch logic for build parameters in the spack package does not work for Apple M2, and in https://github.com/xianyi/OpenBLAS/issues/3995#issuecomment-1503592445, it has been suggested to just use `TARGET=VORTEX`.

I look forward to suggestions on how to declare the conflict in the correct way.
Specifically in terms of what target should I use, since

```python
conflicts("@:0.3.23", when="target=m2")
```

is probably too specific.

Thanks in advance for any suggestion.