### PR TITLE
fastp: add v0.23.4

### DIFF
--- a/var/spack/repos/builtin/packages/fastp/package.py
+++ b/var/spack/repos/builtin/packages/fastp/package.py
@@ -13,6 +13,7 @@ class Fastp(MakefilePackage):
     homepage = "https://github.com/OpenGene/fastp"
     url = "https://github.com/OpenGene/fastp/archive/v0.20.0.tar.gz"
 
+    version("0.23.4", sha256="4fad6db156e769d46071add8a778a13a5cb5186bc1e1a5f9b1ffd499d84d72b5")
     version("0.23.3", sha256="a37ee4b5dcf836a5a19baec645657b71d9dcd69ee843998f41f921e9b67350e3")
     version("0.20.0", sha256="8d751d2746db11ff233032fc49e3bcc8b53758dd4596fdcf4b4099a4d702ac22")
 


### PR DESCRIPTION
Add fastp v0.23.4. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.