### PR TITLE
hashcat: add v6.2.6

### DIFF
--- a/var/spack/repos/builtin/packages/hashcat/package.py
+++ b/var/spack/repos/builtin/packages/hashcat/package.py
@@ -16,6 +16,7 @@ class Hashcat(MakefilePackage):
     homepage = "https://hashcat.net/hashcat/"
     url = "https://github.com/hashcat/hashcat/archive/v6.1.1.tar.gz"
 
+    version("6.2.6", sha256="b25e1077bcf34908cc8f18c1a69a2ec98b047b2cbcf0f51144dcf3ba1e0b7b2a")
     version("6.1.1", sha256="39c140bbb3c0bdb1564bfa9b9a1cff49115a42f4c9c19e9b066b617aea309f80")
     version("6.1.0", sha256="916f92434e3b36a126be1d1247a95cd3b32b4d814604960a2ca325d4cc0542d1")
     version("6.0.0", sha256="e8e70f2a5a608a4e224ccf847ad2b8e4d68286900296afe00eb514d8c9ec1285")


### PR DESCRIPTION
Add hashcat v6.2.6. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.