### PR TITLE
libxcb/xcb-proto: add python variant

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -31,7 +31,7 @@ class Libxcb(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 
-    variant("python", default=False, description="Build with python support.")
+    variant("python", default=False, description="Build with spack managed python.")
 
     def url_for_version(self, version):
         if version >= Version("1.14"):

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -27,9 +27,11 @@ class Libxcb(AutotoolsPackage):
     depends_on("xcb-proto@1.14:", when="@1.14")
     depends_on("xcb-proto@1.13:", when="@1.13")
 
-    depends_on("python", type="build")
+    depends_on("python", type="build", when="+python")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+
+    variant("python", default=False, description="Build with python support.")
 
     def url_for_version(self, version):
         if version >= Version("1.14"):

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -22,7 +22,7 @@ class XcbProto(AutotoolsPackage):
 
     extends("python", when="+python")
 
-    variant("python", default=False, description="Build with python support.")
+    variant("python", default=False, description="Build with spack managed python.")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -20,7 +20,9 @@ class XcbProto(AutotoolsPackage):
     version("1.12", sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59")
     version("1.11", sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906")
 
-    extends("python")
+    extends("python", when="+python")
+
+    variant("python", default=False, description="Build with python support.")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 


### PR DESCRIPTION
I hit #37947 earlier today while rebuilding our software stack. Building python+tkinter results in cyclic dependency after the changes in #37575 if there isn't another python~tkinter built.

This may be a reasonable compromise.