### PR TITLE
e4s oneapi ci: use official intel oneapi-derived runner image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -324,7 +324,7 @@ gpu-tests-build:
 
 e4s-oneapi-generate:
   extends: [ ".e4s-oneapi", ".generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
+  image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.06.01
 
 e4s-oneapi-build:
   extends: [ ".e4s-oneapi", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -247,11 +247,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
-        before_script:
-        - - . /bootstrap/runner/view/lmod/lmod/init/bash
-          - module use /opt/intel/oneapi/modulefiles
-          - module load compiler
+        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.06.01
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -231,11 +231,11 @@ spack:
   - cabana +sycl ^kokkos +sycl +openmp std=17 +tests +examples
   - kokkos +sycl +openmp std=17 +tests +examples
   - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp std=17 +tests +examples
-  - tau +mpi +opencl +level_zero ~pdt
   # --
-  # - ginkgo +oneapi            # InstallError: Ginkgo's oneAPI backend requires theDPC++ compiler as main CXX compiler.
-  # - hpctoolkit +level_zero    # intel-tbb: icpx: error: unknown argument: '-flifetime-dse=1'
-  # - sundials +sycl cxxstd=17  # sundials: include/sunmemory/sunmemory_sycl.h:20:10: fatal error: 'CL/sycl.hpp' file not found
+  # - ginkgo +oneapi                    # InstallError: Ginkgo's oneAPI backend requires theDPC++ compiler as main CXX compiler.
+  # - hpctoolkit +level_zero            # intel-tbb: icpx: error: unknown argument: '-flifetime-dse=1'
+  # - sundials +sycl cxxstd=17          # sundials: include/sunmemory/sunmemory_sycl.h:20:10: fatal error: 'CL/sycl.hpp' file not found
+  # - tau +mpi +opencl +level_zero ~pdt # builds ok in container, but needs libdrm, will update container
 
   # SKIPPED
   # - nvhpc

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -1,35 +1,87 @@
 spack:
+
   view: false
+
+  concretizer:
+    reuse: false
+    unify: false
+
+  packages:
+    all:
+      require: '%oneapi'
+      providers:
+        blas: [openblas]
+        mpi: [mpich]
+        tbb: [intel-tbb]
+      target: [x86_64]
+      variants: +mpi
+    elfutils:
+      variants: +bzip2 ~nls +xz
+    libfabric:
+      variants: fabrics=sockets,tcp,udp,rxm
+    libunwind:
+      variants: +pic +xz
+    ncurses:
+      variants: +termlib
+    openblas:
+      variants: threads=openmp
+    trilinos:
+      variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
+        +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
+        +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
+        +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    xz:
+      variants: +pic
+    mesa:
+      version: [21.3.8]
+    hdf5:
+      require: "%gcc"
+      variants: +fortran +hl +shared
+    mpi:
+      require: mpich
+    mpich:
+      require: '@4.1.1 ~wrapperrpath ~hwloc'
+    python:
+      require: '@3.7.15'
+    py-cryptography:
+      require: '@38.0.1'
+    unzip:
+      require: '%gcc'
+    binutils:
+      require: '%gcc'
+      variants: +ld +gold +headers +libiberty ~nls
+    llvm:
+      require: '%gcc'
+    ruby:
+      require: '%gcc'
+    rust:
+      require: '%gcc'
+    krb5:
+      require: '%gcc'
+    papi:
+      require: '%gcc'
+    openssh:
+      require: '%gcc'
+    bison:
+      require: '%gcc'
+    libffi:
+      require: "@3.4.4"
+    dyninst:
+      require: "%gcc"
+
   compilers:
   - compiler:
-      spec: dpcpp@2023.0.0
+      spec: oneapi@2023.1.0
       paths:
-        cc: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/icx
-        cxx: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/dpcpp
-        f77: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/ifx
-        fc: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/ifx
+        cc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/icx
+        cxx: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/icpx
+        f77: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/ifx
+        fc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/ifx
       flags: {}
       operating_system: ubuntu20.04
       target: x86_64
-      modules: [compiler]
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/2023.0.0/linux/compiler/lib/intel64_lin
-      extra_rpaths: []
-  - compiler:
-      spec: oneapi@2023.0.0
-      paths:
-        cc: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/icx
-        cxx: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx
-        f77: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/ifx
-        fc: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/ifx
-      flags: {}
-      operating_system: ubuntu20.04
-      target: x86_64
-      modules: [compiler]
-      environment:
-        prepend_path:
-          LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/2023.0.0/linux/compiler/lib/intel64_lin
+      modules: []
+      environment: {}
       extra_rpaths: []
   - compiler:
       spec: gcc@11.1.0
@@ -45,108 +97,53 @@ spack:
       environment: {}
       extra_rpaths: []
 
-  packages:
-    all:
-      require: '%oneapi'
-      providers:
-        blas: [openblas]
-        mpi: [mpich]
-      target: [x86_64]
-      variants: +mpi
-    elfutils:
-      variants: +bzip2 ~nls +xz
-    hdf5:
-      variants: +fortran +hl +shared
-    libfabric:
-      variants: fabrics=sockets,tcp,udp,rxm
-    libunwind:
-      variants: +pic +xz
-    mpich:
-      variants: ~wrapperrpath
-    ncurses:
-      variants: +termlib
-    openblas:
-      variants: threads=openmp
-    python:
-      version: [3.8.13]
-    trilinos:
-      variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
-        +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
-        +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
-        +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
-    vtk-m:
-      require: ~openmp
-    xz:
-      variants: +pic
-    mesa:
-      version: [21.3.8]
-
-    binutils:
-      require: '%gcc'
-      variants: +ld +gold +headers +libiberty ~nls
-    bison:
-      require: '%gcc'
-    krb5:
-      require: '%gcc'
-    llvm:
-      require: '%gcc'
-    m4:
-      require: '%gcc'
-    openssh:
-      require: '%gcc'
-    papi:
-      require: '%gcc'
-    py-scipy:
-      require: '%gcc'
-    ruby:
-      require: '%gcc'
-    rust:
-      require: '%gcc'
-    unzip:
-      require: '%gcc'
-
   specs:
   # CPU
   - adios
-  - adios2
-  - alquimia
   - aml
+  - amrex
   - arborx
   - archer
   - argobots
-  - ascent
-  - amrex
   - axom
   - bolt
+  - boost
+  - bricks ~cuda
   - butterflypack
   - cabana
   - caliper
   - chai ~benchmarks ~tests
+  - charliecloud
   - conduit
-  - darshan-runtime
-  - darshan-util
   - datatransferkit
-  - faodel
+  - exaworks
+  - flecsi
   - flit
+  - flux-core
   - fortrilinos
   - gasnet
   - globalarrays
   - gmp
   - gotcha
-  - hdf5 +fortran +hl +shared
+  - h5bench
+  - hdf5-vol-async
+  - hdf5-vol-log
   - heffte +fftw
+  - hpx networking=mpi
   - hypre
-  - kokkos-kernels +openmp
   - kokkos +openmp
+  - kokkos-kernels +openmp
   - lammps
+  - lbann
   - legion
-  - libnrm
+  - libnrm 
   - libquo
   - libunwind
   - loki
   - mercury
   - metall
   - mfem
+  - mgard +serial +openmp +timing +unstructured ~cuda
   - mpark-variant
   - mpifileutils ~xattr
   - nccmp
@@ -157,17 +154,19 @@ spack:
   - openpmd-api
   - papi
   - papyrus
-  - parallel-netcdf
   - parsec ~cuda
   - pdt
   - petsc
+  - phist
   - plasma
   - plumed
   - precice
   - pumi
+  - py-h5py
   - py-libensemble
   - py-petsc4py
   - qthreads scheduler=distrib
+  - quantum-espresso
   - raja
   - rempi
   - slate ~cuda
@@ -175,93 +174,73 @@ spack:
   - stc
   - strumpack ~slate
   - sundials
-  - superlu-dist
   - superlu
-  - swig
-  - sz
+  - superlu-dist
+  - swig@4.0.2-fortran
+  - sz3
   - tasmanian
-  - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext
-    +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu
-    +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos
-    +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+  - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
   - turbine
   - umap
   - umpire
-  - unifyfs
-  - upcxx
-  - veloc
-  - vtk-m ~openmp # can't build +openmp w/ %oneapi: https://github.com/spack/spack/issues/31830
+  - variorum
   - wannier90
-  - zfp
+  # INCLUDED IN ECP DAV CPU
+  # - adios2
+  # - ascent
+  # - darshan-runtime
+  # - darshan-util
+  # - faodel
+  # - hdf5
+  # - libcatalyst
+  # - parallel-netcdf
+  # - paraview
+  # - py-cinemasci
+  # - sz
+  # - unifyfs
+  # - veloc
+  # - visit
+  # - vtk-m ~openmp # https://github.com/spack/spack/issues/31830
+  # - zfp
+  # --
+  # - alquimia          # pflotran: pflotran/hdf5_aux.F90(5): error #7013: This module file was not generated by any release of this compiler.   [HDF5]
+  # - dealii            # intel-tbb: icpx: error: unknown argument: '-flifetime-dse=1'
+  # - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp # sz: hdf5-filter/H5Z-SZ/src/H5Z_SZ.c:24:9: error: call to undeclared function 'gettimeofday'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  # - geopm             # geopm: In file included from src/ProfileTable.cpp:34: ./src/ProfileTable.hpp:79:45: error: no type named 'string' in namespace 'std'
+  # - ginkgo            # ginkgo: icpx: error: clang frontend command failed with exit code 139 (use -v to see invocation)
+  # - gptune ~mpispawn  # py-scipy: for_main.c:(.text+0x19): undefined reference to `MAIN__'
+  # - hdf5-vol-cache    # /H5VLcache_ext.c:580:9: error: incompatible function pointer types initializing 'herr_t (*)(const void *, uint64_t *)' (aka 'int (*)(const void *, unsigned long *)') with an expression of type 'herr_t (const void *, unsigned int *)' (aka 'int (const void *, unsigned int *)') [-Wincompatible-function-pointer-types]
+  # - hpctoolkit        # intel-tbb: icpx: error: unknown argument: '-flifetime-dse=1'
+  # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs: c-blosc/internal-complibs/zlib-1.2.8/gzread.c:30:15: error: call to undeclared function 'read'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  # - nrm               # py-scipy: for_main.c:(.text+0x19): undefined reference to `MAIN__'
+  # - openfoam          # adios2: patch failed
+  # - pruners-ninja     # pruners-ninja: ninja_test_pingpong.c:79:5: error: call to undeclared library function 'memset' with type 'void *(void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  # - py-jupyterhub     # py-ruamel-yaml-clib: setuptools/dist.py:287: SetuptoolsDeprecationWarning: The namespace_packages parameter is deprecated, consider using implicit namespaces instead (PEP 420). See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+  # - py-warpx ^warpx dims=2 # py-scipy: for_main.c:(.text+0x19): undefined reference to `MAIN__'
+  # - py-warpx ^warpx dims=3 # py-scipy: for_main.c:(.text+0x19): undefined reference to `MAIN__'
+  # - py-warpx ^warpx dims=rz # py-scipy: for_main.c:(.text+0x19): undefined reference to `MAIN__'  
+  # - scr               # libyogrt: configure: error: slurm is not in specified location!
+  # - tau +mpi +python  # tau: x86_64/lib/Makefile.tau-icpx-papi-mpi-pthread-python-pdt: No such file or directory
+  # - upcxx             # upcxx: /opt/intel/oneapi/mpi/2021.9.0//libfabric/bin/fi_info: error while loading shared libraries: libfabric.so.1: cannot open shared object file: No such file or directory
+  # - xyce +mpi +shared +pymi +pymi_static_tpls ^trilinos~shylu # cmake/tps.cmake:220 (message): Unable to compile against Trilinos.  It is possible Trilinos was not properly configured, or the environment has changed since Trilinos was installed.  See the CMake log files for more information.
 
   # GPU
   - aml +ze
+  - amrex +sycl
   - arborx +sycl ^kokkos +sycl +openmp std=17 +tests +examples
   - cabana +sycl ^kokkos +sycl +openmp std=17 +tests +examples
-  - kokkos +sycl +openmp std=17 +tests +examples %oneapi
-  - kokkos-kernels build_type=Release ^kokkos +sycl +openmp std=17 +tests +examples %oneapi
-
-  # CPU FAILURES
-  # - bricks                                    # bricks
-  # - charliecloud                              # charliecloud
-  # - dyninst                                   # old intel-tbb
-  # - exaworks                                  # py-setuptools-scm
-  # - flux-core                                 # py-setuptools-scm
-  # - geopm                                     # geopm
-  # - ginkgo                                    # ginkgo
-  # - gptune                                    # py-scipy@1.3.3
-  # - h5bench                                   # h5bench
-  # - hpctoolkit                                # dyninst
-  # - hpx max_cpu_count=512 networking=mpi      # boost cxxstd=17
-  # - nrm                                       # py-scipy
-  # - paraview +qt                              # qt
-  # - phist                                     # phist
-  # - pruners-ninja                             # pruners-ninja
-  # - py-cinemasci                              # py-scipy@1.3.3, py-setuptools-scm
-  # - py-jupyterhub                             # py-setuptools-scm
-  # - py-warpx ^warpx dims=2                    # py-scipy@1.5.4
-  # - py-warpx ^warpx dims=3                    # py-scipy@1.5.4
-  # - py-warpx ^warpx dims=rz                   # py-scipy@1.5.4
-  # - scr                                       # libyogrt
-  # - swig@4.0.2-fortran                        # swig
-  # - tau +mpi +python                          # tau
-  # - variorum                                  # variorum
+  - kokkos +sycl +openmp std=17 +tests +examples
+  - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp std=17 +tests +examples
+  - tau +mpi +opencl +level_zero ~pdt
   # --
-  # amrex: /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/detail/defines_elementary.hpp:52:40: note: expanded from macro '__SYCL2020_DEPRECATED'
-  # amrex: /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/detail/defines_elementary.hpp:52:40: note: expanded from macro '__SYCL2020_DEPRECATED'
-  # binutils: gold/powerpc.cc:3590: undefined reference to `gold::Sized_symbol<64>::Value_type gold::Symbol_table::compute_final_value<64>(gold::Sized_symbol<64> const*, gold::Symbol_table::Compute_final_value_status*) const'
-  # boost cxxstd=17: ./boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type [-Wenum-constexpr-conversion]
-  # bricks: cc1plus: error: bad value ('OFF') for '-mtune=' switch
-  # charliecloud: autoreconf phase: RuntimeError: configure script not found in ...
-  # flux-sched: include/yaml-cpp/emitter.h:164:9: error: comparison with NaN always evaluates to false in fast floating point modes [-Werror,-Wtautological-constant-compare]
-  # flux-sched: include/yaml-cpp/emitter.h:171:24: error: comparison with infinity always evaluates to false in fast floating point modes [-Werror,-Wtautological-constant-compare]
-  # ginkgo: icpx: error: clang frontend command failed with exit code 139
-  # h5bench: commons/h5bench_util.h:196: multiple definition of `has_vol_async';
-  # intel-tbb: clang++clang++clang++clang++clang++clang++clang++: : : : : : : clang++error: : unknown argument: '-flifetime-dse=1'
-  # libyogrt: configure: error: slurm is not in specified location!
-  # phist: fortran_bindings/test/kernels.F90(63): error #8284: If the actual argument is scalar, the dummy argument shall be scalar unless the actual argument is of type character or is an element of an array that is not assumed shape, pointer, or polymorphic.   [ARGV]
-  # pruners-ninja: test/ninja_test_util.c:34: multiple definition of `a';
-  # py-cryptography: ??
-  # py-scipy@1.3.3: gcc: error: unrecognized command-line option '-fp-model=strict'
-  # py-scipy@1.5.4: gcc: error: unrecognized command-line option '-fp-model=strict'
-  # py-setuptools-scm: ??
-  # ruby: limits.c:415:34: error: invalid suffix 'D' on floating constant
-  # rust: /usr/bin/ld: /opt/intel/oneapi/compiler/2022.1.0/linux/bin-llvm/../compiler/lib/intel64_lin/libimf.a(libm_feature_flag.o): in function `__libm_feature_flag_init': libm_feature_flag.c:(.text+0x25): undefined reference to `__intel_cpu_feature_indicator_x'
-  # swig@4.0.2-fortran: /spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-11.1.0/m4-1.4.19-p3otmjixpi6zibdsyoqib5dpzfshq3nj/bin/m4:/spack/opt/spack/linux-ubuntu20.04-x86_64/oneapi-2023.0.0/bison-3.8.2-xca2sot4jhd72hvj2m2b3ajchagczvau/share/bison/skeletons/yacc.c:420: undefined macro `b4_symbol(103, tag)'
-  # tau: Error: Unable to identify ifort lib directory
-  # variorum: ld: Intel/CMakeFiles/variorum_intel.dir/msr_core.c.o:(.bss+0x0): multiple definition of `g_platform'; CMakeFiles/variorum.dir/config_architecture.c.o:(.bss+0x0): first defined here
-  # vtk-m +openmp: clang++: error: clang frontend command failed with exit code 139 (use -v to see invocation)
-
-  # GPU FAILURES
-  # - amrex +sycl                           # amrex
-  # - ginkgo +oneapi                        # ginkgo
-  # - hpctoolkit +level_zero                # dyninst
-  # - sundials +sycl cxxstd=17              # sundials
-  # - tau +mpi +opencl +level_zero ~pdt     # tau
-  # --
+  # - ginkgo +oneapi            # InstallError: Ginkgo's oneAPI backend requires theDPC++ compiler as main CXX compiler.
+  # - hpctoolkit +level_zero    # intel-tbb: icpx: error: unknown argument: '-flifetime-dse=1'
+  # - sundials +sycl cxxstd=17  # sundials: include/sunmemory/sunmemory_sycl.h:20:10: fatal error: 'CL/sycl.hpp' file not found
 
   # SKIPPED
-  # - flecsi                                # dependency pfunit marks oneapi as an unsupported compiler
+  # - nvhpc
+  # - dyninst  # only %gcc
+
 
   mirrors: { "mirror": "s3://spack-binaries/develop/e4s-oneapi" }
 


### PR DESCRIPTION
Updating the E4S OneAPI CI stack to use latest OneAPI compilers via new runner image derived from Intel's latest official OneAPI docker image. Some minor tweaks to `specs:` and `packages:` as well. Unlike the current stack, there should be no need for modules here.

FYI @wspear
