### PR TITLE
delta: add v2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/delta/package.py
+++ b/var/spack/repos/builtin/packages/delta/package.py
@@ -13,6 +13,7 @@ class Delta(Package):
     homepage = "https://delta.io/"
     url = "https://github.com/delta-io/delta/archive/v0.7.0.tar.gz"
 
+    version("2.3.0", sha256="0c0ea5edb5e8f30fc56b5ab5c8fed50db93d75b047d8241fe1b2449858d9db1c")
     version("0.7.0", sha256="1fb01e36c1cf670f201c615e5fd7df88f72c27157b7d2780d146e21b266bdb64")
     version("0.6.1", sha256="c932eaf01ead08ff30ddb13ab5ad9cd43405ed8f12d5fff49bd27c59033b80df")
     version("0.6.0", sha256="bd4a4b0f164bc6a9efc58369b3f466fa2e6ae977bd6f9cd97d83dfd27a90ba3a")


### PR DESCRIPTION
Add delta v2.3.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.