### PR TITLE
fasttransforms: add v0.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/fasttransforms/package.py
+++ b/var/spack/repos/builtin/packages/fasttransforms/package.py
@@ -16,6 +16,7 @@ class Fasttransforms(MakefilePackage):
     homepage = "https://github.com/MikaelSlevinsky/FastTransforms"
     url = "https://github.com/MikaelSlevinsky/FastTransforms/archive/v0.3.4.tar.gz"
 
+    version("0.6.2", sha256="fd00befcb0c20ba962a8744a7b9139355071ee95be70420de005b7c0f6e023aa")
     version("0.5.0", sha256="9556d0037bd5348a33f15ad6100e32053b6e22cab16a97c504f30d6c52fd0efd")
     version("0.3.4", sha256="a5c8b5aedbdb40218521d061a7df65ef32ce153d4e19d232957db7e3e63c7e9b")
 


### PR DESCRIPTION
Add fasttransforms v0.6.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.