### PR TITLE
Revert "openblas: do not build tests when installing"

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -463,9 +463,7 @@ class Openblas(MakefilePackage):
 
     @property
     def build_targets(self):
-        # Do not build tests: see #38591
-        # And note that "shared" is allowed (but ignored) when ~shared
-        return ["-s"] + self.make_defs + ["libs", "netlib", "shared"]
+        return ["-s"] + self.make_defs + ["all"]
 
     @run_after("build")
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
Reverts spack/spack#38591

@sethrj you cannot build individual targets, that leads to race conditions :( the all target prereqs are marked .NOTPARALLEL and that's not respected when you list (a subset of) those on the command line.

It's marked not parallel because different sub makes add to the same static library.

Also, the list of prereqs of all is somewhat dynamic, so best to just run `make all`.

See https://github.com/spack/spack/pull/35905.