### PR TITLE
breseq: add v0.38.1

### DIFF
--- a/var/spack/repos/builtin/packages/breseq/package.py
+++ b/var/spack/repos/builtin/packages/breseq/package.py
@@ -14,6 +14,7 @@ class Breseq(AutotoolsPackage):
     homepage = "https://barricklab.org/breseq"
     url = "https://github.com/barricklab/breseq/archive/v0.31.1.tar.gz"
 
+    version("0.38.1", sha256="2b5d0aa9c751881c3ee31c0384953156b848b80d2d2d9c451763d74da0465902")
     version("0.33.2", sha256="c698d2d25cc7ed251ff916343a8c04f79b5540281288cb7c955f458255ac21de")
     version("0.33.1", sha256="e24a50e254ad026c519747313b9e42bbeb32bd766a6a06ed369bd5b9dc50e84d")
     version("0.31.1", sha256="ffc8a7f40a5ad918234e465e9d4cdf74be02fd29091b13720c2cab1dc238cf5c")


### PR DESCRIPTION
Add breseq v0.38.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.