### PR TITLE
Damask fix

### DIFF
--- a/var/spack/repos/builtin/packages/damask-grid/T-init.patch
+++ b/var/spack/repos/builtin/packages/damask-grid/T-init.patch
@@ -1,0 +1,11 @@
+--- damask.orig/src/grid/grid_thermal_spectral.f90	2023-06-17 00:35:03.454061742 +0200
++++ damask/src/grid/grid_thermal_spectral.f90	2023-06-17 00:38:50.641104409 +0200
+@@ -110,7 +110,7 @@
+   T_current = discretization_grid_getInitialCondition('T')
+   T_lastInc = T_current
+   T_stagInc = T_current
+-  dotT_lastInc = 0.0_pReal
++  dotT_lastInc = 0.0_pREAL * T_current
+ 
+ !--------------------------------------------------------------------------------------------------
+ ! initialize solver specific parts of PETSc

--- a/var/spack/repos/builtin/packages/damask-grid/package.py
+++ b/var/spack/repos/builtin/packages/damask-grid/package.py
@@ -40,6 +40,7 @@ class DamaskGrid(CMakePackage):
     depends_on("fftw+mpi")
     depends_on("libfyaml", when="@3.0.0-alpha7:")
 
+    patch("T-init.patch", when="@3.0.0-alpha7")
     patch("long-lines.patch", when="@3.0.0-alpha7")
     patch("CMakeDebugRelease.patch", when="@3.0.0-alpha4")
 

--- a/var/spack/repos/builtin/packages/damask-grid/package.py
+++ b/var/spack/repos/builtin/packages/damask-grid/package.py
@@ -40,7 +40,9 @@ class DamaskGrid(CMakePackage):
     depends_on("fftw+mpi")
     depends_on("libfyaml", when="@3.0.0-alpha7:")
 
+    # proper initialization of temperature to avoid segmentation fault. created by @MarDiehl
     patch("T-init.patch", when="@3.0.0-alpha7")
+    # relax Fortran sourc limit to 132 char to enable PETSc macro expansion. created by @MarDiehl
     patch("long-lines.patch", when="@3.0.0-alpha7")
     patch("CMakeDebugRelease.patch", when="@3.0.0-alpha4")
 

--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -39,6 +39,7 @@ class DamaskMesh(CMakePackage):
     depends_on("hdf5@1.10:+mpi+fortran")
     depends_on("libfyaml", when="@3.0.0-alpha7:")
 
+    patch("long-lines.patch", when="@3.0.0-alpha7")
     patch("CMakeDebugRelease.patch", when="@3.0.0-alpha4")
 
     variant(

--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -39,6 +39,7 @@ class DamaskMesh(CMakePackage):
     depends_on("hdf5@1.10:+mpi+fortran")
     depends_on("libfyaml", when="@3.0.0-alpha7:")
 
+    # relax Fortran sourc limit to 132 char to enable PETSc macro expansion. created by @MarDiehl
     patch("long-lines.patch", when="@3.0.0-alpha7")
     patch("CMakeDebugRelease.patch", when="@3.0.0-alpha4")
 


### PR DESCRIPTION
fixes to current DAMASK alpha release: avoid segmentation fault and enable compilation.