### PR TITLE
flecsi: disable cinch dependency for v1 release

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -29,9 +29,19 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     version("2.0.0", tag="v2.0.0")
     version("1.4.1", tag="v1.4.1", submodules=True)
     version(
-        "1.4.develop", git="https://github.com/laristra/flecsi.git", branch="1.4", submodules=True, deprecated=True
+        "1.4.develop",
+        git="https://github.com/laristra/flecsi.git",
+        branch="1.4",
+        submodules=True,
+        deprecated=True,
     )
-    version("1.4.2", git="https://github.com/laristra/flecsi.git", tag="v1.4.2", submodules=True, deprecated=True)
+    version(
+        "1.4.2",
+        git="https://github.com/laristra/flecsi.git",
+        tag="v1.4.2",
+        submodules=True,
+        deprecated=True,
+    )
     version(
         "flecsph",
         git="https://github.com/laristra/flecsi.git",

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -27,11 +27,11 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     version("2.2.0", tag="v2.2.0", preferred=True)
     version("2.1.0", tag="v2.1.0")
     version("2.0.0", tag="v2.0.0")
-    version("1.4.1", tag="v1.4.1")
+    version("1.4.1", tag="v1.4.1", submodules=True)
     version(
-        "1.4.develop", git="https://github.com/laristra/flecsi.git", branch="1.4", deprecated=True
+        "1.4.develop", git="https://github.com/laristra/flecsi.git", branch="1.4", submodules=True, deprecated=True
     )
-    version("1.4.2", git="https://github.com/laristra/flecsi.git", tag="v1.4.2", deprecated=True)
+    version("1.4.2", git="https://github.com/laristra/flecsi.git", tag="v1.4.2", submodules=True, deprecated=True)
     version(
         "flecsph",
         git="https://github.com/laristra/flecsi.git",
@@ -71,7 +71,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     variant("doxygen", default=False, description="Enable doxygen", when="@:1")
     variant("tutorial", default=False, description="Build FleCSI Tutorials", when="@:1")
     variant("flecstan", default=False, description="Build FleCSI Static Analyzer", when="@:1")
-    variant("external_cinch", default=True, description="Enable External Cinch", when="@:1")
+    variant("external_cinch", default=False, description="Enable External Cinch", when="@:1")
     variant("unit_tests", default=False, description="Build with Unit Tests Enabled", when="@:1")
 
     # All Current FleCSI Releases


### PR DESCRIPTION
This should resolve at least our part of https://github.com/spack/spack/pull/34800

Note, for v2+, cinch isn't a dependency anymore and no longer an issue.
The original problem happened because the default was still v1.4 some time ago.

In any case,  there has not been a cinch release for a long time and I don't expect one in the near future. This keeps the older FleCSI v1.4.1 version installable without having to rely on `cinch@master`. I could have removed the `external_cinch` variant completely, but I believe that is not what Spack likes to see (please correct me if I'm wrong).