### PR TITLE
py-jaxlib: patch bazel server cpu limit (#37548)

### DIFF
--- a/var/spack/repos/builtin/packages/py-jaxlib/package.py
+++ b/var/spack/repos/builtin/packages/py-jaxlib/package.py
@@ -51,6 +51,16 @@ class PyJaxlib(PythonPackage, CudaPackage):
         self.tmp_path = tempfile.mkdtemp(prefix="spack")
         self.buildtmp = tempfile.mkdtemp(prefix="spack")
         filter_file(
+            "build --spawn_strategy=standalone",
+            f"""
+# Limit CPU workers to spack jobs instead of using all HOST_CPUS.
+build --spawn_strategy=standalone
+build --local_cpu_resources={make_jobs}
+""".strip(),
+            ".bazelrc",
+            string=True,
+        )
+        filter_file(
             'f"--output_path={output_path}",',
             'f"--output_path={output_path}",'
             f' "--sources_path={self.tmp_path}",'


### PR DESCRIPTION
Bazel server currently uses all CPU cores, and ignores spack's CPU limit. This patch sets the server limit, which applies to all targets at different phases of the build. See https://github.com/spack/spack/issues/37548#issuecomment-1574232758