### PR TITLE
WarpX 23.06

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -121,9 +121,7 @@ spack:
   - py-jupyterhub
   - py-libensemble +mpi +nlopt
   - py-petsc4py
-  - py-warpx ^warpx dims=2
-  - py-warpx ^warpx dims=3
-  - py-warpx ^warpx dims=rz
+  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -128,9 +128,7 @@ spack:
   - py-jupyterhub
   - py-libensemble +mpi +nlopt
   - py-petsc4py
-  - py-warpx ^warpx dims=2
-  - py-warpx ^warpx dims=3
-  - py-warpx ^warpx dims=rz
+  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja

--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -16,6 +16,10 @@ class PyPicmistandard(PythonPackage):
     maintainers("ax3l", "dpgrote", "RemiLehe")
 
     version("develop", branch="master")
+    version("0.25.0", sha256="0a78b3b17054d0861626287ace1fb9321469a9c95795b92981103b27d7797f67")
+    version("0.24.0", sha256="55a82adcc14b41eb612caf0d9e47b0e2a56ffc196a58b41fa0cc395c6924be9a")
+    version("0.23.2", sha256="e6b4c46b23520d0a97b904df90d53ff6a3209b2b6b2fa741f684c594429a591c")
+    version("0.23.1", sha256="90ad1d3d2759d910cfdb88484516b7d0434ec98e881af46961b7e2faa534434d")
     version("0.0.22", sha256="e234a431274254b22cd70be64d6555b383d98426b2763ea0c174cf77bf4d0890")
     version("0.0.21", sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b")
     version("0.0.20", sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905")

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.03.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.06.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
@@ -27,6 +27,9 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version("develop", branch="development")
+    version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
+    version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
+    version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")
     version("23.03", sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718")
     version("23.02", sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1")
     version("23.01", sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c")
@@ -55,6 +58,9 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
+        "23.06",
+        "23.05",
+        "23.04",
         "23.03",
         "23.02",
         "23.01",
@@ -93,7 +99,9 @@ class PyWarpx(PythonPackage):
     depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
     depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
     depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")
-    depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:")
+    depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:23.03")
+    depends_on("py-picmistandard@0.23.2", type=("build", "run"), when="@23.04:23.05")
+    depends_on("py-picmistandard@0.24.0", type=("build", "run"), when="@23.06:")
     depends_on("py-setuptools@42:", type="build")
     # Since we use PYWARPX_LIB_DIR to pull binaries out of the
     # 'warpx' spack package, we don't need py-cmake as declared

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -71,7 +71,7 @@ class Warpx(CMakePackage):
         values=("1", "2", "3", "rz"),
         multi=False,
         description="Number of spatial dimensions",
-        when="@:23.05"
+        when="@:23.05",
     )
     variant(
         "dims",
@@ -79,7 +79,7 @@ class Warpx(CMakePackage):
         values=("1", "2", "3", "rz"),
         multi=True,
         description="Number of spatial dimensions",
-        when="@23.06:"
+        when="@23.06:",
     )
     variant("eb", default=False, description="Embedded boundary support (in development)")
     variant("lib", default=True, description="Build WarpX as a shared library")

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -151,6 +151,8 @@ class Warpx(CMakePackage):
         msg="WarpX spectral solvers are not yet tested with SYCL " '(use "warpx ~psatd")',
     )
 
+    build_directory = "spack-build"
+
     # The symbolic aliases for our +lib target were missing in the install
     # location
     # https://github.com/ECP-WarpX/WarpX/pull/2626

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.03.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.06.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "MaxThevenet", "RemiLehe")
@@ -25,6 +25,9 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
+    version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
+    version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
+    version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")
     version("23.03", sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718")
     version("23.02", sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1")
     version("23.01", sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c")
@@ -68,6 +71,15 @@ class Warpx(CMakePackage):
         values=("1", "2", "3", "rz"),
         multi=False,
         description="Number of spatial dimensions",
+        when="@:23.05"
+    )
+    variant(
+        "dims",
+        default="1,2,rz,3",
+        values=("1", "2", "3", "rz"),
+        multi=True,
+        description="Number of spatial dimensions",
+        when="@23.06:"
     )
     variant("eb", default=False, description="Embedded boundary support (in development)")
     variant("lib", default=True, description="Build WarpX as a shared library")

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -196,7 +196,7 @@ class Warpx(CMakePackage):
             self.define_from_variant("WarpX_ASCENT", "ascent"),
             self.define_from_variant("WarpX_SENSEI", "sensei"),
             "-DWarpX_COMPUTE={0}".format(spec.variants["compute"].value.upper()),
-            "-DWarpX_DIMS={0}".format(spec.variants["dims"].value.upper()),
+            "-DWarpX_DIMS={0}".format(";".join(spec.variants["dims"].value).upper()),
             self.define_from_variant("WarpX_EB", "eb"),
             self.define_from_variant("WarpX_LIB", "lib"),
             self.define_from_variant("WarpX_MPI", "mpi"),
@@ -226,50 +226,53 @@ class Warpx(CMakePackage):
     @property
     def libs(self):
         libsuffix = {"1": "1d", "2": "2d", "3": "3d", "rz": "rz"}
-        dims = self.spec.variants["dims"].value
-        libs = find_libraries(
-            ["libwarpx." + libsuffix[dims]], root=self.prefix, recursive=True, shared=True
-        )
-        libs += find_libraries(
-            ["libablastr"], root=self.prefix, recursive=True, shared=self.spec.variants["shared"]
-        )
+        libs = []
+        for dim in self.spec.variants["dims"].value:
+            libs += find_libraries(
+                ["libwarpx." + libsuffix[dim]], root=self.prefix, recursive=True, shared=True
+            )
+            libs += find_libraries(
+                ["libablastr"], root=self.prefix, recursive=True, shared=self.spec.variants["shared"]
+            )
         return libs
 
     # WarpX has many examples to serve as a suitable smoke check. One
     # that is typical was chosen here
     examples_src_dir = "Examples/Physics_applications/laser_acceleration/"
 
-    def _get_input_options(self, post_install):
+    def _get_input_options(self, dim, post_install):
         spec = self.spec
         examples_dir = join_path(
             self.install_test_root if post_install else self.stage.source_path,
             self.examples_src_dir,
         )
-        dims = spec.variants["dims"].value
         inputs_nD = {"1": "inputs_1d", "2": "inputs_2d", "3": "inputs_3d", "rz": "inputs_rz"}
         if spec.satisfies("@:21.12"):
             inputs_nD["rz"] = "inputs_2d_rz"
-        inputs = join_path(examples_dir, inputs_nD[dims])
+        inputs = join_path(examples_dir, inputs_nD[dim])
 
         cli_args = [inputs, "max_step=50", "diag1.intervals=10"]
         # test openPMD output if compiled in
         if "+openpmd" in spec:
             cli_args.append("diag1.format=openpmd")
             # RZ: New openPMD thetaMode output
-            if dims == "rz" and spec.satisfies("@22.04:"):
+            if dim == "rz" and spec.satisfies("@22.04:"):
                 cli_args.append("diag1.fields_to_plot=Er Et Ez Br Bt Bz jr jt jz rho")
         return cli_args
 
     def check(self):
         """Checks after the build phase"""
-        if "+app" not in self.spec:
+        spec = self.spec
+        if "+app" not in spec:
             print("WarpX check skipped: requires variant +app")
             return
 
         with working_dir("spack-check", create=True):
-            cli_args = self._get_input_options(False)
-            warpx = Executable(join_path(self.build_directory, "bin/warpx"))
-            warpx(*cli_args)
+            for dim in spec.variants["dims"].value:
+                cli_args = self._get_input_options(dim, False)
+                exe_nD = {"1": "warpx.1d", "2": "warpx.2d", "3": "warpx.3d", "rz": "warpx.rz"}
+                warpx = Executable(join_path(self.build_directory, "bin/" + exe_nD[dim]))
+                warpx(*cli_args)
 
     @run_after("install")
     def copy_test_sources(self):
@@ -284,9 +287,11 @@ class Warpx(CMakePackage):
             return
 
         # our executable names are a variant-dependent and naming evolves
-        exe = find(self.prefix.bin, "warpx.*", recursive=False)[0]
+        for dim in self.spec.variants["dims"].value:
+            exe_nD = {"1": "warpx.1d", "2": "warpx.2d", "3": "warpx.3d", "rz": "warpx.rz"}
+            exe = find(self.prefix.bin, exe_nD[dim] + ".*", recursive=False)[0]
 
-        cli_args = self._get_input_options(True)
-        self.run_test(
-            exe, cli_args, [], installed=True, purpose="Smoke test for WarpX", skip_missing=False
-        )
+            cli_args = self._get_input_options(dim, True)
+            self.run_test(
+                exe, cli_args, [], installed=True, purpose="Smoke test for WarpX", skip_missing=False
+            )

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -151,8 +151,6 @@ class Warpx(CMakePackage):
         msg="WarpX spectral solvers are not yet tested with SYCL " '(use "warpx ~psatd")',
     )
 
-    build_directory = "spack-build"
-
     # The symbolic aliases for our +lib target were missing in the install
     # location
     # https://github.com/ECP-WarpX/WarpX/pull/2626

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -234,7 +234,10 @@ class Warpx(CMakePackage):
                 ["libwarpx." + libsuffix[dim]], root=self.prefix, recursive=True, shared=True
             )
             libs += find_libraries(
-                ["libablastr"], root=self.prefix, recursive=True, shared=self.spec.variants["shared"]
+                ["libablastr"],
+                root=self.prefix,
+                recursive=True,
+                shared=self.spec.variants["shared"],
             )
         return libs
 
@@ -295,5 +298,10 @@ class Warpx(CMakePackage):
 
             cli_args = self._get_input_options(dim, True)
             self.run_test(
-                exe, cli_args, [], installed=True, purpose="Smoke test for WarpX", skip_missing=False
+                exe,
+                cli_args,
+                [],
+                installed=True,
+                purpose="Smoke test for WarpX",
+                skip_missing=False,
             )


### PR DESCRIPTION
Update WarpX and related Python packages to the lastest releases.

WarpX 23.06 introduces multi-dimension support in a single package, which will ease deployment in E4S et al. that can ship now a single, full-feature module/package that is NOT incompatible with itself anymore.

More background in this blog article: https://bssw.io/blog_posts/rethinking-software-variants

Ping @spack/e4s team: for WarpX 23.06, we now can build the default spec
- `warpx compute=<omp/cuda/>`

and do NOT need to ship four packages anymore, as in <=23.05:
- `warpx compute=<omp/cuda/> dims=1`
- `warpx compute=<omp/cuda/> dims=2`
- `warpx compute=<omp/cuda/> dims=rz`
- `warpx compute=<omp/cuda/> dims=3`
