### PR TITLE
druid: add v1.2.8

### DIFF
--- a/var/spack/repos/builtin/packages/druid/package.py
+++ b/var/spack/repos/builtin/packages/druid/package.py
@@ -14,6 +14,7 @@ class Druid(MavenPackage):
     homepage = "https://github.com/alibaba/druid/"
     url = "https://github.com/alibaba/druid/archive/1.1.23.tar.gz"
 
+    version("1.2.8", sha256="e7e3726ea6d16f98bcf027eaa8591078827d249830ff3b3ba6579d70735d0003")
     version("1.1.23", sha256="f29a0c5e60eb8a4d6fcfdf21bb4b6f54c1076a214f65190b8cdce2663cf84432")
     version("1.1.22", sha256="0bd64e518beca840cd2f79bbfa612f47defbb3366333a11cff937af4424f96ce")
     version("1.1.21", sha256="c0dae665c9fffd991dd9b9880cb69fa48f6b04608b395f380c93f59df599423e")


### PR DESCRIPTION
Add druid v1.2.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.