### PR TITLE
CMake Builder: Filter defines for posix paths

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -274,6 +274,27 @@ def paths_containing_libs(paths, library_names):
 
 
 @system_path_filter
+def is_str_valid_path(path):
+    """Return True if string 'path' could represent a legal
+    path on the current filesystem. 'path' does not need to be
+    writeable - just a properly formed path.
+    Returns false otherwise"""
+    ret = True
+    try:
+        os.lstat(path)
+    except OSError as exc:
+        if hasattr(exc, "winerror"):
+            # Win error code for invalid path
+            if exc.winerror == 123:
+                ret = False
+        elif exc.errno in (errno.ENAMETOOLONG, errno.ERANGE):
+            ret = False
+    except TypeError:
+        ret = False
+    return ret
+
+
+@system_path_filter
 def same_path(path1, path2):
     norm1 = os.path.abspath(path1).rstrip(os.path.sep)
     norm2 = os.path.abspath(path2).rstrip(os.path.sep)

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -276,10 +276,12 @@ def paths_containing_libs(paths, library_names):
 @system_path_filter
 def is_str_valid_path(path):
     """Return True if string 'path' could represent a legal
-    path on the current filesystem. 'path' does not need to be
-    writeable - just a properly formed path.
+    path on the current filesystem and contains at least one path sep.
+    'path' does not need to be writeable - just a properly formed path.
     Returns false otherwise"""
-    ret = True
+    ret = False if not os.path.sep in path else True
+    if not ret:
+        return ret
     try:
         os.lstat(path)
     except OSError as exc:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -277,11 +277,13 @@ def paths_containing_libs(paths, library_names):
 def is_str_valid_path(path):
     """Return True if string 'path' could represent a legal
     path on the current filesystem and contains at least one path sep.
-    'path' does not need to be writeable - just a properly formed path.
+    'path' does not need to be writeable or exist - just a properly formed path.
     Returns false otherwise"""
-    ret = False if os.path.sep not in path else True
-    if not ret:
-        return ret
+    ret = True
+    if not isinstance(path, str):
+        return False
+    if os.path.sep not in path:
+        return False
     try:
         os.lstat(path)
     except OSError as exc:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -279,7 +279,7 @@ def is_str_valid_path(path):
     path on the current filesystem and contains at least one path sep.
     'path' does not need to be writeable - just a properly formed path.
     Returns false otherwise"""
-    ret = False if not os.path.sep in path else True
+    ret = False if os.path.sep not in path else True
     if not ret:
         return ret
     try:

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -330,7 +330,7 @@ class CMakeBuilder(BaseBuilder):
             if isinstance(value, bool):
                 return True
             if isinstance(value, str) or isinstance(value, int):
-                return bool(re.match(r"on|yes|true|y|[1-9]", str(value), re.IGNORECASE))
+                return bool(re.match(r"on|yes|true|y|[1-9]$", str(value), re.IGNORECASE))
             return False
 
         # helper method to ensure posix paths are passed to CMake

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -325,14 +325,19 @@ class CMakeBuilder(BaseBuilder):
         """
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
-
+        def is_cmake_bool(value):
+            if isinstance(value, bool):
+                return True
+            if isinstance(value, str) or isinstance(value, int):
+                return bool(re.match(r"on|yes|true|y|[1-9]", str(value), re.IGNORECASE))
+            return False
         # helper method to ensure posix paths are passed to CMake
         def ensure_posix(string):
             if fs.is_str_valid_path(string):
                 string = pathlib.PurePath(string).as_posix()
             return string
 
-        if isinstance(value, bool):
+        if is_cmake_bool(value):
             kind = "BOOL"
             value = "ON" if value else "OFF"
         else:

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -323,6 +323,7 @@ class CMakeBuilder(BaseBuilder):
                  "-DSWR:STRING=avx;avx2]
 
         """
+
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
         def is_cmake_bool(value):
@@ -331,6 +332,7 @@ class CMakeBuilder(BaseBuilder):
             if isinstance(value, str) or isinstance(value, int):
                 return bool(re.match(r"on|yes|true|y|[1-9]", str(value), re.IGNORECASE))
             return False
+
         # helper method to ensure posix paths are passed to CMake
         def ensure_posix(string):
             if fs.is_str_valid_path(string):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -325,15 +325,22 @@ class CMakeBuilder(BaseBuilder):
         """
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
+
+        # helper method to ensure posix paths are passed to CMake
+        def ensure_posix(string):
+            if fs.is_str_valid_path(string):
+                string = pathlib.PurePath(string).as_posix()
+            return string
+
         if isinstance(value, bool):
             kind = "BOOL"
             value = "ON" if value else "OFF"
         else:
-            kind = "STRING"
+            kind = "PATH" if fs.is_str_valid_path(value) else "STRING"
             if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
-                value = ";".join(str(v) for v in value)
+                value = ";".join(ensure_posix(str(v)) for v in value)
             else:
-                value = str(value)
+                value = ensure_posix(str(value))
 
         return "".join(["-D", cmake_var, ":", kind, "=", value])
 


### PR DESCRIPTION
CMake requires that posix paths be provided on the command line. This presents an issue on Windows as Windows like paths can easily slip into a CMake define through attributes like `.libs` or `.directories` or `.prefix`.
Handling this from the package recipes would place a burden on all users to have to consider this Windows oddity and would generally make packages less readable/easy to develop.
Instead we can handle this from the CMake builder class.
If a definition is a valid path, we format it as a posix path. Additionally, we now inform CMake that such attributes are in fact paths instead of the current behavior of defaulting to strings.