### PR TITLE
remove another Python 3.7 requirement & preference, since it was deprecated

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
@@ -16,8 +16,3 @@ packages:
     # - aws-isc-aarch64
     #   - sse2neon
     #require: "@:999999999"
-  python:
-    # This is redundant after https://github.com/spack/spack/pull/33898
-    # but specified to allow the existance of a package.yaml for CI configs
-    require: "@3.7:"
-

--- a/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
@@ -1,18 +1,19 @@
-packages:
-  #all:
-    # CI should never build develop/main/master versions of
-    # packages.
-    # Current issues:
-    # - e4s/dav
-    #   - hdf5-vol-async => argobot@main
-    # - aws-ahug-*
-    #   - snap
-    #   - tycho2
-    #   - amg2013
-    #   - cosp2
-    #   - snbone
-    #   - vpfft
-    #   - vpic
-    # - aws-isc-aarch64
-    #   - sse2neon
-    #require: "@:999999999"
+packages: {}
+
+# CI should never build develop/main/master versions of packages. Current issues:
+# - e4s/dav
+#   - hdf5-vol-async => argobot@main
+# - aws-ahug-*
+#   - snap
+#   - tycho2
+#   - amg2013
+#   - cosp2
+#   - snbone
+#   - vpfft
+#   - vpic
+# - aws-isc-aarch64
+#   - sse2neon
+
+# packages:
+#   all:
+#     require: "@:999999999"

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -41,8 +41,6 @@ spack:
       require: mpich
     mpich:
       require: '@4.1.1 ~wrapperrpath ~hwloc'
-    python:
-      require: '@3.7.15'
     py-cryptography:
       require: '@38.0.1'
     unzip:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -30,8 +30,6 @@ spack:
       variants: threads=openmp
     paraview:
       require: '@5.11 ~qt+osmesa'
-    python:
-      version: [3.7.15]
     trilinos:
       require:
       - one_of: [+amesos +amesos2 +anasazi +aztec +boost +epetra +epetraext +ifpack

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -312,7 +312,7 @@ class Python(Package):
 
     # See https://github.com/python/cpython/issues/106424
     # datetime.now(timezone.utc) segfaults
-    conflicts("@3.8:", when="%oneapi@2022.2.1:")
+    conflicts("@3.9:", when="%oneapi@2022.2.1:")
 
     # Used to cache various attributes that are expensive to compute
     _config_vars: Dict[str, Dict[str, str]] = {}

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -310,6 +310,10 @@ class Python(Package):
     # https://bugs.python.org/issue45405
     conflicts("@:3.7.2,3.8.0:3.8.12,3.9.0:3.9.10,3.10.0:3.10.2", when="%apple-clang@13:")
 
+    # See https://github.com/python/cpython/issues/106424
+    # datetime.now(timezone.utc) segfaults
+    conflicts("@3.8:", when="%oneapi@2022.2.1:")
+
     # Used to cache various attributes that are expensive to compute
     _config_vars: Dict[str, Dict[str, str]] = {}
 


### PR DESCRIPTION
Python 3.7 was deprecated in Spack
