### PR TITLE
ngmlr: add v0.2.7

### DIFF
--- a/var/spack/repos/builtin/packages/ngmlr/package.py
+++ b/var/spack/repos/builtin/packages/ngmlr/package.py
@@ -14,6 +14,7 @@ class Ngmlr(CMakePackage):
     homepage = "https://github.com/philres/ngmlr"
     url = "https://github.com/philres/ngmlr/archive/v0.2.5.tar.gz"
 
+    version("0.2.7", sha256="5126a6b3e726cac0da0713883daac688f38587f118428247a9a3ace5a55b29aa")
     version("0.2.5", sha256="719944a35cc7ff9c321eedbf3385a7375ce2301f609b3fd7be0a850cabbb028b")
 
     depends_on("zlib", type="link")


### PR DESCRIPTION
Add ngmlr v0.2.7. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.