### PR TITLE
trimgalore: add 0.6.10, adding variants for compression systems

### DIFF
--- a/var/spack/repos/builtin/packages/trimgalore/package.py
+++ b/var/spack/repos/builtin/packages/trimgalore/package.py
@@ -14,6 +14,7 @@ class Trimgalore(Package):
     homepage = "https://github.com/FelixKrueger/TrimGalore"
     url = "https://github.com/FelixKrueger/TrimGalore/archive/0.4.4.tar.gz"
 
+    version("0.6.10", sha256="3a4e414fc658d6eb4356f1572351204e8475a9d7dc79f6798270b57d35bda017")
     version("0.6.9", sha256="d50ce6106f979c316c89c7e7bcb44e5f841935d88bc4f756ccf0bc4cbab4e6f5")
     version("0.6.6", sha256="b8db8ffd131d9d9e7c8532a5a1f1caee656c0c58d3eafd460fee3c39b9fcab5e")
     version("0.6.4", sha256="eb57e18203d8a1dce1397b930a348a9969eebaa758b8a7304d04c22f216cea2d")
@@ -24,9 +25,16 @@ class Trimgalore(Package):
     version("0.4.5", sha256="a6b97e554944ddc6ecd50e78df486521f17225d415aad84e9911163faafe1f3c")
     version("0.4.4", sha256="485a1357e08eadeb5862bbb796022a25a6ace642c4bc13bbaf453b7dc7cff8e2")
 
+    variant("pigz", default=False, description="Use pigz for compression", when="@0.6.0:")
+    variant("igzip", default=False, description="Use igzip for compression", when="@0.6.8:")
+
+    # general dependencies
     depends_on("perl", type=("build", "run"))
     depends_on("py-cutadapt", type=("build", "run"))
     depends_on("fastqc")
+    # variant dependencies
+    depends_on("pigz", type="run", when="+pigz")
+    depends_on("libisal", type="run", when="+igzip")
 
     def install(self, spec, prefix):
         filter_file(r"#!/usr/bin/perl", "#!/usr/bin/env perl", "trim_galore")


### PR DESCRIPTION
Updating to `@0.6.10`. Since `@0.6.0` there has been a variant for `pigz` and since `@0.6.8` one for `igzip`/`libisal`, which I've now added in here (this is a perl script, so they're both just runtime dependencies).