### PR TITLE
openssh: depend on krb5+shared when +gssapi

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -52,7 +52,7 @@ class Openssh(AutotoolsPackage):
         "gssapi", default=True, description="Enable authentication via Kerberos through GSSAPI"
     )
 
-    depends_on("krb5", when="+gssapi")
+    depends_on("krb5+shared", when="+gssapi")
     depends_on("openssl@:1.0", when="@:7.7p1")
     depends_on("openssl")
     depends_on("libedit")


### PR DESCRIPTION
If you somehow end up with a krb5~shared installed spack'll try to link against the static libs and fail when trying to build openssh.