### PR TITLE
Bugfix/tests: write, not append, stand-alone test status

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -460,7 +460,8 @@ class PackageTest:
             elif self.counts[TestStatus.PASSED] > 0:
                 status = TestStatus.PASSED
 
-        _add_msg_to_file(self.tested_file, f"{status.value}")
+        with open(self.tested_file, "w") as f:
+            f.write(f"{status.value}\n")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes #37840 

This PR fixes a bug that occurs if stand-alone tests are run multiple times for the same specs.  Test status was being appended instead of writing/replacing the file's contents.  (So much for QAD re-use.)

The unit test reproduces the effect.  Results of the test *before the fix* illustrates the reported failure:

```
$ spack unit-test --showlocals -k test_write_tested_status_no_repeats
============================= test session starts ==============================
platform linux -- Python 3.9.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /usr/WS1/dahlgren/spack, configfile: pytest.ini, testpaths: lib/spack/spack/test
plugins: hypothesis-6.23.1
collected 4363 items / 4362 deselected / 1 selected                            

lib/spack/spack/test/test_suite.py F                                     [100%]

=================================== FAILURES ===================================
______________ test_write_tested_status_no_repeats[mock_archive0] ______________
...
>           status = int(f.read().strip("\n"))
E           ValueError: invalid literal for int() with base 10: '2\n2'
...
=========================== short test summary info ============================
FAILED lib/spack/spack/test/test_suite.py::test_write_tested_status_no_repeats[mock_archive0]
===================== 1 failed, 4362 deselected in 10.48s ======================
```

Test results *after the fix*:
```
$ spack unit-test --showlocals -k test_write_tested_status_no_repeats
============================= test session starts ==============================
...
lib/spack/spack/test/test_suite.py .                                     [100%]
...
===================== 1 passed, 4362 deselected in 11.93s ======================
```