### PR TITLE
yoda: add v1.9.8

### DIFF
--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -15,6 +15,7 @@ class Yoda(AutotoolsPackage):
 
     tags = ["hep"]
 
+    version("1.9.8", sha256="7bc3062468abba50aff3ecb8b22ce677196036009890688ef4533aaa7f92e6e4")
     version("1.9.7", sha256="8d07bb04dcb79364858718a18203452d8d9fa00029fa94239eafa8529032b8ff")
     version("1.9.6", sha256="21523fa2f6b6c8f3348959f3a948734a930ca25951d3c9190b4424e13735f2a4")
     version("1.9.5", sha256="59191a0e9afa8db53ffaa2079f8532e5b13de1be622703d6f7060d3610528b6b")


### PR DESCRIPTION
Add yoda v1.9.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.