### PR TITLE
Update pthreadpool package.py

### DIFF
--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -27,7 +27,7 @@ class Pthreadpool(CMakePackage):
     resource(
         name="fxdiv",
         git="https://github.com/Maratyszcza/FXdiv.git",
-        branch="master",
+        commit="b408327ac2a15ec3e43352421954f5b1967701d1",
         destination="deps",
         placement="fxdiv",
     )


### PR DESCRIPTION
To allow a mirror or source_cache to be used for resource fxdiv, change from using branch master to the commit that master uses - b408327ac2a15ec3e43352421954f5b1967701d1