### PR TITLE
OPENMPI: disable use of sphinx

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -905,7 +905,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = ["--enable-shared", "--disable-silent-rules"]
+        config_args = ["--enable-shared", "--disable-silent-rules", "--disable-sphinx"]
 
         # All rpath flags should be appended with self.compiler.cc_rpath_arg.
         # Later, we might need to update share/openmpi/mpic++-wrapper-data.txt


### PR DESCRIPTION
Sphinx is used to build Open MPI manpages, etc. as part of the make dist process to create release tarballs.  There should be no need/use to do this within Spack.  Also some sites have older Sphinx installs which aren't compatible with the needs of the Open MPI documentation. For example, attempts to install openmpi@main fail at NERSC Perlmutter owing to such a situation.

Since Spack normally is used to build from release tarballs, in which the docs have already been installed, this should present no issues.

This configuration option will be ignored for older than 5.0.0 Open MPI releases.