### PR TITLE
tests/libxml2: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
-import llnl.util.filesystem as fs
-import llnl.util.tty as tty
-
 from spack.build_systems import autotools, nmake
 from spack.package import *
 
@@ -101,41 +98,91 @@ class Libxml2(AutotoolsPackage, NMakePackage):
             )
             filter_file("-Wno-long-long -Wno-format-extra-args", "", "configure")
 
-    def test(self):
-        """Perform smoke tests on the installed package"""
-        # Start with what we already have post-install
-        tty.msg("test: Performing simple import test")
-        self.builder.import_module_test()
+    def test_import(self):
+        """import module test"""
+        if "+python" not in self.spec:
+            raise SkipTest("Package must be built with +python")
+
+        with working_dir("spack-test", create=True):
+            python("-c", "import libxml2")
+
+    def test_xmlcatalog(self):
+        """check minimal creation output"""
+        path = self.prefix.bin.xmlcatalog
+        if not os.path.exists(path):
+            raise SkipTest("xmlcatalog is not installed")
+
+        xmlcatalog = which(path)
+        out = xmlcatalog("--create", output=str.split, error=str.split)
+
+        expected = [r"<catalog xmlns", r'catalog"/>']
+        check_outputs(expected, out)
+
+    def test_xml2_config(self):
+        """check version output"""
+        path = join_path(self.prefix.bin, "xml2-config")
+        if not os.path.exists(path):
+            raise SkipTest("xml2-config is not installed")
+
+        xml2_config = which(path)
+        out = xml2_config("--version", output=str.split, error=str.split)
+        assert str(self.spec.version) in out
+
+    def test_xmllint(self):
+        """run xmllint generation and validation checks"""
+        path = self.prefix.bin.xmllint
+        if not os.path.exists(path):
+            raise SkipTest("xmllint is not installed")
+
+        test_filename = "test.xml"
+        xmllint = which(path)
+
+        with test_part(self, "test_xmllint_auto", purpose="generate {0}".format(test_filename)):
+            xmllint("--auto", "-o", test_filename)
+
+        with test_part(
+            self,
+            "test_xmllint_validate_no_dtd",
+            purpose="validate {0} without a DTD".format(test_filename),
+        ):
+            out = xmllint(
+                "--postvalid",
+                test_filename,
+                output=str.split,
+                error=str.split,
+                fail_on_error=False,
+            )
+
+            expected = [r"validity error", r"no DTD found", r"does not validate"]
+            check_outputs(expected, out)
 
         data_dir = self.test_suite.current_test_data_dir
-
-        # Now run defined tests based on expected executables
         dtd_path = data_dir.join("info.dtd")
-        test_filename = "test.xml"
-        exec_checks = {
-            "xml2-config": [("--version", [str(self.spec.version)], 0)],
-            "xmllint": [
-                (["--auto", "-o", test_filename], [], 0),
-                (
-                    ["--postvalid", test_filename],
-                    ["validity error", "no DTD found", "does not validate"],
-                    3,
-                ),
-                (
-                    ["--dtdvalid", dtd_path, test_filename],
-                    ["validity error", "does not follow the DTD"],
-                    3,
-                ),
-                (["--dtdvalid", dtd_path, data_dir.join("info.xml")], [], 0),
-            ],
-            "xmlcatalog": [("--create", ["<catalog xmlns", 'catalog"/>'], 0)],
-        }
-        for exe in exec_checks:
-            for options, expected, status in exec_checks[exe]:
-                self.run_test(exe, options, expected, status)
 
-        # Perform some cleanup
-        fs.force_remove(test_filename)
+        with test_part(
+            self,
+            "test_xmllint_validate_with_dtd",
+            purpose="validate {0} with a DTD".format(test_filename),
+        ):
+            out = xmllint(
+                "--dtdvalid",
+                dtd_path,
+                test_filename,
+                output=str.split,
+                error=str.split,
+                fail_on_error=False,
+            )
+
+            expected = [r"validity error", r"does not follow the DTD"]
+            check_outputs(expected, out)
+
+        test_filename = data_dir.join("info.xml")
+        with test_part(
+            self,
+            "test_xmllint_validate_works",
+            purpose="validate {0} with a DTD".format(test_filename),
+        ):
+            xmllint("--dtdvalid", dtd_path, data_dir.join("info.xml"))
 
 
 class RunAfter(object):


### PR DESCRIPTION
Converts the stand-alone tests to the new process.  

Note that I tried a couple of refactoring so the module import test is shareable at runtime *and* stand-alone testing but could not get any to work.  In fact, I was not able to "prove" that the import tests are actually executed by `spack test --test=root libxml2+python`.

The following results were obtained with a libxml2 installation without and with `+python`:

```
$ spack -v test run libxml2
==> Spack test axevadnjfmfdxnspq2rodnmtbqwp2rhs
==> Testing package libxml2-2.10.3-67o33aj
==> [2023-05-15-19:28:51.905364] test: test_import: import module test
SKIPPED: Libxml2::test_import: Package must be built with +python
==> [2023-05-15-19:28:51.906021] test: test_xml2_config: check version output
==> [2023-05-15-19:28:51.907766] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xml2-config' '--version'
2.10.3
PASSED: Libxml2::test_xml2_config
==> [2023-05-15-19:28:51.911882] test: test_xmlcatalog: check minimal creation output
==> [2023-05-15-19:28:51.913600] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xmlcatalog' '--create'
<?xml version="1.0"?>
<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>
PASSED: Libxml2::test_xmlcatalog
==> [2023-05-15-19:28:51.948934] test: test_xmllint: run xmllint generation and validation checks
==> [2023-05-15-19:28:51.950373] test: test_xmllint_auto: generate test.xml
==> [2023-05-15-19:28:51.950705] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xmllint' '--auto' '-o' 'test.xml'
PASSED: Libxml2::test_xmllint_auto
==> [2023-05-15-19:28:51.959625] test: test_xmllint_validate_no_dtd: validate test.xml without a DTD
==> [2023-05-15-19:28:51.959954] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xmllint' '--postvalid' 'test.xml'
<?xml version="1.0"?>
<info>abc</info>
validity error : no DTD found!
Document test.xml does not validate
PASSED: Libxml2::test_xmllint_validate_no_dtd
==> [2023-05-15-19:28:51.966109] test: test_xmllint_validate_with_dtd: validate test.xml with a DTD
==> [2023-05-15-19:28:51.966410] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xmllint' '--dtdvalid' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-67o33aj/data/libxml2/info.dtd' 'test.xml'
<?xml version="1.0"?>
<info>abc</info>
test.xml:2: element info: validity error : Element info content does not follow the DTD, expecting (data), got (CDATA)
Document test.xml does not validate against /g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-67o33aj/data/libxml2/info.dtd
PASSED: Libxml2::test_xmllint_validate_with_dtd
==> [2023-05-15-19:28:51.974668] test: test_xmllint_validate_works: validate /g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-67o33aj/data/libxml2/info.xml with a DTD
==> [2023-05-15-19:28:51.974915] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-67o33ajvtzmicmyfwvyxhugj6l6h6mm5/bin/xmllint' '--dtdvalid' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-67o33aj/data/libxml2/info.dtd' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-67o33aj/data/libxml2/info.xml'
<?xml version="1.0"?>
<info>
<data>abc</data>
</info>
PASSED: Libxml2::test_xmllint_validate_works
PASSED: Libxml2::test_xmllint
==> [2023-05-15-19:28:51.983113] Completed testing
==> [2023-05-15-19:28:51.983263] 
======================= SUMMARY: libxml2-2.10.3-67o33aj ========================
Libxml2::test_import .. SKIPPED
Libxml2::test_xml2_config .. PASSED
Libxml2::test_xmlcatalog .. PASSED
Libxml2::test_xmllint_auto .. PASSED
Libxml2::test_xmllint_validate_no_dtd .. PASSED
Libxml2::test_xmllint_validate_with_dtd .. PASSED
Libxml2::test_xmllint_validate_works .. PASSED
Libxml2::test_xmllint .. PASSED
======================== 1 skipped, 7 passed of 8 parts ========================
==> Testing package libxml2-2.10.3-fdm3slk
==> [2023-05-15-19:28:52.844677] test: test_import: import module test
==> [2023-05-15-19:28:52.846806] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-izyxorc4w7nsnsviahgw4fdq6w6rzozp/bin/python3.10' '-c' 'import libxml2'
PASSED: Libxml2::test_import
==> [2023-05-15-19:28:52.937530] test: test_xml2_config: check version output
==> [2023-05-15-19:28:52.939501] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xml2-config' '--version'
2.10.3
PASSED: Libxml2::test_xml2_config
==> [2023-05-15-19:28:52.963366] test: test_xmlcatalog: check minimal creation output
==> [2023-05-15-19:28:52.965043] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xmlcatalog' '--create'
<?xml version="1.0"?>
<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>
PASSED: Libxml2::test_xmlcatalog
==> [2023-05-15-19:28:52.988227] test: test_xmllint: run xmllint generation and validation checks
==> [2023-05-15-19:28:52.989695] test: test_xmllint_auto: generate test.xml
==> [2023-05-15-19:28:52.989971] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xmllint' '--auto' '-o' 'test.xml'
PASSED: Libxml2::test_xmllint_auto
==> [2023-05-15-19:28:53.015888] test: test_xmllint_validate_no_dtd: validate test.xml without a DTD
==> [2023-05-15-19:28:53.016167] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xmllint' '--postvalid' 'test.xml'
<?xml version="1.0"?>
<info>abc</info>
validity error : no DTD found!
Document test.xml does not validate
PASSED: Libxml2::test_xmllint_validate_no_dtd
==> [2023-05-15-19:28:53.037667] test: test_xmllint_validate_with_dtd: validate test.xml with a DTD
==> [2023-05-15-19:28:53.037946] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xmllint' '--dtdvalid' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-fdm3slk/data/libxml2/info.dtd' 'test.xml'
<?xml version="1.0"?>
<info>abc</info>
test.xml:2: element info: validity error : Element info content does not follow the DTD, expecting (data), got (CDATA)
Document test.xml does not validate against /g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-fdm3slk/data/libxml2/info.dtd
PASSED: Libxml2::test_xmllint_validate_with_dtd
==> [2023-05-15-19:28:53.052778] test: test_xmllint_validate_works: validate /g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-fdm3slk/data/libxml2/info.xml with a DTD
==> [2023-05-15-19:28:53.053130] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/libxml2-2.10.3-fdm3slka4gq2slgfz65ji6ypzdms2i45/bin/xmllint' '--dtdvalid' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-fdm3slk/data/libxml2/info.dtd' '/g/g21/dahlgren/.spack/test/axevadnjfmfdxnspq2rodnmtbqwp2rhs/libxml2-2.10.3-fdm3slk/data/libxml2/info.xml'
<?xml version="1.0"?>
<info>
<data>abc</data>
</info>
PASSED: Libxml2::test_xmllint_validate_works
PASSED: Libxml2::test_xmllint
==> [2023-05-15-19:28:53.081375] Completed testing
==> [2023-05-15-19:28:53.081653] 
======================= SUMMARY: libxml2-2.10.3-fdm3slk ========================
Libxml2::test_import .. PASSED
Libxml2::test_xml2_config .. PASSED
Libxml2::test_xmlcatalog .. PASSED
Libxml2::test_xmllint_auto .. PASSED
Libxml2::test_xmllint_validate_no_dtd .. PASSED
Libxml2::test_xmllint_validate_with_dtd .. PASSED
Libxml2::test_xmllint_validate_works .. PASSED
Libxml2::test_xmllint .. PASSED
============================= 8 passed of 8 parts ==============================
============================= 2 passed of 2 specs ==============================
```