### PR TITLE
qt-base: disable accessibility by default

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -110,7 +110,10 @@ class QtBase(QtPackage):
 
     # GUI-only dependencies
     variant(
-        "accessibility", default=False, when="+gui", description="Build with accessibility support."
+        "accessibility",
+        default=False,
+        when="+gui",
+        description="Build with accessibility support.",
     )
     variant("gtk", default=False, when="+gui", description="Build with gtkplus.")
     variant("opengl", default=False, when="+gui", description="Build with OpenGL support.")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -110,7 +110,7 @@ class QtBase(QtPackage):
 
     # GUI-only dependencies
     variant(
-        "accessibility", default=True, when="+gui", description="Build with accessibility support."
+        "accessibility", default=False, when="+gui", description="Build with accessibility support."
     )
     variant("gtk", default=False, when="+gui", description="Build with gtkplus.")
     variant("opengl", default=False, when="+gui", description="Build with OpenGL support.")


### PR DESCRIPTION
See https://github.com/spack/spack/issues/34037#issuecomment-1616135586

I generally prefer to disable all variants by default to prevent this kind of issue and speed up builds anyway.