### PR TITLE
cromwell: add 85

### DIFF
--- a/var/spack/repos/builtin/packages/cromwell/package.py
+++ b/var/spack/repos/builtin/packages/cromwell/package.py
@@ -10,19 +10,24 @@ from spack.package import *
 
 class Cromwell(Package):
     """Cromwell is a Workflow Management System geared towards scientific
-    workflows.
-    """
+    workflows"""
 
     homepage = "https://cromwell.readthedocs.io/"
     url = "https://github.com/broadinstitute/cromwell/releases/download/44/cromwell-44.jar"
 
+    version(
+        "85",
+        sha256="100f6c61df72b4079b3ad0f03e8f73e6e2c0afe99d212ec8d42faf4bd4de1e23",
+        expand=False,
+    )
     version(
         "44",
         sha256="8b411673f6b3c835c6031db3094a7404b9a371133794046fd295719d61e56db0",
         expand=False,
     )
 
-    depends_on("java@8", type="run")
+    depends_on("java@11", when="@60:", type="run")
+    depends_on("java@8", when="@:59", type="run")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Updating to `@85`. As of `@60:` they're now on `^java@11` rather than `@8`.