### PR TITLE
Add version 1.8.23 of HDF5

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -127,6 +127,11 @@ class Hdf5(CMakePackage):
         preferred=True,
     )
     version(
+        "1.8.23",
+        sha256="37fa4eb6cd0e181eb49a10d54611cb00700e9537f805d03e6853503afe5abc27",
+        preferred=True,
+    )
+    version(
         "1.8.22",
         sha256="8406d96d9355ef8961d2739fb8fd5474ad4cdf52f3cfac657733defd9709bfaa",
         preferred=True,


### PR DESCRIPTION
Version 1.8.22 has this compilation issue with Fedora 37's clang 15.0.7 (Fedora 15.0.7-2.fc37).
```
     562    /home/dir/current/lido/lido_libs/linux_fedora_37/2023_06_23_11_33_40/spack/var/spack/stage/spack-stage-hdf5-1.8.21-wzq6y6ektygj7ckf2r3b5gbjawkv4bzc/spack-src/src/H5Dio.c:698:5: warning: call to undeclared function 'H5T_patch_vlen_file'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
     563        H5T_patch_vlen_file(dataset->shared->type, dataset->oloc.file);
     564        ^
  >> 565    /home/dir/current/lido/lido_libs/linux_fedora_37/2023_06_23_11_33_40/spack/var/spack/stage/spack-stage-hdf5-1.8.21-wzq6y6ektygj7ckf2r3b5gbjawkv4bzc/spack-src/src/H5Aint.c:2102:21: error: incompatible integer to pointer conversion assigning to 'H5A_t *' (aka 'struct H5A_t *') from 'int' [-Wint-conversion]
     566                        HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
     567                        ^                                    ~~~~
     568    /home/dir/current/lido/lido_libs/linux_fedora_37/2023_06_23_11_33_40/spack/var/spack/stage/spack-stage-hdf5-1.8.21-wzq6y6ektygj7ckf2r3b5gbjawkv4bzc/spack-src/src/H5Eprivate.h:67:4: note: expanded from macro 'HGOTO_ERROR'
     569       HGOTO_DONE(ret_val)                                                        \
     570       ^          ~~~~~~~
     571    /home/dir/current/lido/lido_libs/linux_fedora_37/2023_06_23_11_33_40/spack/var/spack/stage/spack-stage-hdf5-1.8.21-wzq6y6ektygj7ckf2r3b5gbjawkv4bzc/spack-src/src/H5Eprivate.h:76:40: note: expanded from macro 'HGOTO_DONE'
```
Based on my snooping around the source code, `FAIL` is defined to be `(-1)` and the return value is meant to be a pointer. In 1.8.23, `FAIL` is replaced by `NULL`.