### PR TITLE
tests/openrasmol: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/openrasmol/package.py
+++ b/var/spack/repos/builtin/packages/openrasmol/package.py
@@ -58,11 +58,13 @@ class Openrasmol(MakefilePackage):
             bash = which("bash")
             bash("./rasmol_install.sh", "--prefix={0}".format(prefix))
 
-    def test(self):
-        testdir = self.test_suite.current_test_data_dir
-        opts = []
-        opts.append("-insecure")
-        opts.append("-script")
-        opts.append(join_path(testdir, "test.rsc"))
-        opts.append(join_path(self.prefix.sample, "1crn.pdb"))
-        self.run_test("rasmol", options=opts)
+    def test_rasmol(self):
+        """run rasmol on sample"""
+        opts = [
+            "-insecure",
+            "-script",
+            join_path(self.test_suite.current_test_data_dir, "test.rsc"),
+            join_path(self.prefix.sample, "1crn.pdb"),
+        ]
+        rasmol = which(self.prefix.bin.rasmol)
+        rasmol(*opts)


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.

```
$ spack -v test run openrasmol
==> Spack test 7se3oyfoiy263vzknmgjpxbs7lgq2wlx
==> Testing package openrasmol-2.7.5.2-ozpdmq3
==> [2023-06-28-17:55:28.648852] test: test_rasmol: run rasmol on sample
==> [2023-06-28-17:55:28.650444] 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openrasmol-2.7.5.2-ozpdmq3rcshvlqzrasspyyjy7o3g6eni/bin/rasmol' '-insecure' '-script' 'SPACK_TEST_ROOT/7se3oyfoiy263vzknmgjpxbs7lgq2wlx/openrasmol-2.7.5.2-ozpdmq3/data/openrasmol/test.rsc' 'SPACK_ROOT/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/openrasmol-2.7.5.2-ozpdmq3rcshvlqzrasspyyjy7o3g6eni/sample/1crn.pdb'
unable to find codepage 1251 fonts
PASSED: Openrasmol::test_rasmol
==> [2023-06-28-17:55:29.319071] Completed testing
==> [2023-06-28-17:55:29.319222] 
===================== SUMMARY: openrasmol-2.7.5.2-ozpdmq3 ======================
Openrasmol::test_rasmol .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```