### PR TITLE
spack make-installer: deterministic choice order

### DIFF
--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -50,8 +50,7 @@ def setup_parser(subparser):
         "--git-installer-verbosity",
         default="",
         choices=["SILENT", "VERYSILENT"],
-        help="Level of verbosity provided by bundled Git Installer.\
-             Default is fully verbose",
+        help="Level of verbosity provided by bundled Git Installer. Default is fully verbose",
         required=False,
         action="store",
         dest="git_verbosity",

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -49,7 +49,7 @@ def setup_parser(subparser):
         "-g",
         "--git-installer-verbosity",
         default="",
-        choices=set(["SILENT", "VERYSILENT"]),
+        choices=["SILENT", "VERYSILENT"],
         help="Level of verbosity provided by bundled Git Installer.\
              Default is fully verbose",
         required=False,


### PR DESCRIPTION
When you run `spack help make-installer`, the choices for the `-g` flag are non-deterministic. On its own, this is fairly innocuous. But when generating the tab completion script for fish (#29549), we discovered that it results in non-deterministic output files, breaking the check that ensures that the file is up-to-date. Solution is to use a list instead of a set.