### PR TITLE
whizard: build in parallel

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -87,7 +87,6 @@ class Whizard(AutotoolsPackage):
         # On 3.1.0 it doesn't seem to happen
         return self.spec.version > Version("3.0.3")
 
-
     def setup_build_environment(self, env):
         # whizard uses the compiler during runtime,
         # and seems incompatible with

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -43,17 +43,11 @@ class Whizard(AutotoolsPackage):
     )
 
     variant("pythia8", default=True, description="builds with pythia8")
-
     variant("fastjet", default=False, description="builds with fastjet")
-
     variant("lcio", default=False, description="builds with lcio")
-
     variant("lhapdf", default=False, description="builds with fastjet")
-
     variant("openmp", default=False, description="builds with openmp")
-
     variant("openloops", default=False, description="builds with openloops")
-
     variant("latex", default=False, description="data visualization with latex")
 
     depends_on("libtirpc")
@@ -86,9 +80,13 @@ class Whizard(AutotoolsPackage):
         msg="The fortran compiler needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html",
     )
 
-    # Trying to build in parallel leads to a race condition at the build step.
-    # See: https://github.com/key4hep/k4-spack/issues/71
-    parallel = False
+    @property
+    def parallel(self):
+        # Trying to build in parallel leads to a race condition at the build step.
+        # See: https://github.com/key4hep/key4hep-spack/issues/71
+        # On 3.1.0 it doesn't seem to happen
+        return self.spec.version > Version("3.0.3")
+
 
     def setup_build_environment(self, env):
         # whizard uses the compiler during runtime,


### PR DESCRIPTION
Tentatively adding back the parallel option for recent builds since I was able to build fine with it with many threads. I'll do a few more builds in parallel and see if there are any problems. Total installation time goes down from 18 minutes to 9 m on my machine with parallel enabled