### PR TITLE
p11-kit: add v0.24.1

### DIFF
--- a/var/spack/repos/builtin/packages/p11-kit/package.py
+++ b/var/spack/repos/builtin/packages/p11-kit/package.py
@@ -17,6 +17,7 @@ class P11Kit(AutotoolsPackage):
     homepage = "https://p11-glue.github.io/p11-glue/p11-kit.html"
     url = "https://github.com/p11-glue/p11-kit/archive/0.23.21.tar.gz"
 
+    version("0.24.1", sha256="27f3c23531b24a2672ab198a3118f4f399d3a1faa8697924cc8a1065a17ead25")
     version("0.23.21", sha256="0361bcc55858618625a8e99e7fe9069f81514849b7b51ade51f8117d3ad31d88")
     version("0.23.20", sha256="8f6116f34735f6902e9db461c5dbe3e7e25b5cb8c38f42ea2a5aede1cf693749")
     version("0.23.19", sha256="c27921404e82244d97b27f46bae654e5814b5963e0ce3c75ad37007ded46f700")


### PR DESCRIPTION
Add p11-kit v0.24.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.