### PR TITLE
images: Add a preinstall command before the optional update

### DIFF
--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -181,7 +181,8 @@
       "clean": "true"
     },
     "apt": {
-      "update": "apt-get -yqq update && apt-get -yqq upgrade",
+      "preinstall": "apt-get -yqq update",
+      "update": "apt-get -yqq upgrade",
       "install": "apt-get -yqq install",
       "clean": "rm -rf /var/lib/apt/lists/*"
     },

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -83,10 +83,10 @@ def commands_for(package_manager):
         package_manager (str): package manager to be used
 
     Returns:
-        A tuple of (update, install, clean) commands.
+        A tuple of (preinstall, update, install, clean) commands.
     """
     info = data()["os_package_managers"][package_manager]
-    return info["update"], info["install"], info["clean"]
+    return info.get("preinstall", "true"), info["update"], info["install"], info["clean"]
 
 
 def bootstrap_template_for(image):

--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -255,10 +255,14 @@ class PathContext(tengine.Context):
         else:
             os_pkg_manager = self._os_pkg_manager()
 
-        update, install, clean = commands_for(os_pkg_manager)
+        preinstall, update, install, clean = commands_for(os_pkg_manager)
 
-        Packages = collections.namedtuple("Packages", ["update", "install", "list", "clean"])
-        return Packages(update=update, install=install, list=package_list, clean=clean)
+        Packages = collections.namedtuple(
+            "Packages", ["preinstall", "update", "install", "list", "clean"]
+        )
+        return Packages(
+            preinstall=preinstall, update=update, install=install, list=package_list, clean=clean
+        )
 
     def _os_pkg_manager(self):
         try:

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -24,7 +24,8 @@ def test_build_info(image, spack_version, expected):
 @pytest.mark.parametrize("image", ["ubuntu:18.04"])
 def test_package_info(image):
     pkg_manager = spack.container.images.os_package_manager_for(image)
-    update, install, clean = spack.container.images.commands_for(pkg_manager)
+    preinstall, update, install, clean = spack.container.images.commands_for(pkg_manager)
+    assert preinstall
     assert update
     assert install
     assert clean

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -9,7 +9,8 @@ FROM {{ build.image }} as builder
 {% block build_stage %}
 {% if os_packages_build %}
 # Install OS packages needed to build the software
-RUN {% if os_package_update %}{{ os_packages_build.update }} \
+RUN {{ os_packages_build.preinstall }} \
+ && {% if os_package_update %}{{ os_packages_build.update }} \
  && {% endif %}{{ os_packages_build.install }} {{ os_packages_build.list | join | replace('\n', ' ') }} \
  && {{ os_packages_build.clean }}
 {% endif %}
@@ -58,7 +59,8 @@ COPY --from=builder /etc/profile.d/z10_spack_environment.sh /etc/profile.d/z10_s
 {% block final_stage %}
 
 {% if os_packages_final %}
-RUN {% if os_package_update %}{{ os_packages_final.update }} \
+RUN {{ os_packages_final.preinstall }} \
+ && {% if os_package_update %}{{ os_packages_final.update }} \
  && {% endif %}{{ os_packages_final.install }} {{ os_packages_final.list | join | replace('\n', ' ') }} \
  && {{ os_packages_final.clean }}
 {% endif %}

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -6,6 +6,7 @@ Stage: build
 {% block build_stage %}
 {% if os_packages_build.list %}
   # Update, install and cleanup of system packages needed at build-time
+  {{ os_packages_build.preinstall }}
   {% if os_package_update %}
   {{ os_packages_build.update }}
   {% endif %}
@@ -69,6 +70,7 @@ Stage: final
 {% block final_stage %}
 {% if os_packages_final.list %}
   # Update, install and cleanup of system packages needed at run-time
+  {{ os_packages_final.preinstall }}
   {% if os_package_update %}
   {{ os_packages_final.update }}
   {% endif %}


### PR DESCRIPTION
This PR adds the new (optional) command "`preinstall`" to the package manager table. This command runs before the contents of `update` or `install`.

Intended primarily for `apt`, since `apt-get update` always needs to be run before `apt-get upgrade` or `apt-get install`.

Fixes https://github.com/spack/spack/issues/37772