### PR TITLE
diamond: add v2.1.7

### DIFF
--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -14,6 +14,7 @@ class Diamond(CMakePackage):
     url = "https://github.com/bbuchfink/diamond/archive/v2.0.9.tar.gz"
     maintainers("snehring")
 
+    version("2.1.7", sha256="2dcaba0e79ecb02c3d2a6816d317e714767118a9a056721643abff4c586ca95b")
     version("2.1.6", sha256="852d27c7535d53f1ce59db0625ff23ac3bf17e57f7a3b1c46c08718f77e19c54")
     version("2.0.15", sha256="cc8e1f3fd357d286cf6585b21321bd25af69aae16ae1a8f605ea603c1886ffa4")
     version("2.0.14", sha256="3eaef2b957e4ba845eac27a2ca3249aae4259ff1fe0ff5a21b094481328fdc53")


### PR DESCRIPTION
Add diamond v2.1.7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.