### PR TITLE
hdf5-vol-async: add v1.6

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
@@ -24,6 +24,7 @@ class Hdf5VolAsync(CMakePackage):
     tags = ["e4s"]
 
     version("develop", branch="develop")
+    version("1.6", tag="v1.6")
     version("1.5", tag="v1.5")
     version("1.4", tag="v1.4")
     version("1.3", tag="v1.3")


### PR DESCRIPTION
[https://github.com/hpc-io/vol-async/releases/tag/v1.6](https://github.com/hpc-io/vol-async/releases/tag/v1.6)