### PR TITLE
py-jupyterlab: add 4.0.1 incl. new dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-fqdn/package.py
+++ b/var/spack/repos/builtin/packages/py-fqdn/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFqdn(PythonPackage):
+    """Validates fully-qualified domain names against RFC 1123, so that they
+    are acceptable to modern bowsers."""
+
+    homepage = "https://github.com/ypcrts/fqdn"
+    pypi = "fqdn/fqdn-1.5.1.tar.gz"
+
+    version("1.5.1", sha256="105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-cached-property@1.3:", when="^python@:3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-hatch-jupyter-builder/package.py
+++ b/var/spack/repos/builtin/packages/py-hatch-jupyter-builder/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHatchJupyterBuilder(PythonPackage):
+    """A hatch plugin to help build Jupyter packages."""
+
+    homepage = "https://github.com/jupyterlab/hatch-jupyter-builder"
+    pypi = "hatch_jupyter_builder/hatch_jupyter_builder-0.8.3.tar.gz"
+
+    version("0.8.3", sha256="0dbd14a8aef6636764f88a8fd1fcc9a91921e5c50356e6aab251782f264ae960")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-hatchling@1.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-isoduration/package.py
+++ b/var/spack/repos/builtin/packages/py-isoduration/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyIsoduration(PythonPackage):
+    """Operations with ISO 8601 durations."""
+
+    homepage = "https://github.com/bolsote/isoduration"
+    pypi = "isoduration/isoduration-20.11.0.tar.gz"
+
+    version("20.11.0", sha256="ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-arrow@0.15.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jsonschema/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema/package.py
@@ -23,6 +23,14 @@ class PyJsonschema(PythonPackage):
     version("2.6.0", sha256="6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02")
     version("2.5.1", sha256="36673ac378feed3daa5956276a829699056523d7961027911f064b52255ead41")
 
+    # for versions @:4.5 this same variant was called format_nongpl
+    variant(
+        "format-nongpl",
+        default=False,
+        when="@3.2:",
+        description="Enable format-nongpl functionality",
+    )
+
     depends_on("py-hatchling", when="@4.10:", type="build")
     depends_on("py-hatch-vcs", when="@4.10:", type="build")
     depends_on("py-hatch-fancy-pypi-readme", when="@4.11:", type="build")
@@ -45,3 +53,14 @@ class PyJsonschema(PythonPackage):
     depends_on("py-six@1.11:", when="@3", type=("build", "run"))
 
     conflicts("^py-pyrsistent@0.17.0:0.17.2")
+
+    with when("+format-nongpl"):
+        depends_on("py-fqdn", when="@4:", type=("build", "run"))
+        depends_on("py-idna", type=("build", "run"))
+        depends_on("py-isoduration", when="@4:", type=("build", "run"))
+        depends_on("py-jsonpointer@1.14:", type=("build", "run"))
+        depends_on("py-rfc3339-validator", type=("build", "run"))
+        depends_on("py-rfc3986-validator@0.1.1:", type=("build", "run"))
+        depends_on("py-uri-template", when="@4:", type=("build", "run"))
+        depends_on("py-webcolors@1.11:", when="@4:", type=("build", "run"))
+        depends_on("py-webcolors", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-events/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-events/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyJupyterEvents(PythonPackage):
+    """Jupyter Event System library."""
+
+    homepage = "https://github.com/jupyter/jupyter_events"
+    pypi = "jupyter_events/jupyter_events-0.6.3.tar.gz"
+
+    version("0.6.3", sha256="9a6e9995f75d1b7146b436ea24d696ce3a35bfa8bfe45e0c33c334c79464d0b3")
+
+    depends_on("py-hatchling@1.5:", type="build")
+
+    depends_on("py-jsonschema+format-nongpl@3.2:", type=("build", "run"))
+    depends_on("py-python-json-logger@2.0.4:", type=("build", "run"))
+    depends_on("py-pyyaml@5.3:", type=("build", "run"))
+    depends_on("py-traitlets@5.3:", type=("build", "run"))
+    depends_on("py-rfc3339-validator", type=("build", "run"))
+    depends_on("py-rfc3986-validator@0.1.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-lsp/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-lsp/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyJupyterLsp(PythonPackage):
+    """Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server."""
+
+    homepage = "https://github.com/jupyter-lsp/jupyterlab-lsp"
+    pypi = "jupyter-lsp/jupyter-lsp-2.2.0.tar.gz"
+
+    version("2.2.0", sha256="8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-jupyter-server@1.1.2:", type=("build", "run"))
+    depends_on("py-importlib-metadata@4.8.3:", when="^python@:3.9", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server-terminals/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server-terminals/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyJupyterServerTerminals(PythonPackage):
+    """A Jupyter Server Extension Providing Terminals."""
+
+    homepage = "https://github.com/jupyter-server/jupyter_server_terminals"
+    pypi = "jupyter_server_terminals/jupyter_server_terminals-0.4.4.tar.gz"
+
+    version("0.4.4", sha256="57ab779797c25a7ba68e97bcfb5d7740f2b5e8a83b5e8102b10438041a7eac5d")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-hatchling@1.5:", type="build")
+
+    # for windows depends_on pywinpty@2.0.3:
+    # py-pywinpty is not in spack and requires the build system maturin
+    depends_on("py-terminado@0.8.3:", type=("build", "run"))
+    # to prevent: ModuleNotFoundError: Jupyter Server must be installed to use this extension.
+    # there should be a dependency on `py-jupyter-server` but this would create
+    # a cyclic dependency

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -14,6 +14,7 @@ class PyJupyterServer(PythonPackage):
     homepage = "https://github.com/jupyter-server/jupyter_server"
     pypi = "jupyter_server/jupyter_server-1.9.0.tar.gz"
 
+    version("2.6.0", sha256="ae4af349f030ed08dd78cb7ac1a03a92d886000380c9ea6283f3c542a81f4b06")
     version("1.21.0", sha256="d0adca19913a3763359be7f0b8c2ea8bfde356f4b8edd8e3149d7d0fbfaa248b")
     version("1.18.1", sha256="2b72fc595bccae292260aad8157a0ead8da2c703ec6ae1bb7b36dbad0e267ea7")
     version("1.17.0", sha256="7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c")
@@ -25,37 +26,51 @@ class PyJupyterServer(PythonPackage):
     version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
     version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 
-    depends_on("python@3.7:", when="@1.13.2:", type=("build", "run"))
-    depends_on("python@3.6:", type=("build", "run"))
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", when="@1.6.2:", type="build")
-    # depends_on('py-jupyter-packaging@0.9:0', when='@1.6.2:', type='build')
-    depends_on("py-pre-commit", when="@1.16:", type="build")
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.8:", when="@2:", type=("build", "run"))
+    depends_on("py-hatchling@1.11:", when="@2:", type="build")
+    # under [tool.hatch.build.hooks.jupyter-builder] in pyproject.toml
+    depends_on("py-hatch-jupyter-builder@0.8.1:", when="@2:", type="build")
 
-    depends_on("py-anyio@3.1.0:3", type=("build", "run"))
+    with when("@:1"):
+        # TODO: replace this after concretizer learns how to concretize separate build deps
+        depends_on("py-jupyter-packaging11", when="@1.6.2:", type="build")
+        # depends_on('py-jupyter-packaging@0.9:0', when='@1.6.2:', type='build')
+        depends_on("py-pre-commit", when="@1.16:", type="build")
+        depends_on("py-setuptools", type="build")
+
+    depends_on("py-anyio@3.1.0:", when="@2.2.1:", type=("build", "run"))
+    depends_on("py-anyio@3.1.0:3", when="@:2.2.0", type=("build", "run"))
     depends_on("py-argon2-cffi", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"))
+    depends_on("py-jupyter-client@7.4.4:", when="@2:", type=("build", "run"))
     depends_on("py-jupyter-client@6.1.12:", when="@1.16:", type=("build", "run"))
     depends_on("py-jupyter-client@6.1.1:", type=("build", "run"))
+    depends_on("py-jupyter-core@4.12:4,5.1:", when="@1.23.5:", type=("build", "run"))
     depends_on("py-jupyter-core@4.7:", when="@1.16:", type=("build", "run"))
     depends_on("py-jupyter-core@4.6:", type=("build", "run"))
+    depends_on("py-jupyter-server-terminals", when="@2:", type=("build", "run"))
     depends_on("py-nbconvert@6.4.4:", when="@1.16:", type=("build", "run"))
     depends_on("py-nbconvert", type=("build", "run"))
+    depends_on("py-nbformat@5.3:", when="@2:", type=("build", "run"))
     depends_on("py-nbformat@5.2:", when="@1.15:", type=("build", "run"))
     depends_on("py-nbformat", type=("build", "run"))
     depends_on("py-packaging", when="@1.13.2:", type=("build", "run"))
     depends_on("py-prometheus-client", type=("build", "run"))
-    # for windows depends_on pywinpty@:1, when='@1.13.2:'
+    # for windows depends_on pywinpty, when='@1.13.2:'
     # py-pywinpty is not in spack and requires the build system maturin
+    depends_on("py-pyzmq@24:", when="@2:", type=("build", "run"))
     depends_on("py-pyzmq@17:", type=("build", "run"))
     depends_on("py-send2trash", type=("build", "run"))
     depends_on("py-terminado@0.8.3:", type=("build", "run"))
+    depends_on("py-tornado@6.2:", when="@2:", type=("build", "run"))
     depends_on("py-tornado@6.1:", type=("build", "run"))
+    depends_on("py-traitlets@5.6:", when="@2.0.1:", type=("build", "run"))
     depends_on("py-traitlets@5.1:", when="@1.16:", type=("build", "run"))
     depends_on("py-traitlets@5:", when="@1.13.3:", type=("build", "run"))
     depends_on("py-traitlets@4.2.1:", type=("build", "run"))
     depends_on("py-websocket-client", type=("build", "run"))
+    depends_on("py-jupyter-events@0.6:", when="@2.6:", type=("build", "run"))
+    depends_on("py-overrides", when="@2.6:", type=("build", "run"))
 
     # old
     depends_on("py-ipython-genutils", when="@:1.15", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
@@ -14,24 +14,36 @@ class PyJupyterlabServer(PythonPackage):
     homepage = "https://github.com/jupyterlab/jupyterlab_server"
     pypi = "jupyterlab_server/jupyterlab_server-1.2.0.tar.gz"
 
+    version("2.22.1", sha256="dfaaf898af84b9d01ae9583b813f378b96ee90c3a66f24c5186ea5d1bbdb2089")
     version("2.10.3", sha256="3fb84a5813d6d836ceda773fb2d4e9ef3c7944dbc1b45a8d59d98641a80de80a")
     version("2.6.0", sha256="f300adf6bb0a952bebe9c807a3b2a345d62da39b476b4f69ea0dc6b5f3f6b97d")
     version("1.2.0", sha256="5431d9dde96659364b7cc877693d5d21e7b80cea7ae3959ecc2b87518e5f5d8c")
     version("1.1.0", sha256="bac27e2ea40f686e592d6429877e7d46947ea76c08c878081b028c2c89f71733")
 
-    depends_on("python@3.6:", when="@2.5:", type=("build", "run"))
-    depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", type="build")
-    # depends_on('py-jupyter-packaging@0.9:0', type='build')
+    depends_on("py-hatchling@1.5:", when="@2.16:", type="build")
 
+    with when("@:2.14"):
+        depends_on("py-setuptools", type="build")
+        # TODO: replace this after concretizer learns how to concretize separate build deps
+        depends_on("py-jupyter-packaging11", type="build")
+        # depends_on('py-jupyter-packaging@0.9:0', type='build')
+
+    depends_on("py-babel@2.10:", when="@2.16.4:", type=("build", "run"))
     depends_on("py-babel", when="@2.5.1:", type=("build", "run"))
-    depends_on("py-entrypoints@0.2.2:", when="@2.7:", type=("build", "run"))
+    depends_on("py-importlib-metadata@4.8.3:", when="@2.13: ^python@:3.9", type=("build", "run"))
+    depends_on("py-jinja2@3.0.3:", when="@2.11:", type=("build", "run"))
     depends_on("py-jinja2@2.10:", type=("build", "run"))
+    depends_on("py-json5@0.9.0:", when="@2.16.4:", type=("build", "run"))
     depends_on("py-json5", type=("build", "run"))
+    depends_on("py-jsonschema@4.17.3:", when="@2.17:", type=("build", "run"))
     depends_on("py-jsonschema@3.0.1:", type=("build", "run"))
+    depends_on("py-jupyter-server@1.21:2", when="@2.16.4:", type=("build", "run"))
+    depends_on("py-jupyter-server@1.4:1", when="@2.5.1:2.10", type=("build", "run"))
+    depends_on("py-packaging@21.3:", when="@2.16.4:", type=("build", "run"))
     depends_on("py-packaging", when="@2.5.1:", type=("build", "run"))
+    depends_on("py-requests@2.28:", when="@2.16.4:", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
-    depends_on("py-jupyter-server@1.4:1", when="@2.5.1:", type=("build", "run"))
+
+    # old dependencies
+    depends_on("py-entrypoints@0.2.2:", when="@2.7:2.12", type=("build", "run"))
     depends_on("py-notebook@4.2.0:", when="@:2.5.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -14,9 +14,7 @@ class PyJupyterlab(PythonPackage):
     homepage = "https://github.com/jupyterlab/jupyterlab"
     pypi = "jupyterlab/jupyterlab-2.2.7.tar.gz"
 
-    # Skip 'jupyterlab.tests' packages
-    import_modules = ["jupyterlab", "jupyterlab.handlers"]
-
+    version("4.0.1", sha256="4dc3901f7bbfd4704c994b7a893a49955256abf57dba9831f4825e3f3165b8bb")
     version("3.4.8", sha256="1fafb8b657005d91603f3c3adfd6d9e8eaf33fdc601537fef09283332efe67cb")
     version("3.4.2", sha256="38abd3a4f83a8f97e3f15bebbcc0825903c15519809eedfaa41340d260be2160")
     version("3.2.9", sha256="65ddc34e5da1a764606e38c4f70cf9d4ac1c05182813cf0ab2dfea312c701124")
@@ -30,42 +28,57 @@ class PyJupyterlab(PythonPackage):
     version("2.2.7", sha256="a72ffd0d919cba03a5ef8422bc92c3332a957ff97b0490494209c83ad93826da")
     version("2.1.0", sha256="8c239aababf5baa0b3d36e375fddeb9fd96f3a9a24a8cda098d6a414f5bbdc81")
 
-    depends_on("python@3.7:", when="@3.3:", type=("build", "run"))
-    depends_on("python@3.6:", when="@3:", type=("build", "run"))
-    depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type=("build", "run"))
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", when="@3.0.15:", type="build")
-    depends_on("py-jupyter-packaging7", when="@3.0.0:3.0.14", type="build")
-    # depends_on('py-jupyter-packaging@0.9:0', when='@3.0.15:', type='build')
-    # depends_on('py-jupyter-packaging@0.7.3:0.7', when='@3.0.0:3.0.14',
-    #            type=('build', 'run'))
-    depends_on("py-pre-commit", when="@3.4:3.4.3", type="build")
+    depends_on("python@3.8:", when="@4:", type=("build", "run"))
+    depends_on("py-hatchling@1.5:", when="@4:", type=("build", "run"))
+    # under [tool.hatch.build.hooks.jupyter-builder] in pyproject.toml
+    depends_on("py-hatch-jupyter-builder@0.3.2:", when="@4:", type=("build", "run"))
 
-    # @3:
-    depends_on("py-ipython", when="@3:", type=("build", "run"))
-    depends_on("py-packaging", when="@3:", type=("build", "run"))
-    depends_on("py-tornado@6.1:", when="@3:", type=("build", "run"))
+    depends_on("py-async-lru@1:", when="@4:", type=("build", "run"))
+    depends_on("py-importlib-metadata@4.8.3:", when="@4: ^python@:3.9", type=("build", "run"))
+    depends_on("py-importlib-resources@1.4:", when="@4: ^python@:3.8", type=("build", "run"))
+    depends_on("py-ipykernel", when="@4:", type=("build", "run"))
+    depends_on("py-jinja2@3.0.3", when="@4:", type=("build", "run"))
     depends_on("py-jupyter-core", when="@3:", type=("build", "run"))
-    depends_on("py-jupyterlab-server@2.10:2", when="@3.3:", type=("build", "run"))
-    depends_on("py-jupyterlab-server@2.3:2", when="@3.0.9:3.2", type=("build", "run"))
-    depends_on("py-jupyterlab-server@2.0:2", when="@3.0.0:3.0.8", type=("build", "run"))
-    depends_on("py-jupyter-server@1.16:1", when="@3.4:", type=("build", "run"))
-    depends_on("py-jupyter-server@1.4:1", when="@3.0.9:3.3", type=("build", "run"))
-    depends_on("py-jupyter-server@1.2:1", when="@3.0.3:3.0.8", type=("build", "run"))
-    depends_on("py-jupyter-server@1.1:1", when="@3.0.0:3.0.2", type=("build", "run"))
-    depends_on("py-nbclassic", when="@3.4.4:", type=("build", "run"))
-    depends_on("py-nbclassic@0.2.0:0", when="@3:3.4.3", type=("build", "run"))
-    depends_on("py-notebook@:6", when="@3.4.8:", type=("build", "run"))
-    # dependency on py-jinja2@2.1 seems to be a migration issue from the switch
-    # to setup.cfg in 3.0.15, leave it a 2.10
-    depends_on("py-jinja2@2.10:", type=("build", "run"))
-    depends_on("py-tomli", when="@3.4.7:", type=("build", "run"))
+    depends_on("py-jupyter-lsp@2:", when="@4:", type=("build", "run"))
+    depends_on("py-jupyter-server@2.4:2", when="@4:", type=("build", "run"))
+    depends_on("py-jupyterlab-server@2.19:2", when="@4:", type=("build", "run"))
+    depends_on("py-notebook-shim@0.2:", when="@4:", type=("build", "run"))
+    depends_on("py-packaging", when="@3:", type=("build", "run"))
+    depends_on("py-traitlets", when="@4:", type=("build", "run"))
+    depends_on("py-tornado@6.2:", when="@4:", type=("build", "run"))
+    depends_on("py-tomli", when="@3.4.7: ^python@:3.10", type=("build", "run"))
 
-    # @:2
-    depends_on("py-notebook@4.3.1:", when="@:2", type=("build", "run"))
-    depends_on("py-tornado@:5,6.0.3:", when="@:2", type=("build", "run"))
-    depends_on("py-jupyterlab-server@1.1.5:1", when="@:2", type=("build", "run"))
+    with when("@:3"):
+        depends_on("py-setuptools", when="@:3", type=("build", "run"))
+        # TODO: replace this after concretizer learns how to concretize separate build deps
+        depends_on("py-jupyter-packaging11", when="@3.0.15:3", type="build")
+        depends_on("py-jupyter-packaging7", when="@3.0.0:3.0.14", type="build")
+        # depends_on('py-jupyter-packaging@0.9:0', when='@3.0.15:', type='build')
+        # depends_on('py-jupyter-packaging@0.7.3:0.7', when='@3.0.0:3.0.14',
+        #            type=('build', 'run'))
+        depends_on("py-pre-commit", when="@3.4:3.4.3", type="build")
+
+        depends_on("py-ipython", when="@3", type=("build", "run"))
+        depends_on("py-tornado@6.1:", when="@3:", type=("build", "run"))
+        depends_on("py-jupyterlab-server@2.10:2", when="@3.3:", type=("build", "run"))
+        depends_on("py-jupyterlab-server@2.3:2", when="@3.0.9:3.2", type=("build", "run"))
+        depends_on("py-jupyterlab-server@2.0:2", when="@3.0.0:3.0.8", type=("build", "run"))
+        depends_on("py-jupyter-server@1.16:1", when="@3.4:", type=("build", "run"))
+        depends_on("py-jupyter-server@1.4:1", when="@3.0.9:3.3", type=("build", "run"))
+        depends_on("py-jupyter-server@1.2:1", when="@3.0.3:3.0.8", type=("build", "run"))
+        depends_on("py-jupyter-server@1.1:1", when="@3.0.0:3.0.2", type=("build", "run"))
+        depends_on("py-nbclassic", when="@3.4.4:", type=("build", "run"))
+        depends_on("py-nbclassic@0.2.0:0", when="@3:3.4.3", type=("build", "run"))
+        depends_on("py-notebook@:6", when="@3.4.8:", type=("build", "run"))
+        # dependency on py-jinja2@2.1 seems to be a migration issue from the switch
+        # to setup.cfg in 3.0.15, leave it a 2.10
+        depends_on("py-jinja2@2.10:", type=("build", "run"))
+
+    with when("@:2"):
+        depends_on("python@:3.9", when="@:2.1", type=("build", "run"))
+        depends_on("py-notebook@4.3.1:", type=("build", "run"))
+        depends_on("py-tornado@:5,6.0.3:", type=("build", "run"))
+        depends_on("py-jupyterlab-server@1.1.5:1", type=("build", "run"))
 
     def setup_run_environment(self, env):
         env.set("JUPYTERLAB_DIR", self.prefix.share.jupyter.lab)

--- a/var/spack/repos/builtin/packages/py-overrides/package.py
+++ b/var/spack/repos/builtin/packages/py-overrides/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyOverrides(PythonPackage):
+    """A decorator to automatically detect mismatch when overriding a method."""
+
+    homepage = "https://github.com/mkorpela/overrides"
+    pypi = "overrides/overrides-7.3.1.tar.gz"
+
+    version("7.3.1", sha256="8b97c6c1e1681b78cbc9424b138d880f0803c2254c5ebaabdde57bb6c62093f2")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-python-json-logger/package.py
+++ b/var/spack/repos/builtin/packages/py-python-json-logger/package.py
@@ -15,4 +15,4 @@ class PyPythonJsonLogger(PythonPackage):
     version("2.0.7", sha256="23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c")
     version("0.1.11", sha256="b7a31162f2a01965a5efb94453ce69230ed208468b0bbc7fdfc56e6d8df2e281")
 
-    depends_on("py-setuptools")
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-python-json-logger/package.py
+++ b/var/spack/repos/builtin/packages/py-python-json-logger/package.py
@@ -12,7 +12,7 @@ class PyPythonJsonLogger(PythonPackage):
     homepage = "https://github.com/madzak/python-json-logger"
     pypi = "python-json-logger/python-json-logger-0.1.11.tar.gz"
 
+    version("2.0.7", sha256="23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c")
     version("0.1.11", sha256="b7a31162f2a01965a5efb94453ce69230ed208468b0bbc7fdfc56e6d8df2e281")
 
-    depends_on("python@2.7:", type=("build", "run"))
     depends_on("py-setuptools")

--- a/var/spack/repos/builtin/packages/py-rfc3339-validator/package.py
+++ b/var/spack/repos/builtin/packages/py-rfc3339-validator/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRfc3339Validator(PythonPackage):
+    """A pure python RFC3339 validator."""
+
+    homepage = "https://github.com/naimetti/rfc3339-validator"
+    pypi = "rfc3339_validator/rfc3339_validator-0.1.4.tar.gz"
+
+    version("0.1.4", sha256="138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-six", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-rfc3986-validator/package.py
+++ b/var/spack/repos/builtin/packages/py-rfc3986-validator/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRfc3986Validator(PythonPackage):
+    """Pure python rfc3986 validator."""
+
+    homepage = "https://github.com/naimetti/rfc3986-validator"
+    pypi = "rfc3986_validator/rfc3986_validator-0.1.1.tar.gz"
+
+    version("0.1.1", sha256="3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pytest-runner", type="build")

--- a/var/spack/repos/builtin/packages/py-uri-template/package.py
+++ b/var/spack/repos/builtin/packages/py-uri-template/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyUriTemplate(PythonPackage):
+    """RFC 6570 URI Template Processor."""
+
+    homepage = "https://github.com/plinss/uri_template"
+    pypi = "uri_template/uri_template-1.2.0.tar.gz"
+
+    version("1.2.0", sha256="934e4d09d108b70eb8a24410af8615294d09d279ce0e7cbcdaef1bd21f932b06")
+
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab/tree/v4.0.1
(explicit definition of import_modules not needed, all versions build with "--test=root")

https://github.com/jupyterlab/hatch-jupyter-builder/tree/v0.8.3
https://github.com/jupyter-server/jupyter_server/tree/v2.6.0
https://github.com/jupyter-server/jupyter_server_terminals/tree/v0.4.4
(does not build on its own because it would need a dependency on py-jupyter-server which would create a cyclic dependency)
https://github.com/jupyter/jupyter_events/tree/v0.6.3
https://github.com/python-jsonschema/jsonschema/tree/v4.17.3
https://github.com/ypcrts/fqdn/tree/v1.5.1
https://github.com/bolsote/isoduration/tree/20.11.0
https://github.com/naimetti/rfc3339-validator/tree/v0.1.4
https://pypi.org/project/rfc3986-validator/#files
https://github.com/plinss/uri-template/tree/v1.2.0
https://github.com/madzak/python-json-logger/tree/v2.0.7
https://github.com/mkorpela/overrides/tree/7.3.1
https://pypi.org/project/jupyter-lsp/#files
https://github.com/jupyterlab/jupyterlab_server/tree/v2.22.1