### PR TITLE
hip: get_paths for hipify-clang

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -373,6 +373,7 @@ class Hip(CMakePackage):
 
             paths = {
                 "hip-path": hip_path,
+                "hipify-clang": rocm_prefix,
                 "rocm-path": rocm_prefix,
                 "llvm-amdgpu": rocm_prefix.llvm,
                 "hsa-rocr-dev": rocm_prefix.hsa,
@@ -382,6 +383,7 @@ class Hip(CMakePackage):
         else:
             paths = {
                 "hip-path": self.spec.prefix,
+                "hipify-clang": rocm_prefix,
                 "rocm-path": self.spec.prefix,
                 "llvm-amdgpu": self.spec["llvm-amdgpu"].prefix,
                 "hsa-rocr-dev": self.spec["hsa-rocr-dev"].prefix,

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -379,6 +379,9 @@ class Hip(CMakePackage):
                 "rocminfo": rocm_prefix,
                 "rocm-device-libs": rocm_prefix,
             }
+
+            if self.spec.satisfies("@5.4:"):
+                paths["hipify-clang"] = rocm_prefix
         else:
             paths = {
                 "hip-path": self.spec.prefix,
@@ -388,9 +391,9 @@ class Hip(CMakePackage):
                 "rocminfo": self.spec["rocminfo"].prefix,
                 "rocm-device-libs": self.spec["llvm-amdgpu"].prefix,
             }
-
-        if self.spec.satisfies("@5.4:"):
-            paths["hipify-clang"] = rocm_prefix
+            
+            if self.spec.satisfies("@5.4:"):
+                paths["hipify-clang"] = self.spec["hipify-clang"].prefix
 
         if "@:3.8.0" in self.spec:
             paths["bitcode"] = paths["rocm-device-libs"].lib

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -373,7 +373,6 @@ class Hip(CMakePackage):
 
             paths = {
                 "hip-path": hip_path,
-                "hipify-clang": rocm_prefix,
                 "rocm-path": rocm_prefix,
                 "llvm-amdgpu": rocm_prefix.llvm,
                 "hsa-rocr-dev": rocm_prefix.hsa,
@@ -383,13 +382,15 @@ class Hip(CMakePackage):
         else:
             paths = {
                 "hip-path": self.spec.prefix,
-                "hipify-clang": rocm_prefix,
                 "rocm-path": self.spec.prefix,
                 "llvm-amdgpu": self.spec["llvm-amdgpu"].prefix,
                 "hsa-rocr-dev": self.spec["hsa-rocr-dev"].prefix,
                 "rocminfo": self.spec["rocminfo"].prefix,
                 "rocm-device-libs": self.spec["llvm-amdgpu"].prefix,
             }
+
+        if self.spec.satisfies("@5.4:"):
+            paths["hipify-clang"] = rocm_prefix
 
         if "@:3.8.0" in self.spec:
             paths["bitcode"] = paths["rocm-device-libs"].lib
@@ -419,7 +420,7 @@ class Hip(CMakePackage):
             # there is a common prefix /opt/rocm-x.y.z.
             env.set("ROCM_PATH", paths["rocm-path"])
             if self.spec.satisfies("@5.4:"):
-                env.set("HIPIFY_CLANG_PATH", self.spec["hipify-clang"].prefix)
+                env.set("HIPIFY_CLANG_PATH", paths["hipify-clang"])
 
             # hipcc recognizes HIP_PLATFORM == hcc and HIP_COMPILER == clang, even
             # though below we specified HIP_PLATFORM=rocclr and HIP_COMPILER=clang

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -391,7 +391,7 @@ class Hip(CMakePackage):
                 "rocminfo": self.spec["rocminfo"].prefix,
                 "rocm-device-libs": self.spec["llvm-amdgpu"].prefix,
             }
-            
+
             if self.spec.satisfies("@5.4:"):
                 paths["hipify-clang"] = self.spec["hipify-clang"].prefix
 


### PR DESCRIPTION
External hip stopped working after https://github.com/spack/spack/pull/36993 because `hipify-clang` path was trying to be pulled out of `spec` instead of `get_paths`

This fixes https://github.com/spack/spack/issues/37489

What do you think @renjithravindrankannath @blue42u?