### PR TITLE
libtheora: enforce math library (libm.so) linkage

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -57,7 +57,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
         args = []
         args += self.enable_or_disable("doc")
-        args += ["LIBS=-lm"]    # Include the math library
+        args += ["LIBS=-lm"]
         return args
 
     def autoreconf(self, pkg, spec, prefix):

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -57,6 +57,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
         args = []
         args += self.enable_or_disable("doc")
+        args += ["LIBS=-lm"]    # Include the math library
         return args
 
     def autoreconf(self, pkg, spec, prefix):


### PR DESCRIPTION
New GCC compiler builds are being tested as part of recent upgrades to LLNL's RZAnsel system. Unfortunately, the `libtheora` build seems to have trouble finding symbols from `libm.so`:

```
/usr/tce/packages/gcc/gcc-11.2.1/bin/ld: player_example-player_example.o: undefined reference to symbol 'rintf@@GLIBC_2.17'
/usr/tce/packages/gcc/gcc-11.2.1/bin/ld: /lib64/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:287: player_example] Error 1
```

If you pass`-lm` to the linker, the build succeeds.

I have tested this modification in the following environments:

- x86_64, Intel Classic  compiler v. 2021.9.0 20230302
- x86_64, GCC 8.5.0
- power9, GCC 11.2.1
- power9, GCC 8.5.0

All succeeded.

I don't believe this package has any maintainers, but I'll mention @gyllenhaal1 as he is involved in the system upgrade. I'll also mention my colleague @KineticTheory as he will be interested as well.