### PR TITLE
direnv: add v2.32.3

### DIFF
--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -14,6 +14,7 @@ class Direnv(Package):
 
     maintainers("acastanedam", "alecbcs")
 
+    version("2.32.3", sha256="c66f6d1000f28f919c6106b5dcdd0a0e54fb553602c63c60bf59d9bbdf8bd33c")
     version("2.32.2", sha256="352b3a65e8945d13caba92e13e5666e1854d41749aca2e230938ac6c64fa8ef9")
     version("2.32.1", sha256="dc7df9a9e253e1124748aa74da94bf2b96f5a61d581c60d52d3f8e8dc86ecfde")
     version("2.31.0", sha256="f82694202f584d281a166bd5b7e877565f96a94807af96325c8f43643d76cb44")


### PR DESCRIPTION
Add direnv v2.32.3. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.