### PR TITLE
py-jupyter-packaging: remove duplicate packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipycanvas/package.py
+++ b/var/spack/repos/builtin/packages/py-ipycanvas/package.py
@@ -17,9 +17,7 @@ class PyIpycanvas(PythonPackage):
 
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools@40.8:", type="build")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging7", type="build")
-    # depends_on('py-jupyter-packaging@0.7.0:0.7', type='build')
+    depends_on("py-jupyter-packaging@0.7", type="build")
     depends_on("py-jupyterlab@3.0:3", type="build")
     depends_on("py-ipywidgets@7.6:", type=("build", "run"))
     depends_on("pil@6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipyevents/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyevents/package.py
@@ -16,8 +16,6 @@ class PyIpyevents(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8:", type="build")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging7", type="build")
-    # depends_on('py-jupyter-packaging@0.7.0:0.7', type='build')
+    depends_on("py-jupyter-packaging@0.7", type="build")
     depends_on("py-jupyterlab@3.0:3", type="build")
     depends_on("py-ipywidgets@7.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipympl/package.py
+++ b/var/spack/repos/builtin/packages/py-ipympl/package.py
@@ -23,8 +23,6 @@ class PyIpympl(PythonPackage):
     depends_on("py-traitlets@:5", type=("build", "run"))
     depends_on("py-ipywidgets@7.6:7", type=("build", "run"))
     depends_on("py-matplotlib@2:3", type=("build", "run"))
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging7", type="build")
-    # depends_on('py-jupyter-packaging@0.7', type='build')
+    depends_on("py-jupyter-packaging@0.7", type="build")
     depends_on("py-jupyterlab@3", type="build")
     depends_on("yarn", type="build")

--- a/var/spack/repos/builtin/packages/py-jupyter-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-packaging/package.py
@@ -12,6 +12,8 @@ class PyJupyterPackaging(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter-packaging"
     pypi = "jupyter_packaging/jupyter_packaging-0.10.4.tar.gz"
 
+    tags = ["build-tools"]
+
     version("0.12.0", sha256="b27455d60adc93a7baa2e0b8f386be81b932bb4e3c0116046df9ed230cd3faac")
     version("0.11.1", sha256="6f5c7eeea98f7f3c8fb41d565a94bf59791768a93f93148b3c2dfb7ebade8eec")
     version("0.10.6", sha256="a8a2c90bf2e0cae83be63ccb0b7035032a1589f268cc08b1d479e37ce50fc940")

--- a/var/spack/repos/builtin/packages/py-jupyter-packaging11/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-packaging11/package.py
@@ -16,9 +16,21 @@ class PyJupyterPackaging11(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter-packaging"
     pypi = "jupyter_packaging/jupyter_packaging-0.11.1.tar.gz"
 
-    version("0.12.3", sha256="9d9b2b63b97ffd67a8bc5391c32a421bc415b264a32c99e4d8d8dd31daae9cf4")
-    version("0.12.0", sha256="b27455d60adc93a7baa2e0b8f386be81b932bb4e3c0116046df9ed230cd3faac")
-    version("0.11.1", sha256="6f5c7eeea98f7f3c8fb41d565a94bf59791768a93f93148b3c2dfb7ebade8eec")
+    version(
+        "0.12.3",
+        sha256="9d9b2b63b97ffd67a8bc5391c32a421bc415b264a32c99e4d8d8dd31daae9cf4",
+        deprecated=True,
+    )
+    version(
+        "0.12.0",
+        sha256="b27455d60adc93a7baa2e0b8f386be81b932bb4e3c0116046df9ed230cd3faac",
+        deprecated=True,
+    )
+    version(
+        "0.11.1",
+        sha256="6f5c7eeea98f7f3c8fb41d565a94bf59791768a93f93148b3c2dfb7ebade8eec",
+        deprecated=True,
+    )
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-packaging7/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-packaging7/package.py
@@ -16,7 +16,11 @@ class PyJupyterPackaging7(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter-packaging"
     pypi = "jupyter_packaging/jupyter-packaging-0.7.12.tar.gz"
 
-    version("0.7.12", sha256="b140325771881a7df7b7f2d14997b619063fe75ae756b9025852e4346000bbb8")
+    version(
+        "0.7.12",
+        sha256="b140325771881a7df7b7f2d14997b619063fe75ae756b9025852e4346000bbb8",
+        deprecated=True,
+    )
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server-mathjax/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server-mathjax/package.py
@@ -18,6 +18,6 @@ class PyJupyterServerMathjax(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-jupyter-packaging", type="build")
-    depends_on("py-jupyter-packaging11@:1", when="@0.2.6:", type="build")
+    depends_on("py-jupyter-packaging@0.10:1", when="@0.2.6:", type="build")
     depends_on("py-jupyter-server@1.1:1", when="@0.2.3", type=("build", "run"))
     depends_on("py-jupyter-server@1.1:", when="@0.2.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server-proxy/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server-proxy/package.py
@@ -19,7 +19,7 @@ class PyJupyterServerProxy(PythonPackage):
 
     version("3.2.2", sha256="54690ea9467035d187c930c599e76065017baf16e118e6eebae0d3a008c4d946")
 
-    depends_on("py-jupyter-packaging7@0.7.9:0.7", type="build")
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-jupyterlab@3.0:3", type="build")
     depends_on("py-setuptools@40.8.0:", type="build")
 

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -32,9 +32,7 @@ class PyJupyterServer(PythonPackage):
     depends_on("py-hatch-jupyter-builder@0.8.1:", when="@2:", type="build")
 
     with when("@:1"):
-        # TODO: replace this after concretizer learns how to concretize separate build deps
-        depends_on("py-jupyter-packaging11", when="@1.6.2:", type="build")
-        # depends_on('py-jupyter-packaging@0.9:0', when='@1.6.2:', type='build')
+        depends_on("py-jupyter-packaging@0.9:0", when="@1.6.2:", type="build")
         depends_on("py-pre-commit", when="@1.16:", type="build")
         depends_on("py-setuptools", type="build")
 

--- a/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
@@ -24,9 +24,8 @@ class PyJupyterlabServer(PythonPackage):
 
     with when("@:2.14"):
         depends_on("py-setuptools", type="build")
-        # TODO: replace this after concretizer learns how to concretize separate build deps
-        depends_on("py-jupyter-packaging11", type="build")
-        # depends_on('py-jupyter-packaging@0.9:0', type='build')
+        depends_on("py-jupyter-packaging@0.10:1", when="@2.10.3", type="build")
+        depends_on("py-jupyter-packaging@0.9:0", when="@:2.6", type="build")
 
     depends_on("py-babel@2.10:", when="@2.16.4:", type=("build", "run"))
     depends_on("py-babel", when="@2.5.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -50,12 +50,9 @@ class PyJupyterlab(PythonPackage):
 
     with when("@:3"):
         depends_on("py-setuptools", when="@:3", type=("build", "run"))
-        # TODO: replace this after concretizer learns how to concretize separate build deps
-        depends_on("py-jupyter-packaging11", when="@3.0.15:3", type="build")
-        depends_on("py-jupyter-packaging7", when="@3.0.0:3.0.14", type="build")
-        # depends_on('py-jupyter-packaging@0.9:0', when='@3.0.15:', type='build')
-        # depends_on('py-jupyter-packaging@0.7.3:0.7', when='@3.0.0:3.0.14',
-        #            type=('build', 'run'))
+        depends_on("py-jupyter-packaging@0.9:1", when="@3.4.8", type="build")
+        depends_on("py-jupyter-packaging@0.9:0", when="@3.0.15:3.4.2", type="build")
+        depends_on("py-jupyter-packaging@0.7.3:0.7", when="@3.0.0:3.0.14", type=("build", "run"))
         depends_on("py-pre-commit", when="@3.4:3.4.3", type="build")
 
         depends_on("py-ipython", when="@3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -24,7 +24,11 @@ class PyJupyterlab(PythonPackage):
     version("3.1.14", sha256="13174cb6076dd5da6f1b85725ccfcc9518d8f98e86b8b644fc89b1dfaeda63a9")
     version("3.0.18", sha256="0e4bb4b89014607a16658b54f13df2f0af14f3c286109a0e14d5a46cbbe28caf")
     version("3.0.16", sha256="7ad4fbe1f6d38255869410fd151a8b15692a663ca97c0a8146b3f5c40e275c23")
-    version("3.0.14", sha256="713a84991dfcca8c0bc260911f1bd54ac25a386a86285713b9555a60f795059b")
+    version(
+        "3.0.14",
+        sha256="713a84991dfcca8c0bc260911f1bd54ac25a386a86285713b9555a60f795059b",
+        deprecated=True,
+    )
     version("2.2.7", sha256="a72ffd0d919cba03a5ef8422bc92c3332a957ff97b0490494209c83ad93826da")
     version("2.1.0", sha256="8c239aababf5baa0b3d36e375fddeb9fd96f3a9a24a8cda098d6a414f5bbdc81")
 

--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -31,6 +31,4 @@ class PyJupytext(PythonPackage):
     # todo: in order to use jupytext as a jupyterlab extension,
     # some additional dependencies need to be added (and checked):
     depends_on("py-jupyterlab@3", type=("build", "run"))
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging7", type="build")
-    # depends_on('py-jupyter-packaging@0.7.9:0.7', type='build')```
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")

--- a/var/spack/repos/builtin/packages/py-nbclassic/package.py
+++ b/var/spack/repos/builtin/packages/py-nbclassic/package.py
@@ -18,9 +18,7 @@ class PyNbclassic(PythonPackage):
     version("0.3.1", sha256="f920f8d09849bea7950e1017ff3bd101763a8d68f565a51ce053572e65aa7947")
 
     depends_on("py-setuptools", type="build")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", when="@0.3.3:", type="build")
-    # depends_on('py-jupyter-packaging@0.9:1', when='@0.3.3:', type='build')
+    depends_on("py-jupyter-packaging@0.9:0", when="@0.3.3:", type="build")
     depends_on("py-babel", when="@0.4:", type="build")
 
     depends_on("py-jinja2", when="@0.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-notebook/package.py
@@ -40,9 +40,7 @@ class PyNotebook(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"), when="@6.4:")
     depends_on("python@3.6:", type=("build", "run"), when="@6.3:")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", when="@6.4.1:", type="build")
-    # depends_on('py-jupyter-packaging@0.9:0', when='@6.4.1:', type='build')
+    depends_on("py-jupyter-packaging@0.9:0", when="@6.4.1:", type="build")
 
     depends_on("py-setuptools", when="@5:", type="build")
     depends_on("py-jinja2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-widgetsnbextension/package.py
+++ b/var/spack/repos/builtin/packages/py-widgetsnbextension/package.py
@@ -20,8 +20,7 @@ class PyWidgetsnbextension(PythonPackage):
     version("1.2.6", sha256="c618cfb32978c9517caf0b4ef3aec312f8dd138577745e7b0d4abfcc7315ce51")
 
     depends_on("py-setuptools", type="build")
-    # TODO: replace this after concretizer learns how to concretize separate build deps
-    depends_on("py-jupyter-packaging11", when="@4.0.3:", type="build")
+    depends_on("py-jupyter-packaging@0.10:0", when="@4.0.3:", type="build")
 
     depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
     depends_on("python@3.7:", when="@4.0.3:", type=("build", "run"))


### PR DESCRIPTION
Not possible to merge at the moment but should help test #38447 @alalazo 

Example of current behavior on develop:
```console
> spack spec py-jupytext                                                                                                                                                                                        0.1s
==> Error: concretization failed for the following reasons:

   1. Cannot select a single "version" for package "py-jupyter-packaging"
   2. Cannot satisfy 'py-jupyter-packaging@0.9:1'
   3. Cannot satisfy 'py-jupyter-packaging@0.9:0'
   4. Cannot satisfy 'py-jupyter-packaging@0.8:'
   5. Cannot satisfy 'py-jupyter-packaging@0.7.9:0.7'
   6. Cannot satisfy 'py-jupyter-packaging@0.7.3:0.7'
   7. Cannot satisfy 'py-jupyter-packaging@0.10:1'
```