### PR TITLE
fastp: add version 0.23.3, add build dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/fastp/package.py
+++ b/var/spack/repos/builtin/packages/fastp/package.py
@@ -13,7 +13,11 @@ class Fastp(MakefilePackage):
     homepage = "https://github.com/OpenGene/fastp"
     url = "https://github.com/OpenGene/fastp/archive/v0.20.0.tar.gz"
 
+    version("0.23.3", sha256="a37ee4b5dcf836a5a19baec645657b71d9dcd69ee843998f41f921e9b67350e3")
     version("0.20.0", sha256="8d751d2746db11ff233032fc49e3bcc8b53758dd4596fdcf4b4099a4d702ac22")
+
+    depends_on("libisal", type=("build", "link"), when="@0.23:")
+    depends_on("libdeflate", type=("build", "link"), when="@0.23:")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Added latest version of `fastp`. As of `@0.23:` there are build and link dependencies for `libisal` and `libdeflate` (no specific versions are specified - GitHub README recommends the user to clone the repos).