### PR TITLE
tests/arborx: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 
 from spack.package import *
 
@@ -16,6 +17,8 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s", "ecp"]
 
     maintainers("aprokop")
+
+    test_requires_compiler = True
 
     version("master", branch="master")
     version("1.3", sha256="3f1e17f029a460ab99f8396e2772cec908eefc4bf3868c8828907624a2d0ce5d")
@@ -117,18 +120,18 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-    def build_tests(self):
-        """Build the stand-alone/smoke test."""
+    def test_run_ctest(self):
+        """run ctest tests on the installed package"""
 
         arborx_dir = self.spec["arborx"].prefix
-        cmake_prefix_path = "-DCMAKE_PREFIX_PATH={0}".format(arborx_dir)
+        cmake_prefix_path = f"-DCMAKE_PREFIX_PATH={arborx_dir}"
         if "+mpi" in self.spec:
-            cmake_prefix_path += ";{0}".format(self.spec["mpi"].prefix)
+            cmake_prefix_path += f";{self.spec['mpi'].prefix}"
 
         cmake_args = [
             ".",
             cmake_prefix_path,
-            "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
+            f"-DCMAKE_CXX_COMPILER={os.environ['CXX']}",
             self.define(
                 "Kokkos_ROOT",
                 self.spec["kokkos"].prefix
@@ -136,23 +139,11 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
                 else self.spec["trilinos"].prefix,
             ),
         ]
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        make = which("make")
 
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
-
-        self.run_test(
-            "make", [], purpose="test: building the tests", work_dir=self.cached_tests_work_dir
-        )
-
-    def test(self):
-        """Perform stand-alone/smoke tests on the installed package."""
-        self.build_tests()
-
-        self.run_test(
-            "ctest",
-            ["-V"],
-            purpose="test: running the tests",
-            installed=False,
-            work_dir=self.cached_tests_work_dir,
-        )
+        with working_dir(self.cached_tests_work_dir):
+            cmake(*cmake_args)
+            make()
+            ctest = which("ctest")
+            ctest("-V")

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -141,9 +141,9 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
         ]
         cmake = which(self.spec["cmake"].prefix.bin.cmake)
         make = which("make")
+        ctest = which("ctest")
 
         with working_dir(self.cached_tests_work_dir):
             cmake(*cmake_args)
             make()
-            ctest = which("ctest")
             ctest("-V")


### PR DESCRIPTION
This PR converts `arborx` to use the new stand-alone test process.  It has been tested with and without `mpi` enabled.

```
$ spack -v test run arborx
==> Spack test 4spucbk6flr3rbmdtz5bylksuyc3iqf4
==> Testing package arborx-1.3-hbzrw3g
...
PASSED: Arborx::test_run_ctest
==> [2023-05-18-12:51:52.300540] Completed testing
==> [2023-05-18-12:51:52.300807]
========================= SUMMARY: arborx-1.3-7zhjacp ==========================
Arborx::test_run_ctest .. PASSED
============================= 1 passed of 1 parts ==============================
============================= 2 passed of 2 specs ==============================
```

The full test output for both versions are in 
[arborx-tests.txt](https://github.com/spack/spack/files/11511182/arborx-tests.txt).
