### PR TITLE
CI: Disable building VisIt in CI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -60,9 +60,9 @@ spack:
       - [$^paraview_specs]
       - - ^hdf5@1.14 # Non-VisIt can build HDF5 1.14
     # Test ParaView builds with differnt GL backends
-    - matrix:
-      - [$sdk_base_spec]
-      - [$^visit_specs]
+    # - matrix:
+    #   - [$sdk_base_spec]
+    #   - [$^visit_specs]
 
   mirrors: { "mirror": "s3://spack-binaries/develop/data-vis-sdk" }
 


### PR DESCRIPTION
VisIt requires a deprecated version of Python (3.7) due to a VTK 8 dependency. Spack CI does not support building deprecated versions.