### PR TITLE
perl-gd: update to 2.77, update urls

### DIFF
--- a/var/spack/repos/builtin/packages/perl-gd/package.py
+++ b/var/spack/repos/builtin/packages/perl-gd/package.py
@@ -10,11 +10,20 @@ class PerlGd(PerlPackage):
     """Interface to Gd Graphics Library"""
 
     homepage = "https://metacpan.org/pod/GD"
-    url = "http://search.cpan.org/CPAN/authors/id/L/LD/LDS/GD-2.53.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/R/RU/RURBAN/GD-2.77.tar.gz"
 
+    version("2.77", sha256="b56c88b8ef3be016ce29bb62dd1f1b6f6b5fbcaa57fea59e9468af6901016fb5")
+    version("2.56", sha256="1f103d1c98de8621504642ed7fb79f1b40f5f6a63c2abe9390a8ab78617248f9")
     version("2.53", sha256="d05d01fe95e581adb3468cf05ab5d405db7497c0fb3ec7ecf23d023705fab7aa")
 
     depends_on("perl-module-build", type="build")
     depends_on("perl-extutils-makemaker", type=("build", "run"))
     depends_on("perl-extutils-pkgconfig", type=("build", "run"))
     depends_on("libgd")
+
+    def url_for_version(self, version):
+        if version <= Version("2.56"):
+            url = "http://search.cpan.org/CPAN/authors/id/L/LD/LDS/GD-{0}.tar.gz"
+        else:
+            url = "https://cpan.metacpan.org/authors/id/R/RU/RURBAN/GD-{0}.tar.gz"
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/perl-gd/package.py
+++ b/var/spack/repos/builtin/packages/perl-gd/package.py
@@ -13,7 +13,6 @@ class PerlGd(PerlPackage):
     url = "https://cpan.metacpan.org/authors/id/R/RU/RURBAN/GD-2.77.tar.gz"
 
     version("2.77", sha256="b56c88b8ef3be016ce29bb62dd1f1b6f6b5fbcaa57fea59e9468af6901016fb5")
-    version("2.56", sha256="1f103d1c98de8621504642ed7fb79f1b40f5f6a63c2abe9390a8ab78617248f9")
     version("2.53", sha256="d05d01fe95e581adb3468cf05ab5d405db7497c0fb3ec7ecf23d023705fab7aa")
 
     depends_on("perl-module-build", type="build")


### PR DESCRIPTION
Updating to `@2.77`. The url for this package changed a while ago - updated it here.