### PR TITLE
e4s ci: trilinos +rocm: enable belos to fix build failure

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -217,7 +217,7 @@ spack:
   - superlu-dist +rocm
   - tasmanian ~openmp +rocm
   - tau +mpi +rocm
-  - "trilinos@13.4.0: ~belos ~ifpack2 ~stokhos +rocm"
+  - "trilinos@13.4.0: +belos ~ifpack2 ~stokhos +rocm"
   - umpire +rocm
   - upcxx +rocm
 


### PR DESCRIPTION
This is a workaround to resolve the following issue for CI builds:
https://github.com/spack/spack/issues/37583

Ideally we will also fix the CMake for Trilinos so this is properly handled for the `~belos` case.