### PR TITLE
py-charset-normalizer: add 3.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-charset-normalizer/package.py
+++ b/var/spack/repos/builtin/packages/py-charset-normalizer/package.py
@@ -13,10 +13,9 @@ class PyCharsetNormalizer(PythonPackage):
     homepage = "https://github.com/ousret/charset_normalizer"
     pypi = "charset-normalizer/charset-normalizer-2.0.7.tar.gz"
 
+    version("3.1.0", sha256="34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5")
     version("2.1.1", sha256="5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845")
     version("2.0.12", sha256="2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597")
     version("2.0.7", sha256="e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0")
 
-    depends_on("python@3.6:", when="@2.1:", type=("build", "run"))
-    depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/ousret/charset_normalizer/tree/3.1.0