### PR TITLE
superlu: new version 6.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -24,7 +24,7 @@ class Superlu(CMakePackage, Package):
     version("6.0.0", sha256="5c199eac2dc57092c337cfea7e422053e8f8229f24e029825b0950edd1d17e8e")
     version(
         "5.3.0",
-        sha256="3e464afa77335de200aeb739074a11e96d9bef6d0b519950cfa6684c4be1f350", 
+        sha256="3e464afa77335de200aeb739074a11e96d9bef6d0b519950cfa6684c4be1f350",
         preferred=True,
     )
     version("5.2.2", sha256="470334a72ba637578e34057f46948495e601a5988a602604f5576367e606a28c")

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -21,7 +21,12 @@ class Superlu(CMakePackage, Package):
 
     tags = ["e4s"]
 
-    version("5.3.0", sha256="3e464afa77335de200aeb739074a11e96d9bef6d0b519950cfa6684c4be1f350")
+    version("6.0.0", sha256="5c199eac2dc57092c337cfea7e422053e8f8229f24e029825b0950edd1d17e8e")
+    version(
+        "5.3.0",
+        sha256="3e464afa77335de200aeb739074a11e96d9bef6d0b519950cfa6684c4be1f350", 
+        preferred=True,
+    )
     version("5.2.2", sha256="470334a72ba637578e34057f46948495e601a5988a602604f5576367e606a28c")
     version("5.2.1", sha256="28fb66d6107ee66248d5cf508c79de03d0621852a0ddeba7301801d3d859f463")
     version(


### PR DESCRIPTION
No changes to build system required. Changelog: https://github.com/xiaoyeli/superlu/compare/v5.3.0...v6.0.0

Since this new version adds "64-bit indexing support", and since at least one dependent package (`armadillo`) requires "32-bit integers" (https://gitlab.com/conradsnicta/armadillo-code/-/commit/faa6cbf895ba6f526473ed48779685919b36aa9f), the previous version remains preferred.

Test report:
```console
==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@12.2.0 -----------------------
kbuuw6k superlu@6.0.0~ipo+pic build_system=cmake build_type=Release generator=make
==> 1 installed package
```