### PR TITLE
deleted package.py better error message

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1239,7 +1239,7 @@ class Repo(object):
         try:
             module = importlib.import_module(fullname)
         except ImportError:
-            raise UnknownPackageError(pkg_name)
+            raise UnknownPackageError(fullname)
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             raise RepoError(msg) from e


### PR DESCRIPTION
before:
```
==> Error: Package '<package>' not found.
You may need to run 'spack clean -m'.
```
after:
```
==> Error: Package 'spack.pkg.<namespace>.<package>' not found.
You may need to run 'spack clean -m'.
```
if namespace != "builtin" then I know that I need to look in my package repository and check for a deleted package file