### PR TITLE
tests/upcxx: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -246,7 +246,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         make("tests-clean")  # cleanup
 
     def test_upcxx_install(self):
-        """checking UPC++ compiler+link for all installed backends"""
+        """checking UPC++ compile+link for all installed backends"""
         test_install = join_path(self.prefix.bin, "test-upcxx-install.sh")
         test_upcxx_install = which(test_install)
         out = test_upcxx_install(output=str.split, error=str.split)

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -233,7 +233,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
+    def check_install(self):
         # enable testing of unofficial conduits (mpi)
         test_networks = "NETWORKS=$(CONDUITS)"
         # build hello world against installed tree in all configurations
@@ -245,16 +245,12 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             make("run-tests", "NETWORKS=smp")  # runs tests for smp backend
         make("tests-clean")  # cleanup
 
-    def test(self):
-        # run post-install smoke test:
+    def test_upcxx_install(self):
+        """checking UPC++ compiler+link for all installed backends"""
         test_install = join_path(self.prefix.bin, "test-upcxx-install.sh")
-        self.run_test(
-            test_install,
-            expected=["SUCCESS"],
-            status=0,
-            installed=True,
-            purpose="Checking UPC++ compile+link " + "for all installed backends",
-        )
+        test_upcxx_install = which(test_install)
+        out = test_upcxx_install(output=str.split, error=str.split)
+        assert "SUCCESS" in out
 
     # `spack external find` support
     executables = ["^upcxx$"]


### PR DESCRIPTION
Converted package to use the new stand-alone test process.

```
spack  -v test run upcxx
==> Spack test lfdjen76frtsusqwmilcb47h5sazgawm
==> Testing package upcxx-2023.3.0-rmzaksi
==> [2023-05-22-12:11:09.823437] test: test_upcxx_install: checking UPC++ compiler+link for all installed backends
==> [2023-05-22-12:11:09.825698] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/test-upcxx-install.sh'
========
Testing the UPC++ install at /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl
========
========
SUCCESS
========
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=seq -network=smp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=seq -network=udp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=seq -network=ibv test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=par -network=smp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=par -network=udp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=debug -threadmode=par -network=ibv test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=seq -network=smp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=seq -network=udp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=seq -network=ibv test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=par -network=smp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=par -network=udp test-upcxx-2966910.cpp -o test-upcxx-2966910
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/upcxx-2023.3.0-rmzaksi47t4raqazklcvkhrockwcplsl/bin/upcxx -codemode=opt -threadmode=par -network=ibv test-upcxx-2966910.cpp -o test-upcxx-2966910
PASSED: Upcxx::test_upcxx_install
==> [2023-05-22-12:11:33.686322] Completed testing
==> [2023-05-22-12:11:33.686521] 
======================= SUMMARY: upcxx-2023.3.0-rmzaksi ========================
Upcxx::test_upcxx_install .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```