### PR TITLE
circos: add v0.69-9

### DIFF
--- a/var/spack/repos/builtin/packages/circos/package.py
+++ b/var/spack/repos/builtin/packages/circos/package.py
@@ -14,6 +14,7 @@ class Circos(Package):
     homepage = "http://circos.ca/"
     url = "http://circos.ca/distribution/circos-0.69-6.tgz"
 
+    version("0.69-9", sha256="34d8d7ebebf3f553d62820f8f4a0a57814b610341f836b4740c46c3057f789d2")
     version("0.69-6", sha256="52d29bfd294992199f738a8d546a49754b0125319a1685a28daca71348291566")
 
     depends_on("perl", type="run")


### PR DESCRIPTION
Add circos v0.69-9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.