### PR TITLE
Adding ncbi-vdb 3.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-vdb/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-vdb/package.py
@@ -14,6 +14,7 @@ class NcbiVdb(CMakePackage):
     homepage = "https://github.com/ncbi/ncbi-vdb"
     git = "https://github.com/ncbi/ncbi-vdb.git"
 
+    version("3.0.2", tag="3.0.2")
     version("3.0.0", tag="3.0.0")
 
     depends_on("openjdk")

--- a/var/spack/repos/builtin/packages/sra-tools/package.py
+++ b/var/spack/repos/builtin/packages/sra-tools/package.py
@@ -20,6 +20,7 @@ class SraTools(CMakePackage):
     depends_on("flex@2.6:")
     depends_on("libxml2")
     depends_on("ncbi-vdb")
+    depends_on("ncbi-vdb@3.0.2:", when="@3.0.3:")
 
     # The CMakeLists.txt  file set the path to ${TARGDIR}/obj but the code
     # actually uses ${TARGDIR}.


### PR DESCRIPTION
This also fixes a compilation issue with sra-tools in the latest version.