### PR TITLE
Add Wi4MPI as an MPI provider

### DIFF
--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -33,6 +33,8 @@ class Wi4mpi(CMakePackage):
     )
 
     depends_on("mpi", when="@:3.5")
+    provides("mpi@:4.0", when="@3.6:")
+    filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
 
     def cmake_args(self):
         if "%gcc" in self.spec:
@@ -62,3 +64,29 @@ class Wi4mpi(CMakePackage):
         env.set("WI4MPI_CC", self.compiler.cc)
         env.set("WI4MPI_CXX", self.compiler.cxx)
         env.set("WI4MPI_FC", self.compiler.fc)
+
+        env.set("MPICC", join_path(self.prefix.bin, "mpicc"))
+        env.set("MPICXX", join_path(self.prefix.bin, "mpic++"))
+        env.set("MPIF77", join_path(self.prefix.bin, "mpif77"))
+        env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+        env.set("MPICH_CC", spack_cc)
+        env.set("MPICH_CXX", spack_cxx)
+        env.set("MPICH_F77", spack_f77)
+        env.set("MPICH_F90", spack_fc)
+        env.set("MPICH_FC", spack_fc)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        spec = self.spec
+        spec.mpicc = join_path(self.prefix.bin, "mpicc")
+        spec.mpicxx = join_path(self.prefix.bin, "mpicxx")
+        spec.mpifc = join_path(self.prefix.bin, "mpifort")
+        spec.mpif77 = join_path(self.prefix.bin, "mpif77")
+
+        spec.mpicxx_shared_libs = [
+            join_path(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
+            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
+        ]


### PR DESCRIPTION
Hello all ! I needed to compile a package with the MPI interface Wi4MPI provides, so I whipped this up to allow to specify Wi4MPI as provider.