### PR TITLE
py-hatch-fancy-pypi-readme: depends_on when typo

### DIFF
--- a/var/spack/repos/builtin/packages/py-hatch-fancy-pypi-readme/package.py
+++ b/var/spack/repos/builtin/packages/py-hatch-fancy-pypi-readme/package.py
@@ -16,5 +16,5 @@ class PyHatchFancyPypiReadme(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-hatchling", type=("build", "run"))
-    depends_on("py-tomli", when="python@:3.10", type=("build", "run"))
-    depends_on("py-typing-extensions", when="python@:3.7", type=("build", "run"))
+    depends_on("py-tomli", when="^python@:3.10", type=("build", "run"))
+    depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
Stumbled upon this typo. The `when` should refer to the dependencies.

`audit` might be able to catch this class of errors, but seems like it didn't.