### PR TITLE
intel-xed: add version 2023.04.16

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/libxed-ild.patch
+++ b/var/spack/repos/builtin/packages/intel-xed/libxed-ild.patch
@@ -1,0 +1,32 @@
+Fixes a bug where libxed-ild didn't understand some instructions.
+
+https://github.com/intelxed/xed/issues/298
+
+
+diff --git a/src/dec/xed-ild.c b/src/dec/xed-ild.c
+index 8bf7cbe..0ab90ac 100644
+--- a/src/dec/xed-ild.c
++++ b/src/dec/xed-ild.c
+@@ -1385,6 +1385,7 @@ void xed_ild_lookup_init(void) {
+ void xed_ild_init(void) {
+     init_prefix_table();
+     xed_ild_lookup_init();
++    xed_init_chip_model_info();
+ #if defined(XED_EXTENSION_XOP_DEFINED) 
+     xed_ild_chip_init();
+ #endif
+diff --git a/xed_mbuild.py b/xed_mbuild.py
+index db34179..5a7842c 100755
+--- a/xed_mbuild.py
++++ b/xed_mbuild.py
+@@ -1081,7 +1081,8 @@ def build_xed_ild_library(env, lib_env, lib_dag, sources_to_replace):
+                        'xed-ild-disp-l3.c',         # generated
+                        'xed-ild-eosz.c',            # generated
+                        'xed-ild-easz.c',            # generated
+-                       'xed-ild-imm-l3.c']          # generated
++                       'xed-ild-imm-l3.c',          # generated
++                       'xed-error-enum.c',]         # generated
+     common_objs = lib_env.make_obj(common_sources)
+     
+     ild_objs += xbc.build_dir_join(lib_env, common_objs)
+

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -35,19 +35,11 @@ class IntelXed(Package):
 
     # Match xed more closely with the version of mbuild at the time.
     resource(
-        name="mbuild",
-        placement="mbuild",
-        git=mbuild_git,
-        tag="v2022.07.28",
-        when="@2022.07:9999",
+        name="mbuild", placement="mbuild", git=mbuild_git, tag="v2022.07.28", when="@2022.07:9999"
     )
 
     resource(
-        name="mbuild",
-        placement="mbuild",
-        git=mbuild_git,
-        tag="v2022.04.17",
-        when="@:2022.06",
+        name="mbuild", placement="mbuild", git=mbuild_git, tag="v2022.04.17", when="@:2022.06"
     )
 
     variant("debug", default=False, description="Enable debug symbols")

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -21,6 +21,7 @@ class IntelXed(Package):
 
     # Current versions now have actual releases and tags.
     version("main", branch="main")
+    version("2023.04.16", tag="v2023.04.16")
     version("2022.10.11", tag="v2022.10.11")
     version("2022.08.11", tag="v2022.08.11")
     version("2022.04.17", tag="v2022.04.17")
@@ -32,26 +33,34 @@ class IntelXed(Package):
 
     resource(name="mbuild", placement="mbuild", git=mbuild_git, branch="main", when="@main")
 
+    # Match xed more closely with the version of mbuild at the time.
     resource(
         name="mbuild",
         placement="mbuild",
         git=mbuild_git,
-        commit="09b6654be0c52bf1df44e88c88b411a67b624cbd",
-        when="@:9999",
+        tag="v2022.07.28",
+        when="@2022.07:9999",
+    )
+
+    resource(
+        name="mbuild",
+        placement="mbuild",
+        git=mbuild_git,
+        tag="v2022.04.17",
+        when="@:2022.06",
     )
 
     variant("debug", default=False, description="Enable debug symbols")
     variant("pic", default=False, description="Compile with position independent code.")
 
     # The current mfile uses python3 by name.
-    depends_on("python@3.4:", type="build")
+    depends_on("python@3.6:", type="build")
 
     patch("1201-segv.patch", when="@12.0.1")
     patch("2019-python3.patch", when="@10.2019.03")
+    patch("libxed-ild.patch", when="@12.0:2022.12")
 
-    conflicts("target=ppc64:", msg="intel-xed only runs on x86")
-    conflicts("target=ppc64le:", msg="intel-xed only runs on x86")
-    conflicts("target=aarch64:", msg="intel-xed only runs on x86")
+    requires("target=x86_64:", msg="intel-xed only runs on x86/x86_64")
 
     mycflags = []  # type: List[str]
 

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -81,7 +81,7 @@ class IntelXed(Package):
         try:
             lname = join_path(self.stage.source_path, "..", "xed")
             os.symlink("spack-src", lname)
-        except:
+        except OSError:
             pass
 
         mfile = Executable(join_path(".", "mfile.py"))

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -41,9 +41,7 @@ class IntelXed(Package):
         name="mbuild", placement=mdir, git=mbuild_git, tag="v2022.07.28", when="@2022.07:9999"
     )
 
-    resource(
-        name="mbuild", placement=mdir, git=mbuild_git, tag="v2022.04.17", when="@:2022.06"
-    )
+    resource(name="mbuild", placement=mdir, git=mbuild_git, tag="v2022.04.17", when="@:2022.06")
 
     variant("debug", default=False, description="Enable debug symbols")
     variant("pic", default=False, description="Compile with position independent code.")


### PR DESCRIPTION
 1. add version 2023.04.16
 2. adjust the mbuild resource to better match the xed version at the time
 3. replace three conflicts() with one new requires() for x86_64 target
 4. add patch for libxed-ild for some new avx512 instructions

----------

Is it possible to specify the `resource` args globally for things like
`name`, `placement` and `git` in the same way that `version` uses?
