### PR TITLE
xrootd: add _STAT_VER patch

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -124,7 +124,8 @@ class Xrootd(CMakePackage):
 
     extends("python", when="+python")
 
-    patch("https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff",
+    # Issue with _STAT_VER not being defined, fixed in 5.0.3
+    patch("https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff?full_index=1",
           sha256="cfb5c2a13257012c6f117e8a1d0a3831b02586e910d845b5ff5e80d1ab2119bc",
           when="@4:5.0.2"
     )

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -123,6 +123,11 @@ class Xrootd(CMakePackage):
     conflicts("openssl@3:", when="@:5.3.99")
 
     extends("python", when="+python")
+
+    patch("https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff",
+          sha256="cfb5c2a13257012c6f117e8a1d0a3831b02586e910d845b5ff5e80d1ab2119bc",
+          when="@4:5.0.2"
+    )
     patch("python-support.patch", level=1, when="@:4.8+python")
     # https://github.com/xrootd/xrootd/pull/1805
     patch(

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -125,9 +125,10 @@ class Xrootd(CMakePackage):
     extends("python", when="+python")
 
     # Issue with _STAT_VER not being defined, fixed in 5.0.3
-    patch("https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff?full_index=1",
-          sha256="cfb5c2a13257012c6f117e8a1d0a3831b02586e910d845b5ff5e80d1ab2119bc",
-          when="@4:5.0.2"
+    patch(
+        "https://github.com/xrootd/xrootd/commit/1f2d48fa23ba220ce92bf8ec6c15305ebbf19564.diff?full_index=1",
+        sha256="cfb5c2a13257012c6f117e8a1d0a3831b02586e910d845b5ff5e80d1ab2119bc",
+        when="@4:5.0.2",
     )
     patch("python-support.patch", level=1, when="@:4.8+python")
     # https://github.com/xrootd/xrootd/pull/1805


### PR DESCRIPTION
Fixed in 5.0.3. I'm getting it in my builds with 4.9.x; I checked and at least every version 4.x.x has this bug, maybe older versions also have it.