### PR TITLE
gaudi: remove the py-qmtest dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -86,7 +86,6 @@ class Gaudi(CMakePackage):
         ["catch2", "@36.8:"],
         ["py-nose", "@35:"],
         ["py-pytest", "@36.2:"],
-        ["py-qmtest", "@35:"],
     ):
         depends_on(pv[0], when=pv[1], type="test")
         depends_on(pv[0], when=pv[1] + " +examples")

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -82,11 +82,7 @@ class Gaudi(CMakePackage):
 
     # Testing dependencies
     # Note: gaudi only builds examples when testing enabled
-    for pv in (
-        ["catch2", "@36.8:"],
-        ["py-nose", "@35:"],
-        ["py-pytest", "@36.2:"],
-    ):
+    for pv in (["catch2", "@36.8:"], ["py-nose", "@35:"], ["py-pytest", "@36.2:"]):
         depends_on(pv[0], when=pv[1], type="test")
         depends_on(pv[0], when=pv[1] + " +examples")
 


### PR DESCRIPTION
It hasn't been a dependency for many years (~6), since around version 27 which we don't even build. Also py-qmtest is unmaintained (last change happened in 2011) and it doesn't build with recent versions of python (see https://github.com/spack/spack/pull/38253) so it would definitely be better not to keep it around