### PR TITLE
libhio: package update for new sha256 checksum for v1.4.1.5

### DIFF
--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -25,7 +25,7 @@ class Libhio(AutotoolsPackage):
     #
     version("master", branch="master")
     version("1.4.1.6", sha256="863e7274f9e32d97bd5d9e6745ad9449735bdc8bd5623f152a32be45e6f3a212")
-    version("1.4.1.5", sha256="af5cb2a799a8470ed95847c3b07ea3ad61f8f7d5a2b79c52a46ca784846e8962")
+    version("1.4.1.5", sha256="76f5a0eb306e9596cdef558586ed2ba47bf50a9cc7782beb1a8b37115c00b1ee")
     version("1.4.1.4", sha256="6998a424cff97be9a207032b3addd19f292d8ebda72043be92a8f942ae3b4da1")
     version("1.4.1.3", sha256="b6ad2354f1bc597e7e55fc989ff50944835d64149f4925c2f45df950919e4d08")
     version("1.4.1.2", sha256="87a0f9b72b7aa69485c40d9bd36f02af653b70e8eed3eb0b50eaeb02ff0a9049")


### PR DESCRIPTION
The checksum that is present for libhio@1.4.1.5 supplied a broken autotools configuration.  The release has since been updated to address the issue, but the Spack package is still checking against the old checksum, and therefore fails to fetch.  

This PR supplies the new correct checksum for the corrected package source.