### PR TITLE
py-pybktree: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybktree/package.py
+++ b/var/spack/repos/builtin/packages/py-pybktree/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class PyPybktree(PythonPackage):
-    """pykbtree: pure-Python BK-tree data structure to allow fast querying of close matches"""
+    """pybktree: pure-Python BK-tree data structure to allow fast querying of close matches"""
 
     homepage = "https://github.com/benhoyt/pybktree"
     pypi = "pybktree/pybktree-1.1.tar.gz"

--- a/var/spack/repos/builtin/packages/py-pybktree/package.py
+++ b/var/spack/repos/builtin/packages/py-pybktree/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPybktree(PythonPackage):
+    """pykbtree: pure-Python BK-tree data structure to allow fast querying of close matches"""
+
+    homepage = "https://github.com/benhoyt/pybktree"
+    pypi = "pybktree/pybktree-1.1.tar.gz"
+
+    version("1.1", sha256="eec0037cdd3d7553e6d72435a4379bede64be17c6712f149e485169638154d2b")
+
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Adding the `py-pybktree` package from PyPI - a pure-Python BK tree implementation with no external dependencies.