### PR TITLE
llvm: fix build against libstdc++ 13

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -403,7 +403,8 @@ class Llvm(CMakePackage, CudaPackage):
     )
     #
     # fix compilation against libstdc++13
-    patch("https://github.com/llvm/llvm-project/commit/1b4fdf18bc2aaa2d46bf072475dd9cbcd44a9fee.patch?full_index=1",
+    patch(
+        "https://github.com/llvm/llvm-project/commit/1b4fdf18bc2aaa2d46bf072475dd9cbcd44a9fee.patch?full_index=1",
         sha256="82481418766b4b949ea808d956ff3800b9a241a576370114862428bb0e25ee1f",
         when="@14:15",
     )

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -401,6 +401,12 @@ class Llvm(CMakePackage, CudaPackage):
         sha256="514926d661635de47972c7d403c9c4669235aa51e22e56d44676d2a2709179b6",
         when="@8:11",
     )
+    #
+    # fix compilation against libstdc++13
+    patch("https://github.com/llvm/llvm-project/commit/1b4fdf18bc2aaa2d46bf072475dd9cbcd44a9fee.patch?full_index=1",
+        sha256="82481418766b4b949ea808d956ff3800b9a241a576370114862428bb0e25ee1f",
+        when="@14:15",
+    )
 
     # fix building of older versions of llvm with newer versions of glibc
     for compiler_rt_as in ["project", "runtime"]:


### PR DESCRIPTION
llvm @13-15 is required for ispc, but fails to build with GCC 13. 14.0.6 and 15.0.7 built successfully with upstream patch, 13.0.1 still fails. Thus upstream patch is applied to 14 and 15 only.