### PR TITLE
fix acl builds on ubuntu

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -138,15 +138,14 @@ dependency, since ``autoconf`` already depends on it.
 Using a custom autoreconf phase
 """""""""""""""""""""""""""""""
 
-In some cases, packages will provide a custom script to generate ``configure``,
-often named ``autogen.sh``. The default implementation of the autoreconf phase
-can be overridden to execute such a script.
+In some cases, it might be needed to replace the default implementation
+of the autoreconf phase with one running a script interpreter. In this
+example, the ``bash`` shell is used to run the ``autogen.sh`` script.
 
 .. code-block:: python
 
    def autoreconf(self, spec, prefix):
-       autogen = Executable("./autogen.sh")
-       autogen()
+       which('bash')('autogen.sh')
 
 """""""""""""""""""""""""""""""""""""""
 patching configure or Makefile.in files

--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -138,14 +138,15 @@ dependency, since ``autoconf`` already depends on it.
 Using a custom autoreconf phase
 """""""""""""""""""""""""""""""
 
-In some cases, it might be needed to replace the default implementation
-of the autoreconf phase with one running a script interpreter. In this
-example, the ``bash`` shell is used to run the ``autogen.sh`` script.
+In some cases, packages will provide a custom script to generate ``configure``,
+often named ``autogen.sh``. The default implementation of the autoreconf phase
+can be overridden to execute such a script.
 
 .. code-block:: python
 
    def autoreconf(self, spec, prefix):
-       which('bash')('autogen.sh')
+       autogen = Executable("./autogen.sh")
+       autogen()
 
 """""""""""""""""""""""""""""""""""""""
 patching configure or Makefile.in files

--- a/var/spack/repos/builtin/packages/acl/makefile-autoconf-only.patch
+++ b/var/spack/repos/builtin/packages/acl/makefile-autoconf-only.patch
@@ -1,0 +1,30 @@
+diff --git a/./Makefile b/./Makefile
+index dce32d30e3..60becd7a7e 100644
+--- a/./Makefile
++++ b/./Makefile
+@@ -62,24 +62,11 @@ endif
+ # versions will copy those files anyway, and don't understand -i.
+ LIBTOOLIZE_INSTALL = `libtoolize -n -i >/dev/null 2>/dev/null && echo -i`
+ 
+-configure include/builddefs:
++autoconf include/builddefs:
+ 	libtoolize -c $(LIBTOOLIZE_INSTALL) -f
+ 	cp include/install-sh .
+ 	aclocal -I m4
+ 	autoconf
+-	./configure \
+-		--prefix=/ \
+-		--exec-prefix=/ \
+-		--sbindir=/bin \
+-		--bindir=/usr/bin \
+-		--libdir=/lib \
+-		--libexecdir=/usr/lib \
+-		--enable-lib64=yes \
+-		--includedir=/usr/include \
+-		--mandir=/usr/share/man \
+-		--datadir=/usr/share \
+-		$$LOCAL_CONFIGURE_OPTIONS
+-	touch .census
+ 
+ include/config.h: include/builddefs
+ ## Recover from the removal of $@

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -51,14 +51,6 @@ class Acl(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         make("autoconf")
 
-    # The "make configure" target in the unpatched Makefile touched this file after executing the
-    # hardcoded ./configure command line. The purpose of this file is not documented, and this step
-    # may not be necessary.
-    @when("@:2.2.52")
-    @run_after("configure")
-    def touch_census(self):
-        touch(".census")
-
     def flag_handler(self, name, flags):
         if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,6 +27,7 @@ class Acl(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("bash", type="build")
     depends_on("gettext")
 
     depends_on("attr")
@@ -37,8 +38,7 @@ class Acl(AutotoolsPackage):
     # In 2.2.53 and later, the codebase provides a nice autogen script.
     @when("@2.2.53:")
     def autoreconf(self, spec, prefix):
-        autogen = Executable("./autogen.sh")
-        autogen()
+        which("bash")("./autogen.sh")
 
     # Before 2.2.53, the project's script to generate ./configure was contained in a Makefile which
     # both generated the ./configure file and then executed a hardcoded ./configure command line

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -10,8 +10,12 @@ class Acl(AutotoolsPackage):
     """Commands for Manipulating POSIX Access Control Lists."""
 
     homepage = "https://savannah.nongnu.org/projects/acl"
-    url = "https://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.2.53.tar.gz"
+    url = "https://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.3.1.tar.gz"
 
+    maintainers("cosmicexplorer")
+
+    version("2.3.1", sha256="8cad1182cc5703c3e8bf7a220fc267f146246f088d1ba5dd72d8b02736deedcc")
+    version("2.3.0", sha256="3659cf37ca29c0493f7d692d81dba5e1032b966d14674b6f0d637ff92afca4be")
     version("2.2.53", sha256="9e905397ac10d06768c63edd0579c34b8431555f2ea8e8f2cee337b31f856805")
     version("2.2.52", sha256="f3f31d2229c903184ff877aa0ee658b87ec20fec8aebb51e65eaa68d7b24e629")
     version("2.2.51", sha256="31a43d96a274a39bfcb805fb903d45840515344884d224cef166b482693a9f48")
@@ -23,14 +27,41 @@ class Acl(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
-    depends_on("attr")
     depends_on("gettext")
+
+    depends_on("attr")
+    # The configure step fails to find attr/xattr.h for these versions of acl unless this exact
+    # version of attr is used.
+    depends_on("attr@2.4.47", when="@:2.2.51")
+
+    # In 2.2.53 and later, the codebase provides a nice autogen script.
+    @when("@2.2.53:")
+    def autoreconf(self, spec, prefix):
+        autogen = Executable("./autogen.sh")
+        autogen()
+
+    # Before 2.2.53, the project's script to generate ./configure was contained in a Makefile which
+    # both generated the ./configure file and then executed a hardcoded ./configure command line
+    # with hardcoded install prefixes pointing to / and /usr. This patch removes the
+    # "make configure" target and replaces it with a "make autoconf" target that stops after
+    # generating the ./configure script, allowing spack to take over afterwards.
+    patch("makefile-autoconf-only.patch", when="@:2.2.52")
+
+    @when("@:2.2.52")
+    def autoreconf(self, spec, prefix):
+        make("autoconf")
+
+    # The "make configure" target in the unpatched Makefile touched this file after executing the
+    # hardcoded ./configure command line. The purpose of this file is not documented, and this step
+    # may not be necessary.
+    @when("@:2.2.52")
+    @run_after("configure")
+    def touch_census(self):
+        touch(".census")
 
     def flag_handler(self, name, flags):
         if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
-        return self.build_system_flags(name, flags)
-
-    def autoreconf(self, spec, prefix):
-        bash = which("bash")
-        bash("./autogen.sh")
+        # For some reason, self.build_system_flags(...) fails to link libintl, and results in link
+        # errors for functions in that library. self.inject_flags(...) seems to fix this.
+        return self.inject_flags(name, flags)

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -28,16 +28,14 @@ class Attr(AutotoolsPackage):
             url = "http://download.savannah.gnu.org/releases/attr/attr-{0}.src.tar.gz"
         return url.format(version)
 
+    # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
     def configure_args(self):
         args = []
         args.append("--disable-static")
         return args
 
-    # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
-    @when("@2.4.48:")
-    def install(self, spec, prefix):
-        make("install")
-
     @when("@:2.4.47")
     def install(self, spec, prefix):
+        make("install", "install-dev", "install-lib")
+
         make("install", "install-dev", "install-lib")

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -12,6 +12,11 @@ class Attr(AutotoolsPackage):
     homepage = "https://savannah.nongnu.org/projects/attr"
     url = "http://download.savannah.gnu.org/releases/attr/attr-2.4.47.src.tar.gz"
 
+    maintainers("cosmicexplorer")
+
+    # FIXME: spack does not validate any of the checksums for this package for some reason!
+    version("2.5.1", sha256="bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8")
+    version("2.5.0", sha256="421501c3f7a56ab12e2c34a187bcae44f7d141f965ade18d01e6261d138f163b")
     version("2.4.48", sha256="5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7")
     version("2.4.47", sha256="25772f653ac5b2e3ceeb89df50e4688891e21f723c460636548971652af0a859")
     version("2.4.46", sha256="dcd69bdca7ff166bc45141eddbcf21967999a6b66b0544be12a1cc2fd6340e1f")
@@ -29,8 +34,10 @@ class Attr(AutotoolsPackage):
         return args
 
     # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
+    @when("@2.4.48:")
     def install(self, spec, prefix):
-        if self.version >= Version("2.4.48"):
-            make("install")
-        else:
-            make("install", "install-dev", "install-lib")
+        make("install")
+
+    @when("@:2.4.47")
+    def install(self, spec, prefix):
+        make("install", "install-dev", "install-lib")

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -37,5 +37,3 @@ class Attr(AutotoolsPackage):
     @when("@:2.4.47")
     def install(self, spec, prefix):
         make("install", "install-dev", "install-lib")
-
-        make("install", "install-dev", "install-lib")


### PR DESCRIPTION
### Problem

Very strangely, every single version of the `acl` package started to fail builds on my personal ubuntu laptop recently. **I'm not sure why this is working for anyone else**, but I was able to identify three separate issues:
1. `self.build_system_flags(...)` was failing to inject `-lintl` for some reason.
2. Versions up to `2.2.52` didn't have any `./autogen.sh`, but still required a special incantation instead of just running `autoreconf`.
3. Versions up to `2.2.51` required a specific header file from an older version of the `attr` dependency.

### Solution
1. Use `self.inject_flags(...)` to inject `-lintl` **(I have no clue why this works!)**.
2. Patch the codebase's `Makefile` to use their special `autoconf` incantation for versions up to `2.2.52`.
3. Pin the `attr` dependency to `2.4.47` for versions up to `2.2.51` *(older versions of `attr` do not work either, it must be exactly this version!)*.

### Result
All versions of the `acl` package now build on my laptop!