### PR TITLE
Add new version 5.0.0 of PyAMG

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyamg/package.py
+++ b/var/spack/repos/builtin/packages/py-pyamg/package.py
@@ -28,5 +28,6 @@ class PyPyamg(PythonPackage):
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
-    depends_on("py-setuptools-scm@7.1.0:+toml", type="build", when="@4.2.0:")
+    depends_on("py-setuptools-scm", type="build", when="@4.2.0:")
+    depends_on("py-setuptools-scm@7.1.0", type="build", when="@5.0.0:")
     depends_on("py-pybind11@2.8.0:", type=("build"), when="@4.2.0:")

--- a/var/spack/repos/builtin/packages/py-pyamg/package.py
+++ b/var/spack/repos/builtin/packages/py-pyamg/package.py
@@ -26,5 +26,7 @@ class PyPyamg(PythonPackage):
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.12:", type=("build", "run"))
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
+    # Later version required due to
+    # https://github.com/pypa/setuptools_scm/issues/758
     depends_on("py-setuptools-scm@7.1.0:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build"), when="@4.2.0:")

--- a/var/spack/repos/builtin/packages/py-pyamg/package.py
+++ b/var/spack/repos/builtin/packages/py-pyamg/package.py
@@ -16,6 +16,7 @@ class PyPyamg(PythonPackage):
     # A list of GitHub accounts to notify when the package is updated.
     maintainers("benc303")
 
+    version("5.0.0", sha256="088be4b38203e708905fa45295593c1336b127a28391486d4f5917cf0b96f5f2")
     version("4.2.3", sha256="dcf23808e0e8edf177fc4f71a6b36e0823ffb117137a33a9eee14b391ddbb733")
     version("4.1.0", sha256="9e340aef5da11280a1e28f28deeaac390f408e38ee0357d0fdbb77503747bbc4")
     version("4.0.0", sha256="015d5e706e6e54d3de82e05fdb173c30d8b27cb8a117ab584cd62ad41d9ea042")
@@ -25,5 +26,5 @@ class PyPyamg(PythonPackage):
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.12:", type=("build", "run"))
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
-    depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
+    depends_on("py-setuptools-scm@7.1.0:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build"), when="@4.2.0:")

--- a/var/spack/repos/builtin/packages/py-pyamg/package.py
+++ b/var/spack/repos/builtin/packages/py-pyamg/package.py
@@ -28,6 +28,6 @@ class PyPyamg(PythonPackage):
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
-    depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
+    depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
     depends_on("py-pybind11@2.8.0:", type=("build"), when="@4.2.0:")

--- a/var/spack/repos/builtin/packages/py-pyamg/package.py
+++ b/var/spack/repos/builtin/packages/py-pyamg/package.py
@@ -28,6 +28,6 @@ class PyPyamg(PythonPackage):
     depends_on("py-setuptools@42:", type="build", when="@4.2.0:")
     # Later version required due to
     # https://github.com/pypa/setuptools_scm/issues/758
-    depends_on("py-setuptools-scm", type="build", when="@4.2.0:")
-    depends_on("py-setuptools-scm@7.1.0", type="build", when="@5.0.0:")
+    depends_on("py-setuptools-scm@5:+toml", type="build", when="@4.2.0:")
+    depends_on("py-setuptools-scm@7.1:+toml", type="build", when="@5.0.0:")
     depends_on("py-pybind11@2.8.0:", type=("build"), when="@4.2.0:")

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -12,6 +12,7 @@ class PySetuptoolsScm(PythonPackage):
     homepage = "https://github.com/pypa/setuptools_scm"
     pypi = "setuptools_scm/setuptools_scm-4.1.2.tar.gz"
 
+    version("7.1.0", sha256="6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27")
     version("7.0.5", sha256="031e13af771d6f892b941adb6ea04545bbf91ebc5ce68c78aaf3fff6e1fb4844")
     version("7.0.3", sha256="cf8ab8e235bed840cd4559b658af0d8e8a70896a191bbc510ee914ec5325332d")
     version("6.3.2", sha256="a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2")

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -38,7 +38,7 @@ class PySetuptoolsScm(PythonPackage):
     depends_on("py-setuptools@34.4:", type=("build", "run"))
     depends_on("py-toml", when="+toml @:6.1.0", type=("build", "run"))
     depends_on("py-tomli@1:", when="+toml @6.1.0:", type=("build", "run"))
-    depends_on("py-tomli@1:", when="@7.0:", type=("build", "run"))
+    depends_on("py-tomli@1:", when="@7.0", type=("build", "run"))
     depends_on("py-tomli@1:", when="@7.1: ^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions", when="@7:", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@7: ^python@:3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -38,6 +38,7 @@ class PySetuptoolsScm(PythonPackage):
     depends_on("py-setuptools@34.4:", type=("build", "run"))
     depends_on("py-toml", when="+toml @:6.1.0", type=("build", "run"))
     depends_on("py-tomli@1:", when="+toml @6.1.0:", type=("build", "run"))
-    depends_on("py-tomli@1:", when="@7:", type=("build", "run"))
+    depends_on("py-tomli@1:", when="@7.0:", type=("build", "run"))
+    depends_on("py-tomli@1:", when="@7.1: ^python@:3.10", type=("build", "run"))
     depends_on("py-typing-extensions", when="@7:", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@7: ^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
This adds version 5.0.0 of PyAMG. To build it, a newer version of setuptools_scm is needed, so this adds that too.