### PR TITLE
Add ncvis package and add option to wxwidgets

### DIFF
--- a/var/spack/repos/builtin/packages/ncvis/package.py
+++ b/var/spack/repos/builtin/packages/ncvis/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Ncvis(CMakePackage):
     """A NetCDF file viewer. ncvis is inspired by David Pierce's
     most excellent ncview utility."""
@@ -15,7 +16,9 @@ class Ncvis(CMakePackage):
 
     maintainers("vanderwb")
 
-    version("2022.08.28", sha256="a522926739b2a05ef0b436fe67a2014557f9e5fecf3b7d7700964e9006a4bf3e")
+    version(
+        "2022.08.28", sha256="a522926739b2a05ef0b436fe67a2014557f9e5fecf3b7d7700964e9006a4bf3e"
+    )
 
     depends_on("cmake", type="build")
     depends_on("netcdf-c", type="link")

--- a/var/spack/repos/builtin/packages/ncvis/package.py
+++ b/var/spack/repos/builtin/packages/ncvis/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+class Ncvis(CMakePackage):
+    """A NetCDF file viewer. ncvis is inspired by David Pierce's
+    most excellent ncview utility."""
+
+    homepage = "https://github.com/SEATStandards/ncvis"
+    url = "https://github.com/SEATStandards/ncvis/archive/refs/tags/2022.08.28.tar.gz"
+    git = "https://github.com/SEATStandards/ncvis.git"
+
+    maintainers("vanderwb")
+
+    version("2022.08.28", sha256="a522926739b2a05ef0b436fe67a2014557f9e5fecf3b7d7700964e9006a4bf3e")
+
+    depends_on("cmake", type="build")
+    depends_on("netcdf-c", type="link")
+    depends_on("wxwidgets+opengl", type="link")
+
+    @run_after("install")
+    def install_resources(self):
+        install_tree("resources", self.prefix.resources)
+
+    def setup_run_environment(self, env):
+        env.set("NCVIS_RESOURCE_DIR", self.prefix.resources)

--- a/var/spack/repos/builtin/packages/wxwidgets/package.py
+++ b/var/spack/repos/builtin/packages/wxwidgets/package.py
@@ -45,7 +45,7 @@ class Wxwidgets(AutotoolsPackage):
         spec = self.spec
         options = ["--enable-unicode", "--disable-precomp-headers"]
 
-        if "+opengl" in self.spec:
+        if self.spec.satisfies("+opengl"):
             options.append("--with-opengl")
 
         # see https://trac.wxwidgets.org/ticket/17639

--- a/var/spack/repos/builtin/packages/wxwidgets/package.py
+++ b/var/spack/repos/builtin/packages/wxwidgets/package.py
@@ -29,10 +29,13 @@ class Wxwidgets(AutotoolsPackage):
     version("3.0.2", sha256="346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d")
     version("3.0.1", sha256="bd671b79ec56af8fb3844e11cafceac1a4276fb02c79404d06b91b6c19d2c5f5")
 
+    variant("opengl", default=False, description="Enable OpenGL support")
+
     patch("math_include.patch", when="@3.0.1:3.0.2")
 
     depends_on("pkgconfig", type="build")
     depends_on("gtkplus")
+    depends_on("mesa-glu", when="+opengl")
 
     @when("@:3.0.2")
     def build(self, spec, prefix):
@@ -41,6 +44,9 @@ class Wxwidgets(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         options = ["--enable-unicode", "--disable-precomp-headers"]
+
+        if "+opengl" in self.spec:
+            options.append("--with-opengl")
 
         # see https://trac.wxwidgets.org/ticket/17639
         if spec.satisfies("@:3.1.0") and sys.platform == "darwin":


### PR DESCRIPTION
This PR adds the ncvis package, which is a NetCDF viewer in the style of ncview. This package depends on wxWidgets, and for CMake to find wxWidgets we need OpenGL support. Since the current wxWidgets package does not include a dependency on anything providing glu.h, I have added an `opengl` variant which ensures that it is available for building OpenGL components in wxWidgets. The default behavior of wxWidgets is unchanged - if the system provides glu.h, it will optionally detect and build with it.