### PR TITLE
mummer4: patching to allow building with %gcc@13:

### DIFF
--- a/var/spack/repos/builtin/packages/mummer4/48bit_index.patch
+++ b/var/spack/repos/builtin/packages/mummer4/48bit_index.patch
@@ -1,0 +1,10 @@
+--- include/mummer/48bit_index.hpp	2020-10-01 01:47:50.000000000 +0100
++++ include/mummer/48bit_index.hpp.patched	2023-06-09 12:07:09.949856479 +0100
+@@ -6,6 +6,7 @@
+ #endif
+ 
++#include <cstdint>
+ #include "48bit_iterator.hpp"
+ 
+ template<typename IDX>
+ struct fortyeight_index {

--- a/var/spack/repos/builtin/packages/mummer4/package.py
+++ b/var/spack/repos/builtin/packages/mummer4/package.py
@@ -25,3 +25,5 @@ class Mummer4(AutotoolsPackage):
     depends_on("perl@5.6.0:", type=("build", "run"))
     depends_on("awk", type="run")
     depends_on("sed", type="run")
+
+    patch("48bit_index.patch", level=0, when="%gcc@13:")

--- a/var/spack/repos/builtin/packages/mummer4/package.py
+++ b/var/spack/repos/builtin/packages/mummer4/package.py
@@ -26,4 +26,5 @@ class Mummer4(AutotoolsPackage):
     depends_on("awk", type="run")
     depends_on("sed", type="run")
 
+    # Adds missing inclusion of <cstdint>
     patch("48bit_index.patch", level=0, when="%gcc@13:")


### PR DESCRIPTION
Changes in the way `gcc@13:` handles includes meant `mummer4` was failing to build. Applying patch that I've also submitted to the main repo as a PR: https://github.com/mummer4/mummer/pull/199

With this change the build works as expected.