### PR TITLE
bugfix: env with unify:false can concretize abstract hash without name

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2380,17 +2380,28 @@ def _concretize_from_constraints(spec_constraints, tests=False):
     # Accept only valid constraints from list and concretize spec
     # Get the named spec even if out of order
     root_spec = [s for s in spec_constraints if s.name]
-    if len(root_spec) != 1:
-        m = "The constraints %s are not a valid spec " % spec_constraints
-        m += "concretization target. all specs must have a single name "
-        m += "constraint for concretization."
-        raise InvalidSpecConstraintError(m)
-    spec_constraints.remove(root_spec[0])
+    hash_spec = [s for s in spec_constraints if s.abstract_hash]
+
+    error_message = "The constraints %s are not a valid spec " % spec_constraints
+    error_message += "concretization target. all specs must have a single name "
+    error_message += "constraint for concretization."
+
+    if len(root_spec) > 1:
+        raise InvalidSpecConstraintError(error_message)
+
+    if len(root_spec) < 1:
+        if len(hash_spec) < 1:
+            raise InvalidSpecConstraintError(error_message)
+
+    if root_spec:
+        spec_constraints.remove(root_spec[0])
+
+    root_spec = root_spec[0] if root_spec else Spec()
 
     invalid_constraints = []
     while True:
         # Attach all anonymous constraints to one named spec
-        s = root_spec[0].copy()
+        s = root_spec.copy()
         for c in spec_constraints:
             if c not in invalid_constraints:
                 s.constrain(c)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2402,7 +2402,7 @@ def test_env_activate_default_view_root_unconditional(mutable_mock_env_path):
     )
 
 
-@pytest.mark.regression("")
+@pytest.mark.regression("38510")
 def test_concretize_separately_abstract_hash(install_mockery, mock_fetch):
     """Check that a root can have no name if it has a hash."""
     s = Spec("trivial-install-test-package").concretized()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2402,6 +2402,21 @@ def test_env_activate_default_view_root_unconditional(mutable_mock_env_path):
     )
 
 
+@pytest.mark.regression("")
+def test_concretize_separately_abstract_hash(install_mockery, mock_fetch):
+    """Check that a root can have no name if it has a hash."""
+    s = Spec("trivial-install-test-package").concretized()
+    install(str(s))
+
+    e = ev.create("test")
+    e.unify = False
+
+    e.add(f"/{s.dag_hash()}")
+    e.concretize()
+
+    assert list(e.concretized_specs()) == [(Spec(f"/{s.dag_hash()}"), s)]
+
+
 def test_concretize_user_specs_together():
     e = ev.create("coconcretization")
     e.unify = True


### PR DESCRIPTION
Fixes a bug reported on slack.

Environments were checking that every constraint set in a concretization with `unify: false` has a name. That's not correct, as some could have an abstract hash but no name.