### PR TITLE
kokkos-kernels: require kokkos+cuda_lambda

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -78,6 +78,9 @@ class KokkosKernels(CMakePackage, CudaPackage):
         variant(eti, default=deflt, description=descr)
         depends_on("kokkos+%s" % backend_required, when="+%s" % eti)
 
+    # kokkos-kernels requires KOKKOS_LAMBDA to be available since 4.0.00
+    depends_on("kokkos+cuda_lambda", when="@4.0.00:+cuda")
+
     numeric_etis = {
         "ordinals": (
             "int",


### PR DESCRIPTION
(when +cuda, and on version 4.0.00 and up)

#36655 should be merged first because it actually defines version 4.0.00