### PR TITLE
DaV: Drop propagation of HDF5 to darshan

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -107,7 +107,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
         propagate=["cuda", "hdf5", "sz", "zfp", "fortran"] + cuda_arch_variants,
     )
 
-    dav_sdk_depends_on("darshan-runtime+mpi", when="+darshan", propagate=["hdf5"])
+    dav_sdk_depends_on("darshan-runtime+mpi", when="+darshan")
     dav_sdk_depends_on("darshan-util", when="+darshan")
 
     dav_sdk_depends_on("faodel+shared+mpi network=libfabric", when="+faodel", propagate=["hdf5"])


### PR DESCRIPTION
Darshan Runtime does not properly link symbols for HDF5 when using shared libraries. This is normally not an issue, but some Cray compiler wrappers seem to implicitly link the darshan-runtime and running applications requires setting `LD_PRELOAD=/path/to/libhdf5.so` which is not worth having the HDF5 darshan module enabled.