### PR TITLE
whizard: Fix parallel build race condition

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -69,7 +69,8 @@ class Whizard(AutotoolsPackage):
     # Fix for https://github.com/key4hep/key4hep-spack/issues/71
     # NOTE: This will become obsolete in a future release of whizard, so once
     # that happens, this needs to be adapted with a when clause
-    patch("parallel_build_fix.patch")
+    patch("parallel_build_fix.patch", when="@3:")
+    patch("parallel_build_fix_2.8.patch", when="@2.8")
     # Make sure that the patch actually has an effect by running autoreconf
     force_autoreconf = True
     # Which then requires the following build dependencies

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -66,6 +66,18 @@ class Whizard(AutotoolsPackage):
     depends_on("texlive", when="+latex")
     depends_on("zlib")
 
+    # Fix for https://github.com/key4hep/key4hep-spack/issues/71
+    # NOTE: This will become obsolete in a future release of whizard, so once
+    # that happens, this needs to be adapted with a when clause
+    patch("parallel_build_fix.patch")
+    # Make sure that the patch actually has an effect by running autoreconf
+    force_autoreconf = True
+    # Which then requires the following build dependencies
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("pkgconf", type="build")
+
     conflicts(
         "%gcc@:5.0",
         msg="gfortran needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html",
@@ -79,13 +91,6 @@ class Whizard(AutotoolsPackage):
         "%intel@:17",
         msg="The fortran compiler needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html",
     )
-
-    @property
-    def parallel(self):
-        # Trying to build in parallel leads to a race condition at the build step.
-        # See: https://github.com/key4hep/key4hep-spack/issues/71
-        # On 3.1.0 it doesn't seem to happen
-        return self.spec.version > Version("3.0.3")
 
     def setup_build_environment(self, env):
         # whizard uses the compiler during runtime,

--- a/var/spack/repos/builtin/packages/whizard/parallel_build_fix.patch
+++ b/var/spack/repos/builtin/packages/whizard/parallel_build_fix.patch
@@ -1,0 +1,14 @@
+diff --git a/circe2/src/Makefile.am b/circe2/src/Makefile.am
+index 2b14dbec1..ad0a90fba 100644
+--- a/circe2/src/Makefile.am
++++ b/circe2/src/Makefile.am
+@@ -249,6 +249,9 @@ Makefile.depend_ocaml: $(CIRCE2_SRC) $(CIRCE2TOOL_SRC)
+ 	echo parser.cmx: parser.cmi syntax.cmi syntax.cmx >>$@
+ 	echo events_lexer.cmo: events_lexer.cmi >>$@
+ 	echo events_lexer.cmx: events_lexer.cmi >>$@
++	echo bigarray_compat.cmi: bigarray_compat.mli >>$@
++	echo bigarray_compat.cmo: bigarray_compat.cmi >>$@
++	echo bigarray_compat.cmx: bigarray_compat.cmi >>$@
+ 
+ DISTCLEANFILES += Makefile.depend_ocaml
+ 

--- a/var/spack/repos/builtin/packages/whizard/parallel_build_fix_2.8.patch
+++ b/var/spack/repos/builtin/packages/whizard/parallel_build_fix_2.8.patch
@@ -1,0 +1,14 @@
+diff --git a/circe2/src/Makefile.am b/circe2/src/Makefile.am
+index 9c9a3232..22de723b 100644
+--- a/circe2/src/Makefile.am
++++ b/circe2/src/Makefile.am
+@@ -237,5 +237,8 @@ Makefile.depend_ocaml: $(CIRCE2_SRC) $(CIRCE2TOOL_SRC)
+ 	echo lexer.cmx: lexer.cmi parser.cmx >>$@
+ 	echo parser.cmo: parser.cmi syntax.cmi >>$@
+ 	echo parser.cmx: parser.cmi syntax.cmi syntax.cmx >>$@
++	echo bigarray_compat.cmi: bigarray_compat.mli >> $@
++	echo bigarray_compat.cmo: bigarray_compat.cmi >> $@
++	echo bigarray_compat.cmx: bigarray_compat.cmi >> $@
+ 
+ DISTCLEANFILES += Makefile.depend_ocaml
+


### PR DESCRIPTION
After talking to the whizard developers about the race condition in the build step (see key4hep/key4hep-spack#71), they were able to come up with a patch that properly fixes the race condition. In order for the patch to take effect `autoreconf` has to be run again, which requires a few more changes than simply adding the patch.

Tested this with whizard versions, 3.1.0, 3.0.3 and 2.8.5 and the patches apply cleanly and I am able to consistently build whizard in parallel. Previously I ran into the race condition in about half of the cases on my machine.