### PR TITLE
magma: add python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -46,6 +46,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda@8:", when="@2.5.1: +cuda")  # See PR #14471
     depends_on("hipblas", when="+rocm")
     depends_on("hipsparse", when="+rocm")
+    depends_on("python", when="@master", type="build")
 
     conflicts("~cuda", when="~rocm", msg="Either CUDA or HIP support must be enabled")
     conflicts("+rocm", when="+cuda", msg="CUDA must be disabled to support HIP (ROCm)")


### PR DESCRIPTION
```
Fixes: magma@master

env: 'python': No such file or directory
make: *** Deleting file 'Makefile.gen.cuda'
make: *** No rule to make target 'Makefile.gen.cuda', needed by 'CMake.src.cuda'.  Stop.
```

https://gitlab.com/xsdk-project/spack-xsdk/-/jobs/4459102221
