### PR TITLE
amdfftw: turn conflicts into conditional variants

### DIFF
--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -60,26 +60,26 @@ class Amdfftw(FftwBase):
         "amd-top-n-planner",
         default=False,
         when="@3.0.1: ~amd-fast-planner ~mpi ~openmp ~threads",
-        description="Build with amd-top-n-planner support"
+        description="Build with amd-top-n-planner support",
     )
     variant(
         "amd-mpi-vader-limit",
         default=False,
         when="@3.0.1:",
-        description="Build with amd-mpi-vader-limit support"
+        description="Build with amd-mpi-vader-limit support",
     )
     variant("static", default=False, description="Build with static suppport")
     variant(
         "amd-trans",
         default=False,
         when="~mpi ~openmp ~threads",
-        description="Build with amd-trans suppport"
+        description="Build with amd-trans suppport",
     )
     variant(
         "amd-app-opt",
         default=False,
         when="@3.1: ~mpi",
-        description="Build with amd-app-opt suppport"
+        description="Build with amd-app-opt suppport",
     )
     variant(
         "amd-dynamic-dispatcher",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -75,7 +75,12 @@ class Amdfftw(FftwBase):
         when="~mpi ~openmp ~threads",
         description="Build with amd-trans suppport"
     )
-    variant("amd-app-opt", default=False, description="Build with amd-app-opt suppport")
+    variant(
+        "amd-app-opt",
+        default=False,
+        when="@3.1: ~mpi",
+        description="Build with amd-app-opt suppport"
+    )
     variant(
         "amd-dynamic-dispatcher",
         default=False,
@@ -130,8 +135,6 @@ class Amdfftw(FftwBase):
     conflicts(
         "+amd-trans", when="precision=quad", msg="Quad precision is not supported with amd-trans"
     )
-    conflicts("+amd-app-opt", when="@:3.0.1", msg="amd-app-opt is supported from 3.1 onwards")
-    conflicts("+amd-app-opt", when="+mpi", msg="mpi thread is not supported with amd-app-opt")
     conflicts(
         "+amd-app-opt",
         when="precision=long_double",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -56,7 +56,12 @@ class Amdfftw(FftwBase):
         "tradeoff in the performance. It is supported for "
         "float and double precisions only.",
     )
-    variant("amd-top-n-planner", default=False, description="Build with amd-top-n-planner support")
+    variant(
+        "amd-top-n-planner",
+        default=False,
+        when="@3.0.1: ~amd-fast-planner ~mpi ~openmp ~threads",
+        description="Build with amd-top-n-planner support"
+    )
     variant(
         "amd-mpi-vader-limit", default=False, description="Build with amd-mpi-vader-limit support"
     )
@@ -96,11 +101,6 @@ class Amdfftw(FftwBase):
     )
     conflicts(
         "+amd-top-n-planner",
-        when="@:3.0.0",
-        msg="amd-top-n-planner is supported from 3.0.1 onwards",
-    )
-    conflicts(
-        "+amd-top-n-planner",
         when="precision=long_double",
         msg="long_double precision is not supported with amd-top-n-planner",
     )
@@ -108,22 +108,6 @@ class Amdfftw(FftwBase):
         "+amd-top-n-planner",
         when="precision=quad",
         msg="Quad precision is not supported with amd-top-n-planner",
-    )
-    conflicts(
-        "+amd-top-n-planner",
-        when="+amd-fast-planner",
-        msg="amd-top-n-planner cannot be used with amd-fast-planner",
-    )
-    conflicts(
-        "+amd-top-n-planner", when="+threads", msg="amd-top-n-planner works only for single thread"
-    )
-    conflicts(
-        "+amd-top-n-planner", when="+mpi", msg="mpi thread is not supported with amd-top-n-planner"
-    )
-    conflicts(
-        "+amd-top-n-planner",
-        when="+openmp",
-        msg="openmp thread is not supported with amd-top-n-planner",
     )
     conflicts(
         "+amd-mpi-vader-limit",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -63,7 +63,10 @@ class Amdfftw(FftwBase):
         description="Build with amd-top-n-planner support"
     )
     variant(
-        "amd-mpi-vader-limit", default=False, description="Build with amd-mpi-vader-limit support"
+        "amd-mpi-vader-limit",
+        default=False,
+        when="@3.0.1:",
+        description="Build with amd-mpi-vader-limit support"
     )
     variant("static", default=False, description="Build with static suppport")
     variant("amd-trans", default=False, description="Build with amd-trans suppport")
@@ -108,11 +111,6 @@ class Amdfftw(FftwBase):
         "+amd-top-n-planner",
         when="precision=quad",
         msg="Quad precision is not supported with amd-top-n-planner",
-    )
-    conflicts(
-        "+amd-mpi-vader-limit",
-        when="@:3.0.0",
-        msg="amd-mpi-vader-limit is supported from 3.0.1 onwards",
     )
     conflicts(
         "+amd-mpi-vader-limit",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -51,6 +51,7 @@ class Amdfftw(FftwBase):
     variant(
         "amd-fast-planner",
         default=False,
+        when="@3.0:",
         description="Option to reduce the planning time without much "
         "tradeoff in the performance. It is supported for "
         "float and double precisions only.",
@@ -83,9 +84,6 @@ class Amdfftw(FftwBase):
         "+debug", when="@2.2 %aocc", msg="debug mode is not supported by AOCC clang version 2.2"
     )
     conflicts("%gcc@:7.2", when="@2.2:", msg="GCC version above 7.2 is required for AMDFFTW")
-    conflicts(
-        "+amd-fast-planner", when="@2.2", msg="amd-fast-planner is supported from 3.0 onwards"
-    )
     conflicts(
         "+amd-fast-planner",
         when="precision=quad",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -69,7 +69,12 @@ class Amdfftw(FftwBase):
         description="Build with amd-mpi-vader-limit support"
     )
     variant("static", default=False, description="Build with static suppport")
-    variant("amd-trans", default=False, description="Build with amd-trans suppport")
+    variant(
+        "amd-trans",
+        default=False,
+        when="~mpi ~openmp ~threads",
+        description="Build with amd-trans suppport"
+    )
     variant("amd-app-opt", default=False, description="Build with amd-app-opt suppport")
     variant(
         "amd-dynamic-dispatcher",
@@ -117,9 +122,6 @@ class Amdfftw(FftwBase):
         when="precision=quad",
         msg="Quad precision is not supported with amd-mpi-vader-limit",
     )
-    conflicts("+amd-trans", when="+threads", msg="amd-trans works only for single thread")
-    conflicts("+amd-trans", when="+mpi", msg="mpi thread is not supported with amd-trans")
-    conflicts("+amd-trans", when="+openmp", msg="openmp thread is not supported with amd-trans")
     conflicts(
         "+amd-trans",
         when="precision=long_double",

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -102,49 +102,39 @@ class Amdfftw(FftwBase):
         "+debug", when="@2.2 %aocc", msg="debug mode is not supported by AOCC clang version 2.2"
     )
     conflicts("%gcc@:7.2", when="@2.2:", msg="GCC version above 7.2 is required for AMDFFTW")
-    conflicts(
-        "+amd-fast-planner",
-        when="precision=quad",
-        msg="Quad precision is not supported with amd-fast-planner",
-    )
-    conflicts(
-        "+amd-fast-planner",
-        when="precision=long_double",
-        msg="long_double precision is not supported with amd-fast-planner",
-    )
-    conflicts(
-        "+amd-top-n-planner",
-        when="precision=long_double",
-        msg="long_double precision is not supported with amd-top-n-planner",
-    )
-    conflicts(
-        "+amd-top-n-planner",
-        when="precision=quad",
-        msg="Quad precision is not supported with amd-top-n-planner",
-    )
+
+    with when("+amd-fast-planner"):
+        conflicts("precision=quad", msg="Quad precision is not supported with amd-fast-planner")
+        conflicts(
+            "precision=long_double",
+            msg="long_double precision is not supported with amd-fast-planner",
+        )
+
+    with when("+amd-top-n-planner"):
+        conflicts("precision=quad", msg="Quad precision is not supported with amd-top-n-planner")
+        conflicts(
+            "precision=long_double",
+            msg="long_double precision is not supported with amd-top-n-planner",
+        )
+
     conflicts(
         "+amd-mpi-vader-limit",
         when="precision=quad",
         msg="Quad precision is not supported with amd-mpi-vader-limit",
     )
-    conflicts(
-        "+amd-trans",
-        when="precision=long_double",
-        msg="long_double precision is not supported with amd-trans",
-    )
-    conflicts(
-        "+amd-trans", when="precision=quad", msg="Quad precision is not supported with amd-trans"
-    )
-    conflicts(
-        "+amd-app-opt",
-        when="precision=long_double",
-        msg="long_double precision is not supported with amd-app-opt",
-    )
-    conflicts(
-        "+amd-app-opt",
-        when="precision=quad",
-        msg="Quad precision is not supported with amd-app-opt",
-    )
+
+    with when("+amd-trans"):
+        conflicts(
+            "precision=long_double", msg="long_double precision is not supported with amd-trans"
+        )
+        conflicts("precision=quad", msg="Quad precision is not supported with amd-trans")
+
+    with when("+amd-app-opt"):
+        conflicts(
+            "precision=long_double", msg="long_double precision is not supported with amd-app-opt"
+        )
+        conflicts("precision=quad", msg="Quad precision is not supported with amd-app-opt")
+
     conflicts(
         "+amd-dynamic-dispatcher",
         when="%aocc",


### PR DESCRIPTION
The `amdfftw` package has many variants which have their own list of requirements to be enabled. These requirements are currently encoded as conflicts which aren't shown in `spack info amdfftw` so enabling variants takes more work than it could.

I've turned most of the conflicts into conditional variants. The ones that remain are conflicts with specific `precision` values that I don't know how to encode atm, but I cleaned them up a bit anyway.