### PR TITLE
hcoll: ucx version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/hcoll/package.py
+++ b/var/spack/repos/builtin/packages/hcoll/package.py
@@ -14,6 +14,14 @@ class Hcoll(Package):
     homepage = "https://www.mellanox.com/products/fca"
     has_code = False
 
+    # To get the version number
+    # grep HCOLL_VERNO_STRING path/include/hcoll/api/hcoll_version.h
+    version("4.8.3221")  # HPC-X 2.14/2.15, UCX 1.15
+    version("4.8.3220")  # HPC-X 2.13, UCX 1.14
+    version("4.8.3217")  # HPC-X 2.12, UCX 1.14
+    version("4.7.3208")  # HPC-X 2.11, UCX 1.13
+    version("4.7.3202")  # HPC-X 2.10, UCX 1.12
+    version("4.7.3199")  # HPC-X 2.9, UCX 1.11
     version("3.9.1927")
 
     # HCOLL needs to be added as an external package to SPACK. For this, the

--- a/var/spack/repos/builtin/packages/hcoll/package.py
+++ b/var/spack/repos/builtin/packages/hcoll/package.py
@@ -24,6 +24,13 @@ class Hcoll(Package):
     version("4.7.3199")  # HPC-X 2.9, UCX 1.11
     version("3.9.1927")
 
+    # ucx throws warnings when running alongside the wrong version of hcoll
+    requires("ucx@1.15", when="@4.8.3221")
+    requires("ucx@1.14", when="@4.8.3217:4.8.3220")
+    requires("ucx@1.13", when="@4.7.3208")
+    requires("ucx@1.12", when="@4.7.3202")
+    requires("ucx@1.11", when="@4.7.3199")
+
     # HCOLL needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:
     #


### PR DESCRIPTION
NVIDIA HPC-X `hcoll` package has libraries that expect to link with HPC-X's `ucx` package.
If you define `hcoll` as external but not `ucx`, when you build a spec that depends on `ucx` (e.g. `openmpi fabrics=hcoll,ucx`) you might encounter warnings like:
`ucp_context.c:1518 UCX  WARN  UCP version is incompatible, required: 1.12, actual: 1.11 (release 2 /path/ucx-1.11.2-awg3hlqwervpiysoqnc7pcme3del7z4m/lib/libucp.so.0)`

This PR adds `ucx` version requirements to `hcoll` to avoid mismatched libraries.