### PR TITLE
cni-plugins: add v1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/cni-plugins/package.py
+++ b/var/spack/repos/builtin/packages/cni-plugins/package.py
@@ -13,6 +13,7 @@ class CniPlugins(Package):
     url = "https://github.com/containernetworking/plugins/archive/v1.0.1.tar.gz"
     maintainers("bernhardkaindl")
 
+    version("1.3.0", sha256="f9871b9f6ccb51d2b264532e96521e44f926928f91434b56ce135c95becf2901")
     version("1.2.0", sha256="f3496ddda9c7770a0b695b67ae7ee80a4ee331ac2745af4830054b81627f79b7")
     version("1.1.1", sha256="c86c44877c47f69cd23611e22029ab26b613f620195b76b3ec20f589367a7962")
     version("1.0.1", sha256="2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619")


### PR DESCRIPTION
Add cni-plugins v1.3.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.