### PR TITLE
sbt: add v1.8.3

### DIFF
--- a/var/spack/repos/builtin/packages/sbt/package.py
+++ b/var/spack/repos/builtin/packages/sbt/package.py
@@ -12,6 +12,7 @@ class Sbt(Package):
     homepage = "https://www.scala-sbt.org"
     url = "https://github.com/sbt/sbt/releases/download/v1.1.4/sbt-1.1.4.tgz"
 
+    version("1.8.3", sha256="21f4210786fd68fd15dca3f4c8ee9cae0db249c54e1b0ef6e829e9fa4936423a")
     version("1.1.6", sha256="f545b530884e3abbca026df08df33d5a15892e6d98da5b8c2297413d1c7b68c1")
     version("1.1.5", sha256="8303d7496bc70eb441e8136bd29ffc295c629dadecefa4e7a475176ab4d282d5")
     version("1.1.4", sha256="2fbd592b1cfd7bc3612154a32925d5843b602490e8c8977a53fa86b35e308341")


### PR DESCRIPTION
Add sbt v1.8.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.