### PR TITLE
py-pymatgen: add 2022.9.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -15,32 +15,38 @@ class PyPymatgen(PythonPackage):
     homepage = "http://www.pymatgen.org/"
     pypi = "pymatgen/pymatgen-4.7.2.tar.gz"
 
+    version("2022.9.8", sha256="2250e05b81af3313bc0fc70cb558c2f528ed4eefb32d943ed9bd7a9756f03652")
     version("2021.3.9", sha256="a6f22d69133a48b7801bfd5e6a2878b47b4b4b2ef1a377b87c6c573be14cbf16")
     version(
         "2020.12.31", sha256="5002490facd47c55d2dae42c35712e061c1f5d881180485c0543a899589856d6"
     )
 
-    depends_on("py-setuptools@18.0:", type="build")
+    depends_on("python@3.8:", when="@2022.1.8:", type=("build", "run"))
+    # to prevent: 'PyThreadState' {aka 'struct _ts'} has no member named
+    # 'use_tracing'; did you mean 'tracing'?
+    depends_on("python@:3.9", when="@:2021.3.9", type=("build", "run"))
+    depends_on("py-setuptools@43:", type="build")
+    depends_on("py-cython@0.29.23:", when="@2022.1.7:", type="build")
 
+    depends_on("py-numpy@1.20.1:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-numpy@1.9:", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.17:", when="@2022.4.26:", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.15.6:", when="@2021.1.1:", type=("build", "run"))
+    depends_on("py-monty@3.0.2:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-monty@0.9.6:", type=("build", "run"))
+    depends_on("py-scipy@1.5.0:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-scipy@0.14:", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))
+    depends_on("py-spglib@1.9.9.44:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-spglib@1.9.8.7:", type=("build", "run"))
+    depends_on("py-networkx@2.2:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-matplotlib@1.5:", type=("build", "run"))
-    depends_on("py-palettable@2.1.1:", type=("build", "run"))
-
-    # dependencies of never versions
-    depends_on("py-matplotlib@1.5:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-monty@3.0.2:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-numpy@1.20.1:", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-palettable@3.1.1:", when="@2021.1.1:", type=("build", "run"))
+    depends_on("py-palettable@2.1.1:", type=("build", "run"))
+    depends_on("py-sympy", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-pandas", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-plotly@4.5.0:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-ruamel-yaml@0.15.6:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-scipy@1.5.0:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-spglib@1.9.9.44:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-sympy", when="@2021.1.1:", type=("build", "run"))
     depends_on("py-uncertainties@3.1.4:", when="@2021.1.1:", type=("build", "run"))
-    depends_on("py-networkx@2.2:", when="@2021.1.1:", type=("build", "run"))
+    depends_on("py-pybtex", when="@2022.1.9:", type=("build", "run"))
+    depends_on("py-tqdm", when="@2022.1.9:", type=("build", "run"))


### PR DESCRIPTION
https://github.com/materialsproject/pymatgen/tree/v2022.9.8

I did not manage to build newer versions of `py-pymatgen because
- cyclic dependency: `py-pymatgen` depends on `py-mp-api` which depends on `py-pymatgen`
- newer `py-pymatgen` need `py-setuptools@65:` but have a dependency on `py-numpy` which needs `py-setuptools@:63`