### PR TITLE
libspiro: add v20221101

### DIFF
--- a/var/spack/repos/builtin/packages/libspiro/package.py
+++ b/var/spack/repos/builtin/packages/libspiro/package.py
@@ -13,6 +13,7 @@ class Libspiro(AutotoolsPackage):
     homepage = "https://github.com/fontforge/"
     url = "https://github.com/fontforge/libspiro/archive/20200505.tar.gz"
 
+    version("20221101", sha256="d5d8af0648e33fe2344c41824823974a32c4e880c4ae9d846ec4414836a421c4")
     version("20200505", sha256="00be530b5c0ea9274baadf6c05521f0b192d4c3c1db636ac8b08efd44aaea8f5")
     version("20190731", sha256="24c7d1ccc7c7fe44ff10c376aa9f96e20e505f417ee72b63dc91a9b34eeac354")
 


### PR DESCRIPTION
Add libspiro v20221101. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.