### PR TITLE
iozone: add v3_506

### DIFF
--- a/var/spack/repos/builtin/packages/iozone/package.py
+++ b/var/spack/repos/builtin/packages/iozone/package.py
@@ -16,6 +16,7 @@ class Iozone(MakefilePackage):
     homepage = "https://www.iozone.org/"
     url = "https://www.iozone.org/src/current/iozone3_465.tar"
 
+    version("3_506", sha256="114ce5c071873b9a2c7ba6e73d05d5ef7e66564392acbfcdc0b3261db10fcbe7")
     version("3_491", sha256="2cc4842d382e46a585d1df9ae1e255695480dcc0fc05c3b1cb32ef3493d0ec9a")
     version("3_465", sha256="2e3d72916e7d7340a7c505fc0c3d28553fcc5ff2daf41d811368e55bd4e6a293")
 


### PR DESCRIPTION
Add iozone v3_506. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.