### PR TITLE
Memoize more results when installing environments

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1843,7 +1843,6 @@ class Environment:
 
         changed_dev_specs = set(s for s in specs_to_check if _is_dev_spec_and_has_changed(s))
 
-
         overwrite_specs = {}
         return [
             s.dag_hash()


### PR DESCRIPTION
This is another improvement on top of #27167 and "memoizes" a bit more information when checking which specs need to be overwritten. Without this I wait in the order of 10 - 30 minutes for a `spack install` in an environment with many `develop` packages (around 50) even if there were no changes at all. With this, this get's down to a more acceptable 1 - 2 minutes again for me.