### PR TITLE
`spack spec`: remove noisy `@=` from output

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -140,12 +140,10 @@ def _process_result(result, show, required_format, kwargs):
 
 def solve(parser, args):
     # these are the same options as `spack spec`
-    name_fmt = "{namespace}.{name}" if args.namespaces else "{name}"
-    fmt = "{@versions}{%compiler}{compiler_flags}{variants}{arch=architecture}"
     install_status_fn = spack.spec.Spec.install_status
     kwargs = {
         "cover": args.cover,
-        "format": name_fmt + fmt,
+        "format": spack.cmd.spec.get_default_fmt(args),
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -141,9 +141,14 @@ def _process_result(result, show, required_format, kwargs):
 def solve(parser, args):
     # these are the same options as `spack spec`
     install_status_fn = spack.spec.Spec.install_status
+
+    fmt = spack.spec.display_format
+    if args.namespaces:
+        fmt = "{namespace}." + fmt
+
     kwargs = {
         "cover": args.cover,
-        "format": spack.cmd.spec.get_default_fmt(args),
+        "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -79,13 +79,24 @@ for further documentation regarding the spec syntax, see:
     arguments.add_concretizer_args(subparser)
 
 
+def get_default_fmt(args):
+    """Get the format we'll use to print out specs."""
+    fmt = "{namespace}.{name}" if args.namespaces else "{name}"
+    fmt += (
+        "{@version}"
+        "{%compiler.name}{@compiler.version}"
+        "{compiler_flags}"
+        "{variants}"
+        "{arch=architecture}"
+    )
+    return fmt
+
+
 def spec(parser, args):
-    name_fmt = "{namespace}.{name}" if args.namespaces else "{name}"
-    fmt = "{@versions}{%compiler}{compiler_flags}{variants}{arch=architecture}"
     install_status_fn = spack.spec.Spec.install_status
     tree_kwargs = {
         "cover": args.cover,
-        "format": name_fmt + fmt,
+        "format": get_default_fmt(args),
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -79,24 +79,16 @@ for further documentation regarding the spec syntax, see:
     arguments.add_concretizer_args(subparser)
 
 
-def get_default_fmt(args):
-    """Get the format we'll use to print out specs."""
-    fmt = "{namespace}.{name}" if args.namespaces else "{name}"
-    fmt += (
-        "{@version}"
-        "{%compiler.name}{@compiler.version}"
-        "{compiler_flags}"
-        "{variants}"
-        "{arch=architecture}"
-    )
-    return fmt
-
-
 def spec(parser, args):
     install_status_fn = spack.spec.Spec.install_status
+
+    fmt = spack.spec.display_format
+    if args.namespaces:
+        fmt = "{namespace}." + fmt
+
     tree_kwargs = {
         "cover": args.cover,
-        "format": get_default_fmt(args),
+        "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2324,6 +2324,7 @@ def display_specs(concretized_specs):
     def _tree_to_display(spec):
         return spec.tree(
             recurse_dependencies=True,
+            format=spack.spec.display_format,
             status_fn=spack.spec.Spec.install_status,
             hashlen=7,
             hashes=True,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -144,9 +144,20 @@ color_formats = {
 #: ``color_formats.keys()``.
 _separators = "[\\%s]" % "\\".join(color_formats.keys())
 
-default_format = "{name}{@versions}"
-default_format += "{%compiler.name}{@compiler.versions}{compiler_flags}"
-default_format += "{variants}{arch=architecture}{/abstract_hash}"
+#: Default format for Spec.format(). This format can be round-tripped, so that:
+#:     Spec(Spec("string").format()) == Spec("string)"
+default_format = (
+    "{name}{@versions}"
+    "{%compiler.name}{@compiler.versions}{compiler_flags}"
+    "{variants}{arch=architecture}{/abstract_hash}"
+)
+
+#: Display format, which eliminates extra `@=` in the output, for readability.
+display_format = (
+    "{name}{@version}"
+    "{%compiler.name}{@compiler.version}{compiler_flags}"
+    "{variants}{arch=architecture}{/abstract_hash}"
+)
 
 #: Regular expression to pull spec contents out of clearsigned signature
 #: file.

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -24,12 +24,12 @@ spec = SpackCommand("spec")
 def test_spec():
     output = spec("mpileaks")
 
-    assert "mpileaks@=2.3" in output
-    assert "callpath@=1.0" in output
-    assert "dyninst@=8.2" in output
-    assert "libdwarf@=20130729" in output
-    assert "libelf@=0.8.1" in output
-    assert "mpich@=3.0.4" in output
+    assert "mpileaks@2.3" in output
+    assert "callpath@1.0" in output
+    assert "dyninst@8.2" in output
+    assert "libdwarf@20130729" in output
+    assert "libelf@0.8.1" in output
+    assert "mpich@3.0.4" in output
 
 
 def test_spec_concretizer_args(mutable_config, mutable_database):
@@ -197,12 +197,12 @@ def test_env_aware_spec(mutable_mock_env_path):
 
     with env:
         output = spec()
-        assert "mpileaks@=2.3" in output
-        assert "callpath@=1.0" in output
-        assert "dyninst@=8.2" in output
-        assert "libdwarf@=20130729" in output
-        assert "libelf@=0.8.1" in output
-        assert "mpich@=3.0.4" in output
+        assert "mpileaks@2.3" in output
+        assert "callpath@1.0" in output
+        assert "dyninst@8.2" in output
+        assert "libdwarf@20130729" in output
+        assert "libelf@0.8.1" in output
+        assert "mpich@3.0.4" in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
syntax, which is accurate but noisy in output like this. Other UI commands tend not to print the redundant `@=` for known concrete versions; make `spack spec` consistent with them.

- [x] pull `spack spec` default format out into its own method.
- [x] fix formatting in `spack spec` and `spack solve`

before:


```console
> spack spec tcl
Input spec
--------------------------------
tcl

Concretized
--------------------------------
tcl@=8.6.12%apple-clang@=14.0.0 build_system=autotools arch=darwin-ventura-m1
    ^gnuconfig@=2022-09-17%apple-clang@=14.0.0 build_system=generic arch=darwin-ventura-m1
    ^zlib@=1.2.13%apple-clang@=14.0.0+optimize+pic+shared build_system=makefile arch=darwin-ventura-m1
```

after:

```console
> spack spec tcl
Input spec
--------------------------------
tcl

Concretized
--------------------------------
tcl@8.6.12%apple-clang@14.0.0 build_system=autotools arch=darwin-ventura-m1
    ^gnuconfig@2022-09-17%apple-clang@14.0.0 build_system=generic arch=darwin-ventura-m1
    ^zlib@1.2.13%apple-clang@14.0.0+optimize+pic+shared build_system=makefile arch=darwin-ventura-m1
```