### PR TITLE
Add pic and shared variants to freetype package

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -44,6 +44,13 @@ class Freetype(AutotoolsPackage, CMakePackage):
         "support __builtin_shuffle)",
     )
 
+    variant("shared", default=True, description="Build shared libraries")
+    variant(
+        "pic",
+        default=False,
+        description="Enable position-independent code (PIC)",
+    )
+
     patch("windows.patch", when="@2.9.1")
 
     @property
@@ -51,7 +58,6 @@ class Freetype(AutotoolsPackage, CMakePackage):
         headers = find_headers("*", self.prefix.include, recursive=True)
         headers.directories = [self.prefix.include.freetype2]
         return headers
-
 
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
@@ -64,8 +70,12 @@ class AutotoolsBuilder(AutotoolsBuilder):
         ]
         if self.spec.satisfies("@2.9.1:"):
             args.append("--enable-freetype-config")
+        args.extend(self.enable_or_disable("shared"))
         return args
 
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("+pic"):
+            env.set("CFLAGS", "-fPIC")
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
@@ -75,4 +85,6 @@ class CMakeBuilder(CMakeBuilder):
             self.define("FT_DISABLE_HARFBUZZ", True),
             self.define("FT_REQUIRE_PNG", True),
             self.define("FT_REQUIRE_BZIP2", True),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -71,11 +71,8 @@ class AutotoolsBuilder(AutotoolsBuilder):
         if self.spec.satisfies("@2.9.1:"):
             args.append("--enable-freetype-config")
         args.extend(self.enable_or_disable("shared"))
+        args.extend(self.with_or_without("pic"))
         return args
-
-    def setup_build_environment(self, env):
-        if self.spec.satisfies("+pic"):
-            env.set("CFLAGS", "-fPIC")
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -45,7 +45,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
-    variant("pic", default=False, description="Enable position-independent code (PIC)")
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
 
     patch("windows.patch", when="@2.9.1")
 

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -45,11 +45,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
-    variant(
-        "pic",
-        default=False,
-        description="Enable position-independent code (PIC)",
-    )
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
 
     patch("windows.patch", when="@2.9.1")
 
@@ -58,6 +54,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
         headers = find_headers("*", self.prefix.include, recursive=True)
         headers.directories = [self.prefix.include.freetype2]
         return headers
+
 
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
@@ -73,6 +70,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args.extend(self.enable_or_disable("shared"))
         args.extend(self.with_or_without("pic"))
         return args
+
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -47,6 +47,8 @@ class Freetype(AutotoolsPackage, CMakePackage):
     variant("shared", default=True, description="Build shared libraries")
     variant("pic", default=True, description="Enable position-independent code (PIC)")
 
+    requires("+pic", when="+shared build_system=autotools")
+
     patch("windows.patch", when="@2.9.1")
 
     @property


### PR DESCRIPTION
This PR adds pic and shared variants to the freetype package. These changes support NOAA/National Weather Service R&D and operational forecasting applications.