### PR TITLE
tests/cmake: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -440,7 +440,7 @@ class Cmake(Package):
         """Runs and checks output of the installed binary."""
         exe_path = join_path(self.prefix.bin, bin)
         if not os.path.exists(exe_path):
-            raise SkipTest("{0} is not installed".format(exe))
+            raise SkipTest(f"{exe} is not installed")
 
         exe = which(exe_path)
         out = exe("--version", output=str.split, error=str.split)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -436,17 +436,28 @@ class Cmake(Package):
         module.cmake = Executable(self.spec.prefix.bin.cmake)
         module.ctest = Executable(self.spec.prefix.bin.ctest)
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        spec_vers_str = "version {0}".format(self.spec.version)
+    def run_version_check(self, bin):
+        """Runs and checks output of the installed binary."""
+        exe_path = join_path(self.prefix.bin, bin)
+        if not os.path.exists(exe_path):
+            raise SkipTest("{0} is not installed".format(exe))
 
-        for exe in ["ccmake", "cmake", "cpack", "ctest"]:
-            reason = "test version of {0} is {1}".format(exe, spec_vers_str)
-            self.run_test(
-                exe,
-                ["--version"],
-                [spec_vers_str],
-                installed=True,
-                purpose=reason,
-                skip_missing=True,
-            )
+        exe = which(exe_path)
+        out = exe("--version", output=str.split, error=str.split)
+        assert f"version {self.spec.version}" in out
+
+    def test_ccmake(self):
+        """check version from ccmake"""
+        self.run_version_check("ccmake")
+
+    def test_cmake(self):
+        """check version from cmake"""
+        self.run_version_check("cmake")
+
+    def test_cpack(self):
+        """check version from cpack"""
+        self.run_version_check("cpack")
+
+    def test_ctest(self):
+        """check version from ctest"""
+        self.run_version_check("ctest")


### PR DESCRIPTION
Converted the stand-alone tests to use the new process.

```
$ spack -v test run cmake
==> Spack test 5dhh4ha6vufwvq2zeo6sxqjfpgrdcjip
==> Testing package cmake-3.26.3-jjbp24a
==> [2023-05-16-16:41:46.790929] test: test_ccmake: check version from ccmake
==> [2023-05-16-16:41:46.792956] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/ccmake' '--version'
ccmake version 3.26.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
PASSED: Cmake::test_ccmake
==> [2023-05-16-16:41:47.498928] test: test_cmake: check version from cmake
==> [2023-05-16-16:41:47.500185] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '--version'
cmake version 3.26.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
PASSED: Cmake::test_cmake
==> [2023-05-16-16:41:47.888614] test: test_cpack: check version from cpack
==> [2023-05-16-16:41:47.890277] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cpack' '--version'
cpack version 3.26.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
PASSED: Cmake::test_cpack
==> [2023-05-16-16:41:48.176781] test: test_ctest: check version from ctest
==> [2023-05-16-16:41:48.178531] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/ctest' '--version'
ctest version 3.26.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
PASSED: Cmake::test_ctest
==> [2023-05-16-16:41:48.401277] Completed testing
==> [2023-05-16-16:41:48.401425] 
======================== SUMMARY: cmake-3.26.3-jjbp24a =========================
Cmake::test_ccmake .. PASSED
Cmake::test_cmake .. PASSED
Cmake::test_cpack .. PASSED
Cmake::test_ctest .. PASSED
============================= 4 passed of 4 parts ==============================
============================== 1 passed of 1 spec ==============================
```