### PR TITLE
dd4hep: add LD_LIBRARY_PATH for plugins for Gaudi

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -222,6 +222,8 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
+        env.set("LD_LIBRARY_PATH", self.prefix.lib)
+        env.set("LD_LIBRARY_PATH", self.prefix.lib64)
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero


### PR DESCRIPTION
Same as https://github.com/spack/spack/pull/37821, DD4hep has some plugins that Gaudi can't find if they are not in `LD_LIBRARY_PATH`