### PR TITLE
Guard for define in netcdf 4.9.0 and later.

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/exodusII-netcdf4.9.0.patch
+++ b/var/spack/repos/builtin/packages/paraview/exodusII-netcdf4.9.0.patch
@@ -1,0 +1,14 @@
+*** a/VTK/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c	2023-03-16 16:57:14.172102586 -0400
+--- b/VTK/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c	2023-03-16 11:20:28.230116660 -0400
+***************
+*** 1770,1776 ****
+--- 1770,1778 ----
+          */
+  
+          /* const int NC_SZIP_EC = 4; */ /* Selects entropy coding method for szip. */
++ #ifndef NC_SZIP_NN
+          const int NC_SZIP_NN = 32;      /* Selects nearest neighbor coding method for szip. */
++ #endif
+          /* Even and between 4 and 32; typical values are 8, 10, 16, 32 */
+          const int SZIP_PIXELS_PER_BLOCK =
+              file->compression_level == 0 ? 32 : file->compression_level;

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -289,6 +289,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113
     patch("adios2-remove-deprecated-functions.patch", when="@5.10: ^adios2@2.9:")
 
+    patch("exodusII-netcdf4.9.0.patch", when="@:5.10.1")
+
     generator("ninja", "make", default="ninja")
     # https://gitlab.kitware.com/paraview/paraview/-/issues/21223
     conflicts("generator=ninja", when="%xl")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -289,7 +289,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113
     patch("adios2-remove-deprecated-functions.patch", when="@5.10: ^adios2@2.9:")
 
-    patch("exodusII-netcdf4.9.0.patch", when="@:5.10.1")
+    patch("exodusII-netcdf4.9.0.patch", when="@:5.10.2")
 
     generator("ninja", "make", default="ninja")
     # https://gitlab.kitware.com/paraview/paraview/-/issues/21223


### PR DESCRIPTION
This code is already available in ParaView 5.11.0 so no patching needed there.