### PR TITLE
ftxui: add v4.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/ftxui/package.py
+++ b/var/spack/repos/builtin/packages/ftxui/package.py
@@ -13,5 +13,6 @@ class Ftxui(CMakePackage):
     homepage = "https://arthursonzogni.github.io"
     url = "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v2.0.0.tar.gz"
 
+    version("4.1.1", sha256="9009d093e48b3189487d67fc3e375a57c7b354c0e43fc554ad31bec74a4bc2dd")
     version("4.0.0", sha256="7276e4117429ebf8e34ea371c3ea4e66eb99e0f234cb4c5c85fca17174a53dfa")
     version("2.0.0", sha256="d891695ef22176f0c09f8261a37af9ad5b262dd670a81e6b83661a23abc2c54f")


### PR DESCRIPTION
Add ftxui v4.1.1. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.