### PR TITLE
pfunit: Fixes for max_array_rank

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -85,11 +85,11 @@ class Pfunit(CMakePackage):
 
     # The maximum rank of an array in the Fortran 2008 standard is 15
     max_rank = 15
-    allowed_array_ranks = tuple(str(i) for i in range(1, max_rank + 1))
+    allowed_array_ranks = tuple(str(i) for i in range(3, max_rank + 1))
 
     variant(
         "max_array_rank",
-        default=5,
+        default="5",
         values=allowed_array_ranks,
         description="Max rank for assertion overloads (higher values may be slower to build)",
     )


### PR DESCRIPTION
This PR has a couple of fixes for pfunit.

1. We set the minimum for `max_array_rank` to 3
2. We make the default for `max_array_rank` a string. 

That last one was discovered on an M1 Mac where it did...weird things when an integer. Not sure why, but making it a string fixed it.