### PR TITLE
libffi: add -Wno-error=implicit-function-declaration for clang >= 16

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -40,7 +40,11 @@ class Libffi(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%oneapi@2023:") or self.spec.satisfies("%arm@23.04:"):
+            if (
+                self.spec.satisfies("%oneapi@2023:")
+                or self.spec.satisfies("%arm@23.04:")
+                or self.spec.satisfies("%clang@16:")
+            ):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)
 


### PR DESCRIPTION
clang starts erroring on implicit function declarations by default with version 16

This breaks libffi build similarly as for oneapi and arm compilers. This workarounds the issue in wait for the release of the actual fix in libffi.