### PR TITLE
fix oneapi modules

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -121,7 +121,7 @@ class IntelOneApiPackage(Package):
            $ source {prefix}/{component}/{version}/env/vars.sh
         """
         # Only if environment modifications are desired (default is +envmods)
-        if "+envmods" in self.spec:
+        if "~envmods" not in self.spec:
             env.extend(
                 EnvironmentModifications.from_sourcing_file(
                     join_path(self.component_prefix, "env", "vars.sh")


### PR DESCRIPTION
This behavior should only be disabled if `envmods` is explicitly false. "not explicitly true" is not good enough. Every previously installed package since the dawn of time is "not explicitly true" for a variant that didn't exist yet.