### PR TITLE
dd4hep: restrict podio versions

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -157,6 +157,7 @@ class Dd4hep(CMakePackage):
     depends_on("lcio", when="+lcio")
     depends_on("edm4hep", when="+edm4hep")
     depends_on("podio", when="+edm4hep")
+    depends_on("podio@:0.16.03", when="@:1.23 +edm4hep")
     depends_on("podio@0.16:", when="@1.24: +edm4hep")
     depends_on("py-pytest", type=("build", "test"))
 


### PR DESCRIPTION
[This PR](https://github.com/AIDASoft/podio/pull/415) was merged yesterday in
podio and makes dd4hep before 1.24 not buildable with the current podio head so I restricted the podio versions for dd4hep < 1.24