### PR TITLE
Fix libpng build error on macOS arm64

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
@@ -48,6 +46,6 @@ class CMakeBuilder(CMakeBuilder):
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
             ]
-        if platform.system() == "Darwin" and platform.machine() == "arm64":
+        if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("-DPNG_ARM_NEON=off")
         return args

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
@@ -38,12 +40,14 @@ class Libpng(CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
-
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        return [
+        args = [
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
-        ]
+            ]
+        if platform.system() == "Darwin" and platform.machine() == "arm64":
+            args.append("-DPNG_ARM_NEON=off")
+        return args

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -38,6 +38,7 @@ class Libpng(CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
+
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [
@@ -45,7 +46,7 @@ class CMakeBuilder(CMakeBuilder):
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
-            ]
+        ]
         if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("-DPNG_ARM_NEON=off")
         return args


### PR DESCRIPTION
## Description

See https://github.com/NOAA-EMC/spack-stack/issues/572 for the error and https://github.com/NOAA-EMC/spack/pull/265 for the bug fix that went into our fork first. I cherry-picked the commits directly to avoid merge conflicts later on.

Tested successfully on our own macOS laptops with M1 / arm64 native architecture.

@srherbener @scheibelp 