### PR TITLE
cronie: add v1.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/cronie/package.py
+++ b/var/spack/repos/builtin/packages/cronie/package.py
@@ -13,6 +13,7 @@ class Cronie(AutotoolsPackage):
     homepage = "https://github.com/cronie-crond/cronie"
     url = "https://github.com/cronie-crond/cronie/archive/cronie-1.5.5.tar.gz"
 
+    version("1.6.1", sha256="1ddbc8f8d07dfe1d45998b0a0cbd9a216cd4d7bc64d1626b2bc8b3a69e4641d1")
     version("1.5.5", sha256="22c2a2b22577c0f776c1268d0e0f305c5c041e10155022a345b43b665da0ffe9")
 
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Add cronie v1.6.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.