### PR TITLE
alluxio: add v2.9.3

### DIFF
--- a/var/spack/repos/builtin/packages/alluxio/package.py
+++ b/var/spack/repos/builtin/packages/alluxio/package.py
@@ -17,6 +17,7 @@ class Alluxio(Package):
     list_url = "https://downloads.alluxio.io/downloads/files"
     list_depth = 1
 
+    version("2.9.3", sha256="c71abc5e852d37cfd6b1dea076f056c6997e3f60fbb940bf005acb3a6354a369")
     version("2.9.1", sha256="e9456db7a08488af22dee3a44e4135bc03a0444e31c7753bf00f72465f68ffb9")
 
     # https://nvd.nist.gov/vuln/detail/CVE-2022-23848


### PR DESCRIPTION
Add alluxio v2.9.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.