### PR TITLE
star: add 2.7.10

### DIFF
--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -36,8 +36,11 @@ class Star(Package):
     depends_on("zlib")
 
     def install(self, spec, prefix):
+        make_args = ["STAR", "STARlong"]
+        if "avx2" not in spec.target:
+            make_args += ["CXXFLAGS_SIMD=sse"]
         with working_dir("source"):
-            make("STAR", "STARlong")
+            make(*make_args)
             mkdirp(prefix.bin)
             install("STAR", prefix.bin)
             install("STARlong", prefix.bin)

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Star(Package):
+class Star(MakefilePackage):
     """STAR is an ultrafast universal RNA-seq aligner."""
 
     homepage = "https://github.com/alexdobin/STAR"
@@ -35,12 +35,18 @@ class Star(Package):
 
     depends_on("zlib")
 
-    def install(self, spec, prefix):
-        make_args = ["STAR", "STARlong"]
+    build_directory = "source"
+
+    def edit(self, spec, prefix):
         if "avx2" not in spec.target:
-            make_args += ["CXXFLAGS_SIMD=sse"]
-        with working_dir("source"):
-            make(*make_args)
-            mkdirp(prefix.bin)
+            env["CXXFLAGS_SIMD"]=""
+
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make("STAR", "STARlong")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
             install("STAR", prefix.bin)
             install("STARlong", prefix.bin)

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -39,7 +39,7 @@ class Star(MakefilePackage):
 
     def edit(self, spec, prefix):
         if "avx2" not in spec.target:
-            env["CXXFLAGS_SIMD"]=""
+            env["CXXFLAGS_SIMD"] = ""
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -12,6 +12,8 @@ class Star(Package):
     homepage = "https://github.com/alexdobin/STAR"
     url = "https://github.com/alexdobin/STAR/archive/2.7.6a.tar.gz"
 
+    version("2.7.10b", sha256="0d1b71de6c5be1c5d90b32130d2abcd5785a4fc7c1e9bf19cc391947f2dc46e5")
+    version("2.7.10a", sha256="af0df8fdc0e7a539b3ec6665dce9ac55c33598dfbc74d24df9dae7a309b0426a")
     version("2.7.6a", sha256="9320797c604673debea0fe8f2e3762db364915cc59755de1a0d87c8018f97d51")
     version("2.7.0e", sha256="2fc9d9103bd02811904d41e3a3d50e47c7de17cb55c3b4880ea5f39300a9ba0d")
     version("2.7.0d", sha256="7a757478868dc73fe7619bf6ea302dd642bd30e1c8c1fb4acdbe7fa151cf9fd1")


### PR DESCRIPTION
Adding checksums for the `star@2.7.10` versions. No other changes required to get this installed.