### PR TITLE
bismark: add 0.24.1, add HISAT2 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bismark/package.py
+++ b/var/spack/repos/builtin/packages/bismark/package.py
@@ -13,6 +13,7 @@ class Bismark(Package):
     homepage = "https://www.bioinformatics.babraham.ac.uk/projects/bismark"
     url = "https://github.com/FelixKrueger/Bismark/archive/0.23.0.tar.gz"
 
+    version("0.24.1", sha256="c5409f5fa470ea5ac07327ced28c60b793f5ef88c5a7bc75b71dde0f52f39894")
     version("0.23.0", sha256="ea1625808487c1442dbf825d9cbe5c0cbc37ea5bd1460f59e1e0ccc80cc01c9e")
     version("0.19.0", sha256="91707737f96a0574956a282b635abad7560e7d90bee188a67a7807b2470deae2")
     version("0.18.2", sha256="83391c5b5af33047178e7774ac25f5a69ce9315c13ae02f016baf7c50b73e702")
@@ -20,6 +21,7 @@ class Bismark(Package):
     depends_on("bowtie2", type="run")
     depends_on("perl", type="run")
     depends_on("samtools", type="run")
+    depends_on("hisat2", type="run", when="@0.21.0:")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Updating to `@0.24.1`. There was a missing dependency for `hisat2` as of `@0.21.0:` that wasn't included in the spec, so I've added it in here.