### PR TITLE
find: add `--hashes` shortcut for piping to other commands

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -37,8 +37,8 @@ def setup_parser(subparser):
         "--hashes",
         action="store_const",
         dest="format",
-        const="/{hash}",
-        help="same as '--format /{hash}'; use with xargs or $()",
+        const="{/hash}",
+        help="same as '--format {/hash}'; use with xargs or $()",
     )
     format_group.add_argument(
         "--json",

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -33,6 +33,14 @@ def setup_parser(subparser):
         help="output specs with the specified format string",
     )
     format_group.add_argument(
+        "-H",
+        "--hashes",
+        action="store_const",
+        dest="format",
+        const="/{hash}",
+        help="same as '--format /{hash}', for piping to other commands",
+    )
+    format_group.add_argument(
         "--json",
         action="store_true",
         default=False,

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -38,7 +38,7 @@ def setup_parser(subparser):
         action="store_const",
         dest="format",
         const="/{hash}",
-        help="same as '--format /{hash}', for piping to other commands",
+        help="same as '--format /{hash}'; use with xargs or $()",
     )
     format_group.add_argument(
         "--json",

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1075,7 +1075,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
     else
         _installed_packages
     fi


### PR DESCRIPTION
People frequently ask us how to pipe `spack find` output to other commands, and we tell them to do things like this:

```console
> spack uninstall -ay $(spack find --format "/{hash}")
```

Sometimes users don't know about hash references and come up with potentially ambiguous formulations like this:

```console
> spack find --format {name}@{version}%{compiler} | xargs spack uninstall -ay
```

Since this is a common enough thing to want to do, and to make it more obvious how, this PR adds a `-H` / `--hashes` as a shortcut.  Example:

```console
> spack find zlib
-- darwin-ventura-aarch64 / apple-clang@14.0.0 ------------------
zlib@1.2.13

-- darwin-ventura-m1 / apple-clang@14.0.0 -----------------------
zlib@1.2.12  zlib@1.2.13
==> 3 installed packages
```

```console
> spack find -H zlib
/xdiau3qpahjcwf3bkjmwrc4lr2xim3zv  /hsazhft66dizqvlgfuu7v4xulp3soqyh
/2iaqlis6z5ogtxwuupsg2o7mli5kxycf
```

So now, you can now just do one of these:

```console
> spack find -H | xargs spack uninstall -ay
> spack uninstall -ay $(spack find -H)
```