### PR TITLE
minimap2: adding 2.26

### DIFF
--- a/var/spack/repos/builtin/packages/minimap2/package.py
+++ b/var/spack/repos/builtin/packages/minimap2/package.py
@@ -14,6 +14,7 @@ class Minimap2(PythonPackage):
     homepage = "https://github.com/lh3/minimap2"
     url = "https://github.com/lh3/minimap2/releases/download/v2.2/minimap2-2.2.tar.bz2"
 
+    version("2.26", sha256="6a588efbd273bff4f4808d5190957c50272833d2daeb4407ccf4c1b78143624c")
     version("2.14", sha256="9088b785bb0c33488ca3a27c8994648ce21a8be54cb117f5ecee26343facd03b")
     version("2.10", sha256="52b36f726ec00bfca4a2ffc23036d1a2b5f96f0aae5a92fd826be6680c481c20")
     version("2.2", sha256="7e8683aa74c4454a8cfe3821f405c4439082e24c152b4b834fdb56a117ecaed9")


### PR DESCRIPTION
Updated `minimap2` to 2.26. There are 12 intervening versions that I've not checksummed here.