### PR TITLE
py-torch: Make sure CMAKE_PREFIX_PATH and LD_LIBRARY_PATH are set properly for run envs

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -602,9 +602,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         # environment that one gets with spack load py-torch
         env.prepend_path("CMAKE_PREFIX_PATH", self.cmake_prefix_paths[0])
         # Similarly the libraries do not live at their "standard location"
-        ld_lib_base = join_path(self.prefix, self.spec["python"].package.platlib, "torch")
-        env.prepend_path("LD_LIBRARY_PATH", join_path(ld_lib_base, "lib"))
-        env.prepend_path("LD_LIBRARY_PATH", join_path(ld_lib_base, "lib64"))
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["py-torch"].libs.directories[0])
 
     @run_before("install")
     def build_amd(self):

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -597,6 +597,15 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             # https://github.com/pytorch/pytorch/issues/60332
             # env.set("USE_SYSTEM_XNNPACK", "ON")
 
+    def setup_run_environment(self, env):
+        # The cmake_prefix_paths property from below doesn't end up in the run
+        # environment that one gets with spack load py-torch
+        env.prepend_path("CMAKE_PREFIX_PATH", self.cmake_prefix_paths[0])
+        # Similarly the libraries do not live at their "standard location"
+        ld_lib_base = join_path(self.prefix, self.spec["python"].package.platlib, "torch")
+        env.prepend_path("LD_LIBRARY_PATH", join_path(ld_lib_base, "lib"))
+        env.prepend_path("LD_LIBRARY_PATH", join_path(ld_lib_base, "lib64"))
+
     @run_before("install")
     def build_amd(self):
         if "+rocm" in self.spec:


### PR DESCRIPTION
The `cmake_prefix_paths` seems to not get picked up for run environments (the one that can be obtained via `spack load`), which instead still points to the prefix. A similar situation arises for the `LD_LIBRARY_PATH`, which seems to still be necessary in my testing to actually run something that is linked against the torch library.

There was some discussion already in https://github.com/spack/spack/pull/37012 about this, it seems that this might have worked in the past, but doesn't any longer(?)