### PR TITLE
repeatmodeler: patch perl shebangs

### DIFF
--- a/var/spack/repos/builtin/packages/repeatmodeler/package.py
+++ b/var/spack/repos/builtin/packages/repeatmodeler/package.py
@@ -46,6 +46,46 @@ class Repeatmodeler(Package):
     depends_on("blat", type="run", when="@2.0.4:")
     depends_on("ltr-retriever", type="run", when="@2.0.4:")
 
+    def patch(self):
+        file_list = [
+            "BuildDatabase",
+            "Job.pm",
+            "LTRPipeline",
+            "MultAln.pm",
+            "NeedlemanWunschGotohAlgorithm.pm",
+            "Refiner",
+            "RepeatClassifier",
+            "RepeatModeler",
+            "RepeatUtil.pm",
+            "RepModelConfig.pm",
+            "SeedAlignmentCollection.pm",
+            "SeedAlignment.pm",
+            "SequenceSimilarityMatrix.pm",
+            "Task.pm",
+            "ThreadedJob.pm",
+            "ThreadedTaskSimple.pm",
+            "TRFMask",
+            "util/alignAndCallConsensus.pl",
+            "util/align.pl",
+            "util/AutoRunBlocker.pl",
+            "util/bestwindow.pl",
+            "util/Blocker.pl",
+            "util/ClusterPartialMatchingSubs.pl",
+            "util/CntSubst",
+            "util/extendFlankingSeqs.pl",
+            "util/fasta-trf-filter.pl",
+            "util/generateSeedAlignments.pl",
+            "util/Linup",
+            "util/renameIds.pl",
+            "util/resolveIndels.pl",
+            "util/rmblast.pl",
+            "util/TSD.pl",
+            "util/viewMSA.pl",
+            "util/visualizeAlignPNG.pl",
+        ]
+        for f in file_list:
+            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f)
+
     def install(self, spec, prefix):
         # interactive configuration script
         if spec.satisfies("@1.0.11"):

--- a/var/spack/repos/builtin/packages/repeatmodeler/package.py
+++ b/var/spack/repos/builtin/packages/repeatmodeler/package.py
@@ -84,7 +84,7 @@ class Repeatmodeler(Package):
             "util/visualizeAlignPNG.pl",
         ]
         for f in file_list:
-            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f)
+            filter_file("^#!/usr/bin/perl.*$", "#!/usr/bin/env perl", f, ignore_absent=True)
 
     def install(self, spec, prefix):
         # interactive configuration script


### PR DESCRIPTION
I missed all the /usr/bin/perl's and the like when updating this, whoops. I've submitted a PR upstream to replace them, we'll see if that's approved.