### PR TITLE
bugfix/tests: fix stand-alone test suite status reporting

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -668,8 +668,9 @@ def process_test_parts(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool
             try:
                 tests = test_functions(spec.package_class)
             except spack.repo.UnknownPackageError:
-                # some virtuals don't have a package
-                tests = []
+                # Some virtuals don't have a package so we don't want to report
+                # them as not having tests when that isn't appropriate.
+                continue
 
             if len(tests) == 0:
                 tester.status(spec.name, TestStatus.NO_TESTS)

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -319,3 +319,17 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     spack.cmd.common.arguments.sanitize_reporter_options(args)
     filename = spack.cmd.test.report_filename(args, suite)
     assert filename != "https://blahblah/submit.php?project=debugging"
+
+
+def test_test_output_multiple_specs(
+    mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config
+):
+    """Ensure proper reporting for suite with skipped, failing, and passed tests."""
+    install("test-error", "simple-standalone-test@0.9", "simple-standalone-test@1.0")
+    out = spack_test("run", "test-error", "simple-standalone-test", fail_on_error=False)
+
+    # Note that a spec with passing *and* skipped tests is still considered
+    # to have passed at this level. If you want to see the spec-specific
+    # part result summaries, you'll have to look at the "test-out.txt" files
+    # for each spec.
+    assert "1 failed, 2 passed of 3 specs" in out

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -20,7 +20,7 @@ def _true(*args, **kwargs):
     return True
 
 
-def ensure_results(filename, expected):
+def ensure_results(filename, expected, present=True):
     assert os.path.exists(filename)
     with open(filename, "r") as fd:
         lines = fd.readlines()
@@ -29,7 +29,10 @@ def ensure_results(filename, expected):
             if expected in line:
                 have = True
                 break
-        assert have
+        if present:
+            assert have, f"Expected '{expected}' in the file"
+        else:
+            assert not have, f"Expected '{expected}' NOT to be in the file"
 
 
 def test_test_log_name(mock_packages, config):
@@ -78,8 +81,8 @@ def test_write_test_result(mock_packages, mock_test_stage):
         assert spec.name in msg
 
 
-def test_test_uninstalled(mock_packages, install_mockery, mock_test_stage):
-    """Attempt to perform stand-alone test for uninstalled package."""
+def test_test_not_installed(mock_packages, install_mockery, mock_test_stage):
+    """Attempt to perform stand-alone test for not_installed package."""
     spec = spack.spec.Spec("trivial-smoke-test").concretized()
     test_suite = spack.install_test.TestSuite([spec])
 
@@ -156,6 +159,7 @@ def test_test_spec_passes(mock_packages, install_mockery, mock_test_stage, monke
 
     ensure_results(test_suite.results_file, "PASSED")
     ensure_results(test_suite.log_file_for_spec(spec), "simple stand-alone")
+    ensure_results(test_suite.log_file_for_spec(spec), "standalone-ifc", present=False)
 
 
 def test_get_test_suite():

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -216,8 +216,10 @@ def test_test_functions_pkgless(mock_packages, install_mockery, ensure_debug, ca
     spec = spack.spec.Spec("simple-standalone-test").concretized()
     fns = spack.install_test.test_functions(spec.package, add_virtuals=True)
     out = capsys.readouterr()
-    assert len(fns) == 1, "Expected only one test function"
-    assert "does not appear to have a package file" in out[1]
+    assert len(fns) == 2, "Expected two test functions"
+    for f in fns:
+        assert f[1].__name__ in ["test_echo", "test_skip"]
+    assert "virtual does not appear to have a package file" in out[1]
 
 
 # TODO: This test should go away when compilers as dependencies is supported

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -12,7 +12,8 @@ class SimpleStandaloneTest(Package):
     homepage = "http://www.example.com/simple_test"
     url = "http://www.unit-test-should-replace-this-url/simple_test-1.0.tar.gz"
 
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("1.0", md5="123456789abcdef0123456789abcdefg")
+    version("0.9", md5="0123456789abcdef0123456789abcdef")
 
     provides("standalone-ifc")
 
@@ -20,3 +21,10 @@ class SimpleStandaloneTest(Package):
         """simple stand-alone test"""
         echo = which("echo")
         echo("testing echo", output=str.split, error=str.split)
+
+    def test_skip(self):
+        """simple skip test"""
+        if self.spec.satisfies("@1.0:"):
+            raise SkipTest("This test is not available from v1.0 on")
+
+        print("Ran test_skip")

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -7,14 +7,14 @@ from spack.package import *
 
 
 class SimpleStandaloneTest(Package):
-    """This package has a simple stand-alone test features."""
+    """This package has simple stand-alone test features."""
 
     homepage = "http://www.example.com/simple_test"
     url = "http://www.unit-test-should-replace-this-url/simple_test-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    provides("standalone-test")
+    provides("standalone-ifc")
 
     def test_echo(self):
         """simple stand-alone test"""


### PR DESCRIPTION
This PR fixes the summarization of test suite results involving multiple specs.  Consequently, it leverages the subprocess tested file to pass the overall spec status back to main process.  It also does NOT (unnecessarily) report a package-less virtual class as having no tests.

An example of the output with this fix is:

```
$ spack -v test run amrex
==> Spack test bh4zl5uwgid7s3ntztk3hmaoxttmiuo5
==> Testing package amrex-21.11-c5zlps6
==> [2023-05-10-18:35:07.994419] test: test_run_install_test: build and run AmrCore test
SKIPPED: Amrex::test_run_install_test: Test is not supported for versions @:21.11
==> [2023-05-10-18:35:07.997003] Completed testing
==> [2023-05-10-18:35:07.997168] 
========================= SUMMARY: amrex-21.11-c5zlps6 =========================
Amrex::test_run_install_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package amrex-23.05-3j2ybow
==> [2023-05-10-18:35:12.879354] Installing $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/amrex-23.05-3j2ybowi5iamfrqesqonooonf2kjgkyg/.spack/test to $HOME/.spack/test/bh4zl5uwgid7s3ntztk3hmaoxttmiuo5/amrex-23.05-3j2ybow/cache/amrex
==> [2023-05-10-18:35:23.863530] test: test_run_install_test: build and run AmrCore test
==> [2023-05-10-18:35:23.882685] '$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-fauieins74p2to63u2buzfnvgmumiojp/bin/cmake' '-S./cache/amrex/Tests/SpackSmokeTest' '-DAMReX_ROOT=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/amrex-23.05-3j2ybowi5iamfrqesqonooonf2kjgkyg' '-DMPI_C_COMPILER=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpicc' '-DMPI_CXX_COMPILER=$SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpic++' '-DUSE_XSDK_DEFAULTS=ON' '-DAMReX_SPACEDIM:STRING=3' '-DBUILD_SHARED_LIBS:BOOL=OFF' '-DAMReX_MPI:BOOL=ON' '-DAMReX_OMP:BOOL=OFF' '-DXSDK_PRECISION:STRING=DOUBLE' '-DXSDK_ENABLE_Fortran:BOOL=OFF' '-DAMReX_FORTRAN_INTERFACES:BOOL=OFF' '-DAMReX_EB:BOOL=OFF' '-DAMReX_LINEAR_SOLVERS:BOOL=ON' '-DAMReX_AMRDATA:BOOL=OFF' '-DAMReX_PARTICLES:BOOL=OFF' '-DAMReX_PLOTFILE_TOOLS:BOOL=OFF' '-DAMReX_TINY_PROFILE:BOOL=OFF' '-DAMReX_HDF5:BOOL=OFF' '-DAMReX_HYPRE:BOOL=OFF' '-DAMReX_PETSC:BOOL=OFF' '-DAMReX_SUNDIALS:BOOL=OFF' '-DAMReX_PIC:BOOL=OFF'
-- The C compiler identification is GNU 10.3.1
-- The CXX compiler identification is GNU 10.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: $SPACK_ROOT/releases/spack/lib/spack/env/gcc/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: $SPACK_ROOT/releases/spack/lib/spack/env/gcc/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- Found MPI_C: $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/lib/libmpi.so (found version "3.1") 
-- Found MPI_CXX: $SPACK_ROOT/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/lib/libmpi.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1") found components: C CXX 
-- Configuring done (5.8s)
-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    AMReX_LINEAR_SOLVERS
    AMReX_PLOTFILE_TOOLS
    AMReX_SUNDIALS
    USE_XSDK_DEFAULTS
    XSDK_ENABLE_Fortran
    XSDK_PRECISION


-- Build files have been written to: $HOME/.spack/test/bh4zl5uwgid7s3ntztk3hmaoxttmiuo5/amrex-23.05-3j2ybow
==> [2023-05-10-18:35:29.833625] '/usr/bin/make'
[ 16%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp.o
[ 33%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp.o
[ 50%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp.o
[ 66%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp.o
[ 83%] Building CXX object CMakeFiles/install_test.dir/cache/amrex/Tests/Amr/Advection_AmrCore/Source/main.cpp.o
[100%] Linking CXX executable install_test
[100%] Built target install_test
==> [2023-05-10-18:35:54.203103] './install_test' './cache/amrex/Tests/Amr/Advection_AmrCore/Exec/inputs-ci'
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (23.05) initialized
Successfully read inputs file ... 
Writing plotfile plt00000

Coarse STEP 1 starts ...
[Level 0 step 1] ADVANCE with time = 0 dt = 0.01093983378
[Level 0 step 1] Advanced 32768 cells
[Level 1 step 1] ADVANCE with time = 0 dt = 0.005469916891
[Level 1 step 1] Advanced 65536 cells
[Level 2 step 1] ADVANCE with time = 0 dt = 0.002734958446
[Level 2 step 1] Advanced 204800 cells
[Level 2 step 2] ADVANCE with time = 0.002734958446 dt = 0.002734958446
[Level 2 step 2] Advanced 204800 cells
[Level 1 step 2] ADVANCE with time = 0.005469916891 dt = 0.005469916891
[Level 1 step 2] Advanced 65536 cells
[Level 2 step 3] ADVANCE with time = 0.005469916891 dt = 0.002734958446
[Level 2 step 3] Advanced 204800 cells
[Level 2 step 4] ADVANCE with time = 0.008204875337 dt = 0.002734958446
[Level 2 step 4] Advanced 204800 cells
Coarse STEP 1 ends. TIME = 0.01093983378 DT = 0.01093983378 Sum(Phi) = 33797.09926

Coarse STEP 2 starts ...
[Level 0 step 2] ADVANCE with time = 0.01093983378 dt = 0.01094187841
[Level 0 step 2] Advanced 32768 cells
[Level 1 step 3] ADVANCE with time = 0.01093983378 dt = 0.005470939206
[Level 1 step 3] Advanced 65536 cells
[Level 2 step 5] ADVANCE with time = 0.01093983378 dt = 0.002735469603
[Level 2 step 5] Advanced 225280 cells
[Level 2 step 6] ADVANCE with time = 0.01367530339 dt = 0.002735469603
[Level 2 step 6] Advanced 225280 cells
[Level 1 step 4] ADVANCE with time = 0.01641077299 dt = 0.005470939206
[Level 1 step 4] Advanced 65536 cells
[Level 2 step 7] ADVANCE with time = 0.01641077299 dt = 0.002735469603
[Level 2 step 7] Advanced 225280 cells
[Level 2 step 8] ADVANCE with time = 0.01914624259 dt = 0.002735469603
[Level 2 step 8] Advanced 225280 cells
Coarse STEP 2 ends. TIME = 0.02188171219 DT = 0.01094187841 Sum(Phi) = 33797.09926

Coarse STEP 3 starts ...
[Level 0 step 3] ADVANCE with time = 0.02188171219 dt = 0.01094713318
[Level 0 step 3] Advanced 32768 cells
[Level 1 step 5] ADVANCE with time = 0.02188171219 dt = 0.005473566591
[Level 1 step 5] Advanced 65536 cells
[Level 2 step 9] ADVANCE with time = 0.02188171219 dt = 0.002736783295
[Level 2 step 9] Advanced 247808 cells
[Level 2 step 10] ADVANCE with time = 0.02461849549 dt = 0.002736783295
[Level 2 step 10] Advanced 247808 cells
[Level 1 step 6] ADVANCE with time = 0.02735527878 dt = 0.005473566591
[Level 1 step 6] Advanced 65536 cells
[Level 2 step 11] ADVANCE with time = 0.02735527878 dt = 0.002736783295
[Level 2 step 11] Advanced 247808 cells
[Level 2 step 12] ADVANCE with time = 0.03009206208 dt = 0.002736783295
[Level 2 step 12] Advanced 247808 cells
Coarse STEP 3 ends. TIME = 0.03282884538 DT = 0.01094713318 Sum(Phi) = 33797.09926

Coarse STEP 4 starts ...
[Level 0 step 4] ADVANCE with time = 0.03282884538 dt = 0.01095563625
[Level 0 step 4] Advanced 32768 cells
[Level 1 step 7] ADVANCE with time = 0.03282884538 dt = 0.005477818126
[Level 1 step 7] Advanced 65536 cells
[Level 2 step 13] ADVANCE with time = 0.03282884538 dt = 0.002738909063
[Level 2 step 13] Advanced 247808 cells
[Level 2 step 14] ADVANCE with time = 0.03556775444 dt = 0.002738909063
[Level 2 step 14] Advanced 247808 cells
[Level 1 step 8] ADVANCE with time = 0.0383066635 dt = 0.005477818126
[Level 1 step 8] Advanced 65536 cells
[Level 2 step 15] ADVANCE with time = 0.0383066635 dt = 0.002738909063
[Level 2 step 15] Advanced 247808 cells
[Level 2 step 16] ADVANCE with time = 0.04104557256 dt = 0.002738909063
[Level 2 step 16] Advanced 247808 cells
Coarse STEP 4 ends. TIME = 0.04378448163 DT = 0.01095563625 Sum(Phi) = 33797.09926

Coarse STEP 5 starts ...
[Level 0 step 5] ADVANCE with time = 0.04378448163 dt = 0.01096740925
[Level 0 step 5] Advanced 32768 cells
[Level 1 step 9] ADVANCE with time = 0.04378448163 dt = 0.005483704627
[Level 1 step 9] Advanced 65536 cells
[Level 2 step 17] ADVANCE with time = 0.04378448163 dt = 0.002741852314
[Level 2 step 17] Advanced 247808 cells
[Level 2 step 18] ADVANCE with time = 0.04652633394 dt = 0.002741852314
[Level 2 step 18] Advanced 247808 cells
[Level 1 step 10] ADVANCE with time = 0.04926818625 dt = 0.005483704627
[Level 1 step 10] Advanced 65536 cells
[Level 2 step 19] ADVANCE with time = 0.04926818625 dt = 0.002741852314
[Level 2 step 19] Advanced 247808 cells
[Level 2 step 20] ADVANCE with time = 0.05201003857 dt = 0.002741852314
[Level 2 step 20] Advanced 247808 cells
Coarse STEP 5 ends. TIME = 0.05475189088 DT = 0.01096740925 Sum(Phi) = 33797.09926
Writing plotfile plt00005

Total Time: 12.35738275
Unused ParmParse Variables:
  [TOP]::amr.do_tracers(nvals = 1)  :: [1]

AMReX (23.05) finalized
PASSED: Amrex::test_run_install_test
==> [2023-05-10-18:36:06.960638] Completed testing
==> [2023-05-10-18:36:06.960817] 
========================= SUMMARY: amrex-23.05-3j2ybow =========================
Amrex::test_run_install_test .. PASSED
============================= 1 passed of 1 parts ==============================
==> Testing package amrex-21.10-qy3z336
==> [2023-05-10-18:36:13.558201] test: test_run_install_test: build and run AmrCore test
SKIPPED: Amrex::test_run_install_test: Test is not supported for versions @:21.11
==> [2023-05-10-18:36:13.561322] Completed testing
==> [2023-05-10-18:36:13.561533] 
========================= SUMMARY: amrex-21.10-qy3z336 =========================
Amrex::test_run_install_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
======================== 2 skipped, 1 passed of 3 specs ========================
32.148u 5.759s 1:23.12 45.5%	0+0k 19888+35960io 21pf+0w
```

TODO:

- [x] Add unit test(s)