### PR TITLE
tests/py-eccodes: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -38,12 +38,7 @@ class PyEccodes(PythonPackage):
     def setup_dependent_run_environment(self, env, dependent_spec):
         self.setup_build_environment(env)
 
-    def test(self):
-        super(PyEccodes, self).test()
-
-        self.run_test(
-            self.spec["python"].command.path,
-            ["-m", "eccodes", "selfcheck"],
-            purpose="checking system setup",
-            work_dir="spack-test",
-        )
+    def test_selfcheck(self):
+        """checking system setup"""
+        python = self.spec["python"].command
+        python("-m", "eccodes", "selfcheck")


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v install --test=root py-eccodes
..
Successfully installed eccodes-1.5.0
Removed build tracker: '/tmp/dahlgren/pip-build-tracker-auyyn3z5'
==> Testing package py-eccodes-1.5.0-rup6y2m
==> [2023-06-12-19:01:06.524928] Running install-time tests
==> [2023-06-12-19:01:06.573901] RUN-TESTS: install-time tests [test]
==> [2023-06-12-19:01:06.593192] Detected the following modules: ['eccodes', 'eccodes.highlevel', 'gribapi']
==> [2023-06-12-19:01:06.593483] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for py-eccodes to process python3.10.
==> [2023-06-12-19:01:06.593957] test: test_python3.10_c_importeccodes: checking import of eccodes
==> [2023-06-12-19:01:06.594666] Expecting return code in [0]
==> [2023-06-12-19:01:06.595079] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import eccodes'
PASSED: PyEccodes::test_python3.10_c_importeccodes
==> [2023-06-12-19:01:07.628444] test: test_python3.10_c_importeccodes.highlevel: checking import of eccodes.highlevel
==> [2023-06-12-19:01:07.629051] Expecting return code in [0]
==> [2023-06-12-19:01:07.629413] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import eccodes.highlevel'
PASSED: PyEccodes::test_python3.10_c_importeccodes.highlevel
==> [2023-06-12-19:01:08.289771] test: test_python3.10_c_importgribapi: checking import of gribapi
==> [2023-06-12-19:01:08.290374] Expecting return code in [0]
==> [2023-06-12-19:01:08.290733] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import gribapi'
PASSED: PyEccodes::test_python3.10_c_importgribapi
==> [2023-06-12-19:01:08.848785] Completed testing
==> py-eccodes: Successfully installed py-eccodes-1.5.0-rup6y2mzd4s5hcinhu4idsm6ikniiayz
  Stage: 0.09s.  Install: 6.63s.  Post-install: 0.90s.  Total: 9.49s
  [+] $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-eccodes-1.5.0-rup6y2mzd4s5hcinhu4idsm6ikniiayz
  752.896u 122.319s 16:55.25 86.2%	0+0k 448080+665640io 254pf+0w
  quartz1538{64}:$SPACK_ROOT> spack -v test run py-eccodes   ==> Spack test bpkvgjkcpzf6oxh3wlbskgo3vhoqanle
  ==> Testing package py-eccodes-1.5.0-rup6y2m
  ==> [2023-06-12-19:02:33.614303] Warning: py-eccodes: the 'test' method is deprecated. Convert stand-alone test(s) to methods with names starting 'test_'.
  ==> [2023-06-12-19:02:33.615162] test: test: Attempts to import modules of the installed package.
  ==> [2023-06-12-19:02:33.630655] Detected the following modules: ['eccodes', 'eccodes.highlevel', 'gribapi']
  ==> [2023-06-12-19:02:33.630828] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for py-eccodes to process python3.10.
  ==> [2023-06-12-19:02:33.631232] test: test_python3.10_c_importeccodes: checking import of eccodes
  ==> [2023-06-12-19:02:33.633635] Expecting return code in [0]
  ==> [2023-06-12-19:02:33.633958] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import eccodes'
  PASSED: PyEccodes::test_python3.10_c_importeccodes
  ==> [2023-06-12-19:02:34.378133] test: test_python3.10_c_importeccodes.highlevel: checking import of eccodes.highlevel
  ==> [2023-06-12-19:02:34.378627] Expecting return code in [0]
  ==> [2023-06-12-19:02:34.378902] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import eccodes.highlevel'
  PASSED: PyEccodes::test_python3.10_c_importeccodes.highlevel
  ==> [2023-06-12-19:02:34.900660] test: test_python3.10_c_importgribapi: checking import of gribapi
  ==> [2023-06-12-19:02:34.901185] Expecting return code in [0]
  ==> [2023-06-12-19:02:34.901459] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-c' 'import gribapi'
  PASSED: PyEccodes::test_python3.10_c_importgribapi
  PASSED: PyEccodes::test
  ==> [2023-06-12-19:02:35.405135] test: test_selfcheck: checking system setup
  ==> [2023-06-12-19:02:35.406054] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-bmsjbb3kgcn5e7tgey5w7rlps2byhbhx/bin/python3.10' '-m' 'eccodes' 'selfcheck'
  Found: ecCodes v2.25.0.
  Library: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/eccodes-2.25.0-2lp4mz4mqhdf4mepwspuzkbf5pxkzg5k/lib64/libeccodes.so
  Definitions: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/eccodes-2.25.0-2lp4mz4mqhdf4mepwspuzkbf5pxkzg5k/share/eccodes/definitions
  Samples: $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/eccodes-2.25.0-2lp4mz4mqhdf4mepwspuzkbf5pxkzg5k/share/eccodes/samples
  Your system is ready.
  PASSED: PyEccodes::test_selfcheck
  ==> [2023-06-12-19:02:35.914420] Completed testing
  ==> [2023-06-12-19:02:35.914667]
  ====================== SUMMARY: py-eccodes-1.5.0-rup6y2m =======================
  PyEccodes::test_python3.10_c_importeccodes .. PASSED
  PyEccodes::test_python3.10_c_importeccodes.highlevel .. PASSED
  PyEccodes::test_python3.10_c_importgribapi .. PASSED
  PyEccodes::test .. PASSED
  PyEccodes::test_selfcheck .. PASSED
  ============================= 5 passed of 5 parts ==============================
  ============================== 1 passed of 1 spec ==============================
```