### PR TITLE
New package: FDS

### DIFF
--- a/var/spack/repos/builtin/packages/fds/package.py
+++ b/var/spack/repos/builtin/packages/fds/package.py
@@ -1,0 +1,94 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Fds(MakefilePackage):
+    """
+    Fire Dynamics Simulator (FDS) is a large-eddy simulation (LES) code for low-speed flows,
+    with an emphasis on smoke and heat transport from fires.
+    FDS and Smokeview are free and open-source software tools provided by the National Institute
+    of Standards and Technology (NIST) of the United States Department of Commerce. Pursuant
+    to Title 17, Section 105 of the United States Code, this software is not subject to copyright
+    protection and is in the public domain. View the full disclaimer for NIST-developed software.
+    """
+
+    maintainers("kjrstory")
+    homepage = "https://pages.nist.gov/fds-smv"
+    url = "https://github.com/firemodels/fds/archive/refs/tags/FDS-6.8.0.tar.gz"
+    git = "https://github.com/firemodels/fds.git"
+
+    version("6.8.0", commit="886e0096535519b7358a3c4393c91da3caee5072")
+
+    depends_on("mpi")
+    depends_on("mkl")
+
+    build_directory = "Build"
+
+    requires(
+        "%gcc",
+        "%intel",
+        "%oneapi",
+        policy="one_of",
+        msg="FDS builds only with GNU Fortran or Intel Fortran",
+    )
+
+    requires(
+        "^intel-mkl",
+        "^intel-oneapi-mkl",
+        policy="one_of",
+        msg="FDS builds require either Intel MKL or Intel oneAPI MKL library",
+    )
+
+    requires(
+        "^openmpi",
+        when="%gcc platform=linux",
+        msg="OpenMPI can only be used with GNU Fortran on Linux platform",
+    )
+
+    requires(
+        "^intel-mpi^intel-mkl",
+        when="%intel platform=linux",
+        msg="Intel MPI and Intel MKL can only be used with Intel Fortran on Linux platform",
+    )
+
+    requires(
+        "^intel-oneapi-mpi^intel-oneapi-mkl",
+        when="%oneapi platform=linux",
+        msg="Intel oneAPI MPI and MKL can only be used with oneAPI Fortran on Linux platform",
+    )
+
+    requires(
+        "^openmpi%intel",
+        when="platform=darwin",
+        msg="OpenMPI can only be used with Intel Fortran on macOS",
+    )
+
+    def edit(self, spec, prefix):
+        env["MKL_ROOT"] = self.spec["mkl"].prefix
+        if spec.compiler.name == "oneapi":
+            env["INTEL_IFORT"] = "ifx"
+        makefile = FileFilter("Build/makefile")
+        makefile.filter(r"\.\./Scripts", "./Scripts")
+        makefile.filter(r"\.\.\\Scripts", ".\\Scripts")
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        mpi_mapping = {"openmpi": "ompi", "intel-oneapi-mpi": "impi", "intel-mpi": "impi"}
+        compiler_mapping = {"gcc": "gnu", "oneapi": "intel", "intel": "intel"}
+        platform_mapping = {"linux": "linux", "darwin": "osx"}
+        mpi_prefix = mpi_mapping[spec["mpi"].name]
+        compiler_prefix = compiler_mapping[spec.compiler.name]
+        platform_prefix = platform_mapping[spec.architecture.platform]
+        return ["{}_{}_{}".format(mpi_prefix, compiler_prefix, platform_prefix)]
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("*.mod", prefix.bin)
+            install("*.o", prefix.bin)
+            install("fds_" + self.build_targets[0], prefix.bin + "/fds")


### PR DESCRIPTION
I would like to add the FDS package.
https://github.com/firemodels/fds
Fire Dynamics Simulator (FDS) is a large-eddy simulation (LES) code for low-speed flows, with an emphasis on smoke and heat transport from fires.
FDS supports the installation of OpenMPI when using GNU Fortran, and IntelMPI when using Intel Fortran (platform=linux). I have added only these options for installation.
In the future, I plan to add several features:
+ Compile modes: "db" (debug),"dv" (lower levels of optimization)
+ OpenMP support for Intel and OneAPI
known issues:
+ Although I haven't been able to test it on a Mac OS device, I have included support for the Intel compiler and OpenMPI in FDS when platform=darwin. 