### PR TITLE
Adjust cc90 to require at least CUDA 12

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -102,11 +102,10 @@ class CudaPackage(PackageBase):
 
     depends_on("cuda@11.0:", when="cuda_arch=80")
     depends_on("cuda@11.1:", when="cuda_arch=86")
-
     depends_on("cuda@11.4:", when="cuda_arch=87")
-
     depends_on("cuda@11.8:", when="cuda_arch=89")
-    depends_on("cuda@11.8:", when="cuda_arch=90")
+
+    depends_on("cuda@12.0:", when="cuda_arch=90")
 
     # From the NVIDIA install guide we know of conflicts for particular
     # platforms (linux, darwin), architectures (x86, powerpc) and compilers


### PR DESCRIPTION
Thanks @eugeneswalker for confirming that certain packages won't build for compute capability 9.0 with CUDA 11.8.