### PR TITLE
beast-tracer: add v1.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/beast-tracer/package.py
+++ b/var/spack/repos/builtin/packages/beast-tracer/package.py
@@ -15,6 +15,7 @@ class BeastTracer(Package):
     homepage = "https://beast.community/tracer"
     url = "https://github.com/beast-dev/tracer/archive/v1.7.1.tar.gz"
 
+    version("1.7.2", sha256="fd891e2244445fef71ab8010d8fab924abff2e5436e035bb335834e7c2e6d83b")
     version("1.7.1", sha256="947d51c5afa52354099b9b182ba6036e352356bd62df94031f33cdcb7e8effd3")
 
     depends_on("ant", type="build")


### PR DESCRIPTION
Add beast-tracer v1.7.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.