### PR TITLE
krb5: add missing findutils dependency

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -34,6 +34,7 @@ class Krb5(AutotoolsPackage):
     depends_on("openssl@:1", when="@:1.19")
     depends_on("openssl")
     depends_on("gettext")
+    depends_on("findutils")
 
     variant(
         "shared", default=True, description="install shared libraries if True, static if false"

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -34,7 +34,7 @@ class Krb5(AutotoolsPackage):
     depends_on("openssl@:1", when="@:1.19")
     depends_on("openssl")
     depends_on("gettext")
-    depends_on("findutils")
+    depends_on("findutils", type="build")
 
     variant(
         "shared", default=True, description="install shared libraries if True, static if false"


### PR DESCRIPTION
When installing krb5 in a rockylinux:8 container I get the following error:

```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j20' 'V=1'

4 errors found in build log:
     1343    /bin/sh: line 2: find: command not found
     1344    ln: failed to create symbolic link './.': File exists
     1345    /bin/sh: line 2: find: command not found
     1346    ln: failed to create symbolic link './.': File exists
     1347    /bin/sh: line 2: find: command not found
     1348    ln: failed to create symbolic link './.': File exists
  >> 1349    make[3]: *** [Makefile:658: .links] Error 1
     1350    make[3]: *** Waiting for unfinished jobs....
     1351    make[3]: Leaving directory '/tmp/root/spack-stage/spack-stage-krb5-1.20.1-62dpgjkwgrfynpszb3gy2c2ntvv
             cnhw6/spack-src/src/lib/krb5/unicode'
  >> 1352    make[2]: *** [Makefile:1121: all-recurse] Error 1
     1353    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-krb5-1.20.1-62dpgjkwgrfynpszb3gy2c2ntvv
             cnhw6/spack-src/src/lib/krb5'
  >> 1354    make[1]: *** [Makefile:973: all-recurse] Error 1
     1355    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-krb5-1.20.1-62dpgjkwgrfynpszb3gy2c2ntvv
             cnhw6/spack-src/src/lib'
  >> 1356    make: *** [Makefile:1521: all-recurse] Error 1
```