### PR TITLE
SU2: Update new versions and many variants

### DIFF
--- a/var/spack/repos/builtin/packages/su2/meson_version.patch
+++ b/var/spack/repos/builtin/packages/su2/meson_version.patch
@@ -1,0 +1,12 @@
+--- a/meson.build	2022-12-20 21:08:29.000000000 +0900
++++ b/meson.build	2023-05-19 03:24:08.870966665 +0900
+@@ -6,9 +6,6 @@
+                           'c_std=c99',
+                           'cpp_std=c++11'])
+ 
+-if meson.version() != '0.61.1'
+-  error('SU2 must be configured with the extended Meson script (./meson.py) in the SU2 root directory.')
+-endif
+ 
+ pymod = import('python')
+ python = pymod.find_installation()

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -55,7 +55,7 @@ class Su2(MesonPackage):
     depends_on("zlib")
     depends_on("pkg-config")
     depends_on("mpi", when="+mpi")
-    depends_on("swig", when="+pywrapper")
+    depends_on("swig", type="build", when="+pywrapper")
     depends_on("py-mpi4py", when="+pywrapper")
     depends_on("intel-oneapi-mkl", when="+mkl")
     depends_on("openblas", when="+openblas ~mkl")

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -61,7 +61,7 @@ class Su2(MesonPackage):
     depends_on("openblas", when="+openblas ~mkl")
     depends_on("cmake", type="build", when="+mpp")
 
-    # Remove the part that fixes the meson version to 0.61.1. 
+    # Remove the part that fixes the meson version to 0.61.1.
     # This fix is considered meaningless and will be removed in the next version(@7.6:) of SU2.
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -59,7 +59,7 @@ class Su2(MesonPackage):
     depends_on("py-mpi4py", when="+pywrapper")
     depends_on("intel-oneapi-mkl", when="+mkl")
     depends_on("openblas", when="+openblas ~mkl")
-    depends_on("cmake", when="+mpp")
+    depends_on("cmake", type="build", when="+mpp")
 
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -61,6 +61,8 @@ class Su2(MesonPackage):
     depends_on("openblas", when="+openblas ~mkl")
     depends_on("cmake", type="build", when="+mpp")
 
+    # Remove the part that fixes the meson version to 0.61.1. 
+    # This fix is considered meaningless and will be removed in the next version(@7.6:) of SU2.
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 
     def meson_args(self):

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -16,6 +16,9 @@ class Su2(MesonPackage):
     url = "https://github.com/su2code/SU2/archive/v7.0.3.tar.gz"
     git = "https://github.com/su2code/SU2.git"
 
+    version("7.5.1", commit="09ba9e3a9605c02d38290e34f42aa6982cb4dd05", submodules=True)
+    version("7.5.0", commit="8e8ea59fe6225c8ec4e94d0e0a4b6690ea4294e5", submodules=True)
+    version("7.4.0", commit="745e5d922c63c8ec6963b31808c20df2e3bfd075", submodules=True)
     version("7.3.1", commit="328a1b747a4785d13b749e7fb6cc4589fd1b9529", submodules=True)
     version("7.2.0", sha256="e929f25dcafc93684df2fe0827e456118d24b8b12b0fb74444bffa9b3d0baca8")
     version("7.1.1", sha256="6ed3d791209317d5916fd8bae54c288f02d6fe765062a4e3c73a1e1c7ea43542")
@@ -31,5 +34,55 @@ class Su2(MesonPackage):
     version("7.0.0", sha256="6207dcca15eaebc11ce12b2866c937b4ad9b93274edf6f23d0487948ac3963b8")
     version("6.2.0", sha256="ffc953326e8432a1a6534556a5f6cf086046d3149cfcec6b4e7390eebe30ce2e")
 
+    variant("mpi", default=False, description="enable MPI support")
+    variant("openmp", default=False, description="enable OpenMP support")
+    variant("tecio", default=True, description="enable TECIO support")
+    variant("cgns", default=True, description="enable CGNS support")
+    variant("autodiff", default=False, description="enable AD(reverse) support")
+    variant("directdiff", default=False, description="enable AD(forward) support")
+    variant("pywrapper", default=False, description="enable Python wrapper support")
+    variant("mkl", default=False, description="enable Intel MKL support")
+    variant("openblas", default=False, description="enable OpenBLAS support")
+    variant("mpp", default=False, description="enable Mutation++ support")
+    variant(
+        "mixedprec",
+        default=False,
+        description="use single precision floating point arithmetic for sparse algebra",
+    )
+
+    depends_on("meson@0.61.1:", type=("build"))
     depends_on("python@3:", type=("build", "run"))
     depends_on("zlib")
+    depends_on("pkg-config")
+    depends_on("mpi", when="+mpi")
+    depends_on("swig", when="+pywrapper")
+    depends_on("py-mpi4py", when="+pywrapper")
+    depends_on("intel-oneapi-mkl", when="+mkl")
+    depends_on("openblas", when="+openblas ~mkl")
+    depends_on("cmake", when="+mpp")
+
+    patch("meson_version.patch", when="@7.4.0:7.5.1")
+
+    def meson_args(self):
+        args = [
+            "-Dwith-omp={}".format("+openmp" in self.spec),
+            "-Denable-tecio={}".format("+tecio" in self.spec),
+            "-Denable-cgns={}".format("+cgns" in self.spec),
+            "-Denable-autodiff={}".format("+autodiff" in self.spec),
+            "-Denable-directdiff={}".format("+direcdiff" in self.spec),
+            "-Denable-pywrapper={}".format("+pywrapper" in self.spec),
+            "-Denable-mkl={}".format("+mkl" in self.spec),
+            "-Denable-openblas={}".format("+openblas" in self.spec),
+            "-Denable-mpp={}".format("+mpp" in self.spec),
+            "-Denable-mixedprec={}".format("+midexprec" in self.spec),
+        ]
+
+        if "+mkl" in self.spec:
+            args.append("-Dmkl_root=" + self.spec["intel-oneapi-mkl"].prefix)
+
+        if "+mpi" in self.spec:
+            args.append("-Dwith-mpi=enabled")
+        else:
+            args.append("-Dwith-mpi=disabled")
+
+        return args


### PR DESCRIPTION
* Add new versions(7.4.0, 7.5.0, 7.5.1)
* Add variants and its dependency.
  + MPI(depends on mpi)
  + OpenMP
  + tecio
  + cgns
  + autodiff
  + directdiff
  + pywrapper (depends on swig,py-mpi4py)
  + mkl(depends on intel-oneapi-mkl)
  + openblas(depends on openblas)
  + mpp(mutation++) 
  + mixedprec
  
  I have tested using %gcc@9.5.0 ubuntu20 cascadelake