### PR TITLE
tests/mptensor: convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -66,33 +66,40 @@ class Mptensor(CMakePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
+
+        # Tests only supported when spec built with mpi
+        if "+mpi" not in self.spec:
+            print("Skipping copy of stand-alone test files: requires +mpi build")
+            return
+
         self.cache_extra_test_sources(".")
 
-    def test(self):
+        # Clean cached makefiles now so only done once
+        print("Converting cached Makefile for stand-alone test use")
+        with working_dir(join_path(self.install_test_root, "tests"), create=False):
+            make("clean")
+            makefile = FileFilter("Makefile")
+            makefile.filter("g++", "{0}".format(spack_cxx), string=True)
+
+        print("Converting cached Makefile.option for stand-alone test use")
+        with working_dir(join_path(self.install_test_root), create=False):
+            makefile = FileFilter("Makefile.option")
+            makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
+            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
+
+    def test_tensor_test(self):
+        """build and run tensor_test.out"""
         if "+mpi" not in self.spec:
-            print("Test of mptensor only runs with +mpi option.")
-        else:
-            with working_dir(join_path(self.install_test_root, "tests"), create=False):
-                make("clean")
-                makefile = FileFilter("Makefile")
-                makefile.filter("g++", "{0}".format(spack_cxx), string=True)
+            raise SkipTest("Package must be installed with +mpi")
 
-            with working_dir(join_path(self.install_test_root), create=False):
-                makefile = FileFilter("Makefile.option")
-                makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
-                makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
+        math_libs = self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
 
-            math_libs = (
-                self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
-            )
+        with working_dir(self.test_suite.current_test_cache_dir.tests):
+            make = which("make")
+            make(f"LDFLAGS={math_libs.ld_flags}")
 
-            with working_dir(join_path(self.install_test_root, "tests"), create=False):
-                make("LDFLAGS={0}".format(math_libs.ld_flags))
+            mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+            mpirun("-n", "1", "tensor_test.out")
 
-                mpirun = self.spec["mpi"].prefix.bin.mpirun
-                mpiexec = Executable(mpirun)
-                mpiexec("-n", "1", "tensor_test.out")
-
-                # Test of mptensor has checker
-                # and checker is abort when check detect any errors.
-                print("Test of mptensor PASSED !")
+            # Test of mptensor has checker that aborts when any errors detected.
+            print("Test of mptensor PASSED !")


### PR DESCRIPTION
This PR converts the stand-alone test to the new process.  It also:

- skips caching test sources if they won't be used (i.e., package not built with `+mpi`); and
- cleans the cached makefiles post-install so only done once.

Results from running the test when the package is built without `+mpi`:
```
$ spack -v test run mptensor
==> Spack test sohbowpe2ooyb7tg5lqzudnr5vemsmpi
==> Testing package mptensor-0.3.0-fl6gxnm
==> [2023-06-28-18:35:49.106708] test: test_tensor_test: build and run tensor_test.out
SKIPPED: Mptensor::test_tensor_test: Package must be installed with +mpi
==> [2023-06-28-18:35:49.109696] Completed testing
==> [2023-06-28-18:35:49.109810] 
======================= SUMMARY: mptensor-0.3.0-fl6gxnm ========================
Mptensor::test_tensor_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
============================= 1 skipped of 1 spec ==============================
```

TODO:

- [ ] Resolve test failures when build with `+mpi`: can't load `libscalapack.so`