### PR TITLE
Improve the message for errors in package recipes

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1240,6 +1240,9 @@ class Repo(object):
             module = importlib.import_module(fullname)
         except ImportError:
             raise UnknownPackageError(pkg_name)
+        except Exception as e:
+            msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
+            raise RepoError(msg) from e
 
         cls = getattr(module, class_name)
         if not inspect.isclass(cls):


### PR DESCRIPTION
fixes #30355

Applying this diff:
```diff
diff --git a/var/spack/repos/builtin/packages/zlib/package.py b/var/spack/repos/builtin/packages/zlib/package.py
index 16341ecbaf..b523cca7ae 100644
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -53,7 +53,7 @@ class Zlib(MakefilePackage, Package):
 
     conflicts("build_system=makefile", when="platform=windows")
 
-    patch("w_patch.patch", when="@1.2.11%cce")
+    patch("w_patch.patch", when=":1.2.11")
     patch("configure-cc.patch", when="@1.2.12")
 
     @property
```
On `develop`:
```console
$ spack spec zlib
==> Error: unexpected tokens in the spec string
:1.2.11
^ 
```
while with this PR:
```console
$ spack spec zlib
==> Error: cannot load package 'zlib' from the 'builtin' repository: unexpected tokens in the spec string
:1.2.11
^ 
```