### PR TITLE
Trillinos version 13.0.1 or later is specified

### DIFF
--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -26,7 +26,7 @@ class FrontistrBase(CMakePackage):
     # depends_on('revocap-coupler')
     depends_on("metis")
     depends_on("mumps")
-    depends_on("trilinos@:12.18.1")
+    depends_on("trilinos@:13.0.1")
 
     def cmake_args(self):
         define = self.define


### PR DESCRIPTION
Trillinos 12 cannot be compilied probably because of some gaps on Kokkos.
Version 13 can be compiled without any issues, and the compilation of FrontISTR also seems correct.