### PR TITLE
tests/tix: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -75,12 +75,12 @@ class Tix(AutotoolsPackage):
         if "platform=darwin" in self.spec:
             fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))
 
-    def test(self):
+    def test_tcl(self):
+        """test that tix can be loaded"""
         test_data_dir = self.test_suite.current_test_data_dir
         test_file = test_data_dir.join("test.tcl")
-        self.run_test(
-            self.spec["tcl"].command.path, test_file, purpose="test that tix can be loaded"
-        )
+        tcl = self.spec["tcl"].command
+        tcl(test_file)
 
     @property
     def libs(self):


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

Unfortunately, I am unable to build the package:
```
$ spack install tix
...
==> Installing tix-8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz
==> No binary for tix-8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz found: installing from source
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/56/562f040ff7657e10b5cffc2c41935f1a53c6402eb3d5f3189113d734fd6c03cb.tar.gz
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/1b/1be1a1c7453f6ab8771f90d7e7c0f8959490104752a16a8755bbb7287a841a96
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/8a/8a2720368c7757896814684147029d8318b9aa3b0914b3f37dd5e8a8603a61d3
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/99/99b33cc307f71bcf9cc6f5a44b588f22956884ce3f1e4c716ad64c79cf9c5f41
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/d9/d9f789dcfe5f4c5ee4589a18f9f410cdf162e41d35d00648c1ef37831f4a2b2b
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/1e/1e28d8eee1aaa956a00571cf495a4775e72a993958dff1cabfbc5f102e327a6f
==> Applied patch https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/panic.patch
==> Applied patch https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/implicit.patch
==> Applied patch https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-generic-tixGrSort.c.diff
==> Applied patch https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-missing-headers.diff
==> Applied patch https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-tk_x11.diff
==> tix: Executing phase: 'autoreconf'
==> tix: Executing phase: 'configure'
==> tix: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

32 errors found in build log:
     105    SPACK_ROOT/lib/spack/env/gcc/gcc -DPACKAGE_NA
            ME=\"Tix\" -DPACKAGE_TARNAME=\"tix\" -DPACKAGE_VERSION=\"8.4.3\" -D
            PACKAGE_STRING=\"Tix\ 8.4.3\" -DPACKAGE_BUGREPORT=\"\" -DSTDC_HEADE
            RS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DH
            AVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES
            _H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_LIMITS_H=1 -DHAVE_S
            YS_PARAM_H=1 -DUSE_THREAD_ALLOC=1 -D_REENTRANT=1 -D_THREAD_SAFE=1 -
            DTCL_THREADS=1 -D_LARGEFILE64_SOURCE=1 -DTCL_WIDE_INT_IS_LONG=1 -DU
            SE_TCL_STUBS=1 -DUSE_TK_STUBS=1   -I. -I"/var/tmp/dahlgren/spack-st
            age/spack-stage-tix-8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-sr
            c/generic" -I. -I"/TMPDIR/spack-stage-tix-8.4
            .3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/unix" -I"/usr/WS1/dah
            lgren/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/tcl
            -8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/generic" -I"
            SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            unix" -I"SPACK_ROOT/opt/spack/linux-rhel8-bro
            adwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx4vdvur/share/
            tk/src/generic" -I"SPACK_ROOT/opt/spack/linux
            -rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx4vd
            vur/share/tk/src/unix" -ISPACK_ROOT/opt/spack
            /linux-rhel8-broadwell/gcc-10.3.1/libx11-1.8.4-v7fyfq5bsdzxnj4km62l
            5yeqgjok3dj6/include    -pipe -O2 -fomit-frame-pointer -Wall -Wno-i
            mplicit-int -fPIC  -c `echo /TMPDIR/spack-sta
            ge-tix-8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tix
            DiImg.c`
     106    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     107                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx
            4vdvur/share/tk/src/generic/tk.h:19,
     108                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tix.h:30,
     109                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixInt.h:
            19,
     110                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixScroll
            .c:11:
  >> 111    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     112     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     113          |              ^~
     114    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     115     2607 | #   define panic  Tcl_Panic
     116          |                   ^~~~~~~~~
     117    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     118       63 | EXTERN void panic(char * format, ...);
     119          |             ^~~~~
  >> 120    make: *** [Makefile:293: tixScroll.o] Error 1
     121    make: *** Waiting for unfinished jobs....
     122    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     123                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixUtils.
            c:16:
  >> 124    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     125     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     126          |              ^~
     127    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     128     2607 | #   define panic  Tcl_Panic
     129          |                   ^~~~~~~~~
     130    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     131       63 | EXTERN void panic(char * format, ...);
     132          |             ^~~~~
     133    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     134                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     135                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixError.
            c:16:
  >> 136    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     137     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     138          |              ^~
     139    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     140     2607 | #   define panic  Tcl_Panic
     141          |                   ^~~~~~~~~
     142    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     143       63 | EXTERN void panic(char * format, ...);
     144          |             ^~~~~
     145    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     146                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx
            4vdvur/share/tk/src/generic/tk.h:19,
     147                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixMethod
            .c:17:
  >> 148    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     149     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     150          |              ^~
     151    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     152     2607 | #   define panic  Tcl_Panic
     153          |                   ^~~~~~~~~
     154    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     155       63 | EXTERN void panic(char * format, ...);
     156          |             ^~~~~
     157    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     158                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx
            4vdvur/share/tk/src/generic/tk.h:19,
     159                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixOption
            .c:25:
  >> 160    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     161     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     162          |              ^~
     163    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     164     2607 | #   define panic  Tcl_Panic
     165          |                   ^~~~~~~~~
     166    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     167       63 | EXTERN void panic(char * format, ...);
     168          |             ^~~~~
     169    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     170                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tk-8.6.11-xxwhyculliwhekavr3zenaimfx
            4vdvur/share/tk/src/generic/tk.h:19,
     171                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixClass.
            c:28:
  >> 172    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     173     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     174          |              ^~
     175    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     176     2607 | #   define panic  Tcl_Panic
     177          |                   ^~~~~~~~~
     178    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     179       63 | EXTERN void panic(char * format, ...);
     180          |             ^~~~~
     181    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     182                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     183                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixCmds.c
            :17:
  >> 184    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     185     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     186          |              ^~
     187    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     188     2607 | #   define panic  Tcl_Panic
     189          |                   ^~~~~~~~~
     190    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     191       63 | EXTERN void panic(char * format, ...);
     192          |             ^~~~~
     193    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     194                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     195                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixSmpLs.
            c:17:
  >> 196    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     197     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     198          |              ^~
     199    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     200     2607 | #   define panic  Tcl_Panic
     201          |                   ^~~~~~~~~
     202    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     203       63 | EXTERN void panic(char * format, ...);
     204          |             ^~~~~
     205    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     206                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     207                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixList.c
            :15:
  >> 208    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     209     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     210          |              ^~
     211    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     212     2607 | #   define panic  Tcl_Panic
     213          |                   ^~~~~~~~~
     214    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     215       63 | EXTERN void panic(char * format, ...);
     216          |             ^~~~~
     217    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     218                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     219                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixCompat
            .c:16:
  >> 220    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     221     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     222          |              ^~
     223    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     224     2607 | #   define panic  Tcl_Panic
     225          |                   ^~~~~~~~~
     226    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     227       63 | EXTERN void panic(char * format, ...);
     228          |             ^~~~~
     229    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     230                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     231                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixInit.c
            :18:
  >> 232    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     233     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     234          |              ^~
     235    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     236     2607 | #   define panic  Tcl_Panic
     237          |                   ^~~~~~~~~
     238    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     239       63 | EXTERN void panic(char * format, ...);
     240          |             ^~~~~
     241    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     242                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     243                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixDItem.
            c:25:
  >> 244    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     245     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     246          |              ^~
     247    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     248     2607 | #   define panic  Tcl_Panic
     249          |                   ^~~~~~~~~
     250    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     251       63 | EXTERN void panic(char * format, ...);
     252          |             ^~~~~
     253    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     254                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     255                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixDiImg.
            c:16:
  >> 256    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     257     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     258          |              ^~
     259    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     260     2607 | #   define panic  Tcl_Panic
     261          |                   ^~~~~~~~~
     262    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     263       63 | EXTERN void panic(char * format, ...);
     264          |             ^~~~~
     265    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     266                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     267                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixGeomet
            ry.c:16:
  >> 268    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     269     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     270          |              ^~
     271    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     272     2607 | #   define panic  Tcl_Panic
     273          |                   ^~~~~~~~~
     274    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     275       63 | EXTERN void panic(char * format, ...);
     276          |             ^~~~~
     277    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     278                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixPort.h
            :22,
     279                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixDiITxt
            .c:16:
  >> 280    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     281     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     282          |              ^~
     283    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     284     2607 | #   define panic  Tcl_Panic
     285          |                   ^~~~~~~~~
     286    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'

     ...

     296          |                   ^~~~~~~~~~~
     297    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixDItem.c: At top level:
     298    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixDItem.c:517:21: warning: ini
            tialization of 'const char * (*)(void *, struct Tk_Window_ *, char 
            *, int,  void (**)(char *))' from incompatible pointer type 'char *
             (*)(void *, struct Tk_Window_ *, char *, int,  void (**)(char *))'
             [-Wincompatible-pointer-types]
     299      517 |     DItemParseProc, DItemPrintProc, 0,
     300          |                     ^~~~~~~~~~~~~~
     301    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixDItem.c:517:21: note: (near 
            initialization for 'tixConfigItemType.printProc')
  >> 302    make: *** [Makefile:293: tixSmpLs.o] Error 1
  >> 303    make: *** [Makefile:293: tixError.o] Error 1
  >> 304    make: *** [Makefile:293: tixCompat.o] Error 1
  >> 305    make: *** [Makefile:293: tixList.o] Error 1
  >> 306    make: *** [Makefile:293: tixInit.o] Error 1
  >> 307    make: *** [Makefile:293: tixOption.o] Error 1
  >> 308    make: *** [Makefile:293: tixUtils.o] Error 1
  >> 309    make: *** [Makefile:293: tixMethod.o] Error 1
  >> 310    make: *** [Makefile:293: tixGeometry.o] Error 1
  >> 311    make: *** [Makefile:293: tixDiImg.o] Error 1
  >> 312    make: *** [Makefile:293: tixDItem.o] Error 1
  >> 313    make: *** [Makefile:293: tixDiITxt.o] Error 1
  >> 314    make: *** [Makefile:293: tixClass.o] Error 1
  >> 315    make: *** [Makefile:293: tixCmds.o] Error 1
     316    In file included from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tcl.h:2418,
     317                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tclPort.h:25,
     318                     from SPACK_ROOT/opt/spack/li
            nux-rhel8-broadwell/gcc-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vq
            zqcbnv3/share/tcl/src/generic/tclInt.h:36,
     319                     from /TMPDIR/spack-stage-tix
            -8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-src/generic/tixWidget
            .c:15:
  >> 320    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tclDecls.h:2564:14: error: expected ')' before '->' token
     321     2564 |  (tclStubsPtr->tcl_Panic) /* 2 */
     322          |              ^~
     323    SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gc
            c-10.3.1/tcl-8.6.12-c2rd7kh33hpriunc45aata3vqzqcbnv3/share/tcl/src/
            generic/tcl.h:2607:19: note: in expansion of macro 'Tcl_Panic'
     324     2607 | #   define panic  Tcl_Panic
     325          |                   ^~~~~~~~~
     326    /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zos
            uqmspitheph2y2ajz/spack-src/generic/tixPort.h:63:13: note: in expan
            sion of macro 'panic'
     327       63 | EXTERN void panic(char * format, ...);
     328          |             ^~~~~
  >> 329    make: *** [Makefile:293: tixWidget.o] Error 1

See build log for details:
  /TMPDIR/spack-stage-tix-8.4.3-ehhzqrimrob2zosuqmspitheph2y2ajz/spack-build-out.txt
```