### PR TITLE
containers: Retain (shallow) Git data

### DIFF
--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -5,6 +5,7 @@
 """Manages the details on the images used in the various stages."""
 import json
 import os.path
+import shlex
 import sys
 
 import llnl.util.filesystem as fs
@@ -130,8 +131,11 @@ def checkout_command(url, ref, enforce_sha, verify):
     if enforce_sha or verify:
         ref = _verify_ref(url, ref, enforce_sha)
 
-    command = (
-        "git clone {0} . && git fetch origin {1}:container_branch &&"
-        " git checkout container_branch "
-    ).format(url, ref)
-    return command
+    return " && ".join(
+        [
+            "git init --quiet",
+            f"git remote add origin {shlex.quote(url)}",
+            f"git fetch --depth=1 origin {shlex.quote(ref)}",
+            "git checkout --detach FETCH_HEAD",
+        ]
+    )

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -41,5 +41,7 @@ def test_bootstrap_phase(minimal_configuration, config_dumper, capsys):
         with fs.working_dir(spack_yaml_dir):
             output = containerize()
 
-    # Check for the presence of the clone command
-    assert "git clone" in output
+    # Check for the presence of the Git commands
+    assert "git init" in output
+    assert "git fetch" in output
+    assert "git checkout" in output

--- a/share/spack/templates/container/bootstrap-base.dockerfile
+++ b/share/spack/templates/container/bootstrap-base.dockerfile
@@ -23,7 +23,7 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
 RUN mkdir -p /root/.spack \
  && cp $SPACK_ROOT/share/spack/docker/modules.yaml \
         /root/.spack/modules.yaml \
- && rm -rf /root/*.* /run/nologin $SPACK_ROOT/.git
+ && rm -rf /root/*.* /run/nologin
 
 # [WORKAROUND]
 # https://superuser.com/questions/1241548/


### PR DESCRIPTION
The [official Spack container images](https://github.com/orgs/spack/packages?repo_name=spack) strip the Git tree (`.git`) from the Spack installation. This means when you manage to reproduce a bug in the official images (instead of some weird instance far afield), you go to report it only to find an incomplete version number:

```console
# spack debug report
* **Spack:** 0.20.0.dev0
* **Python:** 3.6.8
* **Platform:** linux-almalinux8-zen2
* **Concretizer:** clingo
```

This PR removes the removal of `/opt/spack/.git` from the Dockerfile, and then rewrites the `git clone <url>` sequence with a slightly more manual approach that (in the end) retains only a single commit in the Git history. The end result is useful version numbers with a minuscule increase in image size:
```console
$ podman run --rm -it $img debug report
* **Spack:** 0.20.0.dev0 (9ee2d79de172de14477a78e5d407548a63eea33a)
* **Python:** 3.10.6
* **Platform:** linux-ubuntu22.04-zen2
* **Concretizer:** clingo 
$ podman run --rm -it --entrypoint spack-env $img du -hs /opt/spack/.git
15M     /opt/spack/.git
```