### PR TITLE
Deprecate `env:` as top level environment key

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -357,7 +357,14 @@ def ensure_env_root_path_exists():
 
 def config_dict(yaml_data):
     """Get the configuration scope section out of an spack.yaml"""
+    # TODO (env:): Remove env: as a possible top level keyword in v0.21
     key = spack.config.first_existing(yaml_data, spack.schema.env.keys)
+    if key == "env":
+        msg = (
+            "using 'env:' as a top-level attribute of a Spack environment is deprecated and "
+            "will be removed in Spack v0.21. Please use 'spack:' instead."
+        )
+        warnings.warn(msg)
     return yaml_data[key]
 
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -193,7 +193,7 @@ def test_dev_build_env(tmpdir, mock_packages, install_mockery, mutable_mock_env_
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - dev-build-test-install@0.0.0
 
@@ -233,7 +233,7 @@ def test_dev_build_env_version_mismatch(
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - dev-build-test-install@0.0.0
 
@@ -286,7 +286,7 @@ def test_dev_build_multiple(
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - dev-build-test-dependent@0.0.0
 
@@ -339,7 +339,7 @@ def test_dev_build_env_dependency(
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - dependent-of-dev-build@0.0.0
 
@@ -397,7 +397,7 @@ def test_dev_build_rebuild_on_source_changes(
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - %s@0.0.0
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -342,7 +342,7 @@ def test_env_install_two_specs_same_dep(install_mockery, mock_fetch, tmpdir, cap
         with open(str(path), "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - a
   - depb
@@ -522,7 +522,7 @@ def test_user_removed_spec(environment_from_manifest):
     """Ensure a user can remove from any position in the spack.yaml file."""
     before = environment_from_manifest(
         """\
-env:
+spack:
   specs:
   - mpileaks
   - hypre
@@ -536,7 +536,7 @@ env:
     with open(before.manifest_path, "w") as f:
         f.write(
             """\
-env:
+spack:
   specs:
   - mpileaks
   - libelf
@@ -557,7 +557,7 @@ def test_init_from_lockfile(environment_from_manifest):
     """Test that an environment can be instantiated from a lockfile."""
     e1 = environment_from_manifest(
         """
-env:
+spack:
   specs:
   - mpileaks
   - hypre
@@ -584,7 +584,7 @@ def test_init_from_yaml(environment_from_manifest):
     """Test that an environment can be instantiated from a lockfile."""
     e1 = environment_from_manifest(
         """
-env:
+spack:
   specs:
   - mpileaks
   - hypre
@@ -615,7 +615,7 @@ def test_env_view_external_prefix(tmp_path, mutable_database, mock_packages):
     manifest_file = manifest_dir / ev.manifest_name
     manifest_file.write_text(
         """
-env:
+spack:
   specs:
   - a
   view: true
@@ -663,7 +663,7 @@ def test_init_with_file_and_remove(tmpdir):
         with open(str(path), "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - mpileaks
 """
@@ -686,7 +686,7 @@ env:
 def test_env_with_config(environment_from_manifest):
     e = environment_from_manifest(
         """
-env:
+spack:
   specs:
   - mpileaks
   packages:
@@ -723,7 +723,7 @@ spack:
 def test_env_with_include_config_files_same_basename(environment_from_manifest):
     e = environment_from_manifest(
         """
-env:
+spack:
   include:
   - ./path/to/included-config.yaml
   - ./second/path/to/include-config.yaml
@@ -781,7 +781,7 @@ def mpileaks_env_config(include_path):
     """Return the contents of an environment that includes the provided
     path and lists mpileaks as the sole spec."""
     return """\
-env:
+spack:
   include:
   - {0}
   specs:
@@ -798,7 +798,7 @@ def test_env_with_included_config_file(environment_from_manifest, packages_file)
     include_filename = "included-config.yaml"
     e = environment_from_manifest(
         f"""\
-env:
+spack:
   include:
   - {os.path.join(".", include_filename)}
   specs:
@@ -892,7 +892,7 @@ def test_env_with_included_config_var_path(environment_from_manifest, packages_f
 def test_env_config_precedence(environment_from_manifest):
     e = environment_from_manifest(
         """
-env:
+spack:
   packages:
     libelf:
       version: [0.8.12]
@@ -926,7 +926,7 @@ packages:
 def test_included_config_precedence(environment_from_manifest):
     e = environment_from_manifest(
         """
-env:
+spack:
   include:
   - ./high-config.yaml  # this one should take precedence
   - ./low-config.yaml
@@ -968,7 +968,7 @@ def test_bad_env_yaml_format(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   spacks:
     - mpileaks
 """
@@ -1268,7 +1268,7 @@ def test_env_config_view_default(
     # This config doesn't mention whether a view is enabled
     environment_from_manifest(
         """
-env:
+spack:
   specs:
   - mpileaks
 """
@@ -1377,7 +1377,7 @@ def test_stack_yaml_definitions(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
@@ -1397,7 +1397,7 @@ def test_stack_yaml_definitions_as_constraints(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - mpis: [mpich, openmpi]
@@ -1422,7 +1422,7 @@ def test_stack_yaml_definitions_as_constraints_on_matrix(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - mpis:
@@ -1451,7 +1451,7 @@ def test_stack_yaml_definitions_write_reference(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - indirect: [$packages]
@@ -1475,7 +1475,7 @@ def test_stack_yaml_add_to_list(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
@@ -1499,7 +1499,7 @@ def test_stack_yaml_remove_from_list(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
@@ -1522,7 +1522,7 @@ def test_stack_yaml_remove_from_list_force(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
   specs:
@@ -1551,7 +1551,7 @@ def test_stack_yaml_remove_from_matrix_no_effect(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages:
         - matrix:
@@ -1576,7 +1576,7 @@ def test_stack_yaml_force_remove_from_matrix(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages:
         - matrix:
@@ -1618,7 +1618,7 @@ def test_stack_concretize_extraneous_deps(tmpdir, config, mock_packages):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - install:
@@ -1650,7 +1650,7 @@ def test_stack_concretize_extraneous_variants(tmpdir, config, mock_packages):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - install:
@@ -1682,7 +1682,7 @@ def test_stack_concretize_extraneous_variants_with_dash(tmpdir, config, mock_pac
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - install:
@@ -1710,7 +1710,7 @@ def test_stack_definition_extension(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1733,7 +1733,7 @@ def test_stack_definition_conditional_false(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1757,7 +1757,7 @@ def test_stack_definition_conditional_true(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1781,7 +1781,7 @@ def test_stack_definition_conditional_with_variable(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1805,7 +1805,7 @@ def test_stack_definition_conditional_with_satisfaction(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
       when: arch.satisfies('platform=foo')  # will be "test" when testing
@@ -1830,7 +1830,7 @@ def test_stack_definition_complex_conditional(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1854,7 +1854,7 @@ def test_stack_definition_conditional_invalid_variable(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1873,7 +1873,7 @@ def test_stack_definition_conditional_add_write(tmpdir):
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [libelf, mpileaks]
     - packages: [callpath]
@@ -1890,7 +1890,7 @@ env:
         test = ev.read("test")
 
         packages_lists = list(
-            filter(lambda x: "packages" in x, test.manifest["env"]["definitions"])
+            filter(lambda x: "packages" in x, test.manifest["spack"]["definitions"])
         )
 
         assert len(packages_lists) == 2
@@ -1908,7 +1908,7 @@ def test_stack_combinatorial_view(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -1942,7 +1942,7 @@ def test_stack_view_select(tmpdir, mock_fetch, mock_packages, mock_archive, inst
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -1982,7 +1982,7 @@ def test_stack_view_exclude(tmpdir, mock_fetch, mock_packages, mock_archive, ins
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -2024,7 +2024,7 @@ def test_stack_view_select_and_exclude(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -2065,7 +2065,7 @@ def test_view_link_roots(tmpdir, mock_fetch, mock_packages, mock_archive, instal
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -2152,7 +2152,7 @@ def test_view_link_type(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   specs:
     - mpileaks
   view:
@@ -2181,7 +2181,7 @@ def test_view_link_all(tmpdir, mock_fetch, mock_packages, mock_archive, install_
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, callpath]
     - compilers: ['%%gcc', '%%clang']
@@ -2225,7 +2225,7 @@ def test_stack_view_activate_from_default(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, cmake]
     - compilers: ['%%gcc', '%%clang']
@@ -2260,7 +2260,7 @@ def test_stack_view_no_activate_without_default(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, cmake]
     - compilers: ['%%gcc', '%%clang']
@@ -2294,7 +2294,7 @@ def test_stack_view_multiple_views(
     with open(filename, "w") as f:
         f.write(
             """\
-env:
+spack:
   definitions:
     - packages: [mpileaks, cmake]
     - compilers: ['%%gcc', '%%clang']
@@ -2461,7 +2461,7 @@ def test_env_write_only_non_default_nested(tmpdir):
     filename = "spack.yaml"
     filepath = str(tmpdir.join(filename))
     contents = """\
-env:
+spack:
   specs:
   - matrix:
     - [mpileaks]

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -25,7 +25,7 @@ def test_undevelop(tmpdir, config, mock_packages, mutable_mock_env_path):
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - mpich
 
@@ -54,7 +54,7 @@ def test_undevelop_nonexistent(tmpdir, config, mock_packages, mutable_mock_env_p
         with open("spack.yaml", "w") as f:
             f.write(
                 """\
-env:
+spack:
   specs:
   - mpich
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -74,7 +74,7 @@ def env_yaml(tmpdir):
     with open(env_yaml, "w") as f:
         f.write(
             """\
-env:
+spack:
     config:
         verify_ssl: False
         dirty: False
@@ -918,7 +918,7 @@ config:
 
 
 def test_single_file_scope(config, env_yaml):
-    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["env"])
+    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["spack"])
 
     with spack.config.override(scope):
         # from the single-file config
@@ -943,7 +943,7 @@ def test_single_file_scope_section_override(tmpdir, config):
     with open(env_yaml, "w") as f:
         f.write(
             """\
-env:
+spack:
     config:
         verify_ssl: False
     packages::
@@ -954,7 +954,7 @@ env:
 """
         )
 
-    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["env"])
+    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["spack"])
 
     with spack.config.override(scope):
         # from the single-file config
@@ -1015,7 +1015,7 @@ def test_bad_env_yaml(tmpdir):
         check_schema(
             spack.schema.env.schema,
             """\
-env:
+spack:
     foobar:
         verify_ssl: False
         dirty: False
@@ -1169,7 +1169,7 @@ def test_license_dir_config(mutable_config, mock_packages):
 
 @pytest.mark.regression("22547")
 def test_single_file_scope_cache_clearing(env_yaml):
-    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["env"])
+    scope = spack.config.SingleFileScope("env", env_yaml, spack.schema.env.schema, ["spack"])
     # Check that we can retrieve data from the single file scope
     before = scope.get_section("config")
     assert before

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -82,7 +82,7 @@ def test_env_change_spec(tmp_path, mock_packages, config):
 
 
 _test_matrix_yaml = """\
-env:
+spack:
   definitions:
   - compilers: ["%gcc", "%clang"]
   - desired_specs: ["mpileaks@2.1"]


### PR DESCRIPTION
Modifications:
- [x] Add a warning message for environment that still use `env:` as a top level key
- [x] Update our unit tests to be in line with the deprecation

Example of a warning:
![Screenshot from 2023-05-04 11-50-03](https://user-images.githubusercontent.com/4199709/236171089-54765436-ac57-4315-ab90-a15b58acbdbc.png)
