### PR TITLE
Feature: find optionally report stand-alone test method names

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def gray_hash(spec, length):
     return colorize("@K{%s}" % h)
 
 
-def display_specs_as_json(specs, deps=False):
+def display_specs_as_json(specs, deps=False, tests=False):
     """Convert specs to a list of json records."""
     seen = set()
     records = []
@@ -355,7 +355,7 @@ def display_specs_as_json(specs, deps=False):
         dag_hash = spec.dag_hash()
         if dag_hash in seen:
             continue
-        records.append(spec.node_dict_with_hashes())
+        records.append(spec.node_dict_with_hashes(tests=tests))
         seen.add(dag_hash)
 
         if deps:
@@ -363,7 +363,7 @@ def display_specs_as_json(specs, deps=False):
                 dep_dag_hash = dep.dag_hash()
                 if dep_dag_hash in seen:
                     continue
-                records.append(dep.node_dict_with_hashes())
+                records.append(dep.node_dict_with_hashes(tests=tests))
                 seen.add(dep_dag_hash)
 
     sjson.dump(records, sys.stdout)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -12,6 +12,7 @@ import llnl.util.tty.color as color
 import spack.cmd as cmd
 import spack.config
 import spack.environment as ev
+import spack.install_test
 import spack.repo
 import spack.spec
 import spack.store

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -159,6 +159,12 @@ def setup_parser(subparser):
         default="all",
         help="Install trees to query: 'all' (default), 'local', 'upstream', upstream name or path",
     )
+    subparser.add_argument(
+        "--tests",
+        action="store_true",
+        default=False,
+        help="""show relevant stand-alone test methods in json output""",
+    )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")
     subparser.add_argument("--end-date", help="latest date of installation [YYYY-MM-DD]")
@@ -377,9 +383,13 @@ def find(parser, args):
     else:
         status_fn = None
 
+    if args.tests and args.json:
+        for res in results:
+            res.tests = spack.install_test.test_function_names(res.package, add_virtuals=True)
+
     # Display the result
     if args.json:
-        cmd.display_specs_as_json(results, deps=args.deps)
+        cmd.display_specs_as_json(results, deps=args.deps, tests=args.tests)
     else:
         decorator = make_env_decorator(env) if env else lambda s, f: f
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2517,13 +2517,15 @@ class Spec:
 
         return {"spec": {"_meta": {"version": SPECFILE_FORMAT_VERSION}, "nodes": node_list}}
 
-    def node_dict_with_hashes(self, hash=ht.dag_hash):
+    def node_dict_with_hashes(self, hash=ht.dag_hash, tests=None):
         """Returns a node_dict of this spec with the dag hash added.  If this
         spec is concrete, the full hash is added as well.  If 'build' is in
         the hash_type, the build hash is also added."""
         node = self.to_node_dict(hash)
         # All specs have at least a DAG hash
         node[ht.dag_hash.name] = self.dag_hash()
+        if tests is not None and hasattr(self, "tests") and self.tests:
+            node["tests"] = self.tests
 
         if not self.concrete:
             node["concrete"] = False

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -612,3 +612,10 @@ def test_find_concretized_not_installed(
         assert _nresults(_query(e, "--tag=tag0")) == (1, 0)
         assert _nresults(_query(e, "--tag=tag1")) == (1, 1)
         assert _nresults(_query(e, "--tag=tag2")) == (0, 1)
+
+
+@pytest.mark.db
+def test_find_json_tests(mutable_database):
+    output = find("--json", "--tests", "simple-standalone-test")
+    tests = json.loads(output)[0]["tests"]
+    assert all([name.startswith("SimpleStandaloneTest.test_") for name in tests])

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -33,7 +33,7 @@ def test_mark_all_explicit(mutable_database):
     mark("-e", "-a")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 16
 
 
 @pytest.mark.db
@@ -50,7 +50,7 @@ def test_mark_one_explicit(mutable_database):
     uninstall("-y", "-a", "mpileaks")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 3
+    assert len(all_specs) == 4
 
 
 @pytest.mark.db
@@ -58,7 +58,7 @@ def test_mark_one_implicit(mutable_database):
     mark("-i", "externaltest")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 14
+    assert len(all_specs) == 15
 
 
 @pytest.mark.db
@@ -67,4 +67,4 @@ def test_mark_all_implicit_then_explicit(mutable_database):
     mark("-e", "-a")
     gc("-y")
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 16

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -81,7 +81,7 @@ def test_recursive_uninstall(mutable_database):
     uninstall("-y", "-a", "--dependents", "callpath")
 
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 9
+    assert len(all_specs) == 10
     # query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies("mpileaks")]
     callpath_specs = [s for s in all_specs if s.satisfies("callpath")]
@@ -94,7 +94,7 @@ def test_recursive_uninstall(mutable_database):
 
 @pytest.mark.db
 @pytest.mark.regression("3690")
-@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 8), ("libelf", 6)])
+@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 9), ("libelf", 7)])
 def test_uninstall_spec_with_multiple_roots(
     constraint, expected_number_of_specs, mutable_database
 ):
@@ -105,7 +105,7 @@ def test_uninstall_spec_with_multiple_roots(
 
 
 @pytest.mark.db
-@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 14), ("libelf", 14)])
+@pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 15), ("libelf", 15)])
 def test_force_uninstall_spec_with_ref_count_not_zero(
     constraint, expected_number_of_specs, mutable_database
 ):
@@ -176,7 +176,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
 
     all_specs, mpileaks_specs, callpath_specs, mpi_specs = db_specs()
     total_specs = len(all_specs)
-    assert total_specs == 14
+    assert total_specs == 15
     assert len(mpileaks_specs) == 3
     assert len(callpath_specs) == 2
     assert len(mpi_specs) == 3

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3163,7 +3163,7 @@ def test_filtering_reused_specs(
 @pytest.mark.usefixtures("mutable_database", "mock_store")
 @pytest.mark.parametrize(
     "reuse_yaml,expected_length",
-    [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "buildcache"}]}, 0)],
+    [({"from": [{"type": "local"}]}, 18), ({"from": [{"type": "buildcache"}]}, 0)],
 )
 @pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_selecting_reused_sources(

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -889,6 +889,7 @@ def _populate(mock_db):
     _install("mpileaks ^zmpi")
     _install("externaltest ^externalvirtual")
     _install("trivial-smoke-test")
+    _install("simple-standalone-test")
 
 
 @pytest.fixture(scope="session")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -491,7 +491,7 @@ def test_005_db_exists(database):
 def test_010_all_install_sanity(database):
     """Ensure that the install layout reflects what we think it does."""
     all_specs = spack.store.STORE.layout.all_specs()
-    assert len(all_specs) == 15
+    assert len(all_specs) == 16
 
     # Query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies("mpileaks")]
@@ -608,7 +608,7 @@ def test_050_basic_query(database):
     """Ensure querying database is consistent with what is installed."""
     # query everything
     total_specs = len(spack.store.STORE.db.query())
-    assert total_specs == 17
+    assert total_specs == 18
 
     # query specs with multiple configurations
     mpileaks_specs = database.query("mpileaks")
@@ -820,6 +820,7 @@ def test_query_unused_specs(mutable_database):
     ml_mpich2 = spack.store.STORE.db.query_one("mpileaks ^mpich2").dag_hash()
     ml_zmpi = spack.store.STORE.db.query_one("mpileaks ^zmpi").dag_hash()
     externaltest = spack.store.STORE.db.query_one("externaltest").dag_hash()
+    simple_standalone_test = spack.store.STORE.db.query_one("simple-standalone-test").dag_hash()
     trivial_smoke_test = spack.store.STORE.db.query_one("trivial-smoke-test").dag_hash()
 
     def check_unused(roots, deptype, expected):
@@ -831,22 +832,29 @@ def test_query_unused_specs(mutable_database):
     check_unused(
         [si, ml_mpich, ml_mpich2, ml_zmpi, externaltest],
         default_dt,
-        ["trivial-smoke-test", "cmake"],
+        ["trivial-smoke-test", "simple-standalone-test", "cmake"],
     )
     check_unused(
         [si, ml_mpich, ml_mpich2, ml_zmpi, externaltest],
         dt.LINK | dt.RUN | dt.BUILD,
-        ["trivial-smoke-test"],
+        ["trivial-smoke-test", "simple-standalone-test"],
     )
     check_unused(
-        [si, ml_mpich, ml_mpich2, externaltest, trivial_smoke_test],
+        [si, ml_mpich, ml_mpich2, externaltest, simple_standalone_test, trivial_smoke_test],
         dt.LINK | dt.RUN | dt.BUILD,
         ["mpileaks", "callpath", "zmpi", "fake"],
     )
     check_unused(
         [si, ml_mpich, ml_mpich2, ml_zmpi],
         default_dt,
-        ["trivial-smoke-test", "cmake", "externaltest", "externaltool", "externalvirtual"],
+        [
+            "trivial-smoke-test",
+            "cmake",
+            "simple-standalone-test",
+            "externaltest",
+            "externaltool",
+            "externalvirtual",
+        ],
     )
 
 
@@ -1080,7 +1088,7 @@ def test_check_parents(spec_str, parent_name, expected_nparents, database):
 def test_db_all_hashes(database):
     # ensure we get the right number of hashes without a read transaction
     hashes = database.all_hashes()
-    assert len(hashes) == 17
+    assert len(hashes) == 18
 
     # and make sure the hashes match
     with database.read_transaction():

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1201,7 +1201,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --tests --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1783,7 +1783,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= tests start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1839,6 +1839,8 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a depre
 complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -f -a install_tree
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query: '"'"'all'"'"' (default), '"'"'local'"'"', '"'"'upstream'"'"', upstream name or path'
+complete -c spack -n '__fish_spack_using_command find' -l tests -f -a tests
+complete -c spack -n '__fish_spack_using_command find' -l tests -d 'show relevant stand-alone test methods in json output'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date


### PR DESCRIPTION
Fixes #37025 ?

@shahzebsiddiqui @wspear 

This PR adds the `--tests` option to `spack find` to output stand-alone test method names when combined with `--json`.  

```
usage: spack find [-hdplLcfumvMN] [--format FORMAT | -H | --json] [--groups]
                  [--no-groups] [-t TAG] [--show-full-compiler] [-x | -X]
                  [--loaded] [--deprecated] [--only-deprecated] [--tests]
                  [--start-date START_DATE] [--end-date END_DATE]
                  ...

list and search installed packages

positional arguments:
  installed_specs       constraint to select a subset of installed packages

optional arguments:
  --deprecated          show deprecated packages as well as installed specs
  --end-date END_DATE   latest date of installation [YYYY-MM-DD]
  --format FORMAT       output specs with the specified format string
  --groups              display specs in arch/compiler groups (default on)
  --json                output specs as machine-readable json records
  --loaded              show only packages loaded in the user environment
  --no-groups           do not group specs by arch/compiler
  --only-deprecated     show only deprecated packages
  --show-full-compiler  show full compiler specs
  --start-date START_DATE
                        earliest date of installation [YYYY-MM-DD]
  --tests               show relevant stand-alone test methods in json output
  -H, --hashes          same as '--format {/hash}'; use with xargs or $()
  -L, --very-long       show full dependency hashes as well as versions
  -M, --only-missing    show only missing dependencies
  -N, --namespace       show fully qualified package names
  -X, --implicit        show only specs that were installed as dependencies
  -c, --show-concretized
                        show concretized specs in an environment
  -d, --deps            output dependencies along with found specs
  -f, --show-flags      show spec compiler flags
  -h, --help            show this help message and exit
  -l, --long            show dependency hashes as well as versions
  -m, --missing         show missing dependencies as well as installed specs
  -p, --paths           show paths to package install directories
  -t TAG, --tag TAG     filter a package query by tag (multiple use allowed)
  -u, --unknown         show only specs Spack does not have a package for
  -v, --variants        show variants in output (can be long)
  -x, --explicit        show only specs that were installed explicitly
```

```
$ spack find -x --tests --json openmpi
==> No package matches the query: openmpi

$ spack find -X --tests --json openmpi | jq
[
  {
    "name": "openmpi",
    "version": "4.1.5",
    [...snip...]
    "tests": [
      "Openmpi.test_example",
      "Openmpi.test_mpirun",
      "Openmpi.test_opmpi_info",
      "Openmpi.test_version",
      "Mpi.test_mpi_hello"
    ]
  }
]
```