### PR TITLE
hdf5: Add conflict for older cmake versions.

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -238,6 +238,8 @@ class Hdf5(CMakePackage):
     conflicts("+fortran", when="+shared@:1.8.15")
     # See https://github.com/spack/spack/issues/31085
     conflicts("+fortran+mpi", when="@1.8.22")
+    # See https://github.com/HDFGroup/hdf5/issues/2906#issue-1697749645
+    conflicts("+fortran", when="@1.13.3:^cmake@3.18:3.22", msg="cmake_minimum_required is not set correctly.")
 
     # There are several officially unsupported combinations of the features:
     # 1. Thread safety is not guaranteed via high-level C-API but in some cases

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -239,7 +239,9 @@ class Hdf5(CMakePackage):
     # See https://github.com/spack/spack/issues/31085
     conflicts("+fortran+mpi", when="@1.8.22")
     # See https://github.com/HDFGroup/hdf5/issues/2906#issue-1697749645
-    conflicts("+fortran", when="@1.13.3:^cmake@:3.22", msg="cmake_minimum_required is not set correctly.")
+    conflicts(
+        "+fortran", when="@1.13.3:^cmake@:3.22", msg="cmake_minimum_required is not set correctly."
+    )
 
     # There are several officially unsupported combinations of the features:
     # 1. Thread safety is not guaranteed via high-level C-API but in some cases

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -239,7 +239,7 @@ class Hdf5(CMakePackage):
     # See https://github.com/spack/spack/issues/31085
     conflicts("+fortran+mpi", when="@1.8.22")
     # See https://github.com/HDFGroup/hdf5/issues/2906#issue-1697749645
-    conflicts("+fortran", when="@1.13.3:^cmake@3.18:3.22", msg="cmake_minimum_required is not set correctly.")
+    conflicts("+fortran", when="@1.13.3:^cmake@:3.22", msg="cmake_minimum_required is not set correctly.")
 
     # There are several officially unsupported combinations of the features:
     # 1. Thread safety is not guaranteed via high-level C-API but in some cases


### PR DESCRIPTION
Add conflict for older CMake versions to fix a build issue caused by incorrect cmake_minimum_required. See https://github.com/HDFGroup/hdf5/issues/2906#issue-1697749645