### PR TITLE
trimgalore: add v0.6.9

### DIFF
--- a/var/spack/repos/builtin/packages/trimgalore/package.py
+++ b/var/spack/repos/builtin/packages/trimgalore/package.py
@@ -14,6 +14,7 @@ class Trimgalore(Package):
     homepage = "https://github.com/FelixKrueger/TrimGalore"
     url = "https://github.com/FelixKrueger/TrimGalore/archive/0.4.4.tar.gz"
 
+    version("0.6.9", sha256="d50ce6106f979c316c89c7e7bcb44e5f841935d88bc4f756ccf0bc4cbab4e6f5")
     version("0.6.6", sha256="b8db8ffd131d9d9e7c8532a5a1f1caee656c0c58d3eafd460fee3c39b9fcab5e")
     version("0.6.4", sha256="eb57e18203d8a1dce1397b930a348a9969eebaa758b8a7304d04c22f216cea2d")
     version("0.6.3", sha256="c85104452dbb5cfa8c9307920e804fb53baaad355ce656b111f5243e5eb92db4")


### PR DESCRIPTION
Add trimgalore v0.6.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.