### PR TITLE
NetCDF-C: default to CMake

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -252,9 +252,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         conflicts("+blosc")
         conflicts("+zstd")
 
-    default_build_system = "cmake" if sys.platform == "win32" else "autotools"
-
-    build_system("cmake", "autotools", default=default_build_system)
+    build_system("cmake", "autotools", default="cmake")
 
     def setup_run_environment(self, env):
         if self.spec.satisfies("@4.9.0:+shared"):

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -5,7 +5,6 @@
 
 import itertools
 import os
-import sys
 
 from llnl.util.lang import dedupe
 


### PR DESCRIPTION
I tried building netcdf-c on macOS and got the following error:
```
configure: error: Error: OSX requires libxml2 => --disable-dap4.
```
Building with CMake went fine. I'm sure it's possible to fix this error, but is there any reason we don't default to CMake on all systems?