### PR TITLE
py-cutadapt: add 4.4, 4.3, 4.2 versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -27,7 +27,7 @@ class PyCutadapt(PythonPackage):
     # version 4 deps
     depends_on("py-setuptools@63:", type=("build", "run"), when="@4.2:")
     depends_on("py-setuptools@43:", type=("build", "run"), when="@:4.1")
-    depends_on("py-setuptools-scm@6.2:", type="build", when="@2.0:")
+    depends_on("py-setuptools-scm@6.2:+toml", type="build", when="@2.0:")
     depends_on("python@3.7:", type=("build", "run"), when="@4.1:")
     depends_on("py-cython@0.29.20:", type=("build", "run"))
     depends_on("py-dnaio@0.10:", type=("build", "run"), when="@4.3:")

--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -29,7 +29,7 @@ class PyCutadapt(PythonPackage):
     depends_on("py-setuptools@43:", type=("build", "run"), when="@:4.1")
     depends_on("py-setuptools-scm@6.2:+toml", type="build", when="@2.0:")
     depends_on("python@3.7:", type=("build", "run"), when="@4.1:")
-    depends_on("py-cython@0.29.20:", type=("build", "run"))
+    depends_on("py-cython@0.29.20:", type="build")
     depends_on("py-dnaio@0.10:", type=("build", "run"), when="@4.3:")
     depends_on("py-dnaio@0.9.1:", type=("build", "run"), when="@4.2")
     depends_on("py-dnaio@0.7.1:", type=("build", "run"), when="@4.1")

--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -15,20 +15,26 @@ class PyCutadapt(PythonPackage):
     pypi = "cutadapt/cutadapt-1.13.tar.gz"
     git = "https://github.com/marcelm/cutadapt.git"
 
+    version("4.4", sha256="4554157c673022e1c433fcd6e3b803008fef60c8e71c01215e4aa04b0f09fe83")
+    version("4.3", sha256="319de860f975977e080ea42d9d255322060693ca39b7be51187831311702fe29")
+    version("4.2", sha256="ab0ac450baecc1576cc5ccbc06eab2685be9ee7676763938237d954a644237f1")
     version("4.1", sha256="be745ff24adfb4a3eaf715dfad0e2ccdfad7792ef00c1122adf4fbf3aed9227b")
     version("2.10", sha256="936b88374b5b393a954852a0fe317a85b798dd4faf5ec52cf3ef4f3c062c242a")
     version("2.9", sha256="cad8875b461ca09cea498b4f0e78b0d3dcd7ea84d27d51dac4ed45080bf1499e")
     version("2.5", sha256="ced79e49b93e922e579d0bb9d21298dcb2d7b7b1ea721feed484277e08b1660b")
     version("1.13", sha256="aa9f2c1f33dc081fe94f42b1250e4382b8fb42cabbf6e70a76ff079f211d5fc0")
 
-    # universal deps
-    depends_on("py-setuptools@43:", type=("build", "run"))
+    # version 4 deps
+    depends_on("py-setuptools@63:", type=("build", "run"), when="@4.2:")
+    depends_on("py-setuptools@43:", type=("build", "run"), when="@:4.1")
     depends_on("py-setuptools-scm@6.2:", type="build", when="@2.0:")
     depends_on("python@3.7:", type=("build", "run"), when="@4.1:")
     depends_on("py-cython@0.29.20:", type=("build", "run"))
-    # 4.1 deps
-    depends_on("py-dnaio@0.7.1:", type=("build", "run"), when="@4.1:")
-    depends_on("py-xopen@1.1:", type=("build", "run"), when="@4.1:")
+    depends_on("py-dnaio@0.10:", type=("build", "run"), when="@4.3:")
+    depends_on("py-dnaio@0.9.1:", type=("build", "run"), when="@4.2")
+    depends_on("py-dnaio@0.7.1:", type=("build", "run"), when="@4.1")
+    depends_on("py-xopen@1.6:", type=("build", "run"), when="@4.2:")
+    depends_on("py-xopen@1.1:", type=("build", "run"), when="@4.1")
     # older version deps
     depends_on("py-xopen@0.1.1:", type=("build", "run"), when="@1.13")
     depends_on("py-xopen@0.5.0:", type=("build", "run"), when="@2.0:2.3")

--- a/var/spack/repos/builtin/packages/py-dnaio/package.py
+++ b/var/spack/repos/builtin/packages/py-dnaio/package.py
@@ -22,7 +22,7 @@ class PyDnaio(PythonPackage):
     depends_on("py-setuptools-scm@6.2:", when="@0.4:", type="build")
     # 0.9.1 deps
     depends_on("python@3.7:", type=("build", "run"), when="@0.9.1:")
-    depends_on("py-cython@0.29.20:", type=("build", "run"), when="@0.9.1:")
+    depends_on("py-cython@0.29.20:", type="build", when="@0.9.1:")
     depends_on("py-xopen@1.4.0:", type=("build", "run"), when="@0.9.1:")
     # older deps
     depends_on("py-xopen", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-dnaio/package.py
+++ b/var/spack/repos/builtin/packages/py-dnaio/package.py
@@ -13,6 +13,7 @@ class PyDnaio(PythonPackage):
     pypi = "dnaio/dnaio-0.3.tar.gz"
     git = "https://github.com/marcelm/dnaio.git"
 
+    version("0.10.0", sha256="de51a50948f00b864297d74eddb588fbee5ac229855754e77564d18b24619d18")
     version("0.9.1", sha256="a1a14181995b27197b7e2b8897994a3107c649b9fc2dfe263caff3c455b0d0c4")
     version("0.4.2", sha256="fa55a45bfd5d9272409b714158fb3a7de5dceac1034a0af84502c7f503ee84f8")
     version("0.3", sha256="47e4449affad0981978fe986684fc0d9c39736f05a157f6cf80e54dae0a92638")


### PR DESCRIPTION
Adding the three latest versions of `py-cutadapt`, excluding 4.2rc1.

4.4 requires `py-dnaio@0.10:`, so have also updated this dependency.