### PR TITLE
asdcplib: add v2_10_38

### DIFF
--- a/var/spack/repos/builtin/packages/asdcplib/package.py
+++ b/var/spack/repos/builtin/packages/asdcplib/package.py
@@ -12,6 +12,7 @@ class Asdcplib(AutotoolsPackage):
     homepage = "https://github.com/cinecert/asdcplib"
     url = "https://github.com/cinecert/asdcplib/archive/rel_2_10_35.tar.gz"
 
+    version("2_10_38", sha256="f8cb3b1fecfe18f1a64e12e96e5696480631509e9088e29f5a259eb25b1b1656")
     version("2_10_35", sha256="a68eec9ae0cc363f75331dc279c6dd6d3a9999a9e5f0a4405fd9afa8a29ca27b")
     version("2_10_34", sha256="faa54ee407c1afceb141e08dae9ebf83b3f839e9c49a1793ac741ec6cdee5c3c")
     version("2_10_33", sha256="16fafb5da3d46b0f44570ef9780c85dd82cca60106a9e005e538809ea1a95373")


### PR DESCRIPTION
Add asdcplib v2_10_38. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.