### PR TITLE
libxcb/xcb-proto: Enable internal Python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -33,7 +33,7 @@ class Libxcb(AutotoolsPackage):
     depends_on("xcb-proto@1.11:", when="@1.11:1.11.999")
 
     # libxcb 1.13 added Python 3 support
-    depends_on('python@3', when='@1.13:', type='build')
+    depends_on("python@3", when="@1.13:", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -32,11 +32,8 @@ class Libxcb(AutotoolsPackage):
     depends_on("xcb-proto@1.12:", when="@1.12:1.12.999")
     depends_on("xcb-proto@1.11:", when="@1.11:1.11.999")
 
-    # TODO: uncomment once build deps can be resolved separately
-    # See #7646, #4145, #4063, and #2548 for details
     # libxcb 1.13 added Python 3 support
-    # depends_on('python', type='build')
-    # depends_on('python@2:2.8', when='@:1.12', type='build')
+    depends_on('python@3', when='@1.13:', type='build')
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -20,7 +20,7 @@ class XcbProto(AutotoolsPackage):
     version("1.12", sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59")
     version("1.11", sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906")
 
-    extends('python')
+    extends("python")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -20,9 +20,7 @@ class XcbProto(AutotoolsPackage):
     version("1.12", sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59")
     version("1.11", sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906")
 
-    # TODO: uncomment once build deps can be resolved separately
-    # See #7646, #4145, #4063, and #2548 for details
-    # extends('python')
+    extends('python')
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 


### PR DESCRIPTION
In the past, Spack did not allow two different versions of the same package within a DAG. That led to difficulties with packages that still required Python 2 while other packages had already switched to Python 3.

The `libxcb` and `xcb-proto` packages did not have Python 3 support for a time. To get around this issue, Spack maintainers disabled their dependency on an internal (i.e., Spack-provided) Python (see #4145), forcing these packages to look for a system-provided Python (see #7646).

This has worked for us all right, but with the arrival of our most recent platform we seem to be missing the critical xcbgen Python module on the system. Since most software has largely moved on to Python 3 now, let's re-enable internal Spack dependencies for the `libxcb` and `xcb-proto` packages.

This MR addresses #37400.

These packages do not have an official maintainer, so I'm mentioning @adamjstewart and @scheibelp as they have both worked on this issue in the past. 