### PR TITLE
zoltan: add v3.901

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -23,6 +23,7 @@ class Zoltan(AutotoolsPackage):
     homepage = "http://www.cs.sandia.gov/zoltan"
     url = "https://github.com/sandialabs/Zoltan/archive/v3.83.tar.gz"
 
+    version("3.901", sha256="030c22d9f7532d3076e40cba1f03a63b2ee961d8cc9a35149af4a3684922a910")
     version("3.83", sha256="17320a9f08e47f30f6f3846a74d15bfea6f3c1b937ca93c0ab759ca02c40e56c")
 
     patch("notparallel.patch", when="@3.8")


### PR DESCRIPTION
Add zoltan v3.901. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.