### PR TITLE
gitlab ci: fix pipeline generation error

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -24,4 +24,4 @@ spack:
   mirrors: { "mirror": "s3://spack-binaries/develop/build_systems" }
 
   cdash:
-    build-group: Build tests for different build systems
+    build-group: Build Systems


### PR DESCRIPTION
Since #37601 was merged, the `build_systems` stack has been failing at the `build` stage, even though the generated yaml seems to pass linting.

The problem seems to be generated job names that get too long, triggering a bug in gitlab: https://gitlab.com/gitlab-org/gitlab/-/issues/411509

If this works around the problem, we should maybe follow up with a PR to ensure `len(job_name) <= 128` for all generated job names. 