### PR TITLE
ncbi-rmblastn: patching to support building with %gcc@13:

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/gcc13.patch
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/gcc13.patch
@@ -1,0 +1,10 @@
+--- c++/include/util/impl/compile_time_bits.hpp	2023-01-05 15:04:14.000000000 +0000
++++ c++/include/util/impl/compile_time_bits.hpp.patched	2023-06-14 10:38:16.316603211 +0100
+@@ -39,6 +39,7 @@
+ #include <limits>
+ #include <stdexcept>
+ #include <array>
++#include <cstdint>
+ 
+ // forward declarations to avoid unnecessary includes
+ namespace ncbi

--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -43,6 +43,9 @@ class NcbiRmblastn(AutotoolsPackage):
         archive_sha256="e746ee480ade608052306fd21f015c8a323f27029f65399275216f9a4c882d59",
         when="@2.9.0",
     )
+
+    patch("gcc13.patch", level=0, when="%gcc@13:")
+
     depends_on("cpio", type="build")
     depends_on("boost")
     depends_on("lzo")

--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -44,7 +44,7 @@ class NcbiRmblastn(AutotoolsPackage):
         when="@2.9.0",
     )
 
-    patch("gcc13.patch", level=0, when="%gcc@13:")
+    patch("gcc13.patch", level=0, when="@2.14.0:%gcc@13:")
 
     depends_on("cpio", type="build")
     depends_on("boost")


### PR DESCRIPTION
Patch for a single file to allow `@2.14.0` to build with `%gcc@13:`. `@2.11.0` compiles without this patch, so I've set it to apply from this point forwards (until it's fixed upstream).