### PR TITLE
tests/py-shapely: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -89,7 +89,7 @@ class PyShapely(PythonPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
+    def ensure_pytest(self):
         # https://shapely.readthedocs.io/en/latest/installation.html#testing-shapely
         if self.version >= Version("2"):
             with working_dir("spack-test", create=True):


### PR DESCRIPTION
This PR changes the existing test to conform to the new stand-alone test process in the sense that it no longer allows the build-time test method name to start with `test_`.  

It does not convert the existing test to be used as a stand-alone test because the the `pytest` dependency is of the wrong type.

```
$ spack -v install --test=root py-shapely
...
==> [2023-06-12-17:12:52.530129] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-m' 'pytest' '--pyargs' 'shapely.tests'
============================= test session starts ==============================
platform linux -- Python 3.10.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /tmp/dahlgren/spack-stage/spack-stage-py-shapely-2.0.1-2w5wfpwjqxmogqsckbalkbgbmhma6olp/spack-src, configfile: setup.cfg
plugins: cov-4.0.0
collected 3214 items / 1 skipped

../test_constructive.py ................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  8%]
................................................s....................... [ 10%]
........................................................................ [ 12%]
...................................                                      [ 13%]
../test_coordinates.py ................................................. [ 15%]
........................................................................ [ 17%]
...........                                                              [ 17%]
../test_creation.py .................................................... [ 19%]
...........................................................              [ 21%]
../test_creation_indices.py ............................................ [ 22%]
........................................................................ [ 24%]
..............................                                           [ 25%]
../test_geometry.py .................................................... [ 27%]
........................................................................ [ 29%]
........................................................................ [ 31%]
.............................................                            [ 33%]
../test_io.py ............................s........s........s........s.. [ 35%]
...................s..s..........s...................................... [ 37%]
.................................s......                                 [ 38%]
../test_linear.py ...............................................s...... [ 40%]
...                                                                      [ 40%]
../test_measurement.py ................................................. [ 41%]
............................                                             [ 42%]
../test_misc.py ......................                                   [ 43%]
../test_predicates.py .................................................. [ 45%]
........................................................................ [ 47%]
........................................................................ [ 49%]
........................................................................ [ 51%]
........................................................................ [ 54%]
........................................................................ [ 56%]
.......................................                                  [ 57%]
../test_ragged_array.py ....................................             [ 58%]
../test_set_operations.py ....................................ssssssss.. [ 60%]
........................................................................ [ 62%]
....................................................................ss.. [ 64%]
......................................................................   [ 66%]
../test_strtree.py ..................................................... [ 68%]
........................................................................ [ 70%]
........................................................................ [ 72%]
........................................................................ [ 75%]
........................................................................ [ 77%]
........................................................................ [ 79%]
........................................................................ [ 81%]
.................................ssssss................................. [ 84%]
........................................................................ [ 86%]
........................................................................ [ 88%]
........................................................                 [ 90%]
../test_testing.py ..................................................... [ 91%]
..............................................                           [ 93%]
../geometry/test_collection.py .........                                 [ 93%]
../geometry/test_coords.py ........                                      [ 93%]
../geometry/test_decimal.py .........                                    [ 94%]
../geometry/test_emptiness.py ....................                       [ 94%]
../geometry/test_format.py ...                                           [ 94%]
../geometry/test_geometry_base.py ...................................... [ 96%]
...................................                                      [ 97%]
../geometry/test_hash.py .....                                           [ 97%]
../geometry/test_linestring.py ....................                      [ 97%]
../geometry/test_multilinestring.py ......                               [ 98%]
../geometry/test_multipoint.py .......                                   [ 98%]
../geometry/test_multipolygon.py ....                                    [ 98%]
../geometry/test_point.py ..............                                 [ 98%]
../geometry/test_polygon.py ....................................         [100%]

======================= 3188 passed, 27 skipped in 8.36s =======================
==> Testing package py-shapely-2.0.1-2w5wfpw
==> [2023-06-12-17:13:02.161665] Running install-time tests
==> [2023-06-12-17:13:02.179304] RUN-TESTS: install-time tests [test]
==> [2023-06-12-17:13:02.213601] Detected the following modules: ['shapely', 'shapely.algorithms', 'shapely.geometry', 'shapely.tests', 'shapely.tests.geometry', 'shapely.vectorized']
==> [2023-06-12-17:13:02.213878] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for py-shapely to process python3.10.
==> [2023-06-12-17:13:02.214315] test: test_python3.10_c_importshapely: checking import of shapely
==> [2023-06-12-17:13:02.214938] Expecting return code in [0]
==> [2023-06-12-17:13:02.215308] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely'
PASSED: PyShapely::test_python3.10_c_importshapely
==> [2023-06-12-17:13:02.693094] test: test_python3.10_c_importshapely.algorithms: checking import of shapely.algorithms
==> [2023-06-12-17:13:02.693596] Expecting return code in [0]
==> [2023-06-12-17:13:02.693936] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely.algorithms'
PASSED: PyShapely::test_python3.10_c_importshapely.algorithms
==> [2023-06-12-17:13:03.232509] test: test_python3.10_c_importshapely.geometry: checking import of shapely.geometry
==> [2023-06-12-17:13:03.232970] Expecting return code in [0]
==> [2023-06-12-17:13:03.233295] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely.geometry'
PASSED: PyShapely::test_python3.10_c_importshapely.geometry
==> [2023-06-12-17:13:03.771799] test: test_python3.10_c_importshapely.tests: checking import of shapely.tests
==> [2023-06-12-17:13:03.772250] Expecting return code in [0]
==> [2023-06-12-17:13:03.772581] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely.tests'
PASSED: PyShapely::test_python3.10_c_importshapely.tests
==> [2023-06-12-17:13:04.301880] test: test_python3.10_c_importshapely.tests.geometry: checking import of shapely.tests.geometry
==> [2023-06-12-17:13:04.302400] Expecting return code in [0]
==> [2023-06-12-17:13:04.302755] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely.tests.geometry'
PASSED: PyShapely::test_python3.10_c_importshapely.tests.geometry
==> [2023-06-12-17:13:04.824438] test: test_python3.10_c_importshapely.vectorized: checking import of shapely.vectorized
==> [2023-06-12-17:13:04.824916] Expecting return code in [0]
==> [2023-06-12-17:13:04.825255] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import shapely.vectorized'
PASSED: PyShapely::test_python3.10_c_importshapely.vectorized
==> [2023-06-12-17:13:05.351519] Completed testing
==> py-shapely: Successfully installed py-shapely-2.0.1-2w5wfpwjqxmogqsckbalkbgbmhma6olp
  Stage: 0.03s.  Install: 39.76s.  Post-install: 1.90s.  Total: 44.46s
[+] /usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-shapely-2.0.1-2w5wfpwjqxmogqsckbalkbgbmhma6olp
61.596u 5.201s 1:28.44 75.5%	0+0k 9840+14232io 5pf+0w
```