### PR TITLE
hdfview: add 3.1.4, 3.2.0, 3.3.0. Update dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -15,26 +15,14 @@ class Hdfview(Package):
     homepage = "https://www.hdfgroup.org/downloads/hdfview/"
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.4/src/hdfview-3.1.4.tar.gz"
 
-    version(
-        "3.3.0",
-        sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430",
-    )
-    version(
-        "3.2.0",
-        sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8",
-    )
-    version(
-        "3.1.4",
-        sha256="898fcd5227d4e7b697efde5e5a969405f96b72517f9dfbdbdce2991290fd56a0",
-    )
-    version(
-        "3.1.1",
-        sha256="1cfd127ebb4c3b0ab1cfe54649a410fc7a1c2d73f45564697d3729f4aa6b0ba3",
-    )
+    version("3.3.0", sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430")
+    version("3.2.0", sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8")
+    version("3.1.4", sha256="898fcd5227d4e7b697efde5e5a969405f96b72517f9dfbdbdce2991290fd56a0")
+    version("3.1.1", sha256="1cfd127ebb4c3b0ab1cfe54649a410fc7a1c2d73f45564697d3729f4aa6b0ba3")
     version(
         "3.0",
         sha256="e2a16d3842d8947f3d4f154ee9f48a106c7f445914a9e626a53976d678a0e934",
-        url="https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz"
+        url="https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz",
     )
 
     # unknown flag: --ignore-missing-deps
@@ -67,4 +55,4 @@ class Hdfview(Package):
     def setup_build_environment(self, env):
         env.set("HDF5LIBS", self.spec["hdf5"].prefix)
         env.set("HDFLIBS", self.spec["hdf"].prefix)
-        env.set('ANT_HOME', self.spec['ant'].prefix)
+        env.set("ANT_HOME", self.spec["ant"].prefix)

--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -13,14 +13,29 @@ class Hdfview(Package):
     and editing HDF (HDF5 and HDF4) files."""
 
     homepage = "https://www.hdfgroup.org/downloads/hdfview/"
-    url = "https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz"
+    url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.4/src/hdfview-3.1.4.tar.gz"
 
+    version(
+        "3.3.0",
+        sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430",
+    )
+    version(
+        "3.2.0",
+        sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8",
+    )
+    version(
+        "3.1.4",
+        sha256="898fcd5227d4e7b697efde5e5a969405f96b72517f9dfbdbdce2991290fd56a0",
+    )
     version(
         "3.1.1",
         sha256="1cfd127ebb4c3b0ab1cfe54649a410fc7a1c2d73f45564697d3729f4aa6b0ba3",
-        url="https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.1/src/hdfview-3.1.1.tar.gz",
     )
-    version("3.0", sha256="e2a16d3842d8947f3d4f154ee9f48a106c7f445914a9e626a53976d678a0e934")
+    version(
+        "3.0",
+        sha256="e2a16d3842d8947f3d4f154ee9f48a106c7f445914a9e626a53976d678a0e934",
+        url="https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz"
+    )
 
     # unknown flag: --ignore-missing-deps
     patch("fix_build.patch", when="@3.1.1")
@@ -29,10 +44,11 @@ class Hdfview(Package):
     depends_on("hdf5 +java")
     depends_on("hdf +java -external-xdr +shared")
 
-    def install(self, spec, prefix):
-        env["HDF5LIBS"] = spec["hdf5"].prefix
-        env["HDFLIBS"] = spec["hdf"].prefix
+    depends_on("hdf5@1.10", when="@:3.1")
+    depends_on("hdf5@1.12:", when="@3.2")
+    depends_on("hdf5@1.14:", when="@3.3:")
 
+    def install(self, spec, prefix):
         ant = which("ant")
         ant("-Dbuild.debug=false", "deploy")
 
@@ -47,3 +63,8 @@ class Hdfview(Package):
         chmod = which("chmod")
         chmod("+x", self.prefix.bin.hdfview)
         install_tree(path, prefix)
+
+    def setup_build_environment(self, env):
+        env.set("HDF5LIBS", self.spec["hdf5"].prefix)
+        env.set("HDFLIBS", self.spec["hdf"].prefix)
+        env.set('ANT_HOME', self.spec['ant'].prefix)


### PR DESCRIPTION
As title.  I tested the compatibility matrix of HDF5 versions [1.10, 1.12, 1.14] against hdfview [3.0, 3.1, 3.2, 3.3] and updated `package.py` with the results.  The findings are only slightly less restrictive than the officially tested combinations, listed here: https://portal.hdfgroup.org/display/HDFVIEW/HDFView.

The other non-trivial fix required was `env.set('ANT_HOME', self.spec['ant'].prefix)`.  I'm wondering if this is actually supposed to be a `setup_dependent_build_environment()` modification in ant itself?  Without it, you get errors like:

```
2 errors found in build log:
  >> 5    /usr/bin/build-classpath: error: Some specified jars were not found
  >> 6    Error occurred during initialization of VM
     7    java.lang.Error: Could not create SecurityManager
     8          at java.lang.System.initPhase3(java.base@11.0.17/System.java:2065)
     9    Caused by: java.lang.ClassNotFoundException: allow
     10         at jdk.internal.loader.BuiltinClassLoader.loadClass(java.base@11.0.17/BuiltinClassLoader.java:581)
     11         at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(java.base@11.0.17/ClassLoaders.java:178)
     12         at java.lang.ClassLoader.loadClass(java.base@11.0.17/ClassLoader.java:522)
```