### PR TITLE
tests/flibcpp: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/flibcpp/package.py
+++ b/var/spack/repos/builtin/packages/flibcpp/package.py
@@ -13,6 +13,8 @@ class Flibcpp(CMakePackage):
     git = "https://github.com/swig-fortran/flibcpp.git"
     url = "https://github.com/swig-fortran/flibcpp/archive/v1.0.1.tar.gz"
 
+    test_requires_compiler = True
+
     version("1.0.2", sha256="e2c11c1f58ca830eb7ac7f25d66fc3502c4a8d994192ee30c63a1c3b51aac241")
     version("1.0.1", sha256="8569c71eab0257097a6aa666a6d86bdcb6cd6e31244d32cc5b2478d0e936ca7a")
     version("0.5.2", sha256="b9b4eb6431d5b56a54c37f658df7455eafd3d204a5534903b127e0c8a1c9b827")
@@ -73,25 +75,18 @@ class Flibcpp(CMakePackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-    def test(self):
-        """Perform stand-alone/smoke tests."""
+    def test_examples(self):
+        """build and run examples"""
         cmake_args = [
             self.define("CMAKE_PREFIX_PATH", self.prefix),
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
         ]
         cmake_args.append(self.cached_tests_work_dir)
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        make = which("make")
+        sh = which("sh")
 
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
-
-        self.run_test(
-            "make", [], purpose="test: building the tests", work_dir=self.cached_tests_work_dir
-        )
-
-        self.run_test(
-            "run-examples.sh",
-            [],
-            purpose="test: running the examples",
-            work_dir=self.cached_tests_work_dir,
-        )
+        with working_dir(self.cached_tests_work_dir):
+            cmake(*cmake_args)
+            make()
+            sh("run-examples.sh")


### PR DESCRIPTION
This PR converts the stand-alone tests to the new process.  It has been tested manually:

```
$ spack -v test run flibcpp
==> Spack test wgoxrb73pakqnz2enkit4kgqwktsx7kt
==> Testing package flibcpp-1.0.2-nm7vif2
==> [2023-05-18-14:40:14.768688] Installing $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/flibcpp-1.0.2-nm7vif2apsrv3lbrym5q3jgztppybkf4/.spack/test to $SPACK_TEST_ROOT/wgoxrb73pakqnz2enkit4kgqwktsx7kt/flibcpp-1.0.2-nm7vif2/cache/flibcpp
==> [2023-05-18-14:40:14.839874] test: test_examples: build and run examples
==> [2023-05-18-14:40:14.846369] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '-DCMAKE_PREFIX_PATH:STRING=$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/flibcpp-1.0.2-nm7vif2apsrv3lbrym5q3jgztppybkf4' '-DCMAKE_Fortran_COMPILER:STRING=/usr/tce/bin/gfortran' '$SPACK_TEST_ROOT/wgoxrb73pakqnz2enkit4kgqwktsx7kt/flibcpp-1.0.2-nm7vif2/cache/flibcpp/example'
-- The Fortran compiler identification is GNU 10.3.1
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /usr/tce/bin/gfortran - skipped
-- Configuring done (0.6s)
-- Generating done (0.1s)
-- Build files have been written to: $SPACK_TEST_ROOT/wgoxrb73pakqnz2enkit4kgqwktsx7kt/flibcpp-1.0.2-nm7vif2/cache/flibcpp/example
==> [2023-05-18-14:40:15.687383] '/usr/bin/make'
[ 12%] Building Fortran object CMakeFiles/example_utils_lib.dir/example_utils.f90.o
[ 25%] Linking Fortran static library libexample_utils_lib.a
[ 25%] Built target example_utils_lib
[ 37%] Building Fortran object CMakeFiles/sort.exe.dir/sort.f90.o
[ 50%] Linking Fortran executable sort.exe
[ 50%] Built target sort.exe
[ 62%] Building Fortran object CMakeFiles/vecstr.exe.dir/vecstr.f90.o
[ 75%] Linking Fortran executable vecstr.exe
[ 75%] Built target vecstr.exe
[ 87%] Building Fortran object CMakeFiles/sort_generic.exe.dir/sort_generic.f90.o
[100%] Linking Fortran executable sort_generic.exe
[100%] Built target sort_generic.exe
==> [2023-05-18-14:40:16.633254] '/usr/bin/sh' 'run-examples.sh'
Run sort...success!
Run sort_generic...success!
Run vecstr...success!
PASSED: Flibcpp::test_examples
==> [2023-05-18-14:40:16.680101] Completed testing
==> [2023-05-18-14:40:16.680220] 
======================== SUMMARY: flibcpp-1.0.2-nm7vif2 ========================
Flibcpp::test_examples .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```