### PR TITLE
hssp: add v3.1.5

### DIFF
--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -19,6 +19,7 @@ class Hssp(AutotoolsPackage):
     homepage = "https://github.com/cmbi/hssp"
     url = "https://github.com/cmbi/hssp/archive/3.0.10.tar.gz"
 
+    version("3.1.5", sha256="9462608ce6b5b92f13a3a8d94b780d85a3cac68ab38449116193754cc22dc5d0")
     version("3.0.10", sha256="9b2cba9c498e65fd48730f0fc86ca2b480bf12903a2c131521023f3a161fe870")
     version("3.0.9", sha256="2f67743ffd233ed9c4cd298e8fc65a332b863052945fb62bd61d7f1776274da9")
     version("3.0.8", sha256="56c926d2e43a3dd6324de558dde868751355f385d1b60fd85586a0a2c2bc82e0")


### PR DESCRIPTION
Add hssp v3.1.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.