### PR TITLE
arrow: fix conditional spec expression (#38212)

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -148,7 +148,7 @@ class Arrow(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("ARROW_WITH_ZLIB", "zlib"))
         args.append(self.define_from_variant("ARROW_WITH_ZSTD", "zstd"))
 
-        with when("@:8"):
+        if self.spec.satisfies("@:8"):
             args.extend(
                 [
                     self.define("FLATBUFFERS_HOME", self.spec["flatbuffers"].prefix),


### PR DESCRIPTION
Strictly speaking, only the last change on line 150 is necessary to fix the bug. The remaining `variant` changes don't affect this bug, but remove variants that don't do anything for the earlier versions.