### PR TITLE
Create include/lib in prefix for oneapi packages

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -6,11 +6,14 @@
 import getpass
 import platform
 import shutil
+import os
 from os.path import basename, dirname, isdir
 
 from llnl.util.filesystem import find_headers, find_libraries, join_path
+from llnl.util.link_tree import LinkTree
 
 from spack.directives import conflicts, variant
+from spack.package import mkdirp
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 
@@ -125,6 +128,30 @@ class IntelOneApiPackage(Package):
                 )
             )
 
+    def symlink_dir(self, src, dest):
+        # Taken from: https://github.com/spack/spack/pull/31285/files
+        # oneapi bin/lib directories are 2 or 3 levels below the
+        # prefix, but it is more typical to have them directly in the
+        # prefix. The location has changed over time. Rather than make
+        # every package that needs to know where include/lib are
+        # located be aware of this, put in symlinks to conform. This
+        # is good enough for some, but not all packages.
+
+        # If we symlink top-level directories directly, files won't
+        # show up in views Create real dirs and symlink files instead
+
+        # Create a real directory at dest
+        mkdirp(dest)
+
+        # Symlink all files in src to dest keeping directories as dirs
+        for entry in os.listdir(src):
+            src_path = join_path(src, entry)
+            dest_path = join_path(dest, entry)
+            if isdir(src_path) and os.access(src_path, os.X_OK):
+                link_tree = LinkTree(src_path)
+                link_tree.merge(dest_path)
+            else:
+                os.symlink(src_path, dest_path)
 
 class IntelOneApiLibraryPackage(IntelOneApiPackage):
     """Base class for Intel oneAPI library packages.

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Common utilities for managing intel oneapi packages."""
 import getpass
+import os
 import platform
 import shutil
-import os
 from os.path import basename, dirname, isdir
 
 from llnl.util.filesystem import find_headers, find_libraries, join_path
@@ -152,6 +152,7 @@ class IntelOneApiPackage(Package):
                 link_tree.merge(dest_path)
             else:
                 os.symlink(src_path, dest_path)
+
 
 class IntelOneApiLibraryPackage(IntelOneApiPackage):
     """Base class for Intel oneAPI library packages.

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -170,9 +170,12 @@ class Elk(MakefilePackage):
             config["LIB_FFT"] = spec["mkl"].libs.ld_flags
             config["SRC_FFT"] = "mkl_dfti.f90 zfftifc_mkl.f90"
             cp = which("cp")
+            mkl_prefix = spec["mkl"].prefix
+            if spec.satisfies("^intel-mkl"):
+                mkl_prefix = mkl_prefix.mkl
             cp(
-                "{}/mkl/include/mkl_dfti.f90".format(spec["mkl"].prefix),
-                self.build_directory + "/src",
+                join_path(mkl_prefix.include, "mkl_dfti.f90"),
+                join_path(self.build_directory, "src"),
             )
 
         # Define targets

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -170,3 +170,8 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     def _xlp64_lib(self, lib):
         return lib + ("_ilp64" if "+ilp64" in self.spec else "_lp64")
+
+    @run_after("install")
+    def fixup_prefix(self):
+        self.symlink_dir(self.component_prefix.include, self.prefix.include)
+        self.symlink_dir(self.component_prefix.lib, self.prefix.lib)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -176,3 +176,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
                 self.component_prefix.bin.join(wrapper),
                 backup=False,
             )
+
+    @run_after("install")
+    def fixup_prefix(self):
+        self.symlink_dir(self.component_prefix.include, self.prefix.include)
+        self.symlink_dir(self.component_prefix.lib, self.prefix.lib)
+        self.symlink_dir(self.component_prefix.lib.release, self.prefix.lib)
+        self.symlink_dir(self.component_prefix.bin, self.prefix.bin)

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -94,3 +94,8 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     @property
     def component_dir(self):
         return "tbb"
+
+    @run_after("install")
+    def fixup_prefix(self):
+        self.symlink_dir(self.component_prefix.include, self.prefix.include)
+        self.symlink_dir(self.component_prefix.lib, self.prefix.lib)


### PR DESCRIPTION
oneapi bin/lib directories are 2 or 3 levels below the prefix, but it is more typical to have them directly in the prefix. The location has changed over time. Most packages do not need to know where bin/include/lib are located, but some do. Rather than make them aware of this, put in symlinks to conform.

This is support for changing default providers to oneapi instead of paralel studio: #37412 