### PR TITLE
stdexec: Add 23.03

### DIFF
--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -10,9 +10,11 @@ class Stdexec(CMakePackage):
     """The proposed C++ framework for asynchronous and parallel programming."""
 
     homepage = "https://github.com/NVIDIA/stdexec"
+    url = "https://github.com/NVIDIA/stdexec/archive/nvhpc-0.0.tar.gz"
     git = "https://github.com/NVIDIA/stdexec.git"
     maintainers("msimberg", "aurianer")
 
+    version("23.03", sha256="2c9dfb6e56a190543049d2300ccccd1b626f4bb82af5b607869c626886fadd15")
     version("main", branch="main")
 
     depends_on("cmake@3.23.1:", type="build")


### PR DESCRIPTION
stdexec started shipping with NVHPC 23.03. Since then there's also been a corresponding tag in stdexec for the version shipped with NVHPC. This adds the `nvhpc-23.03` tag as version `23.03`.