### PR TITLE
Add up_to_1, up_to_2, and up_to_3 version attributes

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -456,14 +456,13 @@ For instance, the following config options,
        tcl:
          all:
            suffixes:
-             ^python@3: 'python{^python.version}'
+             ^python@3: 'python{^python.version.up_to_2}'
              ^openblas: 'openblas'
 
-will add a ``python-3.12.1`` version string to any packages compiled with
-Python matching the spec, ``python@3``. This is useful to know which
-version of Python a set of Python extensions is associated with. Likewise, the
-``openblas`` string is attached to any program that has openblas in the spec,
-most likely via the ``+blas`` variant specification.
+will add a ``python3.12`` to module names of packages compiled with Python 3.12, and similarly for
+all specs depending on ``python@3``. This is useful to know which version of Python a set of Python
+extensions is associated with. Likewise, the ``openblas`` string is attached to any program that
+has openblas in the spec, most likely via the ``+blas`` variant specification.
 
 The most heavyweight solution to module naming is to change the entire
 naming convention for module files. This uses the projections format

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -869,6 +869,12 @@ class TestSpecSemantics:
             ("{namespace=namespace}", "namespace=", "namespace", lambda spec: spec),
             ("{compiler.name}", "", "name", lambda spec: spec.compiler),
             ("{compiler.version}", "", "version", lambda spec: spec.compiler),
+            (
+                "{compiler.version.up_to_1}",
+                "",
+                "up_to_1",
+                lambda spec: spec.compiler.version.up_to(1),
+            ),
             ("{%compiler.name}", "%", "name", lambda spec: spec.compiler),
             ("{@compiler.version}", "@", "version", lambda spec: spec.compiler),
             ("{architecture.platform}", "", "platform", lambda spec: spec.architecture),

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -490,6 +490,21 @@ class StandardVersion(ConcreteVersion):
         """
         return self[:index]
 
+    @property
+    def up_to_1(self):
+        """The version truncated to the first component."""
+        return self.up_to(1)
+
+    @property
+    def up_to_2(self):
+        """The version truncated to the first two components."""
+        return self.up_to(2)
+
+    @property
+    def up_to_3(self):
+        """The version truncated to the first three components."""
+        return self.up_to(3)
+
 
 _STANDARD_VERSION_TYPEMIN = StandardVersion("", ((), (ALPHA,)), ("",))
 


### PR DESCRIPTION
Adds `up_to_1`, `up_to_2`, and `up_to_3` attributes to the Version class.

Making them also available in **spec format strings**; This is especially useful for spec format strings, for example:

```yaml
modules:
  default:
    tcl:
      projections:
        all: '{name}/{version}-{compiler.name}{compiler.version.up_to_1}'
        ^python: '{name}/{version}-python{^python.version.up_to_2}'
```

Can give you modules like `zlib/1.2.13-gcc11` and `py-numpy/1.24.1-python3.10`.

This seems redundant with `version[0]` and `version.up_to(2)`, but those last construct are not implemented by the spec format string parser.
