### PR TITLE
fastq-screen: add 0.15.3, add variants

### DIFF
--- a/var/spack/repos/builtin/packages/fastq-screen/package.py
+++ b/var/spack/repos/builtin/packages/fastq-screen/package.py
@@ -12,16 +12,31 @@ class FastqScreen(Package):
     the library matches with what you expect."""
 
     homepage = "https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/"
-    url = "https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/fastq_screen_v0.11.2.tar.gz"
+    url = "https://github.com/StevenWingett/FastQ-Screen/archive/refs/tags/v0.15.3.tar.gz"
 
-    version("0.11.2", sha256="a179df1f5803b42bbbb2b50af05ea18ae6fefcbf7020ca2feeb0d3c598a65207")
+    version("0.15.3", sha256="002750d78ca50fe0f789e24445e10988e16244f81b4f0189bf2fc4ee8b680be5")
+    version(
+        "0.11.2",
+        sha256="a179df1f5803b42bbbb2b50af05ea18ae6fefcbf7020ca2feeb0d3c598a65207",
+        url="https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/fastq_screen_v0.11.2.tar.gz",
+    )
 
+    variant("bismark", default=False, description="Enable bisulfite mapping with bismark")
+    variant("bowtie", default=False, description="Enable mapping with bowtie")
+    variant("bwa", default=False, description="Enable mapping with bwa")
+
+    # general dependencies
     depends_on("perl", type="run")
     depends_on("perl-gdgraph", type="run")
-    depends_on("bowtie")
-    depends_on("bowtie2")
-    depends_on("bwa")
-    depends_on("samtools")
+    depends_on("bowtie2", type="run")
+    depends_on("samtools", type="run")
+    # variant dependencies
+    depends_on("bismark", type="run", when="+bismark")
+    depends_on("bowtie", type="run", when="+bowtie")
+    depends_on("bwa", type="run", when="+bwa")
+
+    def patch(self):
+        filter_file("/usr/bin/perl", self.spec["perl"].command.path, "fastq_screen", backup=False)
 
     def install(self, spec, prefix):
         install_tree(".", prefix.bin)


### PR DESCRIPTION
- Updating to `@0.15.3`. 
- Downloads have moved over the GitHub, so updated the url.
- There was a dependency (`bismark`) missing, though this was technically a variant dependency. I've added it here, and clarified that `bowtie` and `bwa` are also variants as well. `bowtie2` is the default aligner and the only required one of the four.
- This is a perl script, so everything's a run-time dependency only.
- Added a patch to correct the `perl` shebang.