### PR TITLE
dos2unix: add v7.4.4

### DIFF
--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -16,6 +16,7 @@ class Dos2unix(MakefilePackage):
 
     maintainers("cessenat")
 
+    version("7.4.4", sha256="28a841db0bd5827d645caba9d8015e3a71983dc6e398070b5287ee137ae4436e")
     version("7.4.2", sha256="6035c58df6ea2832e868b599dfa0d60ad41ca3ecc8aa27822c4b7a9789d3ae01")
     version("7.3.4", sha256="8ccda7bbc5a2f903dafd95900abb5bf5e77a769b572ef25150fde4056c5f30c5")
 


### PR DESCRIPTION
Add dos2unix v7.4.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.