### PR TITLE
Do not set win-sdk version if installing win-sdk

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -151,7 +151,11 @@ class Msvc(Compiler):
         arch = arch.replace("-", "_")
         # vcvars can target specific sdk versions, force it to pick up concretized sdk
         # version, if needed by spec
-        sdk_ver = "" if "win-sdk" not in pkg.spec else pkg.spec["win-sdk"].version.string + ".0"
+        sdk_ver = (
+            ""
+            if "win-sdk" not in pkg.spec or pkg.name == "win-sdk"
+            else pkg.spec["win-sdk"].version.string + ".0"
+        )
         # provide vcvars with msvc version selected by concretization,
         # not whatever it happens to pick up on the system (highest available version)
         out = subprocess.check_output(  # novermin


### PR DESCRIPTION
The current behavior leads to a bug where we try to instantiate a vcvars for an sdk that is not yet installed.
We should simply allow the compiler to select the vcvars toolchain if we're installing an sdk as we would typically, we should only be setting up a specific toolchain in the env if we're targeting a specific sdk version during the build, which we are not if we're installing the sdk. 

Note: the sdk is not actually installable via Spack at the moment as it's a Windows package that is not installable from source, but Spack is aware of that, and reports to the user. This PR stops a very confusing error from occurring _before_ Spack can report that. 