### PR TITLE
pika: add 0.16.0 and pika-algorithms 0.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -15,6 +15,7 @@ class PikaAlgorithms(CMakePackage):
     git = "https://github.com/pika-org/pika-algorithms.git"
     maintainers("msimberg", "albestro", "teonnik", "aurianer")
 
+    version("0.1.3", sha256="53b79fcc0e5decc0a4d70abf0897a4f66141b85eea6d65013f51eec02ad123b7")
     version("0.1.2", sha256="286cf5c4db06717fa66c681cec8c99207154dd07e72d72f2b5b4a3cb9ff698bf")
     version("0.1.1", sha256="4aae88ac19864fd278bbdb49ae56348014c3d0d4b49a46ab3b9ba8a180f745f6")
     version("0.1.0", sha256="64da008897dfa7373155595c46d2ce6b97a8a3cb5bea33ae7f2d1ff359f0d9b6")
@@ -44,6 +45,7 @@ class PikaAlgorithms(CMakePackage):
     depends_on("pika@0.11:")
     depends_on("pika@0.11", when="@0.1.0")
     depends_on("pika@0.11:0.12", when="@0.1.1")
+    depends_on("pika@0.11:0.15", when="@0.1.2")
 
     for cxxstd in cxxstds:
         depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -17,6 +17,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pika-org/pika.git"
     maintainers("msimberg", "albestro", "teonnik", "aurianer")
 
+    version("0.16.0", sha256="59f2baec91cc9bf71ca96d21d0da1ec0092bf59da106efa51789089e0d7adcbb")
     version("0.15.1", sha256="b68b87cf956ad1448f5c2327a72ba4d9fb339ecabeabb0a87b8ea819457e293b")
     version("0.15.0", sha256="4ecd5b64bd8067283a161e1aeacfbab7658d89fe1504b788fd3236298fe66b00")
     version("0.14.0", sha256="c0fc10a3c2c24bccbdc292c22a3373a2ad579583ee9d8bd31aaf1755e49958a4")
@@ -90,8 +91,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("boost@1.71:")
     depends_on("fmt@9:", when="@0.11:")
     # https://github.com/pika-org/pika/issues/686
-    conflicts("fmt@10:", when="+cuda")
-    conflicts("fmt@10:", when="+rocm")
+    conflicts("fmt@10:", when="@:0.15 +cuda")
+    conflicts("fmt@10:", when="@:0.15 +rocm")
     depends_on("hwloc@1.11.5:")
 
     depends_on("gperftools", when="malloc=tcmalloc")


### PR DESCRIPTION
Also adds pika-algorithms 0.1.3 which fixes compilation with pika 0.16.0.

Adds and updates a few conflicts in both packages:
- pika-algorithms does not compile with pika 0.16.0 so require `pika@0.11:0.15`
- cap the previously introduced `fmt@10` conflict at `pika@0.15` since that has been fixed in 0.16.0