### PR TITLE
SUNDIALS: new version of sundials and guard against examples being install

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -27,6 +27,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # Versions
     # ==========================================================================
     version("develop", branch="develop")
+    version("6.5.1", sha256="4252303805171e4dbdd19a01e52c1dcfe0dafc599c3cfedb0a5c2ffb045a8a75")
     version("6.5.0", sha256="4e0b998dff292a2617e179609b539b511eb80836f5faacf800e688a886288502")
     version("6.4.1", sha256="7bf10a8d2920591af3fba2db92548e91ad60eb7241ab23350a9b1bc51e05e8d0")
     version("6.4.0", sha256="0aff803a12c6d298d05b56839197dd09858631864017e255ed89e28b49b652f1")
@@ -782,7 +783,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     def setup_smoke_tests(self):
-        install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
+        if "~examples-install" in self.spec:
+            install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
         self.cmake_bin(set=True)
 
     def build_smoke_tests(self):
@@ -790,6 +792,10 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         if not cmake_bin:
             tty.msg("Skipping sundials test: cmake_bin_path.txt not found")
+            return
+
+        if "~examples-install" in self.spec:
+            tty.msg("Skipping sundials test: examples were not installed")
             return
 
         for smoke_test in self._smoke_tests:
@@ -800,6 +806,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
                 self.run_test(exe="make")
 
     def run_smoke_tests(self):
+        if "~examples-install" in self.spec:
+            return
+
         for smoke_test in self._smoke_tests:
             self.run_test(
                 exe=join_path(self._smoke_tests_path, smoke_test[0]),
@@ -811,6 +820,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             )
 
     def clean_smoke_tests(self):
+        if "~examples-install" in self.spec:
+            return
+
         for smoke_test in self._smoke_tests:
             work_dir = join_path(self._smoke_tests_path, os.path.dirname(smoke_test[0]))
             with working_dir(work_dir):

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -783,7 +783,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     def setup_smoke_tests(self):
-        if "~examples-install" in self.spec:
+        if "+examples-install" in self.spec:
             install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
         self.cmake_bin(set=True)
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -774,6 +774,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         """(Hack) Set/get cmake dependency path."""
         filepath = join_path(self.install_test_root, "cmake_bin_path.txt")
         if set:
+            if not os.path.exists(self.install_test_root):
+                mkdirp(self.install_test_root)
             with open(filepath, "w") as out_file:
                 cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
                 out_file.write("{0}\n".format(cmake_bin))


### PR DESCRIPTION
Got the following error when `sundials~examples-install`:

```
==> sundials: Executing phase: 'install'
==> Error: OSError: No such file or directory: '/prefix/sundials-6.5.1-mfuhaodmjnxlyavjxfqbjdhkhybcval6/examples'

/repo/scripts/spack/packages/sundials/package.py:821, in setup_smoke_tests:
        820    def setup_smoke_tests(self):
  >>    821        install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
        822        self.cmake_bin(set=True)
```

This works around the examples not being in the install prefix.