### PR TITLE
jimtcl: add v0.82

### DIFF
--- a/var/spack/repos/builtin/packages/jimtcl/package.py
+++ b/var/spack/repos/builtin/packages/jimtcl/package.py
@@ -12,6 +12,7 @@ class Jimtcl(AutotoolsPackage):
     homepage = "http://jim.tcl.tk/"
     url = "https://github.com/msteveb/jimtcl/archive/0.79.tar.gz"
 
+    version("0.82", sha256="e8af929b815e4d30e54ff116b2b933e56c00a02b9110529d1a58660b2469aea7")
     version("0.79", sha256="ab8204cd03b946f5149e1273af9c86d8e73b146084a0fbeb1d4f41a75b0b3411")
     version("0.78", sha256="cf801795c9fd98bfff6882c14afdf96424ba86dead58c2a4e15978b176d3e12b")
     version("0.77", sha256="0874c50ab932c68940c29c48c014266a322c54ff357a0919386f32cc341eb3b2")


### PR DESCRIPTION
Add jimtcl v0.82. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.