### PR TITLE
perl: fix jobserver job issue

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -281,6 +281,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if sys.platform == "win32":
             return
         configure = Executable("./Configure")
+        configure.add_default_env("MAKEFLAGS", "")
         configure(*self.configure_args())
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -281,6 +281,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if sys.platform == "win32":
             return
         configure = Executable("./Configure")
+        # The Configure script plays with file descriptors and runs make towards the end,
+        # which results in job tokens not being released under the make jobserver. So, we
+        # disable the jobserver here, and let the Configure script execute make
+        # sequentially. There is barely any parallelism anyway; the most parallelism is
+        # in the build phase, in which the jobserver is enabled again, since we invoke make.
         configure.add_default_env("MAKEFLAGS", "")
         configure(*self.configure_args())
 


### PR DESCRIPTION
When building perl with posix jobserver, it seems to eat jobs, which
reduces parallelism to 1 in many cases, and is rather annoying. This is
solved in GNU Make 4.4 (fifo is more stable than file descriptors), but
that version is typically not available.

So, fix this issue by simply unsetting MAKEFLAGS for the duration of
./Configure. That's enough, and the build phase runs perfectly in
parallel again.
