### PR TITLE
hdf5-vol-log: depends on mpi

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -31,7 +31,7 @@ class Hdf5VolLog(AutotoolsPackage):
 
     def configure_args(self):
         return [
-            args.append("--enable-shared"),
-            args.append("--enable-zlib"),
-            args.append("--with-mpi={}".format(self.spec["mpi"].prefix)),
+            "--enable-shared",
+            "--enable-zlib",
+            "--with-mpi={}".format(self.spec["mpi"].prefix),
         ]

--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -20,6 +20,7 @@ class Hdf5VolLog(AutotoolsPackage):
     version("1.4.0", tag="logvol.1.4.0")
 
     depends_on("hdf5@1.14.0:", when="@1.4.0:")
+    depends_on("mpi")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
@@ -29,9 +30,8 @@ class Hdf5VolLog(AutotoolsPackage):
         env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 
     def configure_args(self):
-        args = []
-
-        args.append("--enable-shared")
-        args.append("--enable-zlib")
-
-        return args
+        return [
+            args.append("--enable-shared"),
+            args.append("--enable-zlib"),
+            args.append("--with-mpi={}".format(self.spec["mpi"].prefix)),
+        ]


### PR DESCRIPTION
From the configure.ac file:

> H5VL_log is built on top of MPI. Configure option --without-mpi or
> --with-mpi=no should not be used. Abort.

This currently fails to build in the oneAPI pipeline on `develop`
