### PR TITLE
Environment/depfile: fix bug with Git hash versions (attempt #2)

### DIFF
--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -46,8 +46,8 @@ class DepfileNode:
     def __init__(
         self, target: spack.spec.Spec, prereqs: List[spack.spec.Spec], buildcache: UseBuildCache
     ):
-        self.target = SpecWrapper(target)
-        self.prereqs = list(SpecWrapper(x) for x in prereqs)
+        self.target = MakefileSpec(target)
+        self.prereqs = list(MakefileSpec(x) for x in prereqs)
         if buildcache == UseBuildCache.ONLY:
             self.buildcache_flag = "--use-buildcache=only"
         elif buildcache == UseBuildCache.NEVER:
@@ -90,7 +90,10 @@ class DepfileSpecVisitor:
         return True
 
 
-class SpecWrapper(object):
+class MakefileSpec(object):
+    """Limited interface to spec to help generate targets etc. without
+       introducing unwanted special characters.
+    """
     def __init__(self, spec):
         self.spec = spec
 
@@ -133,7 +136,7 @@ class MakefileModel:
         self.env_path = env.path
 
         # These specs are built in the default target.
-        self.roots = list(SpecWrapper(x) for x in roots)
+        self.roots = list(MakefileSpec(x) for x in roots)
 
         # The SPACK_PACKAGE_IDS variable is "exported", which can be used when including
         # generated makefiles to add post-install hooks, like pushing to a buildcache,

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -92,8 +92,9 @@ class DepfileSpecVisitor:
 
 class MakefileSpec(object):
     """Limited interface to spec to help generate targets etc. without
-       introducing unwanted special characters.
+    introducing unwanted special characters.
     """
+
     def __init__(self, spec):
         self.spec = spec
 
@@ -156,7 +157,9 @@ class MakefileModel:
                 item.target.safe_name(),
                 " ".join(self._install_target(s.safe_name()) for s in item.prereqs),
                 item.target.spec_hash(),
-                item.target.unsafe_format("{name}{@version}{%compiler}{variants}{arch=architecture}"),
+                item.target.unsafe_format(
+                    "{name}{@version}{%compiler}{variants}{arch=architecture}"
+                ),
                 item.buildcache_flag,
             )
             for item in adjacency_list

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -95,6 +95,8 @@ class MakefileSpec(object):
     introducing unwanted special characters.
     """
 
+    _pattern = None
+
     def __init__(self, spec):
         self.spec = spec
 
@@ -106,7 +108,9 @@ class MakefileSpec(object):
 
     def safe_format(self, format_str):
         unsafe_result = self.spec.format(format_str)
-        return re.sub(r"[^A-Za-z0-9_.-]", "_", unsafe_result)
+        if not MakefileSpec._pattern:
+            MakefileSpec._pattern = re.compile(r"[^A-Za-z0-9_.-]")
+        return MakefileSpec._pattern.sub("_", unsafe_result)
 
     def unsafe_format(self, format_str):
         return self.spec.format(format_str)

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -8,6 +8,7 @@ depfiles from an environment.
 """
 
 import os
+import re
 from enum import Enum
 from typing import List, Optional
 
@@ -45,8 +46,8 @@ class DepfileNode:
     def __init__(
         self, target: spack.spec.Spec, prereqs: List[spack.spec.Spec], buildcache: UseBuildCache
     ):
-        self.target = target
-        self.prereqs = prereqs
+        self.target = SpecWrapper(target)
+        self.prereqs = list(SpecWrapper(x) for x in prereqs)
         if buildcache == UseBuildCache.ONLY:
             self.buildcache_flag = "--use-buildcache=only"
         elif buildcache == UseBuildCache.NEVER:
@@ -89,6 +90,24 @@ class DepfileSpecVisitor:
         return True
 
 
+class SpecWrapper(object):
+    def __init__(self, spec):
+        self.spec = spec
+
+    def safe_name(self):
+        return self.safe_format("{name}-{version}-{hash}")
+
+    def spec_hash(self):
+        return self.spec.dag_hash()
+
+    def safe_format(self, format_str):
+        unsafe_result = self.spec.format(format_str)
+        return re.sub(r"[^A-Za-z0-9_.-]", "_", unsafe_result)
+
+    def unsafe_format(self, format_str):
+        return self.spec.format(format_str)
+
+
 class MakefileModel:
     """This class produces all data to render a makefile for specs of an environment."""
 
@@ -114,7 +133,7 @@ class MakefileModel:
         self.env_path = env.path
 
         # These specs are built in the default target.
-        self.roots = roots
+        self.roots = list(SpecWrapper(x) for x in roots)
 
         # The SPACK_PACKAGE_IDS variable is "exported", which can be used when including
         # generated makefiles to add post-install hooks, like pushing to a buildcache,
@@ -131,17 +150,17 @@ class MakefileModel:
         # And here we collect a tuple of (target, prereqs, dag_hash, nice_name, buildcache_flag)
         self.make_adjacency_list = [
             (
-                self._safe_name(item.target),
-                " ".join(self._install_target(self._safe_name(s)) for s in item.prereqs),
-                item.target.dag_hash(),
-                item.target.format("{name}{@version}{%compiler}{variants}{arch=architecture}"),
+                item.target.safe_name(),
+                " ".join(self._install_target(s.safe_name()) for s in item.prereqs),
+                item.target.spec_hash(),
+                item.target.unsafe_format("{name}{@version}{%compiler}{variants}{arch=architecture}"),
                 item.buildcache_flag,
             )
             for item in adjacency_list
         ]
 
         # Root specs without deps are the prereqs for the environment target
-        self.root_install_targets = [self._install_target(self._safe_name(s)) for s in roots]
+        self.root_install_targets = [self._install_target(s.safe_name()) for s in self.roots]
 
         self.jobserver_support = "+" if jobserver else ""
 
@@ -157,16 +176,13 @@ class MakefileModel:
         self.phony_convenience_targets: List[str] = []
 
         for node in adjacency_list:
-            tgt = self._safe_name(node.target)
+            tgt = node.target.safe_name()
             self.all_pkg_identifiers.append(tgt)
             self.all_install_related_targets.append(self._install_target(tgt))
             self.all_install_related_targets.append(self._install_deps_target(tgt))
             if make_prefix is None:
                 self.phony_convenience_targets.append(os.path.join("install", tgt))
                 self.phony_convenience_targets.append(os.path.join("install-deps", tgt))
-
-    def _safe_name(self, spec: spack.spec.Spec) -> str:
-        return spec.format("{name}-{version}-{hash}")
 
     def _target(self, name: str) -> str:
         # The `all` and `clean` targets are phony. It doesn't make sense to

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -8,7 +8,6 @@ import io
 import itertools
 import os
 import pathlib
-import re
 import shutil
 import sys
 from argparse import Namespace
@@ -3139,9 +3138,8 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
     assert len(specs_that_make_would_install) == len(set(specs_that_make_would_install))
 
 
-def test_environment_depfile_spec_format_special_chars(tmpdir, mock_packages, monkeypatch):
+def test_environment_depfile_spec_format_special_chars(mock_packages, monkeypatch):
     env("create", "test")
-    makefile = str(tmpdir.join("Makefile"))
     with ev.read("test"):
         add("dttop")
         concretize()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -6,8 +6,8 @@ import filecmp
 import glob
 import io
 import os
-import re
 import pathlib
+import re
 import shutil
 import sys
 from argparse import Namespace

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -5,7 +5,6 @@
 import filecmp
 import glob
 import io
-import itertools
 import os
 import pathlib
 import shutil
@@ -25,6 +24,7 @@ import spack.environment.environment
 import spack.environment.shell
 import spack.error
 import spack.modules
+import spack.package_base
 import spack.paths
 import spack.repo
 import spack.util.spack_json as sjson
@@ -3138,35 +3138,55 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
     assert len(specs_that_make_would_install) == len(set(specs_that_make_would_install))
 
 
-def test_environment_depfile_spec_format_special_chars(mock_packages, monkeypatch):
+def test_depfile_safe_format():
+    """Test that depfile.MakefileSpec.safe_format() escapes target names."""
+
+    class SpecLike:
+        def format(self, _):
+            return "abc@def=ghi"
+
+    spec = depfile.MakefileSpec(SpecLike())
+    assert spec.safe_format("{name}") == "abc_def_ghi"
+    assert spec.unsafe_format("{name}") == "abc@def=ghi"
+
+
+def test_depfile_works_with_gitversions(tmpdir, mock_packages, monkeypatch):
+    """Git versions may contain = chars, which should be escaped in targets,
+    otherwise they're interpreted as makefile variable assignments."""
+    monkeypatch.setattr(spack.package_base.PackageBase, "git", "repo.git", raising=False)
     env("create", "test")
+
+    make = Executable("make")
+    makefile = str(tmpdir.join("Makefile"))
+
+    # Create an environment with dttop and dtlink1 both at a git version,
+    # and generate a depfile
     with ev.read("test"):
-        add("dttop")
+        add(f"dttop@{'a' * 40}=1.0 ^dtlink1@{'b' * 40}=1.0")
         concretize()
+        env("depfile", "-o", makefile, "--make-disable-jobserver", "--make-prefix=prefix")
 
-    orig_format = spack.spec.Spec.format
+    # Do a dry run on the generated depfile
+    out = make("-n", "-f", makefile, output=str)
 
-    def _contrived_spec_format(obj, format_str):
-        if obj.name == "dtlink1":
-            return "dtlink1-githash=version-spackhash"
-        else:
-            return orig_format(obj, format_str)
-
-    monkeypatch.setattr(spack.spec.Spec, "format", _contrived_spec_format)
-
-    with ev.read("test") as e:
-        model = depfile.MakefileModel.from_env(e)
-
-    properties_of_interest = set(
-        itertools.chain(
-            model.all_pkg_identifiers,
-            model.all_install_related_targets,
-            model.root_install_targets,
-        )
-    )
-
-    assert not any("dtlink1-githash=version-spackhash" in x for x in properties_of_interest)
-    assert any("dtlink1-githash_version-spackhash" in x for x in properties_of_interest)
+    # Check that all specs are there (without duplicates)
+    specs_that_make_would_install = _parse_dry_run_package_installs(out)
+    expected_installs = [
+        "dtbuild1",
+        "dtbuild2",
+        "dtbuild3",
+        "dtlink1",
+        "dtlink2",
+        "dtlink3",
+        "dtlink4",
+        "dtlink5",
+        "dtrun1",
+        "dtrun2",
+        "dtrun3",
+        "dttop",
+    ]
+    assert set(specs_that_make_would_install) == set(expected_installs)
+    assert len(specs_that_make_would_install) == len(set(specs_that_make_would_install))
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -20,8 +20,8 @@ import llnl.util.link_tree
 
 import spack.cmd.env
 import spack.config
-import spack.environment.depfile as depfile
 import spack.environment as ev
+import spack.environment.depfile as depfile
 import spack.environment.environment
 import spack.environment.shell
 import spack.error
@@ -3159,15 +3159,16 @@ def test_environment_depfile_spec_format_special_chars(tmpdir, mock_packages, mo
     with ev.read("test") as e:
         model = depfile.MakefileModel.from_env(e)
 
-    properties_of_interest = set(itertools.chain(
-        model.all_pkg_identifiers, model.all_install_related_targets,
-        model.root_install_targets
-    ))
+    properties_of_interest = set(
+        itertools.chain(
+            model.all_pkg_identifiers,
+            model.all_install_related_targets,
+            model.root_install_targets,
+        )
+    )
 
-    assert not any("dtlink1-githash=version-spackhash" in x for x in
-                   properties_of_interest)
-    assert any("dtlink1-githash_version-spackhash" in x for x in
-               properties_of_interest)
+    assert not any("dtlink1-githash=version-spackhash" in x for x in properties_of_interest)
+    assert any("dtlink1-githash_version-spackhash" in x for x in properties_of_interest)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replaces https://github.com/spack/spack/pull/36642

If a spec contains a hash=number version, this was resulting in malformed Makefiles generated by spack env depfile (the target cannot include an un-escaped '=' character). This

* Introduces regular expressions to remove special characters from the spec component of generated makefile targets
* Replaces all references to `Spec`s in the `MakefileModel` (and associated objects) with references to a limited interface to avoid similar issues in the future

TODO

- [x] Do one-time regular expression compilation
