### PR TITLE
bedtools2: patching to build with gcc@13

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/bedtools-gcc13.patch
+++ b/var/spack/repos/builtin/packages/bedtools2/bedtools-gcc13.patch
@@ -1,0 +1,25 @@
+https://github.com/arq5x/bedtools2/pull/1045
+
+From 7d7fb513b9b05b7a0512a83520e9f60036e5ff9a Mon Sep 17 00:00:00 2001
+From: David Seifert <soap@gentoo.org>
+Date: Tue, 18 Apr 2023 11:59:58 +0200
+Subject: [PATCH] Add missing <cstdint> include
+
+* breaks build with GCC 13:
+  https://bugs.gentoo.org/895860
+---
+ src/utils/general/ParseTools.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/utils/general/ParseTools.h b/src/utils/general/ParseTools.h
+index e056c149..3418eff1 100644
+--- a/src/utils/general/ParseTools.h
++++ b/src/utils/general/ParseTools.h
+@@ -16,6 +16,7 @@
+ #include "string.h"
+ #include <cstdio>
+ #include <cstdlib>
++#include <cstdint>
+ 
+ using namespace std;
+ 

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -29,7 +29,7 @@ class Bedtools2(Package):
     depends_on("xz", when="@2.29:")
     depends_on("python", type="build")
 
-    patch("bedtools-gcc13.patch", level=1, when="%gcc@13")
+    patch("bedtools-gcc13.patch", level=1, when="@2.27:%gcc@13")
 
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "install")

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -29,5 +29,7 @@ class Bedtools2(Package):
     depends_on("xz", when="@2.29:")
     depends_on("python", type="build")
 
+    patch("bedtools-gcc13.patch", level=1, when="%gcc@13")
+
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "install")

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -29,7 +29,7 @@ class Bedtools2(Package):
     depends_on("xz", when="@2.29:")
     depends_on("python", type="build")
 
-    patch("bedtools-gcc13.patch", level=1, when="@2.27:%gcc@13")
+    patch("bedtools-gcc13.patch", level=1, when="@2.27:%gcc@13:")
 
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "install")


### PR DESCRIPTION
Recent versions of `bedtools2` fail to build with `gcc@13` because of changes in the way it handles includes. Applying the patch from https://github.com/arq5x/bedtools2/pull/1045, which fixes building back to `@2.27:`. This patch is only relevant while that PR has not been merged and/or for existing versions.