### PR TITLE
add new package flux-security

### DIFF
--- a/var/spack/repos/builtin/packages/flux-security/package.py
+++ b/var/spack/repos/builtin/packages/flux-security/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import spack.util.executable
+from spack.package import *
+
+
+class FluxSecurity(AutotoolsPackage):
+    """Independent project for Flux security code and APIs."""
+
+    homepage = "https://github.com/flux-framework/flux-security"
+    url = "https://github.com/flux-framework/flux-security/releases/download/v0.8.0/flux-security-0.8.0.tar.gz"
+    git = "https://github.com/flux-framework/flux-security.git"
+    tags = ["radiuss", "e4s"]
+
+    maintainers("grondo")
+
+    version("master", branch="master")
+    version("0.8.0", sha256="9963628063b4abdff6bece03208444c8f23fbfda33c20544c48b21e9f4819ce2")
+
+    # Need autotools when building on master:
+    depends_on("autoconf", type="build", when="@master")
+    depends_on("automake", type="build", when="@master")
+    depends_on("libtool", type="build", when="@master")
+
+    depends_on("pkgconfig")
+    depends_on("libsodium@1.0.14:")
+    depends_on("jansson")
+    depends_on("libuuid")
+    depends_on("munge")
+    depends_on("libpam")
+
+    def setup(self):
+        pass
+
+    @when("@master")
+    def setup(self):
+        with working_dir(self.stage.source_path):
+            # Allow git-describe to get last tag so flux-version works:
+            git = which("git")
+            # When using spack develop, this will already be unshallow
+            try:
+                git("fetch", "--unshallow")
+                git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                git("fetch", "origin")
+            except spack.util.executable.ProcessError:
+                git("fetch")
+
+    def autoreconf(self, spec, prefix):
+        self.setup()
+        if os.path.exists(self.configure_abs_path):
+            return
+        # make sure configure doesn't get confused by the staging symlink
+        with working_dir(self.configure_directory):
+            # Bootstrap with autotools
+            bash = which("bash")
+            bash("./autogen.sh")


### PR DESCRIPTION
This will add a new package, flux-security, to spack. I'm adding this because I'd like to have a particular container base for the flux-operator (which currently installs with spack to add libfabric) that also generates the flux-imp, which (I believe) requires flux-security to be installed. When I probed into spack, I realized none of our spack containers had the executable.

I've tested this locally for both:

```bash
spack install flux-security
# and to test the autogen.sh
spack install flux-security@master
```

both worked ok, although after I manually updated my compilers.yaml for gcc 12.x to target the actual binary I wanted (it was using 8.x something for some reason...!)

I will follow this up with a variant to flux-core to add flux-security, and then automation in the flux-framework/spack repository.