### PR TITLE
libgcrypt: patch 1.10.2 on macos

### DIFF
--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -38,6 +38,10 @@ class Libgcrypt(AutotoolsPackage):
         # flags, and the build system ensures that
         return (None, flags, None)
 
+    # 1.10.2 fails on macOS when trying to use the Linux getrandom() call
+    # https://dev.gnupg.org/T6442
+    patch("rndgetentropy_no_getrandom.patch", when="@=1.10.2 platform=darwin")
+
     def check(self):
         # Without this hack, `make check` fails on macOS when SIP is enabled
         # https://bugs.gnupg.org/gnupg/issue2056

--- a/var/spack/repos/builtin/packages/libgcrypt/rndgetentropy_no_getrandom.patch
+++ b/var/spack/repos/builtin/packages/libgcrypt/rndgetentropy_no_getrandom.patch
@@ -1,0 +1,34 @@
+diff --git a/random/rndgetentropy.c b/random/rndgetentropy.c
+index 513da0b..d8eedce 100644
+--- a/random/rndgetentropy.c
++++ b/random/rndgetentropy.c
+@@ -81,27 +81,8 @@ _gcry_rndgetentropy_gather_random (void (*add)(const void*, size_t,
+       do
+         {
+           _gcry_pre_syscall ();
+-          if (fips_mode ())
+-            {
+-              /* DRBG chaining defined in SP 800-90A (rev 1) specify
+-               * the upstream (kernel) DRBG needs to be reseeded for
+-               * initialization of downstream (libgcrypt) DRBG. For this
+-               * in RHEL, we repurposed the GRND_RANDOM flag of getrandom API.
+-               * The libgcrypt DRBG is initialized with 48B of entropy, but
+-               * the kernel can provide only 32B at a time after reseeding
+-               * so we need to limit our requests to 32B here.
+-               * This is clarified in IG 7.19 / IG D.K. for FIPS 140-2 / 3
+-               * and might not be applicable on other FIPS modules not running
+-               * RHEL kernel.
+-               */
+-              nbytes = length < 32 ? length : 32;
+-              ret = getrandom (buffer, nbytes, GRND_RANDOM);
+-            }
+-          else
+-            {
+-              nbytes = length < sizeof (buffer) ? length : sizeof (buffer);
+-              ret = getentropy (buffer, nbytes);
+-            }
++          nbytes = length < sizeof (buffer) ? length : sizeof (buffer);
++          ret = getentropy (buffer, nbytes);
+           _gcry_post_syscall ();
+         }
+       while (ret == -1 && errno == EINTR);


### PR DESCRIPTION
macOS doesn't have `getrandom`, and 1.10.2 fails to compile because of this.

There's an upstream fix at https://dev.gnupg.org/T6442 that will be in the next `libgcrypt` release, but the patch is available now.