### PR TITLE
nwchem: Fix for non-FFTW fftw-api providers

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -100,7 +100,7 @@ class Nwchem(Package):
 
         if "+fftw3" in spec:
             args.extend(["USE_FFTW3=y"])
-            args.extend(["FFTW3_LIB=%s" % fftw.ld_flags])
+            args.extend(["LIBFFTW3=%s" % fftw.ld_flags])
             args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         with working_dir("src"):


### PR DESCRIPTION
Building `nwchem +fftw` with a `fftw-api` provider that doesn't support `-lfftw3` (e.g. MKL) fails due to https://github.com/nwchemgit/nwchem/blob/530ef55895c5cc2300829b7c4440a59859ea70d9/src/config/makefile.h#L3623 appending `-lfftw3` to the build if `LIBFFTW3` isn't defined.

This PR points `LIBFFTW3` to the `fftw-api` libs and leaves `FFTW3_LIB` undefined to overwrite that `-lfftw3`.