### PR TITLE
tests/oommf: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/oommf/package.py
+++ b/var/spack/repos/builtin/packages/oommf/package.py
@@ -39,13 +39,6 @@ class Oommf(Package):
     # default URL for versions
     url = "https://github.com/fangohr/oommf/archive/refs/tags/20a1_20180930_ext.tar.gz"
 
-    #: post-install phase methods used to check the installation
-    install_time_test_callbacks = [
-        "check_install_version",
-        "check_install_platform",
-        "check_install_stdprob3",
-    ]
-
     maintainers("fangohr")
 
     version(
@@ -210,14 +203,20 @@ class Oommf(Package):
         # set OOMMFTCL so ubermag / oommf can find oommf
         env.set("OOMMFTCL", join_path(oommfdir, "oommf.tcl"))
 
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def check_install_version(self):
         print("checking oommf.tcl can execute (+version)")
         self.test_version()
 
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def check_install_platform(self):
         print("checking oommf.tcl can execute (+platform)")
         self.test_platform()
 
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def check_install_stdprob3(self):
         print("Testing oommf.tcl standard problem 3")
         self.test_stdprob3()


### PR DESCRIPTION
Converts build-time tests for re-use as stand-alone tests to use the new process

This PR also switches the definition of build-time tests to use the standard, documented process (see the bottom of the following section https://spack.readthedocs.io/en/latest/packaging_guide.html#adding-installation-phase-tests).

Build-time test output:
```
$ spack install --test=root oommf
$ cat $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/.spack/spack-build-out.txt
...
==> oommf: Executing phase: 'install'
Found 'oommf.tcl' in /tmp/dahlgren/spack-stage/spack-stage-oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/spack-src/oommf (looks like source from Github)
==> [2023-05-30-15:52:12.576488] Installing . to $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
==> [2023-05-30-15:52:27.714586] Installing $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/oommf.tcl to $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin
checking oommf.tcl can execute (+version)
==> [2023-05-30-15:52:27.725784] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' '+version'
<1466540> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
<1466540> OOMMF 2.0b0  info:
OOMMF 2.0b0
checking oommf.tcl can execute (+platform)
==> [2023-05-30-15:52:27.852838] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' '+platform'
OOMMF release 2.0b0
Platform Name:		linux-x86_64
Tcl name for OS:	Linux 4.18.0-425.13.1.1toss.t4.x86_64
C++ compiler:   	/usr/WS1/dahlgren/spack/lib/spack/env/gcc/g++
 Version string:	 [spack cc] ERROR: Spack compiler must be run from Spack! Input 'SPACK_ENV_PATH' is missing.
Shell details ---
 tclsh (running): 	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh
                  	(links to $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh8.6)
                  	 --> Version 8.6.12, 64 bit, threaded
 tclsh (OOMMF): 	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh8.6
                  	 --> Version 8.6.12, 64 bit, threaded
 filtersh:           	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/omfsh/linux-x86_64/filtersh
                  	 --> Version 8.6.12, 64 bit, 64 bit, threaded
                  	 *** filtersh RUN ERROR: Tcl patchlevel = 8.6.12
tcl_platform(byteOrder)     = littleEndian
tcl_platform(engine)        = Tcl
tcl_platform(machine)       = x86_64
tcl_platform(os)            = Linux
tcl_platform(osVersion)     = 4.18.0-425.13.1.1toss.t4.x86_64
tcl_platform(pathSeparator) = :
tcl_platform(platform)      = unix
tcl_platform(pointerSize)   = 8
tcl_platform(threaded)      = 1
tcl_platform(user)          = dahlgren
tcl_platform(wordSize)      = 8
Tk version = n/a
WARNING: This version of OOMMF requires g++ 4.7 or later (C++11 support)
                  	 *** This may indicate a Tcl/Tk library version mismatch ***
 tclConfig.sh:        	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/lib/tclConfig.sh
                      	 --> Version 8.6.12
 wish (OOMMF):        	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-nomue4anygqcq63ceqiiqusadqwdavky/bin/wish8.6
 tkConfig.sh:         	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-nomue4anygqcq63ceqiiqusadqwdavky/lib/tkConfig.sh
                      	 --> Tk Version 8.6.11
OOMMF threads:         	Yes: Default thread count = 4
  NUMA support:        	 No
OOMMF API index:       	20181207
Temp file directory: 	/tmp

Relevant environment variables:
  OOMMF_ROOT = $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf

Please see the Installation section of the OOMMF User's Guide
for more information.
<1466541> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
WARNING: This version of OOMMF requires g++ 4.7 or later (C++11 support)
Testing oommf.tcl standard problem 3
==> [2023-05-30-15:52:28.566163] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' 'boxsi' '+fg' '-kill' 'all' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif'
Start: "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif"
Options: -kill all -threads 4
Boxsi version 2.0b0
Running on: quartz1532.llnl.gov
OS/machine: Linux/x86_64
User: dahlgren	PID: 1466562
Number of threads: 4
Mesh geometry: 32 x 32 x 32 = 32 768 cells
Checkpoint file: $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/sp3-random-seed0000.restart
Boxsi run end.
<1466559> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
Logging to file "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/boxsi.errors"

[Boxsi<1466562-quartz1532-dahlgren> 15:52:29.602 2023-05-30] 2.0b0 infolog:
Start: "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif"
Options: -kill all -threads 4

[Boxsi<1466562-quartz1532-dahlgren> 15:52:29.636 2023-05-30] 2.0b0 Oxs_Mif info:
A=1.3939050109491238e-10, K1=100000.0, Ms=1261566.2610100801, lex=1.1806375442739078e-08, L=8.47, seed=0

[Boxsi<1466562-quartz1532-dahlgren> 15:52:30.118 2023-05-30] 2.0b0 infolog:
Boxsi version 2.0b0
Running on: quartz1532.llnl.gov
OS/machine: Linux/x86_64
User: dahlgren	PID: 1466562
Number of threads: 4
Mesh geometry: 32 x 32 x 32 = 32 768 cells
Checkpoint file: $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/sp3-random-seed0000.restart

[Boxsi<1466562-quartz1532-dahlgren> 15:52:30.234 2023-05-30] 2.0b0 infolog:
Loaded "stdprob3.mif", CRC: 0xF7D16E90, 6850 bytes 

[Boxsi<1466562-quartz1532-dahlgren> 15:52:42.996 2023-05-30] 2.0b0 infolog:
End "stdprob3.mif"
```

Stand-alone test output:
```
$ spack -v test run oommf
==> Spack test uwjtiat3mngre7xtrvcr4e2ljwmbowus
==> Testing package oommf-20b0_20220930-hecpsa5
==> [2023-05-30-16:02:24.754102] test: test_platform: Check oommf.tcl can execute (+platform)
==> [2023-05-30-16:02:24.755876] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' '+platform'
OOMMF release 2.0b0
Platform Name:		linux-x86_64
Tcl name for OS:	Linux 4.18.0-425.13.1.1toss.t4.x86_64
C++ compiler:   	/usr/tce/bin/g++
 Version string:	 g++ (GCC) 10.3.1 20210422 (Red Hat 10.3.1-1) / x86_64-redhat-linux
Shell details ---
 tclsh (running): 	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh
                  	(links to $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh8.6)
                  	 --> Version 8.6.12, 64 bit, threaded
 tclsh (OOMMF): 	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh8.6
                  	 --> Version 8.6.12, 64 bit, threaded
 filtersh:           	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/omfsh/linux-x86_64/filtersh
                  	 --> Version 8.6.12, 64 bit, threaded
 tclConfig.sh:        	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/lib/tclConfig.sh
                      	 --> Version 8.6.12
 wish (OOMMF):        	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-nomue4anygqcq63ceqiiqusadqwdavky/bin/wish8.6
 tkConfig.sh:         	$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-nomue4anygqcq63ceqiiqusadqwdavky/lib/tkConfig.sh
                      	 --> Tk Version 8.6.11
OOMMF threads:         	Yes: Default thread count = 4
  NUMA support:        	 No
OOMMF API index:       	20181207
Temp file directory: 	/tmp

Relevant environment variables:
  OOMMF_ROOT = $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
<1468606> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
PASSED: Oommf::test_platform
==> [2023-05-30-16:02:25.294055] test: test_stdprob3: check standard problem 3
==> [2023-05-30-16:02:25.295316] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' 'boxsi' '+fg' '-kill' 'all' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif'
Start: "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif"
Options: -kill all -threads 4
Boxsi version 2.0b0
Running on: quartz1532.llnl.gov
OS/machine: Linux/x86_64
User: dahlgren	PID: 1468625
Number of threads: 4
Mesh geometry: 32 x 32 x 32 = 32 768 cells
Checkpoint file: $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/sp3-random-seed0000.restart
Boxsi run end.
<1468622> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
Logging to file "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/boxsi.errors"

[Boxsi<1468625-quartz1532-dahlgren> 16:02:26.228 2023-05-30] 2.0b0 infolog:
Start: "$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/stdprob3.mif"
Options: -kill all -threads 4

[Boxsi<1468625-quartz1532-dahlgren> 16:02:26.262 2023-05-30] 2.0b0 Oxs_Mif info:
A=1.3939050109491238e-10, K1=100000.0, Ms=1261566.2610100801, lex=1.1806375442739078e-08, L=8.47, seed=0

[Boxsi<1468625-quartz1532-dahlgren> 16:02:26.633 2023-05-30] 2.0b0 infolog:
Boxsi version 2.0b0
Running on: quartz1532.llnl.gov
OS/machine: Linux/x86_64
User: dahlgren	PID: 1468625
Number of threads: 4
Mesh geometry: 32 x 32 x 32 = 32 768 cells
Checkpoint file: $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf/app/oxs/examples/sp3-random-seed0000.restart

[Boxsi<1468625-quartz1532-dahlgren> 16:02:26.645 2023-05-30] 2.0b0 infolog:
Loaded "stdprob3.mif", CRC: 0xF7D16E90, 6850 bytes 

[Boxsi<1468625-quartz1532-dahlgren> 16:02:38.946 2023-05-30] 2.0b0 infolog:
End "stdprob3.mif"
PASSED: Oommf::test_stdprob3
==> [2023-05-30-16:02:38.962762] test: test_version: check oommf.tcl can execute (+version)
==> [2023-05-30-16:02:38.963965] '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-ezqfrghp2fjnqxiwylput6m2aswjbl5z/bin/tclsh' '$SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl' '+version'
<1468734> oommf   warning:
OOMMF_ROOT is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/usr/bin/oommf
Running app is $SPACK_ROOT/linux-rhel8-broadwell/gcc-10.3.1/oommf-20b0_20220930-hecpsa5oawv5f47j77vrexc2yywjyq7y/bin/oommf.tcl
Is that what you intend?
<1468734> OOMMF 2.0b0  info:
OOMMF 2.0b0
PASSED: Oommf::test_version
==> [2023-05-30-16:02:39.049750] Completed testing
==> [2023-05-30-16:02:39.049904] 
===================== SUMMARY: oommf-20b0_20220930-hecpsa5 =====================
Oommf::test_platform .. PASSED
Oommf::test_stdprob3 .. PASSED
Oommf::test_version .. PASSED
============================= 3 passed of 3 parts ==============================
============================== 1 passed of 1 spec ==============================
```