### PR TITLE
libblastrampoline: add v5.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/libblastrampoline/package.py
+++ b/var/spack/repos/builtin/packages/libblastrampoline/package.py
@@ -15,6 +15,7 @@ class Libblastrampoline(MakefilePackage):
 
     maintainers("haampie", "giordano")
 
+    version("5.8.0", sha256="aeceb01ebebdd1068a1147b636451c46c16d64f9e22694075abda4dddfffe13d")
     version("5.4.0", sha256="e1a2258b0ad31cc41e6e9b8ba36f5c239fd1a267f2657ef3d3f669cc5b811f6a")
     version("5.3.0", sha256="95bca73f1567e2acd1110d0dfe5bb58fc86718555cd6eab89f0a769534df3b62")
     version("5.2.0", sha256="5af9ff9cec16087f57109082a362419fc49152034fa90772ebcabd882007fd95")


### PR DESCRIPTION
Add libblastrampoline v5.8.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.