### PR TITLE
hazelcast: add v5.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/hazelcast/package.py
+++ b/var/spack/repos/builtin/packages/hazelcast/package.py
@@ -15,6 +15,7 @@ class Hazelcast(MavenPackage):
     homepage = "http://www.hazelcast.com/"
     url = "https://github.com/hazelcast/hazelcast/archive/v3.12.8.tar.gz"
 
+    version("5.2.3", sha256="026c213d3bb520b6c44587ae2a67eca50b9a5a0fc56d2cdedfb2c09c7858a11f")
     version("4.0.2", sha256="4f01682583ae6603365ac7a24c568d7598cc3c1cbd736e5c6ed98bd75e39ffa3")
     version("4.0.1", sha256="c9c7d5cbcf70c5e1eb72890df2b4104639f7543f11c6ac5d3e80cd2d4a0d2181")
     version("3.12.8", sha256="65d0e131fc993f9517e8ce9ae5af9515f1b8038304abaaf9da535bdef1d71726")


### PR DESCRIPTION
Add hazelcast v5.2.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.