### PR TITLE
SEACAS: Restrict allowable fmt versions

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -138,7 +138,7 @@ class Seacas(CMakePackage):
     depends_on("hdf5+hl~mpi", when="~mpi")
 
     depends_on("fmt@8.1.0:", when="@2022-03-04:2022-05-16")
-    depends_on("fmt@9.1.0:", when="@2022-10-14")
+    depends_on("fmt@9.1.0", when="@2022-10-14")
     depends_on("matio", when="+matio")
     depends_on("libx11", when="+x11")
 


### PR DESCRIPTION
The specified release does not work with the current version of lib::fmt and only works with fmt-9.1.0.  Restrict the fmt requirement to that version.