### PR TITLE
tixi: set PYTHONPATH for run environment

### DIFF
--- a/var/spack/repos/builtin/packages/tixi/package.py
+++ b/var/spack/repos/builtin/packages/tixi/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -38,3 +40,14 @@ class Tixi(CMakePackage):
         if self.spec.satisfies("+fortran"):
             args.append("-DTIXI_ENABLE_FORTRAN=ON")
         return args
+
+    def setup_run_environment(self, env):
+        """Add tixi3wrapper.py location to the PYTHONPATH"""
+        if self.spec.version >= Version("3.0.0"):
+            env.prepend_path(
+                "PYTHONPATH", os.path.join(self.spec.prefix, "share", "tixi3", "python")
+            )
+        else:
+            env.prepend_path(
+                "PYTHONPATH", os.path.join(self.spec.prefix, "share", "tixi", "python")
+            )


### PR DESCRIPTION
Tixi provides a python interface in `share/tixi/python/tixi3wrapper.py`. This adds it to the PYTHONPATH when loaded, so the user does not need to explicitly adjust the PYTHONPATH...

The python-interface uses ctypes and is not bound to a specific python version; so not using `extends("python")` but just add it to the path.