### PR TITLE
Beast2 2.7.4

### DIFF
--- a/var/spack/repos/builtin/packages/beast2/package.py
+++ b/var/spack/repos/builtin/packages/beast2/package.py
@@ -17,6 +17,11 @@ class Beast2(Package):
     homepage = "http://beast2.org/"
     url = "https://github.com/CompEvol/beast2/releases/download/v2.6.4/BEAST.v2.6.4.Linux.tgz"
 
+    version(
+        "2.7.4",
+        sha256="f5086c74a0337190ae3459ef018468fc6b2eff68ae2b53fb5c96eb7b5df84004",
+        url="https://github.com/CompEvol/beast2/releases/download/v2.7.4/BEAST.v2.7.4.Linux.x86.tgz",
+    )
     version("2.6.7", sha256="05dcc619c2e10163f2c1089ec66149f6e53ec5a0583cd2cb8ffdccbbdb1d8183")
     version("2.6.4", sha256="4f80e2920eb9d87f3e9f64433119774dc67aca390fbd13dd480f852e3f8701a4")
     version("2.6.3", sha256="8899277b0d7124ab04dc512444d45f0f1a13505f3ce641e1f117098be3e2e20d")
@@ -24,6 +29,19 @@ class Beast2(Package):
     version("2.4.6", sha256="84029c5680cc22f95bef644824130090f5f12d3d7f48d45cb4efc8e1d6b75e93")
 
     depends_on("java")
+    depends_on("java@17:", when="@2.7.0:")
+    depends_on("javafx", when="@2.7.0:")
+
+    def patch(self):
+        # handle javafx stuff
+        if self.spec.satisfies("@2.7.0:"):
+            javafx = "--module-path {}".format(self.spec["javafx"].prefix.lib)
+            modules = "--add-modules javafx.controls"
+            with working_dir("bin"):
+                for i in find(".", "*"):
+                    filter_file(
+                        r"(beast\.pkgmgmt.*\b)|(viz.*\b)", "{0} {1} \\1".format(javafx, modules), i
+                    )
 
     def setup_run_environment(self, env):
         env.set("BEAST", self.prefix)
@@ -33,4 +51,8 @@ class Beast2(Package):
         install_tree("examples", join_path(self.prefix, "examples"))
         install_tree("images", join_path(self.prefix, "images"))
         install_tree("lib", prefix.lib)
-        install_tree("templates", join_path(self.prefix, "templates"))
+        if spec.satisfies("@:2.6.4"):
+            template_dir = "templates"
+        else:
+            template_dir = "fxtemplates"
+        install_tree(template_dir, join_path(self.prefix, template_dir))

--- a/var/spack/repos/builtin/packages/beast2/package.py
+++ b/var/spack/repos/builtin/packages/beast2/package.py
@@ -17,6 +17,8 @@ class Beast2(Package):
     homepage = "http://beast2.org/"
     url = "https://github.com/CompEvol/beast2/releases/download/v2.6.4/BEAST.v2.6.4.Linux.tgz"
 
+    maintainers("snehring")
+
     version(
         "2.7.4",
         sha256="f5086c74a0337190ae3459ef018468fc6b2eff68ae2b53fb5c96eb7b5df84004",

--- a/var/spack/repos/builtin/packages/javafx/package.py
+++ b/var/spack/repos/builtin/packages/javafx/package.py
@@ -41,9 +41,11 @@ class Javafx(Package):
 
     homepage = "https://openjfx.io/"
     for i in _versions:
-        url, sha256 = _versions[i][platform.system().lower()][platform.machine()]
-        if url:
+        try:
+            url, sha256 = _versions[i][platform.system().lower()][platform.machine()]
             version(i, url=url, sha256=sha256)
+        except KeyError:
+            continue
 
     maintainers("snehring")
 

--- a/var/spack/repos/builtin/packages/javafx/package.py
+++ b/var/spack/repos/builtin/packages/javafx/package.py
@@ -42,7 +42,8 @@ class Javafx(Package):
     homepage = "https://openjfx.io/"
     for i in _versions:
         url, sha256 = _versions[i][platform.system().lower()][platform.machine()]
-        version(i, url=url, sha256=sha256)
+        if url:
+            version(i, url=url, sha256=sha256)
 
     maintainers("snehring")
 

--- a/var/spack/repos/builtin/packages/javafx/package.py
+++ b/var/spack/repos/builtin/packages/javafx/package.py
@@ -49,6 +49,11 @@ class Javafx(Package):
 
     extends("openjdk")
 
+    conflicts("target=ppc64le:", msg="JavaFX is not available for ppc64le")
+    conflicts("target=ppc64:", msg="JavaFX is not available for ppc64")
+    conflicts("target=riscv64:", msg="JavaFX is not available for riscv64")
+    conflicts("target=x86", msg="JavaFX is not available for x86")
+
     def install(self, spec, prefix):
         install_tree("legal", prefix.legal)
         install_tree("lib", prefix.lib)

--- a/var/spack/repos/builtin/packages/javafx/package.py
+++ b/var/spack/repos/builtin/packages/javafx/package.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import platform
+
+from spack.package import *
+
+_versions = {
+    "20.0.1": {
+        "linux": {
+            "aarch64": (
+                "https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_linux-aarch64_bin-sdk.zip",
+                "ded4555c2fa097b3c0307ed3b338956ea1052d1693864c7594ec7ebb7e9486e2",
+            ),
+            "x86_64": (
+                "https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_linux-x64_bin-sdk.zip",
+                "882082b01a7f46792074cbe58e90136b81413438de184a941e051b836cbe90a2",
+            ),
+        },
+        "darwin": {
+            "aarch64": (
+                "https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-aarch64_bin-sdk.zip",
+                "baebdbbe283c17df62fc4c0bdc2bde4415f2253f99ba41437f9336e2272c255e",
+            ),
+            "x86_64": (
+                "https://download2.gluonhq.com/openjfx/20.0.1/openjfx-20.0.1_osx-x64_bin-sdk.zip",
+                "aa01f301bc611997f60ac86c2d9a7d7d1f652fd7092745720ae49cf7bb2935e4",
+            ),
+        },
+    }
+}
+
+
+class Javafx(Package):
+    """JavaFX allows you to create Java applications with a
+    modern, hardware-accelerated user interface that is
+    highly portable.
+    """
+
+    homepage = "https://openjfx.io/"
+    for i in _versions:
+        url, sha256 = _versions[i][platform.system().lower()][platform.machine()]
+        version(i, url=url, sha256=sha256)
+
+    maintainers("snehring")
+
+    extends("openjdk")
+
+    def install(self, spec, prefix):
+        install_tree("legal", prefix.legal)
+        install_tree("lib", prefix.lib)
+
+    def setup_run_environment(self, env):
+        env.set("JAVAFX_HOME", self.prefix.lib)


### PR DESCRIPTION
Adds version 2.7.4 of beast2. Version 2.7.0 and above added javafx as a dependency. 

I waffled back and forth for a bit about making javafx a variant to openjdk, but a package that extends openjdk seems to make the most sense to me.