### PR TITLE
Hotfix to avoid building compilers from sources in pcluster pipelines

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -736,6 +736,9 @@ deprecated-ci-build:
     # Use gcc from local container buildcache
     - - . "./share/spack/setup-env.sh"
       - . /etc/profile.d/modules.sh
+      - spack buildcache rebuild-index /bootstrap/local-cache/
+      - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
+      - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
       - spack mirror add local-cache /bootstrap/local-cache
       - spack gpg trust /bootstrap/public-key
       - cd "${CI_PROJECT_DIR}" && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -737,14 +737,14 @@ deprecated-ci-build:
     - - . "./share/spack/setup-env.sh"
       - . /etc/profile.d/modules.sh
       - spack buildcache rebuild-index /bootstrap/local-cache/
-      - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
-      - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
       - spack mirror add local-cache /bootstrap/local-cache
       - spack gpg trust /bootstrap/public-key
       - cd "${CI_PROJECT_DIR}" && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh
       - sed -i -e "s/spack arch -t/echo ${SPACK_TARGET_ARCH}/g" postinstall.sh
+      - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ postinstall.sh
+      - diff postinstall.sh postinstall.sh.bkp || echo Done
       - /bin/bash postinstall.sh -fg
-      - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
+      - spack config --scope site add "packages:all:target:\"${SPACK_TARGET_ARCH}\""
   after_script:
     - - mv "${CI_PROJECT_DIR}/postinstall.sh" "${CI_PROJECT_DIR}/jobs_scratch_dir/"
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
@@ -43,8 +43,10 @@ spack:
           - spack arch
         # Use gcc from local container buildcache
         - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
@@ -46,7 +46,7 @@ spack:
           - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
-          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp || echo Done
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-icelake/spack.yaml
@@ -42,7 +42,8 @@ spack:
           - spack --version
           - spack arch
         # Use gcc from local container buildcache
-        - - spack mirror add local-cache /bootstrap/local-cache
+        - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
@@ -44,7 +44,8 @@ spack:
           - spack --version
           - spack arch
         # Use gcc from local container buildcache
-        - - spack mirror add local-cache /bootstrap/local-cache
+        - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
@@ -48,7 +48,7 @@ spack:
           - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
-          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp || echo Done
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_n1/spack.yaml
@@ -45,8 +45,10 @@ spack:
           - spack arch
         # Use gcc from local container buildcache
         - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -44,7 +44,8 @@ spack:
           - spack --version
           - spack arch
         # Use gcc from local container buildcache
-        - - spack mirror add local-cache /bootstrap/local-cache
+        - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -48,7 +48,7 @@ spack:
           - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
-          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp || echo Done
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -45,8 +45,10 @@ spack:
           - spack arch
         # Use gcc from local container buildcache
         - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
@@ -43,8 +43,10 @@ spack:
           - spack arch
         # Use gcc from local container buildcache
         - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
@@ -46,7 +46,7 @@ spack:
           - sed -i.bkp s/"spack install gcc"/"spack install --cache-only --reuse gcc"/ /bootstrap/postinstall.sh
           - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
-          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp
+          - diff /bootstrap/postinstall.sh /bootstrap/postinstall.sh.bkp || echo Done
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""
     - signing-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-skylake/spack.yaml
@@ -42,7 +42,8 @@ spack:
           - spack --version
           - spack arch
         # Use gcc from local container buildcache
-        - - spack mirror add local-cache /bootstrap/local-cache
+        - - spack buildcache rebuild-index /bootstrap/local-cache/
+          - spack mirror add local-cache /bootstrap/local-cache
           - spack gpg trust /bootstrap/public-key
         - - /bin/bash "${SPACK_ARTIFACTS_ROOT}/postinstall.sh" -fg
           - spack config --scope site add "packages:all:target:\"target=${SPACK_TARGET_ARCH}\""


### PR DESCRIPTION
This can be reverted as soon as we regenerate Docker images with an indexed buildcache