### PR TITLE
ci: stop downloading recent gmake

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/aarch64/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/aarch64/ci.yaml
@@ -1,8 +1,4 @@
 ci:
   pipeline-gen:
   - build-job:
-      before_script:
-      - - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.aarch64-linux-gnu.tar.gz" -o gmake.tar.gz
-        - printf "2322c175fb092b426f9eb6c24ee22d94ffa6759c3d0c260b74d81abd8120122b gmake.tar.gz" | sha256sum --check --strict --quiet
-        - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       tags: ["aarch64"]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/x86_64_v3/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/x86_64_v3/ci.yaml
@@ -1,8 +1,4 @@
 ci:
   pipeline-gen:
   - build-job:
-      before_script:
-      - - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz" -o gmake.tar.gz
-        - printf "fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz" | sha256sum --check --strict --quiet
-        - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
       tags: ["x86_64_v3"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
@@ -28,11 +28,6 @@ spack:
     broken-specs-url: s3://spack-binaries/broken-specs
     image: ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02
     before_script:
-    - curl -LfsS "https://github.com/JuliaBinaryWrappers/GNUMake_jll.jl/releases/download/GNUMake-v4.3.0+1/GNUMake.v4.3.0.x86_64-linux-gnu.tar.gz"
-      -o gmake.tar.gz
-    - printf "fef1f59e56d2d11e6d700ba22d3444b6e583c663d6883fd0a4f63ab8bd280f0f gmake.tar.gz"
-      | sha256sum --check --strict --quiet
-    - tar -xzf gmake.tar.gz -C /usr bin/make 2> /dev/null
     - uname -a || true
     - grep -E "vendor|model name" /proc/cpuinfo 2>/dev/null | sort -u || head -n10
       /proc/cpuinfo 2>/dev/null || true

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -50,6 +50,7 @@ class Zlib(MakefilePackage, Package):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("shared", default=True, description="Enables the build of shared libraries.")
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
+    variant("rebuild_please", default=True, description="CI test")
 
     conflicts("build_system=makefile", when="platform=windows")
 

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -50,7 +50,6 @@ class Zlib(MakefilePackage, Package):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("shared", default=True, description="Enables the build of shared libraries.")
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
-    variant("rebuild_please", default=True, description="CI test")
 
     conflicts("build_system=makefile", when="platform=windows")
 


### PR DESCRIPTION
Not that downloading this ever caused issues, but this was added as a temporary measure to get --output-sync to work when installing dependencies in parallel. That's optional, and we're building some docker images with newer gmake already, so getting rid of this dependency would be good.