### PR TITLE
tests/pythons: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1195,19 +1195,18 @@ print(json.dumps(config))
             else:
                 os.remove(dst)
 
-    def test(self):
+    def test_hello_world(self):
+        """run simple hello world program"""
         # do not use self.command because we are also testing the run env
-        exe = self.spec["python"].command.name
+        python = self.spec["python"].command
 
-        # test hello world
         msg = "hello world!"
-        reason = "test: running {0}".format(msg)
-        options = ["-c", 'print("{0}")'.format(msg)]
-        self.run_test(exe, options=options, expected=[msg], installed=True, purpose=reason)
+        out = python("-c", f'print("{msg}")', output=str.split, error=str.split)
+        assert msg in out
 
-        # checks import works and executable comes from the spec prefix
-        reason = "test: checking import and executable"
-        options = ["-c", "import sys; print(sys.executable)"]
-        self.run_test(
-            exe, options=options, expected=[self.spec.prefix], installed=True, purpose=reason
-        )
+    def test_import_executable(self):
+        """ensure import of installed executable works"""
+        python = self.spec["python"].command
+
+        out = python("-c", "import sys; print(sys.executable)", output=str.split, error=str.split)
+        assert self.spec.prefix in out


### PR DESCRIPTION
This PR converts the build system and python package to use the new stand-alone test process.

```
$ spack -v install --test=root python
...
==> [2023-06-12-16:42:33.488421] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import readline'
==> [2023-06-12-16:42:33.565671] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import ssl'
==> [2023-06-12-16:42:33.758127] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import hashlib'
==> [2023-06-12-16:42:33.836985] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import sqlite3'
==> [2023-06-12-16:42:33.968587] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import dbm'
==> [2023-06-12-16:42:34.075500] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import zlib'
==> [2023-06-12-16:42:34.144997] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import bz2'
==> [2023-06-12-16:42:34.241026] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import lzma'
==> [2023-06-12-16:42:34.303833] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import xml.parsers.expat'
==> [2023-06-12-16:42:34.416177] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import xml.etree.ElementTree'
==> [2023-06-12-16:42:34.595660] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import ctypes'
==> [2023-06-12-16:42:34.684607] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import uuid'
==> [2023-06-12-16:42:34.843504] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import crypt'
==> python: Successfully installed python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr
  Stage: 0.90s.  Configure: 1m 15.71s.  Build: 33.40s.  Install: 59.20s.  Post-install: 52.56s.  Total: 3m 44.16s

$ spack -v test run /xyx5kz
==> Spack test jwanhy2nce76utxdlg5hll7ug4hbirtp
==> Testing package python-3.10.10-xyx5kzm
==> [2023-06-12-16:52:56.360862] test: test_hello_world: run simple hello world program
==> [2023-06-12-16:52:56.362619] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'print("hello world!")'
hello world!
PASSED: Python::test_hello_world
==> [2023-06-12-16:52:56.412655] test: test_import_executable: ensure import of installed executable works
==> [2023-06-12-16:52:56.413639] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10' '-c' 'import sys; print(sys.executable)'
/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-xyx5kzmjotaa45d75hgcgnzcr6vm4ijr/bin/python3.10
PASSED: Python::test_import_executable
==> [2023-06-12-16:52:56.451556] Completed testing
==> [2023-06-12-16:52:56.451685] 
======================= SUMMARY: python-3.10.10-xyx5kzm ========================
Python::test_hello_world .. PASSED
Python::test_import_executable .. PASSED
============================= 2 passed of 2 parts ==============================
============================== 1 passed of 1 spec ==============================
```