### PR TITLE
meson: change default build type to "release"

### DIFF
--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -33,7 +33,7 @@ class MesonPackage(spack.package_base.PackageBase):
     with when("build_system=meson"):
         variant(
             "buildtype",
-            default="debugoptimized",
+            default="release",
             description="Meson build type",
             values=("plain", "debug", "debugoptimized", "release", "minsize"),
         )

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -55,14 +55,6 @@ class Mesa(MesonPackage):
     depends_on("expat")
     depends_on("zlib@1.2.3:")
 
-    # Override the build type variant so we can default to release
-    variant(
-        "buildtype",
-        default="release",
-        description="Meson build type",
-        values=("plain", "debug", "debugoptimized", "release", "minsize"),
-    )
-
     # Internal options
     variant("llvm", default=True, description="Enable LLVM.")
 


### PR DESCRIPTION
The same was done for CMake in #36679.