### PR TITLE
py-lightly: py-torch~distributed supported in next release

### DIFF
--- a/var/spack/repos/builtin/packages/py-lightly/package.py
+++ b/var/spack/repos/builtin/packages/py-lightly/package.py
@@ -41,4 +41,4 @@ class PyLightly(PythonPackage):
     depends_on("py-pytorch-lightning@1.0.4:1", when="@:1.4.1", type=("build", "run"))
 
     # https://github.com/lightly-ai/lightly/issues/1153
-    depends_on("py-torch+distributed", type=("build", "run"))
+    depends_on("py-torch+distributed", when="@:1.4.4", type=("build", "run"))


### PR DESCRIPTION
This was fixed in master.