### PR TITLE
`spack find`: get rid of @= in arch/compiler headers

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def iter_groups(specs, indent, all_headers):
             spack.spec.architecture_color,
             architecture if architecture else "no arch",
             spack.spec.compiler_color,
-            compiler if compiler else "no compiler",
+            f"{compiler.name}@{compiler.version}" if compiler else "no compiler",
         )
 
         # Sometimes we want to display specs that are not yet concretized.


### PR DESCRIPTION
The @= in `spack find` output adds a bit of noise. Remove it as we did for `spack spec` and `spack concretize`.

This modifies display_specs so it actually covers other places we use that routine, as well, e.g., `spack buildcache list`.

before:

```
-- linux-ubuntu20.04-aarch64 / gcc@=11.1.0 -----------------------
ofdlcpi libpressio@0.88.0
```

after:

```
-- linux-ubuntu20.04-aarch64 / gcc@11.1.0 -----------------------
ofdlcpi libpressio@0.88.0
```