### PR TITLE
Add `spack checksum --verify`, fix `--add`

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -159,7 +159,7 @@ def verify_checksums(pkg, version_hashes, url_dict):
     in the package's instructions.
 
     Args:
-        pkg (package): A package class for a given package in Spack.
+        pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
         version_hashes (dict): A dictionary of the form: version -> checksum.
         url_dict (dict): A dictionary of the form: version -> URL.
 
@@ -204,7 +204,7 @@ def add_versions_to_package(pkg, version_hashes, url_dict):
     editor so they may double check the work of the function.
 
     Args:
-        pkg (package): A package class for a given package in Spack.
+        pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
         version_hashes (dict): A dictionary of the form: version -> checksum.
         url_dict (dict): A dictionary of the form: version -> URL.
 

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -194,6 +194,7 @@ def verify_checksums(pkg, version_hashes):
 
     # Terminate at the end of function to prevent additional output.
     if failed:
+        print()
         tty.die("Invalid checksums found.")
 
     exit(0)

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -214,7 +214,7 @@ def add_versions_to_package(pkg, version_lines):
     filename = spack.repo.path.filename_for_package_name(pkg.name)
 
     version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")
-    version_re = re.compile(r'[\t ]+version\("([^"]+)"[^\)]*\)')
+    version_re = re.compile(r'[\t ]+version\(\s*"([^"]+)"[^\)]*\)')
 
     # Split rendered version lines into tuple of (version, version_line)
     # We reverse sort here to make sure the versions match the version_lines

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -20,7 +20,7 @@ from spack.package_base import deprecated_version, preferred_version
 from spack.util.editor import editor
 from spack.util.format import get_version_lines
 from spack.util.naming import valid_fully_qualified_module_name
-from spack.version import Version, parse_string_components
+from spack.version import Version
 
 description = "checksum available versions of a package"
 section = "packaging"
@@ -161,7 +161,7 @@ def verify_checksums(pkg, version_hashes, url_dict):
     num_total = len(version_hashes)
 
     for version, sha in version_hashes.items():
-        if not version in pkg.versions:
+        if version not in pkg.versions:
             msg = "No previous checksum"
             status = "-"
 
@@ -178,7 +178,7 @@ def verify_checksums(pkg, version_hashes, url_dict):
         results.append("{0:{1}}  {2} {3}".format(str(version), max_len, f"[{status}]", msg))
 
     # Display table of checksum results.
-    tty.msg(f"Found {num_verified} of {num_total}", "", *llnl.util.lang.elide_list(results))
+    tty.msg(f"Found {num_verified} of {num_total}", "", *llnl.util.lang.elide_list(results), "")
 
     # Terminate at the end of function to prevent additional output.
     if failed:
@@ -225,7 +225,7 @@ def add_versions_to_package(pkg, version_hashes, url_dict):
                 parsed_version = Version(contents_version.group(1))
 
                 if parsed_version < new_versions[0][0]:
-                    split_contents[i:i] = [new_versions.pop(0)[1], " #FIX ME", "\n"]
+                    split_contents[i:i] = [new_versions.pop(0)[1], " # FIX ME", "\n"]
 
                 elif parsed_version == new_versions[0][0]:
                     new_versions.pop(0)
@@ -237,4 +237,4 @@ def add_versions_to_package(pkg, version_hashes, url_dict):
     if sys.stdout.isatty():
         editor(filename)
     else:
-        tty.warn("Could not add new versions to {0}.".format(args.package))
+        tty.warn("Could not add new versions to {0}.".format(pkg.name))

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -124,7 +124,9 @@ def checksum(parser, args):
             url_dict[version] = remote_versions[version]
 
     if len(versions) <= 0:
-        url_dict = pkg.fetch_remote_versions()
+        if remote_versions is None:
+            remote_versions = pkg.fetch_remote_versions()
+        url_dict = remote_versions
 
     if not url_dict:
         tty.die("Could not find any remote versions for {0}".format(pkg.name))

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -141,7 +141,7 @@ def checksum(parser, args):
     )
 
     if args.verify:
-        verify_checksums(pkg, version_hashes, url_dict)
+        verify_checksums(pkg, version_hashes)
 
     # convert dict into package.py version statements
     version_lines = get_version_lines(version_hashes, url_dict)
@@ -150,10 +150,10 @@ def checksum(parser, args):
     print()
 
     if args.add_to_package:
-        add_versions_to_package(pkg, version_hashes, url_dict)
+        add_versions_to_package(pkg, version_lines)
 
 
-def verify_checksums(pkg, version_hashes, url_dict):
+def verify_checksums(pkg, version_hashes):
     """
     Verify checksums present in version_hashes against those present
     in the package's instructions.
@@ -161,7 +161,6 @@ def verify_checksums(pkg, version_hashes, url_dict):
     Args:
         pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
         version_hashes (dict): A dictionary of the form: version -> checksum.
-        url_dict (dict): A dictionary of the form: version -> URL.
 
     """
     results = []
@@ -198,15 +197,14 @@ def verify_checksums(pkg, version_hashes, url_dict):
     exit(0)
 
 
-def add_versions_to_package(pkg, version_hashes, url_dict):
+def add_versions_to_package(pkg, version_lines):
     """
     Add checksumed versions to a package's instructions and open a user's
     editor so they may double check the work of the function.
 
     Args:
         pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
-        version_hashes (dict): A dictionary of the form: version -> checksum.
-        url_dict (dict): A dictionary of the form: version -> URL.
+        version_lines (str): A string of rendered version lines.
 
     """
     # Get filename and path for package
@@ -215,13 +213,9 @@ def add_versions_to_package(pkg, version_hashes, url_dict):
     version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")
     version_re = re.compile(r'[\t ]+version\("([^"]+)"[^\)]*\)')
 
-    new_version_lines = get_version_lines(version_hashes, url_dict).split("\n")
-
     # Split rendered version lines into tuple of (version, version_line)
     # We reverse sort here to make sure the versions match the version_lines
-    new_versions = [
-        (v, new_version_lines.pop(0)) for v in sorted(version_hashes.keys(), reverse=True)
-    ]
+    new_versions = [(Version(version_re.match(v).group(1)), v) for v in version_lines.split("\n")]
 
     num_versions_added = 0
 

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -214,15 +214,18 @@ def add_versions_to_package(pkg: Pb, version_lines: str):
     """
     # Get filename and path for package
     filename = spack.repo.path.filename_for_package_name(pkg.name)
+    num_versions_added = 0
 
     version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")
     version_re = re.compile(r'[\t ]+version\(\s*"([^"]+)"[^\)]*\)')
 
     # Split rendered version lines into tuple of (version, version_line)
     # We reverse sort here to make sure the versions match the version_lines
-    new_versions = [(Version(version_re.match(v).group(1)), v) for v in version_lines.split("\n")]
-
-    num_versions_added = 0
+    new_versions = []
+    for ver_line in version_lines.split("\n"):
+        match = version_re.match(ver_line)
+        if match:
+            new_versions.append((Version(match.group(1)), ver_line))
 
     with open(filename, "r+") as f:
         contents = f.read()

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -23,7 +23,7 @@ from spack.util.format import get_version_lines
 from spack.util.naming import valid_fully_qualified_module_name
 from spack.version import Version
 
-Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")  # type: ignore
+Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
 
 description = "checksum available versions of a package"
 section = "packaging"

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -23,7 +23,7 @@ from spack.util.format import get_version_lines
 from spack.util.naming import valid_fully_qualified_module_name
 from spack.version import Version
 
-Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
+Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")  # type: ignore
 
 description = "checksum available versions of a package"
 section = "packaging"

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -6,7 +6,6 @@
 import argparse
 import re
 import sys
-from typing import TypeVar
 
 import llnl.util.lang
 from llnl.util import tty
@@ -17,13 +16,11 @@ import spack.spec
 import spack.stage
 import spack.util.crypto
 from spack.cmd.common import arguments
-from spack.package_base import deprecated_version, preferred_version
+from spack.package_base import PackageBase, deprecated_version, preferred_version
 from spack.util.editor import editor
 from spack.util.format import get_version_lines
 from spack.util.naming import valid_fully_qualified_module_name
 from spack.version import Version
-
-Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
 
 description = "checksum available versions of a package"
 section = "packaging"
@@ -159,7 +156,7 @@ def checksum(parser, args):
         add_versions_to_package(pkg, version_lines)
 
 
-def print_checksum_status(pkg: Pb, version_hashes: dict):
+def print_checksum_status(pkg: PackageBase, version_hashes: dict):
     """
     Verify checksums present in version_hashes against those present
     in the package's instructions.
@@ -202,7 +199,7 @@ def print_checksum_status(pkg: Pb, version_hashes: dict):
         tty.die("Invalid checksums found.")
 
 
-def add_versions_to_package(pkg: Pb, version_lines: str):
+def add_versions_to_package(pkg: PackageBase, version_lines: str):
     """
     Add checksumed versions to a package's instructions and open a user's
     editor so they may double check the work of the function.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -17,6 +17,7 @@ from spack.spec import Spec
 from spack.url import UndetectableNameError, UndetectableVersionError, parse_name, parse_version
 from spack.util.editor import editor
 from spack.util.executable import ProcessError, which
+from spack.util.format import get_version_lines
 from spack.util.naming import mod_to_class, simplify_name, valid_fully_qualified_module_name
 
 description = "create a new package file"
@@ -832,13 +833,15 @@ def get_versions(args, name):
             version = parse_version(args.url)
             url_dict = {version: args.url}
 
-        versions = spack.stage.get_checksums_for_versions(
+        version_hashes = spack.stage.get_checksums_for_versions(
             url_dict,
             name,
             first_stage_function=guesser,
             keep_stage=args.keep_stage,
             batch=(args.batch or len(url_dict) == 1),
         )
+
+        versions = get_version_lines(version_hashes, url_dict)
     else:
         versions = unhashed_versions
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -514,6 +514,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     # These are default values for instance variables.
     #
 
+    # Declare versions dictionary to fix MyPy missing attribute errors.
+    versions: dict
+
     #: By default, packages are not virtual
     #: Virtual packages override this attribute
     virtual = False

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,18 +25,7 @@ import textwrap
 import time
 import traceback
 import warnings
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    no_type_check,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
@@ -438,7 +427,6 @@ class PackageViewMixin:
 Pb = TypeVar("Pb", bound="PackageBase")
 
 
-@no_type_check
 class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     """This is the superclass for all spack packages.
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -514,7 +514,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     # These are default values for instance variables.
     #
 
-    # Declare versions dictionary to fix MyPy missing attribute errors.
+    # Declare versions dictionary as placeholder for values.
+    # This allows analysis tools such as to correctly understand the
+    # class attributes.
     versions: dict
 
     #: By default, packages are not virtual

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,7 +25,7 @@ import textwrap
 import time
 import traceback
 import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, no_type_check
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
@@ -427,6 +427,7 @@ class PackageViewMixin:
 Pb = TypeVar("Pb", bound="PackageBase")
 
 
+@no_type_check
 class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     """This is the superclass for all spack packages.
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,7 +25,18 @@ import textwrap
 import time
 import traceback
 import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, no_type_check
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    no_type_check,
+)
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -515,8 +515,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #
 
     # Declare versions dictionary as placeholder for values.
-    # This allows analysis tools such as to correctly understand the
-    # class attributes.
+    # This allows analysis tools to correctly interpret the class attributes.
     versions: dict
 
     #: By default, packages are not virtual

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -889,7 +889,7 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
             or cookies)
 
     Returns:
-        (str): A multi-line string containing versions and corresponding hashes
+        (dict): A dictionary of the form: version -> checksum
 
     """
     batch = kwargs.get("batch", False)
@@ -929,14 +929,10 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
     urls = [url_dict[v] for v in versions]
 
     tty.debug("Downloading...")
-    version_hashes = []
+    version_hashes = {}
     i = 0
     errors = []
     for url, version in zip(urls, versions):
-        # Wheels should not be expanded during staging
-        expand_arg = ""
-        if url.endswith(".whl") or ".whl#" in url:
-            expand_arg = ", expand=False"
         try:
             if fetch_options:
                 url_or_fs = fs.URLFetchStrategy(url, fetch_options=fetch_options)
@@ -951,9 +947,7 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
                     first_stage_function(stage, url)
 
                 # Checksum the archive and add it to the list
-                version_hashes.append(
-                    (version, spack.util.crypto.checksum(hashlib.sha256, stage.archive_file))
-                )
+                version_hashes[version] = spack.util.crypto.checksum(hashlib.sha256, stage.archive_file)
                 i += 1
         except FailedDownloadError:
             errors.append("Failed to fetch {0}".format(url))
@@ -966,17 +960,12 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
     if not version_hashes:
         tty.die("Could not fetch any versions for {0}".format(name))
 
-    # Generate the version directives to put in a package.py
-    version_lines = "\n".join(
-        ['    version("{0}", sha256="{1}"{2})'.format(v, h, expand_arg) for v, h in version_hashes]
-    )
-
     num_hash = len(version_hashes)
     tty.debug(
         "Checksummed {0} version{1} of {2}:".format(num_hash, "" if num_hash == 1 else "s", name)
     )
 
-    return version_lines
+    return version_hashes
 
 
 class StageError(spack.error.SpackError):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -947,7 +947,9 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
                     first_stage_function(stage, url)
 
                 # Checksum the archive and add it to the list
-                version_hashes[version] = spack.util.crypto.checksum(hashlib.sha256, stage.archive_file)
+                version_hashes[version] = spack.util.crypto.checksum(
+                    hashlib.sha256, stage.archive_file
+                )
                 i += 1
         except FailedDownloadError:
             errors.append("Failed to fetch {0}".format(url))

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -884,7 +884,6 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
         keep_stage (bool): whether to keep staging area when command completes
         batch (bool): whether to ask user how many versions to fetch (false)
             or fetch all versions (true)
-        latest (bool): whether to take the latest version (true) or all (false)
         fetch_options (dict): Options used for the fetcher (such as timeout
             or cookies)
 
@@ -912,7 +911,7 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
     )
     print()
 
-    if batch or latest:
+    if batch:
         archives_to_fetch = len(sorted_versions)
     else:
         archives_to_fetch = tty.get_number(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -896,11 +896,8 @@ def get_checksums_for_versions(url_dict, name, **kwargs):
     fetch_options = kwargs.get("fetch_options", None)
     first_stage_function = kwargs.get("first_stage_function", None)
     keep_stage = kwargs.get("keep_stage", False)
-    latest = kwargs.get("latest", False)
 
     sorted_versions = sorted(url_dict.keys(), reverse=True)
-    if latest:
-        sorted_versions = sorted_versions[:1]
 
     # Find length of longest string in the list for padding
     max_len = max(len(str(v)) for v in sorted_versions)

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -44,6 +44,7 @@ def test_checksum_args(arguments, expected):
         (["--preferred", "preferred-test"], "Found 1 version"),
         (["--add-to-package", "preferred-test"], "Added 0 new versions to"),
         (["--verify", "preferred-test"], "Verified 1 of 1"),
+        (["--verify", "zlib", "1.2.13"], "1.2.13  [-] No previous checksum"),
     ],
 )
 def test_checksum(arguments, expected, mock_packages, mock_clone_repo, mock_stage):

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -119,7 +119,7 @@ def test_checksum_verification_fails(install_mockery, capsys):
     versions = list(pkg.versions.keys())
     version_hashes = {versions[0]: "abadhash", spack.version.Version("0.1"): "123456789"}
     with pytest.raises(SystemExit):
-        spack.cmd.checksum.verify_checksums(pkg, version_hashes)
+        spack.cmd.checksum.print_checksum_status(pkg, version_hashes)
     out = str(capsys.readouterr())
     assert out.count("Correct") == 0
     assert "No previous checksum" in out

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+def get_version_lines(version_hashes_dict, url_dict={}):
+    """
+    Renders out a set of versions like those found in a package's
+    package.py file for a given set of versions and hashes.
+
+    Args:
+        version_hashes_dict (dict): A dictionary of the form: version -> checksum.
+        url_dict (dict): A dictionary of the form: version -> URL.
+
+    Returns:
+        (str): Rendered version lines.
+    """
+    version_lines = []
+
+    for v, h in version_hashes_dict.items():
+        expand_arg = ""
+        url = url_dict[v] if v in url_dict else ""
+
+        # Add expand_arg since wheels should not be expanded during stanging
+        if url.endswith(".whl") or ".whl#" in url:
+            expand_arg = ", expand=False"
+        version_lines.append(f'    version("{v}", sha256="{h}"{expand_arg})')
+
+    return "\n".join(version_lines)

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-def get_version_lines(version_hashes_dict, url_dict={}):
+def get_version_lines(version_hashes_dict: dict, url_dict: dict = None) -> str:
     """
     Renders out a set of versions like those found in a package's
     package.py file for a given set of versions and hashes.

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -22,7 +22,11 @@ def get_version_lines(version_hashes_dict: dict, url_dict: Optional[dict] = None
 
     for v, h in version_hashes_dict.items():
         expand_arg = ""
-        url = url_dict[v] if v in url_dict else ""
+
+        # Extract the url for a version if url_dict is provided.
+        url = ""
+        if url_dict is not None and v in url_dict:
+            url = url_dict[v]
 
         # Add expand_arg since wheels should not be expanded during stanging
         if url.endswith(".whl") or ".whl#" in url:

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from typing import Optional
 
-def get_version_lines(version_hashes_dict: dict, url_dict: dict = None) -> str:
+
+def get_version_lines(version_hashes_dict: dict, url_dict: Optional[dict] = None) -> str:
     """
     Renders out a set of versions like those found in a package's
     package.py file for a given set of versions and hashes.

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -608,7 +608,7 @@ _spack_change() {
 _spack_checksum() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --keep-stage -b --batch -l --latest -p --preferred -a --add-to-package"
+        SPACK_COMPREPLY="-h --help --keep-stage -b --batch -l --latest -p --preferred -a --add-to-package --verify"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -882,7 +882,7 @@ complete -c spack -n '__fish_spack_using_command change' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command change' -s a -l all -d 'change all matching specs (allow changing more than one spec)'
 
 # spack checksum
-set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package
+set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package verify
 complete -c spack -n '__fish_spack_using_command_pos 0 checksum' -f -a '(__fish_spack_packages)'
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 checksum' -f -a '(__fish_spack_package_versions $__fish_spack_argparse_argv[1])'
 complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -f -a help
@@ -892,11 +892,13 @@ complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -d 'don
 complete -c spack -n '__fish_spack_using_command checksum' -s b -l batch -f -a batch
 complete -c spack -n '__fish_spack_using_command checksum' -s b -l batch -d 'don\'t ask which versions to checksum'
 complete -c spack -n '__fish_spack_using_command checksum' -s l -l latest -f -a latest
-complete -c spack -n '__fish_spack_using_command checksum' -s l -l latest -d 'checksum the latest available version only'
+complete -c spack -n '__fish_spack_using_command checksum' -s l -l latest -d 'checksum the latest available version'
 complete -c spack -n '__fish_spack_using_command checksum' -s p -l preferred -f -a preferred
-complete -c spack -n '__fish_spack_using_command checksum' -s p -l preferred -d 'checksum the preferred version only'
+complete -c spack -n '__fish_spack_using_command checksum' -s p -l preferred -d 'checksum the known Spack preferred version'
 complete -c spack -n '__fish_spack_using_command checksum' -s a -l add-to-package -f -a add_to_package
 complete -c spack -n '__fish_spack_using_command checksum' -s a -l add-to-package -d 'add new versions to package'
+complete -c spack -n '__fish_spack_using_command checksum' -l verify -f -a verify
+complete -c spack -n '__fish_spack_using_command checksum' -l verify -d 'verify known package checksums'
 
 # spack ci
 set -g __fish_spack_optspecs_spack_ci h/help


### PR DESCRIPTION
This PR add a `--verify` flag to `spack checksum` that verifies checksums present in a package.py file against those found on the web. This lays the foundation for us to add a PR test that will automatically check new versions have valid checksums.

```
$ spack checksum --verify go 1.20.5 1.20.4 1.20.3

==> Found 3 versions of go:

  1.20.5  https://go.dev/dl/go1.20.5.src.tar.gz
  1.20.4  https://go.dev/dl/go1.20.4.src.tar.gz
  1.20.3  https://go.dev/dl/go1.20.3.src.tar.gz

==> Fetching https://go.dev/dl/go1.20.5.src.tar.gz
==> Fetching https://go.dev/dl/go1.20.4.src.tar.gz
==> Fetching https://go.dev/dl/go1.20.3.src.tar.gz
==> Verified 1 of 3

  1.20.5  [-] No previous checksum
  1.20.4  [=] Correct
  1.20.3  [x] e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a

==> Error: Invalid checksums found.
```

Since I was already mucking about in `spack checksum` I also decided to rewrite `--add` to have it better integrate new versions alongside existing versions.