### PR TITLE
Allow using -j to control the parallelism of concretization

### DIFF
--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -29,6 +29,7 @@ chosen, test dependencies are enabled for all packages in the environment.""",
     )
 
     spack.cmd.common.arguments.add_concretizer_args(subparser)
+    spack.cmd.common.arguments.add_common_arguments(subparser, ["jobs"])
 
 
 def concretize(parser, args):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1475,7 +1475,10 @@ class Environment:
 
         # Solve the environment in parallel on Linux
         start = time.time()
-        max_processes = min(len(arguments), 16)  # Number of specs  # Cap on 16 cores
+        max_processes = min(
+            len(arguments),  # Number of specs
+            spack.config.get("config:build_jobs"),  # Cap on build jobs
+        )
 
         # TODO: revisit this print as soon as darwin is parallel too
         msg = "Starting concretization"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -734,7 +734,7 @@ _spack_compilers() {
 }
 
 _spack_concretize() {
-    SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps"
+    SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps -j --jobs"
 }
 
 _spack_config() {


### PR DESCRIPTION
fixes #29464

This PR allows to use
```console
$ spack concretize -j X
```
to set a cap on the parallelism of concretization from the command line