### PR TITLE
ncbi-rmblastn: switching urls from ftp to https

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -10,7 +10,9 @@ class NcbiRmblastn(AutotoolsPackage):
     """RMBlast search engine for NCBI"""
 
     homepage = "https://www.repeatmasker.org/rmblast/"
-    url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-src.tar.gz"
+    url = (
+        "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-src.tar.gz"
+    )
 
     version("2.14.0", sha256="bf477f1b0c3b82f0b7a7094bf003a9a83e37e3b0716c1df799060c4feab17500")
     version("2.11.0", sha256="d88e1858ae7ce553545a795a2120e657a799a6d334f2a07ef0330cc3e74e1954")
@@ -26,7 +28,7 @@ class NcbiRmblastn(AutotoolsPackage):
     # The patch is downloaded and unzipped in the ncbi-rmblastn Spack package
     # directory to make it available for the patch directive.
     patch(
-        "http://www.repeatmasker.org/rmblast/isb-2.14.0+-rmblast.patch.gz",
+        "https://www.repeatmasker.org/rmblast/isb-2.14.0+-rmblast.patch.gz",
         sha256="cd083f256551c6d6021897a1b08e023976e82c59576787d4885f57d36f9e6fdf",
         archive_sha256="9de0e67467a4cffdde0c5f67e3658fb52ed313e4550f9a36a251bddb2ba33f49",
         when="@2.14.0",
@@ -53,7 +55,9 @@ class NcbiRmblastn(AutotoolsPackage):
     configure_directory = "c++"
 
     def url_for_version(self, version):
-        url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{0}/ncbi-blast-{1}+-src.tar.gz"
+        url = (
+            "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{0}/ncbi-blast-{1}+-src.tar.gz"
+        )
         return url.format(version, version)
 
     def configure_args(self):


### PR DESCRIPTION
I became unable to install this because some firewall rules changed on my buildbox preventing ftp.

They seem to mirror everything on https, which gains transport encryption I guess.