### PR TITLE
environment-modules: fix @main version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -62,6 +62,9 @@ class EnvironmentModules(Package):
     depends_on("automake", type="build", when="@main")
     depends_on("libtool", type="build", when="@main")
     depends_on("m4", type="build", when="@main")
+    depends_on("python", type="build", when="@main")
+    depends_on("py-sphinx@1.0:", type="build", when="@main")
+    depends_on("gzip", type="build", when="@main")
 
     # Dependencies:
     depends_on("tcl", type=("build", "link", "run"))


### PR DESCRIPTION
Some requirements for @main version of environment-modules were missing:

* `python` (to build ChangeLog documentation file)
* `py-sphinx@1.0:` (to build man-pages, etc)

Also adding `gzip`, which is now required to build `ChangeLog.gz` (which is now shipped instead of `ChangeLog`).

Other versions are not requiring these tools (as documentation is pre-built in dist tarball).