### PR TITLE
subread: add 2.0.6, update download paths

### DIFF
--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -13,10 +13,10 @@ class Subread(MakefilePackage):
     sequencing data."""
 
     homepage = "http://subread.sourceforge.net/"
-    url = (
-        "https://iweb.dl.sourceforge.net/project/subread/subread-1.5.2/subread-1.5.2-source.tar.gz"
-    )
+    url = "https://sourceforge.net/projects/subread/files/subread-1.5.2/subread-1.5.2-source.tar.gz/download"
 
+    version("2.0.6", sha256="f0fdda6b98634d2946028948c220253e10a0f27c7fa5f24913b65b3ac6cbb045")
+    version("2.0.4", sha256="c54b37ed83b34318d8f119b5c02fb9d0a65c811195bcc9e1745df6daf74ca2db")
     version("2.0.2", sha256="0b64bd51f39f8d322c4594697fa5f0f64fbe60283113eadadff9f4268f897079")
     version("2.0.0", sha256="bd7b45f7d8872b0f5db5d23a385059f21d18b49e432bcb6e3e4a879fe51b41a8")
     version("1.6.4", sha256="b7bd0ee3b0942d791aecce6454d2f3271c95a010beeeff2daf1ff71162e43969")

--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -12,7 +12,7 @@ class Subread(MakefilePackage):
     """The Subread software package is a tool kit for processing next-gen
     sequencing data."""
 
-    homepage = "http://subread.sourceforge.net/"
+    homepage = "https://subread.sourceforge.net/"
     url = "https://sourceforge.net/projects/subread/files/subread-1.5.2/subread-1.5.2-source.tar.gz/download"
 
     version("2.0.6", sha256="f0fdda6b98634d2946028948c220253e10a0f27c7fa5f24913b65b3ac6cbb045")


### PR DESCRIPTION
Updating to `subread@2.0.6`.

The `iweb.dl.sourceforge.net` download url wasn't resolving as it's changed, so I've updated that to the current version. The previous tarballs were in the `mirror.spack.io` cache so the package was still installing but `versions` and `checksum` weren't working.