### PR TITLE
CMakePackage: remove -DBUILD_TESTING flag

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -274,7 +274,6 @@ class CMakeBuilder(BaseBuilder):
             generator,
             define("CMAKE_INSTALL_PREFIX", pathlib.Path(pkg.prefix).as_posix()),
             define("CMAKE_BUILD_TYPE", build_type),
-            define("BUILD_TESTING", pkg.run_tests),
         ]
 
         # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
@@ -451,7 +450,6 @@ class CMakeBuilder(BaseBuilder):
 
             * CMAKE_INSTALL_PREFIX
             * CMAKE_BUILD_TYPE
-            * BUILD_TESTING
 
         which will be set automatically.
         """


### PR DESCRIPTION
`-DBUILD_TESTING` is not a general CMake flag that exists for all CMake packages, it only exists [when CTest is used](https://cmake.org/cmake/help/latest/module/CTest.html) in CMakeLists.txt. The majority of packages I build issue the following warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
```
For packages that do use CTest, this flag should be added only to those packages, not all packages.