### PR TITLE
python: require xz libs=shared when +lzma

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -172,7 +172,7 @@ class Python(Package):
         depends_on("libnsl", when="+nis")
         depends_on("zlib@1.1.3:", when="+zlib")
         depends_on("bzip2", when="+bz2")
-        depends_on("xz", when="+lzma")
+        depends_on("xz libs=shared", when="+lzma")
         depends_on("expat", when="+pyexpat")
         depends_on("libffi", when="+ctypes")
         # https://docs.python.org/3/whatsnew/3.11.html#build-changes


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37237

Python only builds a `lzma` package if the required C libraries are available as shared libraries. Adjust the `depends_on` in the recipe to match.