### PR TITLE
gsl: set GSL_ROOT_DIR

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -56,5 +56,7 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
 
         return configure_args
 
+    # cmake looks for GSL_ROOT_DIR to find GSL so this helps pick the spack one
+    # when there are multiple installations (e.g. a system one and a spack one)
     def setup_run_environment(self, env):
         env.set("GSL_ROOT_DIR", self.prefix)

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -56,7 +56,7 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
 
         return configure_args
 
-    # cmake looks for GSL_ROOT_DIR to find GSL so this helps pick the spack one
-    # when there are multiple installations (e.g. a system one and a spack one)
     def setup_run_environment(self, env):
+        # cmake looks for GSL_ROOT_DIR to find GSL so this helps pick the spack one
+        # when there are multiple installations (e.g. a system one and a spack one)
         env.set("GSL_ROOT_DIR", self.prefix)

--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -55,3 +55,6 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
             configure_args.append("CBLAS_LIBS=%s" % self.spec["blas"].libs.ld_flags)
 
         return configure_args
+
+    def setup_run_environment(self, env):
+        env.set("GSL_ROOT_DIR", self.prefix)


### PR DESCRIPTION
Based on https://cmake.org/cmake/help/latest/module/FindGSL.html#hints if
$GSL_ROOT_DIR is set then cmake will look there. This change helps in case there
are multiple installations (the system one and another one from spack) in case
we want to compile something without using spack, since otherwise the system one
would take precedence.