### PR TITLE
gaudi: fix issue with fmt::format

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/fmt_fix.patch
+++ b/var/spack/repos/builtin/packages/gaudi/fmt_fix.patch
@@ -1,0 +1,22 @@
+diff --git a/GaudiHive/src/FetchLeavesFromFile.cpp b/GaudiHive/src/FetchLeavesFromFile.cpp
+index 55c60e6a1..5ed8efa91 100644
+--- a/GaudiHive/src/FetchLeavesFromFile.cpp
++++ b/GaudiHive/src/FetchLeavesFromFile.cpp
+@@ -67,7 +67,7 @@ namespace Gaudi {
+         DataObject* obj = nullptr;
+         evtSvc()
+             ->retrieveObject( m_rootNode, obj )
+-            .orThrow( fmt::format( "failed to retrieve {} from {}", m_rootNode.value(), m_dataSvcName ), name() );
++            .orThrow( fmt::format( "failed to retrieve {} from {}", m_rootNode.value(), m_dataSvcName.value() ), name() );
+       }
+       // result
+       IDataStoreLeaves::LeavesList all_leaves;
+@@ -93,7 +93,7 @@ namespace Gaudi {
+                           ->retrieveObject( reg->identifier(), obj )
+                           .orElse( [&]() {
+                             failure_msg =
+-                                fmt::format( "failed to retrieve {} from {}", reg->identifier(), m_dataSvcName );
++                                fmt::format( "failed to retrieve {} from {}", reg->identifier(), m_dataSvcName.value() );
+                             // we do not really care about the exception we throw because traverseSubTree will just use
+                             // it to abort the traversal
+                             throw GaudiException( failure_msg, name(), StatusCode::FAILURE );

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -53,6 +53,7 @@ class Gaudi(CMakePackage):
     # fixes for the cmake config which could not find newer boost versions
     patch("link_target_fixes.patch", when="@33.0:34")
     patch("link_target_fixes32.patch", when="@:32.2")
+    patch("fmt_fix.patch", when="@36.6:36.12 ^fmt@10:")
 
     # These dependencies are needed for a minimal Gaudi build
     depends_on("aida")


### PR DESCRIPTION
fmt has a new version in the recipe since recently, 10.0.0, and Gaudi doesn't compile with it. This patch fixes it, and since the `fmt` dependency in that file was introduced in 36.6, I limited it to the versions between 36.6 and the current one, 36.12. 

Error message:
``` shell
  >> 1157    /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-cen
             tos7-gcc12.2.0-opt/fmt/10.0.0-yvhlcm/include/fmt/core.h:1691:7: er
             ror: static assertion failed: Cannot format an argument. To make t
             ype T formattable provide a formatter<T> specialization: https://f
             mt.dev/latest/api.html#udt
```