### PR TITLE
Refactor code in `spack.compilers`

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -215,6 +215,7 @@ nitpick_ignore = [
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),
     ("py:class", "spack.spec.SpecfileReaderBase"),
+    ("py:class", "spack.spec.ArchSpec"),
     ("py:class", "spack.install_test.Pb"),
 ]
 

--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -35,7 +35,7 @@ class ABI:
         from spack.build_environment import dso_suffix
 
         spec = CompilerSpec("gcc", version)
-        compilers = spack.compilers.compilers_for_spec(spec)
+        compilers = spack.compilers.CompilerQuery(spec).all_compilers()
         if not compilers:
             return None
         compiler = compilers[0]

--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -7,9 +7,6 @@ import os
 
 from llnl.util.lang import memoized
 
-import spack.spec
-from spack.compilers.clang import Clang
-from spack.spec import CompilerSpec
 from spack.util.executable import Executable, ProcessError
 
 
@@ -32,9 +29,11 @@ class ABI:
     def _gcc_get_libstdcxx_version(self, version):
         """Returns gcc ABI compatibility info by getting the library version of
         a compiler's libstdc++ or libgcc_s"""
+        import spack.spec
         from spack.build_environment import dso_suffix
+        from spack.compilers.clang import Clang
 
-        spec = CompilerSpec("gcc", version)
+        spec = spack.spec.CompilerSpec("gcc", version)
         compilers = spack.compilers.CompilerQuery(spec).all_compilers()
         if not compilers:
             return None

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -88,19 +88,24 @@ def compiler_find(args):
     # Below scope=None because we want new compilers that don't appear
     # in any other configuration.
     new_compilers = spack.compilers.find_new_compilers(paths, scope=None)
+    config = spack.config.config
     if new_compilers:
         spack.compilers.add_compilers_to_config(new_compilers, scope=args.scope, init_config=False)
         n = len(new_compilers)
         s = "s" if n > 1 else ""
 
-        config = spack.config.config
         filename = config.get_config_filename(args.scope, "compilers")
         tty.msg("Added %d new compiler%s to %s" % (n, s, filename))
         colify(reversed(sorted(c.spec.display_str for c in new_compilers)), indent=4)
     else:
         tty.msg("Found no new compilers")
     tty.msg("Compilers are defined in the following files:")
-    colify(spack.compilers.compiler_config_files(), indent=4)
+    config_files = [
+        config.get_config_filename(scope.name, "compilers")
+        for scope in config.file_scopes
+        if config.get("compilers", scope=scope.name)
+    ]
+    colify(config_files, indent=4)
 
 
 def compiler_remove(args):

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -105,7 +105,9 @@ def compiler_find(args):
 
 def compiler_remove(args):
     compiler_spec = spack.spec.CompilerSpec(args.compiler_spec)
-    candidate_compilers = spack.compilers.compilers_for_spec(compiler_spec, scope=args.scope)
+    candidate_compilers = spack.compilers.CompilerQuery(compiler_spec).all_compilers(
+        scope=args.scope
+    )
 
     if not candidate_compilers:
         tty.die("No compilers match spec %s" % compiler_spec)
@@ -124,7 +126,7 @@ def compiler_remove(args):
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
     cspec = spack.spec.CompilerSpec(args.compiler_spec)
-    compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
+    compilers = spack.compilers.CompilerQuery(cspec).all_compilers(scope=args.scope)
 
     if not compilers:
         tty.die("No compilers match spec %s" % cspec)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -29,13 +29,6 @@ from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
 _PATH_INSTANCE_VARS = ["cc", "cxx", "f77", "fc"]
-_other_instance_vars = [
-    "modules",
-    "operating_system",
-    "environment",
-    "implicit_rpaths",
-    "extra_rpaths",
-]
 
 #: cache of compilers constructed from config data, keyed by config entry id.
 CACHE: Dict["CacheReference", "spack.compiler.Compiler"] = {}
@@ -288,7 +281,9 @@ def select_new_compilers(compilers, scope=None):
     compilers_not_in_config = []
     for c in compilers:
         arch_spec = spack.spec.ArchSpec((None, c.operating_system, c.target))
-        same_specs = compilers_for_spec(c.spec, arch_spec, scope=scope, init_config=False)
+        same_specs = compilers_for_spec(
+            c.spec, arch_spec=arch_spec, scope=scope, init_config=False
+        )
         if not same_specs:
             compilers_not_in_config.append(c)
 
@@ -326,7 +321,12 @@ def find(compiler_spec, scope=None, init_config=True):
 def find_specs_by_arch(compiler_spec, arch_spec, scope=None, init_config=True):
     """Return specs of available compilers that match the supplied
     compiler spec.  Return an empty list if nothing found."""
-    return [c.spec for c in compilers_for_spec(compiler_spec, arch_spec, scope, True, init_config)]
+    return [
+        c.spec
+        for c in compilers_for_spec(
+            compiler_spec, arch_spec=arch_spec, scope=scope, init_config=init_config
+        )
+    ]
 
 
 def all_compilers(scope=None, init_config=True):
@@ -339,17 +339,11 @@ def all_compilers(scope=None, init_config=True):
 
 
 @_auto_compiler_spec
-def compilers_for_spec(
-    compiler_spec, arch_spec=None, scope=None, use_cache=True, init_config=True
-):
+def compilers_for_spec(compiler_spec, *, arch_spec=None, scope=None, init_config=True):
     """This gets all compilers that satisfy the supplied CompilerSpec.
     Returns an empty list if none are found.
     """
-    if use_cache:
-        config = compiler_config(scope=scope, init_config=init_config)
-    else:
-        config = compiler_config(scope=scope, init_config=init_config)
-
+    config = compiler_config(scope=scope, init_config=init_config)
     matches = set(find(compiler_spec, scope, init_config))
     compilers = []
     for cspec in matches:
@@ -524,9 +518,7 @@ def get_compiler_duplicates(compiler_spec, arch_spec):
 
     scope_to_compilers = {}
     for scope in config.scopes:
-        compilers = compilers_for_spec(
-            compiler_spec, arch_spec=arch_spec, scope=scope, use_cache=False
-        )
+        compilers = compilers_for_spec(compiler_spec, arch_spec=arch_spec, scope=scope)
         if compilers:
             scope_to_compilers[scope] = compilers
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -51,8 +51,8 @@ PACKAGE_TO_COMPILER = {
 }
 
 
-def pkg_spec_for_compiler(cspec):
-    """Return the spec of the package that provides the compiler."""
+def pkg_spec_for_compiler(compiler_spec):
+    """Returns the spec of the package that provides the compiler spec passed as input."""
     compiler_to_package = {
         "clang": "llvm+clang",
         "oneapi": "intel-oneapi-compilers",
@@ -60,12 +60,12 @@ def pkg_spec_for_compiler(cspec):
         "intel@2020:": "intel-oneapi-compilers-classic",
         "arm": "acfl",
     }
-    for compiler_spec, package in compiler_to_package.items():
-        if cspec.satisfies(compiler_spec):
-            spec_str = f"{package}@{cspec.versions}"
+    for compiler_constraint, package in compiler_to_package.items():
+        if compiler_spec.satisfies(compiler_constraint):
+            spec_str = f"{package}@{compiler_spec.versions}"
             break
     else:
-        spec_str = str(cspec)
+        spec_str = str(compiler_spec)
     return spack.spec.parse_with_version_concrete(spec_str)
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -28,7 +28,7 @@ import spack.version
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
-_path_instance_vars = ["cc", "cxx", "f77", "fc"]
+_PATH_INSTANCE_VARS = ["cc", "cxx", "f77", "fc"]
 _flags_instance_vars = ["cflags", "cppflags", "cxxflags", "fflags"]
 _other_instance_vars = [
     "modules",
@@ -85,7 +85,7 @@ def _to_dict(compiler):
     """Return a dict version of compiler suitable to insert in YAML."""
     d = {}
     d["spec"] = str(compiler.spec)
-    d["paths"] = dict((attr, getattr(compiler, attr, None)) for attr in _path_instance_vars)
+    d["paths"] = dict((attr, getattr(compiler, attr, None)) for attr in _PATH_INSTANCE_VARS)
     d["flags"] = dict((fname, " ".join(fvals)) for fname, fvals in compiler.flags.items())
     d["flags"].update(
         dict(
@@ -393,13 +393,13 @@ def compiler_from_dict(items):
     os = items.get("operating_system", None)
     target = items.get("target", None)
 
-    if not ("paths" in items and all(n in items["paths"] for n in _path_instance_vars)):
+    if not ("paths" in items and all(n in items["paths"] for n in _PATH_INSTANCE_VARS)):
         raise InvalidCompilerConfigurationError(cspec)
 
     cls = class_for_compiler_name(cspec.name)
 
     compiler_paths = []
-    for c in _path_instance_vars:
+    for c in _PATH_INSTANCE_VARS:
         compiler_path = items["paths"][c]
         if compiler_path != "None":
             compiler_paths.append(compiler_path)
@@ -823,7 +823,7 @@ class InvalidCompilerConfigurationError(spack.error.SpackError):
         super().__init__(
             'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
             "Compiler configuration must contain entries for all compilers: %s"
-            % _path_instance_vars,
+            % _PATH_INSTANCE_VARS,
         )
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -42,8 +42,9 @@ _other_instance_vars = [
 #: cache of compilers constructed from config data, keyed by config entry id.
 _compiler_cache: Dict[str, "spack.compiler.Compiler"] = {}
 
-# TODO: generating this from the previous dict causes docs errors
-package_name_to_compiler_name = {
+
+#: Maps package names in Spack to the compiler name they provide
+PACKAGE_TO_COMPILER = {
     "llvm": "clang",
     "intel-oneapi-compilers": "oneapi",
     "llvm-amdgpu": "rocmcc",

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -37,10 +37,8 @@ _other_instance_vars = [
     "extra_rpaths",
 ]
 
-# TODO: Caches at module level make it difficult to mock configurations in
-# TODO: unit tests. It might be worth reworking their implementation.
 #: cache of compilers constructed from config data, keyed by config entry id.
-_compiler_cache: Dict[str, "spack.compiler.Compiler"] = {}
+CACHE: Dict["CacheReference", "spack.compiler.Compiler"] = {}
 
 
 #: Maps package names in Spack to the compiler name they provide
@@ -444,11 +442,11 @@ def _compiler_from_config_entry(items):
     entries have changed).
     """
     config_id = CacheReference(items)
-    compiler = _compiler_cache.get(config_id, None)
+    compiler = CACHE.get(config_id, None)
 
     if compiler is None:
         compiler = compiler_from_dict(items)
-        _compiler_cache[config_id] = compiler
+        CACHE[config_id] = compiler
 
     return compiler
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -83,22 +83,23 @@ def _auto_compiler_spec(function):
 
 def _to_dict(compiler):
     """Return a dict version of compiler suitable to insert in YAML."""
-    d = {}
-    d["spec"] = str(compiler.spec)
-    d["paths"] = dict((attr, getattr(compiler, attr, None)) for attr in _PATH_INSTANCE_VARS)
-    d["flags"] = dict((fname, " ".join(fvals)) for fname, fvals in compiler.flags.items())
+    d = {
+        "spec": str(compiler.spec),
+        "paths": {attr: getattr(compiler, attr, None) for attr in _PATH_INSTANCE_VARS},
+        "flags": {fname: " ".join(fvals) for fname, fvals in compiler.flags.items()},
+        "operating_system": str(compiler.operating_system),
+        "target": str(compiler.target),
+        "modules": compiler.modules or [],
+        "environment": compiler.environment or {},
+        "extra_rpaths": compiler.extra_rpaths or [],
+    }
     d["flags"].update(
-        dict(
-            (attr, getattr(compiler, attr, None))
+        {
+            attr: getattr(compiler, attr, None)
             for attr in _flags_instance_vars
             if hasattr(compiler, attr)
-        )
+        }
     )
-    d["operating_system"] = str(compiler.operating_system)
-    d["target"] = str(compiler.target)
-    d["modules"] = compiler.modules or []
-    d["environment"] = compiler.environment or {}
-    d["extra_rpaths"] = compiler.extra_rpaths or []
     if compiler.enable_implicit_rpaths is not None:
         d["implicit_rpaths"] = compiler.enable_implicit_rpaths
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -731,7 +731,7 @@ def detect_version(
         path = fn_args.path
 
         # Get compiler names and the callback to detect their versions
-        callback = getattr(compiler_cls, "{0}_version".format(language))
+        callback = getattr(compiler_cls, f"{language}_version")
 
         try:
             version = callback(path)
@@ -739,13 +739,13 @@ def detect_version(
                 value = fn_args._replace(id=compiler_id._replace(version=version))
                 return value, None
 
-            error = "Couldn't get version for compiler {0}".format(path)
+            error = f"Couldn't get version for compiler {path}"
         except spack.util.executable.ProcessError as e:
-            error = "Couldn't get version for compiler {0}\n".format(path) + str(e)
+            error = f"Couldn't get version for compiler {path}\n" + str(e)
         except Exception as e:
             # Catching "Exception" here is fine because it just
             # means something went wrong running a candidate executable.
-            error = "Error while executing candidate compiler {0}" "\n{1}: {2}".format(
+            error = "Error while executing candidate compiler {}" "\n{}: {}".format(
                 path, e.__class__.__name__, str(e)
             )
         return None, error
@@ -855,17 +855,17 @@ def is_mixed_toolchain(compiler: spack.compiler.Compiler) -> bool:
                 name_matches(fc, compiler_cls.fc_names),
             ]
         ):
-            tty.debug("[TOOLCHAIN] MATCH {0}".format(compiler_cls.__name__))
+            tty.debug(f"[TOOLCHAIN] MATCH {compiler_cls.__name__}")
             toolchains.add(compiler_cls.__name__)
 
     if len(toolchains) > 1:
         if (
-            toolchains == set(["Clang", "AppleClang", "Aocc"])
+            toolchains == {"Clang", "AppleClang", "Aocc"}
             # Msvc toolchain uses Intel ifx
-            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])
+            or toolchains == {"Msvc", "Dpcpp", "Oneapi"}
         ):
             return False
-        tty.debug("[TOOLCHAINS] {0}".format(toolchains))
+        tty.debug(f"[TOOLCHAINS] {toolchains}")
         return True
 
     return False
@@ -874,9 +874,8 @@ def is_mixed_toolchain(compiler: spack.compiler.Compiler) -> bool:
 class InvalidCompilerConfigurationError(spack.error.SpackError):
     def __init__(self, compiler_spec):
         super().__init__(
-            'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
-            "Compiler configuration must contain entries for all compilers: %s"
-            % _PATH_INSTANCE_VARS,
+            f'Invalid configuration for [compiler "{compiler_spec}"]: ',
+            f"Compiler configuration must contain the following entries: {_PATH_INSTANCE_VARS}",
         )
 
 
@@ -887,13 +886,13 @@ class NoCompilersError(spack.error.SpackError):
 
 class UnknownCompilerError(spack.error.SpackError):
     def __init__(self, compiler_name):
-        super().__init__("Spack doesn't support the requested compiler: {0}".format(compiler_name))
+        super().__init__(f"Spack doesn't support the requested compiler: {compiler_name}")
 
 
 class NoCompilerForSpecError(spack.error.SpackError):
     def __init__(self, compiler_spec, target):
         super().__init__(
-            "No compilers for operating system %s satisfy spec %s" % (target, compiler_spec)
+            f"No compilers for operating system {target} satisfy spec {compiler_spec}"
         )
 
 
@@ -902,12 +901,12 @@ class CompilerDuplicateError(spack.error.SpackError):
         config_file_to_duplicates = get_compiler_duplicates(compiler_spec, arch_spec)
         duplicate_table = list((x, len(y)) for x, y in config_file_to_duplicates.items())
         descriptor = lambda num: "time" if num == 1 else "times"
-        duplicate_msg = lambda cfgfile, count: "{0}: {1} {2}".format(
+        duplicate_msg = lambda cfgfile, count: "{}: {} {}".format(
             cfgfile, str(count), descriptor(count)
         )
         msg = (
             "Compiler configuration contains entries with duplicate"
-            + " specification ({0}, {1})".format(compiler_spec, arch_spec)
+            + f" specification ({compiler_spec}, {arch_spec})"
             + " in the following files:\n\t"
             + "\n\t".join(duplicate_msg(x, y) for x, y in duplicate_table)
         )
@@ -916,4 +915,4 @@ class CompilerDuplicateError(spack.error.SpackError):
 
 class CompilerSpecInsufficientlySpecificError(spack.error.SpackError):
     def __init__(self, compiler_spec):
-        super().__init__("Multiple compilers satisfy spec %s" % compiler_spec)
+        super().__init__(f"Multiple compilers satisfy spec {compiler_spec}")

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -42,14 +42,6 @@ _other_instance_vars = [
 #: cache of compilers constructed from config data, keyed by config entry id.
 _compiler_cache: Dict[str, "spack.compiler.Compiler"] = {}
 
-_compiler_to_pkg = {
-    "clang": "llvm+clang",
-    "oneapi": "intel-oneapi-compilers",
-    "rocmcc": "llvm-amdgpu",
-    "intel@2020:": "intel-oneapi-compilers-classic",
-    "arm": "acfl",
-}
-
 # TODO: generating this from the previous dict causes docs errors
 package_name_to_compiler_name = {
     "llvm": "clang",
@@ -62,9 +54,16 @@ package_name_to_compiler_name = {
 
 def pkg_spec_for_compiler(cspec):
     """Return the spec of the package that provides the compiler."""
-    for spec, package in _compiler_to_pkg.items():
-        if cspec.satisfies(spec):
-            spec_str = "%s@%s" % (package, cspec.versions)
+    compiler_to_package = {
+        "clang": "llvm+clang",
+        "oneapi": "intel-oneapi-compilers",
+        "rocmcc": "llvm-amdgpu",
+        "intel@2020:": "intel-oneapi-compilers-classic",
+        "arm": "acfl",
+    }
+    for compiler_spec, package in compiler_to_package.items():
+        if cspec.satisfies(compiler_spec):
+            spec_str = f"{package}@{cspec.versions}"
             break
     else:
         spec_str = str(cspec)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -206,18 +206,11 @@ def _remove_compiler_from_scope(compiler_spec, scope):
     return True
 
 
-def all_compilers_config(scope=None, init_config=True):
-    """Return a set of specs for all the compiler versions currently
-    available to build with.  These are instances of CompilerSpec.
-    """
-    return get_compiler_config(scope, init_config)
-
-
 def all_compiler_specs(scope=None, init_config=True):
     # Return compiler specs from the merged config.
     return [
         spack.spec.parse_with_version_concrete(s["compiler"]["spec"], compiler=True)
-        for s in all_compilers_config(scope, init_config)
+        for s in get_compiler_config(scope, init_config)
     ]
 
 
@@ -347,7 +340,7 @@ def compilers_for_spec(
     Returns an empty list if none are found.
     """
     if use_cache:
-        config = all_compilers_config(scope, init_config)
+        config = get_compiler_config(scope, init_config)
     else:
         config = get_compiler_config(scope, init_config)
 
@@ -359,7 +352,7 @@ def compilers_for_spec(
 
 
 def compilers_for_arch(arch_spec, scope=None):
-    config = all_compilers_config(scope)
+    config = get_compiler_config(scope, True)
     return list(get_compilers(config, arch_spec=arch_spec))
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -29,7 +29,6 @@ from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
 _PATH_INSTANCE_VARS = ["cc", "cxx", "f77", "fc"]
-_flags_instance_vars = ["cflags", "cppflags", "cxxflags", "fflags"]
 _other_instance_vars = [
     "modules",
     "operating_system",
@@ -96,7 +95,7 @@ def _to_dict(compiler):
     d["flags"].update(
         {
             attr: getattr(compiler, attr, None)
-            for attr in _flags_instance_vars
+            for attr in spack.spec.FlagMap.valid_compiler_flags()
             if hasattr(compiler, attr)
         }
     )

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -449,7 +449,7 @@ class Concretizer:
         # compiler_for_spec Should think whether this can be more
         # efficient
         def _proper_compiler_style(cspec, aspec):
-            compilers = spack.compilers.compilers_for_spec(cspec, arch_spec=aspec)
+            compilers = spack.compilers.CompilerQuery(cspec).all_compilers(arch_spec=aspec)
             # If the spec passed as argument is concrete we want to check
             # the versions match exactly
             if (
@@ -483,7 +483,9 @@ class Concretizer:
             return True
 
         if other_compiler:  # Another node has abstract compiler information
-            compiler_list = spack.compilers.find_specs_by_arch(other_compiler, spec.architecture)
+            compiler_list = spack.compilers.CompilerQuery(other_compiler).all_specs(
+                arch_spec=spec.architecture
+            )
             if not compiler_list:
                 # We don't have a matching compiler installed
                 if not self.check_for_compiler_existence:
@@ -561,7 +563,9 @@ class Concretizer:
         # This ensures that spack will detect conflicts that stem from a change
         # in default compiler flags.
         try:
-            compiler = spack.compilers.compiler_for_spec(spec.compiler, spec.architecture)
+            compiler = spack.compilers.CompilerQuery(spec.compiler).ensure_one(
+                arch_spec=spec.architecture
+            )
         except spack.compilers.NoCompilerForSpecError:
             if self.check_for_compiler_existence:
                 raise

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1486,7 +1486,7 @@ class Environment:
 
         # Ensure we have compilers in compilers.yaml to avoid that
         # processes try to write the config file in parallel
-        _ = spack.compilers.get_compiler_config()
+        _ = spack.compilers.compiler_config()
 
         # Early return if there is nothing to do
         if len(arguments) == 0:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -286,7 +286,7 @@ def _packages_needed_to_bootstrap_compiler(
             (``False``).  The list will be empty if there are no compilers.
     """
     tty.debug("Bootstrapping {0} compiler".format(compiler))
-    compilers = spack.compilers.compilers_for_spec(compiler, arch_spec=architecture)
+    compilers = spack.compilers.CompilerQuery(compiler).all_compilers(arch_spec=architecture)
     if compilers:
         return []
 
@@ -977,7 +977,7 @@ class BuildTask:
         # a dependency of the build task. Here we add it to self.dependencies
         compiler_spec = self.pkg.spec.compiler
         arch_spec = self.pkg.spec.architecture
-        if not spack.compilers.compilers_for_spec(compiler_spec, arch_spec=arch_spec):
+        if not spack.compilers.CompilerQuery(compiler_spec).all_compilers(arch_spec=arch_spec):
             # The compiler is in the queue, identify it as dependency
             dep = spack.compilers.pkg_spec_for_compiler(compiler_spec)
             dep.constrain("platform=%s" % str(arch_spec.platform))

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -202,9 +202,9 @@ class LmodConfiguration(BaseConfiguration):
         # If it is in the list of supported compilers family -> compiler
         if self.spec.name in spack.compilers.supported_compilers():
             provides["compiler"] = spack.spec.CompilerSpec(self.spec.format("{name}{@versions}"))
-        elif self.spec.name in spack.compilers.package_name_to_compiler_name:
+        elif self.spec.name in spack.compilers.PACKAGE_TO_COMPILER:
             # If it is the package for a supported compiler, but of a different name
-            cname = spack.compilers.package_name_to_compiler_name[self.spec.name]
+            cname = spack.compilers.PACKAGE_TO_COMPILER[self.spec.name]
             provides["compiler"] = spack.spec.CompilerSpec(cname, self.spec.versions)
 
         # All the other tokens in the hierarchy must be virtual dependencies

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -615,7 +615,7 @@ class CompilerSpec:
         for version in version_list:
             self.versions.add(version)
 
-    def _autospec(self, compiler_spec_like):
+    def _autospec(self, compiler_spec_like: Union[str, "CompilerSpec"]) -> "CompilerSpec":
         if isinstance(compiler_spec_like, CompilerSpec):
             return compiler_spec_like
         return CompilerSpec(compiler_spec_like)
@@ -632,7 +632,7 @@ class CompilerSpec:
         other = self._autospec(other)
         return self.name == other.name and self.versions.intersects(other.versions)
 
-    def satisfies(self, other: "CompilerSpec") -> bool:
+    def satisfies(self, other: Union[str, "CompilerSpec"]) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
 
         For compiler specs this means that the name of the compiler must be the same for

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2917,8 +2917,8 @@ class Spec:
     @staticmethod
     def ensure_external_path_if_external(external_spec):
         if external_spec.external_modules and not external_spec.external_path:
-            compiler = spack.compilers.compiler_for_spec(
-                external_spec.compiler, external_spec.architecture
+            compiler = spack.compilers.CompilerQuery(external_spec.compiler).ensure_one(
+                arch_spec=external_spec.architecture
             )
             for mod in compiler.modules:
                 md.load_module(mod)
@@ -3460,10 +3460,9 @@ class Spec:
             if (not spec.virtual) and spec.name:
                 spack.repo.path.get_pkg_class(spec.fullname)
 
-            # validate compiler in addition to the package name.
-            if spec.compiler:
-                if not spack.compilers.supported(spec.compiler):
-                    raise UnsupportedCompilerError(spec.compiler.name)
+            # Validate the compiler in addition to the package name
+            if spec.compiler and not spack.compilers.CompilerQuery(spec.compiler).supported():
+                raise UnsupportedCompilerError(spec.compiler.name)
 
             # Ensure correctness of variants (if the spec is not virtual)
             if not spec.virtual:

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -145,7 +145,7 @@ class Target:
             # is called we might get either a CompilerSpec or a fully fledged
             # compiler object.
             if isinstance(compiler, spack.spec.CompilerSpec):
-                compiler = spack.compilers.compilers_for_spec(compiler).pop()
+                compiler = spack.compilers.CompilerQuery(compiler).all_compilers().pop()
             try:
                 compiler_version = compiler.real_version
             except spack.util.executable.ProcessError as e:

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -134,7 +134,7 @@ def test_arch_spec_container_semantic(item, architecture_str):
 @pytest.mark.filterwarnings("ignore:microarchitecture specific")
 def test_optimization_flags(compiler_spec, target_name, expected_flags, config):
     target = spack.target.Target(target_name)
-    compiler = spack.compilers.compilers_for_spec(compiler_spec).pop()
+    compiler = spack.compilers.CompilerQuery(compiler_spec).all_compilers().pop()
     opt_flags = target.optimization_flags(compiler)
     assert opt_flags == expected_flags
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -167,7 +167,7 @@ def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, compilers_
     assert "clang@11.0.0" in output
     assert "gcc@8.4.0" in output
 
-    config = spack.compilers.get_compiler_config("site", False)
+    config = spack.compilers.compiler_config(scope="site", init_config=False)
     clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")
     gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@=8.4.0")
 
@@ -203,7 +203,7 @@ def test_compiler_find_prefer_no_suffix(no_compilers_yaml, working_env, compiler
     assert "clang@11.0.0" in output
     assert "gcc@8.4.0" in output
 
-    config = spack.compilers.get_compiler_config("site", False)
+    config = spack.compilers.compiler_config(scope="site", init_config=False)
     clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")
 
     assert clang["paths"]["cc"] == str(compilers_dir / "clang")
@@ -222,7 +222,7 @@ def test_compiler_find_path_order(no_compilers_yaml, working_env, compilers_dir)
 
     compiler("find", "--scope=site")
 
-    config = spack.compilers.get_compiler_config("site", False)
+    config = spack.compilers.compiler_config(scope="site", init_config=False)
     gcc = next(c["compiler"] for c in config if c["compiler"]["spec"] == "gcc@=8.4.0")
     assert gcc["paths"] == {
         "cc": str(new_dir / "gcc-8"),

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -58,7 +58,7 @@ def test_multiple_conflicting_compiler_definitions(mutable_config):
     mutable_config.update_config("compilers", compiler_config)
 
     arch_spec = spack.spec.ArchSpec(("test", "test", "test"))
-    cmp = compilers.compiler_for_spec("clang@=0.0.0", arch_spec)
+    cmp = compilers.CompilerQuery("clang@=0.0.0").ensure_one(arch_spec=arch_spec)
     assert cmp.f77 == "f77"
 
 
@@ -661,7 +661,7 @@ def test_xl_r_flags():
     [("gcc@4.7.2", False), ("clang@3.3", False), ("clang@8.0.0", True)],
 )
 def test_detecting_mixed_toolchains(compiler_spec, expected_result, config):
-    compiler = compilers.compilers_for_spec(compiler_spec).pop()
+    compiler = compilers.CompilerQuery(compiler_spec).all_compilers().pop()
     assert compilers.is_mixed_toolchain(compiler) is expected_result
 
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -689,7 +689,7 @@ def test_raising_if_compiler_target_is_over_specific(config):
     ]
     arch_spec = spack.spec.ArchSpec(("linux", "ubuntu18.04", "haswell"))
     with spack.config.override("compilers", compilers):
-        cfg = spack.compilers.get_compiler_config()
+        cfg = spack.compilers.compiler_config()
         with pytest.raises(ValueError):
             spack.compilers.get_compilers(cfg, spack.spec.CompilerSpec("gcc@9.0.1"), arch_spec)
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -335,8 +335,10 @@ class TestConcretize:
         # Correct arch to use test compiler that has flags
         spec = Spec("a %clang@12.2.0 platform=test os=fe target=fe")
 
-        # Get the compiler that matches the spec (
-        compiler = spack.compilers.compiler_for_spec("clang@=12.2.0", spec.architecture)
+        # Get the compiler that matches the spec
+        compiler = spack.compilers.CompilerQuery("clang@=12.2.0").ensure_one(
+            arch_spec=spec.architecture
+        )
 
         # Configure spack to have two identical compilers with different flags
         default_dict = spack.compilers._to_dict(compiler)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -354,9 +354,9 @@ def reset_compiler_cache():
     This cache can cause later tests to fail if left in a state incompatible
     with the new configuration. Since tests can make almost unlimited changes
     to their setup, default to not use the compiler cache across tests."""
-    spack.compilers._compiler_cache = {}
+    spack.compilers.CACHE.clear()
     yield
-    spack.compilers._compiler_cache = {}
+    spack.compilers.CACHE.clear()
 
 
 def onerror(func, path, error_info):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -498,9 +498,7 @@ def test_packages_needed_to_bootstrap_compiler_packages(install_mockery, monkeyp
     def _conc_spec(compiler):
         return spack.spec.Spec("a").concretized()
 
-    # Ensure we can get past functions that are precluding obtaining
-    # packages.
-    monkeypatch.setattr(spack.compilers, "compilers_for_spec", _none)
+    # Ensure we can get past functions that are precluding obtaining packages.
     monkeypatch.setattr(spack.compilers, "pkg_spec_for_compiler", _conc_spec)
     monkeypatch.setattr(spack.spec.Spec, "concretize", _noop)
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -273,10 +273,10 @@ def test_package_no_extendees():
 
 
 def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
-    def compilers(compiler, arch_spec):
-        return None
+    def compilers(self, **kwargs):
+        return []
 
-    monkeypatch.setattr(spack.compilers, "compilers_for_spec", compilers)
+    monkeypatch.setattr(spack.compilers.CompilerQuery, "all_compilers", compilers)
 
     s = spack.spec.Spec("a")
     pkg = BaseTestPackage(s)


### PR DESCRIPTION
Modifications:
- [x] Fixed a few bugs lurking in the module
- [x] Uppercased global variables
- [x] Collected all functions that needed the `_auto_compiler_spec` in a class, move decorator logic into the constructor
- [x] Removed two compiler specific caches, with wrong logic
- [x] Added type-hints and docstrings
