### PR TITLE
tests/octopus: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -130,6 +130,10 @@ class Octopus(AutotoolsPackage, CudaPackage):
     # TODO: etsf-io, sparskit,
     # feast, libfm, pfft, isf, pnfft, poke
 
+    # Don't run the default command 'make check' for test
+    # as it takes too long to finish
+    build_time_test_callbacks = []
+
     def configure_args(self):
         spec = self.spec
         lapack = spec["lapack"].libs

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -76,6 +76,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         description="Compile with PNFFT - Parallel Nonequispaced FFT library",
     )
     variant("debug", default=False, description="Compile with debug flags")
+    variant("gdlib", default=True, description="Compile with GD image-processing library")
 
     depends_on("autoconf", type="build", when="@develop")
     depends_on("automake", type="build", when="@develop")
@@ -251,6 +252,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         # --with-berkeleygw-prefix=${prefix}
         if "+berkeleygw" in spec:
             args.append("--with-berkeleygw-prefix=%s" % spec["berkeleygw"].prefix)
+
+        args.extend(self.enable_or_disable("gdlib"))
 
         # When preprocessor expands macros (i.e. CFLAGS) defined as quoted
         # strings the result may be > 132 chars and is terminated.


### PR DESCRIPTION
Converted tests to use new stand-alone test process.  ~~Unfortunately, I cannot yet build the package:~~

UPDATE:
According to `configure`, `gdlib` can be disabled so this PR also adds a variant so I can test the package again.

Installing with the new variant:
```
$ spack install --test=root octopus~gdlib
...
==> Installing octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m [26/26]
==> No binary for octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m found: installing from source
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/b4/b4d0fd496c31a9c4aa4677360e631765049373131e61f396b00048235057aeb1.tar.gz
==> No patches needed for octopus
==> octopus: Executing phase: 'autoreconf'
==> octopus: Executing phase: 'configure'
==> octopus: Executing phase: 'build'
==> octopus: Executing phase: 'install'
==> octopus: Successfully installed octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m
  Stage: 1.48s.  Autoreconf: 0.00s.  Configure: 39.11s.  Build: 5m 29.54s.  Install: 23.47s.  Post-install: 10.69s.  Total: 6m 46.49s
[+] SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m
1148.388u 95.702s 7:49.25 265.1%    0+0k 525856+804912io 127pf+0w
```

And testing the above installation:
```
$ spack -v test run octopus
==> Spack test xoajsveoxu6qltmlvnihzc3hwtoske4i
==> Testing package octopus-13.0-dbslafr
==> [2023-07-27-16:06:13.556589] test: test_he: run tiny calculation for He
Current working directory (in example-he)
copying he.inp from SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test
==> [2023-07-27-16:06:13.560508] Copying SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test/he.inp to inp
==> [2023-07-27-16:06:13.571785] 'SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m/bin/octopus' 
    <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
                                ___
                             .-'   `'.
                            /         \
                            |         ;
                            |         |           ___.--,
                   _.._     |0) ~ (0) |    _.---'`__.-( (_.
            __.--'`_.. '.__.\    '--. \_.-' ,.--'`     `""`
           ( ,.--'`   ',__ /./;   ;, '.__.'`    __
           _`) )  .---.__.' / |   |\   \__..--""  """--.,_
          `---' .'.''-._.-'`_./  /\ '.  \ _.-~~~````~~~-._`-.__.'
                | |  .' _.-' |  |  \  \  '.               `~---`
                 \ \/ .'     \  \   '. '-._)
...
PASSED: Octopus::test_recipe
==> [2023-07-27-16:06:17.074766] test: test_version: check version output
==> [2023-07-27-16:06:17.075524] 'SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/octopus-13.0-dbslafrveqvzxvif2xjuaxagu6dj3k7m/bin/octopus' '--version'
octopus 13.0 (git commit )   
PASSED: Octopus::test_version         
==> [2023-07-27-16:06:17.126298] Completed testing
==> [2023-07-27-16:06:17.126473]      
======================== SUMMARY: octopus-13.0-dbslafr =========================
Octopus::test_he .. PASSED
Octopus::test_recipe .. PASSED
Octopus::test_version .. PASSED   
============================= 3 passed of 3 parts ==============================
============================== 1 passed of 1 spec ==============================
```