### PR TITLE
Support deps with constraints based on package versions

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -554,12 +554,13 @@ def depends_on(spec, when=None, type=dt.DEFAULT_TYPES, patches=None, version_tra
         type (str or tuple): str or tuple of legal Spack deptypes
         patches (typing.Callable or list): single result of ``patch()`` directive, a
             ``str`` to be passed to ``patch``, or a list of these
-        version_translator (function): function to generate a version-ish for spec
-            from a parent version. If provided, a distinct conditional dependency
-            requiring ``@ver`` in addition to ```when`` will be added for each valid
-            result ``ver`` obtained by calling ``version_translator()`` on each
-            parent version. If there are no valid results, the behavior is as if
-            ``version_translator`` had not been defined.
+        version_translator (typing.Callable): function to generate a version-ish for
+            spec from a parent version. If provided, a distinct
+            conditional dependency requiring ``@ver`` in addition to
+            ```when`` will be added for each valid result ``ver``
+            obtained by calling ``version_translator()`` on each parent
+            version. If there are no valid results, the behavior is as
+            if ``version_translator`` had not been defined.
 
             Examples of suitable functions:
               - ``spack.version.Version``

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -555,11 +555,17 @@ def depends_on(spec, when=None, type=dt.DEFAULT_TYPES, patches=None, version_tra
         patches (typing.Callable or list): single result of ``patch()`` directive, a
             ``str`` to be passed to ``patch``, or a list of these
         version_translator (function): function to generate a version-ish for spec
-            from a parent version. If provided, this function will be called for
-            each version defined for pkg, and any non-vacuous result will be used to
-            add a dependency with that version as an extra constraint on spec.
-            Examples of suitable functions: ``spack.version.Version`` (NOP) or
-            ``lambda v: v.up_to(2)`` (minor version match)
+            from a parent version. If provided, a distinct conditional dependency
+            requiring ``@ver`` in addition to ```when`` will be added for each valid
+            result ``ver`` obtained by calling ``version_translator()`` on each
+            parent version. If there are no valid results, the behavior is as if
+            ``version_translator`` had not been defined.
+
+            Examples of suitable functions:
+              - ``spack.version.Version``
+                Dependency must match parent's version.
+              - ``lambda v: v.up_to(2)``
+                Dependency must match parent's major and minor versions.
 
     This directive is to be used inside a Package definition to declare
     that the package requires other packages to be built first.


### PR DESCRIPTION
Add optional `version_translator` function argument to `depends_on()`

Closes #14002.

This allows for packages to require—with a single directive—a dependency to have version requirements that are related to the selected version of the parent. This may be an exact match to the parent's version, a major-minor version match, or any other reasonable relation.

For example: the `geant4-data` package nominally defines a set of versioned dependencies on data packages which are required by the `geant4` package whose version matches that of `geant4-data`. Prior to this PR, the following code is necessary in the `geant4` recipe:

```python
    for _vers in [
        "10.3.3",
        "10.4.0",
        "10.4.3",
        "10.5.1",
        "10.6.0",
        "10.6.1",
        "10.6.2",
        "10.6.3",
        "10.7.0",
        "10.7.1",
        "10.7.2",
        "10.7.3",
        "10.7.4",
        "11.0.0:11.0",
        "11.1:",
    ]:
        depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
```

With this PR, this could be replaced by the single line:

```python
    depends_on("geant4-data", spack.version.Version)
```

If one looks more closely at `geant4-data`, one might discover that the datasets are generally the same within a minor version. This could be handled by using:

```python
    depends_on("geant4-data", lambda v: v.up_to(2))
```

with mostly only minor versions (`10.1`, `10.2`, etc.) defined for the `geant4-data` package and special cases handled by patch versions and `conflicts()` directives in the `geant4-data` recipe.