### PR TITLE
gitlab ci: improve pipeline generation output

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -341,6 +341,10 @@ def _compute_spec_deps(spec_list, check_index_only=False, mirrors_to_check=None)
                 spec=s, mirrors_to_check=mirrors_to_check, index_only=check_index_only
             )
 
+            tty.debug("Mirrors containing {0}:".format(s.format("{name}/{hash:7}")))
+            for m_dict in up_to_date_mirrors:
+                tty.debug("  {0}".format(m_dict["mirror_url"]))
+
             skey = _spec_deps_key(s)
             spec_labels[skey] = {"spec": s, "needs_rebuild": not up_to_date_mirrors}
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -101,6 +101,7 @@ default:
     - spack env activate --without-view .
     - export SPACK_CI_CONFIG_ROOT="${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs"
     - spack
+      ${CI_GENERATE_SPACK_ARGS}
       --config-scope "${SPACK_CI_CONFIG_ROOT}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}/${SPACK_TARGET_ARCH}"
@@ -140,7 +141,7 @@ default:
   - spack --version
   - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
   - spack env activate --without-view .
-  - spack -d ci generate --check-index-only
+  - spack ${CI_GENERATE_SPACK_ARGS} ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
@@ -171,7 +172,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
-    - spack
+    - spack ${CI_GENERATE_SPACK_ARGS}
       ci generate --check-index-only
       --buildcache-destination "${SPACK_BUILDCACHE_DESTINATION}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -20,7 +20,8 @@ ci:
         # UO runners mount intermediate ci public key (verification), AWS runners mount public/private (signing/verification)
         - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
         - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-        - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+        - spack --color=always --backtrace ${CI_REBUILD_SPACK_ARGS}
+          ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
       after_script:
       - - cat /proc/loadavg || true
       variables:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ppc64le/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ppc64le/ci.yaml
@@ -19,4 +19,5 @@ ci:
       - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
       - if [[ -r /mnt/key/e4s.gpg ]]; then spack gpg trust /mnt/key/e4s.gpg; fi
       - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack --color=always --backtrace ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+      - spack --color=always --backtrace ${CI_REBUILD_SPACK_ARGS}
+        ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)


### PR DESCRIPTION
Provide better default and debug output from the `spack ci generate` command.  The default output now typically includes a brief reason why each spec was pruned, and with debug turned on, we can also see which mirrors (if any) contained each concrete spec.   This PR also support re-running pipelines in debug/verbose mode without having to push changes.