### PR TITLE
gsl-lite: add v0.41.0

### DIFF
--- a/var/spack/repos/builtin/packages/gsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/gsl-lite/package.py
@@ -17,6 +17,7 @@ class GslLite(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "climbfuji", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("0.41.0", sha256="4682d8a60260321b92555760be3b9caab60e2a71f95eddbdfb91e557ee93302a")
     version("0.40.0", commit="d6c8af99a1d95b3db36f26b4f22dc3bad89952de")
     version("0.39.0", commit="d0903fa87ff579c30f608bc363582e6563570342")
     version("0.38.1", sha256="c2fa2315fff312f3897958903ed4d4e027f73fa44235459ecb467ad7b7d62b18")


### PR DESCRIPTION
Add gsl-lite v0.41.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.