### PR TITLE
py-macs2: add 2.2.8, updated dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -15,6 +15,7 @@ class PyMacs2(PythonPackage):
     homepage = "https://github.com/taoliu/MACS"
     pypi = "MACS2/MACS2-2.2.4.tar.gz"
 
+    version("2.2.8", sha256="2a0a436ac89d8f8c94a1e410690037760e5e37929ad719c54696e74ef84a98e0")
     version("2.2.7.1", sha256="ad2ca69bdd02a8942a68aae23133289b5c16ba382bcbe20c39fabf3948929de5")
     version("2.2.4", sha256="b131aadc8f5fd94bec35308b821e1f7585def788d2e7c756fc8cac402ffee25b")
 
@@ -28,14 +29,14 @@ class PyMacs2(PythonPackage):
     depends_on("python@3.6:", when="@2.2.7.1:", type=("build", "run"))
     # version 2.2.4 does not build with python-3.10
     depends_on("python@3.5:3.9", when="@2.2.4", type=("build", "run"))
-    depends_on("py-cython", type="build")
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-macs2 requires py-setuptools during runtime as well.
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-setuptools@41.2:", when="@2.2.4:", type=("build", "run"))
     depends_on("py-numpy@1.17:", when="@2.2.4:", type=("build", "run"))
-    depends_on("py-cython@0.29:", when="@2.2.4:", type="build")
+    depends_on("py-cython@0.29.24:", when="@2.2.8:", type="build")
+    depends_on("py-cython@0.29:", when="@2.2.4:2.2.7.1", type="build")
 
     def patch(self):
         # regenerate C files from pyx files with cython

--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -30,10 +30,8 @@ class PyMacs2(PythonPackage):
     # version 2.2.4 does not build with python-3.10
     depends_on("python@3.5:3.9", when="@2.2.4", type=("build", "run"))
 
-    # Most Python packages only require py-setuptools as a build dependency.
-    # However, py-macs2 requires py-setuptools during runtime as well.
-    depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-setuptools@41.2:", when="@2.2.4:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@41.2:", when="@2.2.4:", type="build")
     depends_on("py-numpy@1.17:", when="@2.2.4:", type=("build", "run"))
     depends_on("py-cython@0.29.24:", when="@2.2.8:", type="build")
     depends_on("py-cython@0.29:", when="@2.2.4:2.2.7.1", type="build")


### PR DESCRIPTION
Added the latest version of `py-macs2`. 