### PR TITLE
upcxx: needs libfabric fi_info for build

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -113,6 +113,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     variant("gasnet", default=False, description="Override embedded GASNet-EX version")
     depends_on("gasnet conduits=none", when="+gasnet")
 
+    depends_on("libfabric", type="build")  # for fi_info
     depends_on("mpi", when="+mpi")
     depends_on("python@2.7.5:", type=("build", "run"))
 


### PR DESCRIPTION
`upcxx` package.py uses `fi_info` binary to probe fabrics

@bonachea @wspear