### PR TITLE
tests/perl: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -494,16 +494,19 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             msg = "Unable to locate {0} command in {1}"
             raise RuntimeError(msg.format(self.spec.name, self.prefix.bin))
 
-    def test(self):
-        """Smoke tests"""
-        exe = self.spec["perl"].command.name
+    def test_version(self):
+        """check version"""
+        perl = self.spec["perl"].command
+        out = perl("--version", output=str.split, error=str.split)
+        expected = ["perl", str(self.spec.version)]
+        for expect in expected:
+            assert expect in out
 
-        reason = "test: checking version is {0}".format(self.spec.version)
-        self.run_test(
-            exe, "--version", ["perl", str(self.spec.version)], installed=True, purpose=reason
-        )
-
-        reason = "test: ensuring perl runs"
+    def test_hello(self):
+        """ensure perl runs hello world"""
         msg = "Hello, World!"
-        options = ["-e", 'use warnings; use strict;\nprint("%s\n");' % msg]
-        self.run_test(exe, options, msg, installed=True, purpose=reason)
+        options = ["-e", "use warnings; use strict;\nprint('%s\n');" % msg]
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert msg in out


### PR DESCRIPTION
Converted the stand-alone tests to use the new test process.

```
$ spack -v test run perl
==> Spack test w6j7ku76w27xbst7yqxx3emgi5kaxuak
==> Testing package perl-5.36.0-yrskvks
==> [2023-05-16-17:26:08.815235] test: test_hello: ensure perl runs hello world
==> [2023-05-16-17:26:08.816553] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/perl-5.36.0-yrskvkshuudahkpwleefdsidy3bebwiw/bin/perl' '-e' 'use warnings; use strict;
print('"'"'Hello, World!
'"'"');'
Hello, World!
PASSED: Perl::test_hello
==> [2023-05-16-17:26:08.855585] test: test_version: check version
==> [2023-05-16-17:26:08.856311] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/perl-5.36.0-yrskvkshuudahkpwleefdsidy3bebwiw/bin/perl' '--version'

This is perl 5, version 36, subversion 0 (v5.36.0) built for x86_64-linux-thread-multi

Copyright 1987-2022, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page.

PASSED: Perl::test_version
==> [2023-05-16-17:26:08.887163] Completed testing
==> [2023-05-16-17:26:08.887332] 
========================= SUMMARY: perl-5.36.0-yrskvks =========================
Perl::test_hello .. PASSED
Perl::test_version .. PASSED
============================= 2 passed of 2 parts ==============================
============================== 1 passed of 1 spec ==============================
```