### PR TITLE
cpp-httplib: add v0.12.5

### DIFF
--- a/var/spack/repos/builtin/packages/cpp-httplib/package.py
+++ b/var/spack/repos/builtin/packages/cpp-httplib/package.py
@@ -12,6 +12,7 @@ class CppHttplib(CMakePackage):
     homepage = "https://github.com/yhirose/cpp-httplib/"
     url = "https://github.com/yhirose/cpp-httplib/archive/v0.5.10.tar.gz"
 
+    version("0.12.5", sha256="b488f3fa9c6bf35608c3d9a5b69be52e016bbf2fbfe67e5ee684eadb2655493e")
     version("0.12.3", sha256="175ced3c9cdaf221e9edf210297568d8f7d402a41d6db01254ac9e0b25487c54")
     version("0.5.9", sha256="c9e7aef3b0d4e80ee533d10413508d8a6e09a67d0d59646c43111f3993de006e")
     version("0.5.8", sha256="184d4fe79fc836ee26aa8635b3240879af4c6f17257fc7063d0b77a0cf856dfc")


### PR DESCRIPTION
Add cpp-httplib v0.12.5. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.