### PR TITLE
spdlog: patch for fmt::basic_runtime when ^fmt@10

### DIFF
--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -60,6 +60,13 @@ class Spdlog(CMakePackage):
     depends_on("fmt@8:", when="@1.9: +fmt_external")
     depends_on("fmt@9:", when="@1.11: +fmt_external")
 
+    # spdlog@1.11.0 with fmt@10  https://github.com/gabime/spdlog/pull/2694
+    patch(
+        "https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05.patch?full_index=1",
+        sha256="31b22a9bfa6790fdabff186c0a9b0fd588439485f05cbef5e661231d15fec49b",
+        when="@1.11.0 +fmt_external ^fmt@10:",
+    )
+
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
`fmt@10` (current default in spack) removest the `fmt::basic_runtime` used in `spdlog@1.11.0` (current default in spack), which causes `spdlog +fmt_external` to fail currently. This adds the patch to `spdlog` to address this.

Upstream issue: https://github.com/gabime/spdlog/issues/2693, pr and patch: https://github.com/gabime/spdlog/pull/2694

Test results:
```
==> Installing spdlog-1.11.0-2q3o3tnotwbuifutncwpou7pvbe2fw5u
==> No binary for spdlog-1.11.0-2q3o3tnotwbuifutncwpou7pvbe2fw5u found: installing from source
==> Using cached archive: /data/spack/cache/_source-cache/archive/ca/ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb.tar.gz
==> Fetching https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05.patch?full_index=1
==> Applied patch https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05.patch?full_index=1
==> spdlog: Executing phase: 'cmake'
==> spdlog: Executing phase: 'build'
==> spdlog: Executing phase: 'install'
==> spdlog: Successfully installed spdlog-1.11.0-2q3o3tnotwbuifutncwpou7pvbe2fw5u
  Stage: 1.49s.  Cmake: 0.32s.  Build: 7.17s.  Install: 0.05s.  Post-install: 0.02s.  Total: 9.12s
```