### PR TITLE
tests/tk: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -91,14 +91,17 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         with working_dir(self.prefix.bin):
             symlink("wish{0}".format(self.version.up_to(2)), "wish")
 
-    def test(self):
-        self.run_test(self.spec["tk"].command.path, ["-h"], purpose="test wish command")
+    def test_tk_help(self):
+        """run tk help"""
+        tk = self.spec["tk"].command
+        tk("-h")
 
+    def test_tk_load(self):
+        """check that tk can be loaded"""
         test_data_dir = self.test_suite.current_test_data_dir
         test_file = test_data_dir.join("test.tcl")
-        self.run_test(
-            self.spec["tcl"].command.path, test_file, purpose="test that tk can be loaded"
-        )
+        tcl = self.spec["tcl"].command
+        tcl(test_file)
 
     @property
     def command(self):


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v test run tk
==> Spack test eyl7hfbzfvh6fklype2stn3br3ails5l
==> Testing package tk-8.6.11-xxwhycu
==> [2023-06-26-14:33:18.619437] Warning: tk: the 'test' method is deprecated. Convert stand-alone test(s) to methods with names starting 'test_'.
==> [2023-06-26-14:33:18.619836] test: test: unspecified purpose
==> [2023-06-26-14:33:18.622220] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for tk to process wish8.6.
==> [2023-06-26-14:33:18.622721] test: test_wish8.6_h: test wish command
==> [2023-06-26-14:33:18.623234] Expecting return code in [0]
==> [2023-06-26-14:33:18.623564] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx4vdvur/bin/wish8.6' '-h'
% application-specific initialization failed: Command-specific options:
 -sync:     Use synchronous mode for display server
 -colormap: Colormap for main window
 -display:  Display to use
 -geometry: Initial geometry for window
 -name:     Name to use for application
 -visual:   Visual for main window
 -use:      Id of window in which to embed application
 --:        Marks the end of the options
 -help:     Print summary of command-line options and abort
PASSED: Tk::test_wish8.6_h
==> [2023-06-26-14:33:18.700212] Warning: The 'run_test' method is deprecated. Use 'test_part' instead for tk to process tclsh8.6.
==> [2023-06-26-14:33:18.700322] test: test_tclsh8.6_SPACK_TEST_ROOT/eyl7hfbzfvh6fklype2stn3br3ails5l/tk8.6.11xxwhycu/data/tk/test.tcl: test that tk can be loaded
==> [2023-06-26-14:33:18.700834] Expecting return code in [0]
==> [2023-06-26-14:33:18.701169] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/bin/tclsh8.6' 'SPACK_TEST_ROOT/eyl7hfbzfvh6fklype2stn3br3ails5l/tk-8.6.11-xxwhycu/data/tk/test.tcl'
PASSED: Tk::test_tclsh8.6_SPACK_TEST_ROOT/eyl7hfbzfvh6fklype2stn3br3ails5l/tk8.6.11xxwhycu/data/tk/test.tcl
PASSED: Tk::test
==> [2023-06-26-14:33:19.553211] Completed testing
==> [2023-06-26-14:33:19.553362] 
========================== SUMMARY: tk-8.6.11-xxwhycu ==========================
Tk::test_wish8.6_h .. PASSED
Tk::test_tclsh8.6_SPACK_TEST_ROOT/eyl7hfbzfvh6fklype2stn3br3ails5l/tk8.6.11xxwhycu/data/tk/test.tcl .. PASSED
Tk::test .. PASSED
============================= 3 passed of 3 parts ==============================
============================== 1 passed of 1 spec ==============================
```