### PR TITLE
py-qmtest: add patch for the removed bdist_wininst class

### DIFF
--- a/var/spack/repos/builtin/packages/py-qmtest/package.py
+++ b/var/spack/repos/builtin/packages/py-qmtest/package.py
@@ -16,5 +16,8 @@ class PyQmtest(PythonPackage):
 
     version("2.4.1", sha256="098f705aea9c8f7f5b6b5fe131974cee33b50cad3e13977e39708f306ce9ac91")
 
+    # Patch to fix python 3.10 and above compatibility
+    patch("wininst.patch", when="@2.4.1^python@3.10:")
+
     depends_on("python@2.2:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-qmtest/wininst.patch
+++ b/var/spack/repos/builtin/packages/py-qmtest/wininst.patch
@@ -1,0 +1,20 @@
+diff --git a/setup.py b/setup.py
+index 198cc92..2e07495 100644
+--- a/setup.py
++++ b/setup.py
+@@ -23,7 +23,6 @@ from   qmdist.command.build_py import build_py
+ from   qmdist.command.build_scripts import build_scripts
+ from   qmdist.command.build_doc import *
+ from   qmdist.command.install_lib import install_lib
+-from   qmdist.command.bdist_wininst import bdist_wininst
+ from   qmdist.command.check import check
+ import sys, os, os.path, glob, shutil
+ 
+@@ -66,7 +65,6 @@ setup(name="qmtest",
+                 'build_ref_manual': build_ref_manual,
+                 'build_man_page': build_man_page,
+                 'install_lib': install_lib,
+-                'bdist_wininst' : bdist_wininst,
+                 'check': check},
+ 
+       packages=('qm',


### PR DESCRIPTION
Right now it is not possible to build py-qmtest with python 3.10 because `distutils.command.bdist_wininst` has been removed. It is easy to reproduce:

``` python
In [1]: from distutils.command.bdist_wininst import bdist_wininst as base
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[1], line 1
----> 1 from distutils.command.bdist_wininst import bdist_wininst as base

ModuleNotFoundError: No module named 'distutils.command.bdist_wininst'
```

This patch is a workaround to fix the installation on Linux (tested on Centos 7) by removing the offending lines. I may give it a try to actually fix it but the patch will be needed anyway for this version