### PR TITLE
Windows CI: add paraview deps nightly

### DIFF
--- a/.github/workflows/nightly-win-builds.yml
+++ b/.github/workflows/nightly-win-builds.yml
@@ -1,0 +1,35 @@
+name: Windows Paraview Nightly
+
+on:
+  workflow_call:
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 am
+
+concurrency:
+  group: windows-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell:
+     powershell Invoke-Expression -Command "./share/spack/qa/windows_test_setup.ps1"; {0}
+
+
+jobs:
+  build-paraview:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      with:
+        python-version: 3.9
+    - name: Install Python packages
+      run: |
+          python -m pip install --upgrade pip six pywin32 setuptools coverage
+    - name: Build Test
+      run: |
+        spack compiler find
+        spack external find cmake ninja win-sdk win-wdk wgl msmpi
+        spack -d install paraview --cdash-upload-url https://cdash.spack.io/submit.php?project=Spack+on+Windows --cdash-track Nightly

--- a/.github/workflows/nightly-win-builds.yml
+++ b/.github/workflows/nightly-win-builds.yml
@@ -1,13 +1,8 @@
 name: Windows Paraview Nightly
 
 on:
-  workflow_call:
   schedule:
     - cron: '0 2 * * *' # Run at 2 am
-
-concurrency:
-  group: windows-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
-  cancel-in-progress: true
 
 defaults:
   run:
@@ -16,7 +11,7 @@ defaults:
 
 
 jobs:
-  build-paraview:
+  build-paraview-deps:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -32,4 +27,4 @@ jobs:
       run: |
         spack compiler find
         spack external find cmake ninja win-sdk win-wdk wgl msmpi
-        spack -d install paraview --cdash-upload-url https://cdash.spack.io/submit.php?project=Spack+on+Windows --cdash-track Nightly
+        spack -d install -y --cdash-upload-url https://cdash.spack.io/submit.php?project=Spack+on+Windows --cdash-track Nightly --only dependencies paraview

--- a/.github/workflows/nightly-win-builds.yml
+++ b/.github/workflows/nightly-win-builds.yml
@@ -28,3 +28,4 @@ jobs:
         spack compiler find
         spack external find cmake ninja win-sdk win-wdk wgl msmpi
         spack -d install -y --cdash-upload-url https://cdash.spack.io/submit.php?project=Spack+on+Windows --cdash-track Nightly --only dependencies paraview
+        exit 0


### PR DESCRIPTION
Add a nightly build of paraview deps as a non blocking/non failing status check for Spack on Windows support as a stopgap until we get Gitlab CI on its feet for Windows.