### PR TITLE
z-checker: add v0.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/z-checker/package.py
+++ b/var/spack/repos/builtin/packages/z-checker/package.py
@@ -16,6 +16,7 @@ class ZChecker(AutotoolsPackage):
 
     maintainers("disheng222")
 
+    version("0.9.0", sha256="44436ad5971a24dd26a09d8262bc1fcd8c9fd0b746aff009a91ccbe57330baa1")
     version("0.7.0", sha256="02caf3af2dc59d116496f877da888dd2c2dffb9375c413b1d74401927963df3f")
     version("0.6.0", sha256="b01c2c78157234a734c2f4c10a7ab82c329d3cd1a8389d597e09386fa33a3117")
     version("0.5.0", sha256="ad5e68472c511b393ee1ae67d2e3072a22004001cf19a14bd99a2e322a6ce7f9")


### PR DESCRIPTION
Add z-checker v0.9.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.