### PR TITLE
py-loguru: add v0.2.5, v0.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-loguru/package.py
+++ b/var/spack/repos/builtin/packages/py-loguru/package.py
@@ -13,6 +13,7 @@ class PyLoguru(PythonPackage):
     pypi = "loguru/loguru-0.6.0.tar.gz"
 
     version("0.6.0", sha256="066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c")
+    version("0.3.0", sha256="f2a0fa92f334d37a13351aa36ab18e8039649a3741836b4b6d8b8bce7e8457ac")
     version("0.2.5", sha256="68297d9f23064c2f4764bb5d0c5c767f3ed7f9fc1218244841878f5fc7c94add")
 
     depends_on("python@3.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-loguru/package.py
+++ b/var/spack/repos/builtin/packages/py-loguru/package.py
@@ -13,6 +13,7 @@ class PyLoguru(PythonPackage):
     pypi = "loguru/loguru-0.6.0.tar.gz"
 
     version("0.6.0", sha256="066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c")
+    version("0.2.5", sha256="68297d9f23064c2f4764bb5d0c5c767f3ed7f9fc1218244841878f5fc7c94add")
 
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
An older version of `py-loguru` is needed for upcoming PRs

CC @valmar @wspear