### PR TITLE
roctracer-dev-api: add v5.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
@@ -18,6 +18,7 @@ class RoctracerDevApi(Package):
 
     maintainers("srekolam", "renjithravindrankannath")
 
+    version("5.5.0", sha256="fe9ad95628fa96639db6fc33f78d334c814c7161b4a754598f5a4a7852625777")
     version("5.4.3", sha256="6b5111be5efd4d7fd6935ca99b06fab19b43d97a58d26fc1fe6e783c4de9a926")
     version("5.4.0", sha256="04c1e955267a3e8440833a177bb976f57697aba0b90c325d07fc0c6bd4065aea")
     version("5.3.3", sha256="f2cb1e6bb69ea1a628c04f984741f781ae1d8498dc58e15795bb03015f924d13")


### PR DESCRIPTION
Add roctracer-dev-api v5.5.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.