### PR TITLE
py-segmentation-models-pytorch: add v0.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-segmentation-models-pytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-segmentation-models-pytorch/package.py
@@ -12,6 +12,7 @@ class PySegmentationModelsPytorch(PythonPackage):
     homepage = "https://github.com/qubvel/segmentation_models.pytorch"
     pypi = "segmentation_models_pytorch/segmentation_models_pytorch-0.2.0.tar.gz"
 
+    version("0.3.3", sha256="b3b21ab4cd26a6b2b9e7a6ed466ace6452eb26ed3c31ae491ea2d7cbb01e384b")
     version("0.3.2", sha256="8372733e57a10cb8f6b9e18a20577fbb3fb83549b6945664dc774a9b6d3ecd13")
     version("0.3.1", sha256="d4a4817cf48872c3461bb7d22864c00f9d491719a6460adb252c035f9b0e8d51")
     version("0.3.0", sha256="8e00ed1707698d309d23f207aef15f21465e091aa0f1dc8043ec3300f5f67216")
@@ -23,7 +24,8 @@ class PySegmentationModelsPytorch(PythonPackage):
     depends_on("py-pretrainedmodels@0.7.4", type=("build", "run"))
     depends_on("py-efficientnet-pytorch@0.7.1", when="@0.3:", type=("build", "run"))
     depends_on("py-efficientnet-pytorch@0.6.3", when="@:0.2", type=("build", "run"))
-    depends_on("py-timm@0.6.12", when="@0.3.2:", type=("build", "run"))
+    depends_on("py-timm@0.9.2", when="@0.3.3", type=("build", "run"))
+    depends_on("py-timm@0.6.12", when="@0.3.2", type=("build", "run"))
     depends_on("py-timm@0.4.12", when="@:0.3.1", type=("build", "run"))
     depends_on("py-tqdm", when="@0.3:", type=("build", "run"))
     depends_on("pil", when="@0.3:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/qubvel/segmentation_models.pytorch/releases/tag/v0.3.3

Finally upgrades to newer timm which supports Python 3.11!