### PR TITLE
sirius: add rocsolver/wannier90

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -211,6 +211,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("scalapack", when="+scalapack")
 
     depends_on("rocblas", when="+rocm")
+    depends_on("rocsolver", when="@7.5.0: +rocm")
 
     # FindHIP cmake script only works for < 4.1
     depends_on("hip@:4.0", when="@:7.2.0 +rocm")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -150,7 +150,8 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     variant("vdwxc", default=False, description="Enable libvdwxc support")
     variant("scalapack", default=False, description="Enable scalapack support")
     variant("magma", default=False, description="Enable MAGMA support")
-    variant("nlcglib", default=False, description="enable robust wave function optimization")
+    variant("nlcglib", default=False, description="Enable robust wave function optimization")
+    variant("wannier90", default=False, description="Enable Wannier90 library")
     variant(
         "build_type",
         default="Release",
@@ -228,6 +229,9 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blis threads=openmp", when="+openmp ^blis")
     depends_on("intel-mkl threads=openmp", when="+openmp ^intel-mkl")
 
+    depends_on("wannier90", when="@7.5.0: +wannier90")
+    depends_on("wannier90+shared", when="@7.5.0: +wannier90+shared")
+
     depends_on("elpa+openmp", when="+elpa+openmp")
     depends_on("elpa~openmp", when="+elpa~openmp")
 
@@ -286,6 +290,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("USE_FP32", "single_precision"),
             self.define_from_variant("USE_PROFILER", "profiler"),
+            self.define_from_variant("USE_WANNIER90", "wannier90"),
         ]
 
         lapack = spec["lapack"]


### PR DESCRIPTION
- add rocsolver dependency for sirius>7.5
- add wannier90 variant (https://github.com/electronic-structure/SIRIUS/pull/838)