### PR TITLE
Win build env dump support

### DIFF
--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pickle
+import sys
 
 import pytest
 
@@ -39,7 +40,10 @@ def test_dump(tmpdir):
     with tmpdir.as_cwd():
         build_env("--dump", _out_file, "zlib")
         with open(_out_file) as f:
-            assert any(line.startswith("PATH=") for line in f.readlines())
+            if sys.platform == "win32":
+                assert any(line.startswith("set \"PATH=") for line in f.readlines())
+            else:
+                assert any(line.startswith("PATH=") for line in f.readlines())
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -41,7 +41,7 @@ def test_dump(tmpdir):
         build_env("--dump", _out_file, "zlib")
         with open(_out_file) as f:
             if sys.platform == "win32":
-                assert any(line.startswith("set \"PATH=") for line in f.readlines())
+                assert any(line.startswith('set "PATH=') for line in f.readlines())
             else:
                 assert any(line.startswith("PATH=") for line in f.readlines())
 

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -119,7 +119,10 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
     dumpfile_path = str(tmpdir.join("envdump.txt"))
     envutil.dump_environment(dumpfile_path)
     with open(dumpfile_path, "r") as dumpfile:
-        assert "TEST_ENV_VAR={0}; export TEST_ENV_VAR\n".format(test_paths) in list(dumpfile)
+        if sys.platform == "win32":
+            assert "set \"TEST_ENV_VAR={}\"\n".format(test_paths) in list(dumpfile)
+        else:
+            assert "TEST_ENV_VAR={0}; export TEST_ENV_VAR\n".format(test_paths) in list(dumpfile)
 
 
 def test_reverse_environment_modifications(working_env):

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -120,7 +120,7 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
     envutil.dump_environment(dumpfile_path)
     with open(dumpfile_path, "r") as dumpfile:
         if sys.platform == "win32":
-            assert "set \"TEST_ENV_VAR={}\"\n".format(test_paths) in list(dumpfile)
+            assert 'set "TEST_ENV_VAR={}"\n'.format(test_paths) in list(dumpfile)
         else:
             assert "TEST_ENV_VAR={0}; export TEST_ENV_VAR\n".format(test_paths) in list(dumpfile)
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -170,8 +170,9 @@ def path_put_first(var_name: str, directories: List[Path]):
 
 BASH_FUNCTION_FINDER = re.compile(r"BASH_FUNC_(.*?)\(\)")
 
+
 def _win_env_var_to_set_line(var: str, val: str) -> str:
-    return f"set \"{var}={val}\""
+    return f'set "{var}={val}"'
 
 
 def _nix_env_var_to_source_line(var: str, val: str) -> str:

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -170,8 +170,11 @@ def path_put_first(var_name: str, directories: List[Path]):
 
 BASH_FUNCTION_FINDER = re.compile(r"BASH_FUNC_(.*?)\(\)")
 
+def _win_env_var_to_set_line(var: str, val: str) -> str:
+    return f"set {var}={val}"
 
-def _env_var_to_source_line(var: str, val: str) -> str:
+
+def _nix_env_var_to_source_line(var: str, val: str) -> str:
     if var.startswith("BASH_FUNC"):
         source_line = "function {fname}{decl}; export -f {fname}".format(
             fname=BASH_FUNCTION_FINDER.sub(r"\1", var), decl=val
@@ -179,6 +182,13 @@ def _env_var_to_source_line(var: str, val: str) -> str:
     else:
         source_line = f"{var}={double_quote_escape(val)}; export {var}"
     return source_line
+
+
+def _env_var_to_source_line(var: str, val: str) -> str:
+    if sys.platform == "win32":
+        return _win_env_var_to_set_line(var, val)
+    else:
+        return _nix_env_var_to_source_line(var, val)
 
 
 @system_path_filter(arg_slice=slice(1))

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -171,7 +171,7 @@ def path_put_first(var_name: str, directories: List[Path]):
 BASH_FUNCTION_FINDER = re.compile(r"BASH_FUNC_(.*?)\(\)")
 
 def _win_env_var_to_set_line(var: str, val: str) -> str:
-    return f"set {var}={val}"
+    return f"set \"{var}={val}\""
 
 
 def _nix_env_var_to_source_line(var: str, val: str) -> str:


### PR DESCRIPTION
Current build env behavior dumps to file using bash style exports. On Windows we should use batch style env variable settings via `set`. 
This resolves an issue where many shell commands stop working as expected after and env dump is sourced on Windows.