### PR TITLE
Ensure Spack curl is used during configure of netcdf-c

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -464,10 +464,8 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
             # Prevent linking to system c-blosc:
             config_args.append("ac_cv_lib_blosc_blosc_init=no")
 
-        if self.spec.satisfies("@:4.7~dap+byterange"):
+        if "+dap" in self.spec or "+byterange" in self.spec:
             extra_libs.append(self.spec["curl"].libs)
-        elif "+dap" in self.spec or "+byterange" in self.spec:
-            lib_search_dirs.extend(self.spec["curl"].libs.directories)
         elif self.spec.satisfies("@4.7.0"):
             # This particular version fails if curl is not found, even if it is not needed
             # (see https://github.com/Unidata/netcdf-c/issues/1390). Note that the following does


### PR DESCRIPTION
The major refactor in #36485 changed the build logic so that -lcurl is only added to `LIBS` in a very specific instance with byte-range I/O. It used to add the flag whenever `+dap` was used as well, but now only `-L/path/to/curl` is set. This works for some builds, but fails when building with `+mpi +dap`, at least when using *cray-mpich*. See the post I've made in that PR for the exact error.

This PR restores the setting of `LIBS` whenever +dap is used, and also enables it whenever +byterange is used since that also will add a libcurl dependency.