### PR TITLE
`ffmpeg`: patch build failure

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -104,6 +104,12 @@ class Ffmpeg(AutotoolsPackage):
 
     conflicts("%nvhpc")
 
+    # Patch solving a build failure when vulkan is enabled
+    patch("https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/eb0455d64690",
+          sha256="967d25a67297c53dde7151f7bc5eb37ae674525ee468880f973b9ebc3e12ed2c",
+          when="@5.1.2"
+    )
+
     @property
     def libs(self):
         return find_libraries("*", self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -105,9 +105,10 @@ class Ffmpeg(AutotoolsPackage):
     conflicts("%nvhpc")
 
     # Patch solving a build failure when vulkan is enabled
-    patch("https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/eb0455d64690",
-          sha256="967d25a67297c53dde7151f7bc5eb37ae674525ee468880f973b9ebc3e12ed2c",
-          when="@5.1.2"
+    patch(
+        "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/eb0455d64690",
+        sha256="967d25a67297c53dde7151f7bc5eb37ae674525ee468880f973b9ebc3e12ed2c",
+        when="@5.1.2",
     )
 
     @property


### PR DESCRIPTION
This patch fixes the following errors observed when building ffmpeg in vulkan-enabled distros:

```
| src/libavutil/hwcontext_vulkan.c:363:7: error: 'VK_EXT_VIDEO_DECODE_H264_EXTENSION_NAME' undeclared here (not in a function); did you mean 'VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME'?
|   363 |     { VK_EXT_VIDEO_DECODE_H264_EXTENSION_NAME,                FF_VK_EXT_NO_FLAG                },
|       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|       |       VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME
| src/libavutil/hwcontext_vulkan.c:364:7: error: 'VK_EXT_VIDEO_DECODE_H265_EXTENSION_NAME' undeclared here (not in a function); did you mean 'VK_EXT_VIDEO_ENCODE_H265_EXTENSION_NAME'?
|   364 |     { VK_EXT_VIDEO_DECODE_H265_EXTENSION_NAME,                FF_VK_EXT_NO_FLAG                },
|       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|       |       VK_EXT_VIDEO_ENCODE_H265_EXTENSION_NAME
```

https://lists.openembedded.org/g/openembedded-core/topic/97218258