### PR TITLE
Add new variants + bison version min. to scotch

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -38,7 +38,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     build_system(conditional("cmake", when="@7:"), "makefile", default="cmake")
     variant("threads", default=True, description="use POSIX Pthreads within Scotch and PT-Scotch")
-    variant("mpi_thread", default=True, description="use multi-threaded algorithms")
+    variant("mpi_thread", default=False, description="use multi-threaded algorithms")
     variant("mpi", default=True, description="Compile parallel libraries")
     variant("compression", default=True, description="May use compressed files")
     variant("esmumps", default=False, description="Compile esmumps (needed by mumps)")
@@ -59,6 +59,7 @@ class Scotch(CMakePackage, MakefilePackage):
     depends_on("bison@3.4:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("zlib", when="+compression")
+    depends_on("openmpi +threads_multiple", when="+mpi +mpi_thread ^openmpi")
 
     # Version-specific patches
     patch("nonthreaded-6.0.4.patch", when="@6.0.4")

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -59,7 +59,7 @@ class Scotch(CMakePackage, MakefilePackage):
     depends_on("bison@3.4:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("zlib", when="+compression")
-    depends_on("openmpi +threads_multiple", when="+mpi +mpi_thread ^openmpi")
+    depends_on("openmpi +thread_multiple", when="+mpi +mpi_thread ^openmpi")
 
     # Version-specific patches
     patch("nonthreaded-6.0.4.patch", when="@6.0.4")

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -59,7 +59,6 @@ class Scotch(CMakePackage, MakefilePackage):
     depends_on("bison@3.4:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("zlib", when="+compression")
-    depends_on("openmpi +thread_multiple", when="+mpi +mpi_thread ^openmpi")
 
     # Version-specific patches
     patch("nonthreaded-6.0.4.patch", when="@6.0.4")

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -37,6 +37,8 @@ class Scotch(CMakePackage, MakefilePackage):
     version("5.1.10b", sha256="54c9e7fafefd49d8b2017d179d4f11a655abe10365961583baaddc4eeb6a9add")
 
     build_system(conditional("cmake", when="@7:"), "makefile", default="cmake")
+    variant("threads", default=True, description="use POSIX Pthreads within Scotch and PT-Scotch")
+    variant("mpi_thread", default=True, description="use multi-threaded algorithms in conjunction with MPI")
     variant("mpi", default=True, description="Compile parallel libraries")
     variant("compression", default=True, description="May use compressed files")
     variant("esmumps", default=False, description="Compile esmumps (needed by mumps)")
@@ -54,7 +56,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     # Does not build with flex 2.6.[23]
     depends_on("flex@:2.6.1,2.6.4:", type="build")
-    depends_on("bison", type="build")
+    depends_on("bison@3.4:", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("zlib", when="+compression")
 
@@ -115,9 +117,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("BUILD_LIBESMUMPS", "esmumps"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_PTSCOTCH", "mpi"),
+            self.define_from_variant("THREADS", "threads"),
+            self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread")
         ]
-
-        # TODO should we enable/disable THREADS?
 
         if "+int64" in spec:
             args.append("-DINTSIZE=64")

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -38,7 +38,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     build_system(conditional("cmake", when="@7:"), "makefile", default="cmake")
     variant("threads", default=True, description="use POSIX Pthreads within Scotch and PT-Scotch")
-    variant("mpi_thread", default=True, description="use multi-threaded algorithms in conjunction with MPI")
+    variant("mpi_thread", default=True, description="use multi-threaded algorithms")
     variant("mpi", default=True, description="Compile parallel libraries")
     variant("compression", default=True, description="May use compressed files")
     variant("esmumps", default=False, description="Compile esmumps (needed by mumps)")
@@ -118,7 +118,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_PTSCOTCH", "mpi"),
             self.define_from_variant("THREADS", "threads"),
-            self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread")
+            self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
         ]
 
         if "+int64" in spec:


### PR DESCRIPTION
- Add two variants (`threads` and `mpi_thread`) to the scotch package.py to enable control over use of POSIX Pthreads within scotch and pt-scotch &  the use of multi-threaded algorithms in conjunction with mpi
- Add minimum `bison` version based on this comment https://gitlab.inria.fr/scotch/scotch/-/issues/21 and updates to scotch installation requirements
