### PR TITLE
CI: Disable broken stack until fixed on develop

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -688,11 +688,11 @@ ml-linux-x86_64-rocm-build:
   variables:
     SPACK_CI_STACK_NAME: ml-darwin-aarch64-mps
 
-ml-darwin-aarch64-mps-generate:
+.ml-darwin-aarch64-mps-generate:
   tags: [ "macos-ventura", "apple-clang-14", "aarch64-macos" ]
   extends: [ ".ml-darwin-aarch64-mps", ".darwin-generate"]
 
-ml-darwin-aarch64-mps-build:
+.ml-darwin-aarch64-mps-build:
   extends: [ ".ml-darwin-aarch64-mps", ".build" ]
   trigger:
     include:


### PR DESCRIPTION
This PR is triggered by wasting resources while trying to debug develop pipelines. The PR https://github.com/spack/spack/pull/38514 will re-enable this later.