### PR TITLE
modules: ignore more Modules variables in from_sourcing_file

### DIFF
--- a/lib/spack/spack/test/data/sourceme_modules.sh
+++ b/lib/spack/spack/test/data/sourceme_modules.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+_module_raw() { return 1; };
+module() { return 1; };
+ml() { return 1; };
+export -f _module_raw;
+export -f module;
+export -f ml;
+
+export MODULES_AUTO_HANDLING=1
+export __MODULES_LMCONFLICT=bar&foo
+export NEW_VAR=new

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -768,16 +768,21 @@ class EnvironmentModifications:
                 "PS1",
                 "PS2",
                 "ENV",
-                # Environment modules v4
+                # Environment Modules or Lmod
                 "LOADEDMODULES",
                 "_LMFILES_",
-                "BASH_FUNC_module()",
                 "MODULEPATH",
-                "MODULES_(.*)",
-                r"(\w*)_mod(quar|share)",
-                # Lmod configuration
-                r"LMOD_(.*)",
                 "MODULERCFILE",
+                "BASH_FUNC_ml()",
+                "BASH_FUNC_module()",
+                # Environment Modules-specific configuration
+                "MODULESHOME",
+                "BASH_FUNC__module_raw()",
+                r"MODULES_(.*)",
+                r"__MODULES_(.*)",
+                r"(\w*)_mod(quar|share)",
+                # Lmod-specific configuration
+                r"LMOD_(.*)",
             ]
         )
 


### PR DESCRIPTION
Update list of excluded variables in `from_sourcing_file` function to cover all variables specific to Environment Modules or Lmod. Add specifically variables relative to the definition of `module()`, `ml()` and `_module_raw()` Bash functions.

Fixes #13504