### PR TITLE
chemfiles: add v0.10.4

### DIFF
--- a/var/spack/repos/builtin/packages/chemfiles/package.py
+++ b/var/spack/repos/builtin/packages/chemfiles/package.py
@@ -16,6 +16,7 @@ class Chemfiles(CMakePackage):
 
     maintainers("RMeli")
 
+    version("0.10.4", sha256="b8232ddaae2953538274982838aa6c2df87d300f7e2f80e92c171581e06325ba")
     version("0.10.3", sha256="5f53d87a668a85bebf04e0e8ace0f1db984573de1c54891ba7d37d31cced0408")
 
     variant("shared", default=False, description="Build shared libraries")


### PR DESCRIPTION
Add chemfiles v0.10.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.