### PR TITLE
MSVC: detection from registry

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -269,7 +269,7 @@ class WindowsCompilerExternalPaths:
 
         At the moment simply returns location of VS install paths from VSWhere
         But should be extended to include more information as relevant"""
-        return list(winOs.WindowsOs.vs_install_paths)
+        return list(winOs.WindowsOs().vs_install_paths)
 
     @staticmethod
     def find_windows_compiler_cmake_paths() -> List[str]:

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import platform
 import subprocess
-import sys
 
 from spack.error import SpackError
 from spack.util import windows_registry as winreg
@@ -34,71 +33,6 @@ class WindowsOs(OperatingSystem):
     10.
     """
 
-    # First Strategy: Find MSVC directories using vswhere
-    _compiler_search_paths = []
-    comp_search_paths = []
-    vs_install_paths = []
-    root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
-    if root:
-        try:
-            extra_args = {"encoding": "mbcs", "errors": "strict"}
-            paths = subprocess.check_output(  # type: ignore[call-overload] # novermin
-                [
-                    os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
-                    "-prerelease",
-                    "-requires",
-                    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                    "-property",
-                    "installationPath",
-                    "-products",
-                    "*",
-                ],
-                **extra_args,
-            ).strip()
-            vs_install_paths = paths.split("\n")
-            msvc_paths = [os.path.join(path, "VC", "Tools", "MSVC") for path in vs_install_paths]
-            for p in msvc_paths:
-                comp_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
-            if os.getenv("ONEAPI_ROOT"):
-                comp_search_paths.extend(
-                    glob.glob(
-                        os.path.join(
-                            str(os.getenv("ONEAPI_ROOT")), "compiler", "*", "windows", "bin"
-                        )
-                    )
-                )
-        except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
-            pass
-    _compiler_search_paths.extend(comp_search_paths)
-    if not _compiler_search_paths and sys.platform == "win32":
-        # Second strategy: Find MSVC via the registry
-        msft = winreg.WindowsRegistryView(
-            "SOFTWARE\\WOW6432Node\\Microsoft", winreg.HKEY.HKEY_LOCAL_MACHINE
-        )
-        vs_entries = msft.find_subkeys(r"VisualStudio_.*")
-        vs_paths = []
-
-        def clean_vs_path(path):
-            path = path.split(",")[0].lstrip("@")
-            return str(pathlib.Path(path).parent / "..\\..")
-
-        for entry in vs_entries:
-            try:
-                val = entry.get_subkey("Capabilities").get_value("ApplicationDescription").value
-                vs_paths.append(clean_vs_path(val))
-            except FileNotFoundError as e:
-                if hasattr(e, "winerror"):
-                    if e.winerror == 2:
-                        pass
-                    else:
-                        raise
-                else:
-                    raise
-
-        _compiler_search_paths.extend(vs_paths)
-    if _compiler_search_paths:
-        compiler_search_paths = _compiler_search_paths
-
     def __init__(self):
         plat_ver = windows_version()
         if plat_ver < Version("10"):
@@ -107,3 +41,74 @@ class WindowsOs(OperatingSystem):
 
     def __str__(self):
         return self.name
+
+    @property
+    def compiler_search_paths(self):
+        # First Strategy: Find MSVC directories using vswhere
+        _compiler_search_paths = []
+        vs_install_paths = []
+        root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
+        if root:
+            try:
+                extra_args = {"encoding": "mbcs", "errors": "strict"}
+                paths = subprocess.check_output(  # type: ignore[call-overload] # novermin
+                    [
+                        os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
+                        "-prerelease",
+                        "-requires",
+                        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                        "-property",
+                        "installationPath",
+                        "-products",
+                        "*",
+                    ],
+                    **extra_args,
+                ).strip()
+                vs_install_paths = paths.split("\n")
+                msvc_paths = [
+                    os.path.join(path, "VC", "Tools", "MSVC") for path in vs_install_paths
+                ]
+                for p in msvc_paths:
+                    _compiler_search_paths.extend(
+                        glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64"))
+                    )
+                if os.getenv("ONEAPI_ROOT"):
+                    _compiler_search_paths.extend(
+                        glob.glob(
+                            os.path.join(
+                                str(os.getenv("ONEAPI_ROOT")), "compiler", "*", "windows", "bin"
+                            )
+                        )
+                    )
+            except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
+                pass
+        _compiler_search_paths.extend(_compiler_search_paths)
+        if not _compiler_search_paths:
+            # Second strategy: Find MSVC via the registry
+            msft = winreg.WindowsRegistryView(
+                "SOFTWARE\\WOW6432Node\\Microsoft", winreg.HKEY.HKEY_LOCAL_MACHINE
+            )
+            vs_entries = msft.find_subkeys(r"VisualStudio_.*")
+            vs_paths = []
+
+            def clean_vs_path(path):
+                path = path.split(",")[0].lstrip("@")
+                return str(pathlib.Path(path).parent / "..\\..")
+
+            for entry in vs_entries:
+                try:
+                    val = (
+                        entry.get_subkey("Capabilities").get_value("ApplicationDescription").value
+                    )
+                    vs_paths.append(clean_vs_path(val))
+                except FileNotFoundError as e:
+                    if hasattr(e, "winerror"):
+                        if e.winerror == 2:
+                            pass
+                        else:
+                            raise
+                    else:
+                        raise
+
+            _compiler_search_paths.extend(vs_paths)
+        return _compiler_search_paths

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -69,24 +69,18 @@ class WindowsOs(OperatingSystem):
 
     @property
     def msvc_paths(self):
-        return [
-                    os.path.join(path, "VC", "Tools", "MSVC") for path in self.vs_install_paths
-                ]
+        return [os.path.join(path, "VC", "Tools", "MSVC") for path in self.vs_install_paths]
 
     @property
     def compiler_search_paths(self):
         # First Strategy: Find MSVC directories using vswhere
         _compiler_search_paths = []
         for p in self.msvc_paths:
-            _compiler_search_paths.extend(
-                glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64"))
-            )
+            _compiler_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
         if os.getenv("ONEAPI_ROOT"):
             _compiler_search_paths.extend(
                 glob.glob(
-                    os.path.join(
-                        str(os.getenv("ONEAPI_ROOT")), "compiler", "*", "windows", "bin"
-                    )
+                    os.path.join(str(os.getenv("ONEAPI_ROOT")), "compiler", "*", "windows", "bin")
                 )
             )
         if not _compiler_search_paths:

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -96,9 +96,7 @@ class WindowsOs(OperatingSystem):
 
         for entry in vs_entries:
             try:
-                val = (
-                    entry.get_subkey("Capabilities").get_value("ApplicationDescription").value
-                )
+                val = entry.get_subkey("Capabilities").get_value("ApplicationDescription").value
                 vs_paths.append(clean_vs_path(val))
             except FileNotFoundError as e:
                 if hasattr(e, "winerror"):

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -10,8 +10,9 @@ import platform
 import subprocess
 
 from spack.error import SpackError
-from spack.version import Version
 from spack.util import windows_registry as winreg
+from spack.version import Version
+
 from ._operating_system import OperatingSystem
 
 
@@ -69,12 +70,16 @@ class WindowsOs(OperatingSystem):
             pass
     _compiler_search_paths.extend(comp_search_paths)
     # Second strategy: Find MSVC via the registry
-    msft = winreg.WindowsRegistryView("SOFTWARE\\WOW6432Node\\Microsoft", winreg.HKEY.HKEY_LOCAL_MACHINE)
+    msft = winreg.WindowsRegistryView(
+        "SOFTWARE\\WOW6432Node\\Microsoft", winreg.HKEY.HKEY_LOCAL_MACHINE
+    )
     vs_entries = msft.find_subkeys(r"VisualStudio_.*")
     vs_paths = []
+
     def clean_vs_path(path):
         path = path.split(",")[0].lstrip("@")
         return str(pathlib.Path(path).parent / "..\\..")
+
     for entry in vs_entries:
         try:
             val = entry.get_subkey("Capabilities").get_value("ApplicationDescription").value

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -8,8 +8,8 @@ Utility module for dealing with Windows Registry.
 """
 
 import os
-import sys
 import re
+import sys
 from contextlib import contextmanager
 
 from llnl.util import tty
@@ -292,7 +292,11 @@ class WindowsRegistryView:
             ret = self.get_matching_subkeys(subkey_name) if regex else self.get_subkey(subkey_name)
             return ret[0] if ret else None
         else:
-            condition = lambda x: re.match(subkey_name, x.name) if regex else lambda x: x.name == subkey_name
+            condition = (
+                lambda x: re.match(subkey_name, x.name)
+                if regex
+                else lambda x: x.name == subkey_name
+            )
             return self._traverse_subkeys(condition)
 
     def find_subkeys(self, subkey_name, recursive=True):

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -287,7 +287,8 @@ class WindowsRegistryView:
         Args:
             direct_subkey (str): string representing subkey to be searched for.
                                  Cannot be provided alongside `search_key`.
-            search_key (str): regex string represeting a subkey name structure to be matched against.
+            search_key (str): regex string represeting a subkey name structure
+                              to be matched against.
                               Cannot be provided alongside `direct_subkey`
             collect_found (bool): No-op if `direct_subkey` is specified
         Return:

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -339,7 +339,7 @@ class WindowsRegistryView:
 
         For more details, see the WindowsRegistryView._find_subkey_s method docstring
         """
-        kwargs = {"collect_all_matchin": True}
+        kwargs = {"collect_all_matching": True}
         return self._find_subkey_s(
             WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), **kwargs
         )

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -244,7 +244,10 @@ class WindowsRegistryView:
             return self.reg.subkeys
 
     def get_matching_subkeys(self, subkey_name):
-        """Returns all subkeys regex matching subkey name"""
+        """Returns all subkeys regex matching subkey name
+
+        Note: this method obtains only direct subkeys of the given key and does not
+        desced to transtitve subkeys. For this behavior, see `find_matching_subkeys`"""
         self._regex_match_subkeys(subkey_name)
 
     def get_values(self):
@@ -280,22 +283,20 @@ class WindowsRegistryView:
                 queue.extend(key.subkeys)
             return collection if collection else None
 
-    def _find_subkey_s(self, search_key, collect_found=False):
+    def _find_subkey_s(self, search_key, collect_all_matching=False):
         """Retrieve one or more keys regex matching `search_key`.
         One key will be returned unless `collect_all_matching` is enabled,
         in which case call matches are returned.
 
         Args:
-            direct_subkey (str): string representing exact subkey to retrieve.
-                                 Cannot be provided alongside `search_key`.
             search_key (str): regex string represeting a subkey name structure
                               to be matched against.
                               Cannot be provided alongside `direct_subkey`
-            collect_found (bool): No-op if `direct_subkey` is specified
+            collect_all_matching (bool): No-op if `direct_subkey` is specified
         Return:
             the desired subkey as a RegistryKey object, or none
         """
-        return self._traverse_subkeys(search_key, collect_all_matching=collect_found)
+        return self._traverse_subkeys(search_key, collect_all_matching=collect_all_matching)
 
     def find_subkey(self, subkey_name):
         """Perform a BFS of subkeys until desired key is found
@@ -303,7 +304,6 @@ class WindowsRegistryView:
 
         Args:
             subkey_name (str)
-            recursive (bool)
         Return:
             the desired subkey as a RegistryKey object, or none
 
@@ -319,7 +319,6 @@ class WindowsRegistryView:
 
         Args:
             subkey_name (str)
-            recursive (bool)
         Return:
             the desired subkey as a RegistryKey object, or none
 
@@ -335,13 +334,12 @@ class WindowsRegistryView:
 
         Args:
             subkey_name (str)
-            recursive (bool)
         Return:
             the desired subkeys as a list of RegistryKey object, or none
 
         For more details, see the WindowsRegistryView._find_subkey_s method docstring
         """
-        kwargs = {"collect_found": True}
+        kwargs = {"collect_all_matchin": True}
         return self._find_subkey_s(
             WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), **kwargs
         )

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -272,7 +272,7 @@ class WindowsRegistryView:
             queue = self.reg.subkeys
             for key in queue:
                 if stop_condition(key):
-                    if collect_found:
+                    if collect_all_matching:
                         collection.append(key)
                     else:
                         return key
@@ -319,7 +319,7 @@ class WindowsRegistryView:
         if recursive:
             kwargs["search_key"] = WindowsRegistryView.KeyMatchConditions.name_matcher(subkey_name)
         else:
-            kwargs["direct_subkey"] =  subkey_name
+            kwargs["direct_subkey"] = subkey_name
         return self._find_subkey_s(**kwargs)
 
     def find_matching_subkey(self, subkey_name, recursive=True):
@@ -337,9 +337,11 @@ class WindowsRegistryView:
         """
         kwargs = {}
         if recursive:
-            kwargs["search_key"] = WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name)
+            kwargs["search_key"] = WindowsRegistryView.KeyMatchConditions.regex_matcher(
+                subkey_name
+            )
         else:
-            kwargs["direct_subkey"] =  subkey_name
+            kwargs["direct_subkey"] = subkey_name
         return self._find_subkey_s(**kwargs)
 
     def find_subkeys(self, subkey_name, recursive=True):
@@ -356,9 +358,11 @@ class WindowsRegistryView:
         """
         kwargs = {"collect_found": True}
         if recursive:
-            kwargs["search_key"] = WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name)
+            kwargs["search_key"] = WindowsRegistryView.KeyMatchConditions.regex_matcher(
+                subkey_name
+            )
         else:
-            kwargs["direct_subkey"] =  subkey_name
+            kwargs["direct_subkey"] = subkey_name
         return self._find_subkey_s(**kwargs)
 
     def find_value(self, val_name, recursive=True):


### PR DESCRIPTION
Typically MSVC is detected via the VSWhere program, however this may not be available, or may be installed in an unpredictable location. This PR adds an additional approach via Windows Registry queries to determine VS install location root.

Introduces searching to the `WindowsRegistry` interface in addition to direct lookups.

Introduces more robust error handling in `WindowsRegistry` queries in cases where a key is not accusable to the user for one reason or another.
  * Skips over keys for which a user does not have read permissions when performing searches
