### PR TITLE
bugfix: env concretize after remove

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -390,6 +390,19 @@ def test_remove_after_concretize():
     assert not any(s.name == "mpileaks" for s in env_specs)
 
 
+def test_remove_before_concretize():
+    e = ev.create("test")
+    e.unify = True
+
+    e.add("mpileaks")
+    e.concretize()
+
+    e.remove("mpileaks")
+    e.concretize()
+
+    assert not list(e.concretized_specs())
+
+
 def test_remove_command():
     env("create", "test")
     assert "test" in env("list")


### PR DESCRIPTION
Currently, for `unify: true` and `unify: when_possible`, removing a spec from the environment and concretizing does not effectively remove the concretization. E.g.

```
$ spack env create addremove
==> Created environment 'addremove' in /Users/becker33/spack/var/spack/environments/addremove
==> You can activate this environment with:
==>   spack env activate addremove
$ spack env activate addremove
$ spack add zlib libsigsegv
==> Adding zlib to environment addremove
==> Adding libsigsegv to environment addremove
$ spack concretize
==> Concretized libsigsegv
[+]  wyfwsfq  libsigsegv@2.14%apple-clang@14.0.3 build_system=autotools arch=darwin-ventura-m1
[+]  k44gpqp      ^gnuconfig@2022-09-17%apple-clang@14.0.3 build_system=generic arch=darwin-ventura-m1

==> Concretized zlib
[+]  pumxx34  zlib@1.2.13%apple-clang@14.0.3+optimize+pic+shared build_system=makefile arch=darwin-ventura-m1

==> Updating view at /Users/becker33/spack/var/spack/environments/addremove/.spack-env/view
$ spack find -c
==> In environment addremove
==> Root specs
libsigsegv  zlib

==> Concretized roots
-- darwin-ventura-m1 / apple-clang@14.0.3 -----------------------
libsigsegv@2.14  zlib@1.2.13

==> Installed packages
-- darwin-ventura-m1 / apple-clang@14.0.3 -----------------------
gnuconfig@2022-09-17  libsigsegv@2.14  zlib@1.2.13
==> 3 installed packages
$ spack remove zlib
==> zlib has been removed from /Users/becker33/spack/var/spack/environments/addremove/spack.yaml
$ spack concretize
$ spack find -c
==> In environment addremove
==> Root specs
libsigsegv

==> Concretized roots
-- darwin-ventura-m1 / apple-clang@14.0.3 -----------------------
libsigsegv@2.14  zlib@1.2.13

==> Installed packages
-- darwin-ventura-m1 / apple-clang@14.0.3 -----------------------
gnuconfig@2022-09-17  libsigsegv@2.14  zlib@1.2.13
==> 3 installed packages
```

The cause of this bug is a check that we only do a reconcretization if there are new specs to concretize. One solution would be to check whether there are removed specs as well. However, we can improve performance by instead removing the specs that have been removed from the concretization of the environment, and preserving the optimization that we don't call into the solver unless there are new specs to solve. This PR implements the latter.