### PR TITLE
mariadb-c-client: add v3.3.5

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb-c-client/package.py
+++ b/var/spack/repos/builtin/packages/mariadb-c-client/package.py
@@ -22,6 +22,7 @@ class MariadbCClient(CMakePackage):
     list_url = "https://downloads.mariadb.com/Connectors/c/"
     list_depth = 1
 
+    version("3.3.5", sha256="ca72eb26f6db2befa77e48ff966f71bcd3cb44b33bd8bbb810b65e6d011c1e5c")
     version("3.3.4", sha256="486e5fdf976a8e7fadf583ae912128655e013ac575fa79b2d1af0fb8827a78ed")
     version("3.3.2", sha256="7e0722e07d30bb906fac9fe10fb582cde1e148e05a83d9ca7b6fcc884b68fbce")
     version("3.2.7", sha256="9d7196248e6697c09c73e173fe9b282045f55ec9d7ae743c1ebad08b9ea56dda")


### PR DESCRIPTION
Add mariadb-c-client v3.3.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.