### PR TITLE
hyperfine: add v1.16.1

### DIFF
--- a/var/spack/repos/builtin/packages/hyperfine/package.py
+++ b/var/spack/repos/builtin/packages/hyperfine/package.py
@@ -14,6 +14,7 @@ class Hyperfine(Package):
 
     maintainers("michaelkuhn")
 
+    version("1.16.1", sha256="ffb3298945cbe2c068ca1a074946d55b9add83c9df720eda2ed7f3d94d7e65d2")
     version("1.14.0", sha256="59018c22242dd2ad2bd5fb4a34c0524948b7921d02aa79419ccec4c1ffd3da14")
     version("1.13.0", sha256="6e57c8e51962dd24a283ab46dde6fe306da772f4ef9bad86f8c89ac3a499c87e")
     version("1.12.0", sha256="2120870a97e68fa3426eac5646a071c9646e96d2309220e3c258bf588e496454")


### PR DESCRIPTION
Add hyperfine v1.16.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.