### PR TITLE
tests/hdf: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -191,7 +191,7 @@ class Hdf(AutotoolsPackage):
         with working_dir(self.build_directory):
             make("check", parallel=False)
 
-    extra_install_tests = "hdf/util/testfiles"
+    extra_install_tests = join_path("hdf", "util", "testfiles")
 
     @property
     def cached_tests_work_dir(self):
@@ -204,81 +204,78 @@ class Hdf(AutotoolsPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.extra_install_tests)
 
-    def _test_check_versions(self):
-        """Perform version checks on selected installed package binaries."""
-        spec_vers_str = "Version {0}".format(self.spec.version.up_to(2))
+    def _check_version_match(self, exe):
+        """Ensure exe version check yields spec version."""
+        path = join_path(self.prefix.bin, exe)
+        if not os.path.isfile(path):
+            raise SkipTest(f"{exe} is not installed")
 
-        exes = ["hdfimport", "hrepack", "ncdump", "ncgen"]
-        for exe in exes:
-            reason = "test: ensuring version of {0} is {1}".format(exe, spec_vers_str)
-            self.run_test(
-                exe, ["-V"], spec_vers_str, installed=True, purpose=reason, skip_missing=True
-            )
+        exe = which(path)
+        out = exe("-V", output=str.split, error=str.split)
+        vers = f"Version {self.spec.version.up_to(2)}"
+        assert vers in out
 
-    def _test_gif_converters(self):
-        """This test performs an image conversion sequence and diff."""
-        work_dir = "."
-        storm_fn = os.path.join(self.cached_tests_work_dir, "storm110.hdf")
+    def test_hdfimport_version(self):
+        """ensure hdfimport version matches spec"""
+        self._check_version_match("hdfimport")
 
-        gif_fn = "storm110.gif"
-        new_hdf_fn = "storm110gif.hdf"
+    def test_hrepack_version(self):
+        """ensure hrepack version matches spec"""
+        self._check_version_match("hrepack")
 
-        # Convert a test HDF file to a gif
-        self.run_test(
-            "hdf2gif",
-            [storm_fn, gif_fn],
-            "",
-            installed=True,
-            purpose="test: hdf-to-gif",
-            work_dir=work_dir,
-        )
+    def test_ncdump_version(self):
+        """ensure ncdump version matches spec"""
+        self._check_version_match("hrepack")
 
-        # Convert the gif to an HDF file
-        self.run_test(
-            "gif2hdf",
-            [gif_fn, new_hdf_fn],
-            "",
-            installed=True,
-            purpose="test: gif-to-hdf",
-            work_dir=work_dir,
-        )
+    def test_ncgen_version(self):
+        """ensure ncgen version matches spec"""
+        self._check_version_match("ncgen")
 
-        # Compare the original and new HDF files
-        self.run_test(
-            "hdiff",
-            [new_hdf_fn, storm_fn],
-            "",
-            installed=True,
-            purpose="test: compare orig to new hdf",
-            work_dir=work_dir,
-        )
+    def test_gif_converters(self):
+        """test image conversion sequence and diff"""
+        base_name = "storm110"
+        storm_fn = join_path(self.cached_tests_work_dir, f"{base_name}.hdf")
+        if not os.path.exists(storm_fn):
+            raise SkipTest(f"Missing test image {storm_fn}")
 
-    def _test_list(self):
-        """This test compares low-level HDF file information to expected."""
-        storm_fn = os.path.join(self.cached_tests_work_dir, "storm110.hdf")
+        if not os.path.exists(self.prefix.bin.hdf2gif) or not os.path.exists(
+            self.prefix.bin.gif2hdf
+        ):
+            raise SkipTest("Missing one or more installed: 'hdf2gif', 'gif2hdf'")
+
+        gif_fn = f"{base_name}.gif"
+        new_hdf_fn = f"{base_name}gif.hdf"
+
+        with test_part(
+            self, "test_gif_converters_hdf2gif", purpose=f"convert {base_name} hdf-to-gif"
+        ):
+            hdf2gif = which(self.prefix.bin.hdf2gif)
+            hdf2gif(storm_fn, gif_fn)
+
+        with test_part(
+            self, "test_gif_converters_gif2hdf", purpose=f"convert {base_name} gif-to-hdf"
+        ):
+            gif2hdf = which(self.prefix.bin.gif2hdf)
+            gif2hdf(gif_fn, new_hdf_fn)
+
+        with test_part(
+            self, "test_gif_converters_hdiff", purpose=f"compare new and orig {base_name} hdf"
+        ):
+            hdiff = which(self.prefix.bin.hdiff)
+            hdiff(new_hdf_fn, storm_fn)
+
+    def test_list(self):
+        """compare low-level HDF file information to expected"""
+        base_name = "storm110"
+        if not os.path.isfile(self.prefix.bin.hdfls):
+            raise SkipTest("hdfls is not installed")
+
         test_data_dir = self.test_suite.current_test_data_dir
-        work_dir = "."
-
-        reason = "test: checking hdfls output"
-        details_file = os.path.join(test_data_dir, "storm110.out")
+        details_file = os.path.join(test_data_dir, f"{base_name}.out")
         expected = get_escaped_text_output(details_file)
-        self.run_test(
-            "hdfls",
-            [storm_fn],
-            expected,
-            installed=True,
-            purpose=reason,
-            skip_missing=True,
-            work_dir=work_dir,
-        )
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        # Simple version check tests on subset of known binaries that respond
-        self._test_check_versions()
+        storm_fn = os.path.join(self.cached_tests_work_dir, f"{base_name}.hdf")
 
-        # Run gif converter sequence test
-        self._test_gif_converters()
-
-        # Run hdfls output
-        self._test_list()
+        hdfls = which(self.prefix.bin.hdfls)
+        out = hdfls(storm_fn, output=str.split, error=str.split)
+        check_outputs(expected, out)


### PR DESCRIPTION
Converted stand-alone tests to use the new process.

```
$ spack -v test run hdf
==> Spack test eorfojnbptjs4v4zprjhcuaerpag35v6
==> Testing package hdf-4.2.15-covggah
==> [2023-05-22-18:52:26.701851] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/.spack/test to /g/g21/dahlgren/.spack/test/eorfojnbptjs4v4zprjhcuaerpag35v6/hdf-4.2.15-covggah/cache/hdf
==> [2023-05-22-18:52:26.895782] test: test_gif_converters: test image conversion sequence and diff
==> [2023-05-22-18:52:26.897192] test: test_gif_converters_hdf2gif: convert storm110 hdf-to-gif
==> [2023-05-22-18:52:26.897968] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hdf2gif' '/g/g21/dahlgren/.spack/test/eorfojnbptjs4v4zprjhcuaerpag35v6/hdf-4.2.15-covggah/cache/hdf/hdf/util/testfiles/storm110.hdf' 'storm110.gif'
PASSED: Hdf::test_gif_converters_hdf2gif
==> [2023-05-22-18:52:26.938135] test: test_gif_converters_gif2hdf: convert storm110 gif-to-hdf
==> [2023-05-22-18:52:26.938739] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/gif2hdf' 'storm110.gif' 'storm110gif.hdf'
PASSED: Hdf::test_gif_converters_gif2hdf
==> [2023-05-22-18:52:26.964033] test: test_gif_converters_hdiff: compare new and orig storm110 hdf
==> [2023-05-22-18:52:26.965077] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hdiff' 'storm110gif.hdf' '/g/g21/dahlgren/.spack/test/eorfojnbptjs4v4zprjhcuaerpag35v6/hdf-4.2.15-covggah/cache/hdf/hdf/util/testfiles/storm110.hdf'
PASSED: Hdf::test_gif_converters_hdiff
PASSED: Hdf::test_gif_converters
==> [2023-05-22-18:52:27.000549] test: test_hdfimport_version: ensure hdfimport version matches spec
==> [2023-05-22-18:52:27.001638] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hdfimport' '-V'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hdfimport, HDF Version 4.2 Release 15, November 28, 2019

PASSED: Hdf::test_hdfimport_version
==> [2023-05-22-18:52:27.030850] test: test_hrepack_version: ensure hrepack version matches spec
==> [2023-05-22-18:52:27.031862] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hrepack' '-V'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hrepack, HDF Version 4.2 Release 15, November 28, 2019

PASSED: Hdf::test_hrepack_version
==> [2023-05-22-18:52:27.062657] test: test_list: compare low-level HDF file information to expected
==> [2023-05-22-18:52:27.065485] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hdfls' '/g/g21/dahlgren/.spack/test/eorfojnbptjs4v4zprjhcuaerpag35v6/hdf-4.2.15-covggah/cache/hdf/hdf/util/testfiles/storm110.hdf'
/g/g21/dahlgren/.spack/test/eorfojnbptjs4v4zprjhcuaerpag35v6/hdf-4.2.15-covggah/cache/hdf/hdf/util/testfiles/storm110.hdf:
File library version: Major= 0, Minor=0, Release=0
String=

Number type                   : (tag 106)
	Ref nos: 110
Machine type                  : (tag 107)
	Ref nos: 4369
Image Dimensions-8            : (tag 200)
	Ref nos: 110
Raster Image-8                : (tag 202)
	Ref nos: 110
Image Dimensions              : (tag 300)
	Ref nos: 110
Raster Image Data             : (tag 302)
	Ref nos: 110
Raster Image Group            : (tag 306)
	Ref nos: 110
PASSED: Hdf::test_list
==> [2023-05-22-18:52:27.093752] test: test_ncdump_version: ensure ncdump version matches spec
==> [2023-05-22-18:52:27.094386] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hrepack' '-V'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/hrepack, HDF Version 4.2 Release 15, November 28, 2019

PASSED: Hdf::test_ncdump_version
==> [2023-05-22-18:52:27.122011] test: test_ncgen_version: ensure ncgen version matches spec
==> [2023-05-22-18:52:27.123022] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/ncgen' '-V'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hdf-4.2.15-covggahmxugmjn7pivwhphet33xnejm6/bin/ncgen, HDF Version 4.2 Release 15, November 28, 2019

PASSED: Hdf::test_ncgen_version
==> [2023-05-22-18:52:27.157913] Completed testing
==> [2023-05-22-18:52:27.158046] 
========================= SUMMARY: hdf-4.2.15-covggah ==========================
Hdf::test_gif_converters_hdf2gif .. PASSED
Hdf::test_gif_converters_gif2hdf .. PASSED
Hdf::test_gif_converters_hdiff .. PASSED
Hdf::test_gif_converters .. PASSED
Hdf::test_hdfimport_version .. PASSED
Hdf::test_hrepack_version .. PASSED
Hdf::test_list .. PASSED
Hdf::test_ncdump_version .. PASSED
Hdf::test_ncgen_version .. PASSED
============================= 9 passed of 9 parts ==============================
============================== 1 passed of 1 spec ==============================
```