### PR TITLE
seal: add v4.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/seal/package.py
+++ b/var/spack/repos/builtin/packages/seal/package.py
@@ -18,6 +18,7 @@ class Seal(CMakePackage):
 
     maintainers("wohlbier")
 
+    version("4.1.1", sha256="af9bf0f0daccda2a8b7f344f13a5692e0ee6a45fea88478b2b90c35648bf2672")
     version("3.7.1", sha256="6737177bfb582cc1a2863ef1e96cc6c39b119257e7192981a3190eb79e0fcfd3")
     version("3.7.0", sha256="06ea835d6c9cdbbc4edb72a8db4bd4b1115995f075774043b9f31938d0624543")
     version("3.6.6", sha256="85a63188a5ccc8d61b0adbb92e84af9b7223fc494d33260fa17a121433790a0e")


### PR DESCRIPTION
Add seal v4.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.