### PR TITLE
tests/patchelf: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -56,29 +56,20 @@ class Patchelf(AutotoolsPackage):
             )
         )
 
-    def test(self):
+    def test_version(self):
+        """ensure patchelf version match"""
         # Check patchelf in prefix and reports the correct version
-        reason = "test: ensuring patchelf version is {0}".format(self.spec.version)
-        self.run_test(
-            "patchelf",
-            options="--version",
-            expected=["patchelf %s" % self.spec.version],
-            installed=True,
-            purpose=reason,
-        )
+        patchelf = which(self.prefix.bin.patchelf)
+        out = patchelf("--version", output=str.split, error=str.split)
+        expected = f"patchelf {self.spec.version}"
+        assert expected in out, f"Expected '{expected}' in output"
 
-        # Check the rpath is changed
+    def test_rpath_change(self):
+        """ensure patchelf can change rpath"""
         currdir = os.getcwd()
         hello_file = self.test_suite.current_test_data_dir.join("hello")
-        self.run_test(
-            "patchelf",
-            ["--set-rpath", currdir, hello_file],
-            purpose="test: ensuring that patchelf can change rpath",
-        )
 
-        self.run_test(
-            "patchelf",
-            options=["--print-rpath", hello_file],
-            expected=[currdir],
-            purpose="test: ensuring that patchelf changed rpath",
-        )
+        patchelf = which(self.prefix.bin.patchelf)
+        patchelf("--set-rpath", currdir, hello_file)
+        out = patchelf("--print-rpath", hello_file, output=str.split, error=str.split)
+        assert currdir in out, f"Expected '{currdir}' in output"


### PR DESCRIPTION
Converted the stand-alone test methods to the new process.

```
$ spack -v test run patchelf
==> Spack test kgqpoo2sy47yl2qvqkazp5baj4qp25td
==> Testing package patchelf-0.17.2-5nxn7s3
==> [2023-05-22-11:29:59.625411] test: test_rpath_change: ensure patchelf can change rpath
==> [2023-05-22-11:29:59.626725] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/patchelf-0.17.2-5nxn7s3ntt4tzjk4w56xjteypqqj5f63/bin/patchelf' '--set-rpath' '/g/g21/dahlgren/.spack/test/kgqpoo2sy47yl2qvqkazp5baj4qp25td/patchelf-0.17.2-5nxn7s3' '/g/g21/dahlgren/.spack/test/kgqpoo2sy47yl2qvqkazp5baj4qp25td/patchelf-0.17.2-5nxn7s3/data/patchelf/hello'
==> [2023-05-22-11:29:59.635403] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/patchelf-0.17.2-5nxn7s3ntt4tzjk4w56xjteypqqj5f63/bin/patchelf' '--print-rpath' '/g/g21/dahlgren/.spack/test/kgqpoo2sy47yl2qvqkazp5baj4qp25td/patchelf-0.17.2-5nxn7s3/data/patchelf/hello'
/g/g21/dahlgren/.spack/test/kgqpoo2sy47yl2qvqkazp5baj4qp25td/patchelf-0.17.2-5nxn7s3
PASSED: Patchelf::test_rpath_change
==> [2023-05-22-11:29:59.639424] test: test_version: ensure patchelf version match
==> [2023-05-22-11:29:59.639995] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/patchelf-0.17.2-5nxn7s3ntt4tzjk4w56xjteypqqj5f63/bin/patchelf' '--version'
patchelf 0.17.2
PASSED: Patchelf::test_version
==> [2023-05-22-11:29:59.645496] Completed testing
==> [2023-05-22-11:29:59.645704] 
======================= SUMMARY: patchelf-0.17.2-5nxn7s3 =======================
Patchelf::test_rpath_change .. PASSED
Patchelf::test_version .. PASSED
============================= 2 passed of 2 parts ==============================
============================== 1 passed of 1 spec ==============================
```