### PR TITLE
tests/py-genshi: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -16,7 +16,7 @@ class PyGenshi(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-six", type=("build", "run", "test"))
 
-    def test(self):
+    def test_testsuite(self):
         # All the unittests pass for py-genshi@0.7.7 but 14 tests fail for
         # @0.6.1:0.7, many of them related to templates, likely because the
         # template path needs to be setup.  But those versions didn't use tox

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -13,13 +13,8 @@ class PyGenshi(PythonPackage):
 
     version("0.7.7", sha256="c100520862cd69085d10ee1a87e91289e7f59f6b3d9bd622bf58b2804e6b9aab")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-six", type=("build", "run", "test"))
 
     def test_testsuite(self):
-        # All the unittests pass for py-genshi@0.7.7 but 14 tests fail for
-        # @0.6.1:0.7, many of them related to templates, likely because the
-        # template path needs to be setup.  But those versions didn't use tox
-        # and setting up the test environment to find the template files doesn't
-        # seem to be documented.
         python("-m", "unittest", "-v", "genshi.tests.suite")


### PR DESCRIPTION
UPDATED

This PR converts the stand-alone test to the new process.  Unfortunately the stand-alone test fails. Test details can be found in [py-genshi-testing.txt](https://github.com/spack/spack/files/11761561/py-genshi-testing.txt).

```
$ spack -v install --test=root py-genshi
...
Successfully installed Genshi-0.7.7
Removed build tracker: '/tmp/dahlgren/pip-build-tracker-opw6ak1i'
==> Testing package py-genshi-0.7.7-kp7idzf
==> [2023-06-15-11:42:05.888734] Running install-time tests
==> [2023-06-15-11:42:05.906852] RUN-TESTS: install-time tests [test]
==> [2023-06-15-11:42:06.009294] Detected the following modules: ['genshi', 'genshi.filters', 'genshi.filters.tests', 'genshi.template', 'genshi.template.tests', 'genshi.template.tests.templates', 'genshi.tests']
...
==> [2023-06-15-11:42:07.535863] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import genshi.tests'
PASSED: PyGenshi::test_python3.10_c_importgenshi.tests
==> [2023-06-15-11:42:07.750149] Completed testing
==> py-genshi: Successfully installed py-genshi-0.7.7-kp7idzfmadfirswlhvhq3qpjmaw5slo2
  Stage: 0.20s.  Install: 41.08s.  Post-install: 8.78s.  Total: 1m 11.55s

$ spack -v test run py-genshi
==> Spack test x7kpxv63g2ies2u4ydaxvhujignohwjj
==> Testing package py-genshi-0.7.7-kp7idzf
==> [2023-06-15-11:43:35.107876] Warning: py-genshi: the 'test' method is deprecated. Convert stand-alone test(s) to methods with names starting 'test_'.
==> [2023-06-15-11:43:35.109110] test: test: Attempts to import modules of the installed package.
...
test_include_expr (genshi.template.tests.text.NewTextTemplateTestCase) ... ok
test_latin1_encoded (genshi.template.tests.text.NewTextTemplateTestCase) ... ok
test_unicode_input (genshi.template.tests.text.NewTextTemplateTestCase) ... ok
LRUCache (genshi.util)
Doctest: genshi.util.LRUCache ... ok
flatten (genshi.util)
Doctest: genshi.util.flatten ... ok
plaintext (genshi.util)
Doctest: genshi.util.plaintext ... ok
stripentities (genshi.util)
Doctest: genshi.util.stripentities ... ok
striptags (genshi.util)
Doctest: genshi.util.striptags ... ok
test_getitem (genshi.tests.util.LRUCacheTestCase) ... ok
test_setitem (genshi.tests.util.LRUCacheTestCase) ... ok

----------------------------------------------------------------------
Ran 894 tests in 1.343s

OK
PASSED: PyGenshi::test_testsuite
==> [2023-06-15-11:43:38.765405] Completed testing
==> [2023-06-15-11:43:38.765639] 
======================= SUMMARY: py-genshi-0.7.7-kp7idzf =======================
PyGenshi::test_python3.10_c_importgenshi .. PASSED
PyGenshi::test_python3.10_c_importgenshi.filters .. PASSED
PyGenshi::test_python3.10_c_importgenshi.filters.tests .. PASSED
PyGenshi::test_python3.10_c_importgenshi.template .. PASSED
PyGenshi::test_python3.10_c_importgenshi.template.tests .. PASSED
PyGenshi::test_python3.10_c_importgenshi.template.tests.templates .. PASSED
PyGenshi::test_python3.10_c_importgenshi.tests .. PASSED
PyGenshi::test .. PASSED
PyGenshi::test_testsuite .. PASSED
============================= 9 passed of 9 parts ==============================
============================== 1 passed of 1 spec ==============================
```