### PR TITLE
Update py-jedi 0.17.2 checksum in package.py

### DIFF
--- a/var/spack/repos/builtin/packages/py-jedi/package.py
+++ b/var/spack/repos/builtin/packages/py-jedi/package.py
@@ -14,7 +14,7 @@ class PyJedi(PythonPackage):
 
     version("0.18.1", sha256="74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab")
     version("0.18.0", sha256="92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707")
-    version("0.17.2", sha256="08d43addcbd656ed07e929631f8071eec567092bf16f2c19fc7bc272a97a77ef")
+    version("0.17.2", sha256="86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20")
     version("0.17.1", sha256="807d5d4f96711a2bcfdd5dfa3b1ae6d09aa53832b182090b222b5efb81f52f63")
     version("0.15.1", sha256="ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e")
     version("0.15.0", sha256="9f16cb00b2aee940df2efc1d7d7c848281fd16391536a3d4561f5aea49db1ee6")


### PR DESCRIPTION
Pypi for jedi-0.17.2.tar.gz does not match the package.py file.

https://pypi.org/project/jedi/0.17.2/#copy-hash-modal-60e943e3-1192-4b12-90e2-4d639cb5b4f7