### PR TITLE
libtiff: disable use of sphinx

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -111,6 +111,7 @@ class Libtiff(CMakePackage, AutotoolsPackage):
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define_from_variant(var) for var in VARIANTS]
+        args.append("-Dsphinx=OFF")
 
         # Remove empty strings
         args = [arg for arg in args if arg]
@@ -123,5 +124,6 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args = []
         for var in VARIANTS:
             args.extend(self.enable_or_disable(var))
+        args.append("--disable-sphinx")
 
         return args


### PR DESCRIPTION
If on a system sphinx is found `libtiff` builds its documentation with it. This can become a problem when the system sphinx is too old (was the case for me) and can result in a failed installation.

Disabling sphinx usage solves this problem.