### PR TITLE
ipopt: add v3.14.9

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -14,6 +14,7 @@ class Ipopt(AutotoolsPackage):
     url = "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/3.13.2.tar.gz"
     maintainers("goxberry")
 
+    version("3.14.9", sha256="e12eba451269ec30f4cf6e2acb8b35399f0d029c97dff10465416f5739c8cf7a")
     version("3.14.5", sha256="9ebbbbf14a64e998e3fba5d2662a8f9bd03f97b1406017e78ae54e5d105ae932")
     version("3.14.4", sha256="60865150b6fad19c5968395b57ff4a0892380125646c3afa2a714926f5ac9487")
     version("3.14.3", sha256="29bbf8bbadd5f2965e18e33451723d1fed0c42b14f6493396cf53a05cdfd2c09")


### PR DESCRIPTION
Add ipopt v3.14.9. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.