### PR TITLE
sentieon-genomics: replacing square brackets in help

### DIFF
--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -16,7 +16,7 @@ class SentieonGenomics(Package):
 
     Please set the path to the sentieon license server with:
 
-    export SENTIEON_LICENSE=[FQDN]:[PORT]
+    export SENTIEON_LICENSE=<FQDN>:<PORT>
     """
 
     homepage = "https://www.sentieon.com/"


### PR DESCRIPTION
The square brackets at the end of the help string upset the lua parser for lmod.

This was a problem before and then went away before coming back in the past couple of weeks. Probably just easier to replace the square brackets in the help text itself than track down where the most recent iteration of this problem is.