### PR TITLE
vdt: add v0.4.4

### DIFF
--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -15,6 +15,7 @@ class Vdt(CMakePackage):
     homepage = "https://github.com/dpiparo/vdt"
     url = "https://github.com/dpiparo/vdt/archive/v0.3.9.tar.gz"
 
+    version("0.4.4", sha256="8b1664b45ec82042152f89d171dd962aea9bb35ac53c8eebb35df1cb9c34e498")
     version("0.4.3", sha256="705674612ebb5c182b65a8f61f4d173eb7fe7cdeee2235b402541a492e08ace1")
     version("0.3.9", sha256="1662d21037a29cae717ee50b73bd177bea79582f4138b7ad11404fc4be4e542e")
     version("0.3.8", sha256="e6d8485c3c8923993cb1b1a5bb85068a86746285058bf77faeb177363647be62")


### PR DESCRIPTION
Add vdt v0.4.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.