### PR TITLE
tests/hypre*: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -102,7 +102,7 @@ class HypreCmake(CMakePackage, CudaPackage):
         filter_file(r"^CXX\s*=.*", "CXX = " + self.spec["mpi"].mpicxx, makefile)
         filter_file(
             r"^LIBS\s*=.*",
-            f"LIBS = -L$(HYPRE_DIR)/lib64 -lHYPRE -lm $(CUDA_LIBS) $(DOMP_LIBS)",
+            r"LIBS = -L$(HYPRE_DIR)/lib64 -lHYPRE -lm $(CUDA_LIBS) $(DOMP_LIBS)",
             makefile,
         )
 


### PR DESCRIPTION
This PR converts the stand-alone tests for `hypre` and `hypre-cmake` to the new process.  It also addresses problems building the packages.

(UPDATE)
~~The `test_bigint` examples for each package built with `+mpi` won't link to the `hypre` library though  the issue is unlikely due to the conversion process.~~

Results for `hypre` builds using `+mpi` and `~mpi` are given below (full details at [hypre-standalone-tests.txt](https://github.com/spack/spack/files/12044088/hypre-standalone-tests.txt)).

```
$ spack -v test run hypre
==> Spack test 3xkqo66pqzcauuu4kzsq75xdp64eoinv
==> Testing package hypre-2.28.0-5uviuqy
==> [2023-07-13-12:58:17.547939] test: test_bigint: build and run bigint tests
SKIPPED: Hypre::test_bigint: HYPRE must be installed with +mpi
==> [2023-07-13-12:58:17.551048] Completed testing
==> [2023-07-13-12:58:17.551286] 
======================== SUMMARY: hypre-2.28.0-5uviuqy =========================
Hypre::test_bigint .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package hypre-2.28.0-zghudos
==> [2023-07-13-12:58:19.204550] Installing SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/hypre-2.28.0-zghudostcqahi32gj7z7aasrpwuyfgz5/.spack/test to SPACK_TEST_ROOT/3xkqo66pqzcauuu4kzsq75xdp64eoinv/hypre-2.28.0-zghudos/cache/hypre
==> [2023-07-13-12:58:20.002827] test: test_bigint: build and run bigint tests
==> [2023-07-13-12:58:20.004938] '/usr/bin/make' 'bigint'
...
PASSED: Hypre::test_bigint_ex15big
PASSED: Hypre::test_bigint
==> [2023-07-13-12:58:21.577911] Completed testing
==> [2023-07-13-12:58:21.578065] 
======================== SUMMARY: hypre-2.28.0-zghudos =========================
Hypre::test_bigint_ex5big .. PASSED
Hypre::test_bigint_ex15big .. PASSED
Hypre::test_bigint .. PASSED
============================= 3 passed of 3 parts ==============================
======================== 1 skipped, 1 passed of 2 specs ========================
...
```

Similarly the results for `hyper-cmake` builds with `+mpi` and `~mpi` are given below (full details at [hypre-cmake-standalone-tests.txt](https://github.com/spack/spack/files/12044092/hypre-cmake-standalone-tests.txt)).
```
$ spack -v test run hypre-cmake 
==> Spack test ixtmrh4spdh2hf2fiwd7nzv5vfwuro7d
==> Testing package hypre-cmake-2.22.0-otnldbc
==> [2023-07-13-12:06:49.709900] Installing SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/hypre-cmake-2.22.0-otnldbcaa3t7oaok736uvzhexgeomicd/.spack/test to SPACK_TEST_ROOT/ixtmrh4spdh2hf2fiwd7nzv5vfwuro7d/hypre-cmake-2.22.0-otnldbc/cache/hypre-cmake
==> [2023-07-13-12:06:50.431674] test: test_bigint: build and run bigint tests
==> [2023-07-13-12:06:50.433934] '/usr/bin/make' 'bigint'
...
PASSED: HypreCmake::test_bigint_ex15big
PASSED: HypreCmake::test_bigint
==> [2023-07-13-12:06:52.007876] Completed testing
==> [2023-07-13-12:06:52.008062] 
===================== SUMMARY: hypre-cmake-2.22.0-otnldbc ======================
HypreCmake::test_bigint_ex5big .. PASSED
HypreCmake::test_bigint_ex15big .. PASSED
HypreCmake::test_bigint .. PASSED
============================= 3 passed of 3 parts ==============================
==> Testing package hypre-cmake-2.22.0-33gltbd
==> [2023-07-13-12:06:52.435373] test: test_bigint: build and run bigint tests
SKIPPED: HypreCmake::test_bigint: Package must be installed with +mpi
==> [2023-07-13-12:06:52.438123] Completed testing
==> [2023-07-13-12:06:52.438321] 
===================== SUMMARY: hypre-cmake-2.22.0-33gltbd ======================
HypreCmake::test_bigint .. SKIPPED
============================= 1 skipped of 1 parts =============================
======================== 1 passed, 1 skipped of 2 specs ========================
```