### PR TITLE
tests/dssp: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/dssp/package.py
+++ b/var/spack/repos/builtin/packages/dssp/package.py
@@ -51,13 +51,9 @@ class Dssp(AutotoolsPackage):
         """Save off the pdb sources for stand-alone testing."""
         self.cache_extra_test_sources("pdb")
 
-    def test(self):
-        """Perform stand-alone/smoke test on installed package."""
-        pdb_path = join_path(self.test_suite.current_test_cache_dir, "pdb")
-        self.run_test(
-            "mkdssp",
-            options=["1ALK.pdb", "1alk.dssp"],
-            purpose="test: calculating structure for example",
-            installed=True,
-            work_dir=pdb_path,
-        )
+    def test_mkdssp(self):
+        """calculate structure for example"""
+        pdb_path = self.test_suite.current_test_cache_dir.pdb
+        mkdssp = which(self.prefix.bin.mkdssp)
+        with working_dir(pdb_path):
+            mkdssp("1ALK.pdb", "1alk.dssp")


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v test run dssp
==> Spack test r74vymb6dtg36ml2sfb2g7ijwkptwgx3
==> Testing package dssp-3.1.4-7djvmcl
==> [2023-06-13-15:39:31.697321] Installing SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/dssp-3.1.4-7djvmclqceaezmhfshsy6e2sitgjjikp/.spack/test to SPACK_TEST_ROOT/r74vymb6dtg36ml2sfb2g7ijwkptwgx3/dssp-3.1.4-7djvmcl/cache/dssp
==> [2023-06-13-15:39:31.742305] test: test_mkdssp: calculate structure for example
==> [2023-06-13-15:39:31.744064] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/dssp-3.1.4-7djvmclqceaezmhfshsy6e2sitgjjikp/bin/mkdssp' '1ALK.pdb' '1alk.dssp'
PASSED: Dssp::test_mkdssp
==> [2023-06-13-15:39:31.850703] Completed testing
==> [2023-06-13-15:39:31.850878] 
========================= SUMMARY: dssp-3.1.4-7djvmcl ==========================
Dssp::test_mkdssp .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```