### PR TITLE
Py-pykerberos needs krb5 for build

### DIFF
--- a/var/spack/repos/builtin/packages/py-pykerberos/package.py
+++ b/var/spack/repos/builtin/packages/py-pykerberos/package.py
@@ -16,4 +16,4 @@ class PyPykerberos(PythonPackage):
 
     depends_on("py-setuptools", type="build")
 
-    depends_on("krb5", type="link")
+    depends_on("krb5", type=("build", "link"))


### PR DESCRIPTION
`py-pykerberos`'s setup.py relies on `krb5-config` from `krb5` to determine proper link and compile args. As the package stands right now, `krb5` is not loaded at build-time and thus this information is missing from the build, and the resulting `py-pykerberos` library does not have access to the symbols it needs. This PR remedies this state of affairs by identifying `krb5` as a build-dep of `py-pykerberos`.

CC @nchaimov @wspear @valmar