### PR TITLE
Add a minimal `spack update` command

### DIFF
--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -85,9 +85,7 @@ def update(parser: ArgumentParser, args: Namespace) -> None:
 
             for file in changed_files.split("\n"):
                 if file.endswith("package.py"):
-                    result = re.search(
-                        "var/spack/repos/builtin/packages/(.*)/package.py", file
-                    )
+                    result = re.search("var/spack/repos/builtin/packages/(.*)/package.py", file)
                     if result is None:
                         continue
                     pkg = result.group(1)

--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -6,7 +6,7 @@
 import re
 import sys
 
-import llnl.util.tty as tty
+from llnl.util import tty
 from llnl.util.filesystem import working_dir
 from llnl.util.tty.colify import colify
 
@@ -75,7 +75,7 @@ def update(parser, args):
         # check to see if the repository updated
         if old_head != new_head:
             changed_files = git(
-                "diff-tree", "-r", "--name-status", "{old_head}..{new_head}", output=str
+                "diff-tree", "-r", "--name-status", f"{old_head}..{new_head}", output=str
             )
             changed_packages = {"Added": [], "Updated": [], "Deleted": []}
 

--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -49,7 +49,7 @@ def update(parser, args):
                     remote = git("config", f"branch.{branch}.remote", output=str).strip()
                     remote_url = git("config", f"remote.{remote}.url", output=str).strip()
 
-                    if remote_url.endswith("spack/spack.git"):
+                    if re.match(r"spack\/spack(\.git)?$", remote_url):
                         upstream_branch = branch
                         break
 

--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -1,0 +1,65 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+
+import llnl.util.tty as tty
+from llnl.util.filesystem import working_dir
+
+import spack.cmd
+import spack.util.git
+from spack.cmd import spack_is_git_repo
+
+description = "update the spack repository to the latest commit"
+section = "system"
+level = "short"
+
+
+def setup_parser(subparser):
+    subparser.add_argument("-b", "--branch", help="name of the branch to upate the repository to")
+
+
+def update(parser, args):
+    # make sure that spack is a git repository
+    if not spack_is_git_repo():
+        tty.die("This spack is not a git clone. Can't use 'spack update'")
+
+    git = spack.util.git.git(required=True)
+
+    # execute git within the spack repository
+    with working_dir(spack.paths.prefix):
+        checked_out_ref = git("symbolic-ref", "-q", "HEAD", output=str)
+        current_branch = checked_out_ref.replace("refs/heads/", "", 1)
+
+        # provide a warning if the user did not specify a branch
+        # and spack's repository is not tracking upstream develop
+        if args.branch is None:
+            upstream_branch = None
+
+            refs = git("for-each-ref", "--format=%(refname)", "refs/heads/", output=str)
+            for ref in refs.split():
+                branch = ref.replace("refs/heads/", "", 1)
+                branch_remote_ref = git("config", f"branch.{branch}.merge", output=str)
+
+                if branch_remote_ref.strip().endswith("develop"):
+                    remote = git("config", f"branch.{branch}.remote", output=str).strip()
+                    remote_url = git("config", f"remote.{remote}.url", output=str).strip()
+
+                    if remote_url.endswith("spack/spack.git"):
+                        upstream_branch = branch
+                        break
+
+            if upstream_branch is not None and current_branch != upstream_branch:
+                tty.warn("Spack is not tracking upstream develop.")
+                tty.warn("Packages may be out of date. To switch to develop run,")
+                print()
+                print(f"    spack update -b {upstream_branch}")
+                print()
+
+        elif args.branch != current_branch:
+            git("checkout", args.branch)
+
+        # perform a git pull to update the repository
+        git("pull", "--rebase", "-n")

--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -3,13 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 import re
 import sys
 
 import llnl.util.tty as tty
-from llnl.util.tty.colify import colify
 from llnl.util.filesystem import working_dir
+from llnl.util.tty.colify import colify
 
 import spack.cmd
 import spack.util.git

--- a/lib/spack/spack/cmd/update.py
+++ b/lib/spack/spack/cmd/update.py
@@ -5,6 +5,7 @@
 
 import re
 import sys
+from argparse import ArgumentParser, Namespace
 
 from llnl.util import tty
 from llnl.util.filesystem import working_dir
@@ -19,11 +20,11 @@ section = "system"
 level = "short"
 
 
-def setup_parser(subparser):
+def setup_parser(subparser: ArgumentParser) -> None:
     subparser.add_argument("-b", "--branch", help="name of the branch to upate the repository to")
 
 
-def update(parser, args):
+def update(parser: ArgumentParser, args: Namespace) -> None:
     # make sure that spack is a git repository
     if not spack_is_git_repo():
         tty.die("This spack is not a git clone. Can't use 'spack update'")

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -13,17 +13,17 @@ import spack.util.executable as exe
 
 
 @llnl.util.lang.memoized
-def git(required: bool = False):
+def git(required: bool = False) -> Optional[exe.Executable]:
     """Get a git executable.
 
     Arguments:
         required: if ``True``, fail if ``git`` is not found. By default return ``None``.
     """
-    git: Optional[exe.Executable] = exe.which("git", required=required)
+    git_exe: Optional[exe.Executable] = exe.which("git", required=required)
 
     # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
     # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
-    if git and "pytest" in sys.modules:
-        git.add_default_arg("-c", "protocol.file.allow=always")
+    if git_exe and "pytest" in sys.modules:
+        git_exe.add_default_arg("-c", "protocol.file.allow=always")
 
-    return git
+    return git_exe

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -401,7 +401,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload update url verify versions view"
     fi
 }
 
@@ -1983,6 +1983,10 @@ _spack_unload() {
     else
         _installed_packages
     fi
+}
+
+_spack_update() {
+    SPACK_COMPREPLY="-h --help -b --branch"
 }
 
 _spack_url() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -425,6 +425,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a undevelop -d 'rem
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a uninstall -d 'remove installed packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a unit-test -d 'run spack'"'"'s unit tests (wrapper around pytest)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a unload -d 'remove package from the user environment'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a update -d 'update the spack repository to the latest commit'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a url -d 'debugging tool for url parsing'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a verify -d 'check that all spack packages are on disk as installed'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a versions -d 'list available versions of a package'
@@ -3046,6 +3047,13 @@ complete -c spack -n '__fish_spack_using_command unload' -l pwsh -f -a shell
 complete -c spack -n '__fish_spack_using_command unload' -l pwsh -d 'print pwsh commands to load the package'
 complete -c spack -n '__fish_spack_using_command unload' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command unload' -s a -l all -d 'unload all loaded Spack packages'
+
+# spack update
+set -g __fish_spack_optspecs_spack_update h/help b/branch=
+complete -c spack -n '__fish_spack_using_command update' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command update' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command update' -s b -l branch -r -f -a branch
+complete -c spack -n '__fish_spack_using_command update' -s b -l branch -r -d 'name of the branch to upate the repository to'
 
 # spack url
 set -g __fish_spack_optspecs_spack_url h/help


### PR DESCRIPTION
This PR adds a minimal `spack update` command which mimics the functionality of similar package managers (e.g. `brew`, `apt`, etc...) allowing users to update their Spack installation without requiring them to explicitly use git in their spack installation directory. *This command is not aimed at upgrading packages.*

### Demo Output:
**Already up to date.**
```
alec@laptop spack % spack update
Already up to date.
```

**Help new users understand the consequences of different branches.**
```
alec@laptop spack % spack update
==> Warning: Spack is not tracking upstream develop.
==> Warning: Packages may be out of date. To switch to develop run,

    spack update -b develop

Already up to date.
```

**Improved human readable `git pull` results.**
```
alec@laptop spack % spack update
Updating 0d37564a..eacb8242
Fast-forward
==> Added 2 packages
perl-email-simple  perl-moox-types-mooselike
==> Updated 4 packages
berkeleygw  fmt  gperftools  py-tensorboard
```

### Design Goals:
- Make use of git plumbing instead of porcelain commands whenever parsing git output.
- Show standard `git pull` output to users instead of trying to overwrite it with our own.
- This command is not a replacement for `git`. If you're actively developing on Spack you should use normal git. This command provides a nice interface for a common action for Spack new/casual users.

Fixes #9134.