### PR TITLE
cmake build system: default to FETCHCONTENT_FULLY_DISCONNECTED=True

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -267,6 +267,11 @@ class CMakeBuilder(BaseBuilder):
         except KeyError:
             ipo = False
 
+        if hasattr(pkg, "fetchcontent"):
+            fetchcontent = pkg.spec.fetchcontent
+        else:
+            fetchcontent = False
+
         define = CMakeBuilder.define
         args = [
             "-G",
@@ -296,6 +301,12 @@ class CMakeBuilder(BaseBuilder):
                 define("CMAKE_PREFIX_PATH", spack.build_environment.get_cmake_prefix_path(pkg)),
             ]
         )
+
+        # Set up FetchContent isolation for recent CMake
+        if pkg.spec.satisfies("^cmake@3.11:"):
+            if isinstance(fetchcontent, bool):
+                args.append(define("FETCHCONTENT_FULLY_DISCONNECTED", not fetchcontent))
+
         return args
 
     @staticmethod


### PR DESCRIPTION
> *Note: this should be considered a draft and is mainly intended to see how much of the standard CI pipelines are going to fail due to this change.*

In CMake projects that use FetchContent, it is easy to pull in external dependencies inadvertently, even when you think you are providing all dependencies and you assume CMake is finding and using them.

This PR turns off FetchContent downloads and updates entirely by default: it sets the [FETCHCONTENT_FULLY_DISCONNECTED](https://cmake.org/cmake/help/latest/module/FetchContent.html#variables) variable to `ON` by default.

Packages can define the attribute `fetchcontent = True` to allow for changing this back to `OFF` and to allow all downloads and updates. These packages should probably use a resource and set `FETCHCONTENT_SOURCE_DIR_<uppercaseName>` instead.

It may be possible to allow for `fetchcontent = ["googletest", "googlebenchmark"]`, while remaining disconnected by default for other dependencies. That needs more work.

This doesn't address vendored dependencies that are already in the original source file. It only affects FetchContent for content that is not bundled with the original source and needs to be obtained using network access.