### PR TITLE
tests/py-horovod: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -274,6 +274,7 @@ class PyHorovod(PythonPackage, CudaPackage):
         else:
             env.set("HOROVOD_CPU_OPERATIONS", self.spec.variants["tensor_ops"].value.upper())
 
-    def test(self):
-        super(PyHorovod, self).test()
-        self.run_test(self.prefix.bin.horovodrun, "--check-build")
+    def test_check_build(self):
+        """run horovodrun --check-build"""
+        horovodrun = which(self.prefix.bin.horovodrun)
+        horovodrun("--check-build")


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v install --test=root py-horovod
...
  Building wheel for horovod (setup.py): finished with status 'done'
  Created wheel for horovod: filename=horovod-0.28.0-cp310-cp310-linux_x86_64.whl size=19633544 sha256=363649b8ac111163f69d5c8a3f1e0f43370f79be564907723d8e159a141ba21a
  Stored in directory: /tmp/dahlgren/pip-ephem-wheel-cache-ske8s75k/wheels/94/dc/14/92d7019648af5cd387c807db5e8bfd1ac872e40e7c4cc67adc
Successfully built horovod
Installing collected packages: horovod

  Creating $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-horovod-0.28.0-4wint4pjnoxgsmdqhtmase6uljwm6nkl/bin
  changing mode of $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-horovod-0.28.0-4wint4pjnoxgsmdqhtmase6uljwm6nkl/bin/horovodrun to 755
Successfully installed horovod-0.28.0
Removed build tracker: '/tmp/dahlgren/pip-build-tracker-ft28znnb'
==> Testing package py-horovod-0.28.0-4wint4p
==> [2023-06-13-11:51:25.601942] Running install-time tests
==> [2023-06-13-11:51:25.669964] RUN-TESTS: install-time tests [test]
==> [2023-06-13-11:51:25.672046] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for py-horovod to process python3.10.
==> [2023-06-13-11:51:25.672852] test: test_python3.10_c_importhorovod: checking import of horovod
==> [2023-06-13-11:51:25.674393] Expecting return code in [0]
==> [2023-06-13-11:51:25.674919] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod'
PASSED: PyHorovod::test_python3.10_c_importhorovod
==> [2023-06-13-11:51:25.821301] test: test_python3.10_c_importhorovod.runner: checking import of horovod.runner
==> [2023-06-13-11:51:25.821841] Expecting return code in [0]
==> [2023-06-13-11:51:25.822306] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner
==> [2023-06-13-11:51:25.920316] test: test_python3.10_c_importhorovod.runner.util: checking import of horovod.runner.util
==> [2023-06-13-11:51:25.920877] Expecting return code in [0]
==> [2023-06-13-11:51:25.921319] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.util'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.util
==> [2023-06-13-11:51:26.033584] test: test_python3.10_c_importhorovod.runner.elastic: checking import of horovod.runner.elastic
==> [2023-06-13-11:51:26.034056] Expecting return code in [0]
==> [2023-06-13-11:51:26.034482] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.elastic'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.elastic
==> [2023-06-13-11:51:26.151702] test: test_python3.10_c_importhorovod.runner.driver: checking import of horovod.runner.driver
==> [2023-06-13-11:51:26.152222] Expecting return code in [0]
==> [2023-06-13-11:51:26.152662] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.driver'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.driver
==> [2023-06-13-11:51:26.268712] test: test_python3.10_c_importhorovod.runner.common: checking import of horovod.runner.common
==> [2023-06-13-11:51:26.269222] Expecting return code in [0]
==> [2023-06-13-11:51:26.269750] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common
==> [2023-06-13-11:51:26.385807] test: test_python3.10_c_importhorovod.runner.common.util: checking import of horovod.runner.common.util
==> [2023-06-13-11:51:26.386323] Expecting return code in [0]
==> [2023-06-13-11:51:26.386811] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common.util'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common.util
==> [2023-06-13-11:51:26.507054] test: test_python3.10_c_importhorovod.runner.common.service: checking import of horovod.runner.common.service
==> [2023-06-13-11:51:26.507605] Expecting return code in [0]
==> [2023-06-13-11:51:26.508019] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common.service'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common.service
==> [2023-06-13-11:51:26.635182] test: test_python3.10_c_importhorovod.runner.http: checking import of horovod.runner.http
==> [2023-06-13-11:51:26.635746] Expecting return code in [0]
==> [2023-06-13-11:51:26.636139] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.http'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.http
==> [2023-06-13-11:51:26.751820] test: test_python3.10_c_importhorovod.runner.task: checking import of horovod.runner.task
==> [2023-06-13-11:51:26.752352] Expecting return code in [0]
==> [2023-06-13-11:51:26.752815] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.task'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.task
==> [2023-06-13-11:51:26.865076] test: test_python3.10_c_importhorovod.common: checking import of horovod.common
==> [2023-06-13-11:51:26.865631] Expecting return code in [0]
==> [2023-06-13-11:51:26.866012] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.common'
PASSED: PyHorovod::test_python3.10_c_importhorovod.common
==> [2023-06-13-11:51:26.984327] test: test_python3.10_c_importhorovod.torch: checking import of horovod.torch
==> [2023-06-13-11:51:26.984880] Expecting return code in [0]
==> [2023-06-13-11:51:26.985261] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.torch'
PASSED: PyHorovod::test_python3.10_c_importhorovod.torch
==> [2023-06-13-11:51:33.122533] test: test_python3.10_c_importhorovod.torch.elastic: checking import of horovod.torch.elastic
==> [2023-06-13-11:51:33.123217] Expecting return code in [0]
==> [2023-06-13-11:51:33.123645] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.torch.elastic'
PASSED: PyHorovod::test_python3.10_c_importhorovod.torch.elastic
==> [2023-06-13-11:51:37.589716] Completed testing
==> py-horovod: Successfully installed py-horovod-0.28.0-4wint4pjnoxgsmdqhtmase6uljwm6nkl
  Stage: 0.84s.  Install: 3m 23.46s.  Post-install: 4.62s.  Total: 3m 34.86s
[+] $SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-horovod-0.28.0-4wint4pjnoxgsmdqhtmase6uljwm6nkl
493.371u 244.398s 7:43.93 159.0%	0+0k 681656+949704io 112pf+0w


$ spack -v test run py-horovod
==> Spack test irvqxiiclcmxkuukflxleqloz6vu624i
==> Testing package py-horovod-0.28.0-4wint4p
==> [2023-06-13-11:57:43.563680] Warning: py-horovod: the 'test' method is deprecated. Convert stand-alone test(s) to methods with names starting 'test_'.
==> [2023-06-13-11:57:43.564584] test: test: Attempts to import modules of the installed package.
==> [2023-06-13-11:57:43.566353] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for py-horovod to process python3.10.
==> [2023-06-13-11:57:43.566837] test: test_python3.10_c_importhorovod: checking import of horovod
==> [2023-06-13-11:57:43.569129] Expecting return code in [0]
==> [2023-06-13-11:57:43.569600] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod'
PASSED: PyHorovod::test_python3.10_c_importhorovod
==> [2023-06-13-11:57:43.802009] test: test_python3.10_c_importhorovod.runner: checking import of horovod.runner
==> [2023-06-13-11:57:43.802563] Expecting return code in [0]
==> [2023-06-13-11:57:43.802815] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner
==> [2023-06-13-11:57:43.903403] test: test_python3.10_c_importhorovod.runner.util: checking import of horovod.runner.util
==> [2023-06-13-11:57:43.903858] Expecting return code in [0]
==> [2023-06-13-11:57:43.904100] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.util'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.util
==> [2023-06-13-11:57:44.135901] test: test_python3.10_c_importhorovod.runner.elastic: checking import of horovod.runner.elastic
==> [2023-06-13-11:57:44.137274] Expecting return code in [0]
==> [2023-06-13-11:57:44.137989] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.elastic'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.elastic
==> [2023-06-13-11:57:44.414111] test: test_python3.10_c_importhorovod.runner.driver: checking import of horovod.runner.driver
==> [2023-06-13-11:57:44.415398] Expecting return code in [0]
==> [2023-06-13-11:57:44.416016] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.driver'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.driver
==> [2023-06-13-11:57:44.591901] test: test_python3.10_c_importhorovod.runner.common: checking import of horovod.runner.common
==> [2023-06-13-11:57:44.592740] Expecting return code in [0]
==> [2023-06-13-11:57:44.593060] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common
==> [2023-06-13-11:57:44.683166] test: test_python3.10_c_importhorovod.runner.common.util: checking import of horovod.runner.common.util
==> [2023-06-13-11:57:44.683611] Expecting return code in [0]
==> [2023-06-13-11:57:44.683872] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common.util'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common.util
==> [2023-06-13-11:57:44.779344] test: test_python3.10_c_importhorovod.runner.common.service: checking import of horovod.runner.common.service
==> [2023-06-13-11:57:44.779774] Expecting return code in [0]
==> [2023-06-13-11:57:44.780022] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.common.service'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.common.service
==> [2023-06-13-11:57:44.874681] test: test_python3.10_c_importhorovod.runner.http: checking import of horovod.runner.http
==> [2023-06-13-11:57:44.875113] Expecting return code in [0]
==> [2023-06-13-11:57:44.875380] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.http'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.http
==> [2023-06-13-11:57:44.988415] test: test_python3.10_c_importhorovod.runner.task: checking import of horovod.runner.task
==> [2023-06-13-11:57:44.988921] Expecting return code in [0]
==> [2023-06-13-11:57:44.989169] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.runner.task'
PASSED: PyHorovod::test_python3.10_c_importhorovod.runner.task
==> [2023-06-13-11:57:45.089282] test: test_python3.10_c_importhorovod.common: checking import of horovod.common
==> [2023-06-13-11:57:45.089783] Expecting return code in [0]
==> [2023-06-13-11:57:45.090045] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.common'
PASSED: PyHorovod::test_python3.10_c_importhorovod.common
==> [2023-06-13-11:57:45.188439] test: test_python3.10_c_importhorovod.torch: checking import of horovod.torch
==> [2023-06-13-11:57:45.188916] Expecting return code in [0]
==> [2023-06-13-11:57:45.189160] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.torch'
PASSED: PyHorovod::test_python3.10_c_importhorovod.torch
==> [2023-06-13-11:57:50.182367] test: test_python3.10_c_importhorovod.torch.elastic: checking import of horovod.torch.elastic
==> [2023-06-13-11:57:50.183040] Expecting return code in [0]
==> [2023-06-13-11:57:50.183363] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-c' 'import horovod.torch.elastic'
PASSED: PyHorovod::test_python3.10_c_importhorovod.torch.elastic
PASSED: PyHorovod::test
==> [2023-06-13-11:57:54.587679] test: test_check_build: run horovodrun --check-build
==> [2023-06-13-11:57:54.589441] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/py-horovod-0.28.0-4wint4pjnoxgsmdqhtmase6uljwm6nkl/bin/horovodrun' '--check-build'
Horovod v0.28.0:

Available Frameworks:
    [ ] TensorFlow
    [X] PyTorch
    [ ] MXNet

Available Controllers:
    [X] MPI
    [X] Gloo

Available Tensor Operations:
    [ ] NCCL
    [ ] DDL
    [ ] CCL
    [X] MPI
    [X] Gloo    
PASSED: PyHorovod::test_check_build
==> [2023-06-13-11:58:15.813453] Completed testing
==> [2023-06-13-11:58:15.814094] 
====================== SUMMARY: py-horovod-0.28.0-4wint4p ======================
PyHorovod::test_python3.10_c_importhorovod .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.util .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.elastic .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.driver .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.common .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.common.util .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.common.service .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.http .. PASSED
PyHorovod::test_python3.10_c_importhorovod.runner.task .. PASSED
PyHorovod::test_python3.10_c_importhorovod.common .. PASSED
PyHorovod::test_python3.10_c_importhorovod.torch .. PASSED
PyHorovod::test_python3.10_c_importhorovod.torch.elastic .. PASSED
PyHorovod::test .. PASSED
PyHorovod::test_check_build .. PASSED
============================ 15 passed of 15 parts =============================
============================== 1 passed of 1 spec ==============================
20.490u 5.369s 0:47.65 54.2%	0+0k 1960+800io 0pf+0w
...
