### PR TITLE
Rename fpic variant to pic for fms

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -71,7 +71,7 @@ class Fms(CMakePackage):
         when="@2022.02:",
     )
     variant(
-        "fpic", default=False, description="Build with position independent code", when="@2022.02:"
+        "pic", default=False, description="Build with position independent code", when="@2022.02:"
     )
 
     depends_on("netcdf-c")
@@ -86,9 +86,9 @@ class Fms(CMakePackage):
             self.define_from_variant("ENABLE_QUAD_PRECISION", "quad_precision"),
             self.define_from_variant("WITH_YAML", "yaml"),
             self.define_from_variant("CONSTANTS"),
-            self.define_from_variant("FPIC"),
             self.define("32BIT", "precision=32" in self.spec),
             self.define("64BIT", "precision=64" in self.spec),
+            self.define_from_variant("FPIC", "pic"),
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))


### PR DESCRIPTION
This PR renames the 'fpic' variant to 'pic' for the fms package, which is done for consistency. These changes support NOAA/National Weather Service R&D and operational forecasting applications.