### PR TITLE
Add shared and pic variants to libtiff

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -76,6 +76,7 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     build_system(conditional("cmake", when="@4.0.5:"), "autotools", default="cmake")
 
     variant("shared", default=True, description="Build shared")
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
 
     with when("build_system=cmake"):
         depends_on("cmake@3.9:", when="@4.3:", type="build")
@@ -115,6 +116,8 @@ class CMakeBuilder(CMakeBuilder):
         args = [self.define_from_variant(var) for var in VARIANTS]
         args.append("-Dsphinx=OFF")
         args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+#        args += [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
+        args += ["-DCMAKE_POSITION_INDEPENDENT_CODE=ON"]
 
         # Remove empty strings
         args = [arg for arg in args if arg]
@@ -131,5 +134,6 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args.append("--disable-sphinx")
 
         args.extend(self.enable_or_disable("shared"))
+        args.extend(self.with_or_without("pic"))
 
         return args

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -75,6 +75,8 @@ class Libtiff(CMakePackage, AutotoolsPackage):
 
     build_system(conditional("cmake", when="@4.0.5:"), "autotools", default="cmake")
 
+    variant("shared", default=True, description="Build shared")
+
     with when("build_system=cmake"):
         depends_on("cmake@3.9:", when="@4.3:", type="build")
         depends_on("cmake@2.8.11:", when="@4.0.10:4.2", type="build")
@@ -112,6 +114,7 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define_from_variant(var) for var in VARIANTS]
         args.append("-Dsphinx=OFF")
+        args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
         # Remove empty strings
         args = [arg for arg in args if arg]
@@ -124,6 +127,9 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args = []
         for var in VARIANTS:
             args.extend(self.enable_or_disable(var))
+
         args.append("--disable-sphinx")
+
+        args.extend(self.enable_or_disable("shared"))
 
         return args

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -116,8 +116,7 @@ class CMakeBuilder(CMakeBuilder):
         args = [self.define_from_variant(var) for var in VARIANTS]
         args.append("-Dsphinx=OFF")
         args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
-#        args += [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
-        args += ["-DCMAKE_POSITION_INDEPENDENT_CODE=ON"]
+        args += [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 
         # Remove empty strings
         args = [arg for arg in args if arg]


### PR DESCRIPTION
This PR adds 'shared' and 'pic' variants to the libtiff package. These changes support NOAA/National Weather Service R&D and operational forecasting applications.