### PR TITLE
Update Intel Pin package up to 3.27

### DIFF
--- a/var/spack/repos/builtin/packages/intel-pin/package.py
+++ b/var/spack/repos/builtin/packages/intel-pin/package.py
@@ -47,7 +47,7 @@ class IntelPin(Package):
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.22-98547-g7a303a835-gcc-linux.tar.gz",
     )
     version(
-        "3.21".
+        "3.21",
         sha256="a0bd6640d7b4a53f78cf0a2df843b034f2e2ec38e77f018d8e3ef032360b0c5c",
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.21-98484-ge7cd811fd-gcc-linux.tar.gz",
     )
@@ -74,7 +74,7 @@ class IntelPin(Package):
     version(
         "3.16",
         sha256="c61abc4a3de48016cdbac9b567630557ec3dfa9b0394cc03ee7ed17d15c791b6",
-        url="http://software.intel.com/sites/landingpage/pintool/downloads/pin-3.16-98275-ge0db48c31-gcc-linux.tar.gz",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.16-98275-ge0db48c31-gcc-linux.tar.gz",
     )
     version(
         "3.15",

--- a/var/spack/repos/builtin/packages/intel-pin/package.py
+++ b/var/spack/repos/builtin/packages/intel-pin/package.py
@@ -17,6 +17,66 @@ class IntelPin(Package):
     maintainers("matthiasdiener")
 
     version(
+        "3.27",
+        sha256="e7d44d25668632007d5a109e5033415e91db543b8ce9e665893a05e852b67707",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.27-98718-gbeaa5d51e-gcc-linux.tar.gz",
+    )
+    version(
+        "3.26",
+        sha256="92ef29a2616b63105b8081157c24c50236e34ea6fc13e4a06fe6894bdc700478",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.26-98690-g1fc9d60e6-gcc-linux.tar.gz",
+    )
+    version(
+        "3.25",
+        sha256="43c0f441234b0e5cb65caf9714e61d3316f1e4ddf77865731121930a05865fa1",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.25-98650-g8f6168173-gcc-linux.tar.gz",
+    )
+    version(
+        "3.24",
+        sha256="0b5183155d86a8aa7cbf7da968fbb37840c48cada94faadb9053489b75d373c8",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.24-98612-g6bd5931f2-gcc-linux.tar.gz",
+    )
+    version(
+        "3.23",
+        sha256="996090dfeec7dd58db1babbc3c95f8e4abfcb9b0e1014b02ffdbc09224bb48c0",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.23-98579-gb15ab7903-gcc-linux.tar.gz",
+    )
+    version(
+        "3.22",
+        sha256="550fdc15e02d03acc6a65a918887467945b7413089fb1080e238380aad3b95eb",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.22-98547-g7a303a835-gcc-linux.tar.gz",
+    )
+    version(
+        "3.21".
+        sha256="a0bd6640d7b4a53f78cf0a2df843b034f2e2ec38e77f018d8e3ef032360b0c5c",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.21-98484-ge7cd811fd-gcc-linux.tar.gz",
+    )
+    version(
+        "3.20",
+        sha256="ca2f542eee2013471961bb683d06ccb20ef5dd8ed0d02537cf4d47f09bd616bf",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.20-98437-gf02b61307-gcc-linux.tar.gz",
+    )
+    version(
+        "3.19",
+        sha256="3af8a86c229a28ecbabba3180bd6a35e013cc3d44a7496087c15db76fd43f86f",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.19-98425-gd666b2bee-gcc-linux.tar.gz",
+    )
+    version(
+        "3.18",
+        sha256="de8ef1a0cb301764a774aa9bcaae8cba997a7dde3155ed271e52d00acceb230b",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.18-98332-gaebd7b1e6-gcc-linux.tar.gz",
+    )
+    version(
+        "3.17",
+        sha256="a9cc3df7667b70dd44e51f66ed506bcdc31d942bb7698e1d4e1f8fe5d01c80bb",
+        url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.17-98314-g0c048d619-gcc-linux.tar.gz",
+    )
+    version(
+        "3.16",
+        sha256="c61abc4a3de48016cdbac9b567630557ec3dfa9b0394cc03ee7ed17d15c791b6",
+        url="http://software.intel.com/sites/landingpage/pintool/downloads/pin-3.16-98275-ge0db48c31-gcc-linux.tar.gz",
+    )
+    version(
         "3.15",
         sha256="51ab5a381ff477335050b20943133965c5c515d074ad6afb801a898dae8af642",
         url="https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.15-98253-gb56e429b1-gcc-linux.tar.gz",


### PR DESCRIPTION
Updating the Intel Pin package through all releases up to 3.27.