### PR TITLE
kentutils: add 449, update download location, update dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/kentutils/package.py
+++ b/var/spack/repos/builtin/packages/kentutils/package.py
@@ -9,26 +9,29 @@ from spack.package import *
 class Kentutils(MakefilePackage):
     """Jim Kent command line bioinformatic utilities"""
 
-    homepage = "https://github.com/ENCODE-DCC/kentUtils"
-    git = "https://github.com/ENCODE-DCC/kentUtils.git"
+    homepage = "https://github.com/ucscGenomeBrowser/kent-core"
+    url = "https://github.com/ucscGenomeBrowser/kent-core/archive/refs/tags/v449.tar.gz"
 
-    version("302.1", commit="d8376c5d52a161f2267346ed3dc94b5dce74c2f9")
+    version("449", sha256="640e7997e9ce220d6ab465e944bf11e678a9e3858ec6b346b024dc6f44e84713")
+    version(
+        "302.1",
+        commit="d8376c5d52a161f2267346ed3dc94b5dce74c2f9",
+        git="https://github.com/ENCODE-DCC/kentUtils.git",
+    )
 
     depends_on("libpng")
     depends_on("openssl")
-
-    # Actually depends on mysql, but mariadb works for now until mysql is
-    # available
+    depends_on("libuuid")
     depends_on("mariadb")
 
-    conflicts("%cce")
-    conflicts("%apple-clang")
-    conflicts("%clang")
-    conflicts("%intel")
-    conflicts("%nag")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
+    conflicts("%cce", when="@302.1")
+    conflicts("%apple-clang", when="@302.1")
+    conflicts("%clang", when="@302.1")
+    conflicts("%intel", when="@302.1")
+    conflicts("%nag", when="@302.1")
+    conflicts("%pgi", when="@302.1")
+    conflicts("%xl", when="@302.1")
+    conflicts("%xl_r", when="@302.1")
 
     def install(self, spec, prefix):
         install_tree("bin", prefix.bin)


### PR DESCRIPTION
- Updating to `@449`.
- The download location was incorrectly pointing to https://github.com/ENCODE-DCC/kentUtils, which is an archive. I've corrected it to the current location: https://github.com/ucscGenomeBrowser/kent-core.
- Added a missing dependency - `libuuid`.
- Clarified that the previous conflicts likely (can't check them all!) only apply to the old release - will use the CI pipeline to check ... (// EDIT // which seems to be happy)