### PR TITLE
llvm: add new versions and set default for libomptarget according to os

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -129,12 +129,11 @@ class Llvm(CMakePackage, CudaPackage):
         "or as a project (with the compiler in use)",
     )
 
-    variant(
-        "libomptarget",
-        default=(sys.platform == "linux"),
-        description="Build the OpenMP offloading library",
-    )
+    variant("libomptarget", default=True, description="Build the OpenMP offloading library")
     conflicts("+libomptarget", when="~clang")
+    for _p in ["darwin", "windows"]:
+        conflicts("+libomptarget", when="platform={0}".format(_p))
+    del _p
 
     variant(
         "libomptarget_debug",

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -35,6 +35,8 @@ class Llvm(CMakePackage, CudaPackage):
     family = "compiler"  # Used by lmod
 
     version("main", branch="main")
+    version("16.0.5", sha256="e0fbca476693fcafa125bc71c8535587b6d9950293122b66b262bb4333a03942")
+    version("16.0.4", sha256="10c3fe1757d2e4f1cd7745dc548ecf687680a71824ec81701c38524c2a0753e2")
     version("16.0.3", sha256="0bd71bc687a4e5a250c40afb0decefc50c85178fcce726137b682039de63919b")
     version("16.0.2", sha256="97c3c6aafb53c4bb0ed2781a18d6f05e75445e24bb1dc57a32b74f8d710ac19f")
     version("16.0.1", sha256="b5a9ff1793b1e2d388a3819bf35797002b1d2e40bb35a10c65605e0ea1435271")
@@ -127,7 +129,11 @@ class Llvm(CMakePackage, CudaPackage):
         "or as a project (with the compiler in use)",
     )
 
-    variant("libomptarget", default=True, description="Build the OpenMP offloading library")
+    variant(
+        "libomptarget",
+        default=(sys.platform == "linux"),
+        description="Build the OpenMP offloading library",
+    )
     conflicts("+libomptarget", when="~clang")
 
     variant(


### PR DESCRIPTION
On a mac with `+libomptarget`, one gets :
```
libomptarget cannot be built on Windows and MacOS X!
```
on os x.

Reference: https://github.com/llvm/llvm-project/blob/48bb7bb868919a090492bffb9f3c170dae5250eb/openmp/CMakeLists.txt#L101-L112

Additionally, add checksums for new versions.