### PR TITLE
intel-oneapi-mkl: handle external mkl with external mpi

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -183,7 +183,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
         resolved_libs = find_libraries(libs, lib_path, shared=shared)
-        if "+cluster" in self.spec:
+        # Add MPI libraries for cluster support. If MPI is not in the
+        # spec, then MKL is externally installed and application must
+        # link with MPI libaries
+        if "+cluster" in self.spec and "mpi" in self.spec:
             resolved_libs = resolved_libs + self.spec["mpi"].libs
         return resolved_libs
 


### PR DESCRIPTION
Address #38238.

When you use intel-oneapi-mkl +cluster, it has a dependence on MPI. If intel-oneapi-mkl is external, then dependencies are ignored and there might not be an MPI in the spec. In that case, do not add MPI link options--assume the application will do it.