### PR TITLE
Refactor util executable to prefer pathlib

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -40,6 +40,7 @@ import re
 import sys
 import traceback
 import types
+from pathlib import Path
 from typing import List, Tuple
 
 import llnl.util.tty as tty
@@ -601,7 +602,8 @@ def set_module_variables_for_package(pkg):
 
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.
-    m.configure = Executable("./configure")
+    config = str(Path(pkg.stage.source_path, "configure"))
+    m.configure = Executable(config)
 
     # Standard CMake arguments
     m.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -40,7 +40,6 @@ import re
 import sys
 import traceback
 import types
-from pathlib import Path
 from typing import List, Tuple
 
 import llnl.util.tty as tty
@@ -602,8 +601,7 @@ def set_module_variables_for_package(pkg):
 
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.
-    config = str(Path(pkg.stage.source_path, "configure"))
-    m.configure = Executable(config)
+    m.configure = Executable("./configure")
 
     # Standard CMake arguments
     m.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -10,6 +10,7 @@ throughout Spack and should bring in a minimal number of external
 dependencies.
 """
 import os
+from pathlib import PurePath
 
 import llnl.util.filesystem
 
@@ -20,45 +21,45 @@ prefix = llnl.util.filesystem.ancestor(__file__, 4)
 spack_root = prefix
 
 #: bin directory in the spack prefix
-bin_path = os.path.join(prefix, "bin")
+bin_path = str(PurePath(prefix, "bin"))
 
 #: The spack script itself
-spack_script = os.path.join(bin_path, "spack")
+spack_script = str(PurePath(bin_path, "spack"))
 
 #: The sbang script in the spack installation
-sbang_script = os.path.join(bin_path, "sbang")
+sbang_script = str(PurePath(bin_path, "sbang"))
 
 # spack directory hierarchy
-lib_path = os.path.join(prefix, "lib", "spack")
-external_path = os.path.join(lib_path, "external")
-build_env_path = os.path.join(lib_path, "env")
-module_path = os.path.join(lib_path, "spack")
-command_path = os.path.join(module_path, "cmd")
-analyzers_path = os.path.join(module_path, "analyzers")
-platform_path = os.path.join(module_path, "platforms")
-compilers_path = os.path.join(module_path, "compilers")
-build_systems_path = os.path.join(module_path, "build_systems")
-operating_system_path = os.path.join(module_path, "operating_systems")
-test_path = os.path.join(module_path, "test")
-hooks_path = os.path.join(module_path, "hooks")
-opt_path = os.path.join(prefix, "opt")
-share_path = os.path.join(prefix, "share", "spack")
-etc_path = os.path.join(prefix, "etc", "spack")
+lib_path = str(PurePath(prefix, "lib", "spack"))
+external_path = str(PurePath(lib_path, "external"))
+build_env_path = str(PurePath(lib_path, "env"))
+module_path = str(PurePath(lib_path, "spack"))
+command_path = str(PurePath(module_path, "cmd"))
+analyzers_path = str(PurePath(module_path, "analyzers"))
+platform_path = str(PurePath(module_path, "platforms"))
+compilers_path = str(PurePath(module_path, "compilers"))
+build_systems_path = str(PurePath(module_path, "build_systems"))
+operating_system_path = str(PurePath(module_path, "operating_systems"))
+test_path = str(PurePath(module_path, "test"))
+hooks_path = str(PurePath(module_path, "hooks"))
+opt_path = str(PurePath(prefix, "opt"))
+share_path = str(PurePath(prefix, "share", "spack"))
+etc_path = str(PurePath(prefix, "etc", "spack"))
 
 #
 # Things in $spack/etc/spack
 #
-default_license_dir = os.path.join(etc_path, "licenses")
+default_license_dir = str(PurePath(etc_path, "licenses"))
 
 #
 # Things in $spack/var/spack
 #
-var_path = os.path.join(prefix, "var", "spack")
+var_path = str(PurePath(prefix, "var", "spack"))
 
 # read-only things in $spack/var/spack
-repos_path = os.path.join(var_path, "repos")
-packages_path = os.path.join(repos_path, "builtin")
-mock_packages_path = os.path.join(repos_path, "builtin.mock")
+repos_path = str(PurePath(var_path, "repos"))
+packages_path = str(PurePath(repos_path, "builtin"))
+mock_packages_path = str(PurePath(repos_path, "builtin.mock"))
 
 #
 # Writable things in $spack/var/spack
@@ -66,13 +67,13 @@ mock_packages_path = os.path.join(repos_path, "builtin.mock")
 # TODO: These should probably move to user cache, or some other location.
 #
 # fetch cache for downloaded files
-default_fetch_cache_path = os.path.join(var_path, "cache")
+default_fetch_cache_path = str(PurePath(var_path, "cache"))
 
 # GPG paths.
-gpg_keys_path = os.path.join(var_path, "gpg")
-mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
-mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
-gpg_path = os.path.join(opt_path, "spack", "gpg")
+gpg_keys_path = str(PurePath(var_path, "gpg"))
+mock_gpg_data_path = str(PurePath(var_path, "gpg.mock", "data"))
+mock_gpg_keys_path = str(PurePath(var_path, "gpg.mock", "keys"))
+gpg_path = str(PurePath(opt_path, "spack", "gpg"))
 
 
 # Below paths are where Spack can write information for the user.
@@ -91,22 +92,22 @@ def _get_user_cache_path():
 user_cache_path = _get_user_cache_path()
 
 #: junit, cdash, etc. reports about builds
-reports_path = os.path.join(user_cache_path, "reports")
+reports_path = str(PurePath(user_cache_path, "reports"))
 
 #: installation test (spack test) output
-default_test_path = os.path.join(user_cache_path, "test")
+default_test_path = str(PurePath(user_cache_path, "test"))
 
 #: spack monitor analysis directories
-default_monitor_path = os.path.join(reports_path, "monitor")
+default_monitor_path = str(PurePath(reports_path, "monitor"))
 
 #: git repositories fetched to compare commits to versions
-user_repos_cache_path = os.path.join(user_cache_path, "git_repos")
+user_repos_cache_path = str(PurePath(user_cache_path, "git_repos"))
 
 #: bootstrap store for bootstrapping clingo and other tools
-default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")
+default_user_bootstrap_path = str(PurePath(user_cache_path, "bootstrap"))
 
 #: transient caches for Spack data (virtual cache, patch sha256 lookup, etc.)
-default_misc_cache_path = os.path.join(user_cache_path, "cache")
+default_misc_cache_path = str(PurePath(user_cache_path, "cache"))
 
 
 # Below paths pull configuration from the host environment.

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -15,51 +15,51 @@ from pathlib import PurePath
 import llnl.util.filesystem
 
 #: This file lives in $prefix/lib/spack/spack/__file__
-prefix = llnl.util.filesystem.ancestor(__file__, 4)
+prefix = str(PurePath(llnl.util.filesystem.ancestor(__file__, 4)))
 
 #: synonym for prefix
 spack_root = prefix
 
 #: bin directory in the spack prefix
-bin_path = str(PurePath(prefix, "bin"))
+bin_path = os.path.join(prefix, "bin")
 
 #: The spack script itself
-spack_script = str(PurePath(bin_path, "spack"))
+spack_script = os.path.join(bin_path, "spack")
 
 #: The sbang script in the spack installation
-sbang_script = str(PurePath(bin_path, "sbang"))
+sbang_script = os.path.join(bin_path, "sbang")
 
 # spack directory hierarchy
-lib_path = str(PurePath(prefix, "lib", "spack"))
-external_path = str(PurePath(lib_path, "external"))
-build_env_path = str(PurePath(lib_path, "env"))
-module_path = str(PurePath(lib_path, "spack"))
-command_path = str(PurePath(module_path, "cmd"))
-analyzers_path = str(PurePath(module_path, "analyzers"))
-platform_path = str(PurePath(module_path, "platforms"))
-compilers_path = str(PurePath(module_path, "compilers"))
-build_systems_path = str(PurePath(module_path, "build_systems"))
-operating_system_path = str(PurePath(module_path, "operating_systems"))
-test_path = str(PurePath(module_path, "test"))
-hooks_path = str(PurePath(module_path, "hooks"))
-opt_path = str(PurePath(prefix, "opt"))
-share_path = str(PurePath(prefix, "share", "spack"))
-etc_path = str(PurePath(prefix, "etc", "spack"))
+lib_path = os.path.join(prefix, "lib", "spack")
+external_path = os.path.join(lib_path, "external")
+build_env_path = os.path.join(lib_path, "env")
+module_path = os.path.join(lib_path, "spack")
+command_path = os.path.join(module_path, "cmd")
+analyzers_path = os.path.join(module_path, "analyzers")
+platform_path = os.path.join(module_path, "platforms")
+compilers_path = os.path.join(module_path, "compilers")
+build_systems_path = os.path.join(module_path, "build_systems")
+operating_system_path = os.path.join(module_path, "operating_systems")
+test_path = os.path.join(module_path, "test")
+hooks_path = os.path.join(module_path, "hooks")
+opt_path = os.path.join(prefix, "opt")
+share_path = os.path.join(prefix, "share", "spack")
+etc_path = os.path.join(prefix, "etc", "spack")
 
 #
 # Things in $spack/etc/spack
 #
-default_license_dir = str(PurePath(etc_path, "licenses"))
+default_license_dir = os.path.join(etc_path, "licenses")
 
 #
 # Things in $spack/var/spack
 #
-var_path = str(PurePath(prefix, "var", "spack"))
+var_path = os.path.join(prefix, "var", "spack")
 
 # read-only things in $spack/var/spack
-repos_path = str(PurePath(var_path, "repos"))
-packages_path = str(PurePath(repos_path, "builtin"))
-mock_packages_path = str(PurePath(repos_path, "builtin.mock"))
+repos_path = os.path.join(var_path, "repos")
+packages_path = os.path.join(repos_path, "builtin")
+mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #
 # Writable things in $spack/var/spack
@@ -67,13 +67,13 @@ mock_packages_path = str(PurePath(repos_path, "builtin.mock"))
 # TODO: These should probably move to user cache, or some other location.
 #
 # fetch cache for downloaded files
-default_fetch_cache_path = str(PurePath(var_path, "cache"))
+default_fetch_cache_path = os.path.join(var_path, "cache")
 
 # GPG paths.
-gpg_keys_path = str(PurePath(var_path, "gpg"))
-mock_gpg_data_path = str(PurePath(var_path, "gpg.mock", "data"))
-mock_gpg_keys_path = str(PurePath(var_path, "gpg.mock", "keys"))
-gpg_path = str(PurePath(opt_path, "spack", "gpg"))
+gpg_keys_path = os.path.join(var_path, "gpg")
+mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
+mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
+gpg_path = os.path.join(opt_path, "spack", "gpg")
 
 
 # Below paths are where Spack can write information for the user.
@@ -89,25 +89,25 @@ def _get_user_cache_path():
     return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack" % os.sep)
 
 
-user_cache_path = _get_user_cache_path()
+user_cache_path = str(PurePath(_get_user_cache_path()))
 
 #: junit, cdash, etc. reports about builds
-reports_path = str(PurePath(user_cache_path, "reports"))
+reports_path = os.path.join(user_cache_path, "reports")
 
 #: installation test (spack test) output
-default_test_path = str(PurePath(user_cache_path, "test"))
+default_test_path = os.path.join(user_cache_path, "test")
 
 #: spack monitor analysis directories
-default_monitor_path = str(PurePath(reports_path, "monitor"))
+default_monitor_path = os.path.join(reports_path, "monitor")
 
 #: git repositories fetched to compare commits to versions
-user_repos_cache_path = str(PurePath(user_cache_path, "git_repos"))
+user_repos_cache_path = os.path.join(user_cache_path, "git_repos")
 
 #: bootstrap store for bootstrapping clingo and other tools
-default_user_bootstrap_path = str(PurePath(user_cache_path, "bootstrap"))
+default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")
 
 #: transient caches for Spack data (virtual cache, patch sha256 lookup, etc.)
-default_misc_cache_path = str(PurePath(user_cache_path, "cache"))
+default_misc_cache_path = os.path.join(user_cache_path, "cache")
 
 
 # Below paths pull configuration from the host environment.

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -20,9 +20,11 @@ def test_read_unicode(tmpdir, working_env):
     script_name = "print_unicode.py"
     # read the unicode back in and see whether things work
     if sys.platform == "win32":
-        script = ex.Executable("%s %s" % (sys.executable, script_name))
+        script = ex.Executable("%s" % (sys.executable))
+        script_args = [script_name]
     else:
         script = ex.Executable("./%s" % script_name)
+        script_args = []
     with tmpdir.as_cwd():
         os.environ["LD_LIBRARY_PATH"] = spack.main.spack_ld_library_path
         # make a script that prints some unicode
@@ -39,7 +41,7 @@ print(u'\\xc3')
         fs.set_executable(script_name)
         filter_shebangs_in_directory(".", [script_name])
 
-        assert "\xc3" == script(output=str).strip()
+        assert "\xc3" == script(*script_args, output=str).strip()
 
 
 def test_which_relative_path_with_slash(tmpdir, working_env):

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+from pathlib import PurePath
 
 import pytest
 
@@ -68,7 +69,7 @@ def test_which_with_slash_ignores_path(tmpdir, working_env):
 
     path = str(tmpdir.join("exe"))
     wrong_path = str(tmpdir.join("bin", "exe"))
-    os.environ["PATH"] = os.path.dirname(wrong_path)
+    os.environ["PATH"] = str(PurePath(wrong_path).parent)
 
     with tmpdir.as_cwd():
         if sys.platform == "win32":

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -17,15 +17,16 @@ from spack.hooks.sbang import filter_shebangs_in_directory
 
 
 def test_read_unicode(tmpdir, working_env):
-    script_name = "print_unicode.py"
-    # read the unicode back in and see whether things work
-    if sys.platform == "win32":
-        script = ex.Executable("%s" % (sys.executable))
-        script_args = [script_name]
-    else:
-        script = ex.Executable("./%s" % script_name)
-        script_args = []
     with tmpdir.as_cwd():
+        script_name = "print_unicode.py"
+        # read the unicode back in and see whether things work
+        if sys.platform == "win32":
+            script = ex.Executable("%s" % (sys.executable))
+            script_args = [script_name]
+        else:
+            script = ex.Executable("./%s" % script_name)
+            script_args = []
+
         os.environ["LD_LIBRARY_PATH"] = spack.main.spack_ld_library_path
         # make a script that prints some unicode
         with open(script_name, "w") as f:

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1109,7 +1109,13 @@ def environment_after_sourcing_files(
         source_file_arguments = " ".join(
             [source_file, suppress_output, concatenate_on_success, dump_environment_cmd]
         )
-        output = shell(*shell_options_list, source_file_arguments, output=str, env=environment, ignore_quotes=True)
+        output = shell(
+            *shell_options_list,
+            source_file_arguments,
+            output=str,
+            env=environment,
+            ignore_quotes=True,
+        )
 
         return json.loads(output)
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1090,10 +1090,11 @@ def environment_after_sourcing_files(
     shell = Executable(shell_cmd)
 
     def _source_single_file(file_and_args, environment):
-        source_file_arguments = [shell_options]
+        shell_options_list = shell_options.split()
 
-        in_bash_args = [source_command]
-        in_bash_args.extend(file_and_args)
+        source_file = [source_command]
+        source_file.extend(x for x in file_and_args)
+        source_file = " ".join(source_file)
 
         # If the environment contains 'python' use it, if not
         # go with sys.executable. Below we just need a working
@@ -1101,16 +1102,15 @@ def environment_after_sourcing_files(
         python_cmd = which("python3", "python", "python2")
         python_cmd = python_cmd.path if python_cmd else sys.executable
 
-        dump_cmd = '"import os, json; print(json.dumps(dict(os.environ)))"'
-        dump_environment = [python_cmd, "-E", "-c", dump_cmd]
+        dump_cmd = "import os, json; print(json.dumps(dict(os.environ)))"
+        dump_environment_cmd = python_cmd + f' -E -c "{dump_cmd}"'
 
         # Try to source the file
-        in_bash_args.extend(suppress_output.split())
-        in_bash_args.append(concatenate_on_success)
-        in_bash_args.extend(dump_environment)
-        source_file_arguments.append(" ".join(in_bash_args))
+        source_file_arguments = " ".join(
+            [source_file, suppress_output, concatenate_on_success, dump_environment_cmd]
+        )
+        output = shell(*shell_options_list, source_file_arguments, output=str, env=environment, ignore_quotes=True)
 
-        output = shell(*source_file_arguments, output=str, env=environment, ignore_quotes=True)
         return json.loads(output)
 
     current_environment = kwargs.get("env", dict(os.environ))

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1066,8 +1066,8 @@ def environment_after_sourcing_files(
 
     Keyword Args:
         env (dict): the initial environment (default: current environment)
-        shell (str): the shell to use (default: ``/bin/bash`` or ``cmd.exe``(Windows))
-        shell_options (str): options passed to the shell (default: ``-c`` or ``/C``(Windows))
+        shell (str): the shell to use (default: ``/bin/bash`` or ``cmd.exe`` (Windows))
+        shell_options (str): options passed to the shell (default: ``-c`` or ``/C`` (Windows))
         source_command (str): the command to run (default: ``source``)
         suppress_output (str): redirect used to suppress output of command
             (default: ``&> /dev/null``)

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1066,8 +1066,8 @@ def environment_after_sourcing_files(
 
     Keyword Args:
         env (dict): the initial environment (default: current environment)
-        shell (str): the shell to use (default: ``/bin/bash``)
-        shell_options (str): options passed to the shell (default: ``-c``)
+        shell (str): the shell to use (default: ``/bin/bash`` or ``cmd.exe``(Windows))
+        shell_options (str): options passed to the shell (default: ``-c`` or ``/C``(Windows))
         source_command (str): the command to run (default: ``source``)
         suppress_output (str): redirect used to suppress output of command
             (default: ``&> /dev/null``)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -20,10 +20,6 @@ class Executable:
     """Class representing a program that can be run on the command line."""
 
     def __init__(self, name):
-        # if " " in name:
-        # raise NotImplementedError("Space in name: `%s`" % name)
-        # names = name.split()
-
         file_path = which_string(name)
         if not file_path:
             # the file does not currently exist but it will exist in the cwd by

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -281,6 +281,7 @@ def which_string(*args, **kwargs):
         paths = [Path(x) for x in path.split(os.pathsep)]
 
     for search_item in args:
+        is_cwd = True if search_item.startswith(".") else False
         search_item = Path(search_item)
         candidate_items = [Path(search_item)]
         if sys.platform == "win32":
@@ -295,7 +296,7 @@ def which_string(*args, **kwargs):
                     paths.append(p.parent)
 
         for candidate_item in candidate_items:
-            search_paths = [Path.cwd()] + paths
+            search_paths = [Path.cwd()] + paths if is_cwd else paths
 
             for directory in search_paths:
                 exe = directory / candidate_item

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -21,9 +21,9 @@ class Executable:
 
     def __init__(self, name):
         file_path = Path(name).as_posix()
-        if sys.platform == "linux":
+        if sys.platform == "linux" and name.startswith("."):
             # pathlib strips the ./ from relative paths so it must be added back
-            file_path = os.path.join('.', file_path)
+            file_path = os.path.join(".", file_path)
         self.exe = [file_path]
 
         self.default_env = {}

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -21,7 +21,7 @@ class Executable:
 
     def __init__(self, name):
         file_path = Path(name).as_posix()
-        if sys.platform == "linux" and name.startswith("."):
+        if sys.platform != "win32" and name.startswith("."):
             # pathlib strips the ./ from relative paths so it must be added back
             file_path = os.path.join(".", file_path)
         self.exe = [file_path]

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -20,13 +20,11 @@ class Executable:
     """Class representing a program that can be run on the command line."""
 
     def __init__(self, name):
-        file_path = which_string(name)
-        if not file_path:
-            # the file does not currently exist but it will exist in the cwd by
-            # the time the executable is called
-            file_path = Path(name).resolve()
-
-        self.exe = [Path(file_path).as_posix()]
+        file_path = Path(name).as_posix()
+        if sys.platform == "linux":
+            # pathlib strips the ./ from relative paths so it must be added back
+            file_path = os.path.join('.', file_path)
+        self.exe = [file_path]
 
         self.default_env = {}
         from spack.util.environment import EnvironmentModifications  # no cycle

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -234,8 +234,8 @@ class Executable:
 
         except OSError as e:
             message = "Command: " + cmd_line_string
-            if sys.platform == "win32" and " " in self.exe[0]:
-                message = "\nDid you mean to add a space to the command?"
+            if " " in self.exe[0]:
+                message += "\nDid you mean to add a space to the command?"
 
             raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
 

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -233,7 +233,11 @@ class Executable:
             return result
 
         except OSError as e:
-            raise ProcessError("%s: %s" % (self.exe[0], e.strerror), "Command: " + cmd_line_string)
+            message = "Command: " + cmd_line_string
+            if sys.platform == "win32" and " " in self.exe[0]:
+                message = "\nDid you mean to add a space to the command?"
+
+            raise ProcessError("%s: %s" % (self.exe[0], e.strerror), message)
 
         except subprocess.CalledProcessError as e:
             if fail_on_error:

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from pathlib import PurePath
 
 from spack.package import *
 
@@ -109,7 +110,7 @@ class CmakeClient(CMakePackage):
         print(cmake)
         print(cmake.exe)
         check(
-            cmake.exe[0].startswith(spec["cmake"].prefix.bin),
+            str(PurePath(cmake.exe[0])).startswith(spec["cmake"].prefix.bin),
             "Wrong cmake was in environment: %s" % cmake,
         )
 

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -110,7 +110,7 @@ class CmakeClient(CMakePackage):
         print(cmake)
         print(cmake.exe)
         check(
-            str(PurePath(cmake.exe[0])).startswith(spec["cmake"].prefix.bin),
+            cmake.path.startswith(spec["cmake"].prefix.bin),
             "Wrong cmake was in environment: %s" % cmake,
         )
 

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from pathlib import PurePath
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -168,15 +168,15 @@ class Oommf(Package):
     def configure(self, spec, prefix):
         # change into directory with source code
         with working_dir(self.get_oommf_source_root()):
-            configure = Executable("./oommf.tcl pimake distclean")
-            configure()
-            configure2 = Executable("./oommf.tcl pimake upgrade")
-            configure2()
+            configure = Executable("./oommf.tcl")
+            configure("pimake", "distclean")
+            configure2 = Executable("./oommf.tcl")
+            configure2("pimake", "upgrade")
 
     def build(self, spec, prefix):
         with working_dir(self.get_oommf_source_root()):
-            make = Executable("./oommf.tcl pimake ")
-            make()
+            make = Executable("./oommf.tcl")
+            make("pimake")
 
     def install(self, spec, prefix):
         # keep a copy of all the tcl files and everything oommf created.


### PR DESCRIPTION
Refactor executable to convert string path inputs to pathlib before finding and launching the executable. 

Note: to make behavior similar for both windows and linux, this class now adds the current working directory to the path when finding the executable.