### PR TITLE
git version semantics: ref=x satisfies x

### DIFF
--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -224,11 +224,11 @@ def test_git_user_supplied_reference_satisfaction(
     assert not hash_eq_ver.satisfies(just_hash)
     assert not hash_eq_ver.intersects(just_hash)
 
-    # Git versions and literal versions are distinct versions, like
-    # pkg@10.1.0 and pkg@10.1.0-suffix are distinct versions.
-    assert not hash_eq_ver.satisfies(just_ver)
+    # Git versions and literal versions are distinct versions,
+    # but ref=x does satisfy x, kinda like a variant on a version
+    assert hash_eq_ver.satisfies(just_ver)
     assert not just_ver.satisfies(hash_eq_ver)
-    assert not hash_eq_ver.intersects(just_ver)
+    assert hash_eq_ver.intersects(just_ver)
     assert hash_eq_ver != just_ver
     assert just_ver != hash_eq_ver
     assert not hash_eq_ver == just_ver

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -433,7 +433,7 @@ class GitVersion(ConcreteVersion):
         if isinstance(other, GitVersion):
             return self == other
         if isinstance(other, StandardVersion):
-            return False
+            return self.ref_version == other
         if isinstance(other, ClosedOpenRange):
             return self.ref_version.intersects(other)
         if isinstance(other, VersionList):
@@ -441,8 +441,10 @@ class GitVersion(ConcreteVersion):
         raise ValueError(f"Unexpected type {type(other)}")
 
     def intersection(self, other):
-        if isinstance(other, ConcreteVersion):
+        if isinstance(other, GitVersion):
             return self if self == other else VersionList()
+        if isinstance(other, StandardVersion):
+            return self if self.ref_version == other else VersionList()
         return other.intersection(self)
 
     def overlaps(self, other) -> bool:
@@ -455,7 +457,7 @@ class GitVersion(ConcreteVersion):
         if isinstance(other, GitVersion):
             return self == other
         if isinstance(other, StandardVersion):
-            return False
+            return self.ref_version == other
         if isinstance(other, ClosedOpenRange):
             return self.ref_version.satisfies(other)
         if isinstance(other, VersionList):


### PR DESCRIPTION
The idea is to make sure that `ref=x` satisfies the version `=x`.

Current blocker is that VersionList simplies `[ref=x,=x]` to `[=x]` now.