### PR TITLE
freeipmi: add v1.6.9

### DIFF
--- a/var/spack/repos/builtin/packages/freeipmi/package.py
+++ b/var/spack/repos/builtin/packages/freeipmi/package.py
@@ -23,6 +23,7 @@ class Freeipmi(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/freeipmi/"
     url = "https://ftp.gnu.org/gnu/freeipmi/freeipmi-1.6.4.tar.gz"
 
+    version("1.6.9", sha256="f25e1c35f3d0f1b5a99cc31ecc2353ca83ed46a15163842fba870127dc9c8206")
     version("1.6.4", sha256="65dfbb95a30438ba247f01a58498862a37d2e71c8c950bcfcee459d079241a3c")
 
     depends_on("libgcrypt")


### PR DESCRIPTION
Add freeipmi v1.6.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.