### PR TITLE
etcd: add v3.5.9

### DIFF
--- a/var/spack/repos/builtin/packages/etcd/package.py
+++ b/var/spack/repos/builtin/packages/etcd/package.py
@@ -15,6 +15,7 @@ class Etcd(Package):
 
     maintainers("alecbcs")
 
+    version("3.5.9", sha256="ab24d74b66ba1ed7d2bc391839d961e7215f0f3d674c3a9592dad6dc67a7b223")
     version("3.4.23", sha256="055c608c4898d25f23aefbc845ff074bf5e8a07e61ed41dbd5cc4d4f59c93093")
 
     depends_on("go@1.19:")


### PR DESCRIPTION
Add etcd v3.5.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.