### PR TITLE
petsc@3.19.1 +rocm: conflicts with rocprim@5.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -145,7 +145,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     variant("fortran", default=True, description="Activates fortran support")
 
     # https://github.com/spack/spack/issues/37416
-    conflicts("^rocprim@5.3.0", when="@3.19.1 +rocm")
+    conflicts("^rocprim@5.3.0:5.3.2", when="+rocm")
 
     # 3.8.0 has a build issue with MKL - so list this conflict explicitly
     conflicts("^intel-mkl", when="@3.8.0")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -144,6 +144,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     variant("kokkos", default=False, description="Activates support for kokkos and kokkos-kernels")
     variant("fortran", default=True, description="Activates fortran support")
 
+    # https://github.com/spack/spack/issues/37416
+    conflicts("^rocprim@5.3.0", when="@3.19.1 +rocm")
+
     # 3.8.0 has a build issue with MKL - so list this conflict explicitly
     conflicts("^intel-mkl", when="@3.8.0")
 


### PR DESCRIPTION
There is an issue with `rocprim@5.3.0:5.3.2` that prevents it being used for `petsc +rocm` builds

Fixes https://github.com/spack/spack/issues/37416

CC @wspear
