### PR TITLE
acts: new variant cxxstd

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -408,6 +408,6 @@ class Acts(CMakePackage, CudaPackage):
             python = spec["python"].command.path
             args.append("-DPython_EXECUTABLE={0}".format(python))
 
-        args.append(define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
+        args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
 
         return args

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -404,12 +404,10 @@ class Acts(CMakePackage, CudaPackage):
             if cuda_arch != "none":
                 args.append("-DCUDA_FLAGS=-arch=sm_{0}".format(cuda_arch[0]))
 
-        if "^root" in spec:
-            cxxstd = spec["root"].variants["cxxstd"].value
-            args.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
-
         if "+python" in spec:
             python = spec["python"].command.path
             args.append("-DPython_EXECUTABLE={0}".format(python))
+
+        args.append(define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
 
         return args

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.variant import Value, _ConditionalVariantValues
+from spack.variant import _ConditionalVariantValues
 
 
 class Acts(CMakePackage, CudaPackage):


### PR DESCRIPTION
ACTS supports C++20, and so does ROOT as a (conditional) dependency. This has been (continues to be) hard to express concisely, and the past solution has unnecessarily restricted ROOT to C++17, which in turn imposes restrictions on other ROOT dependents that support C++20. The past solution was also unnecesarily restrictive in combining the C++ standards with version ranges when ROOT provided the TGeo features required by ACTS.

I think this loosened set of dependencies and added set of conflicts addresses the actual requirements.

I'll mark this as draft, and consider it a request for comments. Thinking through this 3-dimensional inverted-logic puzzle has been making my head hurt.