### PR TITLE
Make cycle detection optional, to speed-up grounding and solving

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -265,15 +265,6 @@ error(10, "'{0}' is not a valid dependency for any package in the DAG", Package)
   :- attr("node", Package),
      not needed(Package).
 
-% Avoid cycles in the DAG
-% some combinations of conditional dependencies can result in cycles;
-% this ensures that we solve around them
-path(Parent, Child) :- depends_on(Parent, Child).
-path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
-error(100, "Cyclic dependency detected between '{0}' and '{1}' (consider changing variants to avoid the cycle)", A, B)
-  :- path(A, B),
-     path(B, A).
-
 #defined dependency_type/2.
 #defined dependency_condition/3.
 

--- a/lib/spack/spack/solver/cycle_detection.lp
+++ b/lib/spack/spack/solver/cycle_detection.lp
@@ -1,0 +1,13 @@
+% Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+% Spack Project Developers. See the top-level COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+% Avoid cycles in the DAG
+% some combinations of conditional dependencies can result in cycles;
+% this ensures that we solve around them
+path(Parent, Child) :- depends_on(Parent, Child).
+path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
+error(100, "Cyclic dependency detected between '{0}' and '{1}' (consider changing variants to avoid the cycle)", A, B)
+  :- path(A, B),
+     path(B, A).


### PR DESCRIPTION
Extracted from #38447 

A detailed profiling showed that computing paths is a very time consuming operation, even for our moderately small DAGs. Avoiding the computation of all possible paths speeds-up the solver greatly. 

Currently we just assume that a solution has no cycle, and if we detect cycles after a fast solve, we fall back to recompute with the cycle detection rule enabled in ASP.