### PR TITLE
py-neurora: add 1.1.6.10

### DIFF
--- a/var/spack/repos/builtin/packages/py-neurora/package.py
+++ b/var/spack/repos/builtin/packages/py-neurora/package.py
@@ -12,6 +12,7 @@ class PyNeurora(PythonPackage):
     homepage = "https://github.com/ZitongLu1996/NeuroRA"
     pypi = "neurora/neurora-1.1.5.16.tar.gz"
 
+    version("1.1.6.10", sha256="cdfed753b9d2e227cd15e3215fc0297ad5df0b131ef87a849e3fcec90788c514")
     version("1.1.6.9", sha256="052d826e17d6a40171d487b188bd68863e36e41e37740da5eec33562241e36ce")
     version("1.1.6.8", sha256="84aebe82ce0e8e99b306dcab7b5e15f85269862c379f16b8161dbab64e7d1dd2")
     version("1.1.6.1", sha256="97b2d1287f273a8db11dcaa623fc906b47ee7c4459e264a42b131e6a4f332916")


### PR DESCRIPTION
https://pypi.org/project/neurora/#files

(sources from pypi because the git repo does not have tags)