### PR TITLE
fd-find: add v8.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/fd-find/package.py
+++ b/var/spack/repos/builtin/packages/fd-find/package.py
@@ -12,6 +12,7 @@ class FdFind(Package):
     homepage = "https://github.com/sharkdp/fd"
     url = "https://github.com/sharkdp/fd/archive/v7.3.0.tar.gz"
 
+    version("8.7.0", sha256="13da15f3197d58a54768aaad0099c80ad2e9756dd1b0c7df68c413ad2d5238c9")
     version("7.4.0", sha256="33570ba65e7f8b438746cb92bb9bc4a6030b482a0d50db37c830c4e315877537")
 
     depends_on("rust")


### PR DESCRIPTION
Add fd-find v8.7.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.