### PR TITLE
py-numpy: add v1.25.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -14,10 +14,12 @@ class PyCython(PythonPackage):
 
     version("3.0.0a9", sha256="23931c45877432097cef9de2db2dc66322cbc4fc3ebbb42c476bb2c768cecff0")
     version(
-        "0.29.33",
-        sha256="5040764c4a4d2ce964a395da24f0d1ae58144995dab92c6b96f44c3f4d72286a",
+        "0.29.35",
+        sha256="6e381fa0bf08b3c26ec2f616b19ae852c06f5750f4290118bf986b6f85c8c527",
         preferred=True,
     )
+    version("0.29.34", sha256="1909688f5d7b521a60c396d20bba9e47a1b2d2784bfb085401e1e1e7d29a29a8")
+    version("0.29.33", sha256="5040764c4a4d2ce964a395da24f0d1ae58144995dab92c6b96f44c3f4d72286a")
     version("0.29.32", sha256="8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7")
     version("0.29.30", sha256="2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3")
     version("0.29.24", sha256="cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443")

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -23,6 +23,7 @@ class PyNumpy(PythonPackage):
     maintainers("adamjstewart", "rgommers")
 
     version("main", branch="main")
+    version("1.25.0", sha256="f1accae9a28dc3cda46a91de86acf69de0d1b5f4edd44a9b0c3ceb8036dfff19")
     version("1.24.3", sha256="ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155")
     version("1.24.2", sha256="003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22")
     version("1.24.1", sha256="2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2")
@@ -87,7 +88,8 @@ class PyNumpy(PythonPackage):
     variant("lapack", default=True, description="Build with LAPACK support")
 
     # Based on wheel availability on PyPI
-    depends_on("python@3.8:3.11", when="@1.23.2:", type=("build", "link", "run"))
+    depends_on("python@3.9:3.11", when="@1.25:", type=("build", "link", "run"))
+    depends_on("python@3.8:3.11", when="@1.23.2:1.24", type=("build", "link", "run"))
     depends_on("python@3.8:3.10", when="@1.22:1.23.1", type=("build", "link", "run"))
     depends_on("python@:3.10", when="@1.21.2:1.21", type=("build", "link", "run"))
     depends_on("python@:3.9", when="@1.19.3:1.21.1", type=("build", "link", "run"))
@@ -98,6 +100,7 @@ class PyNumpy(PythonPackage):
     depends_on("py-setuptools@:63", type=("build", "run"))
     depends_on("py-setuptools@:59", when="@:1.22.1", type=("build", "run"))
     # Check pyproject.toml for updates to the required cython version
+    depends_on("py-cython@0.29.34:2", when="@1.25:", type="build")
     depends_on("py-cython@0.29.13:2", when="@1.18.0:", type="build")
     depends_on("py-cython@0.29.14:2", when="@1.18.1:", type="build")
     depends_on("py-cython@0.29.21:2", when="@1.19.1:", type="build")


### PR DESCRIPTION
https://github.com/numpy/numpy/releases/tag/v1.25.0

It looks like 1.26 will switch to meson and 2.0 will follow that. Excited to see what changes in 2.0!