### PR TITLE
Update py-pennylane ecosystem to support v0.30.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -72,8 +72,7 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("py-pybind11", type="build")
     depends_on("py-pip", type="build")
     depends_on("py-wheel", type="build")
-    depends_on("py-pennylane@:0.29", type=("build", "run"), when="@0.29")
-    depends_on("py-pennylane@0.30:", type=("build", "run"), when="@0.30:")
+    depends_on("py-pennylane@:0.28", type=("build", "run"))
     depends_on("py-pennylane-lightning@0.30:~kokkos", type=("build", "run"), when="@0.30.0:")
     depends_on("py-pennylane-lightning@0.28:0.29~kokkos", type=("build", "run"), when="@0.29.1")
 

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -37,7 +37,7 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
         deflt_bool, descr = backends[backend]
         variant(backend.lower(), default=deflt_bool, description=descr)
         depends_on(
-            f"kokkos@:3.7.01+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build")
+            f"kokkos@3.7+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build")
         )
 
     # CUDA

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -13,11 +13,13 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
 
     homepage = "https://docs.pennylane.ai/projects/lightning-kokkos"
     git = "https://github.com/PennyLaneAI/pennylane-lightning-kokkos.git"
-    url = "https://github.com/PennyLaneAI/pennylane-lightning-kokkos/archive/refs/tags/v0.29.1.tar.gz"
+    url = "https://github.com/PennyLaneAI/pennylane-lightning-kokkos/archive/refs/tags/v0.30.0.tar.gz"
 
     maintainers("AmintorDusko", "vincentmr")
 
     version("main", branch="main")
+
+    version("0.30.0", sha256="7c8f0e0431f8052993cd8033a316f53590c7bf5419445d0725e214b93cbc661b")
     version("0.29.1", sha256="f51ba7718defc7bb5064f690f381e04b2ec58cb09f22a171ae5f410860716e30")
 
     # kokkos backends
@@ -67,7 +69,8 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("py-pip", type="build")
     depends_on("py-wheel", type="build")
     depends_on("py-pennylane@0.28:", type=("build", "run"))
-    depends_on("py-pennylane-lightning@0.28:~kokkos", type=("build", "run"))
+    depends_on("py-pennylane-lightning@0.30:~kokkos", type=("build", "run"), when="@0.30.0:")
+    depends_on("py-pennylane-lightning@0.28:0.29~kokkos", type=("build", "run"), when="@0.29.1")
 
     # variant defined dependencies
     depends_on("llvm-openmp", when="+openmp %apple-clang")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -69,10 +69,10 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("ninja", type="build")
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pybind11", type="build")
+    depends_on("py-pybind11", type="link")
     depends_on("py-pip", type="build")
     depends_on("py-wheel", type="build")
-    depends_on("py-pennylane@:0.28", type=("build", "run"))
+    depends_on("py-pennylane@0.28:", type=("build", "run"))
     depends_on("py-pennylane-lightning@0.30:~kokkos", type=("build", "run"), when="@0.30.0:")
     depends_on("py-pennylane-lightning@0.28:0.29~kokkos", type=("build", "run"), when="@0.29.1")
 

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -72,7 +72,8 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("py-pybind11", type="build")
     depends_on("py-pip", type="build")
     depends_on("py-wheel", type="build")
-    depends_on("py-pennylane@0.28:", type=("build", "run"))
+    depends_on("py-pennylane@:0.29", type=("build", "run"), when="@0.29")
+    depends_on("py-pennylane@0.30:", type=("build", "run"), when="@0.30:")
     depends_on("py-pennylane-lightning@0.30:~kokkos", type=("build", "run"), when="@0.30.0:")
     depends_on("py-pennylane-lightning@0.28:0.29~kokkos", type=("build", "run"), when="@0.29.1")
 

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -36,17 +36,17 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     for backend in backends:
         deflt_bool, descr = backends[backend]
         variant(backend.lower(), default=deflt_bool, description=descr)
-        depends_on(f"kokkos+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build"))
+        depends_on(f"kokkos@:3.7.01+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build"))
 
     # CUDA
     for val in CudaPackage.cuda_arch_values:
-        depends_on("kokkos cuda_arch={0}".format(val), when="cuda_arch={0}".format(val))
+        depends_on("kokkos@:3.7.01 cuda_arch={0}".format(val), when="cuda_arch={0}".format(val))
     # Use +wrapper when not %clang %cce
-    depends_on("kokkos+wrapper", when="%gcc+cuda")
+    depends_on("kokkos@:3.7.01+wrapper", when="%gcc+cuda")
 
     # ROCm
     for val in ROCmPackage.amdgpu_targets:
-        depends_on("kokkos amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val))
+        depends_on("kokkos@:3.7.01 amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val))
 
     conflicts(
         "+cuda",

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -36,7 +36,9 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     for backend in backends:
         deflt_bool, descr = backends[backend]
         variant(backend.lower(), default=deflt_bool, description=descr)
-        depends_on(f"kokkos@:3.7.01+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build"))
+        depends_on(
+            f"kokkos@:3.7.01+{backend.lower()}", when=f"+{backend.lower()}", type=("run", "build")
+        )
 
     # CUDA
     for val in CudaPackage.cuda_arch_values:
@@ -46,7 +48,9 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
 
     # ROCm
     for val in ROCmPackage.amdgpu_targets:
-        depends_on("kokkos@:3.7.01 amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val))
+        depends_on(
+            "kokkos@:3.7.01 amdgpu_target={0}".format(val), when="amdgpu_target={0}".format(val)
+        )
 
     conflicts(
         "+cuda",

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -48,8 +48,8 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
 
     # variant defined dependencies
     depends_on("blas", when="+blas")
-    depends_on("kokkos@3.7.00", when="+kokkos")
-    depends_on("kokkos-kernels@3.7.00", when="+kokkos")
+    depends_on("kokkos@:3.7.01", when="+kokkos")
+    depends_on("kokkos-kernels@:3.7.01", when="+kokkos")
     depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     depends_on("python@3.8:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -55,7 +55,7 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-pybind11", type=("build"))
+    depends_on("py-pybind11", type="link")
     depends_on("py-pip", type="build")
     depends_on("py-wheel", type="build")
     # depends_on("py-pennylane@0.28:", type=("build", "run"))  # circular dependency

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -12,11 +12,12 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
 
     homepage = "https://docs.pennylane.ai/projects/lightning"
     git = "https://github.com/PennyLaneAI/pennylane-lightning.git"
-    url = "https://github.com/PennyLaneAI/pennylane-lightning/archive/refs/tags/v0.28.2.tar.gz"
+    url = "https://github.com/PennyLaneAI/pennylane-lightning/archive/refs/tags/v0.30.0.tar.gz"
 
     maintainers("mlxd", "AmintorDusko")
 
     version("master", branch="master")
+    version("0.30.0", sha256="0f4032409d20d00991b5d14fe0b2b928baca4a13c5a1b16eab91f61f9273e58d")
     version("0.29.0", sha256="da9912f0286d1a54051cc19cf8bdbdcd732795636274c95f376db72a88e52d85")
     version(
         "0.28.0",

--- a/var/spack/repos/builtin/packages/py-pennylane/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane/package.py
@@ -26,6 +26,7 @@ class PyPennylane(PythonPackage):
     )
 
     depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-pip", type=("build", "run")) # Runtime req for pennylane.about()
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@:1.23", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pennylane/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane/package.py
@@ -12,11 +12,12 @@ class PyPennylane(PythonPackage):
 
     homepage = "https://docs.pennylane.ai/"
     git = "https://github.com/PennyLaneAI/pennylane.git"
-    url = "https://github.com/PennyLaneAI/pennylane/archive/refs/tags/v0.29.1.tar.gz"
+    url = "https://github.com/PennyLaneAI/pennylane/archive/refs/tags/v0.30.0.tar.gz"
 
     maintainers("mlxd", "AmintorDusko", "marcodelapierre")
 
     version("master", branch="master")
+    version("0.30.0", sha256="7fe4821fbc733e3e40d7011e054bd2e31edde3151fd9539025c827a5a3579d6b")
     version("0.29.1", sha256="6ecfb305a3898347df8c539a89a67e748766941d159dbef9e34864872f13c45c")
     version(
         "0.28.0",
@@ -30,14 +31,16 @@ class PyPennylane(PythonPackage):
     depends_on("py-numpy@:1.23", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-networkx", type=("build", "run"))
-    depends_on("py-retworkx", type=("build", "run"))
+    depends_on("py-rustworkx", type=("build", "run"), when="@0.30.0:")
+    depends_on("py-retworkx", type=("build", "run"), when="@0.28.0:0.29.1")
     depends_on("py-autograd", type=("build", "run"))
     depends_on("py-toml", type=("build", "run"))
     depends_on("py-appdirs", type=("build", "run"))
     depends_on("py-semantic-version@2.7:", type=("build", "run"))
     depends_on("py-autoray@0.3.1:", type=("build", "run"))
     depends_on("py-cachetools", type=("build", "run"))
-    depends_on("py-pennylane-lightning@0.28.0:", type=("build", "run"))
+    depends_on("py-pennylane-lightning@0.30.0:", type=("build", "run"), when="@0.30.0:")
+    depends_on("py-pennylane-lightning@0.28.0:0.29.0", type=("build", "run"), when="@0.28.0:0.29.1")
     depends_on("py-requests", type=("build", "run"))
 
     # Test deps

--- a/var/spack/repos/builtin/packages/py-pennylane/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane/package.py
@@ -26,7 +26,7 @@ class PyPennylane(PythonPackage):
     )
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-pip", type=("build", "run")) # Runtime req for pennylane.about()
+    depends_on("py-pip", type=("build", "run"))  # Runtime req for pennylane.about()
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@:1.23", type=("build", "run"))
@@ -41,7 +41,9 @@ class PyPennylane(PythonPackage):
     depends_on("py-autoray@0.3.1:", type=("build", "run"))
     depends_on("py-cachetools", type=("build", "run"))
     depends_on("py-pennylane-lightning@0.30.0:", type=("build", "run"), when="@0.30.0:")
-    depends_on("py-pennylane-lightning@0.28.0:0.29.0", type=("build", "run"), when="@0.28.0:0.29.1")
+    depends_on(
+        "py-pennylane-lightning@0.28.0:0.29.0", type=("build", "run"), when="@0.28.0:0.29.1"
+    )
     depends_on("py-requests", type=("build", "run"))
 
     # Test deps


### PR DESCRIPTION
Adds support for [PennyLane v0.30.0](https://github.com/PennyLaneAI/pennylane/releases/tag/v0.30.0), [PennyLane Lightning v0.30.0](https://github.com/PennyLaneAI/pennylane-lightning/releases/tag/v0.30.0) and [Pennylane Lightning Kokkos v0.30.0](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/releases/tag/v0.30.0).
Additionally, sets limits on the Kokkos versions to the 3.7.x release versions.
Fixes missing `py-pip` runtime dependency for PennyLane `qml.about()` functionality.