### PR TITLE
bootstrap: add minimum versions required for flake8 and pytest

### DIFF
--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -81,6 +81,7 @@ jobs:
         shell: runuser -u spack-test -- bash {0}
         run: |
           source share/spack/setup-env.sh
+          spack debug report
           spack -d bootstrap now --dev
           spack style -t black
           spack unit-test -V

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -175,12 +175,12 @@ def black_root_spec() -> str:
 
 def flake8_root_spec() -> str:
     """Return the root spec used to bootstrap flake8"""
-    return _root_spec("py-flake8")
+    return _root_spec("py-flake8@3.8.2:")
 
 
 def pytest_root_spec() -> str:
     """Return the root spec used to bootstrap flake8"""
-    return _root_spec("py-pytest")
+    return _root_spec("py-pytest@6.2.4:")
 
 
 def ensure_environment_dependencies() -> None:


### PR DESCRIPTION
closes #38319

For some reason yet to be determined, adding a new my-py version in https://github.com/spack/spack/pull/38286 resulted in `py-flake8@3.7.8` to be selected on rhel8 instead of `py-flake8@3.8.2`. This added `py-flit` as a dependency to `flake8` and failed because of this change https://github.com/spack/spack/pull/38001 in `py-docutils` that deleted information on old versions.