### PR TITLE
libxcb: depend on python, remove releases that need python 2

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,9 +17,9 @@ class Libxcb(AutotoolsPackage):
 
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
-    version("1.12", sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06")
-    version("1.11.1", sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd")
-    version("1.11", sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4")
+    version("1.12", sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06", deprecated=True)
+    version("1.11.1", sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd", deprecated=True)
+    version("1.11", sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4", deprecated=True)
 
     depends_on("libpthread-stubs")
     depends_on("libxau@0.99.2:")
@@ -27,17 +27,12 @@ class Libxcb(AutotoolsPackage):
 
     # libxcb 1.X requires xcb-proto >= 1.X
     depends_on("xcb-proto")
-    depends_on("xcb-proto@1.14:", when="@1.14:1.14.999")
-    depends_on("xcb-proto@1.13:", when="@1.13:1.13.999")
-    depends_on("xcb-proto@1.12:", when="@1.12:1.12.999")
-    depends_on("xcb-proto@1.11:", when="@1.11:1.11.999")
+    depends_on("xcb-proto@1.14:", when="@1.14")
+    depends_on("xcb-proto@1.13:", when="@1.13")
+    depends_on("xcb-proto@1.12:", when="@1.12")
+    depends_on("xcb-proto@1.11:", when="@1.11")
 
-    # TODO: uncomment once build deps can be resolved separately
-    # See #7646, #4145, #4063, and #2548 for details
-    # libxcb 1.13 added Python 3 support
-    # depends_on('python', type='build')
-    # depends_on('python@2:2.8', when='@:1.12', type='build')
-
+    depends_on("python", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,9 +17,21 @@ class Libxcb(AutotoolsPackage):
 
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
-    version("1.12", sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06", deprecated=True)
-    version("1.11.1", sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd", deprecated=True)
-    version("1.11", sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4", deprecated=True)
+    version(
+        "1.12",
+        sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06",
+        deprecated=True,
+    )
+    version(
+        "1.11.1",
+        sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd",
+        deprecated=True,
+    )
+    version(
+        "1.11",
+        sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4",
+        deprecated=True,
+    )
 
     depends_on("libpthread-stubs")
     depends_on("libxau@0.99.2:")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -17,21 +17,6 @@ class Libxcb(AutotoolsPackage):
 
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
     version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
-    version(
-        "1.12",
-        sha256="092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06",
-        deprecated=True,
-    )
-    version(
-        "1.11.1",
-        sha256="660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd",
-        deprecated=True,
-    )
-    version(
-        "1.11",
-        sha256="4b351e1dc95eb0a1c25fa63611a6f4cf033cb63e20997c4874c80bbd1876d0b4",
-        deprecated=True,
-    )
 
     depends_on("libpthread-stubs")
     depends_on("libxau@0.99.2:")
@@ -41,8 +26,6 @@ class Libxcb(AutotoolsPackage):
     depends_on("xcb-proto")
     depends_on("xcb-proto@1.14:", when="@1.14")
     depends_on("xcb-proto@1.13:", when="@1.13")
-    depends_on("xcb-proto@1.12:", when="@1.12")
-    depends_on("xcb-proto@1.11:", when="@1.11")
 
     depends_on("python", type="build")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
1. We don't support Python 2 anymore, so remove old releases
2. Make it depend on any Python as build dep
3. There was a race condition in creating *.pyc files when using system Python 2 during the build.