### PR TITLE
cloc: add v1.96.1

### DIFF
--- a/var/spack/repos/builtin/packages/cloc/package.py
+++ b/var/spack/repos/builtin/packages/cloc/package.py
@@ -14,6 +14,7 @@ class Cloc(Package):
     homepage = "https://github.com/AlDanial/cloc/"
     url = "https://github.com/AlDanial/cloc/archive/v1.90.tar.gz"
 
+    version("1.96.1", sha256="f0551d98dcce9ca2e78b984adf8e8cc7c6002037a1155e5294338c435e4a1af1")
     version("1.90", sha256="60b429dd2aa5cd65707b359dcbcbeb710c8e4db880886528ced0962c67e52548")
     version("1.84", sha256="c3f0a6bd2319110418ccb3e55a7a1b6d0edfd7528bfd2ae5d530938abe90f254")
     version("1.80", sha256="082f53530eee3f9ee84ec449eca59a77ff114250cd7daf9519679537b5b21d67")


### PR DESCRIPTION
Add cloc v1.96.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.