### PR TITLE
[xrootd] New version 5.5.5

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -15,8 +15,9 @@ class Xrootd(CMakePackage):
     url = "https://xrootd.slac.stanford.edu/download/v5.5.1/xrootd-5.5.1.tar.gz"
     list_url = "https://xrootd.slac.stanford.edu/dload.html"
 
-    maintainers("wdconinc")
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb", "wdconinc")
 
+    version("5.5.5", sha256="0710caae527082e73d3bf8f9d1dffe95808afd3fcaaaa15ab0b937b8b226bc1f")
     version("5.5.4", sha256="41a8557ea2d118b1950282b17abea9230b252aa5ee1a5959173e2534b7d611d3")
     version("5.5.3", sha256="703829c2460204bd3c7ba8eaa23911c3c9a310f6d436211ba0af487ef7f6a980")
     version("5.5.2", sha256="ec4e0490b8ee6a3254a4ea4449342aa364bc95b78dc9a8669151be30353863c6")
@@ -93,6 +94,18 @@ class Xrootd(CMakePackage):
         "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1805.patch?full_index=1",
         sha256="2655e2d609d80bf9c9ab58557f4f6940408a1af9c686e7aa214ac0348c89c8fa",
         when="@5.5.1",
+    )
+    # https://github.com/xrootd/xrootd/pull/1930
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1930.patch?full_index=1",
+        sha256="969f8b07edff42449ad76b02f3e57d93b8d6c829be1ba14bccf831c27bc971e1",
+        when="@5.5.3",
+    )
+    # https://github.com/xrootd/xrootd/pull/1929
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1929.patch?full_index=1",
+        sha256="0c7abb0fc0f0ae3c012be84d1aebd67fc00021aee37c2e0d8d315bd108b5dbec",
+        when="@5.0.0:5 +client_only",
     )
 
     def patch(self):


### PR DESCRIPTION
* Patch to honor C++ standard for client-only builds.
* Version-specific patch for client-only scitokens-cpp support.
* Add FNAL Spack team to maintainers.
