### PR TITLE
libfabric: add 1.18.1

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -22,6 +22,7 @@ class Libfabric(AutotoolsPackage):
     executables = ["^fi_info$"]
 
     version("main", branch="main")
+    version("1.18.1", sha256="4615ae1e22009e59c72ae03c20adbdbd4a3dce95aeefbc86cc2bf1acc81c9e38")
     version("1.18.0", sha256="912fb7c7b3cf2a91140520962b004a1c5d2f39184adbbd98ae5919b0178afd43")
     version("1.17.1", sha256="8b372ddb3f46784c53fdad50a701a6eb0e661239aee45a42169afbedf3644035")
     version("1.17.0", sha256="579c0f5ef636c0c72f4d3d6bd4da91a5aed9ac3ac4ea387404c45dbbdee4745d")


### PR DESCRIPTION
Adds yesterday's 1.18.1 from [ofiwg/libfabric](https://github.com/ofiwg/libfabric/releases) release via `spack checksum`.