### PR TITLE
util-linux: add v2.39.1, fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -16,6 +16,7 @@ class UtilLinux(AutotoolsPackage):
     list_url = "https://www.kernel.org/pub/linux/utils/util-linux"
     list_depth = 1
 
+    version("2.39.1", sha256="d7c8a58eb2c7248a32754eb3a3b6772e368b984d9907ada834c2cf3e13024270")
     version("2.38.1", sha256="0820eb8eea90408047e3715424bc6be771417047f683950fecb4bdd2e2cbbc6e")
     version("2.38", sha256="c31d4e54f30b56b0f7ec8b342658c07de81378f2c067941c2b886da356f8ad42")
     version("2.37.4", sha256="c8b7b4fa541f974cc32c1c6559d9bfca33651020a456ad6ee5fc9b0cacd00151")
@@ -66,6 +67,16 @@ class UtilLinux(AutotoolsPackage):
             )
         else:
             config_args.append("--disable-bash-completion")
+
+        if self.spec.satisfies("platform=darwin"):
+            # Does not build on macOS
+            config_args.extend([
+                "--disable-ipcs",
+                "--disable-ipcrm",
+                "--disable-wall",
+                "--disable-libmount",
+                "--enable-libuuid",
+            ])
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -70,13 +70,15 @@ class UtilLinux(AutotoolsPackage):
 
         if self.spec.satisfies("platform=darwin"):
             # Does not build on macOS
-            config_args.extend([
-                "--disable-ipcs",
-                "--disable-ipcrm",
-                "--disable-wall",
-                "--disable-libmount",
-                "--enable-libuuid",
-            ])
+            config_args.extend(
+                [
+                    "--disable-ipcs",
+                    "--disable-ipcrm",
+                    "--disable-wall",
+                    "--disable-libmount",
+                    "--enable-libuuid",
+                ]
+            )
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -71,12 +71,7 @@ class UtilLinux(AutotoolsPackage):
         if self.spec.satisfies("platform=darwin"):
             # Does not build on macOS
             config_args.extend(
-                [
-                    "--disable-ipcs",
-                    "--disable-ipcrm",
-                    "--disable-wall",
-                    "--disable-libmount",
-                ]
+                ["--disable-ipcs", "--disable-ipcrm", "--disable-wall", "--disable-libmount"]
             )
 
         return config_args

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -76,7 +76,6 @@ class UtilLinux(AutotoolsPackage):
                     "--disable-ipcrm",
                     "--disable-wall",
                     "--disable-libmount",
-                    "--enable-libuuid",
                 ]
             )
 


### PR DESCRIPTION
Flags from https://github.com/Homebrew/homebrew-core/blob/fa810a0920918f77b50dfa233e92df6a762c2937/Formula/util-linux.rb