### PR TITLE
[intel-tbb] support for building 2020.3 with %oneapi (for dyninst)

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/intel-tbb.2020.3-icx.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/intel-tbb.2020.3-icx.patch
@@ -1,0 +1,21 @@
+diff --git a/build/linux.gcc.inc b/build/linux.gcc.inc
+index d820c15d..a20d52ba 100644
+--- a/build/linux.gcc.inc
++++ b/build/linux.gcc.inc
+@@ -54,14 +54,14 @@ endif
+ ifneq (,$(shell $(CONLY) -dumpfullversion -dumpversion | egrep  "^([5-9]|1[0-9])"))
+     # enable -Wsuggest-override via a pre-included header in order to limit to C++11 and above
+     INCLUDE_TEST_HEADERS = -include $(tbb_root)/src/test/harness_preload.h
+-    WARNING_SUPPRESS += -Wno-sized-deallocation
++    #WARNING_SUPPRESS += -Wno-sized-deallocation
+ endif
+ 
+ # gcc 6.0 and later have -flifetime-dse option that controls
+ # elimination of stores done outside the object lifetime
+ ifneq (,$(shell $(CONLY) -dumpfullversion -dumpversion | egrep  "^([6-9]|1[0-9])"))
+     # keep pre-contruction stores for zero initialization
+-    DSE_KEY = -flifetime-dse=1
++    #DSE_KEY = -flifetime-dse=1
+ endif
+ 
+ ifeq ($(cfg), release)

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -144,6 +144,9 @@ class IntelTbb(CMakePackage, MakefilePackage):
     # https://github.com/oneapi-src/oneTBB/commit/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch?full_index=1
     patch("macos-arm64.patch", when="@:2021.0")
 
+    # build older tbb with %oneapi
+    patch("intel-tbb.2020.3-icx.patch", when="@2020.3 %oneapi")
+
     # Support for building with %nvhpc
     # 1) remove flags nvhpc compilers do not recognize
     patch("intel-tbb.nvhpc-remove-flags.2017.patch", when="@2017:2018.9 %nvhpc")


### PR DESCRIPTION
Recent versions of this package work with `%oneapi`. The next release of dyninst will support recent versions of this package. Until then, make 2020.3 work with `%oneapi` so dyninst can be built

Resolves #38567 
