### PR TITLE
Fix no CUDA/HIP architecture set in cached cmake package

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -252,7 +252,7 @@ class CachedCMakeBuilder(CMakeBuilder):
             entries.append(cmake_cache_path("CUDA_TOOLKIT_ROOT_DIR", cudatoolkitdir))
 
             archs = spec.variants["cuda_arch"].value
-            if archs != "none":
+            if archs[0] != "none":
                 arch_str = ";".join(archs)
                 entries.append(
                     cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(arch_str))
@@ -269,7 +269,7 @@ class CachedCMakeBuilder(CMakeBuilder):
                 cmake_cache_path("HIP_CXX_COMPILER", "{0}".format(self.spec["hip"].hipcc))
             )
             archs = self.spec.variants["amdgpu_target"].value
-            if archs != "none":
+            if archs[0] != "none":
                 arch_str = ";".join(archs)
                 entries.append(
                     cmake_cache_string("CMAKE_HIP_ARCHITECTURES", "{0}".format(arch_str))


### PR DESCRIPTION
https://github.com/spack/spack/pull/37592 updated cached cmake packages to set `CMAKE_CUDA_ARCHITECTURES`. The condition `if archs != "none":` lead to `CMAKE_CUDA_ARCHITECTURES=none` when `cuda_arch=none`, i.e. `CMAKE_CUDA_ARCHITECTURES` is always set. This PR updates the condition to `if archs[0] != "none"` to ensure `CMAKE_CUDA_ARCHITECTURES` is only set if `cuda_arch` is not `none` (which seems to be the pattern used in other packages; as far as I can tell the `cuda_arch` variant can never be an empty list). This does the same change for HIP.