### PR TITLE
Allow static-only openssl on Linux

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -335,18 +335,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
         ),
     )
     variant("docs", default=False, description="Install docs and manpages")
-    variant(
-        "shared", default=True, description="Build shared library version", when="platform=linux"
-    )
-    variant(
-        "shared", default=True, description="Build shared library version", when="platform=darwin"
-    )
-    variant(
-        "shared",
-        default=False,
-        description="Build shared library version",
-        when="platform=windows",
-    )
+    variant("shared", default=True, description="Build shared library version")
     with when("platform=windows"):
         variant("dynamic", default=False, description="Link with MSVC's dynamic runtime library")
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -335,9 +335,18 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
         ),
     )
     variant("docs", default=False, description="Install docs and manpages")
-    variant("shared", default=True, description="Build shared library version", when="platform=linux")
-    variant("shared", default=True, description="Build shared library version", when="platform=darwin")
-    variant("shared", default=False, description="Build shared library version", when="platform=windows")
+    variant(
+        "shared", default=True, description="Build shared library version", when="platform=linux"
+    )
+    variant(
+        "shared", default=True, description="Build shared library version", when="platform=darwin"
+    )
+    variant(
+        "shared",
+        default=False,
+        description="Build shared library version",
+        when="platform=windows",
+    )
     with when("platform=windows"):
         variant("dynamic", default=False, description="Link with MSVC's dynamic runtime library")
 
@@ -364,7 +373,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
             ["libssl", "libcrypto"],
             root=self.prefix,
             recursive=True,
-            shared=self.spec.variants["shared"].value
+            shared=self.spec.variants["shared"].value,
         )
 
     def handle_fetch_error(self, error):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -24,6 +24,8 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 
+    maintainers("AlexanderRichert-NOAA")
+
     tags = ["core-packages", "windows"]
 
     executables = ["openssl"]


### PR DESCRIPTION
This PR allows openssl to be built statically on Linux. Currently 'shared' variant is not honored when building on Linux. These changes support NOAA/National Weather Service R&D and operational forecasting applications.