### PR TITLE
tests/sqlite: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -220,53 +220,28 @@ class Sqlite(AutotoolsPackage):
             )
             install(libraryname, self.prefix.lib)
 
-    def _test_example(self):
-        """Ensure a sequence of commands on example db are successful."""
+    def test_example(self):
+        """check example table dump"""
 
         test_data_dir = self.test_suite.current_test_data_dir
         db_filename = test_data_dir.join("packages.db")
-        exe = "sqlite3"
 
         # Ensure the database only contains one table
-        expected = "packages"
-        reason = 'test: ensuring only table is "{0}"'.format(expected)
-        self.run_test(
-            exe,
-            [db_filename, ".tables"],
-            expected,
-            installed=True,
-            purpose=reason,
-            skip_missing=False,
-        )
+        sqlite3 = which(self.prefix.bin.sqlite3)
+        out = sqlite3(db_filename, ".tables", output=str.split, error=str.split)
+        assert "packages" in out
 
         # Ensure the database dump matches expectations, where special
         # characters are replaced with spaces in the expected and actual
         # output to avoid pattern errors.
-        reason = "test: checking dump output"
         expected = get_escaped_text_output(test_data_dir.join("dump.out"))
-        self.run_test(
-            exe,
-            [db_filename, ".dump"],
-            expected,
-            installed=True,
-            purpose=reason,
-            skip_missing=False,
-        )
+        out = sqlite3(db_filename, ".dump", output=str.split, error=str.split)
+        check_outputs(expected, out)
 
-    def _test_version(self):
-        """Perform version check on the installed package."""
-        exe = "sqlite3"
+    def test_version(self):
+        """ensure version is expected"""
         vers_str = str(self.spec.version)
 
-        reason = "test: ensuring version of {0} is {1}".format(exe, vers_str)
-        self.run_test(
-            exe, "-version", vers_str, installed=True, purpose=reason, skip_missing=False
-        )
-
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        # Perform a simple version check
-        self._test_version()
-
-        # Run a sequence of operations
-        self._test_example()
+        sqlite3 = which(self.prefix.bin.sqlite3)
+        out = sqlite3("-version", output=str.split, error=str.split)
+        assert vers_str in out


### PR DESCRIPTION
This PR converts the stand-alone tests to the new process.

```
$ spack -v test run sqlite
==> Spack test 4ipcf54zzvgftmhg2nffnm7ksnnh4oi4
==> Testing package sqlite-3.40.1-5sbsrrh
==> [2023-05-16-16:19:11.841077] test: test_example: check example table dump
==> [2023-05-16-16:19:11.843481] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/sqlite-3.40.1-5sbsrrhuona2fwdhkwuli2xa2ipwnvl4/bin/sqlite3' '$SPACK_TEST_ROOT/4ipcf54zzvgftmhg2nffnm7ksnnh4oi4/sqlite-3.40.1-5sbsrrh/data/sqlite/packages.db' '.tables'
packages
==> [2023-05-16-16:19:12.005892] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/sqlite-3.40.1-5sbsrrhuona2fwdhkwuli2xa2ipwnvl4/bin/sqlite3' '$SPACK_TEST_ROOT/4ipcf54zzvgftmhg2nffnm7ksnnh4oi4/sqlite-3.40.1-5sbsrrh/data/sqlite/packages.db' '.dump'
PRAGMA foreign_keys=OFF;
BEGIN TRANSACTION;
CREATE TABLE packages (
name varchar(80) primary key,
has_code integer,
url varchar(160));
INSERT INTO packages VALUES('sqlite',1,'https://www.sqlite.org');
INSERT INTO packages VALUES('readline',1,'https://tiswww.case.edu/php/chet/readline/rltop.html');
INSERT INTO packages VALUES('xsdk',0,'http://xsdk.info');
COMMIT;
PASSED: Sqlite::test_example
==> [2023-05-16-16:19:12.026887] test: test_version: ensure version is expected
==> [2023-05-16-16:19:12.027511] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/sqlite-3.40.1-5sbsrrhuona2fwdhkwuli2xa2ipwnvl4/bin/sqlite3' '-version'
3.40.1 2022-12-28 14:03:47 df5c253c0b3dd24916e4ec7cf77d3db5294cc9fd45ae7b9c5e82ad8197f38a24
PASSED: Sqlite::test_version
==> [2023-05-16-16:19:12.039123] Completed testing
==> [2023-05-16-16:19:12.039303] 
======================== SUMMARY: sqlite-3.40.1-5sbsrrh ========================
Sqlite::test_example .. PASSED
Sqlite::test_version .. PASSED
============================= 2 passed of 2 parts ==============================
============================== 1 passed of 1 spec ==============================
```