### PR TITLE
py-mypy: add 1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -63,6 +63,9 @@ class PyMypy(PythonPackage):
     depends_on("py-types-setuptools", when="@0.981:", type="build")
     depends_on("py-types-typed-ast@1.5.8:1.5", when="@0.981:", type="build")
 
+    # setup.py
+    depends_on("python@3.7:", when="@0.981:", type=("build", "run"))
+
     # Historical dependencies
     depends_on("py-toml", when="@0.900:0.910", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -63,9 +63,6 @@ class PyMypy(PythonPackage):
     depends_on("py-types-setuptools", when="@0.981:", type="build")
     depends_on("py-types-typed-ast@1.5.8:1.5", when="@0.981:", type="build")
 
-    # setup.py
-    depends_on("py-typed-ast@1.4:1", when="@0.920: ^python@:3.7", type=("build", "run"))
-
     # Historical dependencies
     depends_on("py-toml", when="@0.900:0.910", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -11,9 +11,11 @@ class PyMypy(PythonPackage):
 
     homepage = "http://www.mypy-lang.org/"
     pypi = "mypy/mypy-0.740.tar.gz"
+    git = "https://github.com/python/mypy.git"
 
     maintainers("adamjstewart")
 
+    version("1.3.0", sha256="e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11")
     version("1.2.0", sha256="f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1")
     version("1.1.1", sha256="ae9ceae0f5b9059f33dbc62dea087e942c0ccab4b7a003719cb70f9b8abfa32f")
     version("1.0.1", sha256="28cea5a6392bb43d266782983b5a4216c25544cd7d80be681a155ddcdafd152d")
@@ -62,7 +64,7 @@ class PyMypy(PythonPackage):
     depends_on("py-types-typed-ast@1.5.8:1.5", when="@0.981:", type="build")
 
     # setup.py
-    depends_on("python@3.7:", when="@0.981:", type=("build", "run"))
+    depends_on("py-typed-ast@1.4:1", when="@0.920: ^python@:3.7", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-toml", when="@0.900:0.910", type=("build", "run"))


### PR DESCRIPTION
https://github.com/python/mypy/tree/v1.3.0

There was a missing `py-typed-ast` dependency from the [`setup.py`](https://github.com/python/mypy/blob/v1.3.0/setup.py#L224). Since this is a different package than the already contained `py-types-typed-ast`, I have added it.