### PR TITLE
bugfix/cbflib: fix build with newer gfortran

### DIFF
--- a/var/spack/repos/builtin/packages/cbflib/package.py
+++ b/var/spack/repos/builtin/packages/cbflib/package.py
@@ -43,6 +43,9 @@ class Cbflib(MakefilePackage):
         mf.filter(r"^C\+\+.+", "C++ = {0}".format(spack_cxx))
         mf.filter("gfortran", spack_fc)
         mf.filter(r"^INSTALLDIR .+", "INSTALLDIR = {0}".format(prefix))
+        real_version = Version(self.compiler.get_real_version())
+        if real_version >= Version("10"):
+            mf.filter(r"^F90FLAGS[ \t]*=[ \t]*(.+)", "F90FLAGS = \\1 -fallow-invalid-boz")
 
     def build(self, spec, prefix):
         pass


### PR DESCRIPTION
This PR fixes a problem with building the package with BOZ literals using a `gfortran` compiler >= 10 since it has an extension that can be enabled with `-fallow-invalid-boz` (see the last two sentences of https://gcc.gnu.org/onlinedocs/gfortran/BOZ-literal-constants.html).

```
==> Installing cbflib-0.9.2-5py6asa7w3xmnl737utyseh35ap3mxxf
==> No binary for cbflib-0.9.2-5py6asa7w3xmnl737utyseh35ap3mxxf found: installing from source
==> Using cached archive: SPACK_ROOT/var/spack/cache/_source-cache/archive/36/367e37e1908a65d5472e921150291332823a751206804866e752b793bca17afc.tar.gz
==> Applied patch SPACK_ROOT/var/spack/repos/builtin/packages/cbflib/cbf_f16.patch
==> Applied patch SPACK_ROOT/var/spack/repos/builtin/packages/cbflib/cbf_int.patch
==> cbflib: Executing phase: 'edit'
==> cbflib: Executing phase: 'build'
==> cbflib: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j1' 'install'

157 errors found in build log:
     101    /usr/bin/ranlib lib/libcbf.a
     102    /usr/tce/bin/gfortran -g -fno-range-check -c ./src/fcb_atol_wcnt.f9
            0 ./src/fcb_ci_strncmparr.f90 ./src/fcb_exit_binary.f90 ./src/fcb_n
            blen_array.f90 ./src/fcb_next_binary.f90 ./src/fcb_open_cifin.f90 .
            /src/fcb_packed.f90 ./src/fcb_read_bits.f90 ./src/fcb_read_byte.f90
             ./src/fcb_read_image.f90 ./src/fcb_read_line.f90 ./src/fcb_read_xd
            s_i2.f90 ./src/fcb_skip_whitespace.f90 ./examples/test_fcb_read_ima
            ge.f90 ./examples/test_xds_binary.f90
     103    ./src/fcb_atol_wcnt.f90:10:31:
     104    
     105       10 |       INTEGER, PARAMETER :: I0=Z'30',& !IACHAR('0')
     106          |                               1
  >> 107    Error: BOZ literal constant at (1) is neither a data-stmt-constant 
            nor an actual argument to INT, REAL, DBLE, or CMPLX intrinsic funct
            ion [see '-fno-allow-invalid-boz']
...
```

After the change the build succeeds:

```
$ spack find cbflib
-- linux-rhel8-broadwell / gcc@10.3.1 ---------------------------
cbflib@0.9.2
==> 1 installed package
```