### PR TITLE
tests/libsigsegv: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import os
 
 from spack.package import *
 
@@ -13,6 +13,8 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/libsigsegv/"
     gnu_mirror_path = "libsigsegv/libsigsegv-2.13.tar.gz"
 
+    test_requires_compiler = True
+
     version("2.14", sha256="cdac3941803364cf81a908499beb79c200ead60b6b5b40cad124fd1e06caa295")
     version("2.13", sha256="be78ee4176b05f7c75ff03298d84874db90f4b6c9d5503f0da1226b3a3c48119")
     version("2.12", sha256="3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6")
@@ -21,21 +23,19 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
 
     patch("patch.new_config_guess", when="@2.10")
 
-    test_requires_compiler = True
-
     def configure_args(self):
         return ["--enable-shared"]
 
     extra_install_tests = "tests/.libs"
 
     @run_after("install")
-    def setup_build_tests(self):
+    def setup_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.extra_install_tests)
 
-    def _run_smoke_tests(self):
-        """Build and run the added smoke (install) test."""
+    def test_smoke_test(self):
+        """build and run smoke test"""
         data_dir = self.test_suite.current_test_data_dir
         prog = "smoke_test"
         src = data_dir.join("{0}.c".format(prog))
@@ -49,32 +49,11 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
             "-lsigsegv",
             "{0}{1}".format(self.compiler.cc_rpath_arg, self.prefix.lib),
         ]
-        reason = "test: checking ability to link to the library"
-        self.run_test("cc", options, [], installed=False, purpose=reason)
 
-        # Now run the program and confirm the output matches expectations
+        cc = which(os.environ["CC"])
+        cc(*options)
+
+        exe = which(prog)
+        out = exe(output=str.split, error=str.split)
         expected = get_escaped_text_output(data_dir.join("smoke_test.out"))
-        reason = "test: checking ability to use the library"
-        self.run_test(prog, [], expected, purpose=reason)
-
-    def _run_build_tests(self):
-        """Run selected build tests."""
-        passed = "Test passed"
-        checks = {
-            "sigsegv1": [passed],
-            "sigsegv2": [passed],
-            "sigsegv3": ["caught", passed],
-            "stackoverflow1": ["recursion", "Stack overflow", passed],
-            "stackoverflow2": ["recursion", "overflow", "violation", passed],
-        }
-
-        for exe, expected in checks.items():
-            reason = "test: checking {0} output".format(exe)
-            self.run_test(exe, [], expected, installed=True, purpose=reason, skip_missing=True)
-
-    def test(self):
-        # Run the simple built-in smoke test
-        self._run_smoke_tests()
-
-        # Run test programs pulled from the build
-        self._run_build_tests()
+        check_outputs(expected, out)


### PR DESCRIPTION
Converted the package to the new stand-alone test process *and* dropped the `test_binary*` checks since 1) the package no longer appears to build them and 2) the remaining test actually builds and runs a program with the library.

```
$ spack -v test run libsigsegv
==> Spack test bpdyulsxhvdrq4zpjjbx7jqciifojqix
==> Testing package libsigsegv-2.14-nfvzakz
==> [2023-05-15-17:36:02.164786] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libsigsegv-2.14-nfvzakze4tifkh47slb333fwy5fqushr/.spack/test to /g/g21/dahlgren/.spack/test/bpdyulsxhvdrq4zpjjbx7jqciifojqix/libsigsegv-2.14-nfvzakz/cache/libsigsegv
==> [2023-05-15-17:36:02.225112] test: test_smoke_test: build and run smoke test
==> [2023-05-15-17:36:02.227691] '/usr/WS1/dahlgren/spack/lib/spack/env/gcc/gcc' '-I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libsigsegv-2.14-nfvzakze4tifkh47slb333fwy5fqushr/include' '/g/g21/dahlgren/.spack/test/bpdyulsxhvdrq4zpjjbx7jqciifojqix/libsigsegv-2.14-nfvzakz/data/libsigsegv/smoke_test.c' '-o' 'smoke_test' '-L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libsigsegv-2.14-nfvzakze4tifkh47slb333fwy5fqushr/lib' '-lsigsegv' '-Wl,-rpath,/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libsigsegv-2.14-nfvzakze4tifkh47slb333fwy5fqushr/lib'
==> [2023-05-15-17:36:02.381911] './smoke_test'
Caught sigsegv #1
Hello World!
PASSED: Libsigsegv::test_smoke_test
==> [2023-05-15-17:36:02.388274] Completed testing
==> [2023-05-15-17:36:02.388394] 
======================= SUMMARY: libsigsegv-2.14-nfvzakz =======================
Libsigsegv::test_smoke_test .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```