### PR TITLE
amqp-cpp: add v4.3.24

### DIFF
--- a/var/spack/repos/builtin/packages/amqp-cpp/package.py
+++ b/var/spack/repos/builtin/packages/amqp-cpp/package.py
@@ -17,6 +17,7 @@ class AmqpCpp(CMakePackage):
 
     maintainers("lpottier")
 
+    version("4.3.24", sha256="c3312f8af813cacabf6c257dfaf41bf9e66606bbf7d62d085a9b7da695355245")
     version("4.3.19", sha256="ca29bb349c498948576a4604bed5fd3c27d87240b271a4441ccf04ba3797b31d")
 
     variant(


### PR DESCRIPTION
Add amqp-cpp v4.3.24. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.