### PR TITLE
kubernetes: add v1.27.2

### DIFF
--- a/var/spack/repos/builtin/packages/kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/kubernetes/package.py
@@ -16,6 +16,7 @@ class Kubernetes(Package):
 
     maintainers("alecbcs")
 
+    version("1.27.2", sha256="c6fcfddd38f877ce49c49318973496f9a16672e83a29874a921242950cd1c5d2")
     version("1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f")
     version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
 


### PR DESCRIPTION
Add kubernetes v1.27.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.