### PR TITLE
Bugfix cached cmake build

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -289,6 +289,7 @@ class CachedCMakeBuilder(CMakeBuilder):
             "# CMake executable path: {0}".format(self.pkg.spec["cmake"].command.path),
             "#------------------{0}\n".format("-" * 60),
             cmake_cache_path("CMAKE_PREFIX_PATH", cmake_prefix_path),
+            self.define_cmake_cache_from_variant("CMAKE_BUILD_TYPE", "build_type"),
         ]
 
     def initconfig_package_entries(self):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -347,6 +347,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
+        spec.compiler_flags["cxxflags"].append("-std=c++17")
         entries = super(Lbann, self).initconfig_compiler_entries()
         entries.append(cmake_cache_string("CMAKE_CXX_STANDARD", "17"))
         if not spec.satisfies("^cmake@3.23.0"):
@@ -397,9 +398,15 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(
                 cmake_cache_string(
                     "HIP_HIPCC_FLAGS",
-                    "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str),
+                    "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str),
                 )
             )
+            # entries.append(
+            #     cmake_cache_string(
+            #         "HIP_HIPCC_FLAGS",
+            #         "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str),
+            #     )
+            # )
 
         return entries
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -397,16 +397,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
             entries.append(
                 cmake_cache_string(
-                    "HIP_HIPCC_FLAGS",
-                    "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str),
+                    "HIP_HIPCC_FLAGS", "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str),
                 )
             )
-            # entries.append(
-            #     cmake_cache_string(
-            #         "HIP_HIPCC_FLAGS",
-            #         "-g -fsized-deallocation -fPIC -std=c++17 {0}".format(cxxflags_str),
-            #     )
-            # )
 
         return entries
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -347,7 +347,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        spec.compiler_flags["cxxflags"].append("-std=c++17")
         entries = super(Lbann, self).initconfig_compiler_entries()
         entries.append(cmake_cache_string("CMAKE_CXX_STANDARD", "17"))
         if not spec.satisfies("^cmake@3.23.0"):
@@ -393,13 +392,6 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             if "platform=cray" in spec:
                 entries.append(cmake_cache_option("MPI_ASSUME_NO_BUILTIN_MPI", True))
-
-            cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
-            entries.append(
-                cmake_cache_string(
-                    "HIP_HIPCC_FLAGS", "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str)
-                )
-            )
 
         return entries
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -397,7 +397,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             cxxflags_str = " ".join(self.spec.compiler_flags["cxxflags"])
             entries.append(
                 cmake_cache_string(
-                    "HIP_HIPCC_FLAGS", "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str),
+                    "HIP_HIPCC_FLAGS", "-g -fsized-deallocation -fPIC {0}".format(cxxflags_str)
                 )
             )
 


### PR DESCRIPTION
Fixed the cached CMake package so that the build_type field is saved
in the cached configuration file.