### PR TITLE
py-cutadapt: add 4.4, 4.3, 4.2 versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -15,6 +15,9 @@ class PyCutadapt(PythonPackage):
     pypi = "cutadapt/cutadapt-1.13.tar.gz"
     git = "https://github.com/marcelm/cutadapt.git"
 
+    version("4.4", sha256="4554157c673022e1c433fcd6e3b803008fef60c8e71c01215e4aa04b0f09fe83")
+    version("4.3", sha256="319de860f975977e080ea42d9d255322060693ca39b7be51187831311702fe29")
+    version("4.2", sha256="ab0ac450baecc1576cc5ccbc06eab2685be9ee7676763938237d954a644237f1")
     version("4.1", sha256="be745ff24adfb4a3eaf715dfad0e2ccdfad7792ef00c1122adf4fbf3aed9227b")
     version("2.10", sha256="936b88374b5b393a954852a0fe317a85b798dd4faf5ec52cf3ef4f3c062c242a")
     version("2.9", sha256="cad8875b461ca09cea498b4f0e78b0d3dcd7ea84d27d51dac4ed45080bf1499e")


### PR DESCRIPTION
Adding the latest versions of `py-cutadapt`. 4.2rc1 has been left out. 