### PR TITLE
mpas-model: copy namelist and xml to ./bin

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -163,6 +163,8 @@ class MpasModel(MakefilePackage):
         make(*self.target("init_atmosphere", "all"), parallel=True)
         mkdir("bin")
         copy("init_atmosphere_model", "bin")
+        copy("namelist.init_atmosphere", "bin")
+        copy("streams.init_atmosphere", "bin")
         make(*self.target("init_atmosphere", "clean"))
         make(*self.target("atmosphere", "all"), parallel=True)
         copy("atmosphere_model", "bin")


### PR DESCRIPTION
`namelist.init_atmosphere` and `streams.init_atmosphere` are two important config files generated by compiling `init_atmosphere_model`. 
However, they are removed by `make clean` command before they are copyed into `bin` together with the `in_atmosphere_model` . 
This PR fixs this problem.