### PR TITLE
libvterm: add v0.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/libvterm/package.py
+++ b/var/spack/repos/builtin/packages/libvterm/package.py
@@ -13,6 +13,7 @@ class Libvterm(MakefilePackage):
     homepage = "http://www.leonerd.org.uk/code/libvterm/"
     url = "http://www.leonerd.org.uk/code/libvterm/libvterm-0.1.3.tar.gz"
 
+    version("0.3.1", sha256="25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397")
     version("0.3", sha256="61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358")
     version("0.2", sha256="4c5150655438cfb8c57e7bd133041140857eb04defd0e544521c0e469258e105")
     version("0.1.4", sha256="bc70349e95559c667672fc8c55b9527d9db9ada0fb80a3beda533418d782d3dd")


### PR DESCRIPTION
Add libvterm v0.3.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.