### PR TITLE
azcopy: add v10.19.0

### DIFF
--- a/var/spack/repos/builtin/packages/azcopy/package.py
+++ b/var/spack/repos/builtin/packages/azcopy/package.py
@@ -14,6 +14,7 @@ class Azcopy(Package):
     homepage = "https://github.com/Azure/azure-storage-azcopy"
     url = "https://github.com/Azure/azure-storage-azcopy/archive/refs/tags/v10.18.1.tar.gz"
 
+    version("10.19.0", sha256="33ce1539b56a4e9a38140374630bd9640157bb44d0c57b3224a5e5f592ab5399")
     version("10.18.1", sha256="80292625d7f1a6fc41688c5948b3a20cfdae872464d37d831e20999430819c3f")
 
     depends_on("go", type="build")


### PR DESCRIPTION
Add azcopy v10.19.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.