### PR TITLE
gaudi: add gaudi to LD_LIBRARY_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -137,6 +137,8 @@ class Gaudi(CMakePackage):
         # environment as in Gaudi.xenv
         env.prepend_path("PATH", self.prefix.scripts)
         env.prepend_path("PYTHONPATH", self.prefix.python)
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
 
     def url_for_version(self, version):
         major = str(version[0])


### PR DESCRIPTION
spack doesn't add the packages to `LD_LIBRARY_PATH` anymore but the plugin system from gaudi requires them to be in `LD_LIBRARY_PATH` to be found