### PR TITLE
Package requirements: support cflags (attempt 2)

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2463,11 +2463,16 @@ class SpecBuilder(object):
 
                     # add flags from each source, lowest to highest precedence
                     for name in sorted_sources:
-                        source = self._specs[name] if name in self._hash_specs else cmd_specs[name]
-                        extend_flag_list(from_sources, source.compiler_flags.get(flag_type, []))
+                        all_src_flags = list()
+                        per_pkg_sources = [self._specs[name]]
+                        if name in cmd_specs:
+                            per_pkg_sources.append(cmd_specs[name])
+                        for source in per_pkg_sources:
+                            all_src_flags.extend(source.compiler_flags.get(flag_type, []))
+                        extend_flag_list(from_sources, all_src_flags)
 
                 # compiler flags from compilers config are lowest precedence
-                ordered_compiler_flags = from_compiler + from_sources
+                ordered_compiler_flags = list(llnl.util.lang.dedupe(from_compiler + from_sources))
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
 
                 msg = "%s does not equal %s" % (set(compiler_flags), set(ordered_compiler_flags))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2137,6 +2137,10 @@ class SpackSolverSetup(object):
 
         # get list of all possible dependencies
         self.possible_virtuals = set(x.name for x in specs if x.virtual)
+        for spec in specs:
+            if not spec.virtual:
+                for provided in spec.package_class.provided:
+                    self.possible_virtuals.add(provided.name)
         possible = spack.package_base.possible_dependencies(
             *specs, virtuals=self.possible_virtuals, deptype=spack.dependency.all_deptypes
         )
@@ -2463,11 +2467,16 @@ class SpecBuilder(object):
 
                     # add flags from each source, lowest to highest precedence
                     for name in sorted_sources:
-                        source = self._specs[name] if name in self._hash_specs else cmd_specs[name]
-                        extend_flag_list(from_sources, source.compiler_flags.get(flag_type, []))
+                        all_src_flags = list()
+                        per_pkg_sources = [self._specs[name]]
+                        if name in cmd_specs:
+                            per_pkg_sources.append(cmd_specs[name])
+                        for source in per_pkg_sources:
+                            all_src_flags.extend(source.compiler_flags.get(flag_type, []))
+                        extend_flag_list(from_sources, all_src_flags)
 
                 # compiler flags from compilers config are lowest precedence
-                ordered_compiler_flags = from_compiler + from_sources
+                ordered_compiler_flags = list(llnl.util.lang.dedupe(from_compiler + from_sources))
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
 
                 msg = "%s does not equal %s" % (set(compiler_flags), set(ordered_compiler_flags))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2137,10 +2137,6 @@ class SpackSolverSetup(object):
 
         # get list of all possible dependencies
         self.possible_virtuals = set(x.name for x in specs if x.virtual)
-        for spec in specs:
-            if not spec.virtual:
-                for provided in spec.package_class.provided:
-                    self.possible_virtuals.add(provided.name)
         possible = spack.package_base.possible_dependencies(
             *specs, virtuals=self.possible_virtuals, deptype=spack.dependency.all_deptypes
         )
@@ -2467,16 +2463,11 @@ class SpecBuilder(object):
 
                     # add flags from each source, lowest to highest precedence
                     for name in sorted_sources:
-                        all_src_flags = list()
-                        per_pkg_sources = [self._specs[name]]
-                        if name in cmd_specs:
-                            per_pkg_sources.append(cmd_specs[name])
-                        for source in per_pkg_sources:
-                            all_src_flags.extend(source.compiler_flags.get(flag_type, []))
-                        extend_flag_list(from_sources, all_src_flags)
+                        source = self._specs[name] if name in self._hash_specs else cmd_specs[name]
+                        extend_flag_list(from_sources, source.compiler_flags.get(flag_type, []))
 
                 # compiler flags from compilers config are lowest precedence
-                ordered_compiler_flags = list(llnl.util.lang.dedupe(from_compiler + from_sources))
+                ordered_compiler_flags = from_compiler + from_sources
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
 
                 msg = "%s does not equal %s" % (set(compiler_flags), set(ordered_compiler_flags))

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -501,11 +501,13 @@ requirement_group_satisfied(Package, X) :-
   requirement_group_member(Y, Package, _),
   activate_requirement_rules(Package),
   condition_requirement(Y,"node_flag", A1, A2, A3).
-
 { attr("node_flag_source", A1, A2, A3) } :-
   requirement_group_member(Y, Package, _),
   activate_requirement_rules(Package),
   condition_requirement(Y,"node_flag_source", A1, A2, A3).
+:- impose(ID), do_not_impose(ID).
+virtual(Virtual) :- possible_provider(Package, Virtual).
+attr("virtual_node", Virtual) :- provider(Package, Virtual).
 
 requirement_weight(Package, Group, W) :-
   W = #min {

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -498,13 +498,13 @@ requirement_group_satisfied(Package, X) :-
 % flags if their only source is from a requirement. This is overly-specific
 % and should use a more-generic approach like in https://github.com/spack/spack/pull/37180
 { attr("node_flag", A1, A2, A3) } :-
-  requirement_group_member(Y, Package, _),
-  activate_requirement_rules(Package),
+  requirement_group_member(Y, Package, X),
+  activate_requirement(Package, X),
   condition_requirement(Y,"node_flag", A1, A2, A3).
 
 { attr("node_flag_source", A1, A2, A3) } :-
-  requirement_group_member(Y, Package, _),
-  activate_requirement_rules(Package),
+  requirement_group_member(Y, Package, X),
+  activate_requirement(Package, X),
   condition_requirement(Y,"node_flag_source", A1, A2, A3).
 
 requirement_weight(Package, Group, W) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -501,13 +501,11 @@ requirement_group_satisfied(Package, X) :-
   requirement_group_member(Y, Package, _),
   activate_requirement_rules(Package),
   condition_requirement(Y,"node_flag", A1, A2, A3).
+
 { attr("node_flag_source", A1, A2, A3) } :-
   requirement_group_member(Y, Package, _),
   activate_requirement_rules(Package),
   condition_requirement(Y,"node_flag_source", A1, A2, A3).
-:- impose(ID), do_not_impose(ID).
-virtual(Virtual) :- possible_provider(Package, Virtual).
-attr("virtual_node", Virtual) :- provider(Package, Virtual).
 
 requirement_weight(Package, Group, W) :-
   W = #min {

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -500,12 +500,12 @@ requirement_group_satisfied(Package, X) :-
 { attr("node_flag", A1, A2, A3) } :-
   requirement_group_member(Y, Package, X),
   activate_requirement(Package, X),
-  condition_requirement(Y,"node_flag", A1, A2, A3).
+  imposed_constraint(Y,"node_flag_set", A1, A2, A3).
 
 { attr("node_flag_source", A1, A2, A3) } :-
   requirement_group_member(Y, Package, X),
   activate_requirement(Package, X),
-  condition_requirement(Y,"node_flag_source", A1, A2, A3).
+  imposed_constraint(Y,"node_flag_source", A1, A2, A3).
 
 requirement_weight(Package, Group, W) :-
   W = #min {

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -494,6 +494,19 @@ requirement_group_satisfied(Package, X) :-
   activate_requirement(Package, X),
   requirement_group(Package, X).
 
+% TODO: the following two choice rules allow the solver to add compiler
+% flags if their only source is from a requirement. This is overly-specific
+% and should use a more-generic approach like in https://github.com/spack/spack/pull/37180
+{ attr("node_flag", A1, A2, A3) } :-
+  requirement_group_member(Y, Package, _),
+  activate_requirement_rules(Package),
+  condition_requirement(Y,"node_flag", A1, A2, A3).
+
+{ attr("node_flag_source", A1, A2, A3) } :-
+  requirement_group_member(Y, Package, _),
+  activate_requirement_rules(Package),
+  condition_requirement(Y,"node_flag_source", A1, A2, A3).
+
 requirement_weight(Package, Group, W) :-
   W = #min {
     Z : requirement_has_weight(Y, Z), condition_holds(Y), requirement_group_member(Y, Package, Group);

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -381,6 +381,22 @@ packages:
     assert s2.satisfies("%gcc+shared")
 
 
+@pytest.mark.regression("34241")
+def test_require_cflags(concretize_scope, test_repo):
+    """Ensures that flags can be required from configuration."""
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration" " requirements")
+
+    conf_str = """\
+packages:
+  y:
+    require: cflags="-g"
+"""
+    update_packages_config(conf_str)
+    spec = Spec("y").concretized()
+    assert spec.satisfies("cflags=-g")
+
+
 def test_requirements_for_package_that_is_not_needed(concretize_scope, test_repo):
     """Specify requirements for specs that are not concretized or
     a dependency of a concretized spec (in other words, none of


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37163
Fixes #34241

Temporary alternative to https://github.com/spack/spack/pull/37180

Adds choice rules for compiler flags specifically, allowing solver to set compiler flags introduced by requirements.