### PR TITLE
Bugfix/spack spec: read and use the environment concretizer:unification option

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -731,7 +731,7 @@ class Environment:
 
         self.txlock = lk.Lock(self._transaction_lock_path)
 
-        self.unify = None
+        self._unify = None
         self.new_specs: List[Spec] = []
         self.new_installs: List[Spec] = []
         self.views: Dict[str, ViewDescriptor] = {}
@@ -754,6 +754,16 @@ class Environment:
         with lk.ReadTransaction(self.txlock):
             self.manifest = EnvironmentManifestFile(manifest_dir)
             self._read()
+
+    @property
+    def unify(self):
+        if self._unify is None:
+            self._unify = spack.config.get("concretizer:unify", False)
+        return self._unify
+
+    @unify.setter
+    def unify(self, value):
+        self._unify = value
 
     def __reduce__(self):
         return _create_environment, (self.path,)
@@ -815,15 +825,6 @@ class Environment:
             )
         else:
             self.views = {}
-
-        # Retrieve unification scheme for the concretizer
-        concretizer = configuration.get("concretizer", {})
-        unify = None
-        for entry, value in concretizer.items():
-            if entry == "unify":
-                unify = value
-                break
-        self.unify = unify if unify is not None else spack.config.get("concretizer:unify", False)
 
         # Retrieve dev-build packages:
         self.dev_specs = copy.deepcopy(env_configuration.get("develop", {}))

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -817,7 +817,13 @@ class Environment:
             self.views = {}
 
         # Retrieve unification scheme for the concretizer
-        self.unify = spack.config.get("concretizer:unify", False)
+        concretizer = configuration.get("concretizer", {})
+        unify = None
+        for entry, value in concretizer.items():
+            if entry == "unify":
+                unify = value
+                break
+        self.unify = unify if unify is not None else spack.config.get("concretizer:unify", False)
 
         # Retrieve dev-build packages:
         self.dev_specs = copy.deepcopy(env_configuration.get("develop", {}))

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -519,21 +519,19 @@ def test_environment_concretizer_scheme_used(tmpdir, config_scheme, env_scheme):
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
-            """\
+            f"""\
 spack:
   specs:
   - mpileaks
   concretizer:
-    unify: {0}
-""".format(
-                str(env_scheme).lower()
-            )
+    unify: {str(env_scheme).lower()}
+"""
         )
 
     with tmpdir.as_cwd():
         with spack.config.override("concretizer:unify", config_scheme):
-            e = ev.Environment(tmpdir.strpath)
-            assert e.unify == env_scheme
+            with ev.Environment(tmpdir.strpath) as e:
+                assert e.unify == env_scheme
 
 
 @pytest.mark.parametrize("config_scheme", [True, False, "when_possible"])
@@ -551,5 +549,5 @@ spack:
 
     with tmpdir.as_cwd():
         with spack.config.override("concretizer:unify", config_scheme):
-            e = ev.Environment(tmpdir.strpath)
-            assert e.unify == config_scheme
+            with ev.Environment(tmpdir.strpath) as e:
+                assert e.unify == config_scheme

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -534,3 +534,22 @@ spack:
         with spack.config.override("concretizer:unify", config_scheme):
             e = ev.Environment(tmpdir.strpath)
             assert e.unify == env_scheme
+
+
+@pytest.mark.parametrize("config_scheme", [True, False, "when_possible"])
+def test_environment_config_scheme_used(tmpdir, config_scheme):
+    """Test to ensure environment uses the configuration concretization scheme."""
+    filename = str(tmpdir.join("spack.yaml"))
+    with open(filename, "w") as f:
+        f.write(
+            """\
+spack:
+  specs:
+  - mpileaks
+"""
+        )
+
+    with tmpdir.as_cwd():
+        with spack.config.override("concretizer:unify", config_scheme):
+            e = ev.Environment(tmpdir.strpath)
+            assert e.unify == config_scheme


### PR DESCRIPTION
Fixed #38240 

This PR reads the `concretizer:unify` setting from the environment file (`spack.yaml`), if present, and uses the value it provides instead of the (default) configuration (e.g., https://spack.readthedocs.io/en/latest/build_settings.html#concretizer-options) so that `spack spec` follows the proper concretization path.