### PR TITLE
spack buildcache create w/o args: push the entire database

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -401,15 +401,10 @@ def _matching_specs(specs, spec_file):
         constraints = spack.cmd.parse_specs(specs)
         return spack.store.find(constraints, hashes=hashes)
 
-    if env:
-        return [concrete for _, concrete in env.concretized_specs()]
+    if not env:
+        return spack.store.db.query()
 
-    tty.die(
-        "build cache file creation requires at least one"
-        " installed package spec, an active environment,"
-        " or else a path to a json or yaml file containing a spec"
-        " to install"
-    )
+    return env.concrete_roots()
 
 
 def _concrete_spec_from_args(args):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -334,3 +334,14 @@ def test_correct_specs_are_pushed(
     buildcache(*buildcache_create_args)
 
     assert packages_to_push == expected
+
+
+def test_matching_specs_without_args(default_mock_concretization, temporary_store):
+    # Add dttop + deps to the store
+    temporary_store.db.add(default_mock_concretization("dttop"), directory_layout=None)
+
+    # Collect matching specs
+    to_be_pushed = spack.cmd.buildcache._matching_specs(specs=[], spec_file=None)
+
+    # Assert that all specs in the store are collected
+    assert set(to_be_pushed) == set(temporary_store.db.query_local())


### PR DESCRIPTION
- spack buildcache push w/o args, push the entire store
- add a test


I guess the Q is: `query_local` or `query`?