### PR TITLE
gatk: add 4.4, update to java@17

### DIFF
--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -19,6 +19,7 @@ class Gatk(Package):
     list_url = "https://github.com/broadinstitute/gatk/releases"
     maintainers("snehring")
 
+    version("4.4.0.0", sha256="444600f7b38b46ad0b3606b7d40ce921e0ff1910a50165872f1c73c7c4a1a390")
     version("4.3.0.0", sha256="e2c27229b34c3e22445964adf00639a0909887bbfcc040f6910079177bc6e2dd")
     version("4.2.6.1", sha256="1125cfc862301d437310506c8774d36c3a90d00d52c7b5d6b59dac7241203628")
     version("4.2.2.0", sha256="ddd902441d1874493796566159288e9df178714ac18216ba05092136db1497fd")
@@ -61,7 +62,8 @@ class Gatk(Package):
     # output.
     variant("r", default=False, description="Use R for plotting")
 
-    depends_on("java@8:", type="run")
+    depends_on("java@17", type="run", when="@4.4:")
+    depends_on("java@8", type="run", when="@:4.3")
     depends_on("python@2.6:2.8,3.6:", type="run", when="@4.0:")
     depends_on("r@3.2:", type="run", when="@4.0: +r")
 


### PR DESCRIPTION
Adding the latest `@4.4.0.0`. As of this version (https://github.com/broadinstitute/gatk/releases/tag/4.4.0.0), they're moving over to the LTS `java@17` from `java@8`, so updated that dependency.

The previous spec had `java@8:`, though only `@8` was officially supported (https://gatk.broadinstitute.org/hc/en-us/articles/360035889531). I've updated that here as well.