### PR TITLE
cpio: add v2.14

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -18,6 +18,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
 
     executables = ["^cpio$"]
 
+    version("2.14", sha256="145a340fd9d55f0b84779a44a12d5f79d77c99663967f8cfa168d7905ca52454")
     version("2.13", sha256="e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88")
 
     build_directory = "spack-build"


### PR DESCRIPTION
Add cpio v2.14. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.