### PR TITLE
bbcp deep copy

### DIFF
--- a/var/spack/repos/builtin/packages/bbcp/package.py
+++ b/var/spack/repos/builtin/packages/bbcp/package.py
@@ -12,6 +12,8 @@ class Bbcp(Package):
     homepage = "https://www.slac.stanford.edu/~abh/bbcp/"
     git = "https://www.slac.stanford.edu/~abh/bbcp/bbcp.git"
 
+    maintainers("vanderwb")
+
     # Stanford's git server does not support "smart https" shallow clones
     version("master", branch="master", get_full_repo=True)
 

--- a/var/spack/repos/builtin/packages/bbcp/package.py
+++ b/var/spack/repos/builtin/packages/bbcp/package.py
@@ -12,7 +12,8 @@ class Bbcp(Package):
     homepage = "https://www.slac.stanford.edu/~abh/bbcp/"
     git = "https://www.slac.stanford.edu/~abh/bbcp/bbcp.git"
 
-    version("master", branch="master")
+    # Stanford's git server does not support "smart https" shallow clones
+    version("master", branch="master", get_full_repo=True)
 
     depends_on("zlib")
     depends_on("openssl")


### PR DESCRIPTION
Currently, with certain versions of Git, this package is not installable because the Stanford Git server does not seem to support deep copy operations:
```
==> [2023-05-18-10:19:13.638340] '/usr/bin/git' '-c' 'advice.detachedHead=false' 'clone' '--branch' 'master' '--single-branch' '--depth' '1' 'https://www.slac.stanford.edu/~abh/bbcp/bbcp.git
'
Cloning into 'bbcp'...
fatal: dumb http transport does not support shallow capabilities
==> [2023-05-18-10:19:13.854913] ProcessError: Command exited with status 128:
    '/usr/bin/git' '-c' 'advice.detachedHead=false' 'clone' '--branch' 'master' '--single-branch' '--depth' '1' 'https://www.slac.stanford.edu/~abh/bbcp/bbcp.git'
```
This PR uses a full clone of the bbcp repository to avoid this problem.