### PR TITLE
py-htseq: add 2.0.3, switch to PyPI

### DIFF
--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -15,11 +15,13 @@ class PyHtseq(PythonPackage):
 
     version("0.12.3", sha256="d4710758dd39be2b37a870945b813c6c9e50a1821863c564bf4504636a7eb7a3")
     version(
-        "0.11.2", url="https://github.com/simon-anders/htseq/archive/release_0.11.2.tar.gz",
+        "0.11.2",
+        url="https://github.com/simon-anders/htseq/archive/release_0.11.2.tar.gz",
         sha256="dfc707effa699d5ba9034e1bb9f13c0fb4e9bc60d31ede2444aa49c7e2fc71aa",
     )
     version(
-        "0.9.1", url="https://github.com/simon-anders/htseq/archive/release_0.9.1.tar.gz",
+        "0.9.1",
+        url="https://github.com/simon-anders/htseq/archive/release_0.9.1.tar.gz",
         sha256="28b41d68aa233fce0d57699e649b69bb11957f8f1b9b7b82dfe3415849719534",
     )
 

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -23,7 +23,6 @@ class PyHtseq(PythonPackage):
     variant("h5ad", default=True, description="h5ad output files", when="@2:")
     variant("loom", default=True, description="loom output files", when="@2:")
 
-    depends_on("python@3.7:", type=("build", "run"), when="@:0.12.3")
     # build-only dependencies
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -17,14 +17,14 @@ class PyHtseq(PythonPackage):
     version("0.11.2", sha256="65c4c13968506c7df92e97124df96fdd041c4476c12a548d67350ba8b436bcfc")
     version("0.9.1", sha256="af5bba775e3fb45ed4cde64c691ebef36b0bf7a86efd35c884ad0734c27ad485")
 
-    variant("qa", default=True, description="Install dependencies for quality assessment")
+    variant("qa", default=True, description="Quality assessment")
     variant("mtx", default=True, description="BigWig manipulation", when="@2:")
     variant("mtx", default=True, description="mtx output files", when="@2:")
     variant("h5ad", default=True, description="h5ad output files", when="@2:")
     variant("loom", default=True, description="loom output files", when="@2:")
 
-    # build dependencies
     depends_on("python@3.7:", type=("build", "run"), when="@:0.12.3")
+    # build-only dependencies
     depends_on("py-setuptools", type="build")
     depends_on("py-cython", type="build")
     depends_on("swig", type="build")

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -10,11 +10,18 @@ class PyHtseq(PythonPackage):
     """HTSeq is a Python package that provides infrastructure to process
     data from high-throughput sequencing assays."""
 
-    homepage = "https://htseq.readthedocs.io/en/release_0.9.1/overview.html"
-    url = "https://github.com/simon-anders/htseq/archive/release_0.9.1.tar.gz"
+    homepage = "https://htseq.readthedocs.io/en/master/index.html"
+    url = "https://github.com/htseq/htseq/archive/release_0.12.3.tar.gz"
 
-    version("0.11.2", sha256="dfc707effa699d5ba9034e1bb9f13c0fb4e9bc60d31ede2444aa49c7e2fc71aa")
-    version("0.9.1", sha256="28b41d68aa233fce0d57699e649b69bb11957f8f1b9b7b82dfe3415849719534")
+    version("0.12.3", sha256="d4710758dd39be2b37a870945b813c6c9e50a1821863c564bf4504636a7eb7a3")
+    version(
+        "0.11.2", url="https://github.com/simon-anders/htseq/archive/release_0.11.2.tar.gz",
+        sha256="dfc707effa699d5ba9034e1bb9f13c0fb4e9bc60d31ede2444aa49c7e2fc71aa",
+    )
+    version(
+        "0.9.1", url="https://github.com/simon-anders/htseq/archive/release_0.9.1.tar.gz",
+        sha256="28b41d68aa233fce0d57699e649b69bb11957f8f1b9b7b82dfe3415849719534",
+    )
 
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -11,21 +11,28 @@ class PyHtseq(PythonPackage):
     data from high-throughput sequencing assays."""
 
     homepage = "https://htseq.readthedocs.io/en/master/index.html"
-    url = "https://github.com/htseq/htseq/archive/release_0.12.3.tar.gz"
+    pypi = "HTSeq/HTSeq-2.0.3.tar.gz"
 
-    version("0.12.3", sha256="d4710758dd39be2b37a870945b813c6c9e50a1821863c564bf4504636a7eb7a3")
-    version(
-        "0.11.2", url="https://github.com/simon-anders/htseq/archive/release_0.11.2.tar.gz",
-        sha256="dfc707effa699d5ba9034e1bb9f13c0fb4e9bc60d31ede2444aa49c7e2fc71aa",
-    )
-    version(
-        "0.9.1", url="https://github.com/simon-anders/htseq/archive/release_0.9.1.tar.gz",
-        sha256="28b41d68aa233fce0d57699e649b69bb11957f8f1b9b7b82dfe3415849719534",
-    )
+    version("2.0.3", sha256="c7e7eb29bdc44e80d2d68e3599fa8a8f1d9d6475624dcf1b9644285a8a9c0fac")
+    version("0.11.2", sha256="65c4c13968506c7df92e97124df96fdd041c4476c12a548d67350ba8b436bcfc")
+    version("0.9.1", sha256="af5bba775e3fb45ed4cde64c691ebef36b0bf7a86efd35c884ad0734c27ad485")
 
+    variant("qa", default=True, description="Install dependencies for quality assessment")
+    variant("mtx", default=True, description="BigWig manipulation", when="@2:")
+    variant("mtx", default=True, description="mtx output files", when="@2:")
+    variant("h5ad", default=True, description="h5ad output files", when="@2:")
+    variant("loom", default=True, description="loom output files", when="@2:")
+
+    # build dependencies
+    depends_on("python@3.7:", type=("build", "run"), when="@:0.12.3")
     depends_on("py-setuptools", type="build")
+    depends_on("py-cython", type="build")
+    depends_on("swig", type="build")
+    # run dependencies
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pysam", type=("build", "run"))
-    depends_on("py-matplotlib", type=("build", "run"))
-    depends_on("py-cython", type=("build", "run"))
-    depends_on("swig", type=("build", "run"))
+    # variant dependencies
+    depends_on("py-matplotlib@1.4:", type=("build", "run"), when="+qa")
+    depends_on("py-scipy@1.5.0:", type=("build", "run"), when="+mtx")
+    depends_on("py-anndata", type=("build", "run"), when="+h5ad")
+    depends_on("py-loompy", type=("build", "run"), when="+loom")

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -26,7 +26,6 @@ class PyHtseq(PythonPackage):
     # build-only dependencies
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.5:", type="build")
-    depends_on("swig@3.0.8:", type="build")
     # run dependencies
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pysam", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-htseq/package.py
+++ b/var/spack/repos/builtin/packages/py-htseq/package.py
@@ -25,8 +25,8 @@ class PyHtseq(PythonPackage):
 
     # build-only dependencies
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython", type="build")
-    depends_on("swig", type="build")
+    depends_on("py-cython@0.29.5:", type="build")
+    depends_on("swig@3.0.8:", type="build")
     # run dependencies
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pysam", type=("build", "run"))


### PR DESCRIPTION
Updating to latest version of `py-htseq`. As of `@0.12:` the repo has moved over from `simon-anders/htseq` to `htseq/htseq`, so updating that here and giving `url=` paths for the two versions already here.