### PR TITLE
dd4hep: fix setting LD_LIBRARY_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -229,8 +229,7 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
-        env.set("LD_LIBRARY_PATH", self.prefix.lib)
-        env.set("LD_LIBRARY_PATH", self.prefix.lib64)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec['dd4hep'].libs.directories[0])
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -229,7 +229,7 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
-        env.prepend_path("LD_LIBRARY_PATH", self.spec['dd4hep'].libs.directories[0])
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["dd4hep"].libs.directories[0])
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero


### PR DESCRIPTION
I used `env.set` by mistake instead of `env.prepend_path` and the second call overrides the first one