### PR TITLE
tests/py-chainer: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -48,25 +48,21 @@ class PyChainer(PythonPackage):
         if "+mn" in self.spec:
             self.cache_extra_test_sources("examples")
 
-    def test(self):
-        if "+mn" in self.spec:
-            # Run test of ChainerMN
-            test_dir = self.test_suite.current_test_data_dir
+    def test_chainermn(self):
+        """run the ChainerMN test"""
+        if "+mn" not in self.spec:
+            raise SkipTest("Test only supported when built with +mn")
 
-            mnist_dir = join_path(self.install_test_root, "examples", "chainermn", "mnist")
-            mnist_file = join_path(mnist_dir, "train_mnist.py")
-            mpi_name = self.spec["mpi"].prefix.bin.mpirun
-            python_exe = self.spec["python"].command.path
-            opts = ["-n", "4", python_exe, mnist_file, "-o", test_dir]
-            env["OMP_NUM_THREADS"] = "4"
+        mnist_file = join_path(self.install_test_root.examples.chainermn.mnist, "train_mnist.py")
+        mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+        opts = ["-n", "4", self.spec["python"].command.path, mnist_file, "-o", "."]
+        env["OMP_NUM_THREADS"] = "4"
 
-            self.run_test(mpi_name, options=opts, work_dir=test_dir)
+        mpirun(*opts)
 
-            # check results
-            json_open = open(join_path(test_dir, "log"), "r")
-            json_load = json.load(json_open)
-            v = dict([(d.get("epoch"), d.get("main/accuracy")) for d in json_load])
-            if 1 not in v or 20 not in v:
-                raise RuntimeError("Cannot find epoch 1 or epoch 20")
-            if abs(1.0 - v[1]) < abs(1.0 - v[20]):
-                raise RuntimeError("ChainerMN Test Failed !")
+        # check results
+        json_open = open(join_path(".", "log"), "r")
+        json_load = json.load(json_open)
+        v = dict([(d.get("epoch"), d.get("main/accuracy")) for d in json_load])
+        assert (1 in v) or (20 in v), "Cannot find epoch 1 or epoch 20"
+        assert abs(1.0 - v[1]) >= abs(1.0 - v[20]), "ChainerMN Test Failed!"

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -24,6 +24,8 @@ class PyChainer(PythonPackage):
 
     maintainers("adamjstewart")
 
+    skip_modules = ["onnx_chainer"]
+
     version("7.2.0", sha256="6e2fba648cc5b8a5421e494385b76fe5ec154f1028a1c5908557f5d16c04f0b3")
     version("6.7.0", sha256="87cb3378a35e7c5c695028ec91d58dc062356bc91412384ea939d71374610389")
 


### PR DESCRIPTION
Converted the stand-alone test to use the new process. 

I am having trouble building with `+mn` due to a failure to build one of the dependencies so these results are from a build with the default option(s).

~~Note I am unable to build the package with `--test=root` because of the import error that also shows up during stand-alone testing.  (See test results at 
[py-chainer-test.txt](https://github.com/spack/spack/files/11738177/py-chainer-test.txt).)~~

UPDATE:
```
$ spack -v test run py-chainer
==> Spack test nkjxo3cidfaxqxns2mrq244khig3ckrz
==> Testing package py-chainer-7.2.0-zlwrclo
==> [2023-06-13-11:42:49.765437] Warning: py-chainer: the 'test' method is deprecated. Convert stand-alone test(s) to methods with names starting 'test_'.
==> [2023-06-13-11:42:49.768624] test: test: Attempts to import modules of the installed package.
...
PyChainer::test_python3.10_c_importchainermn.extensions .. PASSED
PyChainer::test_python3.10_c_importchainermn.functions .. PASSED
PyChainer::test_python3.10_c_importchainermn.iterators .. PASSED
PyChainer::test_python3.10_c_importchainermn.links .. PASSED
PyChainer::test_python3.10_c_importchainermn.testing .. PASSED
PyChainer::test_python3.10_c_importchainerx .. PASSED
PyChainer::test .. PASSED
PyChainer::test_chainermn .. SKIPPED
======================= 55 passed, 1 skipped of 56 parts =======================
============================== 1 passed of 1 spec ==============================
```
