### PR TITLE
use @= in some packages

### DIFF
--- a/var/spack/repos/builtin/packages/mount-point-attributes/package.py
+++ b/var/spack/repos/builtin/packages/mount-point-attributes/package.py
@@ -27,4 +27,4 @@ class MountPointAttributes(AutotoolsPackage):
     depends_on("automake", type="build", when="@master")
     depends_on("libtool", type="build", when="@master")
 
-    patch("mpa_type_conversion.patch", when="@1.1:1.1.0")
+    patch("mpa_type_conversion.patch", when="@=1.1")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -175,18 +175,16 @@ with '-Wl,-commons,use_dylibs' and without
     # fix MPI_Barrier segmentation fault
     # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html
     # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
-    patch("mpich32_clang.patch", when="@3.2:3.2.0%clang")
-    patch("mpich32_clang.patch", when="@3.2:3.2.0%apple-clang")
+    patch("mpich32_clang.patch", when="@=3.2%clang")
+    patch("mpich32_clang.patch", when="@=3.2%apple-clang")
 
     # Fix SLURM node list parsing
     # See https://github.com/pmodels/mpich/issues/3572
     # and https://github.com/pmodels/mpich/pull/3578
-    # Even though there is no version 3.3.0, we need to specify 3.3:3.3.0 in
-    # the when clause, otherwise the patch will be applied to 3.3.1, too.
     patch(
         "https://github.com/pmodels/mpich/commit/b324d2de860a7a2848dc38aefb8c7627a72d2003.patch?full_index=1",
         sha256="5f48d2dd8cc9f681cf710b864f0d9b00c599f573a75b1e1391de0a3d697eba2d",
-        when="@3.3:3.3.0",
+        when="@=3.3",
     )
 
     # Fix reduce operations for unsigned integers

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -68,10 +68,8 @@ class Papi(AutotoolsPackage, ROCmPackage):
     conflicts("+sde", when="@:5", msg="Software defined events (SDE) added in 6.0.0")
     conflicts("^cuda", when="@:5", msg="CUDA support for versions < 6.0.0 not implemented")
 
-    # This is the only way to match exactly version 6.0.0 without also
-    # including version 6.0.0.1 due to spack version matching logic
     conflicts(
-        "@6.0:6.0.0.a", when="+static_tools", msg="Static tools cannot build on version 6.0.0"
+        "@=6.0.0", when="+static_tools", msg="Static tools cannot build on version 6.0.0"
     )
 
     # Does not build with newer versions of gcc, see

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -68,9 +68,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
     conflicts("+sde", when="@:5", msg="Software defined events (SDE) added in 6.0.0")
     conflicts("^cuda", when="@:5", msg="CUDA support for versions < 6.0.0 not implemented")
 
-    conflicts(
-        "@=6.0.0", when="+static_tools", msg="Static tools cannot build on version 6.0.0"
-    )
+    conflicts("@=6.0.0", when="+static_tools", msg="Static tools cannot build on version 6.0.0")
 
     # Does not build with newer versions of gcc, see
     # https://bitbucket.org/icl/papi/issues/46/cannot-compile-on-arch-linux

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -310,7 +310,7 @@ class QuantumEspresso(CMakePackage, Package):
     # 6.4
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.diff"
     patch_checksum = "ef08f5089951be902f0854a4dbddaa7b01f08924cdb27decfade6bef0e2b8994"
-    patch(patch_url, sha256=patch_checksum, when="@6.4:6.4.0+qmcpack")
+    patch(patch_url, sha256=patch_checksum, when="@=6.4+qmcpack")
     # 6.3
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.3.diff"
     patch_checksum = "2ee346e24926479f5e96f8dc47812173a8847a58354bbc32cf2114af7a521c13"
@@ -346,14 +346,14 @@ class QuantumEspresso(CMakePackage, Package):
     patch(
         "https://gitlab.com/QEF/q-e/commit/0796e1b7c55c9361ecb6515a0979280e78865e36.diff",
         sha256="bc8c5b8523156cee002d97dab42a5976dffae20605da485a427b902a236d7e6b",
-        when="+patch@6.3:6.3.0",
+        when="+patch@=6.3",
     )
 
     # QE 6.3 `make install` broken and a patch must be applied
     patch(
         "https://gitlab.com/QEF/q-e/commit/88e6558646dbbcfcafa5f3fa758217f6062ab91c.diff",
         sha256="b776890d008e16cca28c31299c62f47de0ba606b900b17cbc27c041f45e564ca",
-        when="+patch@6.3:6.3.0",
+        when="+patch@=6.3",
     )
 
     # QE 6.4.1 patch to work around configure issues that only appear in the

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -87,7 +87,7 @@ class VotcaTools(CMakePackage):
     patch(
         "https://github.com/votca/tools/pull/229.patch?full_index=1",
         sha256="2a9ef179904d5057f36a5ce533c002d8f5880dc4b3eba569825f4a7e7f055eb1",
-        when="@1.6:1.6.0+mkl",
+        when="@=1.6+mkl",
     )
     # https://github.com/votca/tools/pull/361, fix build with newer glibc/gcc, fixed in stable and 2021.1
     patch(

--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -34,7 +34,7 @@ class Wps(Package):
     patch("patches/4.2/arch.configure.defaults.patch", when="@4.2")
     patch("patches/4.2/configure.patch", when="@4.2:4.3.1")
     patch("patches/4.2/preamble.patch", when="@4.2:")
-    patch("patches/4.3/arch.configure.defaults.patch", when="@4.3:4.3.0")
+    patch("patches/4.3/arch.configure.defaults.patch", when="@=4.3")
     patch("patches/4.3.1/arch.configure.defaults.patch", when="@4.3.1")
     patch("patches/4.4/configure.patch", when="@4.4:")
 

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -141,7 +141,7 @@ class Wrf(Package):
     patch("patches/4.0/add_aarch64.patch", when="@4.0")
 
     patch("patches/4.2/arch.Config.pl.patch", when="@4.2:")
-    patch("patches/4.2/arch.configure.defaults.patch", when="@4.2:4.2.0")
+    patch("patches/4.2/arch.configure.defaults.patch", when="@=4.2")
     patch("patches/4.2/4.2.2_arch.configure.defaults.patch", when="@4.2.2")
     patch("patches/4.2/arch.conf_tokens.patch", when="@4.2:")
     patch("patches/4.2/arch.postamble.patch", when="@4.2")

--- a/var/spack/repos/tutorial/packages/mpich/package.py
+++ b/var/spack/repos/tutorial/packages/mpich/package.py
@@ -60,7 +60,7 @@ spack package at this time.""",
     # fix MPI_Barrier segmentation fault
     # see https://lists.mpich.org/pipermail/discuss/2016-May/004764.html
     # and https://lists.mpich.org/pipermail/discuss/2016-June/004768.html
-    patch("mpich32_clang.patch", when="@3.2:3.2.0%clang")
+    patch("mpich32_clang.patch", when="@=3.2%clang")
 
     depends_on("findutils", type="build")
 


### PR DESCRIPTION
Change the pattern `@x.y:x.y.0` -> `@=x.y`

As mentioned on Slack, maybe we should hold off of this until git versions `git_ref=3.2` satisfy the specific version `=3.2`, so that behavior doesn't change when taking the equivalent git commit.