### PR TITLE
py-coloredlogs: add 15.0.1 and py-humanfriendly: add 10.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-coloredlogs/package.py
+++ b/var/spack/repos/builtin/packages/py-coloredlogs/package.py
@@ -9,10 +9,15 @@ from spack.package import *
 class PyColoredlogs(PythonPackage):
     """Colored terminal output for Python's logging module"""
 
+    homepage = "https://coloredlogs.readthedocs.io"
     pypi = "coloredlogs/coloredlogs-10.0.tar.gz"
+    git = "https://github.com/xolox/python-coloredlogs.git"
 
+    version("15.0.1", sha256="7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0")
     version("14.0", sha256="a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505")
     version("10.0", sha256="b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36")
 
     depends_on("py-setuptools", type="build")
+
+    depends_on("py-humanfriendly@9.1:", when="@15:", type=("build", "run"))
     depends_on("py-humanfriendly@4.7:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-humanfriendly/package.py
+++ b/var/spack/repos/builtin/packages/py-humanfriendly/package.py
@@ -10,10 +10,11 @@ class PyHumanfriendly(PythonPackage):
 
     homepage = "https://humanfriendly.readthedocs.io/"
     pypi = "humanfriendly/humanfriendly-8.1.tar.gz"
+    git = "https://github.com/xolox/python-humanfriendly.git"
 
+    version("10.0", sha256="6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc")
     version("8.2", sha256="bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12")
     version("8.1", sha256="25c2108a45cfd1e8fbe9cdb30b825d34ef5d5675c8e11e4775c9aedbfb0bdee2")
     version("4.18", sha256="33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85")
 
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/xolox/python-coloredlogs/tree/15.0.1
https://github.com/xolox/python-humanfriendly/tree/10.0

For `py-humanfriendly`, I was not sure if the `pyreadline` dependencies are needed, see
https://github.com/xolox/python-humanfriendly/blob/10.0/setup.py#L54-L55
If I should add them, please let me know.