### PR TITLE
py-pyqt4: Install/update the qt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyqt4/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt4/package.py
@@ -31,6 +31,7 @@ class PyPyqt4(SIPPackage):
 
     # Supposedly can also be built with Qt 5 compatibility layer
     depends_on("qt@:4")
+    depends_on("qt@4.1:", when="@4.12.3")
     depends_on("py-sip@:4.19.18 module=PyQt4.sip")
 
     # https://www.riverbankcomputing.com/static/Docs/PyQt4/installation.html


### PR DESCRIPTION
This change was needed -- per the build failure -- for me to be able to install `py-pyqt4` so I could test #35693 via `py-pyqt4`.