### PR TITLE
Add Python Prometheus client as dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-psana/package.py
+++ b/var/spack/repos/builtin/packages/py-psana/package.py
@@ -38,6 +38,7 @@ class PyPsana(PythonPackage):
     depends_on("opencv", type=("build", "run"))
     depends_on("py-scikit-learn", type=("build", "run"))
     depends_on("py-pyabel", type=("build", "run"))
+    depends_on("py-prometheus-client", type=("build", "run"))
     depends_on("xtcdata", type=("build", "run", "link"))
     depends_on("psalg", type=("build", "run", "link"))
 


### PR DESCRIPTION
Missing from the original recipe, py-prometheus-client should be considered a dependency of py-psana at the moment