### PR TITLE
Windows: Add PowerShell env support and general env improvements for the platform

### DIFF
--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -214,7 +214,7 @@ goto :end_switch
 if defined _sp_args (
     if NOT "%_sp_args%"=="%_sp_args:--help=%" (
         goto :default_case
-    ) else if NOT "%_sp_args%"=="%_sp_args: -h=%" (
+    ) else if NOT "%_sp_args%"=="%_sp_args:-h=%" (
         goto :default_case
     ) else if NOT "%_sp_args%"=="%_sp_args:--bat=%" (
         goto :default_case

--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -1,0 +1,132 @@
+#  Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+#  Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+#  SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# #######################################################################
+
+function Compare-CommonArgs {
+    $CMDArgs = $args[0]
+    # These aruments take precedence and call for no futher parsing of arguments
+    # invoke actual Spack entrypoint with that context and exit after
+    "--help", "-h", "--version", "-V" | ForEach-Object {
+        $arg_opt = $_
+        if(($CMDArgs) -and ([bool]($CMDArgs.Where({$_ -eq $arg_opt})))) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Read-SpackArgs {
+    $SpackCMD_params = @()
+    $SpackSubCommand = $NULL
+    $SpackSubCommandArgs = @()
+    $args_ = $args[0]
+    $args_ | ForEach-Object {
+        if (!$SpackSubCommand) {
+            if($_.SubString(0,1) -eq "-")
+            {
+                $SpackCMD_params += $_
+            }
+            else{
+                $SpackSubCommand = $_
+            }
+        }
+        else{
+            $SpackSubCommandArgs += $_
+        }
+    }
+    return $SpackCMD_params, $SpackSubCommand, $SpackSubCommandArgs
+}
+
+function Invoke-SpackCD {
+    if (Compare-CommonArgs $SpackSubCommandArgs) {
+        python $Env:SPACK_ROOT/bin/spack cd -h
+    }
+    else {
+        $LOC = $(python $Env:SPACK_ROOT/bin/spack location $SpackSubCommandArgs)
+        if (($NULL -ne $LOC)){
+            if ( Test-Path -Path $LOC){
+                Set-Location $LOC
+            }
+            else{
+                exit 1
+            }
+        }
+        else {
+            exit 1
+        }
+    }
+}
+
+function Invoke-SpackEnv {
+    if (Compare-CommonArgs $SpackSubCommandArgs[0]) {
+        python $Env:SPACK_ROOT/bin/spack env -h
+    }
+    else {
+        $SubCommandSubCommand = $SpackSubCommandArgs[0]
+        $SubCommandSubCommandArgs = $SpackSubCommandArgs[1..$SpackSubCommandArgs.Count]
+        switch ($SubCommandSubCommand) {
+            "activate" {
+                if (Compare-CommonArgs $SubCommandSubCommandArgs) {
+                    python $Env:SPACK_ROOT/bin/spack env activate $SubCommandSubCommandArgs
+                }
+                elseif ([bool]($SubCommandSubCommandArgs.Where({$_ -eq "--pwsh"}))) {
+                    python $Env:SPACK_ROOT/bin/spack env activate $SubCommandSubCommandArgs
+                }
+                elseif (!$SubCommandSubCommandArgs) {
+                    python $Env:SPACK_ROOT/bin/spack env activate $SubCommandSubCommandArgs
+                }
+                else {
+                    $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params env activate "--pwsh" $SubCommandSubCommandArgs)
+                    $ExecutionContext.InvokeCommand($SpackEnv)
+                }
+            }
+            "deactivate" {
+                if ([bool]($SubCommandSubCommandArgs.Where({$_ -eq "--pwsh"}))) {
+                    python $Env:SPACK_ROOT/bin/spack env deactivate $SubCommandSubCommandArgs
+                }
+                elseif($SubCommandSubCommandArgs) {
+                    python $Env:SPACK_ROOT/bin/spack env deactivate -h
+                }
+                else {
+                    $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params env deactivate --pwsh)
+                    $ExecutionContext.InvokeCommand($SpackEnv)
+                }
+            }
+            default {python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs}
+        }
+    }
+}
+
+function Invoke-SpackLoad {
+    if (Compare-CommonArgs $SpackSubCommandArgs) {
+        python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
+    }
+    elseif ([bool]($SpackSubCommandArgs.Where({($_ -eq "--pwsh") -or ($_ -eq "--list")}))) {
+        python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
+    }
+    else {
+        $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand "--pwsh" $SpackSubCommandArgs)
+        $ExecutionContext.InvokeCommand($SpackEnv)
+    }
+}
+
+
+$SpackCMD_params, $SpackSubCommand, $SpackSubCommandArgs = Read-SpackArgs $args
+
+if (Compare-CommonArgs $SpackCMD_params) {
+    python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
+    exit $LASTEXITCODE
+}
+
+# Process Spack commands with special conditions
+# all other commands are piped directly to Spack
+switch($SpackSubCommand)
+{
+    "cd"     {Invoke-SpackCD}
+    "env"    {Invoke-SpackEnv}
+    "load"   {Invoke-SpackLoad}
+    "unload" {Invoke-SpackLoad}
+    default  {python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs}
+}

--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -53,7 +53,7 @@ def shell_init_instructions(cmd, equivalent):
             equivalent.format(sh_arg="--csh ") + "  # csh/tcsh",
             equivalent.format(sh_arg="--fish") + "  # fish",
             equivalent.format(sh_arg="--bat ") + "  # batch",
-            equivalent.format(sh_arg="--pwsh") + "  # powershell"
+            equivalent.format(sh_arg="--pwsh") + "  # powershell",
         ]
     else:
         msg += ["  " + equivalent]

--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -36,7 +36,10 @@ def shell_init_instructions(cmd, equivalent):
         "  source %s/setup-env.fish" % spack.paths.share_path,
         "",
         color.colorize("@*c{For Windows batch:}"),
-        "  source %s/spack_cmd.bat" % spack.paths.share_path,
+        "  %s\\spack_cmd.bat" % spack.paths.bin_path,
+        "",
+        color.colorize("@*c{For PowerShell:}"),
+        "  %s\\setup-env.ps1" % spack.paths.share_path,
         "",
         "Or, if you do not want to use shell support, run "
         + ("one of these" if shell_specific else "this")
@@ -50,6 +53,7 @@ def shell_init_instructions(cmd, equivalent):
             equivalent.format(sh_arg="--csh ") + "  # csh/tcsh",
             equivalent.format(sh_arg="--fish") + "  # fish",
             equivalent.format(sh_arg="--bat ") + "  # batch",
+            equivalent.format(sh_arg="--pwsh") + "  # powershell"
         ]
     else:
         msg += ["  " + equivalent]

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -91,7 +91,7 @@ def env_activate_setup_parser(subparser):
         action="store_const",
         dest="shell",
         const="pwsh",
-        help="print powershell commands to activate environment"
+        help="print powershell commands to activate environment",
     )
 
     view_options = subparser.add_mutually_exclusive_group()

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -86,6 +86,13 @@ def env_activate_setup_parser(subparser):
         const="bat",
         help="print bat commands to activate the environment",
     )
+    shells.add_argument(
+        "--pwsh",
+        action="store_const",
+        dest="shell",
+        const="pwsh",
+        help="print powershell commands to activate environment"
+    )
 
     view_options = subparser.add_mutually_exclusive_group()
     view_options.add_argument(

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -81,6 +81,8 @@ def deactivate_header(shell):
         cmds += 'set "SPACK_ENV="\n'
         # TODO: despacktivate
         # TODO: prompt
+    elif shell == "pwsh":
+        cmds += "Remove-Item Env:SPACK_ENV"
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"
         cmds += "unset SPACK_ENV; export SPACK_ENV;\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -42,6 +42,8 @@ def activate_header(env, shell, prompt=None):
         cmds += 'set "SPACK_ENV=%s"\n' % env.path
         # TODO: despacktivate
         # TODO: prompt
+    elif shell == "pwsh":
+        cmds += "$Env:SPACK_ENV=%s\n" % env.path
     else:
         if "color" in os.getenv("TERM", "") and prompt:
             prompt = colorize("@G{%s}" % prompt, color=True, enclose=True)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1994,11 +1994,13 @@ class BuildProcessInstaller(object):
         # Do the real install in the source directory.
         with fs.working_dir(pkg.stage.source_path):
             # Save the build environment in a file before building.
+            # Need pwsh support here
             dump_environment(pkg.env_path)
 
             # Save just the changes to the environment.  This file can be
             # safely installed, since it does not contain secret variables.
             with open(pkg.env_mods_path, "w") as env_mods_file:
+                # Need pwsh support here
                 mods = self.env_mods.shell_modifications(explicit=True, env=self.unmodified_env)
                 env_mods_file.write(mods)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1994,13 +1994,11 @@ class BuildProcessInstaller(object):
         # Do the real install in the source directory.
         with fs.working_dir(pkg.stage.source_path):
             # Save the build environment in a file before building.
-            # Need pwsh support here
             dump_environment(pkg.env_path)
 
             # Save just the changes to the environment.  This file can be
             # safely installed, since it does not contain secret variables.
             with open(pkg.env_mods_path, "w") as env_mods_file:
-                # Need pwsh support here
                 mods = self.env_mods.shell_modifications(explicit=True, env=self.unmodified_env)
                 env_mods_file.write(mods)
 

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -44,7 +44,7 @@ def test_dump(tmpdir):
             if sys.platform == "win32":
                 is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
                 if is_pwsh:
-                    assert(any(line.startswith("$Env:PATH") for line in f.readlines()))
+                    assert any(line.startswith("$Env:PATH") for line in f.readlines())
                 else:
                     assert any(line.startswith('set "PATH=') for line in f.readlines())
             else:

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import pickle
 import sys
 
@@ -41,7 +42,11 @@ def test_dump(tmpdir):
         build_env("--dump", _out_file, "zlib")
         with open(_out_file) as f:
             if sys.platform == "win32":
-                assert any(line.startswith('set "PATH=') for line in f.readlines())
+                is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
+                if is_pwsh:
+                    assert(any(line.startswith("$Env:PATH") for line in f.readlines()))
+                else:
+                    assert any(line.startswith('set "PATH=') for line in f.readlines())
             else:
                 assert any(line.startswith("PATH=") for line in f.readlines())
 

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -35,18 +35,16 @@ def test_build_env_requires_a_spec(args):
 
 _out_file = "env.out"
 
-
+@pytest.mark.parametrize("shell", ["pwsh", "bat"] if sys.platform == "win32" else ["bash"])
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
-def test_dump(tmpdir):
+def test_dump(shell_as, shell, tmpdir):
     with tmpdir.as_cwd():
         build_env("--dump", _out_file, "zlib")
         with open(_out_file) as f:
-            if sys.platform == "win32":
-                is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
-                if is_pwsh:
-                    assert any(line.startswith("$Env:PATH") for line in f.readlines())
-                else:
-                    assert any(line.startswith('set "PATH=') for line in f.readlines())
+            if shell == "pwsh":
+                assert any(line.startswith("$Env:PATH") for line in f.readlines())
+            elif shell == "bat":
+                assert any(line.startswith('set "PATH=') for line in f.readlines())
             else:
                 assert any(line.startswith("PATH=") for line in f.readlines())
 

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 import pickle
 import sys
 
@@ -34,6 +33,7 @@ def test_build_env_requires_a_spec(args):
 
 
 _out_file = "env.out"
+
 
 @pytest.mark.parametrize("shell", ["pwsh", "bat"] if sys.platform == "win32" else ["bash"])
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1921,6 +1921,7 @@ def default_mock_concretization(config, mock_packages, concretized_specs_cache):
 
     return _func
 
+
 @pytest.fixture
 def shell_as(shell):
     if sys.platform != "win32":

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1925,6 +1925,7 @@ def default_mock_concretization(config, mock_packages, concretized_specs_cache):
 @pytest.fixture
 def shell_as(shell):
     if sys.platform != "win32":
+        yield
         return
     if shell not in ("pwsh", "bat"):
         raise RuntimeError("Shell must be one of supported Windows shells (pwsh|bat)")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1920,3 +1920,19 @@ def default_mock_concretization(config, mock_packages, concretized_specs_cache):
         return concretized_specs_cache[key].copy()
 
     return _func
+
+@pytest.fixture
+def shell_as(shell):
+    if sys.platform != "win32":
+        return
+    if shell not in ("pwsh", "bat"):
+        raise RuntimeError("Shell must be one of supported Windows shells (pwsh|bat)")
+    try:
+        # fetch and store old shell type
+        _shell = os.environ.get("SPACK_SHELL", None)
+        os.environ["SPACK_SHELL"] = shell
+        yield
+    finally:
+        # restore old shell if one was set
+        if _shell:
+            os.environ["SPACK_SHELL"] = _shell

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -6,7 +6,6 @@
 """Test Spack's environment utility functions."""
 import os
 import sys
-from contextlib import contextmanager
 
 import pytest
 

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -169,26 +169,13 @@ def test_escape_double_quotes_in_shell_modifications():
 
     to_validate.set("QUOTED_VAR", '"MY_VAL"')
 
-    # context manager to toggle shell on Windows
-    @contextmanager
-    def shell_set(shell):
-        try:
-            # stash previous set
-            _spack_shell = os.environ.get("SPACK_SHELL", "cmd")
-            os.environ["SPACK_SHELL"] = shell
-            yield
-        finally:
-            os.environ["SPACK_SHELL"] = _spack_shell
-
     if sys.platform == "win32":
-        with shell_set("pwsh"):
-            cmds = to_validate.shell_modifications()
-            assert "$Env:VAR=$PATH;$ANOTHER_PATH" in cmds
-            assert r'$Env:QUOTED_VAR="MY_VAL"' in cmds
-        with shell_set("cmd"):
-            cmds = to_validate.shell_modifications()
-            assert "set VAR=$PATH;$ANOTHER_PATH" in cmds
-            assert r'set QUOTED_VAR="MY_VAL"' in cmds
+        cmds = to_validate.shell_modifications(shell="bat")
+        assert r'set "VAR=$PATH;$ANOTHER_PATH"' in cmds
+        assert r'set "QUOTED_VAR="MY_VAL"' in cmds
+        cmds = to_validate.shell_modifications(shell="pwsh")
+        assert r'$Env:VAR=$PATH;$ANOTHER_PATH' in cmds
+        assert r'$Env:QUOTED_VAR="MY_VAL"' in cmds
     else:
         cmds = to_validate.shell_modifications()
         assert 'export VAR="$PATH:$ANOTHER_PATH"' in cmds

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -113,18 +113,18 @@ def test_path_put_first(prepare_environment_for_tests):
     assert envutil.get_path("TEST_ENV_VAR") == expected
 
 
-def test_dump_environment(prepare_environment_for_tests, tmpdir):
+@pytest.mark.parametrize("shell", ["pwsh", "bat"] if sys.platform == "win32" else ["bash"])
+def test_dump_environment(prepare_environment_for_tests, shell_as, shell, tmpdir):
     test_paths = "/a:/b/x:/b/c"
+    import pdb; pdb.set_trace()
     os.environ["TEST_ENV_VAR"] = test_paths
     dumpfile_path = str(tmpdir.join("envdump.txt"))
     envutil.dump_environment(dumpfile_path)
     with open(dumpfile_path, "r") as dumpfile:
-        if sys.platform == "win32":
-            is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
-            if is_pwsh:
-                assert "$Env:TEST_ENV_VAR={}\n".format(test_paths) in list(dumpfile)
-            else:
-                assert 'set "TEST_ENV_VAR={}"\n'.format(test_paths) in list(dumpfile)
+        if shell == "pwsh":
+            assert "$Env:TEST_ENV_VAR={}\n".format(test_paths) in list(dumpfile)
+        elif shell == "bat":
+            assert 'set "TEST_ENV_VAR={}"\n'.format(test_paths) in list(dumpfile)
         else:
             assert "TEST_ENV_VAR={0}; export TEST_ENV_VAR\n".format(test_paths) in list(dumpfile)
 

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -116,7 +116,6 @@ def test_path_put_first(prepare_environment_for_tests):
 @pytest.mark.parametrize("shell", ["pwsh", "bat"] if sys.platform == "win32" else ["bash"])
 def test_dump_environment(prepare_environment_for_tests, shell_as, shell, tmpdir):
     test_paths = "/a:/b/x:/b/c"
-    import pdb; pdb.set_trace()
     os.environ["TEST_ENV_VAR"] = test_paths
     dumpfile_path = str(tmpdir.join("envdump.txt"))
     envutil.dump_environment(dumpfile_path)

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -174,7 +174,7 @@ def test_escape_double_quotes_in_shell_modifications():
         assert r'set "VAR=$PATH;$ANOTHER_PATH"' in cmds
         assert r'set "QUOTED_VAR="MY_VAL"' in cmds
         cmds = to_validate.shell_modifications(shell="pwsh")
-        assert r'$Env:VAR=$PATH;$ANOTHER_PATH' in cmds
+        assert r"$Env:VAR=$PATH;$ANOTHER_PATH" in cmds
         assert r'$Env:QUOTED_VAR="MY_VAL"' in cmds
     else:
         cmds = to_validate.shell_modifications()

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -180,7 +180,7 @@ def test_escape_double_quotes_in_shell_modifications():
         finally:
             os.environ["SPACK_SHELL"] = _spack_shell
 
-    if sys.patform == "win32":
+    if sys.platform == "win32":
         with shell_set("pwsh"):
             cmds = to_validate.shell_modifications()
             assert "$Env:VAR=$PATH;$ANOTHER_PATH" in cmds

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -122,7 +122,7 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
         if sys.platform == "win32":
             is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
             if is_pwsh:
-                assert '$Env:TEST_ENV_VAR={}\n'.format(test_paths) in list(dumpfile)
+                assert "$Env:TEST_ENV_VAR={}\n".format(test_paths) in list(dumpfile)
             else:
                 assert 'set "TEST_ENV_VAR={}"\n'.format(test_paths) in list(dumpfile)
         else:

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -47,6 +47,7 @@ _SHELL_SET_STRINGS = {
     "csh": "setenv {0} {1};\n",
     "fish": "set -gx {0} {1};\n",
     "bat": 'set "{0}={1}"\n',
+    "pwsh": "$Env:{0}={1}\n"
 }
 
 
@@ -55,6 +56,7 @@ _SHELL_UNSET_STRINGS = {
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
     "bat": 'set "{0}="\n',
+    "pwsh": "Remove-Item Env:{0}\n"
 }
 
 
@@ -181,6 +183,7 @@ def _nix_env_var_to_source_line(var: str, val: str) -> str:
             fname=BASH_FUNCTION_FINDER.sub(r"\1", var), decl=val
         )
     else:
+        # Need pwsh support here
         source_line = f"{var}={double_quote_escape(val)}; export {var}"
     return source_line
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -185,7 +185,6 @@ def _nix_env_var_to_source_line(var: str, val: str) -> str:
             fname=BASH_FUNCTION_FINDER.sub(r"\1", var), decl=val
         )
     else:
-        # Need pwsh support here
         source_line = f"{var}={double_quote_escape(val)}; export {var}"
     return source_line
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -47,7 +47,7 @@ _SHELL_SET_STRINGS = {
     "csh": "setenv {0} {1};\n",
     "fish": "set -gx {0} {1};\n",
     "bat": 'set "{0}={1}"\n',
-    "pwsh": "$Env:{0}={1}\n"
+    "pwsh": "$Env:{0}={1}\n",
 }
 
 
@@ -56,7 +56,7 @@ _SHELL_UNSET_STRINGS = {
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
     "bat": 'set "{0}="\n',
-    "pwsh": "Remove-Item Env:{0}\n"
+    "pwsh": "Remove-Item Env:{0}\n",
 }
 
 
@@ -175,7 +175,7 @@ BASH_FUNCTION_FINDER = re.compile(r"BASH_FUNC_(.*?)\(\)")
 
 def _win_env_var_to_set_line(var: str, val: str) -> str:
     is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
-    env_set_phrase = f'$Env:{var}={val}' if is_pwsh else f'set "{var}={val}"'
+    env_set_phrase = f"$Env:{var}={val}" if is_pwsh else f'set "{var}={val}"'
     return env_set_phrase
 
 
@@ -698,7 +698,7 @@ class EnvironmentModifications:
 
     def shell_modifications(
         self,
-        shell: str = "sh",
+        shell: str = "sh" if sys.platform != "win32" else os.environ.get("SPACK_SHELL", "bat"),
         explicit: bool = False,
         env: Optional[MutableMapping[str, str]] = None,
     ) -> str:

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -174,7 +174,9 @@ BASH_FUNCTION_FINDER = re.compile(r"BASH_FUNC_(.*?)\(\)")
 
 
 def _win_env_var_to_set_line(var: str, val: str) -> str:
-    return f'set "{var}={val}"'
+    is_pwsh = os.environ.get("SPACK_SHELL", None) == "pwsh"
+    env_set_phrase = f'$Env:{var}={val}' if is_pwsh else f'set "{var}={val}"'
+    return env_set_phrase
 
 
 def _nix_env_var_to_source_line(var: str, val: str) -> str:

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -46,6 +46,10 @@ if ($null -eq $Env:EDITOR)
     $Env:EDITOR = "notepad"
 }
 
+# Set spack shell so we can detect powershell context
+$Env:SPACK_SHELL=pwsh
+
+doskey /exename=powershell.exe spack=$Env:SPACK_ROOT\bin\spack.ps1 $args
 
 Write-Output "*****************************************************************"
 Write-Output "**************** Spack Package Manager **************************"

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -47,7 +47,7 @@ if ($null -eq $Env:EDITOR)
 }
 
 # Set spack shell so we can detect powershell context
-$Env:SPACK_SHELL=pwsh
+$Env:SPACK_SHELL="pwsh"
 
 doskey /exename=powershell.exe spack=$Env:SPACK_ROOT\bin\spack.ps1 $args
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -935,7 +935,7 @@ _spack_env() {
 _spack_env_activate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat -v --with-view -V --without-view -p --prompt --temp -d --dir"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh -v --with-view -V --without-view -p --prompt --temp -d --dir"
     else
         _environments
     fi


### PR DESCRIPTION
PowerShell requires explicit shell and env support in Spack.
This is due to the distinct differences in shell interactions between
cmd and pwsh.
Add a doskey in pwsh piping 'spack' commands to a powershell script
similar to the sh function 'spack'
Additionally add improved support for PowerShell specific shell
interactions from Spack
Create env build artifacts that are actually useable from Windows shells