### PR TITLE
Handle cc optimization flags explicitly

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -481,7 +481,6 @@ categorize_arguments() {
     return_lib_dirs_list=""
     return_system_rpath_dirs_list=""
     return_rpath_dirs_list=""
-    return_opt_flag=""
 
     # Global state for keeping track of -Wl,-rpath -Wl,/path
     wl_expect_rpath=no
@@ -553,9 +552,6 @@ categorize_arguments() {
                     append return_isystem_include_dirs_list "$arg"
                 fi
                 ;;
-            -O*)
-                   return_opt_flag="$1"
-                ;;
             -I*)
                 arg="${1#-I}"
                 if [ -z "$arg" ]; then shift; arg="$1"; fi
@@ -588,6 +584,14 @@ categorize_arguments() {
                 arg="${1#-l}"
                 if [ -z "$arg" ]; then shift; arg="$1"; fi
                 append return_other_args_list "-l$arg"
+                ;;
+            -O*)
+                if [ ! -z $override_opt_flag ] && $override_opt_flag; then
+                    shift
+                    continue
+                fi
+                [ "${1#-}" = "O0" ] && override_opt_flag=true || override_opt_flag=false
+                append return_other_args_list "$1"
                 ;;
             -Wl,*)
                 IFS=,
@@ -675,7 +679,6 @@ categorize_arguments "$@"
     isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
     isystem_include_dirs_list="$return_isystem_include_dirs_list"
     other_args_list="$return_other_args_list"
-    opt_flag="$return_opt_flag"
 
 #
 # Add flags from Spack's cppflags, cflags, cxxflags, fcflags, fflags, and
@@ -753,10 +756,7 @@ unset IFS
         spack_flags_isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
         spack_flags_isystem_include_dirs_list="$return_isystem_include_dirs_list"
         spack_flags_other_args_list="$return_other_args_list"
-        if [ -z ${opt_flag} ] || [ ! ${opt_flag#-} == "O0" ]; then
-            # assume the package maintainers have a good reason
-            opt_flag="$return_opt_flag"
-        fi
+
 
 # On macOS insert headerpad_max_install_names linker flag
 if [ "$mode" = ld ] || [ "$mode" = ccld ]; then
@@ -810,7 +810,6 @@ esac
 # Finally, reassemble the command line.
 #
 args_list="$flags_list"
-
 
 # Insert include directories just prior to any system include directories
 # NOTE: adding ${lsep} to the prefix here turns every added element into two
@@ -867,11 +866,6 @@ esac
 # Other arguments from the input command
 extend args_list other_args_list
 extend args_list spack_flags_other_args_list
-
-# Optimization flag
-if [ ! -z $opt_flag ] ; then
-    append args_list "$opt_flag"
-fi
 
 # Inject SPACK_LDLIBS, if supplied
 extend args_list libs_list "-l"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -481,6 +481,7 @@ categorize_arguments() {
     return_lib_dirs_list=""
     return_system_rpath_dirs_list=""
     return_rpath_dirs_list=""
+    return_opt_flag=""
 
     # Global state for keeping track of -Wl,-rpath -Wl,/path
     wl_expect_rpath=no
@@ -551,6 +552,9 @@ categorize_arguments() {
                 else
                     append return_isystem_include_dirs_list "$arg"
                 fi
+                ;;
+            -O*)
+                   return_opt_flag="$1"
                 ;;
             -I*)
                 arg="${1#-I}"
@@ -671,6 +675,7 @@ categorize_arguments "$@"
     isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
     isystem_include_dirs_list="$return_isystem_include_dirs_list"
     other_args_list="$return_other_args_list"
+    opt_flag="$return_opt_flag"
 
 #
 # Add flags from Spack's cppflags, cflags, cxxflags, fcflags, fflags, and
@@ -748,7 +753,10 @@ unset IFS
         spack_flags_isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
         spack_flags_isystem_include_dirs_list="$return_isystem_include_dirs_list"
         spack_flags_other_args_list="$return_other_args_list"
-
+        if [ ! ${opt_flag#-O} == "0" ]; then
+            # assume the package maintainers have a good reason
+            opt_flag="$return_opt_flag"
+        fi
 
 # On macOS insert headerpad_max_install_names linker flag
 if [ "$mode" = ld ] || [ "$mode" = ccld ]; then
@@ -802,6 +810,10 @@ esac
 # Finally, reassemble the command line.
 #
 args_list="$flags_list"
+
+if [ ! -z $opt_flag ] ; then
+    append args_list "$opt_flag"
+fi
 
 # Insert include directories just prior to any system include directories
 # NOTE: adding ${lsep} to the prefix here turns every added element into two

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -811,9 +811,6 @@ esac
 #
 args_list="$flags_list"
 
-if [ ! -z $opt_flag ] ; then
-    append args_list "$opt_flag"
-fi
 
 # Insert include directories just prior to any system include directories
 # NOTE: adding ${lsep} to the prefix here turns every added element into two
@@ -870,6 +867,11 @@ esac
 # Other arguments from the input command
 extend args_list other_args_list
 extend args_list spack_flags_other_args_list
+
+# Optimization flag
+if [ ! -z $opt_flag ] ; then
+    append args_list "$opt_flag"
+fi
 
 # Inject SPACK_LDLIBS, if supplied
 extend args_list libs_list "-l"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -753,7 +753,7 @@ unset IFS
         spack_flags_isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
         spack_flags_isystem_include_dirs_list="$return_isystem_include_dirs_list"
         spack_flags_other_args_list="$return_other_args_list"
-        if [ ! ${opt_flag#-O} == "0" ]; then
+        if [ -z ${opt_flag} ] || [ ! ${opt_flag#-} == "O0" ]; then
             # assume the package maintainers have a good reason
             opt_flag="$return_opt_flag"
         fi

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -124,7 +124,7 @@ fc = Executable(os.path.join(build_env_path, "fc"))
 real_cc = "/bin/mycc"
 
 # mock flags to use in the wrapper environment
-spack_cppflags = ["-g", "-O1", "-DVAR=VALUE"]
+spack_cppflags = ["-g", "-DVAR=VALUE", "-O1"]
 spack_cflags = ["-Wall"]
 spack_cxxflags = ["-Werror"]
 spack_fflags = ["-w"]

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -124,7 +124,7 @@ fc = Executable(os.path.join(build_env_path, "fc"))
 real_cc = "/bin/mycc"
 
 # mock flags to use in the wrapper environment
-spack_cppflags = ["-g", "-DVAR=VALUE", "-O1"]
+spack_cppflags = ["-g", "-O1", "-DVAR=VALUE"]
 spack_cflags = ["-Wall"]
 spack_cxxflags = ["-Werror"]
 spack_fflags = ["-w"]


### PR DESCRIPTION
Also allows the package specified -O flag to win over user flag in specific situation.

I noticed in #38517 that the ordering of compiler flags changed as a result of #37376 causing (at the very least) apptainer to fail to install when user provided cflags included -O2. Beforehand the user cflags would appear pretty early in the gcc invocation emitted by the cc wrapper, and package specified cflags would be near the end, leading to the package provided cflags overriding the user provided ones. 

Obviously this isn't what spack users intend in all cases, hence the change. However, some packages do seem to require their specified flags to compile, apptainer being one of them. There are parts of apptainer that need -O0 to compile correctly otherwise the application fails to compile.

This PR adds a case for -O* in the argument parsing and a condition where if -O0 is specified by the package we let it win out vs the user provided optimization flag.

I'm not married to this implementation, the best way to handle this might be disregarding user provided cflags at a package level, but as it stands this does break some unknown number of packages.

I'm going to make this a draft PR, because I'm not that familiar with the cc wrapper or convinced this is the correct place to fix it necessarily.


Fixes #38517