### PR TITLE
[postgresql,perl] PostGreSQL requires Opcode.pm for Perl bindings

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -137,6 +137,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     variant("shared", default=True, description="Build a shared libperl.so library")
     variant("threads", default=True, description="Build perl with threads support")
     variant("open", default=True, description="Support open.pm")
+    variant("opcode", default=True, description="Support Opcode.pm")
 
     resource(
         name="cpanm",
@@ -199,6 +200,16 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 fail_on_error=False,
             )
             variants += "+open" if perl.returncode == 0 else "~open"
+            # this is just to detect incomplete installs
+            # normally perl installs Opcode.pm
+            perl(
+                "-e",
+                "use Opcode",
+                output=os.devnull,
+                error=os.devnull,
+                fail_on_error=False,
+            )
+            variants += "+opcode" if perl.returncode == 0 else "~opcode"
             return variants
 
     # On a lustre filesystem, patch may fail when files

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -202,13 +202,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             variants += "+open" if perl.returncode == 0 else "~open"
             # this is just to detect incomplete installs
             # normally perl installs Opcode.pm
-            perl(
-                "-e",
-                "use Opcode",
-                output=os.devnull,
-                error=os.devnull,
-                fail_on_error=False,
-            )
+            perl("-e", "use Opcode", output=os.devnull, error=os.devnull, fail_on_error=False)
             variants += "+opcode" if perl.returncode == 0 else "~opcode"
             return variants
 

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -57,7 +57,7 @@ class Postgresql(AutotoolsPackage):
     depends_on("libedit", when="lineedit=libedit")
     depends_on("openssl")
     depends_on("tcl", when="+tcl")
-    depends_on("perl", when="+perl")
+    depends_on("perl+opcode", when="+perl")
     depends_on("python", when="+python")
     depends_on("libxml2", when="+xml")
 


### PR DESCRIPTION
- [perl] Variant `opcode` a la `open` to handle deficient externals
- [postgresql] Opcode.pm is required for perl bindings
