### PR TITLE
acts: ensure Python_EXECUTABLE uses ^python when +python

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -391,4 +391,8 @@ class Acts(CMakePackage, CudaPackage):
             cxxstd = spec["root"].variants["cxxstd"].value
             args.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
 
+        if "+python" in spec:
+            python = spec["python"].command.path
+            args.append("-DPython_EXECUTABLE={0}".format(python))
+
         return args


### PR DESCRIPTION
By default, `find_package(Python)` searches from highest version to lowest version, identifying the highest version that satisfies the requirements. This means that `/usr/bin/python3.11` will be found before `$(spack location -i python)/bin/python3.10`, even when other packages have been built with the `python` in spack.

This ensures that the `python` dependency is explicitly the `python` version that is used by `acts`.