### PR TITLE
tests/papyrus: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -40,16 +40,14 @@ class Papyrus(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([join_path("kv", "tests")])
+        self.cache_extra_test_sources(join_path("kv", "tests"))
 
-    def run_example_tests(self):
+    def test_example(self):
         """Run all c & c++ stand alone test"""
 
-        example_dir = join_path(self.test_suite.current_test_cache_dir, "kv", "tests")
-
+        example_dir = self.test_suite.current_test_cache_dir.kv.tests
         if not os.path.exists(example_dir):
-            print("Skipping all test")
-            return
+            raise SkipTest("Example directory is missing")
 
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64
@@ -71,37 +69,32 @@ class Papyrus(CMakePackage):
             "12_free",
         ]
 
+        mpicxx = which(self.spec["mpi"].mpicxx)
+        mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+
         for example in example_list:
-            test_dir = join_path(self.test_suite.current_test_cache_dir, "kv", "tests", example)
-            test_example = "test{0}.c".format(example)
-
+            test_dir = join_path(example_dir, example)
             if not os.path.exists(test_dir):
-                print("Skipping {0} test".format(example))
-                continue
+                raise SkipTest("{0} is missing".format(test_dir))
 
-            self.run_test(
-                self.spec["mpi"].mpicxx,
-                options=[
-                    "{0}".format(join_path(test_dir, test_example)),
-                    "-I{0}".format(join_path(self.prefix, "include")),
-                    "-L{0}".format(lib_dir),
+            with test_part(
+                self,
+                f"test_example_{example}",
+                purpose=f"build and run {example}",
+                work_dir=test_dir,
+            ):
+                test_example = f"test{example}.c"
+
+                mpicxx(
+                    f"{join_path(test_dir, test_example)}",
+                    f"-I{self.prefix.include}",
+                    f"-L{lib_dir}",
                     "-lpapyruskv",
                     "-g",
                     "-o",
                     example,
                     "-lpthread",
                     "-lm",
-                ],
-                purpose="test: compile {0} example".format(example),
-                work_dir=test_dir,
-            )
+                )
 
-            self.run_test(
-                self.spec["mpi"].prefix.bin.mpirun,
-                options=["-np", "4", example],
-                purpose="test: run {0} example".format(example),
-                work_dir=test_dir,
-            )
-
-    # def test(self):
-    #     self.run_example_tests()
+                mpirun("-np", "4", example)

--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -42,59 +42,81 @@ class Papyrus(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(join_path("kv", "tests"))
 
-    def test_example(self):
-        """Run all c & c++ stand alone test"""
+    @property
+    def _lib_dir(self):
+        """Path to the installed library root."""
+        return self.prefix.lib64 if os.path.isdir(self.prefix.lib64) else self.prefix.lib
 
-        example_dir = self.test_suite.current_test_cache_dir.kv.tests
-        if not os.path.exists(example_dir):
-            raise SkipTest("Example directory is missing")
+    def _build_and_run_kv_test(self, test):
+        """build and run a kv/tests test"""
 
-        if os.path.isdir(self.prefix.lib64):
-            lib_dir = self.prefix.lib64
-        else:
-            lib_dir = self.prefix.lib
+        test_dir = join_path(self.test_suite.current_test_cache_dir.kv.tests, test)
+        if not os.path.exists(test_dir):
+            raise SkipTest(f"Example directory ({test_dir}) is missing")
 
-        example_list = [
-            "01_open_close",
-            "02_put_get",
-            "03_barrier",
-            "04_delete",
-            "05_fence",
-            "06_signal",
-            "07_consistency",
-            "08_protect",
-            "09_cache",
-            "10_checkpoint",
-            "11_restart",
-            "12_free",
-        ]
+        with working_dir(test_dir):
+            options = [
+                f"test{test}.c",
+                f"-I{self.prefix.include}",
+                f"-L{self._lib_dir}",
+                "-lpapyruskv",
+                "-g",
+                "-o",
+                test,
+                "-lpthread",
+                "-lm",
+            ]
 
-        mpicxx = which(self.spec["mpi"].mpicxx)
-        mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+            mpicxx = which(self.spec["mpi"].mpicxx)
+            mpicxx(*options)
 
-        for example in example_list:
-            test_dir = join_path(example_dir, example)
-            if not os.path.exists(test_dir):
-                raise SkipTest("{0} is missing".format(test_dir))
+            mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+            mpirun("-np", "4", test)
 
-            with test_part(
-                self,
-                f"test_example_{example}",
-                purpose=f"build and run {example}",
-                work_dir=test_dir,
-            ):
-                test_example = f"test{example}.c"
+    def test_01_open_close(self):
+        """build and run test01_open_close"""
+        self._build_and_run_kv_test("01_open_close")
 
-                mpicxx(
-                    f"{join_path(test_dir, test_example)}",
-                    f"-I{self.prefix.include}",
-                    f"-L{lib_dir}",
-                    "-lpapyruskv",
-                    "-g",
-                    "-o",
-                    example,
-                    "-lpthread",
-                    "-lm",
-                )
+    def test_02_put_get(self):
+        """build and run test02_put_get"""
+        self._build_and_run_kv_test("02_put_get")
 
-                mpirun("-np", "4", example)
+    def test_03_barrier(self):
+        """build and run test03_barrier"""
+        self._build_and_run_kv_test("03_barrier")
+
+    def test_04_delete(self):
+        """build and run test 04_delete"""
+        self._build_and_run_kv_test("04_delete")
+
+    def test_05_fence(self):
+        """build and run test05_fence"""
+        self._build_and_run_kv_test("05_fence")
+
+    def test_06_signal(self):
+        """build and run test06_signal"""
+        self._build_and_run_kv_test("06_signal")
+
+    def test_07_consistency(self):
+        """build and run test07_consistency"""
+        self._build_and_run_kv_test("07_consistency")
+
+    def test_08_protect(self):
+        """build and run test08_protect"""
+        self._build_and_run_kv_test("08_protect")
+
+    def test_09_cache(self):
+        """build and run test09_cache"""
+        self._build_and_run_kv_test("09_cache")
+
+    def test_10_checkpoint(self):
+        """build and run test10_checkpoint"""
+        self._build_and_run_kv_test("10_checkpoint")
+
+    def test_11_restart(self):
+        """build and run test11_restart"""
+        self._build_and_run_kv_test("11_restart")
+
+    def test_12_free(self):
+        """build and run test12_free"""
+        self._build_and_run_kv_test("12_free")


### PR DESCRIPTION
This PR converts the stand-alone tests to use the new process.  The first commit retains the embedded test part processing while the second eliminates embedded test parts.

Results for the latter:
```
$ spack -v test run papyrus
==> Spack test 4wp3e4syh2zkw4il5jrqjjz7vwpj45qy
==> Testing package papyrus-1.0.2-y6oage5
==> [2023-06-28-16:40:22.004462] Installing SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/papyrus-1.0.2-y6oage5vzuc4agrcto7hulyeztrnykov/.spack/test to SPACK_TEST_ROOT/4wp3e4syh2zkw4il5jrqjjz7vwpj45qy/papyrus-1.0.2-y6oage5/cache/papyrus
==> [2023-06-28-16:40:22.450341] test: test_01_open_close: build and run test01_open_close
==> [2023-06-28-16:40:22.456065] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpic++' 'test01_open_close.c' '-ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/papyrus-1.0.2-y6oage5vzuc4agrcto7hulyeztrnykov/include' '-LSPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/papyrus-1.0.2-y6oage5vzuc4agrcto7hulyeztrnykov/lib' '-lpapyruskv' '-g' '-o' '01_open_close' '-lpthread' '-lm'
==> [2023-06-28-16:40:22.983018] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpirun' '-np' '4' '01_open_close'
...
PASSED: Papyrus::test_11_restart
==> [2023-06-28-16:40:30.584493] test: test_12_free: build and run test12_free
==> [2023-06-28-16:40:30.587942] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpic++' 'test12_free.c' '-ISPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/papyrus-1.0.2-y6oage5vzuc4agrcto7hulyeztrnykov/include' '-LSPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/papyrus-1.0.2-y6oage5vzuc4agrcto7hulyeztrnykov/lib' '-lpapyruskv' '-g' '-o' '12_free' '-lpthread' '-lm'
==> [2023-06-28-16:40:30.896141] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openmpi-4.1.5-3age6xsh53nhbuxmuc46a67zm6jqe2md/bin/mpirun' '-np' '4' '12_free'
[I] [    0:quartz2300] [Platform.cpp:103:Init] PapyrusKV nranks[4] repository[kv_repo] storage_group[1] consistency[2] memtable[1073741824] [1024]MB remotebuf[131072] [128]KB total_remotebuf[524288] [0]MB remotebuf_entry_max[4096] cache[134217728] [128]MB cache_local[0] cache_remote[0] sstable[2] bloom[1] force_redistribute[0] destroy_repository[1]
[test12_free.c:27] [quartz2300] [3/4]
[test12_free.c:27] [quartz2300] [0/4]
[test12_free.c:27] [quartz2300] [1/4]
[test12_free.c:27] [quartz2300] [2/4]
[test12_free.c:31] db[1]
[test12_free.c:31] db[1]
[test12_free.c:31] db[1]
[test12_free.c:31] db[1]
[test12_free.c:37] PUT:rank[0] key[GOOGLE] value[https://google.com]
[test12_free.c:37] PUT:rank[1] key[FACEBOOK] value[https://facebook.com]
[test12_free.c:37] PUT:rank[3] key[JUNGWONKIM] value[http://jungwon.kim]
[test12_free.c:37] PUT:rank[2] key[TWITTER] value[https://twitter.com]
[test12_free.c:42] BARRIER:rank[1]
[test12_free.c:42] BARRIER:rank[0]
[test12_free.c:42] BARRIER:rank[2]
[test12_free.c:42] BARRIER:rank[3]
[test12_free.c:49] GET:rank[1] peer[2] key[TWITTER] value[https://twitter.com] vallen[20]
[test12_free.c:49] GET:rank[2] peer[3] key[JUNGWONKIM] value[http://jungwon.kim] vallen[19]
[test12_free.c:49] GET:rank[0] peer[1] key[FACEBOOK] value[https://facebook.com] vallen[21]
[test12_free.c:49] GET:rank[3] peer[0] key[GOOGLE] value[https://google.com] vallen[19]
PASSED: Papyrus::test_12_free
==> [2023-06-28-16:40:31.336295] Completed testing
==> [2023-06-28-16:40:31.336519] 
======================== SUMMARY: papyrus-1.0.2-y6oage5 ========================
Papyrus::test_01_open_close .. PASSED
Papyrus::test_02_put_get .. PASSED
Papyrus::test_03_barrier .. PASSED
Papyrus::test_04_delete .. PASSED
Papyrus::test_05_fence .. PASSED
Papyrus::test_06_signal .. PASSED
Papyrus::test_07_consistency .. PASSED
Papyrus::test_08_protect .. PASSED
Papyrus::test_09_cache .. PASSED
Papyrus::test_10_checkpoint .. PASSED
Papyrus::test_11_restart .. PASSED
Papyrus::test_12_free .. PASSED
============================ 12 passed of 12 parts =============================
============================== 1 passed of 1 spec ==============================
```