### PR TITLE
hpx: Add conflict with some GCC versions and `+rocm` due to `valarray` bug

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -183,7 +183,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103022
     conflicts("%gcc@9.1:9.4", when="+rocm")
     conflicts("%gcc@10.1:10.3", when="+rocm")
-    conflicts("%gcc@11.1:11.2", when="+rocm")
+    conflicts("%gcc@11.2", when="+rocm")
 
     # boost 1.73.0 build problem with HPX 1.4.0 and 1.4.1
     # https://github.com/STEllAR-GROUP/hpx/issues/4728#issuecomment-640685308

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -177,6 +177,14 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     # both include a fix.
     conflicts("boost@:1.77.0", when="@:1.7 +rocm")
 
+    # libstdc++ has a broken valarray in some versions that clang/hipcc refuses
+    # to compile:
+    # https://github.com/spack/spack/issues/38104
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103022
+    conflicts("%gcc@9.1:9.4", when="+rocm")
+    conflicts("%gcc@10.1:10.3", when="+rocm")
+    conflicts("%gcc@11.1:11.2", when="+rocm")
+
     # boost 1.73.0 build problem with HPX 1.4.0 and 1.4.1
     # https://github.com/STEllAR-GROUP/hpx/issues/4728#issuecomment-640685308
     depends_on("boost@:1.72.0", when="@:1.4")


### PR DESCRIPTION
"Fixes" #38104 by adding conflicts with the buggy GCC versions and `+rocm`.