### PR TITLE
Installations: don't set group permissions when they match what is desired

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -610,6 +610,8 @@ def chgrp(path, group, follow_symlinks=True):
         gid = grp.getgrnam(group).gr_gid
     else:
         gid = group
+    if os.stat(path).st_gid == gid:
+        return
     if follow_symlinks:
         os.chown(path, -1, gid)
     else:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -610,8 +610,8 @@ def chgrp(path, group, follow_symlinks=True):
         gid = grp.getgrnam(group).gr_gid
     else:
         gid = group
-    if os.stat(path).st_gid == gid:
-        return
+    #if os.stat(path).st_gid == gid:
+    #    return
     if follow_symlinks:
         os.chown(path, -1, gid)
     else:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -610,8 +610,8 @@ def chgrp(path, group, follow_symlinks=True):
         gid = grp.getgrnam(group).gr_gid
     else:
         gid = group
-    #if os.stat(path).st_gid == gid:
-    #    return
+    if os.stat(path).st_gid == gid:
+        return
     if follow_symlinks:
         os.chown(path, -1, gid)
     else:

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -514,6 +514,7 @@ def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
             self.st_gid = gid
 
     original_stat = os.stat
+
     def _stat(path):
         if path == "test-dir_chgrp_dont_set_group_if_already_set":
             return FakeStat(gid=1001)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -502,6 +502,7 @@ def test_filter_files_with_different_encodings(regex, replacement, filename, tmp
         assert replacement in f.read()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chgrp isn't used on Windows")
 def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
     with fs.working_dir(tmpdir):
         os.mkdir("test-dir_chgrp_dont_set_group_if_already_set")

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -504,28 +504,33 @@ def test_filter_files_with_different_encodings(regex, replacement, filename, tmp
 
 def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
     with fs.working_dir(tmpdir):
-        os.mkdir("x")
-        stat_info = os.stat("x")
-        group = stat_info.st_gid
-        assert group
-
-    def _makedirs(path):
-        entries = os.path.split(path)
-        for i in range(len(entries)):
-            sub_path = os.path.join(entries[:i])
-            os.mkdir(sub_path)
-            fs.chgrp(sub_path, group)
+        os.mkdir("test-dir_chgrp_dont_set_group_if_already_set")
 
     def _fail(*args, **kwargs):
         raise Exception("chrgrp should not be called")
 
-    monkeypatch.setattr(fs, "chgrp", _fail)
-    #monkeypatch.setattr(os, "")
+    class FakeStat(object):
+        def __init__(self, gid):
+            self.st_gid = gid
+
+    original_stat = os.stat
+    def _stat(path):
+        if path == "test-dir_chgrp_dont_set_group_if_already_set":
+            return FakeStat(gid=1001)
+        else:
+            # Monkeypatching stat can interfere with post-test cleanup, so for
+            # paths that aren't part of the test, we want the original behavior
+            # of stat
+            return original_stat(path)
+
+    monkeypatch.setattr(os, "chown", _fail)
+    monkeypatch.setattr(os, "lchown", _fail)
+    monkeypatch.setattr(os, "stat", _stat)
 
     with fs.working_dir(tmpdir):
-        import pdb; pdb.set_trace()
-        # If this succeeds, then we didn't try to chgrp anything
-        fs.mkdirp("x/y/z")
+        with pytest.raises(Exception):
+            fs.chgrp("test-dir_chgrp_dont_set_group_if_already_set", 1002)
+        fs.chgrp("test-dir_chgrp_dont_set_group_if_already_set", 1001)
 
 
 def test_filter_files_multiple(tmpdir):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -502,6 +502,32 @@ def test_filter_files_with_different_encodings(regex, replacement, filename, tmp
         assert replacement in f.read()
 
 
+def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
+    with fs.working_dir(tmpdir):
+        os.mkdir("x")
+        stat_info = os.stat("x")
+        group = stat_info.st_gid
+        assert group
+
+    def _makedirs(path):
+        entries = os.path.split(path)
+        for i in range(len(entries)):
+            sub_path = os.path.join(entries[:i])
+            os.mkdir(sub_path)
+            fs.chgrp(sub_path, group)
+
+    def _fail(*args, **kwargs):
+        raise Exception("chrgrp should not be called")
+
+    monkeypatch.setattr(fs, "chgrp", _fail)
+    #monkeypatch.setattr(os, "")
+
+    with fs.working_dir(tmpdir):
+        import pdb; pdb.set_trace()
+        # If this succeeds, then we didn't try to chgrp anything
+        fs.mkdirp("x/y/z")
+
+
 def test_filter_files_multiple(tmpdir):
     # All files given as input to this test must satisfy the pre-requisite
     # that the 'replacement' string is not present in the file initially and

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -516,14 +516,15 @@ def test_chgrp_dont_set_group_if_already_set(tmpdir, monkeypatch):
 
     original_stat = os.stat
 
-    def _stat(path):
+    def _stat(*args, **kwargs):
+        path = args[0]
         if path == "test-dir_chgrp_dont_set_group_if_already_set":
             return FakeStat(gid=1001)
         else:
             # Monkeypatching stat can interfere with post-test cleanup, so for
             # paths that aren't part of the test, we want the original behavior
             # of stat
-            return original_stat(path)
+            return original_stat(*args, **kwargs)
 
     monkeypatch.setattr(os, "chown", _fail)
     monkeypatch.setattr(os, "lchown", _fail)


### PR DESCRIPTION
fixes #38233

@dvdgomez

When installing a package Spack will (by default) attempt to create the install directory and all new parent directories using the permissions/group of the first existing parent (e.g. it installs a package in `opt/spack/linux-debian6-core2/gcc-10.2.1/...`, but at the time of the first package install, only `opt/spack/` exists, so it will try to create `linux-debian6-core2/` with the permissions/group of `opt/spack/`).

In a context where setting group permissions is forbidden, this can lead to an error. To avoid the error, this PR skips `chgrp` when the permissions of a created directory match what we would set.
