### PR TITLE
cdhit: add missing perl dep, patch shebangs

### DIFF
--- a/var/spack/repos/builtin/packages/cdhit/package.py
+++ b/var/spack/repos/builtin/packages/cdhit/package.py
@@ -18,6 +18,8 @@ class Cdhit(MakefilePackage):
     version("4.8.1", sha256="f8bc3cdd7aebb432fcd35eed0093e7a6413f1e36bbd2a837ebc06e57cdb20b70")
     version("4.6.8", sha256="37d685e4aa849314401805fe4d4db707e1d06070368475e313d6f3cb8fb65949")
 
+    maintainers("snehring")
+
     variant("openmp", default=True, description="Compile with multi-threading support")
     variant("zlib", default=True, description="Compile with zlib")
 

--- a/var/spack/repos/builtin/packages/cdhit/package.py
+++ b/var/spack/repos/builtin/packages/cdhit/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from glob import glob
+
 from spack.package import *
 
 
@@ -20,7 +22,12 @@ class Cdhit(MakefilePackage):
     variant("zlib", default=True, description="Compile with zlib")
 
     depends_on("perl", type=("build", "run"))
+    depends_on("perl-text-nsp", type="run")
     depends_on("zlib", when="+zlib", type="link")
+
+    def patch(self):
+        for f in glob("*.pl"):
+            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f)
 
     def build(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/perl-text-nsp/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-nsp/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install perl-text-nsp
+#
+# You can edit this file again by typing:
+#
+#     spack edit perl-text-nsp
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+from spack.package import *
+
+
+class PerlTextNsp(PerlPackage):
+    """
+    The Ngram Statistics Package (NSP) is a suite of programs that aids in
+    analyzing Ngrams in text files.
+    """
+
+    homepage = "https://metacpan.org/dist/Text-NSP"
+    url = "https://cpan.metacpan.org/authors/id/T/TP/TPEDERSE/Text-NSP-1.31.tar.gz"
+
+    maintainers("snehring")
+
+    version("1.31", sha256="a01201beb29636b3e41ecda2a6cf6522fd265416bd6d994fad02f59fb49cf595")
+    version("1.29", sha256="26610cc17ddc3a9a239ffd100bbcf42618e2577ab4b051de4c262f2082afd27e")

--- a/var/spack/repos/builtin/packages/perl-text-nsp/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-nsp/package.py
@@ -3,22 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install perl-text-nsp
-#
-# You can edit this file again by typing:
-#
-#     spack edit perl-text-nsp
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 from spack.package import *
 
 


### PR DESCRIPTION
cdhit had a bunch of shebangs that needed rewritten, also a missing dep for one of the scripts.