### PR TITLE
ispc: on ARM, build with ARM targets enabled, and updates

### DIFF
--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -85,6 +85,12 @@ class Ispc(CMakePackage):
         args.append("-DISPC_INCLUDE_UTILS=OFF")
         return args
 
+    @run_after("install")
+    def check_install(self):
+        with working_dir(self.stage.source_path):
+            ispc = Executable(join_path(self.prefix, "bin", "ispc"))
+            ispc("--version")
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -42,6 +42,7 @@ class Ispc(CMakePackage):
     depends_on("flex", type="build")
     depends_on("ncurses", type="link")
     depends_on("zlib", type="link")
+    depends_on("tbb", type="link", when="platform=linux @1.20:")
     depends_on("llvm+clang")
     depends_on("llvm~libcxx", when="platform=darwin")
     depends_on("llvm@13:15", when="@1.19:")

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -51,6 +51,8 @@ class Ispc(CMakePackage):
     depends_on("llvm@11:", when="@1.16")
     depends_on("llvm@10:11", when="@1.15.0:1.15")
     depends_on("llvm@10.0:10", when="@1.13:1.14")
+    depends_on("llvm targets=arm,aarch64", when="target=arm:")
+    depends_on("llvm targets=arm,aarch64", when="target=aarch64:")
 
     patch(
         "don-t-assume-that-ncurses-zlib-are-system-libraries.patch",
@@ -78,6 +80,7 @@ class Ispc(CMakePackage):
             filter_file("bit 32 64", "bit 64", "cmake/GenerateBuiltins.cmake")
 
     def cmake_args(self):
+        spec = self.spec
         args = []
         args.append("-DARM_ENABLED=FALSE")
         args.append("-DISPC_NO_DUMPS=ON")  # otherwise, LLVM needs patching
@@ -85,6 +88,10 @@ class Ispc(CMakePackage):
         args.append("-DISPC_INCLUDE_EXAMPLES=OFF")
         args.append("-DISPC_INCLUDE_TESTS=OFF")
         args.append("-DISPC_INCLUDE_UTILS=OFF")
+        if spec.satisfies("target=x86_64:") or spec.satisfies("target=x86:"):
+            args.append("-DARM_ENABLED=OFF")
+        elif spec.satisfies("target=aarch64:"):
+            args.append("-DARM_ENABLED=ON")
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -44,7 +44,7 @@ class Ispc(CMakePackage):
     depends_on("zlib", type="link")
     depends_on("tbb", type="link", when="platform=linux @1.20:")
     depends_on("llvm+clang")
-    depends_on("llvm~libcxx", when="platform=darwin")
+    depends_on("llvm libcxx=none", when="platform=darwin")
     depends_on("llvm@13:15", when="@1.19:")
     depends_on("llvm@11.0:14.0", when="@1.18")
     depends_on("llvm@11:14", when="@1.17")

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -82,7 +82,6 @@ class Ispc(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append("-DARM_ENABLED=FALSE")
         args.append("-DISPC_NO_DUMPS=ON")  # otherwise, LLVM needs patching
         args.append("-DCURSES_NEED_NCURSES=TRUE")
         args.append("-DISPC_INCLUDE_EXAMPLES=OFF")

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -69,6 +69,7 @@ class Ispc(CMakePackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("@1.18.0:"):
+            env.append_flags("LDFLAGS", "-lcurses")
             env.append_flags("LDFLAGS", "-ltinfo")
             env.append_flags("LDFLAGS", "-lz")
 

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -43,6 +43,7 @@ class Ispc(CMakePackage):
     depends_on("ncurses", type="link")
     depends_on("zlib", type="link")
     depends_on("llvm+clang")
+    depends_on("llvm~libcxx", when="platform=darwin")
     depends_on("llvm@13:15", when="@1.19:")
     depends_on("llvm@11.0:14.0", when="@1.18")
     depends_on("llvm@11:14", when="@1.17")
@@ -65,7 +66,7 @@ class Ispc(CMakePackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("@1.18.0:"):
-            env.append_flags("LDFLAGS", "-lcurses")
+            env.append_flags("LDFLAGS", "-ltinfo")
             env.append_flags("LDFLAGS", "-lz")
 
     def patch(self):
@@ -80,6 +81,7 @@ class Ispc(CMakePackage):
         args = []
         args.append("-DARM_ENABLED=FALSE")
         args.append("-DISPC_NO_DUMPS=ON")  # otherwise, LLVM needs patching
+        args.append("-DCURSES_NEED_NCURSES=TRUE")
         args.append("-DISPC_INCLUDE_EXAMPLES=OFF")
         args.append("-DISPC_INCLUDE_TESTS=OFF")
         args.append("-DISPC_INCLUDE_UTILS=OFF")

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -25,6 +25,7 @@ class Ispc(CMakePackage):
     executables = ["^ispc$"]
 
     version("main", branch="main")
+    version("1.20.0", sha256="8bd30ded7f96859451ead1cecf6f58ac8e937288fe0e5b98c56f6eba4be370b4")
     version("1.19.0", sha256="c1aeae4bdfb28004a6949394ea1b3daa3fdf12f646e17fcc0614861077dc8b6a")
     version("1.18.1", sha256="fee76d42fc0129f81489b7c2b9143e22a44c281940693c1c13cf1e3dd2ab207f")
     version("1.18.0", sha256="ecf1fc6ad5e39242e555b8e0ac539489939a9e475722eaa9da5caa4651cecf05")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -877,6 +877,10 @@ class Llvm(CMakePackage, CudaPackage):
         if self.spec.satisfies("~code_signing platform=darwin"):
             cmake_args.append(define("LLDB_USE_SYSTEM_DEBUGSERVER", True))
 
+        # LLDB test suite requires libc++
+        if "libcxx=none" in spec:
+            cmake_args.append(define("LLDB_INCLUDE_TESTS", False))
+
         # Enable building with CLT [and not require full Xcode]
         # https://github.com/llvm/llvm-project/issues/57037
         if self.spec.satisfies("@15.0.0: platform=darwin"):


### PR DESCRIPTION
These changes fix ispc on macos, including ARM systems.
In order to avoid linking with a libc++ that differs from the system libc++ (an immediate crash of ispc is the consequence), it also fixes the build of llvm~libcxx.

This should also help with #38044