### PR TITLE
Fix *_LIBRARY_PATH support in fish shell

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -372,10 +372,10 @@ end
 
 
 function spack_runner -d "Runner function for the `spack` wrapper"
-    # Store LD_LIBRARY_PATH variables from spack shell function
+    # Store DYLD_* variables from spack shell function
     # This is necessary because MacOS System Integrity Protection clears
     # variables that affect dyld on process start.
-    for var in LD_LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
+    for var in DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
         if set -q $var
             set -gx SPACK_$var $$var
         end

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -372,7 +372,14 @@ end
 
 
 function spack_runner -d "Runner function for the `spack` wrapper"
-
+    # Store LD_LIBRARY_PATH variables from spack shell function
+    # This is necessary because MacOS System Integrity Protection clears
+    # variables that affect dyld on process start.
+    for var in LD_LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
+        if set -q $var
+            set -gx SPACK_$var $$var
+        end
+    end
 
     #
     # Accumulate initial flags for main spack command


### PR DESCRIPTION
Same implementation we use for sh and csh. @becker33 added this in #14062 and may want to review. Also tagging some possible fishers: @JBlaschke @funnell @KiruyaMomochi @carns @severinstrobl @wortiz 

I recently switched to fish and will be slowly fixing all of the bugs I encounter 😄 