### PR TITLE
Check environment module commands exit status

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3285,7 +3285,7 @@ spack:
 
 
 @pytest.mark.regression("18338")
-def test_newline_in_commented_sequence_is_not_an_issue(tmpdir):
+def test_newline_in_commented_sequence_is_not_an_issue(tmpdir, monkeypatch):
     spack_yaml = """
 spack:
   specs:
@@ -3302,6 +3302,9 @@ spack:
 """
     abspath = tmpdir.join("spack.yaml")
     abspath.write(spack_yaml)
+
+    # Don't actually run module commands
+    monkeypatch.setattr(spack.util.module_cmd, "module", lambda *args: "")
 
     def extract_dag_hash(environment):
         _, dyninst = next(iter(environment.specs_by_hash.items()))

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -812,6 +812,9 @@ echo "4.4.4"
     }
     compiler_dict = {"compiler": compiler_info}
 
+    # Don't actually run module commands
+    monkeypatch.setattr(spack.util.module_cmd, "module", lambda *args: "")
+
     # Run and confirm output
     compilers = spack.compilers.get_compilers([compiler_dict])
     assert len(compilers) == 1

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -14,6 +14,7 @@ import spack.repo
 import spack.util.spack_yaml as syaml
 from spack.config import ConfigError
 from spack.spec import CompilerSpec, Spec
+from spack.util.module_cmd import ModuleCmdError
 from spack.version import Version
 
 
@@ -322,6 +323,29 @@ mpi:
         spec = Spec("mpi")
         spec.concretize()
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
+
+    @pytest.mark.not_on_windows("Cannot use modules on Windows")
+    def test_external_missing_module(self):
+        """Test that packages with an invalid module raises an error"""
+        conf = syaml.load_config(
+            """\
+all:
+    providers:
+        mpi: [mpich]
+mpi:
+    buildable: false
+    externals:
+    - spec: mpich@3.0.4
+      modules: [this_module_does_not_exist]
+"""
+        )
+        spack.config.set("packages", conf, scope="concretize")
+        spec = Spec("mpi")
+        # Expect errors like:
+        # - module: command not found
+        # - Unable to locate a modulefile for 'this_module_does_not_exist'
+        with pytest.raises(ModuleCmdError):
+            spec.concretize()
 
     def test_buildable_false(self):
         conf = syaml.load_config(

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -18,7 +18,7 @@ import spack.error
 
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
-module_change_commands = ["load", "swap", "unload", "purge", "use", "unuse"]
+module_change_commands = ["load", "swap", "unload", "purge", "reset", "use", "unuse"]
 
 # This awk script is a posix alternative to `env -0`
 awk_cmd = r"""awk 'BEGIN{for(name in ENVIRON)""" r"""printf("%s=%s%c", name, ENVIRON[name], 0)}'"""


### PR DESCRIPTION
Raise an error when a module command fails.

This means Spack will now fail and report error on:
- missing module command
- missing or invalid module name
- module load failure, e.g., because of a module conflict

I tested with tcl modules. I also checked that `module unload` does not error if there is no module to unload.

Also add `module reset` as an environment-modifying command.

Also make `module_cmd` return the output (stdout+stderr) for both environment-modifying and non-environment-modifying commands.

Fix #38603 

