### PR TITLE
meson: Add installation sanity check

### DIFF
--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -83,6 +83,9 @@ class Meson(PythonPackage):
 
     executables = ["^meson$"]
 
+    # sanity check
+    sanity_check_is_file = [join_path("bin", "meson")]
+
     @classmethod
     def determine_version(cls, exe):
         return Executable(exe)("--version", output=str, error=str).rstrip()


### PR DESCRIPTION
In some cases `meson` may be installed in `local/bin/` instead of `bin/`, this verifies the file has been placed into the right place.  Ref #37632.

CC: @tkoskela