### PR TITLE
tests/formetis: converted to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/formetis/package.py
+++ b/var/spack/repos/builtin/packages/formetis/package.py
@@ -14,6 +14,8 @@ class Formetis(CMakePackage):
 
     maintainers("sethrj")
 
+    test_requires_compiler = True
+
     version("0.0.2", sha256="0067c03ca822f4a3955751acb470f21eed489256e2ec5ff24741eb2b638592f1")
 
     variant("mpi", default=False, description="Enable ParMETIS support")
@@ -53,8 +55,8 @@ class Formetis(CMakePackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-    def test(self):
-        """Perform stand-alone/smoke tests on the installed package."""
+    def test_metis(self):
+        """build and run metis"""
         cmake_args = [
             self.define("CMAKE_PREFIX_PATH", self.prefix),
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
@@ -63,20 +65,11 @@ class Formetis(CMakePackage):
         if "+mpi" in self.spec:
             cmake_args.append(self.define("ParMETIS_ROOT", self.spec["parmetis"].prefix))
         cmake_args.append(self.cached_tests_work_dir)
+        cmake = which(self.spec["cmake"].prefix.bin.cmake)
+        make = which("make")
 
-        self.run_test(
-            "cmake", cmake_args, purpose="test: calling cmake", work_dir=self.cached_tests_work_dir
-        )
-
-        self.run_test(
-            "make", [], purpose="test: building the tests", work_dir=self.cached_tests_work_dir
-        )
-
-        self.run_test(
-            "metis",
-            [],
-            [],
-            purpose="test: checking the installation",
-            installed=False,
-            work_dir=self.cached_tests_work_dir,
-        )
+        with working_dir(self.cached_tests_work_dir):
+            cmake(*cmake_args)
+            make()
+            metis = which("metis")
+            metis()


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.  It has been tested manually using installs with `+mpi` and `~mpi`.

```
$ spack -v test run formetis
==> Spack test 2zvjiswjo7cwnl7pplkfgr7edjni4kno
==> Testing package formetis-0.0.2-wxajzlh
==> [2023-05-18-15:37:21.011415] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/formetis-0.0.2-wxajzlhgx63cvfubhfh4xvfnvxzytay3/.spack/test to $SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-wxajzlh/cache/formetis
==> [2023-05-18-15:37:21.039576] test: test_metis: build and run metis
==> [2023-05-18-15:37:21.044874] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '-DCMAKE_PREFIX_PATH:STRING=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/formetis-0.0.2-wxajzlhgx63cvfubhfh4xvfnvxzytay3' '-DCMAKE_Fortran_COMPILER:STRING=/usr/tce/bin/gfortran' '-DMETIS_ROOT:STRING=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt' '$SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-wxajzlh/cache/formetis/example'
-- The Fortran compiler identification is GNU 10.3.1
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /usr/tce/bin/gfortran - skipped
-- Found METIS: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt/include  
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: $SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-wxajzlh/cache/formetis/example
==> [2023-05-18-15:37:21.784766] '/usr/bin/make'
[ 50%] Building Fortran object CMakeFiles/metis.dir/metis.f90.o
[100%] Linking Fortran executable metis
[100%] Built target metis
==> [2023-05-18-15:37:22.033742] './metis'
========================================
Formetis version: v0.0.2
(Numeric version: 0.0.2)
========================================
 edgecut=           3
 part=           1           1           0           1           0           0
 vwgt=           0           0           0           0           0           0
PASSED: Formetis::test_metis
==> [2023-05-18-15:37:22.050610] Completed testing
==> [2023-05-18-15:37:22.050741] 
======================= SUMMARY: formetis-0.0.2-wxajzlh ========================
Formetis::test_metis .. PASSED
============================= 1 passed of 1 parts ==============================
==> Testing package formetis-0.0.2-e4nub7x
==> [2023-05-18-15:37:22.983979] Installing $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/formetis-0.0.2-e4nub7xtcgqupwbzohets7zqqmrug5ou/.spack/test to $SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-e4nub7x/cache/formetis
==> [2023-05-18-15:37:23.011386] test: test_metis: build and run metis
==> [2023-05-18-15:37:23.015945] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.26.3-jjbp24aosqi4z2pi5g3ae54244uhsf4x/bin/cmake' '-DCMAKE_PREFIX_PATH:STRING=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/formetis-0.0.2-e4nub7xtcgqupwbzohets7zqqmrug5ou' '-DCMAKE_Fortran_COMPILER:STRING=/usr/tce/bin/gfortran' '-DMETIS_ROOT:STRING=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt' '-DParMETIS_ROOT:STRING=$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/parmetis-4.0.3-pjptuvf5v42uaf62ta2v37vqgzhlny4l' '$SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-e4nub7x/cache/formetis/example'
-- The Fortran compiler identification is GNU 10.3.1
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /usr/tce/bin/gfortran - skipped
-- Found METIS: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt/include  
-- Found MPI_Fortran: /usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-classic-2021.6.0/lib/libmpifort.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1")  
-- Found ParMETIS: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/parmetis-4.0.3-pjptuvf5v42uaf62ta2v37vqgzhlny4l/include  
-- Configuring done (3.2s)
-- Generating done (0.0s)
-- Build files have been written to: $SPACK_TEST_ROOT/2zvjiswjo7cwnl7pplkfgr7edjni4kno/formetis-0.0.2-e4nub7x/cache/formetis/example
==> [2023-05-18-15:37:26.312208] '/usr/bin/make'
[ 50%] Building Fortran object CMakeFiles/metis.dir/metis.f90.o
[100%] Linking Fortran executable metis
[100%] Built target metis
==> [2023-05-18-15:37:26.557167] './metis'
========================================
Formetis version: v0.0.2
(Numeric version: 0.0.2)
========================================
 edgecut=           3
 part=           1           1           0           1           0           0
 vwgt=           0           0           0           0           0           0
PASSED: Formetis::test_metis
==> [2023-05-18-15:37:26.569330] Completed testing
==> [2023-05-18-15:37:26.569471] 
======================= SUMMARY: formetis-0.0.2-e4nub7x ========================
Formetis::test_metis .. PASSED
============================= 1 passed of 1 parts ==============================
============================= 2 passed of 2 specs ==============================
```