### PR TITLE
[build_systems/intel] Use self.compiler.cc if self.compiler.cc is gcc

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -715,7 +715,10 @@ class IntelPackage(Package):
     def _gcc_executable(self):
         """Return GCC executable"""
         # Match the available gcc, as it's done in tbbvars.sh.
-        gcc_name = "gcc"
+        if isinstance(self.compiler, spack.compiler.Gcc):
+            gcc_name = self.compiler.cc
+        else:
+            gcc_name = "gcc"
         # but first check if -gcc-name is specified in cflags
         for flag in self.spec.compiler_flags["cflags"]:
             if flag.startswith("-gcc-name="):


### PR DESCRIPTION
Our cluster hides the system (`/usr`) gcc install. As a result, dependents that depend on `tbb` provided by an `IntelPackage` fail to build. This changes behavior such that spack no longer depends on the system gcc when `self.compiler` is gcc.