### PR TITLE
Add --fail-fast option for generating build caches

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -342,7 +342,7 @@ def push_fn(args):
         if len(specs) == 1:
             tty.info("The spec is already in the buildcache. Use --force to overwrite it.")
         elif len(skipped) == len(specs):
-            tty.info("All specs are already in the buildcache. Use --force to overwite them.")
+            tty.info("All specs are already in the buildcache. Use --force to overwrite them.")
         else:
             tty.info(
                 "The following {} specs were skipped as they already exist in the buildcache:\n"
@@ -353,10 +353,16 @@ def push_fn(args):
             )
 
     if failed:
-        tty.info(
-            "The following {} specs were skipped due to errors during the buildcache creation:\n"
-            "    {}".format(len(failed), ", ".join(elide_list(failed, 5)))
-        )
+        if len(failed) == 1:
+            tty.info(
+                "The following spec was skipped due to errors during the buildcache creation:\n"
+                "    {}".format(", ".join(elide_list(failed, 5)))
+            )
+        else:
+            tty.info(
+                "The following {} specs were skipped due to errors during the buildcache creation:\n"
+                "    {}".format(len(failed), ", ".join(elide_list(failed, 5)))
+            )
 
 
 def install_fn(args):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -335,7 +335,7 @@ def push_fn(args):
         # Catch any other exception unless the fail fast option is set
         except Exception as e:
             if args.fail_fast:
-                raise(e)
+                raise (e)
             failed.append(format_spec(spec))
 
     if skipped:
@@ -355,10 +355,9 @@ def push_fn(args):
     if failed:
         tty.info(
             "The following {} specs were skipped due to errors during the buildcache creation:\n"
-            "    {}".format(
-                len(failed), ", ".join(elide_list(failed, 5))
-            )
+            "    {}".format(len(failed), ", ".join(elide_list(failed, 5)))
         )
+
 
 def install_fn(args):
     """install from a binary package"""

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -355,12 +355,12 @@ def push_fn(args):
     if failed:
         if len(failed) == 1:
             tty.info(
-                "The following spec was skipped due to errors during the buildcache creation:\n"
+                "The following spec was skipped due to errors in the buildcache creation:\n"
                 "    {}".format(", ".join(elide_list(failed, 5)))
             )
         else:
             tty.info(
-                "The following {} specs were skipped due to errors during the buildcache creation:\n"
+                "The following {} specs were skipped due to errors in the buildcache creation:\n"
                 "    {}".format(len(failed), ", ".join(elide_list(failed, 5)))
             )
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -337,7 +337,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize config containerize create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve solve-benchmark spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize config containerize create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1707,33 +1707,6 @@ _spack_solve() {
         SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json -c --cover -t --types --timers --stats -U --fresh --reuse --reuse-deps"
     else
         _all_packages
-    fi
-}
-
-_spack_solve_benchmark() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help"
-    else
-        SPACK_COMPREPLY="run plot"
-    fi
-}
-
-_spack_solve_benchmark_run() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help -r --repetitions -o --output --reuse --configs -n --nprocess"
-    else
-        _all_packages
-    fi
-}
-
-_spack_solve_benchmark_plot() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --cdf --scatter --histogram -o --output"
-    else
-        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -337,7 +337,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize config containerize create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize config containerize create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve solve-benchmark spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -498,7 +498,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast"
     else
         _mirrors
     fi
@@ -507,7 +507,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast"
     else
         _mirrors
     fi
@@ -1707,6 +1707,33 @@ _spack_solve() {
         SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json -c --cover -t --types --timers --stats -U --fresh --reuse --reuse-deps"
     else
         _all_packages
+    fi
+}
+
+_spack_solve_benchmark() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY="run plot"
+    fi
+}
+
+_spack_solve_benchmark_run() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -r --repetitions -o --output --reuse --configs -n --nprocess"
+    else
+        _all_packages
+    fi
+}
+
+_spack_solve_benchmark_plot() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --cdf --scatter --histogram -o --output"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -410,7 +410,6 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a repo -d 'manage p
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a resource -d 'list downloadable resources (tarballs, repos, patches, etc.)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a restage -d 'revert checked out package source code'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a solve -d 'concretize a specs using an ASP solver'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a solve-benchmark -d 'benchmark concretization speed'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a spec -d 'show what would be installed, given a spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a stage -d 'expand downloaded archive in preparation for install'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a style -d 'runs source code style checks on spack'
@@ -705,7 +704,7 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l spec-file -
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -d 'select the buildcache mode. The default is to build a cache for the package along with all its dependencies. Alternatively, one can decide to build a cache for only the package or only the dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -f -a fail_fast
-complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -d 'stop creating build caches if any build fails (default is best effort)'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -d 'stop pushing on first failure (default is best effort)'
 
 # spack buildcache create
 set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast
@@ -727,7 +726,7 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l spec-file
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -d 'select the buildcache mode. The default is to build a cache for the package along with all its dependencies. Alternatively, one can decide to build a cache for only the package or only the dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -f -a fail_fast
-complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -d 'stop creating build caches if any build fails (default is best effort)'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -d 'stop pushing on first failure (default is best effort)'
 
 # spack buildcache install
 set -g __fish_spack_optspecs_spack_buildcache_install h/help f/force m/multiple u/unsigned o/otherarch
@@ -2575,43 +2574,6 @@ complete -c spack -n '__fish_spack_using_command solve' -l reuse -f -a concretiz
 complete -c spack -n '__fish_spack_using_command solve' -l reuse -d 'reuse installed packages/buildcaches when possible'
 complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -d 'reuse installed dependencies only'
-
-# spack solve-benchmark
-set -g __fish_spack_optspecs_spack_solve_benchmark h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 solve-benchmark' -f -a run -d 'run benchmarks and produce a CSV file of timing results'
-complete -c spack -n '__fish_spack_using_command_pos 0 solve-benchmark' -f -a plot -d 'plot results recorded in a CSV file'
-complete -c spack -n '__fish_spack_using_command solve-benchmark' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command solve-benchmark' -s h -l help -d 'show this help message and exit'
-
-# spack solve-benchmark run
-set -g __fish_spack_optspecs_spack_solve_benchmark_run h/help r/repetitions= o/output= reuse configs= n/nprocess=
-
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s r -l repetitions -r -f -a repetitions
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s r -l repetitions -r -d 'number of repetitions for each spec'
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s o -l output -r -f -a output
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s o -l output -r -d 'CSV output file'
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l reuse -f -a reuse
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l reuse -d 'maximum reuse of buildcaches and installations'
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l configs -r -f -a configs
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l configs -r -d 'comma separated clingo configurations'
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s n -l nprocess -r -f -a nprocess
-complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s n -l nprocess -r -d 'number of processes to use to produce the results'
-
-# spack solve-benchmark plot
-set -g __fish_spack_optspecs_spack_solve_benchmark_plot h/help cdf scatter histogram o/output=
-
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l cdf -f -a cdf
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l cdf -d 'CDF plot (number of packages vs. execution time)'
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l scatter -f -a scatter
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l scatter -d 'scatter plot (execution time vs. possible dependencies)'
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l histogram -f -a histogram
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l histogram -d 'histogram plot (execution time vs. number of packages)'
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s o -l output -r -f -a output
-complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s o -l output -r -d 'output image file'
 
 # spack spec
 set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse reuse-deps

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -410,6 +410,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a repo -d 'manage p
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a resource -d 'list downloadable resources (tarballs, repos, patches, etc.)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a restage -d 'revert checked out package source code'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a solve -d 'concretize a specs using an ASP solver'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a solve-benchmark -d 'benchmark concretization speed'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a spec -d 'show what would be installed, given a spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a stage -d 'expand downloaded archive in preparation for install'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a style -d 'runs source code style checks on spack'
@@ -685,7 +686,7 @@ complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache push
-set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only=
+set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache push' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -d 'show this help message and exit'
@@ -703,9 +704,11 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l spec-file -
 complete -c spack -n '__fish_spack_using_command buildcache push' -l spec-file -r -d 'create buildcache entry for spec from json or yaml file'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -d 'select the buildcache mode. The default is to build a cache for the package along with all its dependencies. Alternatively, one can decide to build a cache for only the package or only the dependencies'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -f -a fail_fast
+complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -d 'stop creating build caches if any build fails (default is best effort)'
 
 # spack buildcache create
-set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only=
+set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -d 'show this help message and exit'
@@ -723,6 +726,8 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l spec-file
 complete -c spack -n '__fish_spack_using_command buildcache create' -l spec-file -r -d 'create buildcache entry for spec from json or yaml file'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -f -a 'package dependencies'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -d 'select the buildcache mode. The default is to build a cache for the package along with all its dependencies. Alternatively, one can decide to build a cache for only the package or only the dependencies'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -f -a fail_fast
+complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -d 'stop creating build caches if any build fails (default is best effort)'
 
 # spack buildcache install
 set -g __fish_spack_optspecs_spack_buildcache_install h/help f/force m/multiple u/unsigned o/otherarch
@@ -2570,6 +2575,43 @@ complete -c spack -n '__fish_spack_using_command solve' -l reuse -f -a concretiz
 complete -c spack -n '__fish_spack_using_command solve' -l reuse -d 'reuse installed packages/buildcaches when possible'
 complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command solve' -l reuse-deps -d 'reuse installed dependencies only'
+
+# spack solve-benchmark
+set -g __fish_spack_optspecs_spack_solve_benchmark h/help
+complete -c spack -n '__fish_spack_using_command_pos 0 solve-benchmark' -f -a run -d 'run benchmarks and produce a CSV file of timing results'
+complete -c spack -n '__fish_spack_using_command_pos 0 solve-benchmark' -f -a plot -d 'plot results recorded in a CSV file'
+complete -c spack -n '__fish_spack_using_command solve-benchmark' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command solve-benchmark' -s h -l help -d 'show this help message and exit'
+
+# spack solve-benchmark run
+set -g __fish_spack_optspecs_spack_solve_benchmark_run h/help r/repetitions= o/output= reuse configs= n/nprocess=
+
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s r -l repetitions -r -f -a repetitions
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s r -l repetitions -r -d 'number of repetitions for each spec'
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s o -l output -r -f -a output
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s o -l output -r -d 'CSV output file'
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l reuse -f -a reuse
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l reuse -d 'maximum reuse of buildcaches and installations'
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l configs -r -f -a configs
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -l configs -r -d 'comma separated clingo configurations'
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s n -l nprocess -r -f -a nprocess
+complete -c spack -n '__fish_spack_using_command solve-benchmark run' -s n -l nprocess -r -d 'number of processes to use to produce the results'
+
+# spack solve-benchmark plot
+set -g __fish_spack_optspecs_spack_solve_benchmark_plot h/help cdf scatter histogram o/output=
+
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l cdf -f -a cdf
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l cdf -d 'CDF plot (number of packages vs. execution time)'
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l scatter -f -a scatter
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l scatter -d 'scatter plot (execution time vs. possible dependencies)'
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l histogram -f -a histogram
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -l histogram -d 'histogram plot (execution time vs. number of packages)'
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s o -l output -r -f -a output
+complete -c spack -n '__fish_spack_using_command solve-benchmark plot' -s o -l output -r -d 'output image file'
 
 # spack spec
 set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse reuse-deps


### PR DESCRIPTION
## Description

Add `--fail-fast` option for generating build caches to `lib/spack/spack/cmd/buildcache.py`. This implementation follows a suggestion made by @haampie in https://github.com/spack/spack/pull/35601 (comments https://github.com/spack/spack/pull/35601#issuecomment-1472365313 and https://github.com/spack/spack/pull/35601#issuecomment-1473910973).

The default behavior is the same as for `spack install`, which means `spack buildcache create` will make best efforts and ignore build cache creation failures (but report them at the end).