### PR TITLE
tetranscripts: new package @2.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/tetranscripts/package.py
+++ b/var/spack/repos/builtin/packages/tetranscripts/package.py
@@ -21,6 +21,3 @@ class Tetranscripts(PythonPackage):
     # external dependencies
     depends_on("r@2.15:", type="run")
     depends_on("r-deseq2@1.10:", type="run")
-
-    def instal(self, spec, prefix):
-        install_tree("bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/tetranscripts/package.py
+++ b/var/spack/repos/builtin/packages/tetranscripts/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Tetranscripts(PythonPackage):
+    """TEtranscripts: Tools for estimating differential enrichment of Transposable Elements
+    and other highly repetitive regions."""
+
+    homepage = "https://hammelllab.labsites.cshl.edu/software/#TEtranscripts"
+    pypi = "TEtranscripts/TEtranscripts-2.2.3.tar.gz"
+
+    version("2.2.3", sha256="e53577e8e73e41c6495fb819977e3e537bbeac7b2fa1635029201a37ee0bf7b8")
+
+    # python dependencies
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pysam@0.9:", type=("build", "run"))
+    # external dependencies
+    depends_on("r@2.15:", type="run")
+    depends_on("r-deseq2@1.10:", type="run")
+
+    def instal(self, spec, prefix):
+        install_tree("bin", prefix.bin)


### PR DESCRIPTION
Adding the `tetranscripts` package. This is a `PythonPackage` but it's a CLI tool rather than a library, so I've removed the `py-` prefix.