### PR TITLE
Normalize Spack Win entry points

### DIFF
--- a/bin/spack_cmd.bat
+++ b/bin/spack_cmd.bat
@@ -1,71 +1,11 @@
 @ECHO OFF
-setlocal EnableDelayedExpansion
 :: (c) 2021 Lawrence Livermore National Laboratory
 :: To use this file independently of Spack's installer, execute this script in its directory, or add the
 :: associated bin directory to your PATH. Invoke to launch Spack Shell.
 ::
 :: source_dir/spack/bin/spack_cmd.bat
 ::
-pushd %~dp0..
-set SPACK_ROOT=%CD%
-pushd %CD%\..
-set spackinstdir=%CD%
-popd
 
-
-:: Check if Python is on the PATH
-if not defined python_pf_ver (
-(for /f "delims=" %%F in ('where python.exe') do (
-                                                    set "python_pf_ver=%%F"
-                                                    goto :found_python
-                                                  ) ) 2> NUL
-)
-:found_python
-if not defined python_pf_ver (
-    :: If not, look for Python from the Spack installer
-    :get_builtin
-    (for /f "tokens=*" %%g in ('dir /b /a:d "!spackinstdir!\Python*"') do (
-        set "python_ver=%%g")) 2> NUL
-
-    if not defined python_ver (
-        echo Python was not found on your system.
-        echo Please install Python or add Python to your PATH.
-    ) else (
-        set "py_path=!spackinstdir!\!python_ver!"
-        set "py_exe=!py_path!\python.exe"
-    )
-    goto :exitpoint
-) else (
-    :: Python is already on the path
-    set "py_exe=!python_pf_ver!"
-    (for /F "tokens=* USEBACKQ" %%F in (
-        `"!py_exe!" --version`) do (set "output=%%F")) 2>NUL
-    if not "!output:Microsoft Store=!"=="!output!" goto :get_builtin
-    goto :exitpoint
-)
-:exitpoint
-
-set "PATH=%SPACK_ROOT%\bin\;%PATH%"
-if defined py_path (
-    set "PATH=%py_path%;%PATH%"
-)
-
-if defined py_exe (
-    "%py_exe%" "%SPACK_ROOT%\bin\haspywin.py"
-)
-
-set "EDITOR=notepad"
-
-DOSKEY spacktivate=spack env activate $*
-
-@echo **********************************************************************
-@echo ** Spack Package Manager
-@echo **********************************************************************
-
-IF "%1"=="" GOTO CONTINUE
-set
-GOTO:EOF
-
-:continue
-set PROMPT=[spack] %PROMPT%
-%comspec% /k
+call "%~dp0..\share\spack\setup-env.bat"
+pushd %SPACK_ROOT%
+%comspec% /K

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -48,8 +48,6 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         cmds += 'set "SPACK_ENV=%s"\n' % env.path
         if view:
             cmds += 'set "SPACK_ENV_VIEW=%s"\n' % view
-        # TODO: despacktivate
-        # TODO: prompt
     elif shell == "pwsh":
         cmds += "$Env:SPACK_ENV='%s'\n" % env.path
         if view:

--- a/share/spack/setup-env.bat
+++ b/share/spack/setup-env.bat
@@ -1,0 +1,80 @@
+@ECHO OFF
+setlocal EnableDelayedExpansion
+:: (c) 2021 Lawrence Livermore National Laboratory
+:: To use this file independently of Spack's installer, execute this script in its directory, or add the
+:: associated bin directory to your PATH. Invoke to launch Spack Shell.
+::
+:: source_dir/spack/bin/spack_cmd.bat
+::
+pushd %~dp0..\..
+set SPACK_ROOT=%CD%
+pushd %CD%\..
+set spackinstdir=%CD%
+popd
+
+
+:: Check if Python is on the PATH
+if not defined python_pf_ver (
+(for /f "delims=" %%F in ('where python.exe') do (
+                                                    set "python_pf_ver=%%F"
+                                                    goto :found_python
+                                                  ) ) 2> NUL
+)
+:found_python
+if not defined python_pf_ver (
+    :: If not, look for Python from the Spack installer
+    :get_builtin
+    (for /f "tokens=*" %%g in ('dir /b /a:d "!spackinstdir!\Python*"') do (
+        set "python_ver=%%g")) 2> NUL
+
+    if not defined python_ver (
+        echo Python was not found on your system.
+        echo Please install Python or add Python to your PATH.
+    ) else (
+        set "py_path=!spackinstdir!\!python_ver!"
+        set "py_exe=!py_path!\python.exe"
+    )
+    goto :exitpoint
+) else (
+    :: Python is already on the path
+    set "py_exe=!python_pf_ver!"
+    (for /F "tokens=* USEBACKQ" %%F in (
+        `"!py_exe!" --version`) do (set "output=%%F")) 2>NUL
+    if not "!output:Microsoft Store=!"=="!output!" goto :get_builtin
+    goto :exitpoint
+)
+:exitpoint
+endlocal & (
+    set "SPACK_ROOT=%SPACK_ROOT%"
+    set "spackinstdir=%spackinstdir%"
+    set "py_path=%py_path%"
+    set "py_exe=%py_exe%"
+)
+
+set "PATH=%SPACK_ROOT%\bin\;%PATH%"
+if defined py_path (
+    set "PATH=%py_path%;%PATH%"
+)
+
+if defined py_exe (
+    "%py_exe%" "%SPACK_ROOT%\bin\haspywin.py"
+)
+
+if not defined EDITOR (
+   set EDITOR=notepad
+)
+
+DOSKEY spacktivate=spack env activate $*
+
+
+@echo **********************************************************************
+@echo ** Spack Package Manager
+@echo **********************************************************************
+
+IF "%1"=="" GOTO CONTINUE
+set
+GOTO:EOF
+
+:continue
+title Spack
+set PROMPT=[spack] %PROMPT%

--- a/share/spack/setup-env.bat
+++ b/share/spack/setup-env.bat
@@ -64,9 +64,6 @@ if not defined EDITOR (
    set EDITOR=notepad
 )
 
-DOSKEY spacktivate=spack env activate $*
-
-
 @echo **********************************************************************
 @echo ** Spack Package Manager
 @echo **********************************************************************

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -60,5 +60,6 @@ function global:prompt
     $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
     "[spack] PS $pth>"
 }
+[system.console]::title = "Spack"
 Pop-Location
 


### PR DESCRIPTION
Currently Spack has multiple entrypoints on Windows that in addition to differing from *nix implementations, differ from shell to shell on Windows. This is a bit confusing for new users and in general unnecessary.
This PR adds a normal setup script for the batch shell while preserving the previous "click from file explorer for spack shell" behavior. Additionally adds a shell title to both powershell and cmd letting users know this is a Spack shell