### PR TITLE
Fix compiler version issues (concrete vs range)

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -724,7 +724,7 @@ def make_compiler_list(detected_versions):
     def _default_make_compilers(cmp_id, paths):
         operating_system, compiler_name, version = cmp_id
         compiler_cls = spack.compilers.class_for_compiler_name(compiler_name)
-        spec = spack.spec.CompilerSpec(compiler_cls.name, version)
+        spec = spack.spec.CompilerSpec(compiler_cls.name, f"={version}")
         paths = [paths.get(x, None) for x in ("cc", "cxx", "f77", "fc")]
         # TODO: johnwparent - revist the following line as per discussion at:
         # https://github.com/spack/spack/pull/33385/files#r1040036318

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -187,7 +187,9 @@ def remove_compiler_from_config(compiler_spec, scope=None):
     filtered_compiler_config = [
         comp
         for comp in compiler_config
-        if spack.spec.CompilerSpec(comp["compiler"]["spec"]) != compiler_spec
+        if not spack.spec.parse_with_version_concrete(
+            comp["compiler"]["spec"], compiler=True
+        ).satisfies(compiler_spec)
     ]
 
     # Update the cache for changes

--- a/lib/spack/spack/operating_systems/cray_backend.py
+++ b/lib/spack/spack/operating_systems/cray_backend.py
@@ -161,7 +161,7 @@ class CrayBackend(LinuxDistro):
         compilers = []
         for v in compiler_id.version:
             comp = cmp_cls(
-                spack.spec.CompilerSpec(name + "@" + v),
+                spack.spec.CompilerSpec(name + "@=" + v),
                 self,
                 "any",
                 ["cc", "CC", "ftn"],

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -107,10 +107,10 @@ fi
 
 
 def test_compiler_remove(mutable_config, mock_packages):
+    assert spack.spec.CompilerSpec("gcc@=4.5.0") in spack.compilers.all_compiler_specs()
     args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.5.0", add_paths=[], scope=None)
     spack.cmd.compiler.compiler_remove(args)
-    compilers = spack.compilers.all_compiler_specs()
-    assert spack.spec.CompilerSpec("gcc@=4.5.0") not in compilers
+    assert spack.spec.CompilerSpec("gcc@=4.5.0") not in spack.compilers.all_compiler_specs()
 
 
 @pytest.mark.skipif(

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -110,7 +110,7 @@ def test_compiler_remove(mutable_config, mock_packages):
     args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.5.0", add_paths=[], scope=None)
     spack.cmd.compiler.compiler_remove(args)
     compilers = spack.compilers.all_compiler_specs()
-    assert spack.spec.CompilerSpec("gcc@4.5.0") not in compilers
+    assert spack.spec.CompilerSpec("gcc@=4.5.0") not in compilers
 
 
 @pytest.mark.skipif(
@@ -204,12 +204,12 @@ def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, clangdir):
     os.environ["PATH"] = str(clangdir)
     output = compiler("find", "--scope=site")
 
-    assert "clang@11.0.0" in output
-    assert "gcc@8.4.0" in output
+    assert "clang@=11.0.0" in output
+    assert "gcc@=8.4.0" in output
 
     config = spack.compilers.get_compiler_config("site", False)
-    clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@11.0.0")
-    gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@8.4.0")
+    clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")
+    gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@=8.4.0")
 
     gfortran_path = str(clangdir.join("gfortran-8"))
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -246,11 +246,11 @@ def test_compiler_find_prefer_no_suffix(no_compilers_yaml, working_env, clangdir
     os.environ["PATH"] = str(clangdir)
     output = compiler("find", "--scope=site")
 
-    assert "clang@11.0.0" in output
-    assert "gcc@8.4.0" in output
+    assert "clang@=11.0.0" in output
+    assert "gcc@=8.4.0" in output
 
     config = spack.compilers.get_compiler_config("site", False)
-    clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@11.0.0")
+    clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")
 
     assert clang["paths"]["cc"] == str(clangdir.join("clang"))
     assert clang["paths"]["cxx"] == str(clangdir.join("clang++"))
@@ -277,7 +277,7 @@ def test_compiler_find_path_order(no_compilers_yaml, working_env, clangdir):
 
     config = spack.compilers.get_compiler_config("site", False)
 
-    gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@8.4.0")
+    gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@=8.4.0")
 
     assert gcc["paths"] == {
         "cc": str(clangdir.join("first_in_path", "gcc-8")),


### PR DESCRIPTION
Fix some issues where compiler detection creates CompilerSpec instances with non-concrete versions