### PR TITLE
check_modules_set_name: do not check for "enable" key

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -116,21 +116,14 @@ def one_spec_or_raise(specs):
 
 
 def check_module_set_name(name):
-    modules_config = spack.config.get("modules")
-    valid_names = set(
-        [
-            key
-            for key, value in modules_config.items()
-            if isinstance(value, dict) and value.get("enable", [])
-        ]
-    )
-    if "enable" in modules_config and modules_config["enable"]:
-        valid_names.add("default")
+    modules = spack.config.get("modules")
+    if name != "prefix_inspections" and name in modules:
+        return
 
-    if name not in valid_names:
-        msg = "Cannot use invalid module set %s." % name
-        msg += "    Valid module set names are %s" % list(valid_names)
-        raise spack.config.ConfigError(msg)
+    names = [k for k in modules if k != "prefix_inspections"]
+    raise spack.config.ConfigError(
+        f"Cannot use invalid module set {name}.", f"Valid module set names are {names}"
+    )
 
 
 _missing_modules_warning = (

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -121,8 +121,17 @@ def check_module_set_name(name):
         return
 
     names = [k for k in modules if k != "prefix_inspections"]
+
+    if not names:
+        raise spack.config.ConfigError(
+            f"Module set configuration is missing. Cannot use module set '{name}'"
+        )
+
+    pretty_names = "', '".join(names)
+
     raise spack.config.ConfigError(
-        f"Cannot use invalid module set {name}.", f"Valid module set names are {names}"
+        f"Cannot use invalid module set '{name}'.",
+        f"Valid module set names are: '{pretty_names}'.",
     )
 
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -212,7 +212,7 @@ def test_check_module_set_name(mutable_config):
 
     # Invalid module set names
     msg = "Valid module set names are"
-    with pytest.raises(spack.config.ConfigError, match=msg) as e:
+    with pytest.raises(spack.config.ConfigError, match=msg):
         spack.cmd.modules.check_module_set_name("prefix_inspections")
 
     with pytest.raises(spack.config.ConfigError, match=msg):

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -8,6 +8,8 @@ import sys
 
 import pytest
 
+import spack.cmd.modules
+import spack.config
 import spack.error
 import spack.modules.tcl
 import spack.package_base
@@ -187,3 +189,31 @@ def test_load_installed_package_not_in_repo(install_mockery, mock_fetch, monkeyp
     assert module_path
 
     spack.package_base.PackageBase.uninstall_by_spec(spec)
+
+
+@pytest.mark.regression("37649")
+def test_check_module_set_name(mutable_config):
+    """Tests that modules set name are validated correctly and an error is reported if the
+    name we require does not exist or is reserved by the configuration."""
+
+    # Minimal modules.yaml config.
+    spack.config.set(
+        "modules",
+        {
+            "prefix_inspections": {"./bin": ["PATH"]},
+            # module sets
+            "first": {},
+            "second": {},
+        },
+    )
+
+    # Valid module set name
+    spack.cmd.modules.check_module_set_name("first")
+
+    # Invalid module set names
+    msg = "Valid module set names are"
+    with pytest.raises(spack.config.ConfigError, match=msg) as e:
+        spack.cmd.modules.check_module_set_name("prefix_inspections")
+
+    with pytest.raises(spack.config.ConfigError, match=msg):
+        spack.cmd.modules.check_module_set_name("third")


### PR DESCRIPTION
`check_module_set_name` required `enable: [...]` to be a non-empty value, which
is not a requirement for a valid module set.

Also it used the old module set format with top-level key.

Instead, just check that the name is a key in module config, and is not
`prefix_inspections`.

