### PR TITLE
trilinos@develop+stokhos: do not set Stokhos_ENABLE_PCE_Scalar_Type=False

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -656,9 +656,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             ]
         )
 
-        if spec.satisfies("@develop +stokhos"):
-            options.append(self.define("Stokhos_ENABLE_PCE_Scalar_Type", False))
-
         if "+dtk" in spec:
             options.extend(
                 [


### PR DESCRIPTION
Here we revert a workaround that is no longer needed following https://github.com/trilinos/Trilinos/pull/11943

Furthermore, this workaround presents problems as described in:
* https://github.com/spack/spack/issues/37611#issuecomment-1574215603

CC @kuberry @wspear 