### PR TITLE
ssht: add v1.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/ssht/package.py
+++ b/var/spack/repos/builtin/packages/ssht/package.py
@@ -21,6 +21,7 @@ class Ssht(CMakePackage):
 
     maintainers("eschnett")
 
+    version("1.5.2", sha256="6ce3e48d36a4af57cab9d96f5f845f905808dac8ac8b3ec195f6b49d017a890d")
     version("1.5.1", sha256="f0b6fb6a1de40354fcf4eafe09b953c96a72ba9c533a42e290802e93cd14170c")
     version("1.5.0", sha256="ff42103463c973a11da84b757d2a6661679c8a60745e44f0ccf697f88593083a")
     version("1.4.0", sha256="b33f1b763a240df773a1900139aad6f6b5c676bb2b64a8c1062077fd95c08769")


### PR DESCRIPTION
Add ssht v1.5.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.