### PR TITLE
tests/superlu: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -126,20 +126,8 @@ class Superlu(CMakePackage, Package):
 
         return config_args
 
-    def run_superlu_test(self, test_dir, exe, args):
-        if not self.run_test(
-            "make",
-            options=args,
-            purpose="test: compile {0} example".format(exe),
-            work_dir=test_dir,
-        ):
-            tty.warn("Skipping test: failed to compile example")
-            return
-
-        if not self.run_test(exe, purpose="test: run {0} example".format(exe), work_dir=test_dir):
-            tty.warn("Skipping test: failed to run example")
-
-    def test(self):
+    def test_example(self):
+        """build and run test example"""
         config_args = self._generate_make_hdr_for_test()
 
         # Write configuration options to make.inc file
@@ -149,18 +137,23 @@ class Superlu(CMakePackage, Package):
                 inc.write("{0}\n".format(option))
 
         args = []
+        test_exe = "superlu"
+        test_src = "{0}.c".format(test_exe)
+
         if self.version < Version("5.2.2"):
             args.append("HEADER=" + self.prefix.include)
-        args.append("superlu")
+        args.append(test_exe)
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
-        exe = "superlu"
+        with working_dir(test_dir):
+            if not os.path.isfile(test_src):
+                raise SkipTest("{0} is missing".format(test_src))
 
-        if not os.path.isfile(join_path(test_dir, "{0}.c".format(exe))):
-            tty.warn("Skipping superlu test:" "missing file {0}.c".format(exe))
-            return
+            make = which("make")
+            make(*args)
 
-        self.run_superlu_test(test_dir, exe, args)
+            superlu = which(test_exe)
+            superlu()
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
-from llnl.util import tty
-
 import spack.build_systems.cmake
 import spack.build_systems.generic
 from spack.package import *
@@ -20,6 +18,8 @@ class Superlu(CMakePackage, Package):
     url = "https://github.com/xiaoyeli/superlu/archive/refs/tags/v5.3.0.tar.gz"
 
     tags = ["e4s"]
+
+    test_requires_compiler = True
 
     version("6.0.0", sha256="5c199eac2dc57092c337cfea7e422053e8f8229f24e029825b0950edd1d17e8e")
     version(
@@ -43,7 +43,7 @@ class Superlu(CMakePackage, Package):
     )
 
     build_system(
-        conditional("cmake", when="@5:"), conditional("autotools", when="@:4"), default="cmake"
+        conditional("cmake", when="@5:"), conditional("generic", when="@:4"), default="cmake"
     )
 
     variant("pic", default=True, description="Build with position independent code")
@@ -55,99 +55,22 @@ class Superlu(CMakePackage, Package):
         msg="Older SuperLU is incompatible with newer compilers",
     )
 
-    test_requires_compiler = True
-
-    # Pre-cmake installation method
     examples_src_dir = "EXAMPLE"
-    make_hdr_file = "make.inc"
-
-    @run_after("install")
-    def cache_test_sources(self):
-        """Copy the example source files after the package is installed to an
-        install test subdirectory for use during `spack test run`."""
-        if self.spec.satisfies("@5.2.2:"):
-            # Include dir was hardcoded in 5.2.2
-            filter_file(
-                r"INCLUDEDIR  = -I\.\./SRC",
-                "INCLUDEDIR = -I" + self.prefix.include,
-                join_path(self.examples_src_dir, "Makefile"),
-            )
-
-        self.cache_extra_test_sources(self.examples_src_dir)
-
-    def _generate_make_hdr_for_test(self):
-        config_args = []
-
-        # Define make.inc file
-        config_args.extend(
-            [
-                "SuperLUroot = {0}".format(self.prefix),
-                "SUPERLULIB = {0}/libsuperlu.a".format(self.prefix.lib),
-                "BLASLIB    = {0}".format(self.spec["blas"].libs.ld_flags),
-                "TMGLIB     = libtmglib.a",
-                "LIBS       = $(SUPERLULIB) $(BLASLIB)",
-                "ARCH       = ar",
-                "ARCHFLAGS  = cr",
-                "RANLIB     = {0}".format("ranlib" if which("ranlib") else "echo"),
-                "CC         = {0}".format(env["CC"]),
-                "FORTRAN    = {0}".format(env["FC"]),
-                "LOADER     = {0}".format(env["CC"]),
-                "CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_",
-                "NOOPTS     = -O0",
-            ]
-        )
-
-        return config_args
-
-    # Pre-cmake configuration
-    @when("@:4")
-    def _generate_make_hdr_for_test(self):
-        config_args = []
-
-        # Define make.inc file
-        config_args.extend(
-            [
-                "PLAT       = _x86_64",
-                "SuperLUroot = {0}".format(self.prefix),
-                "SUPERLULIB = {0}/libsuperlu_{1}.a".format(self.prefix.lib, self.spec.version),
-                "BLASLIB    = {0}".format(self.spec["blas"].libs.ld_flags),
-                "TMGLIB     = libtmglib.a",
-                "LIBS       = $(SUPERLULIB) $(BLASLIB)",
-                "ARCH       = ar",
-                "ARCHFLAGS  = cr",
-                "RANLIB     = {0}".format("ranlib" if which("ranlib") else "echo"),
-                "CC         = {0}".format(env["CC"]),
-                "FORTRAN    = {0}".format(env["FC"]),
-                "LOADER     = {0}".format(env["CC"]),
-                "CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_",
-                "NOOPTS     = -O0",
-            ]
-        )
-
-        return config_args
 
     def test_example(self):
         """build and run test example"""
-        config_args = self._generate_make_hdr_for_test()
-
-        # Write configuration options to make.inc file
-        make_file_inc = join_path(self.test_suite.current_test_cache_dir, self.make_hdr_file)
-        with open(make_file_inc, "w") as inc:
-            for option in config_args:
-                inc.write("{0}\n".format(option))
-
-        args = []
-        test_exe = "superlu"
-        test_src = "{0}.c".format(test_exe)
-
-        if self.version < Version("5.2.2"):
-            args.append("HEADER=" + self.prefix.include)
-        args.append(test_exe)
-
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
+        test_exe = "superlu"
+        test_src = f"{test_exe}.c"
+
+        if not os.path.isfile(join_path(test_dir, test_src)):
+            raise SkipTest(f"Cached {test_src} is missing")
+
         with working_dir(test_dir):
-            if not os.path.isfile(test_src):
-                raise SkipTest("{0} is missing".format(test_src))
+            args = []
+            if self.version < Version("5.2.2"):
+                args.append("HEADER=" + self.prefix.include)
+            args.append(test_exe)
 
             make = which("make")
             make(*args)
@@ -156,7 +79,61 @@ class Superlu(CMakePackage, Package):
             superlu()
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+    @run_after("install")
+    def setup_standalone_tests(self):
+        """Set up and copy example source files after the package is installed
+        to an install test subdirectory for use during `spack test run`."""
+        makefile = join_path(self.pkg.examples_src_dir, "Makefile")
+
+        if self.spec.satisfies("@5.2.2:"):
+            # Include dir was hardcoded in 5.2.2
+            filter_file(
+                r"INCLUDEDIR  = -I\.\./SRC", "INCLUDEDIR = -I" + self.prefix.include, makefile
+            )
+
+        # Create the example makefile's include file and ensure the new file
+        # is the one use.
+        filename = "make.inc"
+        config_args = []
+        if self.spec.satisfies("@5:"):
+            lib = "libsuperlu.a"
+        else:
+            config_args.append("PLAT       = _x86_64")
+            lib = f"libsuperlu_{self.spec.version}.a"
+        config_args.extend(self._make_hdr_for_test(lib))
+
+        with open(join_path(self.pkg.examples_src_dir, filename), "w") as inc:
+            for option in config_args:
+                inc.write(f"{option}\n")
+
+        # change the path in the example's Makefile to the file written above
+        filter_file(r"include \.\./" + filename, "include ./" + filename, makefile)
+
+        # Cache the examples directory for use by stand-alone tests
+        self.pkg.cache_extra_test_sources(self.pkg.examples_src_dir)
+
+    def _make_hdr_for_test(self, lib):
+        """Standard configure arguments for make.inc"""
+        ranlib = "ranlib" if which("ranlib") else "echo"
+        return [
+            f"SuperLUroot = {self.prefix}",
+            f"SUPERLULIB = {self.prefix.lib}/{lib}",
+            f"BLASLIB    = {self.spec['blas'].libs.ld_flags}",
+            "TMGLIB     = libtmglib.a",
+            "LIBS       = $(SUPERLULIB) $(BLASLIB)",
+            "ARCH       = ar",
+            "ARCHFLAGS  = cr",
+            f"RANLIB     = {ranlib}",
+            f"CC         = {env['CC']}",
+            f"FORTRAN    = {env['FC']}",
+            f"LOADER     = {env['CC']}",
+            "CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_",
+            "NOOPTS     = -O0",
+        ]
+
+
+class CMakeBuilder(BaseBuilder, spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         if self.pkg.version > Version("5.2.1"):
             _blaslib_key = "enable_internal_blaslib"
@@ -171,7 +148,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class GenericBuilder(spack.build_systems.generic.GenericBuilder):
+class GenericBuilder(BaseBuilder, spack.build_systems.generic.GenericBuilder):
     def install(self, pkg, spec, prefix):
         """Use autotools before version 5"""
         # Define make.inc file


### PR DESCRIPTION
This PR converts the stand-alone test to use the new process **and** fixes a bug with post-install processing so the test examples are actually cached.  It also simplifies the creation of the example's `make.inc` file, which it now also creates post-install so it is done once and not for every test run.

Test results after installing the latest super and `4.3`:
```
$ spack -v test run superlu
==> Spack test lzxj5tvb6hbkedjy6fpmfivympawmz5m
==> Testing package superlu-4.3-6sxafcf
==> [2023-06-15-16:27:16.721754] Installing SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-4.3-6sxafcf2esnmi7wmcd63rsayvxqsl4iy/.spack/test to SPACK_TEST_ROOT/lzxj5tvb6hbkedjy6fpmfivympawmz5m/superlu-4.3-6sxafcf/cache/superlu
==> [2023-06-15-16:27:17.141940] test: test_example: build and run test example
==> [2023-06-15-16:27:17.143716] '/usr/bin/make' 'HEADER=SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-4.3-6sxafcf2esnmi7wmcd63rsayvxqsl4iy/include' 'superlu'
SPACK_ROOT/lib/spack/env/gcc/gcc -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_  -ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-4.3-6sxafcf2esnmi7wmcd63rsayvxqsl4iy/include -c superlu.c 
superlu.c:13:1: warning: return type defaults to 'int' [-Wimplicit-int]
   13 | main(int argc, char *argv[])
      | ^~~~
SPACK_ROOT/lib/spack/env/gcc/gcc -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_  -ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-4.3-6sxafcf2esnmi7wmcd63rsayvxqsl4iy/include -c sp_ienv.c 
sp_ienv.c: In function 'sp_ienv':
sp_ienv.c:75:5: warning: implicit declaration of function 'xerbla_' [-Wimplicit-function-declaration]
   75 |     xerbla_("sp_ienv", &i);
      |     ^~~~~~~
SPACK_ROOT/lib/spack/env/gcc/gcc  superlu.o sp_ienv.o SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-4.3-6sxafcf2esnmi7wmcd63rsayvxqsl4iy/lib/libsuperlu_4.3.a -LSPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openblas-0.3.23-ncqllezazdfjsywzgy3zvfp7zruigtly/lib -lopenblas -lm -o superlu
==> [2023-06-15-16:27:17.453757] './superlu'

CompCol matrix A:
Stype 0, Dtype 1, Mtype 0
nrow 5, ncol 5, nnz 12
nzval: 19.000000  12.000000  12.000000  21.000000  12.000000  12.000000  21.000000  16.000000  21.000000  5.000000  21.000000  18.000000  
rowind: 0  1  4  1  2  4  0  2  0  3  3  4  
colptr: 0  3  6  8  10  12  

CompCol matrix U:
Stype 0, Dtype 1, Mtype 4
nrow 5, ncol 5, nnz 11
nzval: 21.000000  -13.263158  7.578947  21.000000  
rowind: 0  1  2  0  
colptr: 0  0  0  1  4  4  

SuperNode matrix L:
Stype 3, Dtype 1, Mtype 1
nrow 5, ncol 5, nnz 11, nsuper 2
nzval:
0	0	1.900000e+01
1	0	6.315789e-01
4	0	6.315789e-01
1	1	2.100000e+01
2	1	5.714286e-01
4	1	5.714286e-01
1	2	-1.326316e+01
2	2	2.357895e+01
4	2	-2.410714e-01
3	3	5.000000e+00
4	3	-7.714286e-01
3	4	2.100000e+01
4	4	3.420000e+01

nzval_colptr: 0  3  6  9  11  13  
rowind: 0  1  4  1  2  4  3  4  
rowind_colptr: 0  3  6  6  8  8  
col_to_sup: 0  1  1  2  2  
sup_to_col: 0  1  3  5  

perm_r
0	0
1	1
2	2
3	3
4	4
PASSED: Superlu::test_example
==> [2023-06-15-16:27:17.461605] Completed testing
==> [2023-06-15-16:27:17.461745] 
========================= SUMMARY: superlu-4.3-6sxafcf =========================
Superlu::test_example .. PASSED
============================= 1 passed of 1 parts ==============================
==> Testing package superlu-5.3.0-swgxxyz
==> [2023-06-15-16:27:17.864359] Installing SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-5.3.0-swgxxyzwwauoonp3p3zbbw2sa2r5bq6f/.spack/test to SPACK_TEST_ROOT/lzxj5tvb6hbkedjy6fpmfivympawmz5m/superlu-5.3.0-swgxxyz/cache/superlu
==> [2023-06-15-16:27:18.258830] test: test_example: build and run test example
==> [2023-06-15-16:27:18.260862] '/usr/bin/make' 'superlu'
SPACK_ROOT/lib/spack/env/gcc/gcc -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_  -ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-5.3.0-swgxxyzwwauoonp3p3zbbw2sa2r5bq6f/include -c superlu.c 
superlu.c:23:1: warning: return type defaults to 'int' [-Wimplicit-int]
   23 | main(int argc, char *argv[])
      | ^~~~
SPACK_ROOT/lib/spack/env/gcc/gcc -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_  -ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-5.3.0-swgxxyzwwauoonp3p3zbbw2sa2r5bq6f/include -c sp_ienv.c 
sp_ienv.c: In function 'sp_ienv':
sp_ienv.c:85:5: warning: implicit declaration of function 'input_error' [-Wimplicit-function-declaration]
   85 |     input_error("sp_ienv", &i);
      |     ^~~~~~~~~~~
SPACK_ROOT/lib/spack/env/gcc/gcc  superlu.o sp_ienv.o SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/superlu-5.3.0-swgxxyzwwauoonp3p3zbbw2sa2r5bq6f/lib/libsuperlu.a -LSPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openblas-0.3.23-ncqllezazdfjsywzgy3zvfp7zruigtly/lib -lopenblas -lm -o superlu
==> [2023-06-15-16:27:18.560855] './superlu'

CompCol matrix A:
Stype 0, Dtype 1, Mtype 0
nrow 5, ncol 5, nnz 12
nzval: 19.000000  12.000000  12.000000  21.000000  12.000000  12.000000  21.000000  16.000000  21.000000  5.000000  21.000000  18.000000  
rowind: 0  1  4  1  2  4  0  2  0  3  3  4  
colptr: 0  3  6  8  10  12  

CompCol matrix U:
Stype 0, Dtype 1, Mtype 4
nrow 5, ncol 5, nnz 11
nzval: 21.000000  -13.263158  21.000000  -13.263158  7.578947  21.000000  
rowind: 0  1  0  1  2  3  
colptr: 0  0  0  2  5  6  

SuperNode matrix L:
Stype 3, Dtype 1, Mtype 1
nrow 5, ncol 5, nnz 11, nsuper 4
nzval:
0	0	1.900000e+01
1	0	6.315789e-01
4	0	6.315789e-01
1	1	2.100000e+01
2	1	5.714286e-01
4	1	5.714286e-01
2	2	2.357895e+01
4	2	-2.410714e-01
3	3	5.000000e+00
4	3	-7.714286e-01
4	4	3.420000e+01

nzval_colptr: 0  3  6  8  10  11  
rowind: 0  1  4  1  2  4  2  4  3  4  4  
rowind_colptr: 0  3  6  8  10  11  
col_to_sup: 0  1  2  3  4  
sup_to_col: 0  1  2  3  4  5  

perm_r
0	0
1	1
2	2
3	3
4	4
PASSED: Superlu::test_example
==> [2023-06-15-16:27:18.569347] Completed testing
==> [2023-06-15-16:27:18.569519] 
======================== SUMMARY: superlu-5.3.0-swgxxyz ========================
Superlu::test_example .. PASSED
============================= 1 passed of 1 parts ==============================
============================= 2 passed of 2 specs ==============================
```

TODO:

- [x] Resolve problem with EXAMPLE subdirectory not being cached post-install
- [x] Possibly move writing the make.inc file to the post-install method so done once per installation
- [x] re-test (once actually have the example copied) 