### PR TITLE
edm4hep: add edm4hep to PYTHONPATH

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -124,6 +124,9 @@ class Edm4hep(CMakePackage):
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 
+    def setup_run_environment(self, env):
+        env.prepend_path("PYTHONPATH", self.prefix.python)
+
     def url_for_version(self, version):
         """Translate version numbers to ilcsoft conventions.
         in spack, the convention is: 0.1 (or 0.1.0) 0.1.1, 0.2, 0.2.1 ...


### PR DESCRIPTION
Since https://github.com/key4hep/EDM4hep/pull/204 was merged, now there are python bindings for edm4hep.