### PR TITLE
hdf-eos2: chmod configure script

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import chmod
 import sys
+from os import chmod
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from os import chmod
 import sys
 
 from spack.package import *
@@ -74,6 +75,10 @@ class HdfEos2(AutotoolsPackage):
                 "ERROR: cannot generate URL for version {0};"
                 "version/checksum not found in version_list".format(version)
             )
+
+    @run_before("configure")
+    def fix_permissions(self):
+        chmod(join_path(self.stage.source_path, "configure"), 0o755)
 
     def configure_args(self):
         extra_args = []


### PR DESCRIPTION
The configure script in hdf-eos2's source tarball is read-only. This causes permission denied errors when Spack tries to run filter_file on configure. This patch fixes the permissions.