### PR TITLE
containerize: Preserve view symlink

### DIFF
--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -176,12 +176,15 @@ class PathContext(tengine.Context):
     @tengine.context_property
     def paths(self):
         """Important paths in the image"""
-        Paths = collections.namedtuple("Paths", ["environment", "store", "hidden_view", "view"])
+        Paths = collections.namedtuple(
+            "Paths", ["environment", "store", "hidden_view", "view", "view_parent"]
+        )
         return Paths(
             environment="/opt/spack-environment",
             store="/opt/software",
             hidden_view="/opt/._view",
             view="/opt/view",
+            view_parent="/opt",
         )
 
     @tengine.context_property

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -39,6 +39,9 @@ RUN find -L {{ paths.view }}/* -type f -exec readlink -f '{}' \; | \
 RUN cd {{ paths.environment }} && \
     spack env activate --sh -d . > activate.sh
 
+# The view is a symlink. Copy it into a separate directory to preserve it's symlink status.
+RUN mkdir /view-final && mv {{ paths.view }} /view-final/
+
 {% if extra_instructions.build %}
 {{ extra_instructions.build }}
 {% endif %}
@@ -52,7 +55,7 @@ FROM {{ run.image }}
 COPY --from=builder {{ paths.environment }} {{ paths.environment }}
 COPY --from=builder {{ paths.store }} {{ paths.store }}
 COPY --from=builder {{ paths.hidden_view }} {{ paths.hidden_view }}
-COPY --from=builder {{ paths.view }} {{ paths.view }}
+COPY --from=builder /view-final {{ paths.view_parent }}/
 
 RUN { \
       echo '#!/bin/sh' \


### PR DESCRIPTION
For a `spack containerize` image, the `/opt/view` symlink is resolved when it is copied to the final image (see [this question on Stack Overflow](https://stackoverflow.com/questions/66821257/what-are-docker-copys-rules-about-symlinks-how-can-i-preserve-symlinks)). This makes the final image larger than necessary with duplicate symlinks, and later attempts to regenerate the view fail. Copy a directory instead of the symlink itself to avoid this quirk.

After building, the final image is over 30 MB smaller for a small environment:
```console
$ cat spack.yaml
spack:
  specs: [dyninst]
  container:
    images:
      os: 'ubuntu:22.04'
      spack: develop
    strip: false
$ podman images 'tmp-*'
REPOSITORY            TAG         IMAGE ID      CREATED             SIZE
localhost/tmp-after   latest      667f5a7fc9fa  About a minute ago  470 MB
localhost/tmp-before  latest      462d8305f041  28 minutes ago      505 MB
```
