### PR TITLE
tests/emacs: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import sys
 
 from spack.package import *
@@ -97,18 +98,32 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
 
         return args
 
-    def _test_check_versions(self):
-        """Perform version checks on installed package binaries."""
-        checks = ["ctags", "ebrowse", "emacs", "emacsclient", "etags"]
+    def run_version_check(self, bin):
+        """Runs and checks output of the installed binary."""
+        exe_path = join_path(self.prefix.bin, bin)
+        if not os.path.exists(exe_path):
+            raise SkipTest(f"{exe_path} is not installed")
 
-        for exe in checks:
-            expected = str(self.spec.version)
-            reason = "test version of {0} is {1}".format(exe, expected)
-            self.run_test(
-                exe, ["--version"], expected, installed=True, purpose=reason, skip_missing=True
-            )
+        exe = which(exe_path)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.spec.version) in out
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        # Simple version check tests on known binaries
-        self._test_check_versions()
+    def test_ctags(self):
+        """check ctags version"""
+        self.run_version_check("ctags")
+
+    def test_ebrowse(self):
+        """check ebrowse version"""
+        self.run_version_check("ebrowse")
+
+    def test_emacs(self):
+        """check emacs version"""
+        self.run_version_check("emacs")
+
+    def test_emacsclient(self):
+        """check emacsclient version"""
+        self.run_version_check("emacsclient")
+
+    def test_etags(self):
+        """check etags version"""
+        self.run_version_check("etags")


### PR DESCRIPTION
This PR converts emacs stand-alone tests to use the new process.

```
$ spack -v test run emacs
==> Spack test rwi4s42od2if2qqrwy2veclc2xserh4r
==> Testing package emacs-28.2-jwdxw6y
==> [2023-05-16-17:13:18.067130] test: test_ctags: check ctags version
==> [2023-05-16-17:13:18.068576] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/emacs-28.2-jwdxw6yevg42dbsovgecfrx22cjerk3n/bin/ctags' '--version'
ctags (GNU Emacs 28.2)
Copyright (C) 2022 Free Software Foundation, Inc.
This program is distributed under the terms in ETAGS.README
PASSED: Emacs::test_ctags
==> [2023-05-16-17:13:18.072503] test: test_ebrowse: check ebrowse version
==> [2023-05-16-17:13:18.073715] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/emacs-28.2-jwdxw6yevg42dbsovgecfrx22cjerk3n/bin/ebrowse' '--version'
ebrowse 28.2
Copyright (C) 2022 Free Software Foundation, Inc.
This program is distributed under the same terms as Emacs.
PASSED: Emacs::test_ebrowse
==> [2023-05-16-17:13:18.077373] test: test_emacs: check emacs version
==> [2023-05-16-17:13:18.079429] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/emacs-28.2-jwdxw6yevg42dbsovgecfrx22cjerk3n/bin/emacs' '--version'
GNU Emacs 28.2
Copyright (C) 2022 Free Software Foundation, Inc.
GNU Emacs comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of GNU Emacs
under the terms of the GNU General Public License.
For more information about these matters, see the file named COPYING.
PASSED: Emacs::test_emacs
==> [2023-05-16-17:13:18.110745] test: test_emacsclient: check emacsclient version
==> [2023-05-16-17:13:18.112020] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/emacs-28.2-jwdxw6yevg42dbsovgecfrx22cjerk3n/bin/emacsclient' '--version'
emacsclient 28.2
PASSED: Emacs::test_emacsclient
==> [2023-05-16-17:13:18.115388] test: test_etags: check etags version
==> [2023-05-16-17:13:18.116504] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/emacs-28.2-jwdxw6yevg42dbsovgecfrx22cjerk3n/bin/etags' '--version'
etags (GNU Emacs 28.2)
Copyright (C) 2022 Free Software Foundation, Inc.
This program is distributed under the terms in ETAGS.README
PASSED: Emacs::test_etags
==> [2023-05-16-17:13:18.122085] Completed testing
==> [2023-05-16-17:13:18.122259] 
========================= SUMMARY: emacs-28.2-jwdxw6y ==========================
Emacs::test_ctags .. PASSED
Emacs::test_ebrowse .. PASSED
Emacs::test_emacs .. PASSED
Emacs::test_emacsclient .. PASSED
Emacs::test_etags .. PASSED
============================= 5 passed of 5 parts ==============================
============================== 1 passed of 1 spec ==============================
```