### PR TITLE
mochi-margo: correct patch versions

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -67,7 +67,7 @@ class MochiMargo(AutotoolsPackage):
 
     # Fix pthread detection
     # https://github.com/mochi-hpc/mochi-margo/pull/177
-    patch("mochi-margo-pthreads.patch", when="@0.9,0.9.1:0.9.7")
+    patch("mochi-margo-pthreads.patch", when="@0.9:0.9.7")
 
     def autoreconf(self, spec, prefix):
         sh = which("sh")


### PR DESCRIPTION
Correct the patch versions to remove patch attempts for all 0.9: versions.