### PR TITLE
amrfinder: add v3.11.8

### DIFF
--- a/var/spack/repos/builtin/packages/amrfinder/package.py
+++ b/var/spack/repos/builtin/packages/amrfinder/package.py
@@ -18,6 +18,7 @@ class Amrfinder(MakefilePackage):
     homepage = "https://github.com/ncbi/amr/wiki"
     url = "https://github.com/ncbi/amr/archive/refs/tags/amrfinder_v3.10.30.tar.gz"
 
+    version("3.11.8", sha256="8aac87595f28d0ba54ed3e97a1c033f9769a9b03e0aba78bc29cf6aff0cf45d1")
     version("3.10.42", sha256="97254f8d6217a4618b7f29c05acbcfe0240ee5e98458f8da7df3840b4be39c1b")
     version("3.10.30", sha256="2f1e30b86935a27cee740bd7229a41fbce278f2f60b33b8e51592bab8bdf23f1")
     version("3.10.24", sha256="fce299c980cda740dcc4f53f9b2dc9061c856213e5bdbc2c339185a5fb7dcf6a")


### PR DESCRIPTION
Add amrfinder v3.11.8. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.