### PR TITLE
ucc: new package

### DIFF
--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -13,8 +13,6 @@ class Ucc(AutotoolsPackage, CudaPackage):
     homepage = "https://openucx.github.io/ucc/"
     url = "https://github.com/openucx/ucc/archive/refs/tags/v1.1.0.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
     # maintainers("github_user1", "github_user2")
 
     version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Ucc(AutotoolsPackage, CudaPackage):
+    """UCC is a collective communication operations API and library that is
+    flexible, complete, and feature-rich for current and emerging programming
+    models and runtimes."""
+
+    homepage = "https://openucx.github.io/ucc/"
+    url = "https://github.com/openucx/ucc/archive/refs/tags/v1.1.0.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers("github_user1", "github_user2")
+
+    version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
+    version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")
+
+    variant("cuda", default=False, description="Enable CUDA TL")
+    variant("nccl", default=False, description="Enable NCCL TL")
+    variant("rccl", default=False, description="Enable RCCL TL", when="@1.1:")
+    variant("ucp", default=True, description="Enable UCP TL")
+
+    conflicts("+cuda", when="@:1.0", msg="UCC CUDA TL added in version 1.1")
+    conflicts("cuda@12:", when="@1.1", msg="UCC 1.1 supports CUDA <12")
+    conflicts("~cuda", when="+nccl", msg="UCC NCCL TL requires CUDA")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+    depends_on("cuda", when="+nccl")
+    depends_on("nccl", when="+nccl")
+    depends_on("rccl", when="+rccl")
+    depends_on("ucx", when="+ucp")
+
+    def autoreconf(self, spec, prefix):
+        Executable("./autogen.sh")()
+
+    def configure_args(self):
+        args = []
+        args.extend(self.with_or_without("cuda", activation_value="prefix"))
+        args.extend(self.with_or_without("nccl", activation_value="prefix"))
+        args.extend(self.with_or_without("rccl", activation_value="prefix"))
+        args.extend(self.with_or_without("ucx", variant="ucp", activation_value="prefix"))
+        return args

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -19,12 +19,11 @@ class Ucc(AutotoolsPackage, CudaPackage):
     version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
     version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")
 
-    variant("cuda", default=False, description="Enable CUDA TL")
+    variant("cuda", default=False, description="Enable CUDA TL", when="@1.1:")
     variant("nccl", default=False, description="Enable NCCL TL")
     variant("rccl", default=False, description="Enable RCCL TL", when="@1.1:")
     variant("ucp", default=True, description="Enable UCP TL")
 
-    conflicts("+cuda", when="@:1.0", msg="UCC CUDA TL added in version 1.1")
     conflicts("cuda@12:", when="@1.1", msg="UCC 1.1 supports CUDA <12")
     conflicts("~cuda", when="+nccl", msg="UCC NCCL TL requires CUDA")
 

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -15,6 +15,7 @@ class Ucc(AutotoolsPackage, CudaPackage):
 
     # maintainers("github_user1", "github_user2")
 
+    version("1.2.0", sha256="c1552797600835c0cf401b82dc89c4d27d5717f4fb805d41daca8e19f65e509d")
     version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
     version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")
 

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -22,7 +22,6 @@ class Ucc(AutotoolsPackage, CudaPackage):
     variant("cuda", default=False, description="Enable CUDA TL", when="@1.1:")
     variant("nccl", default=False, description="Enable NCCL TL")
     variant("rccl", default=False, description="Enable RCCL TL", when="@1.1:")
-    variant("ucp", default=True, description="Enable UCP TL")
 
     conflicts("cuda@12:", when="@1.1", msg="UCC 1.1 supports CUDA <12")
     conflicts("~cuda", when="+nccl", msg="UCC NCCL TL requires CUDA")
@@ -32,9 +31,10 @@ class Ucc(AutotoolsPackage, CudaPackage):
     depends_on("libtool", type="build")
 
     depends_on("cuda", when="+nccl")
+    depends_on("ucx")
+
     depends_on("nccl", when="+nccl")
     depends_on("rccl", when="+rccl")
-    depends_on("ucx", when="+ucp")
 
     def autoreconf(self, spec, prefix):
         Executable("./autogen.sh")()
@@ -44,5 +44,4 @@ class Ucc(AutotoolsPackage, CudaPackage):
         args.extend(self.with_or_without("cuda", activation_value="prefix"))
         args.extend(self.with_or_without("nccl", activation_value="prefix"))
         args.extend(self.with_or_without("rccl", activation_value="prefix"))
-        args.extend(self.with_or_without("ucx", variant="ucp", activation_value="prefix"))
         return args

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -21,7 +21,8 @@ class Ucc(AutotoolsPackage, CudaPackage):
 
     variant("cuda", default=False, description="Enable CUDA TL", when="@1.1:")
     variant("nccl", default=False, description="Enable NCCL TL")
-    variant("rccl", default=False, description="Enable RCCL TL", when="@1.1:")
+    # RCCL build not tested
+    # variant("rccl", default=False, description="Enable RCCL TL")
 
     conflicts("cuda@12:", when="@1.1", msg="UCC 1.1 supports CUDA <12")
     conflicts("~cuda", when="+nccl", msg="UCC NCCL TL requires CUDA")
@@ -34,7 +35,7 @@ class Ucc(AutotoolsPackage, CudaPackage):
     depends_on("ucx")
 
     depends_on("nccl", when="+nccl")
-    depends_on("rccl", when="+rccl")
+    # depends_on("rccl", when="+rccl")
 
     def autoreconf(self, spec, prefix):
         Executable("./autogen.sh")()
@@ -43,5 +44,5 @@ class Ucc(AutotoolsPackage, CudaPackage):
         args = []
         args.extend(self.with_or_without("cuda", activation_value="prefix"))
         args.extend(self.with_or_without("nccl", activation_value="prefix"))
-        args.extend(self.with_or_without("rccl", activation_value="prefix"))
+        # args.extend(self.with_or_without("rccl", activation_value="prefix"))
         return args

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -13,8 +13,6 @@ class Ucc(AutotoolsPackage, CudaPackage):
     homepage = "https://openucx.github.io/ucc/"
     url = "https://github.com/openucx/ucc/archive/refs/tags/v1.1.0.tar.gz"
 
-    # maintainers("github_user1", "github_user2")
-
     version("1.2.0", sha256="c1552797600835c0cf401b82dc89c4d27d5717f4fb805d41daca8e19f65e509d")
     version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
     version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -23,9 +23,10 @@ class Ucc(AutotoolsPackage, CudaPackage):
     # variant("rccl", default=False, description="Enable RCCL TL")
 
     # https://github.com/openucx/ucc/pull/847
-    patch("https://github.com/openucx/ucc/commit/9d716eb9c964ec7a7a23e9ec663f28265ff8a357.patch?full_index=1",
-          sha256="f99d1ba6b94360375d2ea59b04de9cbf6bb3290458bc86ce13891ba90522f7e2",
-          when="@1.2.0 +cuda"
+    patch(
+        "https://github.com/openucx/ucc/commit/9d716eb9c964ec7a7a23e9ec663f28265ff8a357.patch?full_index=1",
+        sha256="f99d1ba6b94360375d2ea59b04de9cbf6bb3290458bc86ce13891ba90522f7e2",
+        when="@1.2.0 +cuda",
     )
 
     depends_on("autoconf", type="build")
@@ -40,10 +41,8 @@ class Ucc(AutotoolsPackage, CudaPackage):
     with when("+nccl"):
         for arch in CudaPackage.cuda_arch_values:
             depends_on(
-                "nccl +cuda cuda_arch={0}".format(arch),
-                when="+cuda cuda_arch={0}".format(arch),
+                "nccl +cuda cuda_arch={0}".format(arch), when="+cuda cuda_arch={0}".format(arch)
             )
-
 
     def autoreconf(self, spec, prefix):
         Executable("./autogen.sh")()

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -13,6 +13,8 @@ class Ucc(AutotoolsPackage, CudaPackage):
     homepage = "https://openucx.github.io/ucc/"
     url = "https://github.com/openucx/ucc/archive/refs/tags/v1.1.0.tar.gz"
 
+    maintainers("zzzoom")
+
     version("1.2.0", sha256="c1552797600835c0cf401b82dc89c4d27d5717f4fb805d41daca8e19f65e509d")
     version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
     version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")

--- a/var/spack/repos/builtin/packages/ucc/package.py
+++ b/var/spack/repos/builtin/packages/ucc/package.py
@@ -11,13 +11,11 @@ class Ucc(AutotoolsPackage, CudaPackage):
     models and runtimes."""
 
     homepage = "https://openucx.github.io/ucc/"
-    url = "https://github.com/openucx/ucc/archive/refs/tags/v1.1.0.tar.gz"
+    url = "https://github.com/openucx/ucc/archive/refs/tags/v1.2.0.tar.gz"
 
     maintainers("zzzoom")
 
     version("1.2.0", sha256="c1552797600835c0cf401b82dc89c4d27d5717f4fb805d41daca8e19f65e509d")
-    version("1.1.0", sha256="74c8ba75037b5bd88cb703e8c8ae55639af3fecfd4428912a433c010c97b4df7")
-    version("1.0.0", sha256="d3b4aa7004bf339d35952a1699a6e408064ba578bdc93861f5f07527ad0a5e8c")
 
     variant("cuda", default=False, description="Enable CUDA TL", when="@1.1:")
     variant("nccl", default=False, description="Enable NCCL TL")


### PR DESCRIPTION
Adding OpenUCX's UCC collective library to Spack.

@hppritcha might want to take a look at this, as adding an `ucc` variant to `openmpi` would follow.

The `rccl` variant hasn't been tested tbh.