### PR TITLE
gpi-space: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/gpi-space/package.py
+++ b/var/spack/repos/builtin/packages/gpi-space/package.py
@@ -24,6 +24,8 @@ class GpiSpace(CMakePackage):
     maintainers("mzeyen1985", "tiberot", "rumach", "mrahn", "acastanedam")
 
     version("latest", branch="main")
+    version("23.06", sha256="b4ee51f309c80c12a7842c0909041903608c6144535bc6faac3bbb8ff40e9213")
+    version("22.12", sha256="1c0ab9a1ada9dbbc0f80fb04ddbbb24ff900231f709cb99aa63f0d135a3ad398")
     version("22.09", sha256="f938847205181081ed24896bba16302ac35bbf478b4ceecae5bb21d5a38c8556")
     version("22.06", sha256="d89d8a7b574430c4f151a3768073fa44d32e5cc7606fbe0f58aeedf6f5fefc0b")
     version("22.03", sha256="b01500b9480452aee865a0ef98cf40864f847b7e22ea572f9a6f0f5ac2ae9a1a")
@@ -53,7 +55,8 @@ class GpiSpace(CMakePackage):
         when="+iml",
     )
 
-    depends_on("cmake@3.15.0:", type="build")
+    depends_on("cmake@3.15.0:", type="build", when="@:22.12")
+    depends_on("cmake@3.16.0:", type="build", when="@23.06:")
     depends_on("chrpath@0.13:", type=("build", "run"))
     depends_on("pkgconfig", type="build")
     depends_on(
@@ -65,8 +68,10 @@ class GpiSpace(CMakePackage):
     depends_on("libssh2@1.7:")
     depends_on("openssl@0.9:")
     with when("+iml"):
-        depends_on("gpi-2@1.3.2:1.3.3 fabrics=infiniband", when="network=infiniband")
-        depends_on("gpi-2@1.3.2:1.3.3 fabrics=ethernet", when="network=ethernet")
+        depends_on("gpi-2@1.3.2:1.3.3 fabrics=infiniband", when="@:22.09 network=infiniband")
+        depends_on("gpi-2@1.3.2:1.3.3 fabrics=ethernet", when="@:22.09 network=ethernet")
+        depends_on("gpi-2@1.5.0: fabrics=infiniband", when="@22.12: network=infiniband")
+        depends_on("gpi-2@1.5.0: fabrics=ethernet", when="@22.12: network=ethernet")
     depends_on("qt@5.9:5.15", when="+monitor")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/gpi-space/package.py
+++ b/var/spack/repos/builtin/packages/gpi-space/package.py
@@ -55,7 +55,7 @@ class GpiSpace(CMakePackage):
         when="+iml",
     )
 
-    depends_on("cmake@3.15.0:", type="build", when="@:22.12")
+    depends_on("cmake@3.15.0:", type="build")
     depends_on("cmake@3.16.0:", type="build", when="@23.06:")
     depends_on("chrpath@0.13:", type=("build", "run"))
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR adds 2 new versions to the gpi-space package (`22.12` and `23.06`).

**Note:**
- Starting `22.12` the GPI-2 dependency is required at version >=1.5.0
- Starting `23.06` the minimum CMake version was bumped to 3.16