### PR TITLE
libthai: add v0.1.29

### DIFF
--- a/var/spack/repos/builtin/packages/libthai/package.py
+++ b/var/spack/repos/builtin/packages/libthai/package.py
@@ -16,6 +16,7 @@ class Libthai(AutotoolsPackage):
     homepage = "https://linux.thai.net"
     url = "https://github.com/tlwg/libthai/releases/download/v0.1.28/libthai-0.1.28.tar.xz"
 
+    version("0.1.29", sha256="fc80cc7dcb50e11302b417cebd24f2d30a8b987292e77e003267b9100d0f4bcd")
     version("0.1.28", sha256="ffe0a17b4b5aa11b153c15986800eca19f6c93a4025ffa5cf2cab2dcdf1ae911")
     version("0.1.27", sha256="1659fa1b7b1d6562102d7feb8c8c3fd94bb2dc5761ed7dbaae4f300e1c03eff6")
 


### PR DESCRIPTION
Add libthai v0.1.29. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.