### PR TITLE
netcdf-c: apply patches

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -79,6 +79,19 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         )
         _force_autoreconf_when.append("@4.8.1")
 
+        # See https://github.com/Unidata/netcdf-c/pull/2710
+        # Versions 4.9.0 and 4.9.1 had a bug in the configure script, which worked to our benefit.
+        # The bug has been fixed in
+        # https://github.com/Unidata/netcdf-c/commit/267b26f1239310ca7ba8304315834939f7cc9886.
+        # So, now we need a patch in cases when we build for macOS with DAP disabled:
+        # TODO: update the patch URL when/if the referenced PR is accepted.
+        patch(
+            "https://github.com/Unidata/netcdf-c/pull/2710/commits/4cdbef4a02b6f0922e805181d4943d5d682ff27c.patch?full_index=1",
+            sha256="75bc04336e26a65fd4a8348226298173001254676ccebebda8ebd4d8b829852c",
+            when="@4.9.2~dap platform=darwin",
+        )
+        _force_autoreconf_when.append("@4.9.2~dap platform=darwin")
+
     with when("@4.7.2"):
         # Fix headers
         # See https://github.com/Unidata/netcdf-c/pull/1505

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -82,12 +82,11 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # See https://github.com/Unidata/netcdf-c/pull/2710
         # Versions 4.9.0 and 4.9.1 had a bug in the configure script, which worked to our benefit.
         # The bug has been fixed in
-        # https://github.com/Unidata/netcdf-c/commit/267b26f1239310ca7ba8304315834939f7cc9886.
-        # So, now we need a patch in cases when we build for macOS with DAP disabled:
-        # TODO: update the patch URL when/if the referenced PR is accepted.
+        # https://github.com/Unidata/netcdf-c/commit/267b26f1239310ca7ba8304315834939f7cc9886 and
+        # now we need a patch in cases when we build for macOS with DAP disabled:
         patch(
-            "https://github.com/Unidata/netcdf-c/pull/2710/commits/4cdbef4a02b6f0922e805181d4943d5d682ff27c.patch?full_index=1",
-            sha256="75bc04336e26a65fd4a8348226298173001254676ccebebda8ebd4d8b829852c",
+            "https://github.com/Unidata/netcdf-c/commit/cfe6231aa6b018062b443cbe2fd9073f15283344.patch?full_index=1",
+            sha256="4e105472de95a1bb5d8b0b910d6935ce9152777d4fe18b678b58347fa0122abc",
             when="@4.9.2~dap platform=darwin",
         )
         _force_autoreconf_when.append("@4.9.2~dap platform=darwin")

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -112,6 +112,13 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         when="@4.9.0:4.9.1~mpi+parallel-netcdf",
     )
 
+    # See https://github.com/Unidata/netcdf-c/issues/2674
+    patch(
+        "https://github.com/Unidata/netcdf-c/commit/f8904d5a1d89420dde0f9d2c0e051ba08d08e086.patch?full_index=1",
+        sha256="0161eb870fdfaf61be9d70132c9447a537320342366362e76b8460c823bf95ca",
+        when="@4.9.0:4.9.2",
+    )
+
     variant("mpi", default=True, description="Enable parallel I/O for netcdf-4")
     variant("parallel-netcdf", default=False, description="Enable parallel I/O for classic files")
     variant("hdf4", default=False, description="Enable HDF4 support")


### PR DESCRIPTION
This applies a couple of patches to fix two problems:
1) fix building `netcdf-c~dap` on macOS (https://github.com/Unidata/netcdf-c/pull/2710);
2) fix HDF5 API calls (https://github.com/Unidata/netcdf-c/issues/2674).