### PR TITLE
tests/darshan-util: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -91,7 +91,7 @@ class DarshanUtil(AutotoolsPackage):
         return extra_args
 
     @property
-    def test_log_path(self):
+    def tests_log_path(self):
         if self.version < Version("3.4.1"):
             return join_path(
                 "darshan-test",
@@ -105,36 +105,23 @@ class DarshanUtil(AutotoolsPackage):
 
     @run_after("install")
     def _copy_test_inputs(self):
-        test_inputs = [self.test_log_path]
+        test_inputs = [self.tests_log_path]
         self.cache_extra_test_sources(test_inputs)
 
-    def _test_parser(self):
-        purpose = "Verify darshan-parser can parse an example log \
-                   and check some expected counter values"
-        # Switch to loading the expected strings from the darshan source in future
+    def test_parser(self):
+        """process example log and check counters"""
+
+        # TODO: Switch to loading the expected strings from the darshan source in future
         # filename = self.test_suite.current_test_cache_dir.
         #            join(join_path(self.basepath, "mpi-io-test-spack-expected.txt"))
         # expected_output = self.get_escaped_text_output(filename)
+
         expected_output = [
             r"POSIX\s+-1\s+\w+\s+POSIX_OPENS\s+\d+",
             r"MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
             r"STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+",
         ]
-        logname = self.test_suite.current_test_cache_dir.join(self.test_log_path)
-        exe = "darshan-parser"
-        options = [logname]
-        status = [0]
-        installed = True
-        self.run_test(
-            exe,
-            options,
-            expected_output,
-            status,
-            installed,
-            purpose,
-            skip_missing=False,
-            work_dir=None,
-        )
-
-    def test(self):
-        self._test_parser()
+        logname = self.test_suite.current_test_cache_dir.join(self.tests_log_path)
+        parser = which(join_path(self.prefix.bin, "darshan-parser"))
+        out = parser(logname, output=str.split, error=str.split)
+        check_outputs(expected_output, out)


### PR DESCRIPTION
Converts the stand-alone test to the new process.  Although not technically necessary, also renames the test log path property/method for maintainability since `test_*` is reserved for stand-alone test methods.

The output is VERY long so a snippet from running is:

```
$ spack -v test run darshan-util
==> Spack test u67oi4emin4gig5bw3iubc55yyohhwwu
==> Testing package darshan-util-3.4.2-s7p7uba
==> [2023-05-22-13:45:34.141864] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/darshan-util-3.4.2-s7p7ubaadzg5nxiycjeguyr6xfp2iejk/.spack/test to /g/g21/dahlgren/.spack/test/u67oi4emin4gig5bw3iubc55yyohhwwu/darshan-util-3.4.2-s7p7uba/cache/darshan-util
==> [2023-05-22-13:45:34.180197] test: test_parser: process example log and check counters
==> [2023-05-22-13:45:34.182017] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/darshan-util-3.4.2-s7p7ubaadzg5nxiycjeguyr6xfp2iejk/bin/darshan-parser' '/g/g21/dahlgren/.spack/test/u67oi4emin4gig5bw3iubc55yyohhwwu/darshan-util-3.4.2-s7p7uba/cache/darshan-util/darshan-util/pydarshan/darshan/tests/input/sample.darshan'
# darshan log version: 3.10
# compression method: ZLIB
# exe: /global/project/projectdirs/m888/glock/tokio-abc-results/bin.edison/vpicio_uni /scratch2/scratchdirs/glock/tokioabc-s.4478544/vpicio/vpicio.hdf5 32
# uid: 69615
# jobid: 4478544
# start_time: 1490000867
# start_time_asci: Mon Mar 20 02:07:47 2017
# end_time: 1490000983
# end_time_asci: Mon Mar 20 02:09:43 2017
# nprocs: 2048
# run time: 117.0000
# metadata: lib_ver = 3.1.3
# metadata: h = romio_no_indep_rw=true;cb_nodes=4

# log file regions
# -------------------------------------------------------
# header: 1328 bytes (uncompressed)
# job data: 348 bytes (compressed)
# record table: 7103 bytes (compressed)
# POSIX module: 186 bytes (compressed), ver=3
# MPI-IO module: 154 bytes (compressed), ver=2
# LUSTRE module: 87 bytes (compressed), ver=1
# STDIO module: 3234 bytes (compressed), ver=1

# mounted file systems (mount point and fs type)
# -------------------------------------------------------
# mount entry:	/.shared/base/default/etc/dat.conf	dvs
# mount entry:	/usr/lib64/libibverbs.so.1.0.0	dvs
# mount entry:	/usr/lib64/libibumad.so.3.0.2	dvs
# mount entry:	/usr/lib64/librdmacm.so.1.0.0	dvs
# mount entry:	/usr/lib64/libibgni.so.1.0.0	dvs
# mount entry:	/global/cscratch1	lustre
# mount entry:	/global/projectb	dvs
# mount entry:	/global/projecta	dvs
# mount entry:	/usr/sbin/ibstat	dvs
# mount entry:	/global/project	dvs
# mount entry:	/global/common	dvs
# mount entry:	/global/syscom	dvs
# mount entry:	/global/dna	dvs
# mount entry:	/opt/slurm	dvs
# mount entry:	/global/u1	dvs
# mount entry:	/global/u2	dvs
# mount entry:	/scratch1	lustre
# mount entry:	/scratch2	lustre
# mount entry:	/scratch3	lustre
# mount entry:	/etc	dvs
# mount entry:	/	rootfs
# mount entry:	/	dvs

# description of columns:
...
STDERR>	UNKNOWN	UNKNOWN
STDIO	2032	7238257241479193519	STDIO_F_SLOWEST_RANK_TIME	0.00000<STDERR>	UNKNOWN	UNKNOWN
STDIO	2032	7238257241479193519	STDIO_F_VARIANCE_RANK_TIME	0.00000<STDERR>	UNKNOWN	UNKNOWN
STDIO	2032	7238257241479193519	STDIO_F_VARIANCE_RANK_BYTES	0.00000<STDERR>	UNKNOWN	UNKNOWN
PASSED: DarshanUtil::test_parser
==> [2023-05-22-13:45:34.256188] Completed testing
==> [2023-05-22-13:45:34.256295] 
===================== SUMMARY: darshan-util-3.4.2-s7p7uba ======================
DarshanUtil::test_parser .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```