### PR TITLE
Spec.format: print false attributes if requested

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4333,7 +4333,7 @@ class Spec(object):
 
                     if callable(current):
                         raise SpecFormatStringError("Attempted to format callable object")
-                    if not current:
+                    if current is None:
                         # We're not printing anything
                         return
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -660,6 +660,7 @@ class TestSpecSemantics(object):
             ("{architecture.os}", "", "os", lambda spec: spec.architecture),
             ("{architecture.target}", "", "target", lambda spec: spec.architecture),
             ("{prefix}", "", "prefix", lambda spec: spec),
+            ("{external}", "", "external", lambda spec: spec),  # test we print "False"
         ]
 
         hash_segments = [


### PR DESCRIPTION
As discussed in the general channel on slack.

Previously, `Spec.format("{external}")` would print nothing if `Spec.external is False`. Now it will print "False".

Includes regression test.