### PR TITLE
lsscsi: add v0.32

### DIFF
--- a/var/spack/repos/builtin/packages/lsscsi/package.py
+++ b/var/spack/repos/builtin/packages/lsscsi/package.py
@@ -15,5 +15,6 @@ class Lsscsi(AutotoolsPackage):
     homepage = "https://sg.danny.cz/scsi/lsscsi.html"
     url = "https://sg.danny.cz/scsi/lsscsi-0.31.tgz"
 
+    version("0.32", sha256="0a800e9e94dca2ab702d65d72777ae8cae078e3d74d0bcbed64ba0849e8029a1")
     version("0.31", sha256="12bf1973014803c6fd6d547e7594a4c049f0eef3bf5d22190d4be29d7c09f3ca")
     version("0.30", sha256="619a2187405f02c5f57682f3478bffc75326803cd08839e39d434250c5518b15")


### PR DESCRIPTION
Add lsscsi v0.32. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.