### PR TITLE
Bugfix/tests: add missing slash to test log message

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1373,7 +1373,7 @@ class ChildError(InstallError):
             test_log = join_path(os.path.dirname(self.log_name), spack_install_test_log)
             if os.path.isfile(test_log):
                 out.write("\nSee test log for details:\n")
-                out.write("  {0}n".format(test_log))
+                out.write("  {0}\n".format(test_log))
 
         return out.getvalue()
 


### PR DESCRIPTION
Add the missing forward slash for a new line when printing the test log path.

Without this change:
```
See test log for details:
  $TMPDIR/spack-stage/spack-stage-<pkg>-<vers>-<hash>/install-time-test-log.txtn
```

With this change:
```
See test log for details:
  $TMPDIR/spack-stage/spack-stage-<pkg>-<vers>-<hash>/install-time-test-log.txt
```