### PR TITLE
flux-core: add missing python-ply dependency

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -122,6 +122,7 @@ class FluxCore(AutotoolsPackage):
     conflicts("platform=darwin", msg="flux-core does not support MacOS based platforms.")
     conflicts("platform=windows", msg="flux-core does not support Windows based platforms.")
 
+    depends_on("ply", when="@0.47.0:")
     depends_on("libarchive", when="@0.38.0:")
     depends_on("ncurses@6.2:", when="@0.32.0:")
     depends_on("libzmq@4.0.4:")


### PR DESCRIPTION
Problem: flux-core versions since v0.47.0 require python-ply at runtime for proper operation of cli submission tools.

Add the missing dependency.