### PR TITLE
gdb: fix debuginfod for version 10

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -84,7 +84,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")
-    depends_on("elfutils@0.178:+debuginfod", when="@10.1:+debuginfod")
+    depends_on("elfutils@0.179:+debuginfod", when="@10.1:+debuginfod")
 
     build_directory = "spack-build"
 

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -84,7 +84,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")
-    depends_on("elfutils@0.178:+debuginfod", when="@11.1:+debuginfod")
+    depends_on("elfutils@0.178:+debuginfod", when="@10.1:+debuginfod")
 
     build_directory = "spack-build"
 


### PR DESCRIPTION
gdb@10.2 did not build with the error
``` 
     5662    checking for libdebuginfod >= 0.179... no
  >> 5663    configure: error: "--with-debuginfod was given, but libdebuginfod is missing or unusable."
  >> 5664    make[1]: *** [Makefile:10068: configure-gdb] Error 1
```
This variant is active since version 10.1, so I suspect this was a typo when adding the `elfutils` dependency.
With the dependency added `gdb@10.2` builds for me (fedora 37, gcc 12.3.1).