### PR TITLE
ocaml: don't use the spack compiler

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -70,7 +70,7 @@ class Ocaml(Package):
                     string=True,
                 )
 
-        configure(*(base_args))
+        configure(*(base_args), f"CC={self.compiler.cc}")
 
         make("world.opt")
         make("install", "PREFIX={0}".format(prefix))


### PR DESCRIPTION
When installing ocaml with the spack compiler the installation is not portable (trying to compile with ocaml won't work) as the path to the spack compiler will be hardcoded. This can be found by running `ocamlopt.opt -config`, this is an example output:

``` shell
version: 4.13.1
standard_library_default: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-30/x86_64-almalinux9-gcc11.3.1-opt/ocaml/4.13.1-rnarqd/lib/ocaml
standard_library: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-30/x86_64-almalinux9-gcc11.3.1-opt/ocaml/4.13.1-rnarqd/lib/ocaml
ccomp_type: cc
c_compiler: /spack/lib/spack/env/gcc/gcc
ocamlc_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC 
ocamlc_cppflags: -D_FILE_OFFSET_BITS=64 
ocamlopt_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC 
ocamlopt_cppflags: -D_FILE_OFFSET_BITS=64 
bytecomp_c_compiler: /spack/lib/spack/env/gcc/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64 
native_c_compiler: /spack/lib/spack/env/gcc/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64 
bytecomp_c_libraries: -lm  -lpthread
native_c_libraries: -lm 
native_pack_linker: ld -r -o 
...
```

This PR fixes it by passing the path to the actual compiler. Tested on Centos7:

``` shell
version: 4.13.1
standard_library_default: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-06-07/x86_64-centos7-gcc12.2.0-opt/ocaml/4.13.1-aeafrb/lib/ocaml
standard_library: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-06-07/x86_64-centos7-gcc12.2.0-opt/ocaml/4.13.1-aeafrb/lib/ocaml
ccomp_type: cc
c_compiler: /cvmfs/sw.hsf.org/contrib/x86_64-centos7-gcc4.8.5-opt/gcc/12.2.0-icg3ob/bin/gcc
ocamlc_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC 
ocamlc_cppflags: -D_FILE_OFFSET_BITS=64 
ocamlopt_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC 
ocamlopt_cppflags: -D_FILE_OFFSET_BITS=64 
bytecomp_c_compiler: /cvmfs/sw.hsf.org/contrib/x86_64-centos7-gcc4.8.5-opt/gcc/12.2.0-icg3ob/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64 
native_c_compiler: /cvmfs/sw.hsf.org/contrib/x86_64-centos7-gcc4.8.5-opt/gcc/12.2.0-icg3ob/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64 
bytecomp_c_libraries: -lm -ldl  -lpthread
native_c_libraries: -lm -ldl 
native_pack_linker: ld -r -o 
...
```