### PR TITLE
tests/dust: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/dust/package.py
+++ b/var/spack/repos/builtin/packages/dust/package.py
@@ -33,12 +33,8 @@ class Dust(Package):
         print("stdout received fromm dust is '{}".format(output))
         assert "Dust " in output
 
-    def test(self):
-        """Run this smoke test when requested explicitly"""
-
-        dustpath = join_path(self.spec["dust"].prefix.bin, "dust")
-        options = ["--version"]
-        purpose = "Check dust can execute (with option '--version')"
-        expected = ["Dust "]
-
-        self.run_test(dustpath, options=options, expected=expected, status=[0], purpose=purpose)
+    def test_run(self):
+        """check dust can execute (with option '--version')"""
+        dust = which(self.prefix.bin.dust)
+        out = dust("--version", output=str.split, error=str.split)
+        assert "Dust " in out


### PR DESCRIPTION
This PR converts the stand-alone test to use the new process.

```
$ spack -v test run dust
==> Spack test nsaz2lmgvsp5sivieklah22vjzwd7b5u
==> Testing package dust-0.8.6-dmlkeca
==> [2023-06-13-12:27:02.186266] test: test_run: check dust can execute (with option '--version')
==> [2023-06-13-12:27:02.188698] '$SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/dust-0.8.6-dmlkecaevbllfhrmilscdhec7h77nm2m/bin/dust' '--version'
Dust 0.8.6
PASSED: Dust::test_run
==> [2023-06-13-12:27:02.197494] Completed testing
==> [2023-06-13-12:27:02.197636] 
========================= SUMMARY: dust-0.8.6-dmlkeca ==========================
Dust::test_run .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```