### PR TITLE
fix logic in setting oneapi microarchitecture flags

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -804,9 +804,11 @@ def is_mixed_toolchain(compiler):
             toolchains.add(compiler_cls.__name__)
 
     if len(toolchains) > 1:
-        if (toolchains == set(["Clang", "AppleClang", "Aocc"])
+        if (
+            toolchains == set(["Clang", "AppleClang", "Aocc"])
             # Msvc toolchain uses Intel ifx
-            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])):
+            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])
+        ):
             return False
         tty.debug("[TOOLCHAINS] {0}".format(toolchains))
         return True

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -804,9 +804,9 @@ def is_mixed_toolchain(compiler):
             toolchains.add(compiler_cls.__name__)
 
     if len(toolchains) > 1:
-        if toolchains == set(["Clang", "AppleClang", "Aocc"]) or toolchains == set(
-            ["Dpcpp", "Oneapi"]
-        ):
+        if (toolchains == set(["Clang", "AppleClang", "Aocc"])
+            # Msvc toolchain uses Intel ifx
+            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])):
             return False
         tty.debug("[TOOLCHAINS] {0}".format(toolchains))
         return True


### PR DESCRIPTION
oneapi builds were not getting microarchitecture optimization flags because it was improperly labeled as a mixed tool chain. Since microsoft does not have a fortran compiler, spack assumes ifx (intel fortran) is the fortran compiler for msvc toolchain.
Thanks to @Andrey1994 for noticing that the flags were not set!