### PR TITLE
codec2: add v1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/codec2/package.py
+++ b/var/spack/repos/builtin/packages/codec2/package.py
@@ -14,5 +14,6 @@ class Codec2(CMakePackage):
     homepage = "https://www.rowetel.com/?page_id=452"
     url = "https://github.com/drowe67/codec2/archive/v0.9.2.tar.gz"
 
+    version("1.1.0", sha256="d56ba661008a780b823d576a5a2742c94d0b0507574643a7d4f54c76134826a3")
     version("1.0.5", sha256="cd9a065dd1c3477f6172a0156294f767688847e4d170103d1f08b3a075f82826")
     version("0.9.2", sha256="19181a446f4df3e6d616b50cabdac4485abb9cd3242cf312a0785f892ed4c76c")


### PR DESCRIPTION
Add codec2 v1.1.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.