### PR TITLE
Use single quotes to inline manifest in Dockerfiles

### DIFF
--- a/lib/spack/spack/container/writers/docker.py
+++ b/lib/spack/spack/container/writers/docker.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import shlex
+
 import spack.tengine as tengine
 
 from . import PathContext, writer
@@ -17,14 +19,15 @@ class DockerContext(PathContext):
     @tengine.context_property
     def manifest(self):
         manifest_str = super(DockerContext, self).manifest
-        # Docker doesn't support HEREDOC so we need to resort to
+        # Docker doesn't support HEREDOC, so we need to resort to
         # a horrible echo trick to have the manifest in the Dockerfile
         echoed_lines = []
         for idx, line in enumerate(manifest_str.split("\n")):
+            quoted_line = shlex.quote(line)
             if idx == 0:
-                echoed_lines.append('&&  (echo "' + line + '" \\')
+                echoed_lines.append("&&  (echo " + quoted_line + " \\")
                 continue
-            echoed_lines.append('&&   echo "' + line + '" \\')
+            echoed_lines.append("&&   echo " + quoted_line + " \\")
 
         echoed_lines[-1] = echoed_lines[-1].replace(" \\", ")")
 

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
+
 import pytest
 
 import spack.container.writers as writers
@@ -149,3 +151,14 @@ def test_not_stripping_all_symbols(minimal_configuration):
     content = writers.create(minimal_configuration)()
     assert "xargs strip" in content
     assert "xargs strip -s" not in content
+
+
+@pytest.mark.regression("22341")
+def test_using_single_quotes_in_dockerfiles(minimal_configuration):
+    """Tests that Dockerfiles written by Spack use single quotes in manifest, to avoid issues
+    with shell substitution. This may happen e.g. when users have "definitions:" they want to
+    expand in dockerfiles.
+    """
+    manifest_in_docker = writers.create(minimal_configuration).manifest
+    assert not re.search(r"echo\s*\"", manifest_in_docker, flags=re.MULTILINE)
+    assert re.search(r"echo\s*'", manifest_in_docker)


### PR DESCRIPTION
fixes #22341

Using double quotes creates issues with shell variable substitutions, in particular when the manifest has "definitions:" in it. Use single quotes instead.