### PR TITLE
bulker: new package @0.7.3

### DIFF
--- a/var/spack/repos/builtin/packages/bulker/package.py
+++ b/var/spack/repos/builtin/packages/bulker/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyBulker(PythonPackage):
+class Bulker(PythonPackage):
     """Bulker: multi-container environment manager"""
 
     homepage = "https://bulker.databio.org/"

--- a/var/spack/repos/builtin/packages/py-bulker/package.py
+++ b/var/spack/repos/builtin/packages/py-bulker/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBulker(PythonPackage):
+    """Bulker: multi-container environment manager"""
+
+    homepage = "https://bulker.databio.org/"
+    pypi = "bulker/bulker-0.7.3.tar.gz"
+
+    version("0.7.3", sha256="a7a3a97184d50d2247dc3b116f31f90c27435d9872c6845152ff46f5c4e39d50")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-yacman@0.8.4:", type=("build", "run"))
+    depends_on("py-pyyaml@5.1:", type=("build", "run"))
+    depends_on("py-logmuse@0.2.0:", type=("build", "run"))
+    depends_on("py-jinja2", type=("build", "run"))
+    depends_on("py-ubiquerg@0.5.1:", type=("build", "run"))
+    depends_on("py-psutil", type=("build", "run"))
+    depends_on("singularityce", type="run")


### PR DESCRIPTION
Adding a new package ... `py-bulker`. `bulker` facilitates inter-container communication for workflow development.

Taking dependencies from: https://github.com/databio/bulker/blob/master/requirements/requirements-all.txt, which is read by `setup.py`, and adding `singularityce` which is required at runtime.

