### PR TITLE
tests/open3d: changed post-install test to check_python_import

### DIFF
--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -117,11 +117,12 @@ class Open3d(CMakePackage, CudaPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test(self):
-        if "+python" in self.spec:
-            self.run_test(
-                self.spec["python"].command.path,
-                ["-c", "import open3d"],
-                purpose="checking import of open3d",
-                work_dir="spack-test",
-            )
+    def check_python_import(self):
+        if "+python" not in self.spec:
+            return
+
+        with test_part(
+            self, "check_import_open3d", purpose="checking import of open3d", work_dir="spack-test"
+        ):
+            python = self.spec["python"].command
+            python("-c", "import open3d")


### PR DESCRIPTION
This PR changes the name of the post-install method since method names starting `test` are reserved for stand-alone testing.  Unfortunately I cannot build the package with or without the change:

```
...
==> Installing open3d-0.13.0-zx6is2q25p5lldxcg2utagthviyzn5t6
==> No binary for open3d-0.13.0-zx6is2q25p5lldxcg2utagthviyzn5t6 found: installing from source
==> Using cached archive: /usr/WS1/dahlgren/releases/spack/var/spack/cache/_source-cache/git//isl-org/Open3D.git/v0.13.0.tar.gz
...
==> open3d: Executing phase: 'cmake'
==> open3d: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    '/usr/WS1/dahlgren/releases/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/gmake-4.4.1-xfwybo56bsim7t5xd2qb2bln7fi3n3ey/bin/make' '-j16'

5 errors found in build log:
     4061      117 |     if (age_write_to_fileage, filename.c_str(), 0,
     4062          |         
     4063    p/dahlgren/spack-stage/spack-stage-open3d-0.13.0-zx6is2q25p5lld
             xcg2utagthviyzn5t6/spack-src/cpp/open3d/t/io/file_format/FilePN
             G.cpp: At global scope:
     4064    p/dahlgren/spack-stage/spack-stage-open3d-0.13.0-zx6is2q25p5lld
             xcg2utagthviyzn5t6/spack-src/cpp/open3d/t/io/file_format/FilePN
             G.cpp:36:13:ageFromImage(const open3d::t::geometry::Image&, int
             , int&)]
     4065       36 | static void ageFromImageetry::Image &image,
     4066          |             
  >> 4067    make[2]: *** [cpp/open3d/t/io/CMakeFiles/tio.dir/build.make:163
             : cpp/open3d/t/io/CMakeFiles/tio.dir/file_format/FilePNG.cpp.o]
              Error 1
     4068    make[2]: Leaving directory '/tmp/dahlgren/spack-stage/spack-sta
             ge-open3d-0.13.0-zx6is2q25p5lldxcg2utagthviyzn5t6/spack-build-z
             x6is2q'
  >> 4069    make[1]: *** [CMakeFiles/Makefile2:1381: cpp/open3d/t/io/CMakeF
             iles/tio.dir/all] Error 2
     4070    make[1]: *** Waiting for unfinished jobs....
...
```