### PR TITLE
nwchem: remove -mtune=native flags

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -76,7 +76,7 @@ class Nwchem(Package):
         else:
             args.extend(["NWCHEM_MODULES=all python"])
             # archspec flags are injected through the compiler wrapper
-            filter_file("(-mtune=native|-mcpu=native)", "", "src/config/makefile.h")
+            filter_file("(-mtune=native|-mcpu=native|-xHost)", "", "src/config/makefile.h")
 
         # TODO: query if blas/lapack/scalapack uses 64bit Ints
         # A flag to distinguish between 32bit and 64bit integers in linear

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -67,6 +67,7 @@ class Nwchem(Package):
                 "MRCC_METHODS=y",  # TCE extra module
                 "IPCCSD=y",  # TCE extra module
                 "EACCSD=y",  # TCE extra module
+                "V=1",  # verbose build
             ]
         )
         if self.spec.satisfies("@7.2.0:"):

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -104,6 +104,9 @@ class Nwchem(Package):
             args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         with working_dir("src"):
+            # archspec flags are injected through the compiler wrapper
+            filter_file("(-mtune=native|-mcpu=native)", "", "config/makefile.h")
+
             make("nwchem_config", *args)
             if use_32_bit_lin_alg:
                 make("64_to_32", *args)

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -72,6 +72,7 @@ class Nwchem(Package):
         )
         if self.spec.satisfies("@7.2.0:"):
             args.extend(["NWCHEM_MODULES=all python gwmol"])
+            args.extend(["USE_HWOPT=n"])
         else:
             args.extend(["NWCHEM_MODULES=all python"])
             # archspec flags are injected through the compiler wrapper

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -74,6 +74,8 @@ class Nwchem(Package):
             args.extend(["NWCHEM_MODULES=all python gwmol"])
         else:
             args.extend(["NWCHEM_MODULES=all python"])
+            # archspec flags are injected through the compiler wrapper
+            filter_file("(-mtune=native|-mcpu=native)", "", "src/config/makefile.h")
 
         # TODO: query if blas/lapack/scalapack uses 64bit Ints
         # A flag to distinguish between 32bit and 64bit integers in linear
@@ -105,9 +107,6 @@ class Nwchem(Package):
             args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         with working_dir("src"):
-            # archspec flags are injected through the compiler wrapper
-            filter_file("(-mtune=native|-mcpu=native)", "", "config/makefile.h")
-
             make("nwchem_config", *args)
             if use_32_bit_lin_alg:
                 make("64_to_32", *args)


### PR DESCRIPTION
Spack injects compiler arch flags sourced from archspec according to the spec's target. NWChem's `makefile.h` overrides some of those flags with `-mtune=native` and `-mcpu=native` so this PR removes them. The PR also turns on verbose mode to show what's being run.

@edoapra please review