### PR TITLE
dd4hep: add patch to fix missing hits when using LCIO

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -110,6 +110,11 @@ class Dd4hep(CMakePackage):
     # Workaround for failing build file generation in some cases
     # See https://github.com/spack/spack/issues/24232
     patch("cmake_language.patch", when="@:1.17")
+    # Fix missing SimCaloHits when using the LCIO format
+    patch("https://patch-diff.githubusercontent.com/raw/AIDASoft/DD4hep/pull/1019.patch?full_index=1",
+          when="@1.20:1.23",
+          sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76"
+          )
 
     # variants for subpackages
     variant("ddcad", default=True, description="Enable CAD interface based on Assimp")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -111,10 +111,11 @@ class Dd4hep(CMakePackage):
     # See https://github.com/spack/spack/issues/24232
     patch("cmake_language.patch", when="@:1.17")
     # Fix missing SimCaloHits when using the LCIO format
-    patch("https://patch-diff.githubusercontent.com/raw/AIDASoft/DD4hep/pull/1019.patch?full_index=1",
-          when="@1.20:1.23",
-          sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76"
-          )
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/AIDASoft/DD4hep/pull/1019.patch?full_index=1",
+        when="@1.19:1.23",
+        sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76"
+    )
 
     # variants for subpackages
     variant("ddcad", default=True, description="Enable CAD interface based on Assimp")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -114,7 +114,7 @@ class Dd4hep(CMakePackage):
     patch(
         "https://patch-diff.githubusercontent.com/raw/AIDASoft/DD4hep/pull/1019.patch?full_index=1",
         when="@1.19:1.23",
-        sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76"
+        sha256="6466719c82de830ce728db57004fb7db03983587a63b804f6dc95c6b92b3fc76",
     )
 
     # variants for subpackages


### PR DESCRIPTION
This was fixed (and merged) in https://github.com/AIDASoft/DD4hep/pull/1019 but we found it again because we were using an older tag, this patch should fix it for versions 1.20 to 1.23.