### PR TITLE
Patch package.extends() to allow external packages to extend each other

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1253,7 +1253,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # if the spec is concrete already, then it extends something
         # that is an *optional* dependency, and the dep isn't there.
-        if self.spec._concrete:
+        if self.spec._concrete and not self.spec.external:
             print("Spec is already concrete, extendee_spec is None")
             return None
         else:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1254,7 +1254,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # if the spec is concrete already, then it extends something
         # that is an *optional* dependency, and the dep isn't there.
         if self.spec._concrete and not self.spec.external:
-            print("Spec is already concrete, extendee_spec is None")
             return None
         else:
             # TODO: do something sane here with more than one extendee
@@ -1297,10 +1296,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         if spec.name not in self.extendees:
             return False
-        print("{} is in self.extendees".format(spec.name))
-        print("{} is {}concrete".format(self.spec.name, '' if self.spec.concrete else 'not '))
         s = self.extendee_spec
-        print("Extendee spec is {}".format(s))
         return s and spec.satisfies(s)
 
     def provides(self, vpkg_name):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1298,7 +1298,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if spec.name not in self.extendees:
             return False
         print("{} is in self.extendees".format(spec.name))
-        print("{} is concrete? {}".format(self.spec.name, self.spec.concrete))
+        print("{} is {}concrete".format(self.spec.name, '' if self.spec.concrete else 'not '))
         s = self.extendee_spec
         print("Extendee spec is {}".format(s))
         return s and spec.satisfies(s)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1254,6 +1254,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # if the spec is concrete already, then it extends something
         # that is an *optional* dependency, and the dep isn't there.
         if self.spec._concrete:
+            print("Spec is already concrete, extendee_spec is None")
             return None
         else:
             # TODO: do something sane here with more than one extendee
@@ -1296,7 +1297,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         if spec.name not in self.extendees:
             return False
+        print("{} is in self.extendees".format(spec.name))
+        print("{} is concrete? {}".format(self.spec.name, self.spec.concrete))
         s = self.extendee_spec
+        print("Extendee spec is {}".format(s))
         return s and spec.satisfies(s)
 
     def provides(self, vpkg_name):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1061,11 +1061,7 @@ print(json.dumps(config))
         # Add direct build/run/test dependencies to PYTHONPATH,
         # needed to build the package and to run import tests
         for direct_dep in dependent_spec.dependencies(deptype=("build", "run", "test")):
-            print()
-            print("Direct dependency: {}".format(direct_dep))
-            print("{}".format(direct_dep.package.extendees))
             if direct_dep.package.extends(self.spec):
-                print("dep added")
                 prefixes.add(direct_dep.prefix)
 
                 # Add recursive run dependencies of all direct dependencies,

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1061,7 +1061,11 @@ print(json.dumps(config))
         # Add direct build/run/test dependencies to PYTHONPATH,
         # needed to build the package and to run import tests
         for direct_dep in dependent_spec.dependencies(deptype=("build", "run", "test")):
+            print()
+            print("Direct dependency: {}".format(direct_dep))
+            print("{}".format(direct_dep.package.extendees))
             if direct_dep.package.extends(self.spec):
+                print("dep added")
                 prefixes.add(direct_dep.prefix)
 
                 # Add recursive run dependencies of all direct dependencies,


### PR DESCRIPTION
Resolves issue #38031.

Prevents `package.extendee_spec` from returning `None` when the spec is an external. Currently, `extendee_spec` is always `None` for concretized externals which causes unexpected behavior when using `package.extends()` with externals.