### PR TITLE
kokkos-nvcc-wrapper: Remove unnecessary dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
@@ -17,6 +17,8 @@ class KokkosNvccWrapper(Package):
     git = "https://github.com/kokkos/kokkos.git"
     url = "https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz"
 
+    maintainers("Rombur")
+
     version("3.2.00", sha256="05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9")
     version("3.1.01", sha256="ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd")
     version("3.1.00", sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878")

--- a/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
@@ -24,10 +24,7 @@ class KokkosNvccWrapper(Package):
     version("master", branch="master")
     version("develop", branch="develop")
 
-    variant("mpi", default=True, description="use with MPI as the underlying compiler")
     depends_on("cuda")
-    depends_on("mpi", when="+mpi")
-    depends_on("cmake@3.10:", type="build")
 
     def install(self, spec, prefix):
         src = os.path.join("bin", "nvcc_wrapper")

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -104,7 +104,6 @@ class SingularityEos(CMakePackage, CudaPackage):
     for _flag in ("~mpi", "+mpi"):
         depends_on("hdf5~cxx+hl" + _flag, when=_flag)
         depends_on("py-h5py" + _flag, when="@:1.6.2 " + _flag)
-        depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
     def flag_handler(self, name, flags):
         if name == "fflags":


### PR DESCRIPTION
This PR removes the dependency of `kokkos-nvcc-wrapper` on `cmake` and `mpi`. `kokkos-nvcc-wrapper` is a script, it doesn't need to be compiled and so it doesn't need `cmake`. The script doesn't require `mpi` either. I think the dependency on `mpi` was added because the package sets `OMPI_CXX` but we do it even when using `~mpi` and we don't need `mpi` to set this environment variable. 