### PR TITLE
seacas: Add latest release; update fmt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -32,6 +32,9 @@ class Seacas(CMakePackage):
     # ###################### Versions ##########################
     version("master", branch="master")
     version(
+        "2023-05-30", sha256="3dd982841854466820a3902163ad1cf1b3fbab65ed7542456d328f2d1a5373c1"
+    )
+    version(
         "2022-10-14", sha256="cde91e7561d2352045d669a25bdf46a604d85ed1ea7f3f5028004455e4ce9d56"
     )
     version(
@@ -138,7 +141,8 @@ class Seacas(CMakePackage):
     depends_on("hdf5+hl~mpi", when="~mpi")
 
     depends_on("fmt@8.1.0:", when="@2022-03-04:2022-05-16")
-    depends_on("fmt@9.1.0:", when="@2022-10-14")
+    depends_on("fmt@9.1.0", when="@2022-10-14")
+    depends_on("fmt@9.1.0:", when="@2023-05-30")
     depends_on("matio", when="+matio")
     depends_on("libx11", when="+x11")
 


### PR DESCRIPTION
The fmt dependency for the previous release was incorrect as does not work with latest lib::fmt.  Fixed that specification

Added latest seacas periodic snapshot