### PR TITLE
jline3: add v3.22.0

### DIFF
--- a/var/spack/repos/builtin/packages/jline3/package.py
+++ b/var/spack/repos/builtin/packages/jline3/package.py
@@ -12,6 +12,7 @@ class Jline3(MavenPackage):
     homepage = "https://github.com/jline/jline3/"
     url = "https://github.com/jline/jline3/archive/jline-parent-3.16.0.tar.gz"
 
+    version("3.22.0", sha256="610ff2fca902f006d230d05be4eb6d62f345bb64371a279d521373c7b61a6279")
     version("3.16.0", sha256="d2de8dfe55a55e20752aeb082a75192bf835baaab75f257d3fab90ce350fdbcb")
     version("3.15.0", sha256="3953c22efad2d525f1d1fbf8f02baa302da21c18f3f60a19ee216e819fab9ac1")
     version("3.14.1", sha256="9b1bdb48af772eb60a010544bc28a6cca565d2856ababe5684e0938ca519335b")


### PR DESCRIPTION
Add jline3 v3.22.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.