### PR TITLE
mutationpp: add v1.0.5

### DIFF
--- a/var/spack/repos/builtin/packages/mutationpp/package.py
+++ b/var/spack/repos/builtin/packages/mutationpp/package.py
@@ -18,6 +18,7 @@ class Mutationpp(CMakePackage):
     homepage = "https://github.com/mutationpp/Mutationpp"
     url = "https://github.com/mutationpp/Mutationpp/archive/v0.3.1.tar.gz"
 
+    version("1.0.5", sha256="319eca4e82a2469946344195373eabf28caaf6a39ddf3142b2337f47aa0835a8")
     version("1.0.0", sha256="928df99accd1a02706a57246edeef8ebbf3bd91bb40492258ee18b810a7e0194")
     version("0.3.1", sha256="a6da2816e145ac9fcfbd8920595b7f65ce7bc8df0bec572b32647720758cbe69")
 


### PR DESCRIPTION
Add mutationpp v1.0.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.