### PR TITLE
ncbi-rmblastn: adding new version 2.14.0

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -9,9 +9,10 @@ from spack.package import *
 class NcbiRmblastn(AutotoolsPackage):
     """RMBlast search engine for NCBI"""
 
-    homepage = "https://www.repeatmasker.org/RMBlast.html"
+    homepage = "https://www.repeatmasker.org/rmblast/"
     url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-src.tar.gz"
 
+    version("2.14.0", sha256="bf477f1b0c3b82f0b7a7094bf003a9a83e37e3b0716c1df799060c4feab17500")
     version("2.11.0", sha256="d88e1858ae7ce553545a795a2120e657a799a6d334f2a07ef0330cc3e74e1954")
     version("2.9.0", sha256="a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257")
 
@@ -22,6 +23,12 @@ class NcbiRmblastn(AutotoolsPackage):
     #   isb-2.11.0+-rmblast.patch.gz
     # The patch is downloaded and unzipped in the ncbi-rmblastn Spack package
     # directory to make it available for the patch directive.
+    patch(
+        "http://www.repeatmasker.org/rmblast/isb-2.14.0+-rmblast.patch.gz",
+        sha256="cd083f256551c6d6021897a1b08e023976e82c59576787d4885f57d36f9e6fdf",
+        archive_sha256="9de0e67467a4cffdde0c5f67e3658fb52ed313e4550f9a36a251bddb2ba33f49",
+        when="@2.14.0",
+    )
     patch(
         "https://www.repeatmasker.org/isb-2.11.0+-rmblast.patch.gz",
         sha256="ce985abd3512834adb9ad3e4078fbf9608a33a2ee6538a1e94b641490c92f899",
@@ -37,6 +44,9 @@ class NcbiRmblastn(AutotoolsPackage):
     depends_on("cpio", type="build")
     depends_on("boost")
     depends_on("lzo")
+    depends_on("bzip2")
+    depends_on("zstd")
+    depends_on("xz")
 
     configure_directory = "c++"
 

--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -16,6 +16,8 @@ class NcbiRmblastn(AutotoolsPackage):
     version("2.11.0", sha256="d88e1858ae7ce553545a795a2120e657a799a6d334f2a07ef0330cc3e74e1954")
     version("2.9.0", sha256="a390cc2d7a09422759fc178db84de9def822cbe485916bbb2ec0d215dacdc257")
 
+    maintainers("snehring")
+
     # There is a corresponding gzipped patch file associated with each version.
     # According to the documentation, https://www.repeatmasker.org/RMBlast.html,
     # Download NCBI Blast+ and rmblast patch file:


### PR DESCRIPTION
Mostly a version update, but I also noticed some compression libs getting linked in from my build environment that I've added in explicitly here.