### PR TITLE
containers: Don't install epel-release on Fedora

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -636,7 +636,7 @@ to customize the generation of container recipes:
      - No
    * - ``os_packages:command``
      - Tool used to manage system packages
-     - ``apt``, ``yum``, ``zypper``, ``apk``, ``yum_amazon``
+     - ``apt``, ``yum``, ``dnf``, ``dnf_epel``, ``zypper``, ``apk``, ``yum_amazon``
      - Only with custom base images
    * - ``os_packages:update``
      - Whether or not to update the list of available packages

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -17,7 +17,7 @@
         "template": "container/fedora_38.dockerfile",
         "image": "docker.io/fedora:38"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "yum_fedora",
       "build": "spack/fedora38",
       "build_tags": {
         "develop": "latest"
@@ -31,7 +31,7 @@
         "template": "container/fedora_37.dockerfile",
         "image": "docker.io/fedora:37"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "yum_fedora",
       "build": "spack/fedora37",
       "build_tags": {
         "develop": "latest"
@@ -187,6 +187,11 @@
     },
     "yum": {
       "update": "yum update -y && yum install -y epel-release && yum update -y",
+      "install": "yum install -y",
+      "clean": "rm -rf /var/cache/yum  && yum clean all"
+    },
+    "yum_fedora": {
+      "update": "yum update -y",
       "install": "yum install -y",
       "clean": "rm -rf /var/cache/yum  && yum clean all"
     },

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -17,7 +17,7 @@
         "template": "container/fedora_38.dockerfile",
         "image": "docker.io/fedora:38"
       },
-      "os_package_manager": "yum_fedora",
+      "os_package_manager": "dnf",
       "build": "spack/fedora38",
       "build_tags": {
         "develop": "latest"
@@ -31,7 +31,7 @@
         "template": "container/fedora_37.dockerfile",
         "image": "docker.io/fedora:37"
       },
-      "os_package_manager": "yum_fedora",
+      "os_package_manager": "dnf",
       "build": "spack/fedora37",
       "build_tags": {
         "develop": "latest"
@@ -45,7 +45,7 @@
         "template": "container/rockylinux_9.dockerfile",
         "image": "docker.io/rockylinux:9"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux9",
       "build_tags": {
         "develop": "latest"
@@ -59,7 +59,7 @@
         "template": "container/rockylinux_8.dockerfile",
         "image": "docker.io/rockylinux:8"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux8",
       "build_tags": {
         "develop": "latest"
@@ -73,7 +73,7 @@
         "template": "container/almalinux_9.dockerfile",
         "image": "quay.io/almalinux/almalinux:9"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "dnf_epel",
       "build": "spack/almalinux9",
       "build_tags": {
         "develop": "latest"
@@ -87,7 +87,7 @@
         "template": "container/almalinux_8.dockerfile",
         "image": "quay.io/almalinux/almalinux:8"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "dnf_epel",
       "build": "spack/almalinux8",
       "build_tags": {
         "develop": "latest"
@@ -101,7 +101,7 @@
         "template": "container/centos_stream.dockerfile",
         "image": "quay.io/centos/centos:stream"
       },
-      "os_package_manager": "yum",
+      "os_package_manager": "dnf_epel",
       "build": "spack/centos-stream",
       "final": {
         "image": "quay.io/centos/centos:stream"
@@ -185,13 +185,18 @@
       "install": "apt-get -yqq install",
       "clean": "rm -rf /var/lib/apt/lists/*"
     },
+    "dnf": {
+      "update": "dnf update -y",
+      "install": "dnf install -y",
+      "clean": "rm -rf /var/cache/dnf && dnf clean all"
+    },
+    "dnf_epel": {
+      "update": "dnf update -y && dnf install -y epel-release && dnf update -y",
+      "install": "dnf install -y",
+      "clean": "rm -rf /var/cache/dnf && dnf clean all"
+    },
     "yum": {
       "update": "yum update -y && yum install -y epel-release && yum update -y",
-      "install": "yum install -y",
-      "clean": "rm -rf /var/cache/yum  && yum clean all"
-    },
-    "yum_fedora": {
-      "update": "yum update -y",
       "install": "yum install -y",
       "clean": "rm -rf /var/cache/yum  && yum clean all"
     },

--- a/share/spack/templates/container/almalinux_8.dockerfile
+++ b/share/spack/templates/container/almalinux_8.dockerfile
@@ -1,7 +1,7 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y \
+RUN dnf update -y \
+ && dnf install -y \
         bzip2 \
         curl \
         file \
@@ -23,6 +23,6 @@ RUN yum update -y \
         unzip \
         zstd \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/almalinux_9.dockerfile
+++ b/share/spack/templates/container/almalinux_9.dockerfile
@@ -1,9 +1,9 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y epel-release \
- && yum update -y \
- && yum --enablerepo epel install -y \
+RUN dnf update -y \
+ && dnf install -y epel-release \
+ && dnf update -y \
+ && dnf --enablerepo epel install -y \
         bzip2 \
         curl-minimal \
         file \
@@ -25,6 +25,6 @@ RUN yum update -y \
         unzip \
         zstd \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/centos_stream.dockerfile
+++ b/share/spack/templates/container/centos_stream.dockerfile
@@ -1,13 +1,13 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
+RUN dnf update -y \
  # See https://fedoraproject.org/wiki/EPEL#Quickstart for powertools
- && yum install -y dnf-plugins-core \
+ && dnf install -y dnf-plugins-core \
  && dnf config-manager --set-enabled powertools \
- && yum install -y epel-release \
- && yum update -y \
- && yum --enablerepo epel groupinstall -y "Development Tools" \
- && yum --enablerepo epel install -y \
+ && dnf install -y epel-release \
+ && dnf update -y \
+ && dnf --enablerepo epel groupinstall -y "Development Tools" \
+ && dnf --enablerepo epel install -y \
         curl \
         findutils \
         gcc-c++ \
@@ -24,6 +24,6 @@ RUN yum update -y \
         python38-setuptools \
         unzip \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/fedora_37.dockerfile
+++ b/share/spack/templates/container/fedora_37.dockerfile
@@ -1,7 +1,7 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y \
+RUN dnf update -y \
+ && dnf install -y \
         bzip2 \
         curl \
         file \
@@ -24,6 +24,6 @@ RUN yum update -y \
         zstd \
         xz \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/fedora_38.dockerfile
+++ b/share/spack/templates/container/fedora_38.dockerfile
@@ -1,7 +1,7 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y \
+RUN dnf update -y \
+ && dnf install -y \
         bzip2 \
         curl \
         file \
@@ -24,6 +24,6 @@ RUN yum update -y \
         xz \
         zstd \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/rockylinux_8.dockerfile
+++ b/share/spack/templates/container/rockylinux_8.dockerfile
@@ -1,7 +1,7 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y \
+RUN dnf update -y \
+ && dnf install -y \
         bzip2 \
         curl \
         file \
@@ -24,6 +24,6 @@ RUN yum update -y \
         xz \
         zstd \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/rockylinux_9.dockerfile
+++ b/share/spack/templates/container/rockylinux_9.dockerfile
@@ -1,9 +1,9 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN yum update -y \
- && yum install -y epel-release \
- && yum update -y \
- && yum --enablerepo epel install -y \
+RUN dnf update -y \
+ && dnf install -y epel-release \
+ && dnf update -y \
+ && dnf --enablerepo epel install -y \
         bzip2 \
         curl-minimal \
         file \
@@ -26,6 +26,6 @@ RUN yum update -y \
         xz \
         zstd \
  && pip3 install boto3 \
- && rm -rf /var/cache/yum \
- && yum clean all
+ && rm -rf /var/cache/dnf \
+ && dnf clean all
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37765

This PR specializes the "`yum update`" command sequence for Fedora, to remove the attempt to install `epel-release`.