### PR TITLE
c-blosc: add v1.21.4

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -15,6 +15,7 @@ class CBlosc(CMakePackage):
     homepage = "https://www.blosc.org"
     url = "https://github.com/Blosc/c-blosc/archive/v1.11.1.tar.gz"
 
+    version("1.21.4", sha256="e72bd03827b8564bbb3dc3ea0d0e689b4863871ce3861d946f2efd7a186ecf3e")
     version("1.21.2", sha256="e5b4ddb4403cbbad7aab6e9ff55762ef298729c8a793c6147160c771959ea2aa")
     version("1.21.1", sha256="f387149eab24efa01c308e4cba0f59f64ccae57292ec9c794002232f7903b55b")
     version("1.21.0", sha256="b0ef4fda82a1d9cbd11e0f4b9685abf14372db51703c595ecd4d76001a8b342d")


### PR DESCRIPTION
Add c-blosc v1.21.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.