### PR TITLE
audit-userspace: add v3.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/audit-userspace/package.py
+++ b/var/spack/repos/builtin/packages/audit-userspace/package.py
@@ -12,6 +12,7 @@ class AuditUserspace(AutotoolsPackage):
     homepage = "https://github.com/linux-audit/audit-userspace"
     url = "https://github.com/linux-audit/audit-userspace/archive/v2.8.5.tar.gz"
 
+    version("3.1.1", sha256="6a97cc472920639d736e9927353be05e323f351067fcf6e5d34439cafa0e9006")
     version("2.8.5", sha256="835ffdd65056ba0c26509dbf48882713b00dbe70e1d8cf25d538501136c2e3e9")
     version("2.8.4", sha256="089dfdceb38edf056202a6de4892fd0c9aaa964c08bd7806c5d0c7c33f09e18d")
     version("2.8.3", sha256="c239e3813b84bc264aaf2f796c131c1fe02960244f789ec2bd8d88aad4561b29")


### PR DESCRIPTION
Add audit-userspace v3.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.