### PR TITLE
xdmf3: fix  #35538

### DIFF
--- a/var/spack/repos/builtin/packages/xdmf3/fix_hdf5_hid_t.diff
+++ b/var/spack/repos/builtin/packages/xdmf3/fix_hdf5_hid_t.diff
@@ -1,0 +1,40 @@
+diff --git a/core/XdmfHDF5Controller.hpp b/core/XdmfHDF5Controller.hpp
+index c5c15d0a..496cc80d 100644
+--- a/core/XdmfHDF5Controller.hpp
++++ b/core/XdmfHDF5Controller.hpp
+@@ -27,13 +27,14 @@
+ // C Compatible Includes
+ #include "XdmfCore.hpp"
+ #include "XdmfHeavyDataController.hpp"
++#include <stdint.h>
+ 
+ // So that hdf5 does not need to be included in the header files
+ // It would add a dependancy to programs that use Xdmf
+ #ifndef _H5Ipublic_H
+   #ifndef XDMF_HID_T
+   #define XDMF_HID_T
+-    typedef int hid_t;
++    typedef int64_t hid_t;
+   #endif
+ #endif
+ 
+diff --git a/core/XdmfHDF5Writer.hpp b/core/XdmfHDF5Writer.hpp
+index cfbec6f4..f83aa0de 100644
+--- a/core/XdmfHDF5Writer.hpp
++++ b/core/XdmfHDF5Writer.hpp
+@@ -28,13 +28,14 @@
+ #include "XdmfCore.hpp"
+ #include "XdmfHeavyDataWriter.hpp"
+ #include "XdmfHeavyDataController.hpp"
++#include <stdint.h>
+ 
+ // So that hdf5 does not need to be included in the header files
+ // It would add a dependancy to programs that use Xdmf
+ #ifndef _H5Ipublic_H
+   #ifndef XDMF_HID_T
+   #define XDMF_HID_T
+-    typedef int hid_t;
++    typedef int64_t hid_t;
+   #endif
+ #endif
+ 

--- a/var/spack/repos/builtin/packages/xdmf3/fix_hdf5_hid_t.diff
+++ b/var/spack/repos/builtin/packages/xdmf3/fix_hdf5_hid_t.diff
@@ -6,7 +6,7 @@ index c5c15d0a..496cc80d 100644
  // C Compatible Includes
  #include "XdmfCore.hpp"
  #include "XdmfHeavyDataController.hpp"
-+#include <stdint.h>
++#include <cstdint>
  
  // So that hdf5 does not need to be included in the header files
  // It would add a dependancy to programs that use Xdmf
@@ -26,7 +26,7 @@ index cfbec6f4..f83aa0de 100644
  #include "XdmfCore.hpp"
  #include "XdmfHeavyDataWriter.hpp"
  #include "XdmfHeavyDataController.hpp"
-+#include <stdint.h>
++#include <cstdint>
  
  // So that hdf5 does not need to be included in the header files
  // It would add a dependancy to programs that use Xdmf

--- a/var/spack/repos/builtin/packages/xdmf3/package.py
+++ b/var/spack/repos/builtin/packages/xdmf3/package.py
@@ -30,8 +30,10 @@ class Xdmf3(CMakePackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     depends_on("mpi", when="+mpi")
-    depends_on("hdf5+mpi", when="+mpi")
-    depends_on("hdf5~mpi", when="~mpi")
+    depends_on("hdf5@1.10:+mpi", when="+mpi")
+    depends_on("hdf5@1.10:~mpi", when="~mpi")
+    # motivated by discussion in https://gitlab.kitware.com/xdmf/xdmf/-/issues/28
+    patch("fix_hdf5_hid_t.diff")
 
     def cmake_args(self):
         """Populate cmake arguments for XDMF."""
@@ -42,7 +44,7 @@ class Xdmf3(CMakePackage):
             "-DXDMF_BUILD_UTILS=ON",
             "-DXDMF_WRAP_JAVA=OFF",
             "-DXDMF_WRAP_PYTHON=OFF",
-            "-DXDMF_BUILD_TESTING=ON",
+            "-DXDMF_BUILD_TESTING=OFF",
         ]
 
         return cmake_args


### PR DESCRIPTION
- Fixes  #35538. It is related to an opened issue in xdmf3 (which has a solution, https://gitlab.kitware.com/xdmf/xdmf/-/issues/28, but which was never merged).
- According to the link above, my solution would only work with hdf1.10 and above. That's why I now specify the hdf5 version. (actually, the link above proposes to change the type based on the HDF5_VERSION, but this does not work (also tried with ${HDF5_VERSION}. 
- Testing needs to be turned off as one test does not compile (not related to the changes proposed).