### PR TITLE
tests/swig: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -102,47 +102,41 @@ class Swig(AutotoolsPackage, SourceforgePackage):
         return match.group(1) if match else None
 
     @property
-    def _installed_exe(self):
-        return join_path(self.prefix, "bin", "swig")
+    def _swig(self):
+        return Executable(join_path(self.prefix, "bin", "swig"))
 
-    def _test_version(self):
+    @property
+    def _swiglib(self):
+        return self._swig("-swiglib", output=str).strip()
+
+    def test_version(self):
+        """check swig version"""
         version = str(self.version)
         if version.endswith("-fortran"):
-            version = version.replace("-", r"\+")
+            version = version.replace("-", r"+")
         elif version in ("fortran", "master"):
-            version = r".*"
+            version = ""
 
-        self.run_test(
-            self._installed_exe,
-            "-version",
-            expected=[r"SWIG Version {0}".format(version)],
-            purpose="test: version",
-        )
+        out = self._swig("-version", output=str.split, error=str.split)
+        expected = f"SWIG Version {version}"
+        assert expected in out, f"Expected '{expected}' in output"
 
-    def _test_swiglib(self):
-        # Get SWIG's alleged path to library files
-        swig = Executable(self._installed_exe)
-        swiglib = swig("-swiglib", output=str).strip()
+    def test_swiglib(self):
+        """check that the lib dir exists"""
+        assert os.path.isdir(self._swiglib), f"SWIG library does not exist at '{swiglib}'"
 
-        # Check that the lib dir exists
-        if not os.path.isdir(swiglib):
-            msg = "SWIG library does not exist at '{0}'".format(swiglib)
-            self.test_failures.append([None, msg])
+    def test_swig_swg(self):
+        """check that swig.swg exists"""
+        swigfile = join_path(self._swiglib, "swig.swg")
+        assert os.path.exists(swigfile), f"SWIG runtime does not exist at '{swigfile}'"
 
-        # Check for existence of other critical SWIG library files
-        swigfile = join_path(swiglib, "swig.swg")
-        if not os.path.exists(swigfile):
-            msg = "SWIG runtime does not exist at '{0}'".format(swigfile)
-            self.test_failures.append([None, msg])
-        if "fortran" in str(self.version):
-            swigfile = join_path(swiglib, "fortran", "fortran.swg")
-            if not os.path.exists(swigfile):
-                msg = "SWIG+Fortran runtime does not exist at '{0}'".format(swigfile)
-                self.test_failures.append([None, msg])
+    def test_fortran_swg(self):
+        """check that fortran.swg exists"""
+        if "fortran" not in str(self.version):
+            raise SkipTest(f"Test does not work with version {self.version}")
 
-    def test(self):
-        self._test_version()
-        self._test_swiglib()
+        swigfile = join_path(self._swiglib, "fortran", "fortran.swg")
+        assert os.path.exists(swigfile), f"SWIG+Fortran runtime does not exist at '{swigfile}'"
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):


### PR DESCRIPTION
This PR converts the stand-alone tests to use the new process.  It was tested manually using using installations:  `4.1.1`, `4.1.1-fortran`, `fortran` and `master`.

```
$ spack -v test run swig
==> Spack test r7x2rbasww5schcf7jowtbehufmu5rmq
==> Testing package swig-4.1.1-u33np34
==> [2023-05-18-16:24:17.096339] test: test_fortran_swg: check that fortran.swg exists
SKIPPED: Swig::test_fortran_swg: Test does not work with version 4.1.1
==> [2023-05-18-16:24:17.096801] test: test_swig_swg: check that swig.swg exists
==> [2023-05-18-16:24:17.097486] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-u33np347rb24lkn3ld2ivorhzhvwbutg/bin/swig' '-swiglib'
PASSED: Swig::test_swig_swg
==> [2023-05-18-16:24:17.103764] test: test_swiglib: check that the lib dir exists
==> [2023-05-18-16:24:17.104358] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-u33np347rb24lkn3ld2ivorhzhvwbutg/bin/swig' '-swiglib'
PASSED: Swig::test_swiglib
==> [2023-05-18-16:24:17.108206] test: test_version: check swig version
==> [2023-05-18-16:24:17.108822] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-u33np347rb24lkn3ld2ivorhzhvwbutg/bin/swig' '-version'

SWIG Version 4.1.1

Compiled with $SPACK_ROOT/lib/spack/env/gcc/g++ [x86_64-pc-linux-gnu]

Configured options: +pcre

Please see https://www.swig.org for reporting bugs and further information
PASSED: Swig::test_version
==> [2023-05-18-16:24:17.114819] Completed testing
==> [2023-05-18-16:24:17.114929] 
========================= SUMMARY: swig-4.1.1-u33np34 ==========================
Swig::test_fortran_swg .. SKIPPED
Swig::test_swig_swg .. PASSED
Swig::test_swiglib .. PASSED
Swig::test_version .. PASSED
======================== 1 skipped, 3 passed of 4 parts ========================
==> Testing package swig-4.1.1-fortran-oeepwg5
==> [2023-05-18-16:24:17.431810] test: test_fortran_swg: check that fortran.swg exists
==> [2023-05-18-16:24:17.432673] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-fortran-oeepwg5rqbf2a2m5pnx5gdvh4tr4fdwt/bin/swig' '-swiglib'
PASSED: Swig::test_fortran_swg
==> [2023-05-18-16:24:17.442473] test: test_swig_swg: check that swig.swg exists
==> [2023-05-18-16:24:17.443036] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-fortran-oeepwg5rqbf2a2m5pnx5gdvh4tr4fdwt/bin/swig' '-swiglib'
PASSED: Swig::test_swig_swg
==> [2023-05-18-16:24:17.451855] test: test_swiglib: check that the lib dir exists
==> [2023-05-18-16:24:17.452410] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-fortran-oeepwg5rqbf2a2m5pnx5gdvh4tr4fdwt/bin/swig' '-swiglib'
PASSED: Swig::test_swiglib
==> [2023-05-18-16:24:17.456789] test: test_version: check swig version
==> [2023-05-18-16:24:17.457394] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-4.1.1-fortran-oeepwg5rqbf2a2m5pnx5gdvh4tr4fdwt/bin/swig' '-version'

SWIG Version 4.1.1+fortran

Compiled with $SPACK_ROOT/lib/spack/env/gcc/g++ [x86_64-pc-linux-gnu]

Configured options: +pcre

Please see https://www.swig.org for reporting bugs and further information
PASSED: Swig::test_version
==> [2023-05-18-16:24:17.464197] Completed testing
==> [2023-05-18-16:24:17.464341] 
===================== SUMMARY: swig-4.1.1-fortran-oeepwg5 ======================
Swig::test_fortran_swg .. PASSED
Swig::test_swig_swg .. PASSED
Swig::test_swiglib .. PASSED
Swig::test_version .. PASSED
============================= 4 passed of 4 parts ==============================
==> Testing package swig-fortran-2i7sbcx
==> [2023-05-18-16:24:17.776553] test: test_fortran_swg: check that fortran.swg exists
==> [2023-05-18-16:24:17.777320] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-fortran-2i7sbcxcc6uxwx63bzjmhvctj2rs75d6/bin/swig' '-swiglib'
PASSED: Swig::test_fortran_swg
==> [2023-05-18-16:24:17.782829] test: test_swig_swg: check that swig.swg exists
==> [2023-05-18-16:24:17.783346] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-fortran-2i7sbcxcc6uxwx63bzjmhvctj2rs75d6/bin/swig' '-swiglib'
PASSED: Swig::test_swig_swg
==> [2023-05-18-16:24:17.787812] test: test_swiglib: check that the lib dir exists
==> [2023-05-18-16:24:17.788313] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-fortran-2i7sbcxcc6uxwx63bzjmhvctj2rs75d6/bin/swig' '-swiglib'
PASSED: Swig::test_swiglib
==> [2023-05-18-16:24:17.791932] test: test_version: check swig version
==> [2023-05-18-16:24:17.792543] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-fortran-2i7sbcxcc6uxwx63bzjmhvctj2rs75d6/bin/swig' '-version'

SWIG Version 4.2.0+fortran

Compiled with $SPACK_ROOT/lib/spack/env/gcc/g++ [x86_64-pc-linux-gnu]

Configured options: +pcre

Please see https://www.swig.org for reporting bugs and further information
PASSED: Swig::test_version
==> [2023-05-18-16:24:17.797958] Completed testing
==> [2023-05-18-16:24:17.798060] 
======================== SUMMARY: swig-fortran-2i7sbcx =========================
Swig::test_fortran_swg .. PASSED
Swig::test_swig_swg .. PASSED
Swig::test_swiglib .. PASSED
Swig::test_version .. PASSED
============================= 4 passed of 4 parts ==============================
==> Testing package swig-master-us56pf5
==> [2023-05-18-16:24:18.131027] test: test_fortran_swg: check that fortran.swg exists
SKIPPED: Swig::test_fortran_swg: Test does not work with version master
==> [2023-05-18-16:24:18.131372] test: test_swig_swg: check that swig.swg exists
==> [2023-05-18-16:24:18.132026] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-master-us56pf5lzea24qia6vcpmqx6y36urk67/bin/swig' '-swiglib'
PASSED: Swig::test_swig_swg
==> [2023-05-18-16:24:18.139347] test: test_swiglib: check that the lib dir exists
==> [2023-05-18-16:24:18.140067] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-master-us56pf5lzea24qia6vcpmqx6y36urk67/bin/swig' '-swiglib'
PASSED: Swig::test_swiglib
==> [2023-05-18-16:24:18.144471] test: test_version: check swig version
==> [2023-05-18-16:24:18.145113] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/swig-master-us56pf5lzea24qia6vcpmqx6y36urk67/bin/swig' '-version'

SWIG Version 4.2.0

Compiled with $SPACK_ROOT/lib/spack/env/gcc/g++ [x86_64-pc-linux-gnu]

Configured options: +pcre

Please see https://www.swig.org for reporting bugs and further information
PASSED: Swig::test_version
==> [2023-05-18-16:24:18.151263] Completed testing
==> [2023-05-18-16:24:18.151425] 
========================= SUMMARY: swig-master-us56pf5 =========================
Swig::test_fortran_swg .. SKIPPED
Swig::test_swig_swg .. PASSED
Swig::test_swiglib .. PASSED
Swig::test_version .. PASSED
======================== 1 skipped, 3 passed of 4 parts ========================
============================= 4 passed of 4 specs ==============================
```