### PR TITLE
[gromacs] Fix intel (classic) libstdc++ path

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -233,9 +233,9 @@ class Gromacs(CMakePackage, CudaPackage):
             depends_on("plumed@{0}".format(plumed_vers), when="@{0}+plumed".format(gmx_ver))
 
     variant(
-        "spack_intel",
+        "intel_provided_gcc",
         default=False,
-        description="If Intel compiler is installed through spack libstdc++ location is known.",
+        description="Use this if Intel compiler is installed through spack. The g++ location is written to icp{c,x}.cfg",
     )
 
     depends_on("fftw-api@3")
@@ -250,8 +250,8 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("sycl", when="+sycl")
     depends_on("lapack", when="+lapack")
     depends_on("blas", when="+blas")
-    depends_on("gcc", when="%oneapi ~spack_intel")
-    depends_on("gcc", when="%intel ~spack_intel")
+    depends_on("gcc", when="%oneapi ~intel_provided_gcc")
+    depends_on("gcc", when="%intel ~intel_provided_gcc")
 
     depends_on("hwloc@1.0:1", when="+hwloc@2016:2018")
     depends_on("hwloc", when="+hwloc@2019:")
@@ -260,6 +260,14 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("dbcsr", when="+cp2k")
 
     depends_on("nvhpc", when="+cufftmp")
+
+    requires(
+        "%intel",
+        "%oneapi",
+        policy="one_of",
+        when="+intel_provided_gcc",
+        msg="Only attempt to find gcc libs for Intel compiler if Intel compiler is used.",
+    )
 
     patch("gmxDetectCpu-cmake-3.14.patch", when="@2018:2019.3^cmake@3.14.0:")
     patch("gmxDetectSimd-cmake-3.14.patch", when="@5.0:2017^cmake@3.14.0:")
@@ -441,7 +449,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             # If intel-oneapi-compilers was installed through spack the gcc is added to the
             # configuration file.
-            if self.spec.satisfies("+spack_intel") and os.path.exists(
+            if self.spec.satisfies("+intel_provided_gcc") and os.path.exists(
                 ".".join([os.environ["SPACK_CXX"], "cfg"])
             ):
                 with open(".".join([os.environ["SPACK_CXX"], "cfg"]), "r") as f:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -431,7 +431,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append("-DGMX_INSTALL_LEGACY_API=ON")
 
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
-            with open (".".join([os.environ["SPACK_CXX"], "cfg"]), "r") as f:
+            with open(".".join([os.environ["SPACK_CXX"], "cfg"]), "r") as f:
                 options.append("-DCMAKE_CXX_FLAGS={}".format(f.read()))
 
         if "+double" in self.spec:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -235,7 +235,8 @@ class Gromacs(CMakePackage, CudaPackage):
     variant(
         "intel_provided_gcc",
         default=False,
-        description="Use this if Intel compiler is installed through spack. The g++ location is written to icp{c,x}.cfg",
+        description="Use this if Intel compiler is installed through spack."
+        + "The g++ location is written to icp{c,x}.cfg",
     )
 
     depends_on("fftw-api@3")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -244,7 +244,6 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("sycl", when="+sycl")
     depends_on("lapack", when="+lapack")
     depends_on("blas", when="+blas")
-    depends_on("gcc", when="%oneapi")
 
     depends_on("hwloc@1.0:1", when="+hwloc@2016:2018")
     depends_on("hwloc", when="+hwloc@2019:")
@@ -431,8 +430,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if self.spec.satisfies("@2020:"):
             options.append("-DGMX_INSTALL_LEGACY_API=ON")
 
-        if self.spec.satisfies("%oneapi"):
-            options.append("-DGMX_GPLUSPLUS_PATH=%s/g++" % self.spec["gcc"].prefix.bin)
+        if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
+            with open (".".join([os.environ["SPACK_CXX"], "cfg"]), "r") as f:
+                options.append("-DCMAKE_CXX_FLAGS={}".format(f.read()))
 
         if "+double" in self.spec:
             options.append("-DGMX_DOUBLE:BOOL=ON")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -439,7 +439,8 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append("-DGMX_INSTALL_LEGACY_API=ON")
 
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
-            # If intel-oneapi-compilers was installed through spack the gcc is added to the configuration file
+            # If intel-oneapi-compilers was installed through spack the gcc is added to the
+            # configuration file.
             if self.spec.satisfies("+spack_intel") and os.path.exists(
                 ".".join([os.environ["SPACK_CXX"], "cfg"])
             ):


### PR DESCRIPTION
Gromacs's `cmake` run will look for `--gcc-toolchain` (e.g. LLVM, icpx) or `--gcc-name` (e.g. icpc) in `CMAKE_CXX_FLAGS`. Only if it does not find a good g++ candidate there it will look for `GMX_GPLUSPLUS_PATH`: https://github.com/gromacs/gromacs/blob/cb6b311c39fc726a72170c4593b754c8d0a492ac/cmake/FindLibStdCpp.cmake#L97

Spack installed intel compilers already define a g++ for std libs. But in `icp{c,x}.cfg` instead of the compile line. If we use the pre-defined g++ we not only have less chance of mixing g++ versions, but also don't need to explicitly add `gcc` as dependency to `gromacs`.