### PR TITLE
fix(protobuf-c): set version bound for protobuf dependency

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf-c/package.py
+++ b/var/spack/repos/builtin/packages/protobuf-c/package.py
@@ -20,5 +20,5 @@ class ProtobufC(AutotoolsPackage):
     version("1.4.1", sha256="4cc4facd508172f3e0a4d3a8736225d472418aee35b4ad053384b137b220339f")
     version("1.3.2", sha256="53f251f14c597bdb087aecf0b63630f434d73f5a10fc1ac545073597535b9e74")
 
-    depends_on("protobuf")
+    depends_on("protobuf@:3.21.12")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
Fix #37887 GitLab CI failure.