### PR TITLE
Update sp package

### DIFF
--- a/var/spack/repos/builtin/packages/sp/package.py
+++ b/var/spack/repos/builtin/packages/sp/package.py
@@ -16,10 +16,28 @@ class Sp(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
     version("2.3.3", sha256="c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f")
 
+    variant("shared", default=False, description="Build shared library", when="@2.4:")
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
+
     def setup_run_environment(self, env):
-        for suffix in ("4", "8", "d"):
-            lib = find_libraries("libsp_" + suffix, root=self.prefix, shared=False, recursive=True)
+        suffixes = ["4", "d"]
+        if self.spec.satisfies("@:2.3"):
+            suffixes += ["8"]
+        for suffix in suffixes:
+            lib = find_libraries(
+                "libsp_" + suffix,
+                root=self.prefix,
+                shared=self.spec.satisfies("+shared"),
+                recursive=True,
+            )
             env.set("SP_LIB" + suffix, lib[0])
             env.set("SP_INC" + suffix, "include_" + suffix)
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
+        return args


### PR DESCRIPTION
This PR updates the sp package. It adds the latest release version, adds shared and pic variants, and does away with the _8 precision option for versions past 2.3.x. These changes support NOAA/National Weather Service R&D and operational forecasting applications.