### PR TITLE
ltr-retriever: changing directory layout

### DIFF
--- a/var/spack/repos/builtin/packages/ltr-retriever/package.py
+++ b/var/spack/repos/builtin/packages/ltr-retriever/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import symlink
-
 from spack.package import *
 
 
@@ -42,9 +40,7 @@ class LtrRetriever(Package):
                 "^TEsorter=.*$", "TEsorter={}".format(spec["py-tesorter"].prefix.bin), "paths"
             )
 
-        mkdirp(prefix.opt)
-        mkdirp(prefix.bin)
+        install_tree(".", prefix)
 
-        install_tree(".", prefix.opt.ltr_retriever)
-
-        symlink(prefix.opt.ltr_retriever.LTR_retriever, prefix.bin.LTR_retriever)
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", self.prefix)


### PR DESCRIPTION
This looks for the 'paths' file in the same directory as the main executable, better to just reproduce the structure it's expecting than try to force it into what was being done.