### PR TITLE
PMIx and PRRTe: disabled use of sphinx

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -118,7 +118,7 @@ class Pmix(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        config_args = ["--enable-shared", "--enable-static"]
+        config_args = ["--enable-shared", "--enable-static", "--disable-sphinx"]
 
         config_args.append("--with-libevent=" + spec["libevent"].prefix)
         config_args.append("--with-hwloc=" + spec["hwloc"].prefix)

--- a/var/spack/repos/builtin/packages/prrte/package.py
+++ b/var/spack/repos/builtin/packages/prrte/package.py
@@ -45,7 +45,7 @@ class Prrte(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = ["--enable-shared", "--enable-static"]
+        config_args = ["--enable-shared", "--enable-static", "--disable-sphinx"]
 
         # libevent
         config_args.append("--with-libevent={0}".format(spec["libevent"].prefix))


### PR DESCRIPTION
Related to https://github.com/spack/spack/pull/37717

No need to be rebuilding openmpi man pages and other docs in spack as it almost always is used with release tarballs.

See #37717 for more details.