### PR TITLE
iso-codes: add v4.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/iso-codes/package.py
+++ b/var/spack/repos/builtin/packages/iso-codes/package.py
@@ -13,6 +13,7 @@ class IsoCodes(AutotoolsPackage):
     homepage = "https://salsa.debian.org/iso-codes-team/iso-codes"
     url = "https://deb.debian.org/debian/pool/main/i/iso-codes/iso-codes_4.3.orig.tar.xz"
 
+    version("4.15.0", sha256="3d50750bf1d62d83b6085f5815ceb8392df34266a15f16bcf8d4cf7eb15d245c")
     version("4.13.0", sha256="2d4d0e5c02327f52cf7c029202da72f2074348472c26904b7104d2be3e0750ef")
     version("4.3", sha256="643eb83b2d714e8650ed7112706968d057bf5b101ba71c8ef219e20f1737b141")
 


### PR DESCRIPTION
Add iso-codes v4.15.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.