### PR TITLE
grep: add v3.11

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -12,6 +12,7 @@ class Grep(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/grep/"
     url = "https://ftp.gnu.org/gnu/grep/grep-3.3.tar.xz"
 
+    version("3.11", sha256="1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab")
     version("3.10", sha256="24efa5b595fb5a7100879b51b8868a0bb87a71c183d02c4c602633b88af6855b")
     version("3.9", sha256="abcd11409ee23d4caf35feb422e53bbac867014cfeed313bb5f488aca170b599")
     version("3.7", sha256="5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c")


### PR DESCRIPTION
Add grep v3.11. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.