### PR TITLE
erlang: add v26.0

### DIFF
--- a/var/spack/repos/builtin/packages/erlang/package.py
+++ b/var/spack/repos/builtin/packages/erlang/package.py
@@ -16,6 +16,7 @@ class Erlang(AutotoolsPackage):
     homepage = "https://erlang.org/"
     url = "https://erlang.org/download/otp_src_23.3.tar.gz"
 
+    version("26.0", sha256="4e411587bd7d18ee2d5a0e7207f638e14036152633db57d2cf49c84a9c92d945")
     version("25.3", sha256="aeaa546e0c38e338010d16348d8c67f7fc8c02df728a88d8499838d8c9131e1c")
     version("25.2", sha256="0df1243afde953647df95785f8e75541fd0ea8ac70c0f639c977513be1761f63")
     version("23.3", sha256="3c888d8f46124e134b75a9ba5d845f079020b7198ed2de64411e183d07e9002a")


### PR DESCRIPTION
Add erlang v26.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.