### PR TITLE
opencascade: fix typo in `True`

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -182,7 +182,7 @@ class Opencascade(CMakePackage):
         args.append("-DBUILD_DOC_Overview=OFF")
 
         # Always build the foundation classes
-        args.append(self.define("BUILD_MODULE_FoundationClasses", true))
+        args.append(self.define("BUILD_MODULE_FoundationClasses", True))
         # Specify which modules to build
         for module in [
             "ApplicationFramework",


### PR DESCRIPTION
Not sure why flake8 didn't catch this as an undefined name, e.g. https://www.flake8rules.com/rules/F823.html.