### PR TITLE
`nvtx`: new package

### DIFF
--- a/var/spack/repos/builtin/packages/nvtx/nvtx-config.patch
+++ b/var/spack/repos/builtin/packages/nvtx/nvtx-config.patch
@@ -1,0 +1,10 @@
+diff --git a/nvtx-config.cmake b/nvtx-config.cmake
+new file mode 100644
+index 0000000000..bcad258624
+--- /dev/null
++++ b/nvtx-config.cmake
+@@ -0,0 +1,4 @@
++include("${CMAKE_CURRENT_LIST_DIR}/nvtxImportedTargets.cmake")
++set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(${CMAKE_FIND_PACKAGE_NAME} CONFIG_MODE)

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -14,7 +14,7 @@ class Nvtx(Package, PythonExtension):
 
     maintainers("thomas-bouvier")
 
-    version("main", branch="dev")
+    version("develop", branch="dev")
     version("3.1.0", sha256="dc4e4a227d04d3da46ad920dfee5f7599ac8d6b2ee1809c9067110fb1cc71ced")
 
     variant("python", default=True, description="Install Python bindings.")

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -8,16 +8,16 @@ from spack.package import *
 
 class Nvtx(Package, PythonExtension):
     """Python code annotation library"""
-    
+
     git = "https://github.com/NVIDIA/NVTX.git"
     url = "https://github.com/NVIDIA/NVTX/archive/refs/tags/v3.1.0.tar.gz"
-    
+
     maintainers("thomas-bouvier")
 
     version("main", branch="dev")
     version("3.1.0", sha256="dc4e4a227d04d3da46ad920dfee5f7599ac8d6b2ee1809c9067110fb1cc71ced")
 
-    variant("python", default=True, description="Install python bindings.")
+    variant("python", default=True, description="Install Python bindings.")
     extends("python", when="+python")
     depends_on("py-pip", type="build", when="+python")
     depends_on("py-setuptools", type="build", when="+python")
@@ -35,11 +35,10 @@ class Nvtx(Package, PythonExtension):
 
     def install(self, spec, prefix):
         install_tree('c/include', prefix.include)
+        install("c/CMakeLists.txt", prefix)
+        install("c/nvtxImportedTargets.cmake", prefix)
         install('./LICENSE.txt', "%s" % prefix)
 
-    @run_after("install")
-    def install_python(self):
-        """Install everything from build directory."""
         args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):
             pip(*args)

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -24,7 +24,7 @@ class Nvtx(Package, PythonExtension):
     depends_on("py-wheel", type="build", when="+python")
     depends_on("py-cython", type="build", when="+python")
 
-    build_directory = 'python'
+    build_directory = "python"
 
     def patch(self):
         """Patch setup.py to provide include directory."""
@@ -34,10 +34,10 @@ class Nvtx(Package, PythonExtension):
         setup.filter("include_dirs=include_dirs", f"include_dirs=['{include_dir}']", string=True)
 
     def install(self, spec, prefix):
-        install_tree('c/include', prefix.include)
+        install_tree("c/include", prefix.include)
         install("c/CMakeLists.txt", prefix)
         install("c/nvtxImportedTargets.cmake", prefix)
-        install('./LICENSE.txt', "%s" % prefix)
+        install("./LICENSE.txt", "%s" % prefix)
 
         args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Nvtx(Package, PythonExtension):
+    
+    git = "https://github.com/NVIDIA/NVTX.git"
+    url = "https://github.com/NVIDIA/NVTX/archive/refs/tags/v3.1.0.tar.gz"
+    
+    maintainers("thomas-bouvier")
+
+    version("main", branch="dev")
+    version("3.1.0", sha256="dc4e4a227d04d3da46ad920dfee5f7599ac8d6b2ee1809c9067110fb1cc71ced")
+
+    variant("python", default=True, description="Install python bindings.")
+    extends("python", when="+python")
+    depends_on("py-setuptools", type="build", when="+python")
+    depends_on("py-wheel", type="build", when="+python")
+    depends_on("py-cython", type="build", when="+python")
+
+    #depends_on("cmake@3.10:", type="build")
+    #root_cmakelists_dir = "c"
+    #install_targets = []
+
+    build_directory = 'python'
+
+    def install(self, spec, prefix):
+        install_tree('c/include', prefix.include)
+        install('./LICENSE.txt', "%s" % prefix)
+
+    @run_after("install")
+    def install_python(self):
+        """Install everything from build directory."""
+        pass

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -42,7 +42,7 @@ class Nvtx(Package, PythonExtension):
         install("c/nvtxImportedTargets.cmake", prefix)
         install("./LICENSE.txt", prefix)
 
-        install("./nvtx-config.cmake", prefix) # added by the patch above
+        install("./nvtx-config.cmake", prefix)  # added by the patch above
 
         args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -26,9 +26,12 @@ class Nvtx(Package, PythonExtension):
 
     build_directory = "python"
 
+    # Create a nvtx-config.cmake file to make calls to find_package(nvtx) to
+    # work as expected
+    patch("nvtx-config.patch")
+
     def patch(self):
         """Patch setup.py to provide include directory."""
-
         include_dir = prefix.include
         setup = FileFilter("python/setup.py")
         setup.filter("include_dirs=include_dirs", f"include_dirs=['{include_dir}']", string=True)
@@ -37,7 +40,9 @@ class Nvtx(Package, PythonExtension):
         install_tree("c/include", prefix.include)
         install("c/CMakeLists.txt", prefix)
         install("c/nvtxImportedTargets.cmake", prefix)
-        install("./LICENSE.txt", "%s" % prefix)
+        install("./LICENSE.txt", prefix)
+
+        install("./nvtx-config.cmake", prefix) # added by the patch above
 
         args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):


### PR DESCRIPTION
This is still a work in progress.

`nvtx` is a header-only C library, so I used `Package` and the `install()` function to install the headers. This works well.

However, I can't figure out how to install the Python wrapper, which is located in the `python` sub-directory of the [Github archive](https://github.com/NVIDIA/NVTX/archive/refs/tags/v3.1.0.tar.gz). How can I install its content? `pyproject.toml` displays `requires = ["setuptools", "wheel", "Cython"]`.

Pinging @shwina.