### PR TITLE
Build NAMD with Tcl by default

### DIFF
--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -45,7 +45,7 @@ class Namd(MakefilePackage, CudaPackage):
 
     variant(
         "interface",
-        default="none",
+        default="tcl",
         values=("none", "tcl", "python"),
         description="Enables Tcl and/or python interface",
     )


### PR DESCRIPTION
NAMD users expect the Tcl scripting interface to be enabled as it is used in many examples and tutorials in addition to being required for features such as multi-copy algorithms.