### PR TITLE
imath: add v3.1.9

### DIFF
--- a/var/spack/repos/builtin/packages/imath/package.py
+++ b/var/spack/repos/builtin/packages/imath/package.py
@@ -15,6 +15,7 @@ class Imath(CMakePackage):
     homepage = "https://github.com/AcademySoftwareFoundation/Imath"
     url = "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.5.tar.gz"
 
+    version("3.1.9", sha256="f1d8aacd46afed958babfced3190d2d3c8209b66da451f556abd6da94c165cf3")
     version("3.1.7", sha256="bff1fa140f4af0e7f02c6cb78d41b9a7d5508e6bcdfda3a583e35460eb6d4b47")
     version("3.1.5", sha256="1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb")
 


### PR DESCRIPTION
Add imath v3.1.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.