### PR TITLE
cracklib: add v2.9.9

### DIFF
--- a/var/spack/repos/builtin/packages/cracklib/package.py
+++ b/var/spack/repos/builtin/packages/cracklib/package.py
@@ -14,6 +14,7 @@ class Cracklib(AutotoolsPackage):
     homepage = "https://github.com/cracklib/cracklib"
     url = "https://github.com/cracklib/cracklib/archive/v2.9.7.tar.gz"
 
+    version("2.9.9", sha256="0a3fd72163512088c6f2add0f6cd6e34954ca0fa3f333ff9cced478b04e73ce1")
     version("2.9.7", sha256="ff4e6c3f86494c93719f5e4186e2c3ea9e265f41972ec21f7b87852aced704e6")
     version("2.9.6", sha256="7cd2c01365f199c466b490ad2585beccbe0108ccd606c1bcc6c1e52800e627fe")
     version("2.9.5", sha256="b3fcf3fba2f4566f8eb2b79502d1a66198a71c557d2ab1011c78001489f0fe26")


### PR DESCRIPTION
Add cracklib v2.9.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.