### PR TITLE
r-rsamtools: add -lz to Makevars

### DIFF
--- a/var/spack/repos/builtin/packages/r-rsamtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rsamtools/package.py
@@ -53,3 +53,8 @@ class RRsamtools(RPackage):
 
     # this is not a listed dependency but is needed
     depends_on("curl")
+    depends_on("zlib")
+
+    def patch(self):
+        with working_dir("src"):
+            filter_file(r"(^PKG_LIBS=)(\$\(RHTSLIB_LIBS\))", "\\1\\2 -lz", "Makevars")

--- a/var/spack/repos/builtin/packages/r-rsamtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rsamtools/package.py
@@ -53,7 +53,7 @@ class RRsamtools(RPackage):
 
     # this is not a listed dependency but is needed
     depends_on("curl")
-    depends_on("zlib")
+    depends_on("zlib-api")
 
     def patch(self):
         with working_dir("src"):


### PR DESCRIPTION
At some point in the past three months (when I last built our list of packages) behavior has changed with this package. 

2.14.0 used to install fine, but now it and the newest version fail installation because of a runtime linking error where the Rsamtools.so library contains a reference to gzopen64 that it isn't able to find.

I don't know why this is happening now or how it was working out before. I'm also not sure if using zlib (as was evidently happening automatically prior) is correct or if we should rework the r-zlibbioc package so it includes the zlib headers and is used instead.

@glennpj I'm guessing you're using this package, are you able to reproduce this behavior on develop?