### PR TITLE
coinutils: add v2.11.9

### DIFF
--- a/var/spack/repos/builtin/packages/coinutils/package.py
+++ b/var/spack/repos/builtin/packages/coinutils/package.py
@@ -14,6 +14,7 @@ class Coinutils(AutotoolsPackage):
     homepage = "https://projects.coin-or.org/Coinutils"
     url = "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
 
+    version("2.11.9", sha256="15d572ace4cd3b7c8ce117081b65a2bd5b5a4ebaba54fadc99c7a244160f88b8")
     version("2.11.6", sha256="6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca")
     version("2.11.4", sha256="d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81")
 


### PR DESCRIPTION
Add coinutils v2.11.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.