### PR TITLE
intel-oneapi-mkl: support gnu openmp

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -105,7 +105,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         multi=False,
     )
 
-    depends_on("intel-oneapi-tbb")
+    depends_on("tbb")
     # cluster libraries need mpi
     depends_on("mpi", when="+cluster")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -105,7 +105,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         multi=False,
     )
 
-    depends_on("tbb")
+    depends_on("intel-oneapi-tbb")
     # cluster libraries need mpi
     depends_on("mpi", when="+cluster")
 
@@ -167,7 +167,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if "threads=tbb" in self.spec:
             libs.append("libmkl_tbb_thread")
         elif "threads=openmp" in self.spec:
-            libs.append("libmkl_intel_thread")
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
+                libs.append("libmkl_intel_thread")
+            else:
+                libs.append("libmkl_gnu_thread")
         else:
             libs.append("libmkl_sequential")
 


### PR DESCRIPTION
Resolves: #35423
recently added threads support for mkl only worked with intel openmp, add support for gnu openmp. Thanks to @RMeli for reporting the problem and suggesting the fix.