### PR TITLE
py-lightning: add v2.0.4, drop +extra

### DIFF
--- a/var/spack/repos/builtin/packages/py-fastapi/package.py
+++ b/var/spack/repos/builtin/packages/py-fastapi/package.py
@@ -13,13 +13,19 @@ class PyFastapi(PythonPackage):
     homepage = "https://github.com/tiangolo/fastapi"
     pypi = "fastapi/fastapi-0.88.0.tar.gz"
 
+    version("0.98.0", sha256="0d3c18886f652038262b5898fec6b09f4ca92ee23e9d9b1d1d24e429f84bf27b")
     version("0.88.0", sha256="915bf304180a0e7c5605ec81097b7d4cd8826ff87a02bb198e336fb9f3b5ff02")
 
     variant("all", default=False, description="Build all optional dependencies")
 
+    depends_on("py-hatchling@1.13:", when="@0.98:", type="build")
     depends_on("py-hatchling", type="build")
-    depends_on("py-starlette@0.22.0", type=("build", "run"))
-    depends_on("py-pydantic@1.6.2:1.6,1.7.4:1.7,1.8.2:1", type=("build", "run"))
+    depends_on("py-starlette@0.27", when="@0.95.2:", type=("build", "run"))
+    depends_on("py-starlette@0.22.0", when="@:0.89.1", type=("build", "run"))
+    depends_on("py-pydantic@1.7.4:1", when="@0.96.1:", type=("build", "run"))
+    depends_on("py-pydantic@1.6.2:1", when="@:0.96.0", type=("build", "run"))
+
+    conflicts("^py-pydantic@1.7.0:1.7.3,1.8.0:1.8.1")
 
     with when("+all"):
         depends_on("py-httpx@0.23:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning/package.py
@@ -16,15 +16,12 @@ class PyLightning(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("2.0.4", sha256="f5f5ed75a657caa8931051590ed000d46bf1b8311ae89bb17a961c3f299dbf33")
     version("2.0.3", sha256="5a70f05e40f1d7882f81eace0d4a86fe2604b423f8df42beaabd187bfdb420cf")
     version("2.0.2", sha256="fa32d671850a5be2d961c6705c927f6f48d1cf9696f61f7d865244142e684430")
     version("2.0.1", sha256="abf4f9e10b0d97348336038db79f4efc75daa2f3f81876822273023294d6ef3e")
     version("2.0.0", sha256="dfe158aa91ac139d8bdfccc7cdb627072e0052076ae9c0459c8fa12a028dbe6c")
     version("1.9.5", sha256="4a6ee1bf338f7677f04d339b84dd0c9c0fa407c3dacea366a111dc86476d4dec")
-
-    variant(
-        "extra", default=False, description="Install extra dependencies for full functionality"
-    )
 
     # src/lightning/__setup__.py
     depends_on("python@3.8:", when="@2:", type=("build", "run"))
@@ -39,8 +36,9 @@ class PyLightning(PythonPackage):
     depends_on("py-croniter@1.3", type=("build", "run"))
     depends_on("py-dateutils@:1", type=("build", "run"))
     depends_on("py-deepdiff@5.7:7", type=("build", "run"))
-    depends_on("py-fastapi@0.69:0.88", when="@2.0.3:", type=("build", "run"))
-    depends_on("py-fastapi@:0.88", type=("build", "run"))
+    depends_on("py-fastapi@0.92:1", when="@2.0.4:", type=("build", "run"))
+    depends_on("py-fastapi@0.69:0.88", when="@2.0.3", type=("build", "run"))
+    depends_on("py-fastapi@:0.88", when="@:2.0.2", type=("build", "run"))
     depends_on("py-fsspec@2022.5:2023+http", type=("build", "run"))
     depends_on("py-inquirer@2.10:4", type=("build", "run"))
     depends_on("py-lightning-cloud@0.5.34:", when="@2.0.3:", type=("build", "run"))
@@ -66,29 +64,9 @@ class PyLightning(PythonPackage):
     depends_on("py-tqdm@4.57:5", type=("build", "run"))
     depends_on("py-traitlets@5.3:6", type=("build", "run"))
     depends_on("py-typing-extensions@4:5", type=("build", "run"))
-    depends_on("py-urllib3@:2", type=("build", "run"))
+    depends_on("py-urllib3@:3", when="@2.0.4:", type=("build", "run"))
+    depends_on("py-urllib3@:2", when="@:2.0.3", type=("build", "run"))
     depends_on("py-uvicorn@:1", type=("build", "run"))
     depends_on("py-websocket-client@:2", type=("build", "run"))
     depends_on("py-websockets@:11", type=("build", "run"))
     depends_on("py-pytorch-lightning", when="@2:", type=("build", "run"))
-
-    with when("+extra"):
-        depends_on("py-aiohttp@3.8:3", type=("build", "run"))
-        depends_on("py-docker@5:6", type=("build", "run"))
-        depends_on("py-hydra-core@1.0.5:1", type=("build", "run"))
-        depends_on("py-jsonargparse@4.18:4+signatures", when="@2.0.3:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.18:4", when="@2:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.18:4+signatures", when="@:1", type=("build", "run"))
-        depends_on("py-lightning-fabric@1.9:", when="@2:", type=("build", "run"))
-        depends_on("py-lightning-api-access@0.0.3:", type=("build", "run"))
-        depends_on("py-matplotlib@3.2:3", type=("build", "run"))
-        depends_on("py-omegaconf@2.0.5:2", type=("build", "run"))
-        depends_on("py-panel@0.12.7:0", type=("build", "run"))
-        depends_on("py-pytorch-lightning@1.9:", when="@2:", type=("build", "run"))
-        depends_on("py-pytorch-lightning@1.8.1:", when="@:1", type=("build", "run"))
-        depends_on("py-redis@4.0.1:4", type=("build", "run"))
-        depends_on("py-rich@12.3:13", when="@2:", type=("build", "run"))
-        depends_on("py-rich@10.14:13", when="@:1", type=("build", "run"))
-        depends_on("py-s3fs@2022.5:2022", type=("build", "run"))
-        depends_on("py-streamlit@1.13:1", type=("build", "run"))
-        depends_on("py-tensorboardx@2.2:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -98,14 +98,6 @@ class PyPytorchLightning(PythonPackage):
     depends_on("py-tensorboard@2.9.1:", when="@1.7:1.8.2", type=("build", "run"))
     depends_on("py-tensorboard@2.2.0:", when="@1.5:1.6", type=("build", "run"))
     depends_on("py-tensorboard@2.2.0:2.4,2.5.1:", when="@:1.4", type=("build", "run"))
-    depends_on("py-gcsfs@2021.5:", when="@1.4:1.7+extra", type=("build", "run"))
-    depends_on("py-horovod@0.21.2:0.23,0.24.1:", when="@:1.6.3+extra", type=("build", "run"))
-    depends_on("py-onnx@1.7:", when="@1.5+extra", type=("build", "run"))
-    depends_on("py-onnxruntime@1.3:", when="@:1.5+extra", type=("build", "run"))
-    depends_on("py-torchtext@0.10:", when="@1.7+extra", type=("build", "run"))
-    depends_on("py-torchtext@0.9:", when="@1.6+extra", type=("build", "run"))
-    depends_on("py-torchtext@0.7:", when="@1.5+extra", type=("build", "run"))
-    depends_on("py-torchtext@0.5:", when="@:1.4+extra", type=("build", "run"))
 
     # https://github.com/Lightning-AI/lightning/issues/16637
     conflicts("^py-torch~distributed", when="@1.9.0")

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -47,10 +47,6 @@ class PyPytorchLightning(PythonPackage):
     version("1.3.8", sha256="60b0a3e464d394864dae4c8d251afa7aa453644a19bb7672f5ee400343cdf7b0")
     version("1.2.10", sha256="2d8365e30ded0c20e73ce6e5b6028478ae460b8fd33727df2275666df005a301")
 
-    variant(
-        "extra", default=False, description="Install extra dependencies for full functionality"
-    )
-
     # src/pytorch_lightning/__setup__.py
     depends_on("python@3.8:", when="@2:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
@@ -88,27 +84,6 @@ class PyPytorchLightning(PythonPackage):
     depends_on("py-lightning-utilities@0.4.2:", when="@1.9.0", type=("build", "run"))
     depends_on("py-lightning-utilities@0.3,0.4.1:", when="@1.8.4:1.8", type=("build", "run"))
     depends_on("py-lightning-utilities@0.3:", when="@1.8.0:1.8.3", type=("build", "run"))
-
-    # requirements/pytorch/extra.txt
-    with when("+extra"):
-        depends_on("py-matplotlib@3.2:", type=("build", "run"))
-        depends_on("py-omegaconf@2.0.5:", when="@1.5:", type=("build", "run"))
-        depends_on("py-omegaconf@2.0.1:", type=("build", "run"))
-        depends_on("py-hydra-core@1.0.5:", when="@1.5:", type=("build", "run"))
-        depends_on("py-hydra-core@1:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.18:+signatures", when="@1.9:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.15.2:+signatures", when="@1.8:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.12:+signatures", when="@1.7:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.7.1:+signatures", when="@1.6.2:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.6:+signatures", when="@1.6.1:", type=("build", "run"))
-        depends_on("py-jsonargparse@4.3:+signatures", when="@1.6:", type=("build", "run"))
-        depends_on("py-jsonargparse@3.19.3:+signatures", when="@1.5:", type=("build", "run"))
-        depends_on("py-jsonargparse@3.17:+signatures", when="@1.4:", type=("build", "run"))
-        depends_on("py-jsonargparse@3.13.1:+signatures", when="@1.3:", type=("build", "run"))
-        depends_on("py-rich@12.3:", when="@2:", type=("build", "run"))
-        depends_on("py-rich@10.14:", when="@1.7:", type=("build", "run"))
-        depends_on("py-rich@10.2.2:", when="@1.5:", type=("build", "run"))
-        depends_on("py-tensorboardx@2.2:", when="@1.9:", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-lightning-lite@1.8.0", when="@1.8.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-starlette/package.py
+++ b/var/spack/repos/builtin/packages/py-starlette/package.py
@@ -13,10 +13,10 @@ class PyStarlette(PythonPackage):
     homepage = "https://github.com/encode/starlette"
     pypi = "starlette/starlette-0.23.1.tar.gz"
 
+    version("0.27.0", sha256="6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75")
     version("0.23.1", sha256="8510e5b3d670326326c5c1d4cb657cc66832193fe5d5b7015a51c7b1e1b1bf42")
     version("0.22.0", sha256="b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff")
 
-    depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-hatchling", type="build")
 
     depends_on("py-anyio@3.4:4", type=("build", "run"))


### PR DESCRIPTION
https://github.com/Lightning-AI/lightning/releases/tag/2.0.4

Supporting `+extra` was becoming too much work and I no longer need it so I just removed it.