### PR TITLE
g2c: add v1.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -20,6 +20,7 @@ class G2c(CMakePackage):
     variant("jasper", default=True)
     variant("openjpeg", default=False)
 
+    version("1.7.0", sha256="73afba9da382fed73ed8692d77fa037bb313280879cd4012a5e5697dccf55175")
     version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
     version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
 


### PR DESCRIPTION
Add g2c v1.7.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.