### PR TITLE
Lbann cached cmake

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -70,7 +70,7 @@ class CachedCMakeBuilder(CMakeBuilder):
     # Implement a version of the define_from_variant for Cached packages
     def define_cmake_cache_from_variant(self, cmake_var, variant=None, comment=""):
         """Return a Cached CMake field from the given variant's value.
-           See define_from_variant in lib/spack/spack/build_systems/cmake.py package
+        See define_from_variant in lib/spack/spack/build_systems/cmake.py package
         """
 
         if variant is None:
@@ -247,7 +247,9 @@ class CachedCMakeBuilder(CMakeBuilder):
             archs = spec.variants["cuda_arch"].value
             if archs != "none":
                 arch_str = ";".join(archs)
-                entries.append(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str)))
+                entries.append(
+                    cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str))
+                )
 
         # Since there is no rocm package, look for the variant
         if "+rocm" in spec:
@@ -257,11 +259,15 @@ class CachedCMakeBuilder(CMakeBuilder):
 
             # Explicitly setting HIP_ROOT_DIR may be a patch that is no longer necessary
             entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
-            entries.append(cmake_cache_path("HIP_CXX_COMPILER", "{0}".format(self.spec["hip"].hipcc)))
+            entries.append(
+                cmake_cache_path("HIP_CXX_COMPILER", "{0}".format(self.spec["hip"].hipcc))
+            )
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ";".join(archs)
-                entries.append(cmake_cache_string("CMAKE_HIP_ARCHITECTURES", "{0}".format(arch_str)))
+                entries.append(
+                    cmake_cache_string("CMAKE_HIP_ARCHITECTURES", "{0}".format(arch_str))
+                )
                 entries.append(cmake_cache_string("AMDGPU_TARGETS", "{0}".format(arch_str)))
                 entries.append(cmake_cache_string("GPU_TARGETS", "{0}".format(arch_str)))
 

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -254,7 +254,9 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append("# ROCm")
             entries.append("#------------------{0}\n".format("-" * 30))
 
-            # This may be a patch that is no longer necessary
+            # Explicitly setting HIP_ROOT_DIR may be a patch that is no longer necessary
+            entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
+            entries.append(cmake_cache_path("HIP_CXX_COMPILER", "{0}".format(self.spec["hip"].hipcc)))
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ";".join(archs)

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -238,9 +238,7 @@ class CachedCMakeBuilder(CMakeBuilder):
 
             cudatoolkitdir = spec["cuda"].prefix
             entries.append(cmake_cache_path("CUDAToolkit_ROOT", cudatoolkitdir))
-            entries.append(cmake_cache_path("CUDA_TOOLKIT_ROOT_DIR", cudatoolkitdir))
-            cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
-            entries.append(cmake_cache_path("CMAKE_CUDA_COMPILER", cudacompiler))
+            entries.append(cmake_cache_path("CMAKE_CUDA_COMPILER", f"{cudatoolkitdir}/bin/nvcc"))
             entries.append(cmake_cache_path("CMAKE_CUDA_HOST_COMPILER", "${CMAKE_CXX_COMPILER}"))
 
             archs = spec.variants["cuda_arch"].value

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -239,7 +239,7 @@ class CachedCMakeBuilder(CMakeBuilder):
 
             cudatoolkitdir = spec["cuda"].prefix
             entries.append(cmake_cache_path("CUDAToolkit_ROOT", cudatoolkitdir))
-            entries.append(cmake_cache_path("CMAKE_CUDA_COMPILER", f"{cudatoolkitdir}/bin/nvcc"))
+            entries.append(cmake_cache_path("CMAKE_CUDA_COMPILER", "${CUDAToolkit_ROOT}/bin/nvcc"))
             entries.append(cmake_cache_path("CMAKE_CUDA_HOST_COMPILER", "${CMAKE_CXX_COMPILER}"))
 
             archs = spec.variants["cuda_arch"].value

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -14,24 +14,24 @@ import spack.builder
 from .cmake import CMakeBuilder, CMakePackage
 
 
-def cmake_cache_path(name, value, comment="", force=True):
+def cmake_cache_path(name, value, comment="", force=False):
     """Generate a string for a cmake cache variable"""
-    force_str = "FORCE" if force else ""
-    return 'set({0} "{1}" CACHE PATH "{2}" {3})\n'.format(name, value, comment, force_str)
+    force_str = " FORCE" if force else ""
+    return 'set({0} "{1}" CACHE PATH "{2}"{3})\n'.format(name, value, comment, force_str)
 
 
-def cmake_cache_string(name, value, comment="", force=True):
+def cmake_cache_string(name, value, comment="", force=False):
     """Generate a string for a cmake cache variable"""
-    force_str = "FORCE" if force else ""
-    return 'set({0} "{1}" CACHE STRING "{2}" {3})\n'.format(name, value, comment, force_str)
+    force_str = " FORCE" if force else ""
+    return 'set({0} "{1}" CACHE STRING "{2}"{3})\n'.format(name, value, comment, force_str)
 
 
-def cmake_cache_option(name, boolean_value, comment="", force=True):
+def cmake_cache_option(name, boolean_value, comment="", force=False):
     """Generate a string for a cmake configuration option"""
 
     value = "ON" if boolean_value else "OFF"
-    force_str = "FORCE" if force else ""
-    return 'set({0} {1} CACHE BOOL "{2}" {3})\n'.format(name, value, comment, force_str)
+    force_str = " FORCE" if force else ""
+    return 'set({0} {1} CACHE BOOL "{2}"{3})\n'.format(name, value, comment, force_str)
 
 
 class CachedCMakeBuilder(CMakeBuilder):

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -89,10 +89,8 @@ class CachedCMakeBuilder(CMakeBuilder):
 
         field = None
         if isinstance(value, bool):
-            kind = "BOOL"
             field = cmake_cache_option(cmake_var, value, comment)
         else:
-            kind = "STRING"
             if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
                 value = ";".join(str(v) for v in value)
             else:

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -168,7 +168,9 @@ class CachedCMakeBuilder(CMakeBuilder):
         if self.spec.satisfies("generator=ninja"):
             entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
             entries.append(
-                cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin))
+                cmake_cache_string(
+                    "CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)
+                )
             )
 
         return entries

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -251,17 +251,14 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append("# ROCm")
             entries.append("#------------------{0}\n".format("-" * 30))
 
-#            "-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix),
-#            "-DHIP_CXX_COMPILER={0}".format(self.spec["hip"].hipcc),
             # This may be a patch that is no longer necessary
-            entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
-            # hipcc_flags = []
+#            entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
-                arch_str = ",".join(archs)
+                arch_str = ";".join(archs)
                 entries.append(cmake_cache_string("CMAKE_HIP_ARCHITECTURES", "{0}".format(arch_str)))
-            #     hipcc_flags.append("--amdgpu-target={0}".format(arch_str))
-            # entries.append(cmake_cache_string("HIP_HIPCC_FLAGS", " ".join(hipcc_flags)))
+                entries.append(cmake_cache_string("AMDGPU_TARGETS", "{0}".format(arch_str)))
+                entries.append(cmake_cache_string("GPU_TARGETS", "{0}".format(arch_str)))
 
         return entries
 

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -249,7 +249,8 @@ class CachedCMakeBuilder(CMakeBuilder):
                 arch_str = ";".join(archs)
                 entries.append(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str)))
 
-        if spec.satisfies("^rocm"):
+        # Since there is no rocm package, look for the variant
+        if "+rocm" in spec:
             entries.append("#------------------{0}".format("-" * 30))
             entries.append("# ROCm")
             entries.append("#------------------{0}\n".format("-" * 30))

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -14,21 +14,24 @@ import spack.builder
 from .cmake import CMakeBuilder, CMakePackage
 
 
-def cmake_cache_path(name, value, comment=""):
+def cmake_cache_path(name, value, comment="", force=True):
     """Generate a string for a cmake cache variable"""
-    return 'set({0} "{1}" CACHE PATH "{2}")\n'.format(name, value, comment)
+    force_str = "FORCE" if force else ""
+    return 'set({0} "{1}" CACHE PATH "{2}" {3})\n'.format(name, value, comment, force_str)
 
 
-def cmake_cache_string(name, value, comment=""):
+def cmake_cache_string(name, value, comment="", force=True):
     """Generate a string for a cmake cache variable"""
-    return 'set({0} "{1}" CACHE STRING "{2}")\n'.format(name, value, comment)
+    force_str = "FORCE" if force else ""
+    return 'set({0} "{1}" CACHE STRING "{2}" {3})\n'.format(name, value, comment, force_str)
 
 
-def cmake_cache_option(name, boolean_value, comment=""):
+def cmake_cache_option(name, boolean_value, comment="", force=True):
     """Generate a string for a cmake configuration option"""
 
     value = "ON" if boolean_value else "OFF"
-    return 'set({0} {1} CACHE BOOL "{2}")\n'.format(name, value, comment)
+    force_str = "FORCE" if force else ""
+    return 'set({0} {1} CACHE BOOL "{2}" {3})\n'.format(name, value, comment, force_str)
 
 
 class CachedCMakeBuilder(CMakeBuilder):
@@ -252,7 +255,6 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append("#------------------{0}\n".format("-" * 30))
 
             # This may be a patch that is no longer necessary
-#            entries.append(cmake_cache_path("HIP_ROOT_DIR", "{0}".format(spec["hip"].prefix)))
             archs = self.spec.variants["amdgpu_target"].value
             if archs != "none":
                 arch_str = ";".join(archs)
@@ -266,9 +268,6 @@ class CachedCMakeBuilder(CMakeBuilder):
         cmake_prefix_path_env = os.environ["CMAKE_PREFIX_PATH"]
         cmake_prefix_path_array = cmake_prefix_path_env.split(":")
         cmake_prefix_path = ";".join(cmake_prefix_path_array)
-        # cmake_pkg_config_path_env = os.environ["PKG_CONFIG_PATH"]
-        # cmake_pkg_config_path_array = cmake_prefix_path_env.split(":")
-        # cmake_pkg_config_path = ";".join(cmake_prefix_path_array)
         return [
             "#------------------{0}".format("-" * 60),
             "# !!!! This is a generated file, edit at own risk !!!!",
@@ -276,7 +275,6 @@ class CachedCMakeBuilder(CMakeBuilder):
             "# CMake executable path: {0}".format(self.pkg.spec["cmake"].command.path),
             "#------------------{0}\n".format("-" * 60),
             cmake_cache_path("CMAKE_PREFIX_PATH", cmake_prefix_path),
-            # cmake_cache_path("CMAKE_PKG_CONFIG_PATH", cmake_pkg_config_path),
         ]
 
     def initconfig_package_entries(self):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -515,7 +515,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:
             hostname = hostname.rstrip("1234567890")
-        return "LBANN_{0}-{1}-{2}@{3}.cmake".format(
+        return "LBANN_{0}_{1}-{2}-{3}@{4}.cmake".format(
+            self.spec.version,
             hostname,
             self._get_sys_type(self.spec),
             self.spec.compiler.name,
@@ -531,7 +532,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             # of CMake
             entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", "ON"))
 
-        entries.append(cmake_cache_string("CMAKE_MAKE_PROGRAM", "ninja"))
+        entries.append(cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)))
+        entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
 
         # if "+rocm" in spec:
         #     entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
@@ -617,6 +619,13 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 # #        if spec.satisfies("^al"):
 #             entries.append(cmake_cache_path("Aluminum_DIR", "{0}/lib64".format(spec["aluminum"].prefix)))
 # #            entries.append(cmake_cache_path("Aluminum_DIR", "{0}".format(spec["aluminum"].prefix)))
+
+        if spec.satisfies("^python") and "+pfe" in spec:
+            entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python".format(spec["python"].prefix.bin)))
+            entries.append(cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])) # do NOT need to sub ; for : because
+                                                                                          # value will only be interpreted by
+                                                                                          # a shell, which expects :
+        
 
         # if spec.satisfies("^conduit"):
         #     entries.append(cmake_cache_path("Conduit_DIR", "{0}".format(spec["conduit"].prefix)))

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -317,7 +317,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("zstr")
 
     generator("ninja")
-    depends_on("ninja", type=("build", "run"))
+    depends_on("ninja", type="build")
 
     @property
     def common_config_args(self):
@@ -515,7 +515,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:
             hostname = hostname.rstrip("1234567890")
-        return "BVE_{0}-{1}-{2}@{3}.cmake".format(
+        return "LBANN_{0}-{1}-{2}@{3}.cmake".format(
             hostname,
             self._get_sys_type(self.spec),
             self.spec.compiler.name,
@@ -560,6 +560,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             #     arch_str = ";".join(archs)
             #     entries.append(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str)))
 
+            entries.append(self.define_cmake_cache_from_variant("CMAKE_CUDA_ARCHITECTURES_BVE", "cuda_arch"))
+            
             if spec.satisfies("%cce") and spec.satisfies("^cuda+allow-unsupported-compilers"):
                 entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS", "-allow-unsupported-compiler"))
 
@@ -585,7 +587,11 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("LBANN_WITH_FFT", "+fft" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_ONEDNN", "+onednn" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_ONNX", "+onnx" in spec))
+
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX_BVE", "onnx"))
+
         entries.append(cmake_cache_option("LBANN_WITH_EMBEDDED_PYTHON", "+python" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON_BVE", "python"))
         entries.append(cmake_cache_option("LBANN_WITH_PYTHON_FRONTEND", "+pfe" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_TBINF", "OFF"))

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 import socket
+import sys
 
 from spack.package import *
 
@@ -354,7 +354,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             # of CMake
             entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
-        entries.append(cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)))
+        entries.append(
+            cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin))
+        )
         entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
 
         # Use lld high performance linker
@@ -379,7 +381,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             if self.spec.satisfies("%clang"):
                 for flag in self.spec.compiler_flags["cxxflags"]:
                     if "gcc-toolchain" in flag:
-                        entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS", "-Xcompiler={0}".format(flag)))
+                        entries.append(
+                            cmake_cache_string("CMAKE_CUDA_FLAGS", "-Xcompiler={0}".format(flag))
+                        )
             if spec.satisfies("^cuda@11.0:"):
                 entries.append(cmake_cache_string("CMAKE_CUDA_STANDARD", "17"))
             else:
@@ -388,7 +392,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_NVPROF", "nvprof"))
 
             if spec.satisfies("%cce") and spec.satisfies("^cuda+allow-unsupported-compilers"):
-                entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS", "-allow-unsupported-compiler"))
+                entries.append(
+                    cmake_cache_string("CMAKE_CUDA_FLAGS", "-allow-unsupported-compiler")
+                )
 
         if "+rocm" in spec:
             # args.extend(
@@ -401,8 +407,12 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
                 entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
 
             cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
-            entries.append(cmake_cache_string("HIP_HIPCC_FLAGS",
-                    "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str)))
+            entries.append(
+                cmake_cache_string(
+                    "HIP_HIPCC_FLAGS",
+                    "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str),
+                )
+            )
 
         return entries
 
@@ -416,31 +426,47 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         ]
 
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CNPY", "numpy"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_DETERMINISTIC", "deterministic"))
+        entries.append(
+            self.define_cmake_cache_from_variant("LBANN_DETERMINISTIC", "deterministic")
+        )
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_HWLOC", "hwloc"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ALUMINUM", "al"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ADDRESS_SANITIZER", "asan"))
+        entries.append(
+            self.define_cmake_cache_from_variant("LBANN_WITH_ADDRESS_SANITIZER", "asan")
+        )
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_BOOST", "boost"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CONDUIT", "conduit"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_NVSHMEM", "nvshmem"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_FFT", "fft"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONEDNN", "onednn"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX", "onnx"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON", "python"))
+        entries.append(
+            self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON", "python")
+        )
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_PYTHON_FRONTEND", "pfe"))
         entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_TBINF", False))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_UNIT_TESTING", "unit_tests"))
+        entries.append(
+            self.define_cmake_cache_from_variant("LBANN_WITH_UNIT_TESTING", "unit_tests")
+        )
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VISION", "vision"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VTUNE", "vtune"))
-        entries.append(cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value)))
+        entries.append(
+            cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value))
+        )
         entries.append(cmake_cache_option("protobuf_MODULE_COMPATIBLE", True))
 
         if spec.satisfies("^python") and "+pfe" in spec:
-            entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python3".format(spec["python"].prefix.bin)))
-            entries.append(cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])) # do NOT need to sub ; for : because
-                                                                                          # value will only be interpreted by
-                                                                                          # a shell, which expects :
+            entries.append(
+                cmake_cache_path(
+                    "LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python3".format(spec["python"].prefix.bin)
+                )
+            )
+            entries.append(
+                cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])
+            )  # do NOT need to sub ; for : because
+            # value will only be interpreted by
+            # a shell, which expects :
 
         # Add support for OpenMP with external (Brew) clang
         if spec.satisfies("%clang platform=darwin"):
@@ -449,16 +475,30 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             clang_root = os.path.dirname(clang_bin)
             entries.append(cmake_cache_string("OpenMP_CXX_FLAGS", "-fopenmp=libomp"))
             entries.append(cmake_cache_string("OpenMP_CXX_LIB_NAMES", "libomp"))
-            entries.append(cmake_cache_string("OpenMP_libomp_LIBRARY", "{0}/lib/libomp.dylib".format(clang_root)))
+            entries.append(
+                cmake_cache_string(
+                    "OpenMP_libomp_LIBRARY", "{0}/lib/libomp.dylib".format(clang_root)
+                )
+            )
 
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DIHYDROGEN", "dihydrogen"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DISTCONV", "distconv"))
 
         # IF IBM ESSL is used it needs help finding the proper LAPACK libraries
         if self.spec.satisfies("^essl"):
-            entries.append(cmake_cache_string("LAPACK_LIBRARIES", "%s;-llapack;-lblas"
-                    % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names)))
-            entries.append(cmake_cache_string("BLAS_LIBRARIES", "%s;-lblas"
-                    % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names)))
+            entries.append(
+                cmake_cache_string(
+                    "LAPACK_LIBRARIES",
+                    "%s;-llapack;-lblas"
+                    % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names),
+                )
+            )
+            entries.append(
+                cmake_cache_string(
+                    "BLAS_LIBRARIES",
+                    "%s;-lblas"
+                    % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names),
+                )
+            )
 
         return entries

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -578,28 +578,28 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             "#------------------{0}\n".format("-" * 60),
         ]
 
-        entries.append(cmake_cache_option("LBANN_WITH_CNPY", "+numpy" in spec))
-        entries.append(cmake_cache_option("LBANN_DETERMINISTIC", "+deterministic" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_HWLOC", "hwloc" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_ALUMINUM", "+al" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_ADDRESS_SANITIZER", "+asan" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_BOOST", "+boost" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_CONDUIT", "+conduit" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_NVSHMEM", "+nvshmem" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_FFT", "+fft" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_ONEDNN", "+onednn" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_ONNX", "+onnx" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CNPY", "numpy"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_DETERMINISTIC", "deterministic"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_HWLOC", "hwloc"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ALUMINUM", "al"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ADDRESS_SANITIZER", "asan"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_BOOST", "boost"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CONDUIT", "conduit"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_NVSHMEM", "nvshmem"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_FFT", "fft"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONEDNN", "onednn"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX", "onnx"))
 
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX_BVE", "onnx"))
 
-        entries.append(cmake_cache_option("LBANN_WITH_EMBEDDED_PYTHON", "+python" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON", "python"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON_BVE", "python"))
-        entries.append(cmake_cache_option("LBANN_WITH_PYTHON_FRONTEND", "+pfe" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_PYTHON_FRONTEND", "pfe"))
         entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_TBINF", "OFF"))
-        entries.append(cmake_cache_option("LBANN_WITH_UNIT_TESTING", "+unit_tests" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_VISION", "+vision" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_VTUNE", "+vtune" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_UNIT_TESTING", "unit_tests"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VISION", "vision"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VTUNE", "vtune"))
         # entries.append(cmake_cache_option())
         entries.append(cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value)))
         # BVE This seems unnecessary to add the part of the path
@@ -650,8 +650,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+vision" in spec:
             entries.append(cmake_cache_path("OpenCV_DIR", "{0}".format(spec["opencv"].prefix)))
 
-        entries.append(cmake_cache_option("LBANN_WITH_DIHYDROGEN", "+dihydrogen" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_DISTCONV", "+distconv" in spec))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DIHYDROGEN", "dihydrogen"))
+        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DISTCONV", "distconv"))
 
         # IF IBM ESSL is used it needs help finding the proper LAPACK libraries
         if self.spec.satisfies("^essl"):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -335,6 +335,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     def cache_name(self):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:
+            # Get a hostname that has no node identifier
             hostname = hostname.rstrip("1234567890")
         return "LBANN_{0}_{1}-{2}-{3}@{4}.cmake".format(
             hostname,
@@ -363,8 +364,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", "-fuse-ld=gold"))
             entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", "-fuse-ld=gold"))
 
-        # if "+rocm" in spec:
-        #     entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         return entries
 
     def initconfig_hardware_entries(self):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -317,7 +317,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("zstr")
 
     generator("ninja")
-    depends_on("ninja", type="build")
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("%apple-clang"):
@@ -353,11 +352,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             # There is a bug with using Ninja generator in this version
             # of CMake
             entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", True))
-
-        entries.append(
-            cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin))
-        )
-        entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
 
         # Use lld high performance linker
         if "+lld" in spec:
@@ -397,12 +391,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
                 )
 
         if "+rocm" in spec:
-            # args.extend(
-            #     [
-            #         "-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix),
-            #         "-DHIP_CXX_COMPILER={0}".format(self.spec["hip"].hipcc),
-            #     ]
-            # )
             if "platform=cray" in spec:
                 entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
 
@@ -425,32 +413,30 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             "#------------------{0}\n".format("-" * 60),
         ]
 
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CNPY", "numpy"))
-        entries.append(
-            self.define_cmake_cache_from_variant("LBANN_DETERMINISTIC", "deterministic")
-        )
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_HWLOC", "hwloc"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ALUMINUM", "al"))
-        entries.append(
-            self.define_cmake_cache_from_variant("LBANN_WITH_ADDRESS_SANITIZER", "asan")
-        )
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_BOOST", "boost"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_CONDUIT", "conduit"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_NVSHMEM", "nvshmem"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_FFT", "fft"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONEDNN", "onednn"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX", "onnx"))
-        entries.append(
-            self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON", "python")
-        )
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_PYTHON_FRONTEND", "pfe"))
+        cmake_variant_fields = [
+            ("LBANN_WITH_CNPY", "numpy"),
+            ("LBANN_DETERMINISTIC", "deterministic"),
+            ("LBANN_WITH_HWLOC", "hwloc"),
+            ("LBANN_WITH_ALUMINUM", "al"),
+            ("LBANN_WITH_ADDRESS_SANITIZER", "asan"),
+            ("LBANN_WITH_BOOST", "boost"),
+            ("LBANN_WITH_CONDUIT", "conduit"),
+            ("LBANN_WITH_NVSHMEM", "nvshmem"),
+            ("LBANN_WITH_FFT", "fft"),
+            ("LBANN_WITH_ONEDNN", "onednn"),
+            ("LBANN_WITH_ONNX", "onnx"),
+            ("LBANN_WITH_EMBEDDED_PYTHON", "python"),
+            ("LBANN_WITH_PYTHON_FRONTEND", "pfe"),
+            ("LBANN_WITH_UNIT_TESTING", "unit_tests"),
+            ("LBANN_WITH_VISION", "vision"),
+            ("LBANN_WITH_VTUNE", "vtune"),
+            ]
+
+        for opt, val in cmake_variant_fields:
+            entries.append(self.define_cmake_cache_from_variant(opt, val))
+
         entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
         entries.append(cmake_cache_option("LBANN_WITH_TBINF", False))
-        entries.append(
-            self.define_cmake_cache_from_variant("LBANN_WITH_UNIT_TESTING", "unit_tests")
-        )
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VISION", "vision"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VTUNE", "vtune"))
         entries.append(
             cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value))
         )

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -319,190 +319,12 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     generator("ninja")
     depends_on("ninja", type="build")
 
-    @property
-    def common_config_args(self):
-        spec = self.spec
-        # Environment variables
-        cppflags = []
-        # cppflags.append("-DLBANN_SET_EL_RNG")
-        # cppflags.append("-std=c++17")
-        args = []
-        # args.extend(["-DCMAKE_CXX_FLAGS=%s" % " ".join(cppflags), "-DLBANN_VERSION=spack"])
-
-        # if "+numpy" in spec:
-        #     args.append("-DCNPY_DIR={0}".format(spec["cnpy"].prefix))
-
-        # # Use lld high performance linker
-        # if "+lld" in spec:
-        #     args.extend(
-        #         [
-        #             "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
-        #             "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
-        #         ]
-        #     )
-
-        # # Use gold high performance linker
-        # if "+gold" in spec:
-        #     args.extend(
-        #         [
-        #             "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold",
-        #             "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=gold",
-        #         ]
-        #     )
-
-        return args
-
     def setup_build_environment(self, env):
         if self.spec.satisfies("%apple-clang"):
             env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
             env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("LDFLAGS", self.spec["llvm-openmp"].libs.ld_flags)
-
-    # Get any recent versions or non-numeric version
-    # Note that develop > numeric and non-develop < numeric
-
-    @when("@:0.90,0.94:")
-    def cmake_args(self):
-        spec = self.spec
-        args = self.common_config_args
-        # args.extend(
-        #     [
-        #         "-DCMAKE_CXX_STANDARD=17",
-        #         "-DLBANN_WITH_CNPY=%s" % ("+numpy" in spec),
-        #         "-DLBANN_DETERMINISTIC:BOOL=%s" % ("+deterministic" in spec),
-        #         "-DLBANN_WITH_HWLOC=%s" % ("+hwloc" in spec),
-        #         "-DLBANN_WITH_ALUMINUM:BOOL=%s" % ("+al" in spec),
-        #         "-DLBANN_WITH_ADDRESS_SANITIZER:BOOL=%s" % ("+asan" in spec),
-        #         "-DLBANN_WITH_BOOST:BOOL=%s" % ("+boost" in spec),
-        #         "-DLBANN_WITH_CONDUIT:BOOL=%s" % ("+conduit" in spec),
-        #         "-DLBANN_WITH_NVSHMEM:BOOL=%s" % ("+nvshmem" in spec),
-        #         "-DLBANN_WITH_FFT:BOOL=%s" % ("+fft" in spec),
-        #         "-DLBANN_WITH_ONEDNN:BOOL=%s" % ("+onednn" in spec),
-        #         "-DLBANN_WITH_ONNX:BOOL=%s" % ("+onnx" in spec),
-        #         "-DLBANN_WITH_EMBEDDED_PYTHON:BOOL=%s" % ("+python" in spec),
-        #         "-DLBANN_WITH_PYTHON_FRONTEND:BOOL=%s" % ("+pfe" in spec),
-        #         "-DLBANN_WITH_ROCTRACER:BOOL=%s" % ("+rocm +distconv" in spec),
-        #         "-DLBANN_WITH_TBINF=OFF",
-        #         "-DLBANN_WITH_UNIT_TESTING:BOOL=%s" % ("+unit_tests" in spec),
-        #         "-DLBANN_WITH_VISION:BOOL=%s" % ("+vision" in spec),
-        #         "-DLBANN_WITH_VTUNE:BOOL=%s" % ("+vtune" in spec),
-        #         "-DLBANN_DATATYPE={0}".format(spec.variants["dtype"].value),
-        #         "-DCEREAL_DIR={0}".format(spec["cereal"].prefix),
-        #         # protobuf is included by py-protobuf+cpp
-        #         "-DProtobuf_DIR={0}".format(spec["protobuf"].prefix),
-        #         "-Dprotobuf_MODULE_COMPATIBLE=ON",
-        #     ]
-        # )
-
-        # if not spec.satisfies("^cmake@3.23.0"):
-        #     # There is a bug with using Ninja generator in this version
-        #     # of CMake
-        #     args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
-
-        # if "+cuda" in spec:
-        #     if self.spec.satisfies("%clang"):
-        #         for flag in self.spec.compiler_flags["cxxflags"]:
-        #             if "gcc-toolchain" in flag:
-        #                 args.append("-DCMAKE_CUDA_FLAGS=-Xcompiler={0}".format(flag))
-        #     if spec.satisfies("^cuda@11.0:"):
-        #         args.append("-DCMAKE_CUDA_STANDARD=17")
-        #     else:
-        #         args.append("-DCMAKE_CUDA_STANDARD=14")
-        #     archs = spec.variants["cuda_arch"].value
-        #     if archs != "none":
-        #         arch_str = ";".join(archs)
-        #         args.append("-DCMAKE_CUDA_ARCHITECTURES=%s" % arch_str)
-
-        #     if spec.satisfies("%cce") and spec.satisfies("^cuda+allow-unsupported-compilers"):
-        #         args.append("-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler")
-
-        # if spec.satisfies("@:0.90") or spec.satisfies("@0.95:"):
-        #     args.append("-DHydrogen_DIR={0}/CMake/hydrogen".format(spec["hydrogen"].prefix))
-        # elif spec.satisfies("@0.94"):
-        #     args.append("-DElemental_DIR={0}/CMake/elemental".format(spec["elemental"].prefix))
-
-        # if spec.satisfies("@0.94:0.98.2"):
-        #     args.append("-DLBANN_WITH_NCCL:BOOL=%s" % ("+cuda +nccl" in spec))
-
-        # if "+vtune" in spec:
-        #     args.append("-DVTUNE_DIR={0}".format(spec["vtune"].prefix))
-
-        # if "+al" in spec:
-        #     args.append("-DAluminum_DIR={0}".format(spec["aluminum"].prefix))
-
-        # if "+conduit" in spec:
-        #     args.append("-DConduit_DIR={0}".format(spec["conduit"].prefix))
-
-        # Add support for OpenMP with external (Brew) clang
-        # if spec.satisfies("%clang platform=darwin"):
-        #     clang = self.compiler.cc
-        #     clang_bin = os.path.dirname(clang)
-        #     clang_root = os.path.dirname(clang_bin)
-        #     args.extend(
-        #         [
-        #             "-DOpenMP_CXX_FLAGS=-fopenmp=libomp",
-        #             "-DOpenMP_CXX_LIB_NAMES=libomp",
-        #             "-DOpenMP_libomp_LIBRARY={0}/lib/libomp.dylib".format(clang_root),
-        #         ]
-        #     )
-
-        # if "+vision" in spec:
-        #     args.append("-DOpenCV_DIR:STRING={0}".format(spec["opencv"].prefix))
-
-        # if "+cuda" in spec:
-        #     args.append("-DCUDA_TOOLKIT_ROOT_DIR={0}".format(spec["cuda"].prefix))
-        #     args.append("-DcuDNN_DIR={0}".format(spec["cudnn"].prefix))
-        #     if spec.satisfies("@0.94:0.98.2"):
-        #         if spec.satisfies("^cuda@:10"):
-        #             args.append("-DCUB_DIR={0}".format(spec["cub"].prefix))
-        #         if "+nccl" in spec:
-        #             args.append("-DNCCL_DIR={0}".format(spec["nccl"].prefix))
-        #     args.append("-DLBANN_WITH_NVPROF:BOOL=%s" % ("+nvprof" in spec))
-
-        # if spec.satisfies("@:0.90") or spec.satisfies("@0.100:"):
-        #     args.append("-DLBANN_WITH_DIHYDROGEN:BOOL=%s" % ("+dihydrogen" in spec))
-
-        # if spec.satisfies("@:0.90") or spec.satisfies("@0.101:"):
-        #     args.append("-DLBANN_WITH_DISTCONV:BOOL=%s" % ("+distconv" in spec))
-
-        if "+rocm" in spec:
-            args.extend(
-                [
-                    "-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix),
-                    "-DHIP_CXX_COMPILER={0}".format(self.spec["hip"].hipcc),
-                ]
-            )
-            if "platform=cray" in spec:
-                args.extend(["-DMPI_ASSUME_NO_BUILTIN_MPI=ON"])
-            archs = self.spec.variants["amdgpu_target"].value
-            if archs != "none":
-                arch_str = ",".join(archs)
-                cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
-                args.append(
-                    "-DHIP_HIPCC_FLAGS=--amdgpu-target={0}"
-                    " -g -fsized-deallocation -fPIC -std=c++17 {1}".format(arch_str, cxxflags_str)
-                )
-                args.extend(
-                    [
-                        "-DCMAKE_HIP_ARCHITECTURES=%s" % arch_str,
-                        "-DAMDGPU_TARGETS=%s" % arch_str,
-                        "-DGPU_TARGETS=%s" % arch_str,
-                    ]
-                )
-
-        # IF IBM ESSL is used it needs help finding the proper LAPACK libraries
-        # if self.spec.satisfies("^essl"):
-        #     args.extend(
-        #         [
-        #             "-DLAPACK_LIBRARIES=%s;-llapack;-lblas"
-        #             % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names),
-        #             "-DBLAS_LIBRARIES=%s;-lblas"
-        #             % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names),
-        #         ]
-        #     )
-
-        return args
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture
@@ -530,7 +352,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         if not spec.satisfies("^cmake@3.23.0"):
             # There is a bug with using Ninja generator in this version
             # of CMake
-            entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", "ON"))
+            entries.append(cmake_cache_option("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
         entries.append(cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)))
         entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
@@ -563,19 +385,24 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             else:
                 entries.append(cmake_cache_string("CMAKE_CUDA_STANDARD", "14"))
 
-            entries.append(cmake_cache_path("cuDNN_DIR", "{0}".format(spec["cudnn"].prefix)))
-            if "+nccl" in spec:
-                entries.append(cmake_cache_path("NCCL_DIR", "{0}".format(spec["nccl"].prefix)))
-            entries.append(cmake_cache_option("LBANN_WITH_NVPROF", "+nvprof" in spec))
-            # archs = spec.variants["cuda_arch"].value
-            # if archs != "none":
-            #     arch_str = ";".join(archs)
-            #     entries.append(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str)))
+            entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_NVPROF", "nvprof"))
 
-            entries.append(self.define_cmake_cache_from_variant("CMAKE_CUDA_ARCHITECTURES_BVE", "cuda_arch"))
-            
             if spec.satisfies("%cce") and spec.satisfies("^cuda+allow-unsupported-compilers"):
                 entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS", "-allow-unsupported-compiler"))
+
+        if "+rocm" in spec:
+            # args.extend(
+            #     [
+            #         "-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix),
+            #         "-DHIP_CXX_COMPILER={0}".format(self.spec["hip"].hipcc),
+            #     ]
+            # )
+            if "platform=cray" in spec:
+                entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
+
+            cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
+            entries.append(cmake_cache_string("HIP_HIPCC_FLAGS",
+                    "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str)))
 
         return entries
 
@@ -599,54 +426,21 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_FFT", "fft"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONEDNN", "onednn"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX", "onnx"))
-
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_ONNX_BVE", "onnx"))
-
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON", "python"))
-        entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_EMBEDDED_PYTHON_BVE", "python"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_PYTHON_FRONTEND", "pfe"))
         entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
-        entries.append(cmake_cache_option("LBANN_WITH_TBINF", "OFF"))
+        entries.append(cmake_cache_option("LBANN_WITH_TBINF", False))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_UNIT_TESTING", "unit_tests"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VISION", "vision"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_VTUNE", "vtune"))
-        # entries.append(cmake_cache_option())
         entries.append(cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value)))
-        # BVE This seems unnecessary to add the part of the path
-#        entries.append(cmake_cache_path("CEREAL_DIR", "{0}/share/cmake/cereal".format(spec["cereal"].prefix)))
-        # protobuf is included by py-protobuf+cpp
-        entries.append(cmake_cache_path("Protobuf_DIR", "{0}".format(spec["protobuf"].prefix)))
-        entries.append(cmake_cache_option("protobuf_MODULE_COMPATIBLE", "ON"))
-
-#        entries.append(cmake_cache_path("Hydrogen_DIR", "{0}/lib/cmake/hydrogen/".format(spec["hydrogen"].prefix)))
-        # BVE this is wrong
-#        entries.append(cmake_cache_path("Hydrogen_DIR", "{0}/CMake/hydrogen".format(spec["hydrogen"].prefix)))
-
-        if "+vtune" in spec:
-            entries.append(cmake_cache_path("VTUNE_DIR", "{0}".format(spec["vtune"].prefix)))
-
-#         if "+al" in spec:
-# #        if spec.satisfies("^al"):
-#             entries.append(cmake_cache_path("Aluminum_DIR", "{0}/lib64".format(spec["aluminum"].prefix)))
-# #            entries.append(cmake_cache_path("Aluminum_DIR", "{0}".format(spec["aluminum"].prefix)))
+        entries.append(cmake_cache_option("protobuf_MODULE_COMPATIBLE", True))
 
         if spec.satisfies("^python") and "+pfe" in spec:
             entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python3".format(spec["python"].prefix.bin)))
             entries.append(cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])) # do NOT need to sub ; for : because
                                                                                           # value will only be interpreted by
                                                                                           # a shell, which expects :
-        
-
-        # if spec.satisfies("^conduit"):
-        #     entries.append(cmake_cache_path("Conduit_DIR", "{0}".format(spec["conduit"].prefix)))
-
-        # BVE Why can't catch find itself in the prefix path
-        # if "^catch2" in spec:
-        #     entries.append(cmake_cache_path("Catch2_ROOT", spec["catch2"].prefix))
-
-        # BVE Why can't clara find itself in the prefix path
-        # if "^clara" in spec:
-        #     entries.append(cmake_cache_path("Clara_DIR", spec["clara"].prefix))
 
         # Add support for OpenMP with external (Brew) clang
         if spec.satisfies("%clang platform=darwin"):
@@ -656,9 +450,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_string("OpenMP_CXX_FLAGS", "-fopenmp=libomp"))
             entries.append(cmake_cache_string("OpenMP_CXX_LIB_NAMES", "libomp"))
             entries.append(cmake_cache_string("OpenMP_libomp_LIBRARY", "{0}/lib/libomp.dylib".format(clang_root)))
-
-        if "+vision" in spec:
-            entries.append(cmake_cache_path("OpenCV_DIR", "{0}".format(spec["opencv"].prefix)))
 
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DIHYDROGEN", "dihydrogen"))
         entries.append(self.define_cmake_cache_from_variant("LBANN_WITH_DISTCONV", "distconv"))

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -324,31 +324,31 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         # Environment variables
         cppflags = []
-        cppflags.append("-DLBANN_SET_EL_RNG")
-        cppflags.append("-std=c++17")
+        # cppflags.append("-DLBANN_SET_EL_RNG")
+        # cppflags.append("-std=c++17")
         args = []
-        args.extend(["-DCMAKE_CXX_FLAGS=%s" % " ".join(cppflags), "-DLBANN_VERSION=spack"])
+        # args.extend(["-DCMAKE_CXX_FLAGS=%s" % " ".join(cppflags), "-DLBANN_VERSION=spack"])
 
-        if "+numpy" in spec:
-            args.append("-DCNPY_DIR={0}".format(spec["cnpy"].prefix))
+        # if "+numpy" in spec:
+        #     args.append("-DCNPY_DIR={0}".format(spec["cnpy"].prefix))
 
-        # Use lld high performance linker
-        if "+lld" in spec:
-            args.extend(
-                [
-                    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
-                    "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
-                ]
-            )
+        # # Use lld high performance linker
+        # if "+lld" in spec:
+        #     args.extend(
+        #         [
+        #             "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
+        #             "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
+        #         ]
+        #     )
 
-        # Use gold high performance linker
-        if "+gold" in spec:
-            args.extend(
-                [
-                    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold",
-                    "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=gold",
-                ]
-            )
+        # # Use gold high performance linker
+        # if "+gold" in spec:
+        #     args.extend(
+        #         [
+        #             "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold",
+        #             "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=gold",
+        #         ]
+        #     )
 
         return args
 
@@ -535,6 +535,16 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_string("CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)))
         entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
 
+        # Use lld high performance linker
+        if "+lld" in spec:
+            entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", "-fuse-ld=lld"))
+            entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", "-fuse-ld=lld"))
+
+        # Use gold high performance linker
+        if "+gold" in spec:
+            entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", "-fuse-ld=gold"))
+            entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", "-fuse-ld=gold"))
+
         # if "+rocm" in spec:
         #     entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         return entries
@@ -621,7 +631,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 # #            entries.append(cmake_cache_path("Aluminum_DIR", "{0}".format(spec["aluminum"].prefix)))
 
         if spec.satisfies("^python") and "+pfe" in spec:
-            entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python".format(spec["python"].prefix.bin)))
+            entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python3".format(spec["python"].prefix.bin)))
             entries.append(cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])) # do NOT need to sub ; for : because
                                                                                           # value will only be interpreted by
                                                                                           # a shell, which expects :

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -430,7 +430,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             ("LBANN_WITH_UNIT_TESTING", "unit_tests"),
             ("LBANN_WITH_VISION", "vision"),
             ("LBANN_WITH_VTUNE", "vtune"),
-            ]
+        ]
 
         for opt, val in cmake_variant_fields:
             entries.append(self.define_cmake_cache_from_variant(opt, val))

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -516,8 +516,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "SYS_TYPE" in env:
             hostname = hostname.rstrip("1234567890")
         return "LBANN_{0}_{1}-{2}-{3}@{4}.cmake".format(
-            self.spec.version,
             hostname,
+            self.spec.version,
             self._get_sys_type(self.spec),
             self.spec.compiler.name,
             self.spec.compiler.version,


### PR DESCRIPTION
Updates the CachedCMakePackage to reduce redundant code in inherited packages:
- Add the CMake prefix path to the cache so that dependent packages are found.
- Enhancements to ensure that CachedCMakePackages get boiler plate fields set in the base level package for both ROCm and CUDA package types.  
- Additionally, it provides a option to make the cached options from variants, bringing it in line with the standard CMakePackage.  
- It also changes the default behavior to force the cached options to overwrite an existing CMakeCache.txt file if one existed.

Added an implementation of the CachedCMakePackage for the LBANN package.