### PR TITLE
tests/mfem: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -1113,33 +1113,26 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         # Clean the 'examples' directory -- at least one example is always built
         # and we do not want to cache executables.
-        make("examples/clean", parallel=False)
+        make(join_path("examples", "clean"), parallel=False)
         self.cache_extra_test_sources([self.examples_src_dir, self.examples_data_dir])
 
-    def test(self):
-        test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
-
+    def test_ex10(self):
+        """build and run ex10(p)"""
         # MFEM has many examples to serve as a suitable smoke check. ex10
         # was chosen arbitrarily among the examples that work both with
         # MPI and without it
-        test_exe = "ex10p" if ("+mpi" in self.spec) else "ex10"
-        self.run_test(
-            "make",
-            ["CONFIG_MK={0}/share/mfem/config.mk".format(self.prefix), test_exe, "parallel=False"],
-            purpose="test: building {0}".format(test_exe),
-            skip_missing=False,
-            work_dir=test_dir,
-        )
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-        self.run_test(
-            "./{0}".format(test_exe),
-            ["--mesh", "../{0}/beam-quad.mesh".format(self.examples_data_dir)],
-            [],
-            installed=False,
-            purpose="test: running {0}".format(test_exe),
-            skip_missing=False,
-            work_dir=test_dir,
-        )
+        makefile = join_path(self.prefix.share.mfem, "config.mk")
+        mesh = join_path("..", self.examples_data_dir, "beam-quad.mesh")
+        test_exe = "ex10p" if ("+mpi" in self.spec) else "ex10"
+
+        with working_dir(test_dir):
+            make = which("make")
+            make("CONFIG_MK={0}".format(makefile), test_exe, "parallel=False")
+
+            ex10 = which(test_exe)
+            ex10("--mesh", mesh)
 
     # this patch is only needed for mfem 4.1, where a few
     # released files include byte order marks

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -1113,7 +1113,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         # Clean the 'examples' directory -- at least one example is always built
         # and we do not want to cache executables.
-        make(join_path("examples", "clean"), parallel=False)
+        make("examples/clean", parallel=False)
         self.cache_extra_test_sources([self.examples_src_dir, self.examples_data_dir])
 
     def test_ex10(self):
@@ -1123,13 +1123,12 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         # MPI and without it
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-        makefile = join_path(self.prefix.share.mfem, "config.mk")
         mesh = join_path("..", self.examples_data_dir, "beam-quad.mesh")
         test_exe = "ex10p" if ("+mpi" in self.spec) else "ex10"
 
         with working_dir(test_dir):
             make = which("make")
-            make("CONFIG_MK={0}".format(makefile), test_exe, "parallel=False")
+            make(f"CONFIG_MK={self.config_mk}", test_exe, "parallel=False")
 
             ex10 = which(test_exe)
             ex10("--mesh", mesh)


### PR DESCRIPTION
Converted the tests to use the new stand-alone process.

```
$ spack -v test run mfem
==> Spack test sbsacbrcjaqbjesodlooyuyiiriyg3od
==> Testing package mfem-4.5.2-m5wdmkv
==> [2023-05-30-18:09:16.124917] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/mfem-4.5.2-m5wdmkvafh22cab7zzrld3xr6ynkl4gi/.spack/test to /g/g21/dahlgren/.spack/test/sbsacbrcjaqbjesodlooyuyiiriyg3od/mfem-4.5.2-m5wdmkv/cache/mfem
==> [2023-05-30-18:09:17.991152] test: test_ex10: build and run ex10(p)
==> [2023-05-30-18:09:17.993398] '/usr/bin/make' 'CONFIG_MK=/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/mfem-4.5.2-m5wdmkvafh22cab7zzrld3xr6ynkl4gi/share/mfem/config.mk' 'ex10p' 'parallel=False'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/mpich-4.1.1-f45emryjrbd7zrjh67umgmmpakut5d6o/bin/mpic++  -O3 -std=c++11 -I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/mfem-4.5.2-m5wdmkvafh22cab7zzrld3xr6ynkl4gi/include -I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hypre-2.28.0-qrva6r3wron4wfscacosfdrx62jhct6s/include -I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt/include -I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/zlib-1.2.13-y2akifnboe4ifn45ylmv7yafd325sc5r/include ex10p.cpp -o ex10p -L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/mfem-4.5.2-m5wdmkvafh22cab7zzrld3xr6ynkl4gi/lib -lmfem -Wl,-rpath,/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hypre-2.28.0-qrva6r3wron4wfscacosfdrx62jhct6s/lib -Wl,-rpath,/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openblas-0.3.23-ncqllezazdfjsywzgy3zvfp7zruigtly/lib -L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hypre-2.28.0-qrva6r3wron4wfscacosfdrx62jhct6s/lib -L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openblas-0.3.23-ncqllezazdfjsywzgy3zvfp7zruigtly/lib -lHYPRE -lopenblas -Wl,-rpath,/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt/lib -L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/metis-5.1.0-ksajziznf544wn4ts5wrbjpxagz4hilt/lib -lmetis -lrt -Wl,-rpath,/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/zlib-1.2.13-y2akifnboe4ifn45ylmv7yafd325sc5r/lib -L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/zlib-1.2.13-y2akifnboe4ifn45ylmv7yafd325sc5r/lib -lz
==> [2023-05-30-18:09:22.726316] './ex10p' '--mesh' '../data/beam-quad.mesh'
Options used:
   --mesh ../data/beam-quad.mesh
   --refine-serial 2
   --refine-parallel 0
   --order 2
   --ode-solver 3
   --t-final 300
   --time-step 3
   --viscosity 0.01
   --shear-modulus 0.25
   --bulk-modulus 5
   --adaptive-lin-rtol
   --visualization
   --visualization-steps 1
Number of velocity/deformation unknowns: 1170
GLVis visualization paused. Press space (in the GLVis window) to resume it.
initial elastic energy (EE) = 2.593e-17
initial kinetic energy (KE) = 0.032381
initial   total energy (TE) = 0.032381
Newton iteration  0 : ||r|| = 0.148477
Eisenstat-Walker rtol = 0.5
Newton iteration  1 : ||r|| = 0.0878991, ||r||/||r_0|| = 0.592004
...
Newton iteration  1 : ||r|| = 0.00203276, ||r||/||r_0|| = 0.592907
Eisenstat-Walker rtol = 0.429225
Newton iteration  2 : ||r|| = 0.000748613, ||r||/||r_0|| = 0.218352
Eisenstat-Walker rtol = 0.254491
Newton iteration  3 : ||r|| = 0.000190075, ||r||/||r_0|| = 0.0554402
Eisenstat-Walker rtol = 0.109234
Newton iteration  4 : ||r|| = 1.97944e-05, ||r||/||r_0|| = 0.00577356
Eisenstat-Walker rtol = 0.025732
Newton iteration  5 : ||r|| = 5.03194e-07, ||r||/||r_0|| = 0.000146769
Eisenstat-Walker rtol = 0.00262752
Newton iteration  6 : ||r|| = 1.29893e-09, ||r||/||r_0|| = 3.78867e-07
Eisenstat-Walker rtol = 6.49062e-05
Newton iteration  7 : ||r|| = 1.41304e-13, ||r||/||r_0|| = 4.12149e-11
step 100, t = 300, EE = 0.0119584, KE = 0.000784203, ΔTE = -0.0196383
PASSED: Mfem::test_ex10
==> [2023-05-30-18:10:08.843411] Completed testing
==> [2023-05-30-18:10:08.843559] 
========================= SUMMARY: mfem-4.5.2-m5wdmkv ==========================
Mfem::test_ex10 .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```