### PR TITLE
podio: bump minimal version of catch2

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -105,7 +105,8 @@ class Podio(CMakePackage):
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"), when="@0.12.0:")
     depends_on("sio", type=("build", "link"), when="+sio")
-    depends_on("catch2@3.0.1:", type=("test"), when="@0.13:")
+    depends_on("catch2@3.0.1:", type=("test"), when="@0.13:0.16.5")
+    depends_on("catch2@3.1:", type=("test"), when="@0.16.6:")
 
     conflicts("+sio", when="@:0.12", msg="sio support requires at least podio@0.13")
 


### PR DESCRIPTION
With https://github.com/AIDASoft/podio/pull/402 podio will need catch2@3.1.0