### PR TITLE
Improve error message for buildcaches when DB is too new

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1654,8 +1654,14 @@ class InvalidDatabaseVersionError(SpackError):
     """Exception raised when the database metadata is newer than current Spack."""
 
     def __init__(self, database, expected, found):
+        self.expected = expected
+        self.found = found
         msg = (
-            f"you need a newer Spack version to read the database in '{database.root}'. "
-            f"The expected database version is '{expected}', but '{found}' was found."
+            f"you need a newer Spack version to read the DB in '{database.root}'. "
+            f"{self.database_version_message}"
         )
         super(InvalidDatabaseVersionError, self).__init__(msg)
+
+    @property
+    def database_version_message(self):
+        return f"The expected DB version is '{self.expected}', but '{self.found}' was found."


### PR DESCRIPTION
Follow up from #37614

With this PR and #37614 the errors look like:
![Screenshot from 2023-05-12 10-18-40](https://github.com/spack/spack/assets/4199709/3cf0f1a2-b18f-4295-a707-1d35ff3e5267)
