### PR TITLE
New package: pipx

### DIFF
--- a/var/spack/repos/builtin/packages/pipx/package.py
+++ b/var/spack/repos/builtin/packages/pipx/package.py
@@ -19,7 +19,7 @@ class Pipx(PythonPackage):
     depends_on("py-hatchling@0.15.0:", type="build")
 
     depends_on("py-argcomplete@1.9.4:", type=("build", "run"))
-    depends_on("py-colorama@0.4.4:", type=("build", "run"), when="platform=Windows")
+    depends_on("py-colorama@0.4.4:", type=("build", "run"), when="platform=windows")
     depends_on("py-importlib-metadata@3.3.0:", type=("build", "run"), when="^python@3.7")
     depends_on("py-packaging@20.0:", type=("build", "run"))
     depends_on("py-userpath@1.6.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/pipx/package.py
+++ b/var/spack/repos/builtin/packages/pipx/package.py
@@ -22,5 +22,4 @@ class Pipx(PythonPackage):
     depends_on("py-colorama@0.4.4:", type=("build", "run"), when="platform=Windows")
     depends_on("py-importlib-metadata@3.3.0:", type=("build", "run"), when="^python@3.7")
     depends_on("py-packaging@20.0:", type=("build", "run"))
-    depends_on("py-platformdirs@2.1.0:", type=("build", "run"))
     depends_on("py-userpath@1.6.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/pipx/package.py
+++ b/var/spack/repos/builtin/packages/pipx/package.py
@@ -19,8 +19,7 @@ class Pipx(PythonPackage):
     depends_on("py-hatchling@0.15.0:", type="build")
 
     depends_on("py-argcomplete@1.9.4:", type=("build", "run"))
-    # FIXME: What's the OS code for Windows in general?
-    # depends_on("py-colorama@0.4.4:", type=("build", "run"), when="os=win32")
+    depends_on("py-colorama@0.4.4:", type=("build", "run"), when="platform=Windows")
     depends_on("py-importlib-metadata@3.3.0:", type=("build", "run"), when="^python@3.7")
     depends_on("py-packaging@20.0:", type=("build", "run"))
     depends_on("py-platformdirs@2.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/pipx/package.py
+++ b/var/spack/repos/builtin/packages/pipx/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Pipx(PythonPackage):
+    """pipx is a tool to install and run Python applications in isolated environments"""
+
+    homepage = "https://pypa.github.io/pipx/"
+    pypi = "pipx/pipx-1.2.0.tar.gz"
+
+    version("1.2.0", sha256="d1908041d24d525cafebeb177efb686133d719499cb55c54f596c95add579286")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-hatchling@0.15.0:", type="build")
+
+    depends_on("py-argcomplete@1.9.4:", type=("build", "run"))
+    # FIXME: What's the OS code for Windows in general?
+    # depends_on("py-colorama@0.4.4:", type=("build", "run"), when="os=win32")
+    depends_on("py-importlib-metadata@3.3.0:", type=("build", "run"), when="^python@3.7")
+    depends_on("py-packaging@20.0:", type=("build", "run"))
+    depends_on("py-platformdirs@2.1.0:", type=("build", "run"))
+    depends_on("py-userpath@1.6.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-userpath/package.py
+++ b/var/spack/repos/builtin/packages/py-userpath/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyUserpath(PythonPackage):
+    """Cross-platform tool for adding locations to the user PATH."""
+
+    homepage = "https://github.com/ofek/userpath"
+    pypi = "userpath/userpath-1.8.0.tar.gz"
+
+    version("1.8.0", sha256="04233d2fcfe5cff911c1e4fb7189755640e1524ff87a4b82ab9d6b875fee5787")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-hatchling@1.17.0:", type="build")
+
+    depends_on("py-click@8.1.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-userpath/package.py
+++ b/var/spack/repos/builtin/packages/py-userpath/package.py
@@ -16,6 +16,6 @@ class PyUserpath(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
 
-    depends_on("py-hatchling@1.17.0:", type="build")
+    depends_on("py-hatchling", type="build")
 
-    depends_on("py-click@8.1.3:", type=("build", "run"))
+    depends_on("py-click", type=("build", "run"))


### PR DESCRIPTION
`pipx` [is a tool to install Python applications in isolated `venv`s](https://pypa.github.io/pipx/#overview-what-is-pipx). It's commonly recommended over plain `pip` for installing applications (not libraries) from the Python packaging infrastructure. The Spack package is named `pipx` instead of `py-pipx` since this is a user-facing application (following the example of `meson`).

`py-userpath` is included in this PR since it is a dependency of `pipx`.

Ping @adamjstewart @pradyunsg @scheibelp @skosukhin. Do any of you want to be maintainers here?