### PR TITLE
curl: add v8.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -26,6 +26,7 @@ class Curl(NMakePackage, AutotoolsPackage):
 
     maintainers("alecbcs")
 
+    version("8.1.2", sha256="b54974d32fd610acace92e3df1f643144015ac65847f0a041fdc17db6f43f243")
     version("8.0.1", sha256="9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf")
     version("7.88.1", sha256="8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907")
 


### PR DESCRIPTION
Add curl v8.1.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.