### PR TITLE
concretizer: don't change concrete environments without `--force`

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -347,7 +347,7 @@ the Environment and then install the concretized specs.
    (see :ref:`build-jobs`). To speed up environment builds further, independent
    packages can be installed in parallel by launching more Spack instances. For
    example, the following will build at most four packages in parallel using
-   three background jobs: 
+   three background jobs:
 
    .. code-block:: console
 
@@ -395,7 +395,7 @@ version (and other constraints) passed as the spec argument to the
 
 For packages with ``git`` attributes, git branches, tags, and commits can
 also be used as valid concrete versions (see :ref:`version-specifier`).
-This means that for a package ``foo``, ``spack develop foo@git.main`` will clone 
+This means that for a package ``foo``, ``spack develop foo@git.main`` will clone
 the ``main`` branch of the package, and ``spack install`` will install from
 that git clone if ``foo`` is in the environment.
 Further development on ``foo`` can be tested by reinstalling the environment,
@@ -589,10 +589,11 @@ user support groups providing a large software stack for their HPC center.
 
 .. admonition:: Re-concretization of user specs
 
-   The ``spack concretize`` command without additional arguments will not change any
-   previously concretized specs. This may cause errors when ``unify: true`` or surprising
-   deviations between packages when ``unify: when_possible`` when compared to reconcretizing
-   using ``spack concretize -f``.
+   The ``spack concretize`` command without additional arguments will *not* change any
+   previously concretized specs. This may prevent it from finding a solution when using
+   ``unify: true``, and it may prevent it from finding a minimal solution when using
+   ``unify: when_possible``. You can force Spack to ignore the existing concrete environment
+   with ``spack concretize -f``.
 
 ^^^^^^^^^^^^^
 Spec Matrices
@@ -1121,19 +1122,19 @@ index once every package is pushed. Note how this target uses the generated
 
    SPACK ?= spack
    BUILDCACHE_DIR = $(CURDIR)/tarballs
-   
+
    .PHONY: all
-   
+
    all: push
-   
+
    include env.mk
-   
+
    example/push/%: example/install/%
    	@mkdir -p $(dir $@)
    	$(info About to push $(SPEC) to a buildcache)
    	$(SPACK) -e . buildcache create --allow-root --only=package --directory $(BUILDCACHE_DIR) /$(HASH)
    	@touch $@
-   
+
    push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))
    	$(info Updating the buildcache index)
    	$(SPACK) -e . buildcache update-index --directory $(BUILDCACHE_DIR)

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -589,10 +589,10 @@ user support groups providing a large software stack for their HPC center.
 
 .. admonition:: Re-concretization of user specs
 
-   When using *unified* concretization (when possible), the entire set of specs will be
-   re-concretized after any addition of new user specs, to ensure that
-   the environment remains consistent / minimal. When instead unified concretization is
-   disabled, only the new specs will be concretized after any addition.
+   The ``spack concretize`` command without additional arguments will not change any
+   previously concretized specs. This may cause errors when ``unify: true`` or surprising
+   deviations between packages when ``unify: when_possible`` when compared to reconcretizing
+   using ``spack concretize -f``.
 
 ^^^^^^^^^^^^^
 Spec Matrices

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1435,11 +1435,15 @@ class Environment:
             # "Enhance" the error message for multiple root specs, suggest a less strict
             # form of concretization.
             if len(self.user_specs) > 1:
+                e.message += ". "
+                if kept_user_specs:
+                    e.message += (
+                        "Couldn't concretize without changing the existing environment. "
+                        "If you are ok with changing it, try `spack concretize --force`. "
+                    )
                 e.message += (
-                    ". If you have previously cached concretizations, consider using "
-                    "`spack concretize -f` to invalidate cached concretizations. If not, "
-                    "Consider setting `concretizer:unify` to `when_possible` "
-                    "or `false` to relax the concretizer strictness."
+                    "You could consider setting `concretizer:unify` to `when_possible` "
+                    "or `false` to allow multiple versions of some packages."
                 )
             raise
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1421,7 +1421,9 @@ class Environment:
             # form of concretization.
             if len(self.user_specs) > 1:
                 e.message += (
-                    ". Consider setting `concretizer:unify` to `when_possible` "
+                    ". If you have previously cached concretizations, consider using "
+                    "`spack concretize -f` to invalidate cached concretizations. If not, "
+                    "Consider setting `concretizer:unify` to `when_possible` "
                     "or `false` to relax the concretizer strictness."
                 )
             raise

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1367,9 +1367,7 @@ class Environment:
         if not new_user_specs:
             return []
 
-        result = [
-            pair for pair in self.concretized_specs() if pair[0] in kept_user_specs
-        ]
+        result = [pair for pair in self.concretized_specs() if pair[0] in kept_user_specs]
         specs_to_concretize = list(new_user_specs) + [concrete for _, concrete in result]
 
         self.concretized_user_specs = []
@@ -1403,7 +1401,8 @@ class Environment:
             return []
 
         concrete_specs_to_keep = [
-            concrete for abstract, concrete in self.concretized_specs()
+            concrete
+            for abstract, concrete in self.concretized_specs()
             if abstract in kept_user_specs
         ]
         specs_to_concretize = list(new_user_specs) + concrete_specs_to_keep

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2442,7 +2442,7 @@ def test_duplicate_packages_raise_when_concretizing_together():
     e.add("mpich")
 
     with pytest.raises(
-        spack.error.UnsatisfiableSpecError, match=r"relax the concretizer strictness"
+        spack.error.UnsatisfiableSpecError, match=r"You could consider setting `concretizer:unify`"
     ):
         e.concretize()
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2407,7 +2407,11 @@ def test_concretize_user_specs_together():
     # Concretize a second time using 'mpich2' as the MPI provider
     e.remove("mpich")
     e.add("mpich2")
-    e.concretize()
+
+    # Concretizing without invalidating the concrete spec for mpileaks fails
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        e.concretize()
+    e.concretize(force=True)
 
     assert all("mpich2" in spec for _, spec in e.concretized_specs())
     assert all("mpich" not in spec for _, spec in e.concretized_specs())


### PR DESCRIPTION
Users generally don't want to change large chunks of their existing concrete environment, but Spack currently does that when using `concretizer:unify:true` (the default) and ``concretizer:unify:when_possible`. Reconcretizing large environments can also be slow, as Spack has to start from scratch and solve everything again.

We can do for `unify:true` and `unify:when_possible` what we already do for `unify:false`: preserve the existing concrete environment state.  This PR adds that functionality, and it lets you invalidate the existing concrete state with `spack concretize -f`.  Now, `spack concretize` will only concretize the new portions of the environment and `spack concretize -f` reconcretizes the entire environment.