### PR TITLE
signify: add v31

### DIFF
--- a/var/spack/repos/builtin/packages/signify/package.py
+++ b/var/spack/repos/builtin/packages/signify/package.py
@@ -12,6 +12,7 @@ class Signify(MakefilePackage):
     homepage = "https://github.com/aperezdc/signify"
     url = "https://github.com/aperezdc/signify/archive/v23.tar.gz"
 
+    version("31", sha256="8111af7424f4cc69dab5cd43a14ccd607ca2d171ac77dd3ae288264a53254e5f")
     version("23", sha256="1c690bf0e4283e0764a4a9dd784cb3debf4bb456b975b275dd1aaac7d5afe030")
 
     depends_on("libbsd@0.8:")


### PR DESCRIPTION
Add signify v31. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.