### PR TITLE
paraview (protobuf failure)

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -217,6 +217,12 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("netcdf-c")
     depends_on("pegtl")
     depends_on("protobuf@3.4:")
+    # Paraview 5.10 can't build with protobuf > 3.18
+    # https://github.com/spack/spack/issues/37437
+    depends_on("protobuf@3.4:3.18", when="@:5.10%oneapi")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%intel@2021:")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%xl")
+    depends_on("protobuf@3.4:3.18", when="@:5.10%xl_r")
     depends_on("libxml2")
     depends_on("lz4")
     depends_on("xz")


### PR DESCRIPTION
When attempting to build paraview@5.10.1 using a recent Intel compiler (Classic or OneAPI) or the IBM XL compiler, the build fails if the version of protobuf used is > 3.18

Tested on Intel Classic 2021.2 and IBM XL 16.1.1.7.

See issue #37437 