### PR TITLE
gh: add conflict for v2.28.0 and macos

### DIFF
--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -29,6 +29,8 @@ class Gh(Package):
     version("1.14.0", sha256="1a99050644b4821477aabc7642bbcae8a19b3191e9227cd8078016d78cdd83ac")
     version("1.13.1", sha256="1a19ab2bfdf265b5e2dcba53c3bd0b5a88f36eff4864dcc38865e33388b600c5")
 
+    conflicts("platform=darwin", when="@2.28.0")
+
     depends_on("go@1.16:", type="build")
 
     phases = ["build", "install"]


### PR DESCRIPTION
Add conflict directive for gh@2.28.0 and MacOS. 

`gh` [moved to a new Makefile format](https://github.com/cli/cli/commit/80f91af1711b077d2ea20aaae693dccfef714433) that expected to be built on systems with a GNU build of the coreutils programs. This was [fixed for future versions](https://github.com/cli/cli/commit/c64032b9815efef846b93cc29ed4eb47a2ce8d6c) and thus this conflict should only apply to v2.28.0.