### PR TITLE
ip: Add v4.1.0, and additional variants

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -35,13 +35,9 @@ class Ip(CMakePackage):
         description="Set precision (_4/_d library versions)",
         when="@4.1:",
     )
-    variant("tests", default=False, description="Build tests of the library")
-
-    requires("precision=d", when="+tests precision=4")
 
     depends_on("sp")
     depends_on("sp@:2.3.3", when="@:4.0")
-    depends_on("pfunit", when="@3.3.3 +tests")
 
     def cmake_args(self):
         args = [
@@ -50,9 +46,9 @@ class Ip(CMakePackage):
         ]
 
         if self.spec.satisfies("@4:"):
-            args.append(self.define_from_variant("BUILD_TESTING", "tests"))
+            args.append(self.define("BUILD_TESTING", "NO"))
         else:
-            args.append(self.define_from_variant("ENABLE_TESTS", "tests"))
+            args.append(self.define("ENABLE_TESTS", "NO"))
 
         if self.spec.satisfies("@4.1:"):
             args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -16,6 +16,7 @@ class Ip(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("4.1.0", sha256="b83ca037d9a5ad3eb0fb1acfe665c38b51e01f6bd73ce9fb8bb2a14f5f63cdbe")
     version("4.0.0", sha256="a2ef0cc4e4012f9cb0389fab6097407f4c623eb49772d96eb80c44f804aa86b8")
     version(
         "3.3.3",
@@ -23,10 +24,54 @@ class Ip(CMakePackage):
         preferred=True,
     )
 
+    variant("openmp", description="Enable OpenMP threading", default=True)
+    variant("pic", default=True, description="Build with position-independent-code")
+    variant("shared", default=False, description="Build shared library", when="@4.1:")
+    variant(
+        "precision",
+        default=["4", "d"],
+        values=["4", "d"],
+        multi=True,
+        description="Set precision (_4/_d library versions)",
+        when="@4.1:",
+    )
+    variant("tests", default=False, description="Build tests of the library")
+
+    requires("precision=d", when="+tests precision=4")
+
     depends_on("sp")
+    depends_on("sp@:2.3.3", when="@:4.0")
+    depends_on("pfunit", when="@3.3.3 +tests")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("OPENMP", "openmp"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+        ]
+
+        if self.spec.satisfies("@4:"):
+            args.append(self.define_from_variant("BUILD_TESTING", "tests"))
+        else:
+            args.append(self.define_from_variant("ENABLE_TESTS", "tests"))
+
+        if self.spec.satisfies("@4.1:"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+            for prec in ["4", "d"]:
+                if not self.spec.satisfies("precision=" + prec):
+                    args += ["-DBUILD_%s:BOOL=OFF" % prec.upper()]
+
+        return args
 
     def setup_run_environment(self, env):
-        for suffix in ("4", "8", "d"):
-            lib = find_libraries("libip_4", root=self.prefix, shared=False, recursive=True)
+        suffixes = (
+            self.spec.variants["precision"].value
+            if self.spec.satisfies("@4.1:")
+            else ["4", "8", "d"]
+        )
+        shared = False if self.spec.satisfies("@:4.0") else self.spec.satisfies("+shared")
+        for suffix in suffixes:
+            lib = find_libraries(
+                "libip_" + suffix, root=self.prefix, shared=shared, recursive=True
+            )
             env.set("IP_LIB" + suffix, lib[0])
             env.set("IP_INC" + suffix, join_path(self.prefix, "include_" + suffix))


### PR DESCRIPTION
This PR adds version 4.1.0 to the ip package, and also adds several variants.

Tested on CentOS 8 installing all versions, including validating setup_run_environment logic for all versions.