### PR TITLE
subversion: add v1.14.2

### DIFF
--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -22,6 +22,7 @@ class Subversion(AutotoolsPackage):
 
     tags = ["build-tools"]
 
+    version("1.14.2", sha256="fd826afad03db7a580722839927dc664f3e93398fe88b66905732c8530971353")
     version("1.14.1", sha256="dee2796abaa1f5351e6cc2a60b1917beb8238af548b20d3e1ec22760ab2f0cad")
     version("1.14.0", sha256="ef3d1147535e41874c304fb5b9ea32745fbf5d7faecf2ce21d4115b567e937d0")
     version("1.13.0", sha256="daad440c03b8a86fcca804ea82217bb1902cfcae1b7d28c624143c58dcb96931")


### PR DESCRIPTION
Add subversion v1.14.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.