### PR TITLE
Openfoam: Replace two boolean variants with multi-valued variant for precision option

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -325,8 +325,6 @@ class Openfoam(Package):
     version("1706", sha256="7779048bb53798d9a5bd2b2be0bf302c5fd3dff98e29249d6e0ef7eeb83db79a")
     version("1612", sha256="2909c43506a68e1f23efd0ca6186a6948ae0fc8fe1e39c78cc23ef0d69f3569d")
 
-    variant("float32", default=False, description="Use single-precision")
-    variant("spdp", default=False, description="Use single/double mixed precision")
     variant("int64", default=False, description="With 64-bit labels")
     variant("knl", default=False, description="Use KNL compiler settings")
     variant("kahip", default=False, description="With kahip decomposition")
@@ -340,6 +338,13 @@ class Openfoam(Package):
     variant("vtk", default=False, description="With VTK runTimePostProcessing")
     variant(
         "source", default=True, description="Install library/application sources and tutorials"
+    )
+    variant(
+        "precision", default="dp", description="Precision option",
+        values=( "sp", "dp",
+               conditional("spdp", when="@1906:")
+        ),
+        multi=False
     )
 
     depends_on("mpi")
@@ -895,7 +900,7 @@ class OpenfoamArch(object):
         self.compiler = None  # <- %compiler
         self.arch_option = ""  # Eg, -march=knl
         self.label_size = None  # <- +int64
-        self.precision_option = "DP"  # <- +float32 | +spdp
+        self.precision_option = "DP"  # <- precision= sp | dp | spdp
         self.compile_option = kwargs.get("compile-option", "-spack")
         self.arch = None
         self.options = None
@@ -908,10 +913,10 @@ class OpenfoamArch(object):
             self.label_size = "32"
 
         # WM_PRECISION_OPTION
-        if "+spdp" in spec:
-            self.precision_option = "SPDP"
-        elif "+float32" in spec:
+        if "precision=sp" in spec:
             self.precision_option = "SP"
+        elif "precision=spdp" in spec:
+            self.precision_option = "SPDP"
 
         # Processor/architecture-specific optimizations
         if "+knl" in spec:

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -341,9 +341,9 @@ class Openfoam(Package):
     )
     variant(
         "precision", default="dp", description="Precision option",
-        values=( "sp", "dp",
-               conditional("spdp", when="@1906:")
-        ),
+        values=("sp", "dp",
+                conditional("spdp", when="@1906:")
+               ),
         multi=False
     )
 

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -340,11 +340,11 @@ class Openfoam(Package):
         "source", default=True, description="Install library/application sources and tutorials"
     )
     variant(
-        "precision", default="dp", description="Precision option",
-        values=("sp", "dp",
-                conditional("spdp", when="@1906:")
-               ),
-        multi=False
+        "precision",
+        default="dp",
+        description="Precision option",
+        values=("sp", "dp", conditional("spdp", when="@1906:")),
+        multi=False,
     )
 
     depends_on("mpi")


### PR DESCRIPTION
This pull request addresses the issue raised in #37588. I propose replacing the current two boolean variants for the precision option in OpenFOAM with a single multi-valued variant. The precision option in OpenFOAM requires one of three specific values, making a multi-valued variant a more suitable choice. By using a multi-valued variant with multi=false, we can ensure that only one value is selected.
Additionally, I have included a condition to account for the spdp option, which was introduced in version 1906. 
Please refer to [ENH: add primitives support for mixed precision](https://develop.openfoam.com/Development/openfoam/-/commit/46bc808261ef44cb29b512cb0c93acabdc09153a)
This condition ensures that the spdp option is available only for compatible versions of OpenFOAM.
Moreover, I have verified that the precision option functions correctly with the values "sp," "dp," and "spdp" in version 2206 %gcc@9.4.0 (ubuntu20.04-cascadelake).
