### PR TITLE
azcopy: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/azcopy/package.py
+++ b/var/spack/repos/builtin/packages/azcopy/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Azcopy(Package):
+    """AzCopy is a command-line utility that you can use to copy data to and from containers and
+    file shares in Azure Storage accounts.
+    """
+
+    homepage = "https://github.com/Azure/azure-storage-azcopy"
+    url = "https://github.com/Azure/azure-storage-azcopy/archive/refs/tags/v10.18.1.tar.gz"
+
+    version("10.18.1", sha256="80292625d7f1a6fc41688c5948b3a20cfdae872464d37d831e20999430819c3f")
+
+    depends_on("go", type="build")
+
+    def install(self, spec, prefix):
+        go("build", "-o", prefix.bin.azcopy)


### PR DESCRIPTION
Successfully installs and runs on macOS 13.3.1 (a) arm64 with Apple Clang 14.0.3.

Chose the name `azcopy` instead of `azure-storage-azcopy` because that's what all other package managers call it.