### PR TITLE
caliper +rocm: patch missing libunwind include dir

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -85,6 +85,7 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+rocm+cuda")
 
     patch("for_aarch64.patch", when="target=aarch64:")
+    patch("sampler-service-missing-libunwind-include-dir.patch", when="@2.9.0 +rocm")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -85,7 +85,7 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+rocm+cuda")
 
     patch("for_aarch64.patch", when="target=aarch64:")
-    patch("sampler-service-missing-libunwind-include-dir.patch", when="@2.9.0 +rocm")
+    patch("sampler-service-missing-libunwind-include-dir.patch", when="@2.9.0 +libunwind +sampler")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/caliper/sampler-service-missing-libunwind-include-dir.patch
+++ b/var/spack/repos/builtin/packages/caliper/sampler-service-missing-libunwind-include-dir.patch
@@ -1,0 +1,14 @@
+diff -ruN spack-src/src/services/sampler/CMakeLists.txt spack-src-patched/src/services/sampler/CMakeLists.txt
+--- spack-src/src/services/sampler/CMakeLists.txt	2022-11-30 13:52:42.000000000 -0500
++++ spack-src-patched/src/services/sampler/CMakeLists.txt	2023-05-04 20:43:47.240310306 -0400
+@@ -17,6 +17,10 @@
+ 
+ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ 
++if (CALIPER_HAVE_LIBUNWIND)
++	  include_directories(${LIBUNWIND_INCLUDE_DIRS})
++endif()
++
+ add_library(caliper-sampler OBJECT ${CALIPER_SAMPLER_SOURCES})
+ 
+ add_service_objlib("caliper-sampler")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37417 by patching in changes recently merged to upstream caliper repo:
* https://github.com/LLNL/Caliper/commit/f6eee70a17e7191f143e9d3b1ab3c4ca8ed2aa10