### PR TITLE
tests/m4: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -118,17 +118,18 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
 
         return args
 
-    def test(self):
-        spec_vers = str(self.spec.version)
-        reason = "test: ensuring m4 version is {0}".format(spec_vers)
-        self.run_test(
-            "m4", "--version", spec_vers, installed=True, purpose=reason, skip_missing=False
-        )
+    def test_version(self):
+        """ensure m4 version matches installed spec"""
+        m4 = which(self.prefix.bin.m4)
+        out = m4("--version", output=str.split, error=str.split)
+        assert str(self.spec.version) in out
 
-        reason = "test: ensuring m4 example succeeds"
+    def test_hello(self):
+        """ensure m4 hello example runs"""
         test_data_dir = self.test_suite.current_test_data_dir
         hello_file = test_data_dir.join("hello.m4")
+        m4 = which(self.prefix.bin.m4)
+        out = m4(hello_file, output=str.split, error=str.split)
+
         expected = get_escaped_text_output(test_data_dir.join("hello.out"))
-        self.run_test(
-            "m4", hello_file, expected, installed=True, purpose=reason, skip_missing=False
-        )
+        check_outputs(expected, out)


### PR DESCRIPTION
This PR converts the `m4` stand-alone tests to use the new process.

```
$ spack -v test run m4
==> Spack test xu7mqeqim5n7g3s5lvwjvidwfdzo6zxm
==> Testing package m4-1.4.19-iwgopvv
==> [2023-05-16-16:24:54.478482] test: test_hello: ensure m4 hello example runs
==> [2023-05-16-16:24:54.481066] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/m4-1.4.19-iwgopvvi5iobov6k4teqfaq6dwgcbbvr/bin/m4' '$SPACK_TEST_ROOT/xu7mqeqim5n7g3s5lvwjvidwfdzo6zxm/m4-1.4.19-iwgopvv/data/m4/hello.m4'

// macro is defined
Hello, World!
PASSED: M4::test_hello
==> [2023-05-16-16:24:54.500012] test: test_version: ensure m4 version matches installed spec
==> [2023-05-16-16:24:54.500620] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/m4-1.4.19-iwgopvvi5iobov6k4teqfaq6dwgcbbvr/bin/m4' '--version'
m4 (GNU M4) 1.4.19
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Rene' Seindal.
PASSED: M4::test_version
==> [2023-05-16-16:24:54.506197] Completed testing
==> [2023-05-16-16:24:54.506337] 
========================== SUMMARY: m4-1.4.19-iwgopvv ==========================
M4::test_hello .. PASSED
M4::test_version .. PASSED
============================= 2 passed of 2 parts ==============================
============================== 1 passed of 1 spec ==============================
```