### PR TITLE
py-markupsafe: add 2.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -16,6 +16,7 @@ class PyMarkupsafe(PythonPackage):
     pypi = "MarkupSafe/MarkupSafe-1.1.1.tar.gz"
     git = "https://github.com/pallets/markupsafe.git"
 
+    version("2.1.3", sha256="af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad")
     version("2.1.1", sha256="7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b")
     version("2.0.1", sha256="594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a")
     version("1.1.1", sha256="29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
@@ -26,7 +27,4 @@ class PyMarkupsafe(PythonPackage):
     version("0.20", sha256="f6cf3bd233f9ea6147b21c7c02cac24e5363570ce4fd6be11dab9f499ed6a7d8")
     version("0.19", sha256="62fcc5d641df8b5ad271ebbd6b77a19cd92eceba1e1a990de4e96c867789f037")
 
-    depends_on("python@3.7:", when="@2.1:", type=("build", "run"))
-    depends_on("python@3.6:", when="@2:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
https://github.com/pallets/markupsafe/tree/2.1.3