### PR TITLE
py-gsutil: add 5.24, fix and add dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-gcs-oauth2-boto-plugin/package.py
+++ b/var/spack/repos/builtin/packages/py-gcs-oauth2-boto-plugin/package.py
@@ -15,12 +15,14 @@ class PyGcsOauth2BotoPlugin(PythonPackage):
 
     maintainers("dorton21")
 
+    version("3.0", sha256="f4120b08b7f8d32904674c98f07d4caf4083a58343c0c0fa0016e0f0254dfe31")
     version("2.7", sha256="c95b011717911a6c40fbd3aa07a8faa0ab57570dee178d7148531327c4c6f93e")
 
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+
+    depends_on("py-rsa@4.7.2", when="@3:", type=("build", "run"))
     depends_on("py-boto@2.29.1:", type=("build", "run"))
-    depends_on("py-google-auth@0.1.0:", type=("build", "run"))
+    depends_on("py-google-reauth@0.1.0:", type=("build", "run"))
     depends_on("py-httplib2@0.18:", type=("build", "run"))
     depends_on("py-oauth2client@2.2.0:", type=("build", "run"))
     depends_on("py-pyopenssl@0.13:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-auth/package.py
+++ b/var/spack/repos/builtin/packages/py-google-auth/package.py
@@ -13,10 +13,13 @@ class PyGoogleAuth(PythonPackage):
     homepage = "https://github.com/GoogleCloudPlatform/google-auth-library-python"
     pypi = "google-auth/google-auth-1.6.3.tar.gz"
 
+    version("2.20.0", sha256="030af34138909ccde0fbce611afc178f1d65d32fbff281f25738b1fe1c6f3eaa")
     version("2.16.2", sha256="07e14f34ec288e3f33e00e2e3cc40c8942aa5d4ceac06256a28cd8e786591420")
     version("2.11.0", sha256="ed65ecf9f681832298e29328e1ef0a3676e3732b2e56f41532d45f70a22de0fb")
     version("2.3.2", sha256="2dc5218ee1192f9d67147cece18f47a929a9ef746cb69c50ab5ff5cfc983647b")
     version("1.6.3", sha256="0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4")
+
+    variant("aiohttp", default=False, when="@1.22.1:", description="Enables aiohttp support")
 
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-cachetools@2:5", when="@2.11:", type=("build", "run"))
@@ -26,3 +29,8 @@ class PyGoogleAuth(PythonPackage):
     depends_on("py-rsa@3.1.4:4", when="@2.3:", type=("build", "run"))
     depends_on("py-rsa@3.1.4:", type=("build", "run"))
     depends_on("py-six@1.9:", type=("build", "run"))
+    depends_on("py-urllib3@:1", when="@2.18:", type=("build", "run"))
+
+    with when("+aiohttp"):
+        depends_on("py-aiohttp@3.6.2:3", type=("build", "run"))
+        depends_on("py-requests@2.20:2", when="@1.30.2:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-google-reauth/package.py
+++ b/var/spack/repos/builtin/packages/py-google-reauth/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGoogleReauth(PythonPackage):
+    """Google Reauth Library."""
+
+    homepage = "https://github.com/Google/google-reauth-python"
+    pypi = "google-reauth/google-reauth-0.1.1.tar.gz"
+
+    version("0.1.1", sha256="f9f6852a55c2c5453d581cd01f3d1278e86147c03d008409800390a834235892")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pyu2f", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-gsutil/package.py
+++ b/var/spack/repos/builtin/packages/py-gsutil/package.py
@@ -11,23 +11,33 @@ class PyGsutil(PythonPackage):
 
     homepage = "https://cloud.google.com/storage/docs/gsutil"
     pypi = "gsutil/gsutil-4.59.tar.gz"
+    git = "https://github.com/GoogleCloudPlatform/gsutil.git"
 
     maintainers("dorton21")
 
+    version("5.24", sha256="1f841645cda40fcc817e9ca84d285cdf541cc015fd38a5862017b085756729a0")
     version("5.2", sha256="08857eedbd89c7c6d10176b14f94fb1168d5ef88f5b5b15b3e8a37e29302b79b")
     version("4.59", sha256="349e0e0b48c281659acec205917530ae57e2eb23db7220375f5add44688d3ddf")
 
     depends_on("python@2.7:2.8,3.5:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+
     depends_on("py-argcomplete@1.9.4:", type=("build", "run"))
     depends_on("py-crcmod@1.7:", type=("build", "run"))
     depends_on("py-fasteners@0.14.1:", type=("build", "run"))
+    depends_on("py-gcs-oauth2-boto-plugin@3:", when="@5:", type=("build", "run"))
     depends_on("py-gcs-oauth2-boto-plugin@2.7:", type=("build", "run"))
     depends_on("py-google-apitools@0.5.32:", type=("build", "run"))
+    depends_on("py-httplib2@0.20.4:", when="@5.7:", type=("build", "run"))
     depends_on("py-httplib2@0.18:", type=("build", "run"))
-    depends_on("py-google-auth@0.1.0:", type=("build", "run"))
-    depends_on("py-mock@2.0.0", type=("build", "run"))
+    depends_on("py-google-reauth@0.1.0:", type=("build", "run"))
     depends_on("py-monotonic@1.4:", type=("build", "run"))
     depends_on("py-pyopenssl@0.13:", type=("build", "run"))
     depends_on("py-retry-decorator@1.0.0:", type=("build", "run"))
     depends_on("py-six@1.12.0:", type=("build", "run"))
+    depends_on("py-google-auth+aiohttp@2.5:", when="@5.7:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-mock@2:3.0.5", when="@:4.67", type=("build", "run"))
+
+    skip_modules = ["gslib.vendored"]

--- a/var/spack/repos/builtin/packages/py-gsutil/package.py
+++ b/var/spack/repos/builtin/packages/py-gsutil/package.py
@@ -28,7 +28,7 @@ class PyGsutil(PythonPackage):
     depends_on("py-gcs-oauth2-boto-plugin@3:", when="@5:", type=("build", "run"))
     depends_on("py-gcs-oauth2-boto-plugin@2.7:", type=("build", "run"))
     depends_on("py-google-apitools@0.5.32:", type=("build", "run"))
-    depends_on("py-httplib2@0.20.4:", when="@5.7:", type=("build", "run"))
+    depends_on("py-httplib2@0.20.4", when="@5.17:", type=("build", "run"))
     depends_on("py-httplib2@0.18:", type=("build", "run"))
     depends_on("py-google-reauth@0.1.0:", type=("build", "run"))
     depends_on("py-monotonic@1.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-httplib2/package.py
+++ b/var/spack/repos/builtin/packages/py-httplib2/package.py
@@ -19,4 +19,5 @@ class PyHttplib2(PythonPackage):
     depends_on("py-setuptools@40.8.0:", when="@0.18.1:", type="build")
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-pyparsing@2.4.2:2,3.0.4:3", when="@0.19:", type=("build", "run"))
+    depends_on("py-pyparsing@2.4.2:3", when="@0.19:", type=("build", "run"))
+    conflicts("py-pyparsing@3.0.1:3.0.3", when="@0.19:")

--- a/var/spack/repos/builtin/packages/py-httplib2/package.py
+++ b/var/spack/repos/builtin/packages/py-httplib2/package.py
@@ -12,7 +12,11 @@ class PyHttplib2(PythonPackage):
     homepage = "https://github.com/httplib2/httplib2"
     pypi = "httplib2/httplib2-0.13.1.tar.gz"
 
+    version("0.22.0", sha256="d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81")
     version("0.18.0", sha256="b0e1f3ed76c97380fe2485bc47f25235453b40ef33ca5921bb2897e257a49c4c")
     version("0.13.1", sha256="6901c8c0ffcf721f9ce270ad86da37bc2b4d32b8802d4a9cec38274898a64044")
 
+    depends_on("py-setuptools@40.8.0:", when="@0.18.1:", type="build")
     depends_on("py-setuptools", type="build")
+
+    depends_on("py-pyparsing@2.4.2:2,3.0.4:3", when="@0.19:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-httplib2/package.py
+++ b/var/spack/repos/builtin/packages/py-httplib2/package.py
@@ -13,6 +13,7 @@ class PyHttplib2(PythonPackage):
     pypi = "httplib2/httplib2-0.13.1.tar.gz"
 
     version("0.22.0", sha256="d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81")
+    version("0.20.4", sha256="58a98e45b4b1a48273073f905d2961666ecf0fbac4250ea5b47aef259eb5c585")
     version("0.18.0", sha256="b0e1f3ed76c97380fe2485bc47f25235453b40ef33ca5921bb2897e257a49c4c")
     version("0.13.1", sha256="6901c8c0ffcf721f9ce270ad86da37bc2b4d32b8802d4a9cec38274898a64044")
 

--- a/var/spack/repos/builtin/packages/py-httplib2/package.py
+++ b/var/spack/repos/builtin/packages/py-httplib2/package.py
@@ -21,4 +21,4 @@ class PyHttplib2(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     depends_on("py-pyparsing@2.4.2:3", when="@0.19:", type=("build", "run"))
-    conflicts("py-pyparsing@3.0.1:3.0.3", when="@0.19:")
+    conflicts("^py-pyparsing@3.0.1:3.0.3", when="@0.19:")

--- a/var/spack/repos/builtin/packages/py-pyopenssl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyopenssl/package.py
@@ -23,9 +23,11 @@ class PyPyopenssl(PythonPackage):
 
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-cryptography@38:39,40.0.2:41", when="@23.2:", type=("build", "run"))
+    depends_on("py-cryptography@38:41", when="@23.2:", type=("build", "run"))
     depends_on("py-cryptography@38", when="@22", type=("build", "run"))
     depends_on("py-cryptography@2.3:", type=("build", "run"))
+
+    conflicts("py-cryptography@40:40.0.1", when="@23.2:")
 
     # Historical dependencies
     depends_on("py-six@1.5.2:", when="@:19", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyopenssl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyopenssl/package.py
@@ -27,7 +27,7 @@ class PyPyopenssl(PythonPackage):
     depends_on("py-cryptography@38", when="@22", type=("build", "run"))
     depends_on("py-cryptography@2.3:", type=("build", "run"))
 
-    conflicts("py-cryptography@40:40.0.1", when="@23.2:")
+    conflicts("^py-cryptography@40:40.0.1", when="@23.2:")
 
     # Historical dependencies
     depends_on("py-six@1.5.2:", when="@:19", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyopenssl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyopenssl/package.py
@@ -17,11 +17,15 @@ class PyPyopenssl(PythonPackage):
     homepage = "https://pyopenssl.org/"
     pypi = "pyOpenSSL/pyOpenSSL-19.0.0.tar.gz"
 
+    version("23.2.0", sha256="276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac")
     version("22.1.0", sha256="7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968")
     version("19.0.0", sha256="aeca66338f6de19d1aa46ed634c3b9ae519a64b458f8468aec688e7e3c20f200")
 
     depends_on("py-setuptools", type="build")
+
+    depends_on("py-cryptography@38:39,40.0.2:41", when="@23.2:", type=("build", "run"))
+    depends_on("py-cryptography@38", when="@22", type=("build", "run"))
     depends_on("py-cryptography@2.3:", type=("build", "run"))
-    depends_on("py-cryptography@38", when="@22:", type=("build", "run"))
-    depends_on("python@3.6:", when="@22:", type=("build", "run"))
+
+    # Historical dependencies
     depends_on("py-six@1.5.2:", when="@:19", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyu2f/package.py
+++ b/var/spack/repos/builtin/packages/py-pyu2f/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyu2f(PythonPackage):
+    """U2F host library for interacting with a U2F device over USB."""
+
+    homepage = "https://github.com/google/pyu2f"
+    pypi = "pyu2f/pyu2f-0.1.5.tar.gz"
+
+    version("0.1.5", sha256="a3caa3a11842fc7d5746376f37195e6af5f17c0a15737538bb1cebf656fb306b")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-six", type=("build", "run"))


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/gsutil/tree/v5.24

- py-google-auth: add 2.20.0 and new variant aiohttp:
	<https://github.com/googleapis/google-auth-library-python/tree/v2.20.0>
- py-openssl: add 23.2.0
	<https://github.com/pyca/pyopenssl/tree/23.2.0>
	to prevent `AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`
- py-httplib2: add 0.22.0
	<https://github.com/httplib2/httplib2/tree/v0.22.0>
- py-gcs-oauth2-boto-plugin: add 3.0
	<https://github.com/GoogleCloudPlatform/gcs-oauth2-boto-plugin/tree/v3.0>
- py-pyu2f: add new package
	<https://github.com/google/pyu2f/tree/v0.1.5>
- py-google-reauth: add new package
	<https://github.com/Google/google-reauth-python/tree/0.1.1>