### PR TITLE
ci: drop pyton@3.7 requirement

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
@@ -61,8 +61,6 @@ spack:
     openblas:
       require: '@0.3.20'
       variants: threads=openmp
-    python:
-      require: '@3.7.15'
     xz:
       variants: +pic
     elfutils:


### PR DESCRIPTION
Don't require deprecated things, it breaks in CI. Python 3.7 was deprecated in #38619, and now any package that would trigger a rebuild of Python fails.
