### PR TITLE
gegl: add v0.4.44

### DIFF
--- a/var/spack/repos/builtin/packages/gegl/package.py
+++ b/var/spack/repos/builtin/packages/gegl/package.py
@@ -18,6 +18,7 @@ class Gegl(MesonPackage):
 
     maintainers("benkirk")
 
+    version("0.4.44", sha256="0a4cdb41635e406a0849cd0d3f03caf7d97cab8aa13d28707d532d0089d56126")
     version("0.4.42", sha256="aba83a0cbaa6c56edc29ea22f2e8172950a53b96daa51592083d59222bdde02d")
     version("0.4.40", sha256="cdde80d15a49dab9a614ef98f804c8ce6e4cfe1339a3c240c34f3fb45436b85d")
     version("0.4.38", sha256="e4a33c8430a5042fba8439b595348e71870f0d95fbf885ff553f9020c1bed750")


### PR DESCRIPTION
Add gegl v0.4.44. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.