### PR TITLE
Fix the '--yes-to-all' option for 'spack install'

### DIFF
--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -30,6 +30,7 @@ _warn_enabled = True
 _error_enabled = True
 _output_filter = lambda s: s
 indent = "  "
+_yes_to_all = False
 
 
 def debug_level():
@@ -77,6 +78,16 @@ def set_warn_enabled(flag):
 def set_error_enabled(flag):
     global _error_enabled
     _error_enabled = flag
+
+
+def set_yes_to_all(flag):
+    global _yes_to_all
+    _yes_to_all = flag
+
+
+def yes_to_all():
+    global _yes_to_all
+    return _yes_to_all
 
 
 def msg_enabled():
@@ -284,6 +295,10 @@ def get_number(prompt, **kwargs):
 
 
 def get_yes_or_no(prompt, **kwargs):
+    global _yes_to_all
+    if _yes_to_all:
+        return True
+
     default_value = kwargs.get("default", None)
 
     if default_value is None:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -318,6 +318,7 @@ def _die_require_env():
 def install(parser, args):
     # TODO: unify args.verbose?
     tty.set_verbose(args.verbose or args.install_verbose)
+    tty.set_yes_to_all(args.yes_to_all)
 
     if args.help_cdash:
         arguments.print_cdash_help()

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1445,11 +1445,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             # Ask the user whether to skip the checksum if we're
             # interactive, but just fail if non-interactive.
             ck_msg = "Add a checksum or use --no-checksum to skip this check."
-            ignore_checksum = False
             if sys.stdout.isatty():
                 ignore_checksum = tty.get_yes_or_no("  Fetch anyway?", default=False)
-                if ignore_checksum:
-                    tty.debug("Fetching with no checksum. {0}".format(ck_msg))
+            else:
+                ignore_checksum = tty.yes_to_all()
+
+            if ignore_checksum:
+                tty.debug("Fetching with no checksum. {0}".format(ck_msg))
 
             if not ignore_checksum:
                 raise spack.error.FetchError(
@@ -1470,12 +1472,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 "of the package, submit a PR to remove `deprecated=False"
                 "`, or use `--deprecated` to skip this check."
             )
-            ignore_deprecation = False
             if sys.stdout.isatty():
                 ignore_deprecation = tty.get_yes_or_no("  Fetch anyway?", default=False)
+            else:
+                ignore_deprecation = tty.yes_to_all()
 
-                if ignore_deprecation:
-                    tty.debug("Fetching deprecated version. {0}".format(dp_msg))
+            if ignore_deprecation:
+                tty.debug("Fetching deprecated version. {0}".format(dp_msg))
 
             if not ignore_deprecation:
                 raise spack.error.FetchError(


### PR DESCRIPTION
`spack install --yes-to-all slurm@17-02-6-1` was ignoring the `--yes-to-all` function. This pull request fixes that.

I think it should also fix issue #29296, although I haven't tested that.