### PR TITLE
Protobuf CMake Bug Fix

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/msvc-abseil-target-namespace.patch
+++ b/var/spack/repos/builtin/packages/protobuf/msvc-abseil-target-namespace.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/abseil-cpp.cmake b/cmake/abseil-cpp.cmake
+index e7bfb2b15..61fcd678d 100644
+--- a/cmake/abseil-cpp.cmake
++++ b/cmake/abseil-cpp.cmake
+@@ -39,7 +39,7 @@ set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFI
+ 
+ if (BUILD_SHARED_LIBS AND MSVC)
+   # On MSVC Abseil is bundled into a single DLL.
+-  set(protobuf_ABSL_USED_TARGETS abseil_dll)
++  set(protobuf_ABSL_USED_TARGETS absl::abseil_dll)
+ 
+   set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+ else()

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -102,6 +102,8 @@ class Protobuf(CMakePackage):
         sha256="fa1abf042eddc1b3b43875dc018c651c90cd1c0c5299975a818a1610bee54ab8",
     )
 
+    patch("msvc-abseil-target-namespace.patch", when="@3.22 %msvc")
+
     def fetch_remote_versions(self, *args, **kwargs):
         """Ignore additional source artifacts uploaded with releases,
         only keep known versions


### PR DESCRIPTION
Protobuf's cmake imports an external abseil-cpp but does not properly prefix the imported target with the abseil namespace, which causes the includes and link lines typically propagated by later calls to `target_link_libraries` to be dropped and the build to subsequently fail.
This patch resolves the issue as simply as possible. 