### PR TITLE
oneapi: before script load modules

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -272,6 +272,7 @@ spack:
         before_script:
         - - . /bootstrap/runner/view/lmod/lmod/init/bash
           - module use /opt/intel/oneapi/modulefiles
+          - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -269,6 +269,11 @@ spack:
     pipeline-gen:
     - build-job:
         image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
+    - any-job:
+        before_script:
+        - . /bootstrap/runner/view/lmod/lmod/init/bash
+        - module use /opt/intel/oneapi/modulefiles
+        - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -272,7 +272,6 @@ spack:
         before_script:
         - - . /bootstrap/runner/view/lmod/lmod/init/bash
           - module use /opt/intel/oneapi/modulefiles
-          - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -269,11 +269,10 @@ spack:
     pipeline-gen:
     - build-job:
         image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
-    - any-job:
         before_script:
-        - . /bootstrap/runner/view/lmod/lmod/init/bash
-        - module use /opt/intel/oneapi/modulefiles
-        - module load compiler
+        - - . /bootstrap/runner/view/lmod/lmod/init/bash
+          - module use /opt/intel/oneapi/modulefiles
+          - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -36,6 +36,7 @@ class Pdt(AutotoolsPackage):
     version("3.18.1", sha256="d06c2d1793fadebf169752511e5046d7e02cf3fead6135a35c34b1fee6d6d3b2")
 
     variant("pic", default=False, description="Builds with pic")
+    variant("rebuildme", default=True, description="Rebuild me please")
 
     patch("cray_configure.patch", when="%cce")
 

--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -36,7 +36,6 @@ class Pdt(AutotoolsPackage):
     version("3.18.1", sha256="d06c2d1793fadebf169752511e5046d7e02cf3fead6135a35c34b1fee6d6d3b2")
 
     variant("pic", default=False, description="Builds with pic")
-    variant("rebuildme", default=True, description="Rebuild me please")
 
     patch("cray_configure.patch", when="%cce")
 


### PR DESCRIPTION
- /etc/bash.bashrc exits after an interactive shell check, so module stuff is not setup when the shell starts during the builds
- It looks like spack doesn't error when the compiler module cannot be loaded.

So, setup module stuff during the build as a quick fix :(
