### PR TITLE
parallel: add v20230522

### DIFF
--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -15,6 +15,7 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/parallel/"
     gnu_mirror_path = "parallel/parallel-20220522.tar.bz2"
 
+    version("20230522", sha256="1af46b7605023b14360bb968845de6413db24bf0f951f5e0208d23803cb64202")
     version("20220522", sha256="bb6395f8d964e68f3bdb26a764d3c48b69bc5b759a92ac3ab2bd1895c7fa8c1f")
     version("20220422", sha256="96e4b73fff1302fc141a889ae43ab2e93f6c9e86ac60ef62ced02dbe70b73ca7")
     version("20220322", sha256="df93ccf6a9f529ad2126b7042aef0486603e938c77b405939c41702d38a4e6d8")


### PR DESCRIPTION
Add parallel v20230522. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.