### PR TITLE
nccmp: add v1.9.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/nccmp/package.py
+++ b/var/spack/repos/builtin/packages/nccmp/package.py
@@ -14,6 +14,7 @@ class Nccmp(CMakePackage):
 
     maintainers("ulmononian", "climbfuji")
 
+    version("1.9.1.0", sha256="5aa8d6cbc54d26f77e3d0511690cfafa57514a4145f75e8cabce782126509c91")
     version("1.9.0.1", sha256="81e9753cf451afe8248d44c841e102349e07cde942b11d1f91b5f85feb622b99")
     version("1.8.9.0", sha256="da5d2b4dcd52aec96e7d96ba4d0e97efebbd40fe9e640535e5ee3d5cd082ae50")
     version("1.8.2.0", sha256="7f5dad4e8670568a71f79d2bcebb08d95b875506d3d5faefafe1a8b3afa14f18")


### PR DESCRIPTION
Add nccmp v1.9.1.0. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.