### PR TITLE
Add verbatim attribute to env.set command

### DIFF
--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -198,6 +198,15 @@ class TestLmod(object):
         assert len([x for x in content if 'setenv("MANPATH", "/path/to/man")' in x]) == 1
         assert len([x for x in content if 'append_path("MANPATH", "", ":")' in x]) == 0
 
+    @pytest.mark.regression("29578")
+    def test_setenv_raw_value(self, modulefile_content, module_configuration):
+        """Tests that we can set environment variable value without formatting it."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content("module-setenv-raw")
+
+        assert len([x for x in content if 'setenv("FOO", "{{name}}, {name}, {{}}, {}")' in x]) == 1
+
     def test_help_message(self, modulefile_content, module_configuration):
         """Tests the generation of module help message."""
 

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -182,6 +182,15 @@ class TestTcl(object):
         assert len([x for x in content if 'setenv MANPATH "/path/to/man"' in x]) == 1
         assert len([x for x in content if 'append-path --delim ":" MANPATH ""' in x]) == 0
 
+    @pytest.mark.regression("29578")
+    def test_setenv_raw_value(self, modulefile_content, module_configuration):
+        """Tests that we can set environment variable value without formatting it."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content("module-setenv-raw")
+
+        assert len([x for x in content if 'setenv FOO "{{name}}, {name}, {{}}, {}"' in x]) == 1
+
     def test_help_message(self, modulefile_content, module_configuration):
         """Tests the generation of module help message."""
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -351,13 +351,20 @@ class NameValueModifier:
 
 
 class SetEnv(NameValueModifier):
-    __slots__ = ("force",)
+    __slots__ = ("force", "raw")
 
     def __init__(
-        self, name: str, value: str, *, trace: Optional[Trace] = None, force: bool = False
+        self,
+        name: str,
+        value: str,
+        *,
+        trace: Optional[Trace] = None,
+        force: bool = False,
+        raw: bool = False,
     ):
         super().__init__(name, value, trace=trace)
         self.force = force
+        self.raw = raw
 
     def execute(self, env: MutableMapping[str, str]):
         tty.debug(f"SetEnv: {self.name}={str(self.value)}", level=3)
@@ -501,15 +508,16 @@ class EnvironmentModifications:
         return Trace(filename=filename, lineno=lineno, context=current_context)
 
     @system_env_normalize
-    def set(self, name: str, value: str, *, force: bool = False):
+    def set(self, name: str, value: str, *, force: bool = False, raw: bool = False):
         """Stores a request to set an environment variable.
 
         Args:
             name: name of the environment variable
             value: value of the environment variable
             force: if True, audit will not consider this modification a warning
+            raw: if True, format of value string is skipped
         """
-        item = SetEnv(name, value, trace=self._trace(), force=force)
+        item = SetEnv(name, value, trace=self._trace(), force=force, raw=raw)
         self.env_modifications.append(item)
 
     @system_env_normalize

--- a/var/spack/repos/builtin.mock/packages/module-setenv-raw/package.py
+++ b/var/spack/repos/builtin.mock/packages/module-setenv-raw/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ModuleSetenvRaw(Package):
+    homepage = "http://www.llnl.gov"
+    url = "http://www.llnl.gov/module-setenv-raw-1.0.tar.gz"
+
+    version("1.0", "0123456789abcdef0123456789abcdef")
+
+    def setup_run_environment(self, env):
+        env.set("FOO", "{{name}}, {name}, {{}}, {}", raw=True)


### PR DESCRIPTION
Update `env.set` command and underlying `SetEnv` object to add the `verbatim` boolean attribute. `verbatim` is optional and set to False by default. When set to True, value format is skipped for object when generating environment modifications.

With this change it is now possible to define environment variable whose value contains variable reference syntax (like `{foo}` or `{}`) that should be set as-is.

Fixes #29578