### PR TITLE
Drop Python 2 super syntax

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -97,9 +97,7 @@ class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         if "refspecific" in node:
             del node["refspecific"]
-        return super().resolve_xref(
-            env, fromdocname, builder, typ, target, node, contnode
-        )
+        return super().resolve_xref(env, fromdocname, builder, typ, target, node, contnode)
 
 
 #

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -97,7 +97,7 @@ class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         if "refspecific" in node:
             del node["refspecific"]
-        return super(PatchedPythonDomain, self).resolve_xref(
+        return super().resolve_xref(
             env, fromdocname, builder, typ, target, node, contnode
         )
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -121,7 +121,7 @@ Since v0.19, Spack supports  two ways of writing a package recipe. The most comm
 
        def url_for_version(self, version):
            if version >= Version("2.1.1"):
-               return super(Openjpeg, self).url_for_version(version)
+               return super().url_for_version(version)
            url_fmt = "https://github.com/uclouvain/openjpeg/archive/version.{0}.tar.gz"
            return url_fmt.format(version)
 
@@ -155,7 +155,7 @@ builder class explicitly. Using the same example as above, this reads:
 
        def url_for_version(self, version):
            if version >= Version("2.1.1"):
-               return super(Openjpeg, self).url_for_version(version)
+               return super().url_for_version(version)
            url_fmt = "https://github.com/uclouvain/openjpeg/archive/version.{0}.tar.gz"
            return url_fmt.format(version)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1890,7 +1890,7 @@ class HeaderList(FileList):
     include_regex = re.compile(r"(.*?)(\binclude\b)(.*)")
 
     def __init__(self, files):
-        super(HeaderList, self).__init__(files)
+        super().__init__(files)
 
         self._macro_definitions = []
         self._directories = None
@@ -1916,7 +1916,7 @@ class HeaderList(FileList):
         """Default computation of directories based on the list of
         header files.
         """
-        dir_list = super(HeaderList, self).directories
+        dir_list = super().directories
         values = []
         for d in dir_list:
             # If the path contains a subdirectory named 'include' then stop

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -766,7 +766,7 @@ def pretty_seconds(seconds):
 
 class RequiredAttributeError(ValueError):
     def __init__(self, message):
-        super(RequiredAttributeError, self).__init__(message)
+        super().__init__(message)
 
 
 class ObjectWrapper(object):

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -430,12 +430,12 @@ class MergeConflictError(Exception):
 
 class ConflictingSpecsError(MergeConflictError):
     def __init__(self, spec_1, spec_2):
-        super(MergeConflictError, self).__init__(spec_1, spec_2)
+        super().__init__(spec_1, spec_2)
 
 
 class SingleMergeConflictError(MergeConflictError):
     def __init__(self, path):
-        super(MergeConflictError, self).__init__("Package merge blocked by file: %s" % path)
+        super().__init__("Package merge blocked by file: %s" % path)
 
 
 class MergeConflictSummary(MergeConflictError):
@@ -450,4 +450,4 @@ class MergeConflictSummary(MergeConflictError):
             msg += "\n    `{0}` and `{1}` both project to `{2}`".format(
                 conflict.src_a, conflict.src_b, conflict.dst
             )
-        super(MergeConflictSummary, self).__init__(msg)
+        super().__init__(msg)

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -770,7 +770,7 @@ class LockDowngradeError(LockError):
 
     def __init__(self, path):
         msg = "Cannot downgrade lock from write to read on file: %s" % path
-        super(LockDowngradeError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class LockLimitError(LockError):
@@ -782,7 +782,7 @@ class LockTimeoutError(LockError):
 
     def __init__(self, lock_type, path, time, attempts):
         fmt = "Timed out waiting for a {} lock after {}.\n    Made {} {} on file: {}"
-        super(LockTimeoutError, self).__init__(
+        super().__init__(
             fmt.format(
                 lock_type,
                 pretty_seconds(time),
@@ -798,7 +798,7 @@ class LockUpgradeError(LockError):
 
     def __init__(self, path):
         msg = "Cannot upgrade lock from read to write on file: %s" % path
-        super(LockUpgradeError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class LockPermissionError(LockError):
@@ -810,7 +810,7 @@ class LockROFileError(LockPermissionError):
 
     def __init__(self, path):
         msg = "Can't take write lock on read-only file: %s" % path
-        super(LockROFileError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class CantCreateLockError(LockPermissionError):
@@ -819,4 +819,4 @@ class CantCreateLockError(LockPermissionError):
     def __init__(self, path):
         msg = "cannot create lock '%s': " % path
         msg += "file does not exist and location is not writable"
-        super(LockError, self).__init__(msg)
+        super().__init__(msg)

--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -68,7 +68,7 @@ class ColorParseError(Exception):
     """Raised when a color format fails to parse."""
 
     def __init__(self, message):
-        super(ColorParseError, self).__init__(message)
+        super().__init__(message)
 
 
 # Text styles for ansi codes

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -80,7 +80,7 @@ class FetchCacheError(Exception):
         else:
             err = errors[0]
             self.message = "{0}: {1}".format(err.__class__.__name__, str(err))
-        super(FetchCacheError, self).__init__(self.message)
+        super().__init__(self.message)
 
 
 class ListMirrorSpecsError(spack.error.SpackError):
@@ -517,7 +517,7 @@ class NoOverwriteException(spack.error.SpackError):
     """Raised when a file would be overwritten"""
 
     def __init__(self, file_path):
-        super(NoOverwriteException, self).__init__(
+        super().__init__(
             f"Refusing to overwrite the following file: {file_path}"
         )
 
@@ -528,7 +528,7 @@ class NoGpgException(spack.error.SpackError):
     """
 
     def __init__(self, msg):
-        super(NoGpgException, self).__init__(msg)
+        super().__init__(msg)
 
 
 class NoKeyException(spack.error.SpackError):
@@ -537,7 +537,7 @@ class NoKeyException(spack.error.SpackError):
     """
 
     def __init__(self, msg):
-        super(NoKeyException, self).__init__(msg)
+        super().__init__(msg)
 
 
 class PickKeyException(spack.error.SpackError):
@@ -548,7 +548,7 @@ class PickKeyException(spack.error.SpackError):
     def __init__(self, keys):
         err_msg = "Multiple keys available for signing\n%s\n" % keys
         err_msg += "Use spack buildcache create -k <key hash> to pick a key."
-        super(PickKeyException, self).__init__(err_msg)
+        super().__init__(err_msg)
 
 
 class NoVerifyException(spack.error.SpackError):
@@ -565,7 +565,7 @@ class NoChecksumException(spack.error.SpackError):
     """
 
     def __init__(self, path, size, contents, algorithm, expected, computed):
-        super(NoChecksumException, self).__init__(
+        super().__init__(
             f"{algorithm} checksum failed for {path}",
             f"Expected {expected} but got {computed}. "
             f"File size = {size} bytes. Contents = {contents!r}",
@@ -578,7 +578,7 @@ class NewLayoutException(spack.error.SpackError):
     """
 
     def __init__(self, msg):
-        super(NewLayoutException, self).__init__(msg)
+        super().__init__(msg)
 
 
 class UnsignedPackageException(spack.error.SpackError):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -517,9 +517,7 @@ class NoOverwriteException(spack.error.SpackError):
     """Raised when a file would be overwritten"""
 
     def __init__(self, file_path):
-        super().__init__(
-            f"Refusing to overwrite the following file: {file_path}"
-        )
+        super().__init__(f"Refusing to overwrite the following file: {file_path}")
 
 
 class NoGpgException(spack.error.SpackError):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -148,7 +148,7 @@ class MakeExecutable(Executable):
 
     def __init__(self, name, jobs, **kwargs):
         supports_jobserver = kwargs.pop("supports_jobserver", True)
-        super(MakeExecutable, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.supports_jobserver = supports_jobserver
         self.jobs = jobs
 
@@ -175,7 +175,7 @@ class MakeExecutable(Executable):
             if jobs_env_jobs is not None:
                 kwargs["extra_env"] = {jobs_env: str(jobs_env_jobs)}
 
-        return super(MakeExecutable, self).__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 def _on_cray():
@@ -1332,7 +1332,7 @@ class ChildError(InstallError):
     build_errors = [("spack.util.executable", "ProcessError")]
 
     def __init__(self, msg, module, classname, traceback_string, log_name, log_type, context):
-        super(ChildError, self).__init__(msg)
+        super().__init__(msg)
         self.module = module
         self.name = classname
         self.traceback = traceback_string

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -312,7 +312,7 @@ class CachedCMakeBuilder(CMakeBuilder):
 
     @property
     def std_cmake_args(self):
-        args = super(CachedCMakeBuilder, self).std_cmake_args
+        args = super().std_cmake_args
         args.extend(["-C", self.cache_path])
         return args
 

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -188,7 +188,7 @@ def _create(pkg):
             # Attribute containing the package wrapped in dispatcher with a `__getattr__`
             # method that will forward certain calls to the default builder.
             self.pkg_with_dispatcher = _ForwardToBaseBuilder(pkg, root_builder=self)
-            super(Adapter, self).__init__(pkg)
+            super().__init__(pkg)
 
         # These two methods don't follow the (self, spec, prefix) signature of phases nor
         # the (self) signature of methods, so they are added explicitly to avoid using a
@@ -530,9 +530,9 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
                 modifications to be applied when the package is built. Package authors
                 can call methods on it to alter the build environment.
         """
-        if not hasattr(super(Builder, self), "setup_build_environment"):
+        if not hasattr(super(), "setup_build_environment"):
             return
-        super(Builder, self).setup_build_environment(env)
+        super().setup_build_environment(env)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Sets up the build environment of packages that depend on this one.
@@ -563,9 +563,9 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
                 the dependent's state. Note that *this* package's spec is
                 available as ``self.spec``
         """
-        if not hasattr(super(Builder, self), "setup_dependent_build_environment"):
+        if not hasattr(super(), "setup_dependent_build_environment"):
             return
-        super(Builder, self).setup_dependent_build_environment(env, dependent_spec)
+        super().setup_dependent_build_environment(env, dependent_spec)
 
     def __getitem__(self, idx):
         key = self.phases[idx]

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -553,9 +553,7 @@ class CommandNameError(spack.error.SpackError):
 
     def __init__(self, name):
         self.name = name
-        super().__init__(
-            "{0} is not a permissible Spack command name.".format(name)
-        )
+        super().__init__("{0} is not a permissible Spack command name.".format(name))
 
 
 ########################################

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -545,7 +545,7 @@ class PythonNameError(spack.error.SpackError):
 
     def __init__(self, name):
         self.name = name
-        super(PythonNameError, self).__init__("{0} is not a permissible Python name.".format(name))
+        super().__init__("{0} is not a permissible Python name.".format(name))
 
 
 class CommandNameError(spack.error.SpackError):
@@ -553,7 +553,7 @@ class CommandNameError(spack.error.SpackError):
 
     def __init__(self, name):
         self.name = name
-        super(CommandNameError, self).__init__(
+        super().__init__(
             "{0} is not a permissible Spack command name.".format(name)
         )
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -479,7 +479,7 @@ class ConfigSetAction(argparse.Action):
         # substituting '_' for ':'.
         dest = dest.replace(":", "_")
 
-        super(ConfigSetAction, self).__init__(
+        super().__init__(
             option_strings=option_strings,
             dest=dest,
             nargs=0,

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -120,7 +120,7 @@ class PackageTemplate(BundlePackageTemplate):
     url_line = '    url = "{url}"'
 
     def __init__(self, name, url, versions):
-        super(PackageTemplate, self).__init__(name, versions)
+        super().__init__(name, versions)
 
         self.url_def = self.url_line.format(url=url)
 
@@ -198,7 +198,7 @@ class LuaPackageTemplate(PackageTemplate):
             # Make it more obvious that we are renaming the package
             tty.msg("Changing package name from {0} to lua-{0}".format(name))
             name = "lua-{0}".format(name)
-        super(LuaPackageTemplate, self).__init__(name, url, *args, **kwargs)
+        super().__init__(name, url, *args, **kwargs)
 
 
 class MesonPackageTemplate(PackageTemplate):
@@ -306,7 +306,7 @@ class RacketPackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to rkt-{0}".format(name))
             name = "rkt-{0}".format(name)
         self.body_def = self.body_def.format(name[4:])
-        super(RacketPackageTemplate, self).__init__(name, url, *args, **kwargs)
+        super().__init__(name, url, *args, **kwargs)
 
 
 class PythonPackageTemplate(PackageTemplate):
@@ -398,7 +398,7 @@ class PythonPackageTemplate(PackageTemplate):
                 + self.url_line
             )
 
-        super(PythonPackageTemplate, self).__init__(name, url, *args, **kwargs)
+        super().__init__(name, url, *args, **kwargs)
 
 
 class RPackageTemplate(PackageTemplate):
@@ -437,7 +437,7 @@ class RPackageTemplate(PackageTemplate):
         if bioc:
             self.url_line = '    url = "{0}"\n' '    bioc = "{1}"'.format(url, r_name)
 
-        super(RPackageTemplate, self).__init__(name, url, *args, **kwargs)
+        super().__init__(name, url, *args, **kwargs)
 
 
 class PerlmakePackageTemplate(PackageTemplate):
@@ -464,7 +464,7 @@ class PerlmakePackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to perl-{0}".format(name))
             name = "perl-{0}".format(name)
 
-        super(PerlmakePackageTemplate, self).__init__(name, *args, **kwargs)
+        super().__init__(name, *args, **kwargs)
 
 
 class PerlbuildPackageTemplate(PerlmakePackageTemplate):
@@ -497,7 +497,7 @@ class OctavePackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to octave-{0}".format(name))
             name = "octave-{0}".format(name)
 
-        super(OctavePackageTemplate, self).__init__(name, *args, **kwargs)
+        super().__init__(name, *args, **kwargs)
 
 
 class RubyPackageTemplate(PackageTemplate):
@@ -525,7 +525,7 @@ class RubyPackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to ruby-{0}".format(name))
             name = "ruby-{0}".format(name)
 
-        super(RubyPackageTemplate, self).__init__(name, *args, **kwargs)
+        super().__init__(name, *args, **kwargs)
 
 
 class MakefilePackageTemplate(PackageTemplate):
@@ -570,7 +570,7 @@ class SIPPackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to py-{0}".format(name))
             name = "py-{0}".format(name)
 
-        super(SIPPackageTemplate, self).__init__(name, *args, **kwargs)
+        super().__init__(name, *args, **kwargs)
 
 
 templates = {

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -673,17 +673,17 @@ class CompilerAccessError(spack.error.SpackError):
     def __init__(self, compiler, paths):
         msg = "Compiler '%s' has executables that are missing" % compiler.spec
         msg += " or are not executable: %s" % paths
-        super(CompilerAccessError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class InvalidCompilerError(spack.error.SpackError):
     def __init__(self):
-        super(InvalidCompilerError, self).__init__("Compiler has no executables.")
+        super().__init__("Compiler has no executables.")
 
 
 class UnsupportedCompilerFlag(spack.error.SpackError):
     def __init__(self, compiler, feature, flag_name, ver_string=None):
-        super(UnsupportedCompilerFlag, self).__init__(
+        super().__init__(
             "{0} ({1}) does not support {2} (as compiler.{3}).".format(
                 compiler.name, ver_string if ver_string else compiler.version, feature, flag_name
             ),

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -820,7 +820,7 @@ def is_mixed_toolchain(compiler):
 
 class InvalidCompilerConfigurationError(spack.error.SpackError):
     def __init__(self, compiler_spec):
-        super(InvalidCompilerConfigurationError, self).__init__(
+        super().__init__(
             'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
             "Compiler configuration must contain entries for all compilers: %s"
             % _path_instance_vars,
@@ -829,19 +829,19 @@ class InvalidCompilerConfigurationError(spack.error.SpackError):
 
 class NoCompilersError(spack.error.SpackError):
     def __init__(self):
-        super(NoCompilersError, self).__init__("Spack could not find any compilers!")
+        super().__init__("Spack could not find any compilers!")
 
 
 class UnknownCompilerError(spack.error.SpackError):
     def __init__(self, compiler_name):
-        super(UnknownCompilerError, self).__init__(
+        super().__init__(
             "Spack doesn't support the requested compiler: {0}".format(compiler_name)
         )
 
 
 class NoCompilerForSpecError(spack.error.SpackError):
     def __init__(self, compiler_spec, target):
-        super(NoCompilerForSpecError, self).__init__(
+        super().__init__(
             "No compilers for operating system %s satisfy spec %s" % (target, compiler_spec)
         )
 
@@ -860,11 +860,11 @@ class CompilerDuplicateError(spack.error.SpackError):
             + " in the following files:\n\t"
             + "\n\t".join(duplicate_msg(x, y) for x, y in duplicate_table)
         )
-        super(CompilerDuplicateError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class CompilerSpecInsufficientlySpecificError(spack.error.SpackError):
     def __init__(self, compiler_spec):
-        super(CompilerSpecInsufficientlySpecificError, self).__init__(
+        super().__init__(
             "Multiple compilers satisfy spec %s" % compiler_spec
         )

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -834,9 +834,7 @@ class NoCompilersError(spack.error.SpackError):
 
 class UnknownCompilerError(spack.error.SpackError):
     def __init__(self, compiler_name):
-        super().__init__(
-            "Spack doesn't support the requested compiler: {0}".format(compiler_name)
-        )
+        super().__init__("Spack doesn't support the requested compiler: {0}".format(compiler_name))
 
 
 class NoCompilerForSpecError(spack.error.SpackError):
@@ -865,6 +863,4 @@ class CompilerDuplicateError(spack.error.SpackError):
 
 class CompilerSpecInsufficientlySpecificError(spack.error.SpackError):
     def __init__(self, compiler_spec):
-        super().__init__(
-            "Multiple compilers satisfy spec %s" % compiler_spec
-        )
+        super().__init__("Multiple compilers satisfy spec %s" % compiler_spec)

--- a/lib/spack/spack/compilers/apple_clang.py
+++ b/lib/spack/spack/compilers/apple_clang.py
@@ -132,7 +132,7 @@ class AppleClang(spack.compilers.clang.Clang):
         the 'DEVELOPER_DIR' environment variables to cause the xcrun and
         related tools to use this Xcode.app.
         """
-        super(AppleClang, self).setup_custom_environment(pkg, env)
+        super().setup_custom_environment(pkg, env)
 
         if not pkg.use_xcode:
             # if we do it for all packages, we get into big troubles with MPI:

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -12,7 +12,7 @@ class Cce(Compiler):
     """Cray compiler environment compiler."""
 
     def __init__(self, *args, **kwargs):
-        super(Cce, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # For old cray compilers on module based systems we replace
         # ``version_argument`` with the old value. Cannot be a property
         # as the new value is used in classmethods for path-based detection

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -77,7 +77,7 @@ class Msvc(Compiler):
     def __init__(self, *args, **kwargs):
         new_pth = [pth if pth else get_valid_fortran_pth(args[0].version) for pth in args[3]]
         args[3][:] = new_pth
-        super(Msvc, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if os.getenv("ONEAPI_ROOT"):
             # If this found, it sets all the vars
             self.setvarsfile = os.path.join(os.getenv("ONEAPI_ROOT"), "setvars.bat")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -792,7 +792,7 @@ class NoCompilersForArchError(spack.error.SpackError):
             " operating systems and targets:\n\t" + "\n\t".join(available_os_target_strs)
         )
 
-        super(NoCompilersForArchError, self).__init__(
+        super().__init__(
             err_msg, "Run 'spack compiler find' to add compilers."
         )
 
@@ -806,7 +806,7 @@ class UnavailableCompilerVersionError(spack.error.SpackError):
         if arch:
             err_msg += " for operating system {0} and target {1}.".format(arch.os, arch.target)
 
-        super(UnavailableCompilerVersionError, self).__init__(
+        super().__init__(
             err_msg,
             "Run 'spack compiler find' to add compilers or "
             "'spack compilers' to see which compilers are already recognized"
@@ -819,7 +819,7 @@ class NoValidVersionError(spack.error.SpackError):
     particular spec."""
 
     def __init__(self, spec):
-        super(NoValidVersionError, self).__init__(
+        super().__init__(
             "There are no valid versions for %s that match '%s'" % (spec.name, spec.versions)
         )
 
@@ -830,7 +830,7 @@ class InsufficientArchitectureInfoError(spack.error.SpackError):
     system"""
 
     def __init__(self, spec, archs):
-        super(InsufficientArchitectureInfoError, self).__init__(
+        super().__init__(
             "Cannot determine necessary architecture information for '%s': %s"
             % (spec.name, str(archs))
         )
@@ -846,4 +846,4 @@ class NoBuildError(spack.error.SpecError):
             "The spec\n    '%s'\n    is configured as not buildable, "
             "and no matching external installs were found"
         )
-        super(NoBuildError, self).__init__(msg % spec)
+        super().__init__(msg % spec)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -792,9 +792,7 @@ class NoCompilersForArchError(spack.error.SpackError):
             " operating systems and targets:\n\t" + "\n\t".join(available_os_target_strs)
         )
 
-        super().__init__(
-            err_msg, "Run 'spack compiler find' to add compilers."
-        )
+        super().__init__(err_msg, "Run 'spack compiler find' to add compilers.")
 
 
 class UnavailableCompilerVersionError(spack.error.SpackError):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -182,7 +182,7 @@ class SingleFileScope(ConfigScope):
                        config:
                          install_tree: $spack/opt/spack
         """
-        super(SingleFileScope, self).__init__(name, path)
+        super().__init__(name, path)
         self._raw_data = None
         self.schema = schema
         self.yaml_path = yaml_path or []
@@ -310,7 +310,7 @@ class InternalConfigScope(ConfigScope):
     """
 
     def __init__(self, name, data=None):
-        super(InternalConfigScope, self).__init__(name, None)
+        super().__init__(name, None)
         self.sections = syaml.syaml_dict()
 
         if data:
@@ -1495,7 +1495,7 @@ class ConfigFormatError(ConfigError):
             location += ":%d" % line
 
         message = "%s: %s" % (location, validation_error.message)
-        super(ConfigError, self).__init__(message)
+        super().__init__(message)
 
     def _get_mark(self, validation_error, data):
         """Get the file/line mark fo a validation error from a Spack YAML file."""

--- a/lib/spack/spack/container/writers/docker.py
+++ b/lib/spack/spack/container/writers/docker.py
@@ -18,7 +18,7 @@ class DockerContext(PathContext):
 
     @tengine.context_property
     def manifest(self):
-        manifest_str = super(DockerContext, self).manifest
+        manifest_str = super().manifest
         # Docker doesn't support HEREDOC, so we need to resort to
         # a horrible echo trick to have the manifest in the Dockerfile
         echoed_lines = []

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -199,4 +199,4 @@ def read(path, apply_updates):
 
 class ManifestValidationError(spack.error.SpackError):
     def __init__(self, msg, long_msg=None):
-        super(ManifestValidationError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1667,7 +1667,7 @@ class InvalidDatabaseVersionError(SpackError):
             f"you need a newer Spack version to read the DB in '{database.root}'. "
             f"{self.database_version_message}"
         )
-        super(InvalidDatabaseVersionError, self).__init__(msg)
+        super().__init__(msg)
 
     @property
     def database_version_message(self):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -388,14 +388,14 @@ class DirectoryLayoutError(SpackError):
     """Superclass for directory layout errors."""
 
     def __init__(self, message, long_msg=None):
-        super(DirectoryLayoutError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
 
 
 class RemoveFailedError(DirectoryLayoutError):
     """Raised when a DirectoryLayout cannot remove an install prefix."""
 
     def __init__(self, installed_spec, prefix, error):
-        super(RemoveFailedError, self).__init__(
+        super().__init__(
             "Could not remove prefix %s for %s : %s" % (prefix, installed_spec.short_spec, error)
         )
         self.cause = error
@@ -405,7 +405,7 @@ class InconsistentInstallDirectoryError(DirectoryLayoutError):
     """Raised when a package seems to be installed to the wrong place."""
 
     def __init__(self, message, long_msg=None):
-        super(InconsistentInstallDirectoryError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
 
 
 class SpecReadError(DirectoryLayoutError):
@@ -416,7 +416,7 @@ class InvalidDirectoryLayoutParametersError(DirectoryLayoutError):
     """Raised when a invalid directory layout parameters are supplied"""
 
     def __init__(self, message, long_msg=None):
-        super(InvalidDirectoryLayoutParametersError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
 
 
 class InvalidExtensionSpecError(DirectoryLayoutError):
@@ -427,7 +427,7 @@ class ExtensionAlreadyInstalledError(DirectoryLayoutError):
     """Raised when an extension is added to a package that already has it."""
 
     def __init__(self, spec, ext_spec):
-        super(ExtensionAlreadyInstalledError, self).__init__(
+        super().__init__(
             "%s is already installed in %s" % (ext_spec.short_spec, spec.short_spec)
         )
 
@@ -436,7 +436,7 @@ class ExtensionConflictError(DirectoryLayoutError):
     """Raised when an extension is added to a package that already has it."""
 
     def __init__(self, spec, ext_spec, conflict):
-        super(ExtensionConflictError, self).__init__(
+        super().__init__(
             "%s cannot be installed in %s because it conflicts with %s"
             % (ext_spec.short_spec, spec.short_spec, conflict.short_spec)
         )

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -427,9 +427,7 @@ class ExtensionAlreadyInstalledError(DirectoryLayoutError):
     """Raised when an extension is added to a package that already has it."""
 
     def __init__(self, spec, ext_spec):
-        super().__init__(
-            "%s is already installed in %s" % (ext_spec.short_spec, spec.short_spec)
-        )
+        super().__init__("%s is already installed in %s" % (ext_spec.short_spec, spec.short_spec))
 
 
 class ExtensionConflictError(DirectoryLayoutError):

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -123,9 +123,7 @@ class UnsatisfiableSpecError(SpecError):
 
     def __init__(self, provided, required, constraint_type):
         # This is only the entrypoint for old concretizer errors
-        super().__init__(
-            "%s does not satisfy %s" % (provided, required)
-        )
+        super().__init__("%s does not satisfy %s" % (provided, required))
 
         self.provided = provided
         self.required = required

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -19,7 +19,7 @@ class SpackError(Exception):
     """
 
     def __init__(self, message, long_message=None):
-        super(SpackError, self).__init__()
+        super().__init__()
         self.message = message
         self._long_message = long_message
 
@@ -91,14 +91,14 @@ class UnsupportedPlatformError(SpackError):
     """Raised by packages when a platform is not supported"""
 
     def __init__(self, message):
-        super(UnsupportedPlatformError, self).__init__(message)
+        super().__init__(message)
 
 
 class NoLibrariesError(SpackError):
     """Raised when package libraries are requested but cannot be found"""
 
     def __init__(self, message_or_name, prefix=None):
-        super(NoLibrariesError, self).__init__(
+        super().__init__(
             message_or_name
             if prefix is None
             else "Unable to locate {0} libraries in {1}".format(message_or_name, prefix)
@@ -123,7 +123,7 @@ class UnsatisfiableSpecError(SpecError):
 
     def __init__(self, provided, required, constraint_type):
         # This is only the entrypoint for old concretizer errors
-        super(UnsatisfiableSpecError, self).__init__(
+        super().__init__(
             "%s does not satisfy %s" % (provided, required)
         )
 

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -188,6 +188,4 @@ class ExtensionNamingError(spack.error.SpackError):
     """
 
     def __init__(self, path):
-        super().__init__(
-            "{0} does not match the format for a Spack extension path.".format(path)
-        )
+        super().__init__("{0} does not match the format for a Spack extension path.".format(path))

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -176,7 +176,7 @@ class CommandNotFoundError(spack.error.SpackError):
     """
 
     def __init__(self, cmd_name):
-        super(CommandNotFoundError, self).__init__(
+        super().__init__(
             "{0} is not a recognized Spack command or extension command;"
             " check with `spack commands`.".format(cmd_name)
         )
@@ -188,6 +188,6 @@ class ExtensionNamingError(spack.error.SpackError):
     """
 
     def __init__(self, path):
-        super(ExtensionNamingError, self).__init__(
+        super().__init__(
             "{0} does not match the format for a Spack extension path.".format(path)
         )

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -234,7 +234,7 @@ class FetchStrategyComposite(pattern.Composite):
     matches = FetchStrategy.matches
 
     def __init__(self):
-        super(FetchStrategyComposite, self).__init__(
+        super().__init__(
             ["fetch", "check", "expand", "reset", "archive", "cachable", "mirror_id"]
         )
 
@@ -263,7 +263,7 @@ class URLFetchStrategy(FetchStrategy):
     optional_attrs = list(crypto.hashes.keys()) + ["checksum"]
 
     def __init__(self, url=None, checksum=None, **kwargs):
-        super(URLFetchStrategy, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Prefer values in kwargs to the positionals.
         self.url = kwargs.get("url", url)
@@ -580,7 +580,7 @@ class VCSFetchStrategy(FetchStrategy):
     """
 
     def __init__(self, **kwargs):
-        super(VCSFetchStrategy, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Set a URL based on the type of fetch strategy.
         self.url = kwargs.get(self.url_attr, None)
@@ -652,7 +652,7 @@ class GoFetchStrategy(VCSFetchStrategy):
         # call to __init__
         forwarded_args = copy.copy(kwargs)
         forwarded_args.pop("name", None)
-        super(GoFetchStrategy, self).__init__(**forwarded_args)
+        super().__init__(**forwarded_args)
 
         self._go = None
 
@@ -681,7 +681,7 @@ class GoFetchStrategy(VCSFetchStrategy):
             self.go("get", "-v", "-d", self.url, env=env)
 
     def archive(self, destination):
-        super(GoFetchStrategy, self).archive(destination, exclude=".git")
+        super().archive(destination, exclude=".git")
 
     @_needs_stage
     def expand(self):
@@ -740,7 +740,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         # to __init__
         forwarded_args = copy.copy(kwargs)
         forwarded_args.pop("name", None)
-        super(GitFetchStrategy, self).__init__(**forwarded_args)
+        super().__init__(**forwarded_args)
 
         self._git = None
         self.submodules = kwargs.get("submodules", False)
@@ -948,7 +948,7 @@ class GitFetchStrategy(VCSFetchStrategy):
                 git(*args)
 
     def archive(self, destination):
-        super(GitFetchStrategy, self).archive(destination, exclude=".git")
+        super().archive(destination, exclude=".git")
 
     @_needs_stage
     def reset(self):
@@ -997,7 +997,7 @@ class CvsFetchStrategy(VCSFetchStrategy):
         # to __init__
         forwarded_args = copy.copy(kwargs)
         forwarded_args.pop("name", None)
-        super(CvsFetchStrategy, self).__init__(**forwarded_args)
+        super().__init__(**forwarded_args)
 
         self._cvs = None
         if self.branch is not None:
@@ -1077,7 +1077,7 @@ class CvsFetchStrategy(VCSFetchStrategy):
                         os.unlink(path)
 
     def archive(self, destination):
-        super(CvsFetchStrategy, self).archive(destination, exclude="CVS")
+        super().archive(destination, exclude="CVS")
 
     @_needs_stage
     def reset(self):
@@ -1113,7 +1113,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
         # to __init__
         forwarded_args = copy.copy(kwargs)
         forwarded_args.pop("name", None)
-        super(SvnFetchStrategy, self).__init__(**forwarded_args)
+        super().__init__(**forwarded_args)
 
         self._svn = None
         if self.revision is not None:
@@ -1172,7 +1172,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
                     shutil.rmtree(path, ignore_errors=True)
 
     def archive(self, destination):
-        super(SvnFetchStrategy, self).archive(destination, exclude=".svn")
+        super().archive(destination, exclude=".svn")
 
     @_needs_stage
     def reset(self):
@@ -1216,7 +1216,7 @@ class HgFetchStrategy(VCSFetchStrategy):
         # to __init__
         forwarded_args = copy.copy(kwargs)
         forwarded_args.pop("name", None)
-        super(HgFetchStrategy, self).__init__(**forwarded_args)
+        super().__init__(**forwarded_args)
 
         self._hg = None
 
@@ -1277,7 +1277,7 @@ class HgFetchStrategy(VCSFetchStrategy):
             shutil.move(repo_name, self.stage.source_path)
 
     def archive(self, destination):
-        super(HgFetchStrategy, self).archive(destination, exclude=".hg")
+        super().archive(destination, exclude=".hg")
 
     @_needs_stage
     def reset(self):
@@ -1306,7 +1306,7 @@ class S3FetchStrategy(URLFetchStrategy):
 
     def __init__(self, *args, **kwargs):
         try:
-            super(S3FetchStrategy, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
         except ValueError:
             if not kwargs.get("url"):
                 raise ValueError("S3FetchStrategy requires a url for fetching.")
@@ -1353,7 +1353,7 @@ class GCSFetchStrategy(URLFetchStrategy):
 
     def __init__(self, *args, **kwargs):
         try:
-            super(GCSFetchStrategy, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
         except ValueError:
             if not kwargs.get("url"):
                 raise ValueError("GCSFetchStrategy requires a url for fetching.")
@@ -1686,7 +1686,7 @@ class FailedDownloadError(web_util.FetchError):
     """Raised when a download fails."""
 
     def __init__(self, url, msg=""):
-        super(FailedDownloadError, self).__init__("Failed to fetch file from URL: %s" % url, msg)
+        super().__init__("Failed to fetch file from URL: %s" % url, msg)
         self.url = url
 
 
@@ -1716,7 +1716,7 @@ class InvalidArgsError(web_util.FetchError):
             if version:
                 msg += "@{version}".format(version=version)
         long_msg = "with arguments: {args}".format(args=args)
-        super(InvalidArgsError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)
 
 
 class ChecksumError(web_util.FetchError):
@@ -1727,6 +1727,6 @@ class NoStageError(web_util.FetchError):
     """Raised when fetch operations are called before set_stage()."""
 
     def __init__(self, method):
-        super(NoStageError, self).__init__(
+        super().__init__(
             "Must call FetchStrategy.set_stage() before calling %s" % method.__name__
         )

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -234,9 +234,7 @@ class FetchStrategyComposite(pattern.Composite):
     matches = FetchStrategy.matches
 
     def __init__(self):
-        super().__init__(
-            ["fetch", "check", "expand", "reset", "archive", "cachable", "mirror_id"]
-        )
+        super().__init__(["fetch", "check", "expand", "reset", "archive", "cachable", "mirror_id"])
 
     def source_id(self):
         component_ids = tuple(i.source_id() for i in self)
@@ -1727,6 +1725,4 @@ class NoStageError(web_util.FetchError):
     """Raised when fetch operations are called before set_stage()."""
 
     def __init__(self, method):
-        super().__init__(
-            "Must call FetchStrategy.set_stage() before calling %s" % method.__name__
-        )
+        super().__init__("Must call FetchStrategy.set_stage() before calling %s" % method.__name__)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -255,7 +255,7 @@ class YamlFilesystemView(FilesystemView):
     """
 
     def __init__(self, root, layout, **kwargs):
-        super(YamlFilesystemView, self).__init__(root, layout, **kwargs)
+        super().__init__(root, layout, **kwargs)
 
         # Super class gets projections from the kwargs
         # YAML specific to get projections from YAML file
@@ -637,7 +637,7 @@ class SimpleFilesystemView(FilesystemView):
     were added."""
 
     def __init__(self, root, layout, **kwargs):
-        super(SimpleFilesystemView, self).__init__(root, layout, **kwargs)
+        super().__init__(root, layout, **kwargs)
 
     def _sanity_check_view_projection(self, specs):
         """A very common issue is that we end up with two specs of the same

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2513,9 +2513,7 @@ class BadInstallPhase(InstallError):
     """Raised for an install phase option is not allowed for a package."""
 
     def __init__(self, pkg_name, phase):
-        super().__init__(
-            "'{0}' is not a valid phase for package {1}".format(phase, pkg_name)
-        )
+        super().__init__("'{0}' is not a valid phase for package {1}".format(phase, pkg_name))
 
 
 class ExternalPackageError(InstallError):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2505,7 +2505,7 @@ class InstallError(spack.error.SpackError):
     """
 
     def __init__(self, message, long_msg=None, pkg=None):
-        super(InstallError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
         self.pkg = pkg
 
 
@@ -2513,7 +2513,7 @@ class BadInstallPhase(InstallError):
     """Raised for an install phase option is not allowed for a package."""
 
     def __init__(self, pkg_name, phase):
-        super(BadInstallPhase, self).__init__(
+        super().__init__(
             "'{0}' is not a valid phase for package {1}".format(phase, pkg_name)
         )
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -195,7 +195,7 @@ def index_commands():
 class SpackHelpFormatter(argparse.RawTextHelpFormatter):
     def _format_actions_usage(self, actions, groups):
         """Formatter with more concise usage strings."""
-        usage = super(SpackHelpFormatter, self)._format_actions_usage(actions, groups)
+        usage = super()._format_actions_usage(actions, groups)
 
         # Eliminate any occurrence of two or more consecutive spaces
         usage = re.sub(r"[ ]{2,}", " ", usage)
@@ -210,7 +210,7 @@ class SpackHelpFormatter(argparse.RawTextHelpFormatter):
 
     def add_arguments(self, actions):
         actions = sorted(actions, key=operator.attrgetter("option_strings"))
-        super(SpackHelpFormatter, self).add_arguments(actions)
+        super().add_arguments(actions)
 
 
 class SpackArgumentParser(argparse.ArgumentParser):
@@ -330,7 +330,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
         if sys.version_info[:2] > (3, 6):
             kwargs.setdefault("required", True)
 
-        sp = super(SpackArgumentParser, self).add_subparsers(**kwargs)
+        sp = super().add_subparsers(**kwargs)
         # This monkey patching is needed for Python 3.6, which supports
         # having a required subparser but don't expose the API used above
         if sys.version_info[:2] == (3, 6):
@@ -380,7 +380,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
             return self.format_help_sections(level)
         else:
             # in subparsers, self.prog is, e.g., 'spack install'
-            return super(SpackArgumentParser, self).format_help()
+            return super().format_help()
 
     def _check_value(self, action, value):
         # converted value must be one of the choices (if specified)

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -693,4 +693,4 @@ class MirrorError(spack.error.SpackError):
     """Superclass of all mirror-creation related errors."""
 
     def __init__(self, msg, long_msg=None):
-        super(MirrorError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -275,14 +275,14 @@ class MultiMethodError(spack.error.SpackError):
     """Superclass for multimethod dispatch errors"""
 
     def __init__(self, message):
-        super(MultiMethodError, self).__init__(message)
+        super().__init__(message)
 
 
 class NoSuchMethodError(spack.error.SpackError):
     """Raised when we can't find a version of a multi-method."""
 
     def __init__(self, cls, method_name, spec, possible_specs):
-        super(NoSuchMethodError, self).__init__(
+        super().__init__(
             "Package %s does not support %s called with %s.  Options are: %s"
             % (cls.__name__, method_name, spec, ", ".join(str(s) for s in possible_specs))
         )

--- a/lib/spack/spack/operating_systems/cray_backend.py
+++ b/lib/spack/spack/operating_systems/cray_backend.py
@@ -86,9 +86,9 @@ class CrayBackend(LinuxDistro):
             # distro.linux_distribution, while still calling __init__
             # methods further up the MRO, we skip LinuxDistro in the MRO and
             # call the OperatingSystem superclass __init__ method
-            super(LinuxDistro, self).__init__(name, version)
+            super().__init__(name, version)
         else:
-            super(CrayBackend, self).__init__()
+            super().__init__()
         self.modulecmd = module
 
     def __str__(self):

--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -67,4 +67,4 @@ class LinuxDistro(OperatingSystem):
         else:
             version = version[0]
 
-        super(LinuxDistro, self).__init__(distname, version)
+        super().__init__(distname, version)

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -152,7 +152,7 @@ class MacOs(OperatingSystem):
 
         mac_ver = str(version.up_to(part))
         name = mac_releases.get(mac_ver, "macos")
-        super(MacOs, self).__init__(name, mac_ver)
+        super().__init__(name, mac_ver)
 
     def __str__(self):
         return self.name

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -72,7 +72,7 @@ class WindowsOs(OperatingSystem):
         plat_ver = windows_version()
         if plat_ver < Version("10"):
             raise SpackError("Spack is not supported on Windows versions older than 10")
-        super(WindowsOs, self).__init__("windows{}".format(plat_ver), plat_ver)
+        super().__init__("windows{}".format(plat_ver), plat_ver)
 
     def __str__(self):
         return self.name

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2549,6 +2549,4 @@ class DependencyConflictError(spack.error.SpackError):
     """Raised when the dependencies cannot be flattened as asked for."""
 
     def __init__(self, conflict):
-        super().__init__(
-            "%s conflicts with another file in the flattened directory." % (conflict)
-        )
+        super().__init__("%s conflicts with another file in the flattened directory." % (conflict))

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -668,7 +668,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             pkg_cls = spack.repo.path.get_pkg_class(self.extendee_spec.name)
             pkg_cls(self.extendee_spec)._check_extendable()
 
-        super(PackageBase, self).__init__()
+        super().__init__()
 
     @classmethod
     def possible_dependencies(
@@ -2511,7 +2511,7 @@ class PackageStillNeededError(InstallError):
     """Raised when package is still needed by another on uninstall."""
 
     def __init__(self, spec, dependents):
-        super(PackageStillNeededError, self).__init__("Cannot uninstall %s" % spec)
+        super().__init__("Cannot uninstall %s" % spec)
         self.spec = spec
         self.dependents = dependents
 
@@ -2520,14 +2520,14 @@ class PackageError(spack.error.SpackError):
     """Raised when something is wrong with a package definition."""
 
     def __init__(self, message, long_msg=None):
-        super(PackageError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
 
 
 class NoURLError(PackageError):
     """Raised when someone tries to build a URL for a package with no URLs."""
 
     def __init__(self, cls):
-        super(NoURLError, self).__init__("Package %s has no version with a URL." % cls.__name__)
+        super().__init__("Package %s has no version with a URL." % cls.__name__)
 
 
 class InvalidPackageOpError(PackageError):
@@ -2542,13 +2542,13 @@ class ActivationError(ExtensionError):
     """Raised when there are problems activating an extension."""
 
     def __init__(self, msg, long_msg=None):
-        super(ActivationError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)
 
 
 class DependencyConflictError(spack.error.SpackError):
     """Raised when the dependencies cannot be flattened as asked for."""
 
     def __init__(self, conflict):
-        super(DependencyConflictError, self).__init__(
+        super().__init__(
             "%s conflicts with another file in the flattened directory." % (conflict)
         )

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -152,7 +152,7 @@ class FilePatch(Patch):
             msg += "package %s.%s does not exist." % (pkg.namespace, pkg.name)
             raise ValueError(msg)
 
-        super(FilePatch, self).__init__(pkg, abs_path, level, working_dir)
+        super().__init__(pkg, abs_path, level, working_dir)
         self.path = abs_path
         self._sha256 = None
         self.ordering_key = ordering_key
@@ -165,7 +165,7 @@ class FilePatch(Patch):
 
     def to_dict(self):
         return llnl.util.lang.union_dicts(
-            super(FilePatch, self).to_dict(), {"relative_path": self.relative_path}
+            super().to_dict(), {"relative_path": self.relative_path}
         )
 
 
@@ -181,7 +181,7 @@ class UrlPatch(Patch):
     """
 
     def __init__(self, pkg, url, level=1, working_dir=".", ordering_key=None, **kwargs):
-        super(UrlPatch, self).__init__(pkg, url, level, working_dir)
+        super().__init__(pkg, url, level, working_dir)
 
         self.url = url
         self._stage = None
@@ -264,7 +264,7 @@ class UrlPatch(Patch):
         self.stage.destroy()
 
     def to_dict(self):
-        data = super(UrlPatch, self).to_dict()
+        data = super().to_dict()
         data["url"] = self.url
         if self.archive_sha256:
             data["archive_sha256"] = self.archive_sha256

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -164,9 +164,7 @@ class FilePatch(Patch):
         return self._sha256
 
     def to_dict(self):
-        return llnl.util.lang.union_dicts(
-            super().to_dict(), {"relative_path": self.relative_path}
-        )
+        return llnl.util.lang.union_dicts(super().to_dict(), {"relative_path": self.relative_path})
 
 
 class UrlPatch(Patch):

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -12,7 +12,7 @@ import spack.error
 class NoPlatformError(spack.error.SpackError):
     def __init__(self):
         msg = "Could not determine a platform for this machine"
-        super(NoPlatformError, self).__init__(msg)
+        super().__init__(msg)
 
 
 @llnl.util.lang.lazy_lexicographic_ordering

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -59,7 +59,7 @@ class Cray(Platform):
           configuration file "targets.yaml" with keys 'front_end', 'back_end'
           scanning /etc/bash/bashrc.local for back_end only
         """
-        super(Cray, self).__init__("cray")
+        super().__init__("cray")
 
         # Make all craype targets available.
         for target in self._avail_targets():

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -20,7 +20,7 @@ class Darwin(Platform):
     binary_formats = ["macho"]
 
     def __init__(self):
-        super(Darwin, self).__init__("darwin")
+        super().__init__("darwin")
 
         for name in archspec.cpu.TARGETS:
             self.add_target(name, spack.target.Target(name))

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -16,7 +16,7 @@ class Linux(Platform):
     priority = 90
 
     def __init__(self):
-        super(Linux, self).__init__("linux")
+        super().__init__("linux")
 
         for name in archspec.cpu.TARGETS:
             self.add_target(name, spack.target.Target(name))

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -31,7 +31,7 @@ class Test(Platform):
 
     def __init__(self, name=None):
         name = name or "test"
-        super(Test, self).__init__(name)
+        super().__init__(name)
         self.add_target(self.default, spack.target.Target(self.default))
         self.add_target(self.front_end, spack.target.Target(self.front_end))
 

--- a/lib/spack/spack/platforms/windows.py
+++ b/lib/spack/spack/platforms/windows.py
@@ -17,7 +17,7 @@ class Windows(Platform):
     priority = 101
 
     def __init__(self):
-        super(Windows, self).__init__("windows")
+        super().__init__("windows")
 
         for name in archspec.cpu.TARGETS:
             self.add_target(name, spack.target.Target(name))

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -39,7 +39,7 @@ class InstallRootStringError(spack.error.SpackError):
             file_path (str): path of the binary
             root_path (str): original Spack's store root string
         """
-        super(InstallRootStringError, self).__init__(
+        super().__init__(
             "\n %s \ncontains string\n %s \n"
             "after replacing it in rpaths.\n"
             "Package should not be relocated.\n Use -a to override." % (file_path, root_path)

--- a/lib/spack/spack/relocate_text.py
+++ b/lib/spack/spack/relocate_text.py
@@ -267,7 +267,7 @@ class BinaryStringReplacementError(spack.error.SpackError):
             old_len (str): original length of the file
             new_len (str): length of the file after substitution
         """
-        super(BinaryStringReplacementError, self).__init__(
+        super().__init__(
             "Doing a binary string replacement in %s failed.\n"
             "The size of the file changed from %s to %s\n"
             "when it should have remanined the same." % (file_path, old_len, new_len)
@@ -280,13 +280,13 @@ class BinaryTextReplaceError(spack.error.SpackError):
             " To fix this, compile with more padding "
             "(config:install_tree:padded_length), or install to a shorter prefix."
         )
-        super(BinaryTextReplaceError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class CannotGrowString(BinaryTextReplaceError):
     def __init__(self, old, new):
         msg = "Cannot replace {!r} with {!r} because the new prefix is longer.".format(old, new)
-        super(CannotGrowString, self).__init__(msg)
+        super().__init__(msg)
 
 
 class CannotShrinkCString(BinaryTextReplaceError):
@@ -298,4 +298,4 @@ class CannotShrinkCString(BinaryTextReplaceError):
         msg = "Cannot replace {!r} with {!r} in the C-string {!r}.".format(
             old, new, full_old_string
         )
-        super(CannotShrinkCString, self).__init__(msg)
+        super().__init__(msg)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -112,9 +112,7 @@ class RepoLoader(_PrependFileLoader):
         self.package_name = package_name
         self.package_py = repo.filename_for_package_name(package_name)
         self.fullname = fullname
-        super().__init__(
-            self.fullname, self.package_py, prepend=self._package_prepend
-        )
+        super().__init__(self.fullname, self.package_py, prepend=self._package_prepend)
 
 
 class SpackNamespaceLoader(object):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -112,7 +112,7 @@ class RepoLoader(_PrependFileLoader):
         self.package_name = package_name
         self.package_py = repo.filename_for_package_name(package_name)
         self.fullname = fullname
-        super(RepoLoader, self).__init__(
+        super().__init__(
             self.fullname, self.package_py, prepend=self._package_prepend
         )
 
@@ -326,7 +326,7 @@ class SpackNamespace(types.ModuleType):
     """Allow lazy loading of modules."""
 
     def __init__(self, namespace):
-        super(SpackNamespace, self).__init__(namespace)
+        super().__init__(namespace)
         self.__file__ = "(spack namespace)"
         self.__path__ = []
         self.__name__ = namespace
@@ -1500,7 +1500,7 @@ class UnknownPackageError(UnknownEntityError):
             else:
                 long_msg = "You may need to run 'spack clean -m'."
 
-        super(UnknownPackageError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)
         self.name = name
 
 
@@ -1512,14 +1512,14 @@ class UnknownNamespaceError(UnknownEntityError):
         if name == "yaml":
             long_msg = "Did you mean to specify a filename with './{}.{}'?"
             long_msg = long_msg.format(namespace, name)
-        super(UnknownNamespaceError, self).__init__(msg, long_msg)
+        super().__init__(msg, long_msg)
 
 
 class FailedConstructorError(RepoError):
     """Raised when a package's class constructor fails."""
 
     def __init__(self, name, exc_type, exc_obj, exc_tb):
-        super(FailedConstructorError, self).__init__(
+        super().__init__(
             "Class constructor failed for package '%s'." % name,
             "\nCaused by:\n"
             + ("%s: %s\n" % (exc_type.__name__, exc_obj))

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -126,14 +126,14 @@ class RewireError(spack.error.SpackError):
     """Raised when something goes wrong with rewiring."""
 
     def __init__(self, message, long_msg=None):
-        super(RewireError, self).__init__(message, long_msg)
+        super().__init__(message, long_msg)
 
 
 class PackageNotInstalledError(RewireError):
     """Raised when the build_spec for a splice was not installed."""
 
     def __init__(self, spliced_spec, build_spec, dep):
-        super(PackageNotInstalledError, self).__init__(
+        super().__init__(
             """Rewire of {0}
             failed due to missing install of build spec {1}
             for spec {2}""".format(

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -30,7 +30,7 @@ class WrapStream(BufferedReader):
             raw.seekable = lambda: False
             raw.closed = False
             raw.flush = lambda: None
-        super(WrapStream, self).__init__(raw)
+        super().__init__(raw)
 
     def detach(self):
         self.raw = None

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -825,7 +825,7 @@ class FlagMap(lang.HashableMap):
     __slots__ = ("spec",)
 
     def __init__(self, spec):
-        super(FlagMap, self).__init__()
+        super().__init__()
         self.spec = spec
 
     def satisfies(self, other):
@@ -1292,7 +1292,7 @@ class SpecBuildInterface(lang.ObjectWrapper):
     libs = ForwardQueryToPackage("libs", default_handler=_libs_default_handler)
 
     def __init__(self, spec, name, query_parameters):
-        super(SpecBuildInterface, self).__init__(spec)
+        super().__init__(spec)
         # Adding new attributes goes after super() call since the ObjectWrapper
         # resets __dict__ to behave like the passed object
         original_spec = getattr(spec, "wrapped_obj", spec)
@@ -5138,7 +5138,7 @@ class LazySpecCache(collections.defaultdict):
     """
 
     def __init__(self):
-        super(LazySpecCache, self).__init__(Spec)
+        super().__init__(Spec)
 
     def __missing__(self, key):
         value = self.default_factory(key)
@@ -5183,7 +5183,7 @@ class SpecParseError(spack.error.SpecError):
     """Wrapper for ParseError for when we're parsing specs."""
 
     def __init__(self, parse_error):
-        super(SpecParseError, self).__init__(parse_error.message)
+        super().__init__(parse_error.message)
         self.string = parse_error.string
         self.pos = parse_error.pos
 
@@ -5220,7 +5220,7 @@ class UnsupportedCompilerError(spack.error.SpecError):
     """Raised when the user asks for a compiler spack doesn't know about."""
 
     def __init__(self, compiler_name):
-        super(UnsupportedCompilerError, self).__init__(
+        super().__init__(
             "The '%s' compiler is not yet supported." % compiler_name
         )
 
@@ -5240,7 +5240,7 @@ class InvalidDependencyError(spack.error.SpecError):
 
     def __init__(self, pkg, deps):
         self.invalid_deps = deps
-        super(InvalidDependencyError, self).__init__(
+        super().__init__(
             "Package {0} does not depend on {1}".format(pkg, spack.util.string.comma_or(deps))
         )
 
@@ -5251,7 +5251,7 @@ class NoProviderError(spack.error.SpecError):
     """
 
     def __init__(self, vpkg):
-        super(NoProviderError, self).__init__(
+        super().__init__(
             "No providers found for virtual package: '%s'" % vpkg
         )
         self.vpkg = vpkg
@@ -5264,7 +5264,7 @@ class MultipleProviderError(spack.error.SpecError):
 
     def __init__(self, vpkg, providers):
         """Takes the name of the vpkg"""
-        super(MultipleProviderError, self).__init__(
+        super().__init__(
             "Multiple providers found for '%s': %s" % (vpkg, [str(s) for s in providers])
         )
         self.vpkg = vpkg
@@ -5275,28 +5275,28 @@ class UnsatisfiableSpecNameError(spack.error.UnsatisfiableSpecError):
     """Raised when two specs aren't even for the same package."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableSpecNameError, self).__init__(provided, required, "name")
+        super().__init__(provided, required, "name")
 
 
 class UnsatisfiableVersionSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec version conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableVersionSpecError, self).__init__(provided, required, "version")
+        super().__init__(provided, required, "version")
 
 
 class UnsatisfiableCompilerSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec comiler conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableCompilerSpecError, self).__init__(provided, required, "compiler")
+        super().__init__(provided, required, "compiler")
 
 
 class UnsatisfiableCompilerFlagSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec variant conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableCompilerFlagSpecError, self).__init__(
+        super().__init__(
             provided, required, "compiler_flags"
         )
 
@@ -5305,7 +5305,7 @@ class UnsatisfiableArchitectureSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec architecture conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableArchitectureSpecError, self).__init__(
+        super().__init__(
             provided, required, "architecture"
         )
 
@@ -5315,7 +5315,7 @@ class UnsatisfiableProviderSpecError(spack.error.UnsatisfiableSpecError):
     a vpkg requirement"""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableProviderSpecError, self).__init__(provided, required, "provider")
+        super().__init__(provided, required, "provider")
 
 
 # TODO: get rid of this and be more specific about particular incompatible
@@ -5324,7 +5324,7 @@ class UnsatisfiableDependencySpecError(spack.error.UnsatisfiableSpecError):
     """Raised when some dependency of constrained specs are incompatible"""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableDependencySpecError, self).__init__(provided, required, "dependency")
+        super().__init__(provided, required, "dependency")
 
 
 class UnconstrainableDependencySpecError(spack.error.SpecError):
@@ -5333,7 +5333,7 @@ class UnconstrainableDependencySpecError(spack.error.SpecError):
     def __init__(self, spec):
         msg = "Cannot constrain by spec '%s'. Cannot constrain by a" % spec
         msg += " spec containing anonymous dependencies"
-        super(UnconstrainableDependencySpecError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class AmbiguousHashError(spack.error.SpecError):
@@ -5341,14 +5341,14 @@ class AmbiguousHashError(spack.error.SpecError):
         spec_fmt = "{namespace}.{name}{@version}{%compiler}{compiler_flags}"
         spec_fmt += "{variants}{arch=architecture}{/hash:7}"
         specs_str = "\n  " + "\n  ".join(spec.format(spec_fmt) for spec in specs)
-        super(AmbiguousHashError, self).__init__(msg + specs_str)
+        super().__init__(msg + specs_str)
 
 
 class InvalidHashError(spack.error.SpecError):
     def __init__(self, spec, hash):
         msg = f"No spec with hash {hash} could be found to match {spec}."
         msg += " Either the hash does not exist, or it does not match other spec constraints."
-        super(InvalidHashError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class SpecFilenameError(spack.error.SpecError):
@@ -5361,7 +5361,7 @@ class NoSuchSpecFileError(SpecFilenameError):
 
 class RedundantSpecError(spack.error.SpecError):
     def __init__(self, spec, addition):
-        super(RedundantSpecError, self).__init__(
+        super().__init__(
             "Attempting to add %s to spec %s which is already concrete."
             " This is likely the result of adding to a spec specified by hash." % (addition, spec)
         )
@@ -5377,7 +5377,7 @@ class SpecFormatSigilError(SpecFormatStringError):
     def __init__(self, sigil, requirement, used):
         msg = "The sigil %s may only be used for %s." % (sigil, requirement)
         msg += " It was used with the attribute %s." % used
-        super(SpecFormatSigilError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class ConflictsInSpecError(spack.error.SpecError, RuntimeError):
@@ -5402,7 +5402,7 @@ class ConflictsInSpecError(spack.error.SpecError, RuntimeError):
             else:
                 long_message += match_fmt_custom.format(idx + 1, c, w, msg)
 
-        super(ConflictsInSpecError, self).__init__(message, long_message)
+        super().__init__(message, long_message)
 
 
 class SpecDependencyNotFoundError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5220,9 +5220,7 @@ class UnsupportedCompilerError(spack.error.SpecError):
     """Raised when the user asks for a compiler spack doesn't know about."""
 
     def __init__(self, compiler_name):
-        super().__init__(
-            "The '%s' compiler is not yet supported." % compiler_name
-        )
+        super().__init__("The '%s' compiler is not yet supported." % compiler_name)
 
 
 class DuplicateArchitectureError(spack.error.SpecError):
@@ -5251,9 +5249,7 @@ class NoProviderError(spack.error.SpecError):
     """
 
     def __init__(self, vpkg):
-        super().__init__(
-            "No providers found for virtual package: '%s'" % vpkg
-        )
+        super().__init__("No providers found for virtual package: '%s'" % vpkg)
         self.vpkg = vpkg
 
 
@@ -5296,18 +5292,14 @@ class UnsatisfiableCompilerFlagSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec variant conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super().__init__(
-            provided, required, "compiler_flags"
-        )
+        super().__init__(provided, required, "compiler_flags")
 
 
 class UnsatisfiableArchitectureSpecError(spack.error.UnsatisfiableSpecError):
     """Raised when a spec architecture conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super().__init__(
-            provided, required, "architecture"
-        )
+        super().__init__(provided, required, "architecture")
 
 
 class UnsatisfiableProviderSpecError(spack.error.UnsatisfiableSpecError):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -674,16 +674,16 @@ class Stage(object):
 
 class ResourceStage(Stage):
     def __init__(self, url_or_fetch_strategy, root, resource, **kwargs):
-        super(ResourceStage, self).__init__(url_or_fetch_strategy, **kwargs)
+        super().__init__(url_or_fetch_strategy, **kwargs)
         self.root_stage = root
         self.resource = resource
 
     def restage(self):
-        super(ResourceStage, self).restage()
+        super().restage()
         self._add_to_root_stage()
 
     def expand_archive(self):
-        super(ResourceStage, self).expand_archive()
+        super().expand_archive()
         self._add_to_root_stage()
 
     def _add_to_root_stage(self):
@@ -744,7 +744,7 @@ class StageComposite(pattern.Composite):
     #
 
     def __init__(self):
-        super(StageComposite, self).__init__(
+        super().__init__(
             [
                 "fetch",
                 "create",

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -125,7 +125,7 @@ default_compiler_entry = {
 # Fake up a mock compiler where everything is defaulted.
 class MockCompiler(Compiler):
     def __init__(self):
-        super(MockCompiler, self).__init__(
+        super().__init__(
             cspec="badcompiler@1.0.0",
             operating_system=default_compiler_entry["operating_system"],
             target=None,
@@ -142,7 +142,7 @@ class MockCompiler(Compiler):
         # Mock os.path.isdir so the link paths don't have to exist
         old_isdir = os.path.isdir
         os.path.isdir = lambda x: True
-        ret = super(MockCompiler, self)._get_compiler_link_paths(paths)
+        ret = super()._get_compiler_link_paths(paths)
         os.path.isdir = old_isdir
         return ret
 

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -830,7 +830,7 @@ class AssertLock(lk.Lock):
     """Test lock class that marks acquire/release events."""
 
     def __init__(self, lock_path, vals):
-        super(AssertLock, self).__init__(lock_path)
+        super().__init__(lock_path)
         self.vals = vals
 
     # assert hooks for subclasses
@@ -841,25 +841,25 @@ class AssertLock(lk.Lock):
 
     def acquire_read(self, timeout=None):
         self.assert_acquire_read()
-        result = super(AssertLock, self).acquire_read(timeout)
+        result = super().acquire_read(timeout)
         self.vals["acquired_read"] = True
         return result
 
     def acquire_write(self, timeout=None):
         self.assert_acquire_write()
-        result = super(AssertLock, self).acquire_write(timeout)
+        result = super().acquire_write(timeout)
         self.vals["acquired_write"] = True
         return result
 
     def release_read(self, release_fn=None):
         self.assert_release_read()
-        result = super(AssertLock, self).release_read(release_fn)
+        result = super().release_read(release_fn)
         self.vals["released_read"] = True
         return result
 
     def release_write(self, release_fn=None):
         self.assert_release_write()
-        result = super(AssertLock, self).release_write(release_fn)
+        result = super().release_write(release_fn)
         self.vals["released_write"] = True
         return result
 

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -916,7 +916,7 @@ class UrlParseError(spack.error.SpackError):
     """Raised when the URL module can't parse something correctly."""
 
     def __init__(self, msg, path):
-        super(UrlParseError, self).__init__(msg)
+        super().__init__(msg)
         self.path = path
 
 
@@ -924,13 +924,13 @@ class UndetectableVersionError(UrlParseError):
     """Raised when we can't parse a version from a string."""
 
     def __init__(self, path):
-        super(UndetectableVersionError, self).__init__("Couldn't detect version in: " + path, path)
+        super().__init__("Couldn't detect version in: " + path, path)
 
 
 class UndetectableNameError(UrlParseError):
     """Raised when we can't parse a package name from a string."""
 
     def __init__(self, path):
-        super(UndetectableNameError, self).__init__(
+        super().__init__(
             "Couldn't parse package name in: " + path, path
         )

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -931,6 +931,4 @@ class UndetectableNameError(UrlParseError):
     """Raised when we can't parse a package name from a string."""
 
     def __init__(self, path):
-        super().__init__(
-            "Couldn't parse package name in: " + path, path
-        )
+        super().__init__("Couldn't parse package name in: " + path, path)

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -496,7 +496,7 @@ class ElfDynamicSectionUpdateFailed(Exception):
     def __init__(self, old, new):
         self.old = old
         self.new = new
-        super(ElfDynamicSectionUpdateFailed, self).__init__(
+        super().__init__(
             "New rpath {} is longer than old rpath {}".format(
                 new.decode("utf-8"), old.decode("utf-8")
             )

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -31,27 +31,27 @@ class Lock(llnl.util.lock.Lock):
     """
 
     def __init__(self, *args, **kwargs):
-        super(Lock, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._enable = spack.config.get("config:locks", sys.platform != "win32")
 
     def _lock(self, op, timeout=0):
         if self._enable:
-            return super(Lock, self)._lock(op, timeout)
+            return super()._lock(op, timeout)
         else:
             return 0, 0
 
     def _unlock(self):
         """Unlock call that always succeeds."""
         if self._enable:
-            super(Lock, self)._unlock()
+            super()._unlock()
 
     def _debug(self, *args):
         if self._enable:
-            super(Lock, self)._debug(*args)
+            super()._debug(*args)
 
     def cleanup(self, *args):
         if self._enable:
-            super(Lock, self).cleanup(*args)
+            super().cleanup(*args)
 
 
 def check_lock_safety(path):

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -171,9 +171,7 @@ class InvalidFullyQualifiedModuleNameError(spack.error.SpackError):
     """Raised when we encounter a bad full package name."""
 
     def __init__(self, name):
-        super().__init__(
-            "Invalid fully qualified package name: " + name
-        )
+        super().__init__("Invalid fully qualified package name: " + name)
         self.name = name
 
 

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -163,7 +163,7 @@ class InvalidModuleNameError(spack.error.SpackError):
     """Raised when we encounter a bad module name."""
 
     def __init__(self, name):
-        super(InvalidModuleNameError, self).__init__("Invalid module name: " + name)
+        super().__init__("Invalid module name: " + name)
         self.name = name
 
 
@@ -171,7 +171,7 @@ class InvalidFullyQualifiedModuleNameError(spack.error.SpackError):
     """Raised when we encounter a bad full package name."""
 
     def __init__(self, name):
-        super(InvalidFullyQualifiedModuleNameError, self).__init__(
+        super().__init__(
             "Invalid fully qualified package name: " + name
         )
         self.name = name

--- a/lib/spack/spack/util/pattern.py
+++ b/lib/spack/spack/util/pattern.py
@@ -131,4 +131,4 @@ class Args(Bunch):
     """Subclass of Bunch to write argparse args more naturally."""
 
     def __init__(self, *flags, **kwargs):
-        super(Args, self).__init__(flags=tuple(flags), kwargs=kwargs)
+        super().__init__(flags=tuple(flags), kwargs=kwargs)

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -33,4 +33,4 @@ class SpackJSONError(spack.error.SpackError):
     """Raised when there are issues with JSON parsing."""
 
     def __init__(self, msg: str, json_error: BaseException):
-        super(SpackJSONError, self).__init__(msg, str(json_error))
+        super().__init__(msg, str(json_error))

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -870,7 +870,7 @@ class NoNetworkConnectionError(SpackWebError):
     """Raised when an operation can't get an internet connection."""
 
     def __init__(self, message, url):
-        super(NoNetworkConnectionError, self).__init__(
+        super().__init__(
             "No network connection: " + str(message), "URL was: " + str(url)
         )
         self.url = url

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -870,7 +870,5 @@ class NoNetworkConnectionError(SpackWebError):
     """Raised when an operation can't get an internet connection."""
 
     def __init__(self, message, url):
-        super().__init__(
-            "No network connection: " + str(message), "URL was: " + str(url)
-        )
+        super().__init__("No network connection: " + str(message), "URL was: " + str(url))
         self.url = url

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -422,7 +422,7 @@ class MultiValuedVariant(AbstractVariant):
         Returns:
             bool: True or False
         """
-        super_sat = super(MultiValuedVariant, self).satisfies(other)
+        super_sat = super().satisfies(other)
 
         if not super_sat:
             return False
@@ -459,7 +459,7 @@ class SingleValuedVariant(AbstractVariant):
 
     def _value_setter(self, value):
         # Treat the value as a multi-valued variant
-        super(SingleValuedVariant, self)._value_setter(value)
+        super()._value_setter(value)
 
         # Then check if there's only a single value
         if len(self._value) != 1:
@@ -473,7 +473,7 @@ class SingleValuedVariant(AbstractVariant):
 
     @implicit_variant_conversion
     def satisfies(self, other):
-        abstract_sat = super(SingleValuedVariant, self).satisfies(other)
+        abstract_sat = super().satisfies(other)
 
         return abstract_sat and (
             self.value == other.value or other.value == "*" or self.value == "*"
@@ -546,7 +546,7 @@ class VariantMap(lang.HashableMap):
     """
 
     def __init__(self, spec):
-        super(VariantMap, self).__init__()
+        super().__init__()
         self.spec = spec
 
     def __setitem__(self, name, vspec):
@@ -567,7 +567,7 @@ class VariantMap(lang.HashableMap):
             raise KeyError(msg.format(name, vspec.name))
 
         # Set the item
-        super(VariantMap, self).__setitem__(name, vspec)
+        super().__setitem__(name, vspec)
 
     def substitute(self, vspec):
         """Substitutes the entry under ``vspec.name`` with ``vspec``.
@@ -580,7 +580,7 @@ class VariantMap(lang.HashableMap):
             raise KeyError(msg.format(vspec.name))
 
         # Set the item
-        super(VariantMap, self).__setitem__(vspec.name, vspec)
+        super().__setitem__(vspec.name, vspec)
 
     def satisfies(self, other):
         return all(k in self and self[k].satisfies(other[k]) for k in other)
@@ -919,7 +919,7 @@ class UnknownVariantError(error.SpecError):
             " has no such {0} [happened during concretization of {3}]"
         )
         msg = msg.format(variant_str, comma_or(variants), spec.name, spec.root)
-        super(UnknownVariantError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class InconsistentValidationError(error.SpecError):
@@ -927,7 +927,7 @@ class InconsistentValidationError(error.SpecError):
 
     def __init__(self, vspec, variant):
         msg = 'trying to validate variant "{0.name}" ' 'with the validator of "{1.name}"'
-        super(InconsistentValidationError, self).__init__(msg.format(vspec, variant))
+        super().__init__(msg.format(vspec, variant))
 
 
 class MultipleValuesInExclusiveVariantError(error.SpecError, ValueError):
@@ -940,7 +940,7 @@ class MultipleValuesInExclusiveVariantError(error.SpecError, ValueError):
         pkg_info = ""
         if pkg is not None:
             pkg_info = ' in package "{0}"'.format(pkg.name)
-        super(MultipleValuesInExclusiveVariantError, self).__init__(msg.format(variant, pkg_info))
+        super().__init__(msg.format(variant, pkg_info))
 
 
 class InvalidVariantValueCombinationError(error.SpecError):
@@ -955,7 +955,7 @@ class InvalidVariantValueError(error.SpecError):
         pkg_info = ""
         if pkg is not None:
             pkg_info = ' in package "{0}"'.format(pkg.name)
-        super(InvalidVariantValueError, self).__init__(
+        super().__init__(
             msg.format(variant, invalid_values, pkg_info)
         )
 
@@ -966,11 +966,11 @@ class InvalidVariantForSpecError(error.SpecError):
     def __init__(self, variant, when, spec):
         msg = "Invalid variant {0} for spec {1}.\n"
         msg += "{0} is only available for {1.name} when satisfying one of {2}."
-        super(InvalidVariantForSpecError, self).__init__(msg.format(variant, spec, when))
+        super().__init__(msg.format(variant, spec, when))
 
 
 class UnsatisfiableVariantSpecError(error.UnsatisfiableSpecError):
     """Raised when a spec variant conflicts with package constraints."""
 
     def __init__(self, provided, required):
-        super(UnsatisfiableVariantSpecError, self).__init__(provided, required, "variant")
+        super().__init__(provided, required, "variant")

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -955,9 +955,7 @@ class InvalidVariantValueError(error.SpecError):
         pkg_info = ""
         if pkg is not None:
             pkg_info = ' in package "{0}"'.format(pkg.name)
-        super().__init__(
-            msg.format(variant, invalid_values, pkg_info)
-        )
+        super().__init__(msg.format(variant, invalid_values, pkg_info))
 
 
 class InvalidVariantForSpecError(error.SpecError):

--- a/var/spack/repos/builder.test/packages/inheritance/package.py
+++ b/var/spack/repos/builder.test/packages/inheritance/package.py
@@ -16,7 +16,7 @@ class Inheritance(spack.pkg.builder.test.callbacks.Callbacks):
 
 class GenericBuilder(spack.pkg.builder.test.callbacks.GenericBuilder):
     def install(self, pkg, spec, prefix):
-        super(GenericBuilder, self).install(pkg, spec, prefix)
+        super().install(pkg, spec, prefix)
         os.environ["INHERITANCE_INSTALL_CALLED"] = "1"
         os.environ["INSTALL_VALUE"] = "INHERITANCE"
 

--- a/var/spack/repos/builder.test/packages/old-style-autotools/package.py
+++ b/var/spack/repos/builder.test/packages/old-style-autotools/package.py
@@ -31,7 +31,7 @@ class OldStyleAutotools(AutotoolsPackage):
         """This override a function in the builder and construct the result using a method
         defined in this class and a super method defined in the builder.
         """
-        return [self.foo()] + super(OldStyleAutotools, self).configure_args()
+        return [self.foo()] + super().configure_args()
 
     def foo(self):
         return "--with-foo"

--- a/var/spack/repos/builder.test/packages/old-style-derived/package.py
+++ b/var/spack/repos/builder.test/packages/old-style-derived/package.py
@@ -18,4 +18,4 @@ class OldStyleDerived(spack.pkg.builder.test.old_style_autotools.OldStyleAutotoo
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     def configure_args(self):
-        return ["--with-bar"] + super(OldStyleDerived, self).configure_args()
+        return ["--with-bar"] + super().configure_args()

--- a/var/spack/repos/builtin.mock/packages/archive-files/package.py
+++ b/var/spack/repos/builtin.mock/packages/archive-files/package.py
@@ -17,7 +17,7 @@ class ArchiveFiles(AutotoolsPackage):
 
     @property
     def archive_files(self):
-        return super(ArchiveFiles, self).archive_files + ["../../outside.log"]
+        return super().archive_files + ["../../outside.log"]
 
     def autoreconf(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -24,6 +24,6 @@ class PyTestCallback(mp.Python):
 
     # TODO (post-34236): "test" -> "test_callback" once remove "test" support
     def test(self):
-        super(PyTestCallback, self).test()
+        super().test()
 
         print("PyTestCallback test")

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -43,7 +43,7 @@ class Amdblis(BlisBase):
 
     def configure_args(self):
         spec = self.spec
-        args = super(Amdblis, self).configure_args()
+        args = super().configure_args()
 
         if spec.satisfies("+ilp64"):
             args.append("--blas-int-size=64")
@@ -62,7 +62,7 @@ class Amdblis(BlisBase):
         return args
 
     def config_args(self):
-        config_args = super(Amdblis, self).config_args()
+        config_args = super().config_args()
 
         # "amdzen" - A fat binary or multiarchitecture binary
         # support for 3.1 release onwards

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -73,7 +73,7 @@ class Amdlibflame(LibflameBase):
 
     def configure_args(self):
         """configure_args function"""
-        args = super(Amdlibflame, self).configure_args()
+        args = super().configure_args()
 
         # From 3.2 version, amd optimized flags are encapsulated under:
         # enable-amd-flags for gcc compiler

--- a/var/spack/repos/builtin/packages/amdlibm/0001-libm-ose-Scripts-cleanup-pyc-files.patch
+++ b/var/spack/repos/builtin/packages/amdlibm/0001-libm-ose-Scripts-cleanup-pyc-files.patch
@@ -325,7 +325,7 @@ index c2f8c8e..eb89a73 100644
  from . import Compiler
  class Gcc(Compiler):
 -    def __init__(self, prod_mode):
--        super(Gcc, self).__init__(prod_mode)
+-        super().__init__(prod_mode)
 -
 -        warnings_cxx  = [
 -            '-Wctor-dtor-privacy',
@@ -334,7 +334,7 @@ index c2f8c8e..eb89a73 100644
 -            '-Wold-style-cast',
 -            '-Woverloaded-virtual',
 +    def __init__(self, prod_mode, bvars = None, opts = None):
-+        super(Gcc, self).__init__(prod_mode, bvars, opts)
++        super().__init__(prod_mode, bvars, opts)
 +        self.cmd = 'gcc'
 +        self.cxxcmd = 'g++'
 +        self.compile_flags_debug = [
@@ -474,13 +474,13 @@ index 0e4c346..b39d341 100644
  
  class LLVM(Compiler):
 -    def __init__(self, prod_mode):
--        super(LLVM, self).__init__(prod_mode)
+-        super().__init__(prod_mode)
 -
 -        compile_flags_release = [
 -            # fp-contract needed to generate FMA instructions
 -            '-ffp-contract=fast',
 +    def __init__(self, prod_mode, bvars = None, opts = None):
-+        super(LLVM, self).__init__(prod_mode, bvars, opts)
++        super().__init__(prod_mode, bvars, opts)
 +        self.cmd = 'clang'
 +        self.cxxcmd = 'clang++'
 +        self.compile_flags_debug = [

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -49,7 +49,7 @@ class Amdscalapack(ScalapackBase):
 
     def cmake_args(self):
         """cmake_args function"""
-        args = super(Amdscalapack, self).cmake_args()
+        args = super().cmake_args()
         spec = self.spec
 
         if spec.satisfies("%gcc@10:"):

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -206,7 +206,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        entries = super(Axom, self).initconfig_compiler_entries()
+        entries = super().initconfig_compiler_entries()
 
         if "+fortran" in spec:
             entries.append(cmake_cache_option("ENABLE_FORTRAN", True))
@@ -229,7 +229,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_hardware_entries(self):
         spec = self.spec
-        entries = super(Axom, self).initconfig_hardware_entries()
+        entries = super().initconfig_hardware_entries()
 
         if "+cuda" in spec:
             entries.append(cmake_cache_option("ENABLE_CUDA", True))
@@ -352,7 +352,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_mpi_entries(self):
         spec = self.spec
-        entries = super(Axom, self).initconfig_mpi_entries()
+        entries = super().initconfig_mpi_entries()
 
         if "+mpi" in spec:
             entries.append(cmake_cache_option("ENABLE_MPI", True))

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -70,7 +70,7 @@ class Bcl2fastq2(Package):
         # wrap (decorate) the standard expand_archive step with a
         # helper, then call the real do_stage().
         self.stage.expand_archive = self.unpack_it(self.stage.expand_archive)
-        super(Bcl2fastq2, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
 
     def unpack_it(self, f):
         def wrap():

--- a/var/spack/repos/builtin/packages/busco/package.py
+++ b/var/spack/repos/builtin/packages/busco/package.py
@@ -44,14 +44,14 @@ class Busco(PythonPackage):
         if self.spec.satisfies("@4.1.3:"):
             install_tree("bin", prefix.bin)
             install_tree("config", prefix.config)
-            super(Busco, self).install(spec, prefix)
+            super().install(spec, prefix)
         if self.spec.satisfies("@3.0.1"):
             with working_dir("scripts"):
                 mkdirp(prefix.bin)
                 install("generate_plot.py", prefix.bin)
                 install("run_BUSCO.py", prefix.bin)
             install_tree("config", prefix.config)
-            super(Busco, self).install(spec, prefix)
+            super().install(spec, prefix)
         if self.spec.satisfies("@2.0.1"):
             mkdirp(prefix.bin)
             install("BUSCO.py", prefix.bin)

--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -86,7 +86,7 @@ class Catalyst(CMakePackage):
     def do_stage(self, mirror_only=False):
         """Unpacks and expands the fetched tarball.
         Then, generate the catalyst source files."""
-        super(Catalyst, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
 
         # extract the catalyst part
         catalyst_script = os.path.join(self.stage.source_path, "Catalyst", "catalyze.py")

--- a/var/spack/repos/builtin/packages/cfitsio/package.py
+++ b/var/spack/repos/builtin/packages/cfitsio/package.py
@@ -33,7 +33,7 @@ class Cfitsio(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version >= Version("3.47"):
-            return super(Cfitsio, self).url_for_version(version)
+            return super().url_for_version(version)
 
         url = "http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio{0}0.tar.gz"
         return url.format(version.joined)

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -114,14 +114,14 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        entries = super(Chai, self).initconfig_compiler_entries()
+        entries = super().initconfig_compiler_entries()
         if "+rocm" in spec:
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         return entries
 
     def initconfig_hardware_entries(self):
         spec = self.spec
-        entries = super(Chai, self).initconfig_hardware_entries()
+        entries = super().initconfig_hardware_entries()
 
         entries.append(cmake_cache_option("ENABLE_OPENMP", "+openmp" in spec))
 

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -50,7 +50,7 @@ class ClingoBootstrap(Clingo):
         return self.define("CLINGO_BUILD_PY_SHARED", "OFF")
 
     def cmake_args(self):
-        args = super(ClingoBootstrap, self).cmake_args()
+        args = super().cmake_args()
         args.extend(
             [
                 # Avoid building the clingo executable

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -705,7 +705,7 @@ class Cp2k(MakefilePackage, CudaPackage):
         # Apparently the Makefile bases its paths on PWD
         # so we need to set PWD = self.build_directory
         with spack.util.environment.set_env(PWD=self.build_directory):
-            super(Cp2k, self).build(spec, prefix)
+            super().build(spec, prefix)
 
             with working_dir(self.build_directory):
                 make("libcp2k", *self.build_targets)

--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -47,7 +47,7 @@ class Cppcheck(CMakePackage):
         return args
 
     def install(self, spec, prefix):
-        super(Cppcheck, self).install(spec, prefix)
+        super().install(spec, prefix)
         # Manually install the final cppcheck binary
         if spec.satisfies("+htmlreport"):
             install("htmlreport/cppcheck-htmlreport", prefix.bin)

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -22,7 +22,7 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
         if version < Version("4.7.0"):
             self.gnu_mirror_path = "findutils/findutils-{0}.tar.gz".format(version)
 
-        return super(Findutils, self).url_for_version(version)
+        return super().url_for_version(version)
 
     executables = ["^find$"]
 

--- a/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
@@ -32,7 +32,7 @@ class FujitsuFrontistr(FrontistrBase):
 
     def cmake_args(self):
         define = self.define
-        args = super(FujitsuFrontistr, self).cmake_args()
+        args = super().cmake_args()
         if self.spec.satisfies("%fj"):
             args.extend(
                 [

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -628,7 +628,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             "7.1.0"
         ):
             self.gnu_mirror_path = self.gnu_mirror_path.replace("xz", "bz2")
-        return super(Gcc, self).url_for_version(version)
+        return super().url_for_version(version)
 
     def patch(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gchp/package.py
+++ b/var/spack/repos/builtin/packages/gchp/package.py
@@ -57,7 +57,7 @@ class Gchp(CMakePackage):
         return args
 
     def install(self, spec, prefix):
-        super(Gchp, self).install(spec, prefix)
+        super().install(spec, prefix)
         # Preserve source code in prefix for two reasons:
         # 1. Run directory creation occurs independently of code compilation,
         # possibly multiple times depending on user needs,

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -88,11 +88,11 @@ class Genie(Package):
 
     def setup_build_environment(self, env):
         env.set("GENIE", self.stage.source_path)
-        return super(Genie, self).setup_build_environment(env)
+        return super().setup_build_environment(env)
 
     def setup_run_environment(self, env):
         env.set("GENIE", self.prefix)
-        return super(Genie, self).setup_run_environment(env)
+        return super().setup_run_environment(env)
 
     def install(self, spec, prefix):
         configure = Executable("./configure")

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -152,7 +152,7 @@ class Graphviz(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         # Set MACOSX_DEPLOYMENT_TARGET to 10.x due to old configure
-        super(Graphviz, self).setup_build_environment(env)
+        super().setup_build_environment(env)
 
         if "+quartz" in self.spec:
             env.set("OBJC", self.compiler.cc)

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -45,7 +45,7 @@ class GromacsChainCoordinate(Gromacs):
                 del self.versions[version_key]
 
     def __init__(self, spec):
-        super(GromacsChainCoordinate, self).__init__(spec)
+        super().__init__(spec)
 
         self.remove_parent_versions()
 

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -148,6 +148,6 @@ class GromacsSwaxs(Gromacs):
                 del self.versions[version_key]
 
     def __init__(self, spec):
-        super(GromacsSwaxs, self).__init__(spec)
+        super().__init__(spec)
 
         self.remove_parent_versions()

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -232,6 +232,6 @@ class HipRocclr(CMakePackage):
         return args
 
     def __init__(self, spec):
-        super(HipRocclr, self).__init__(spec)
+        super().__init__(spec)
         if self.spec.satisfies("@4.5.0:"):
             self.phases = ["cmake", "build"]

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -146,7 +146,7 @@ class IntelMpi(IntelPackage):
         )
 
     def setup_run_environment(self, env):
-        super(IntelMpi, self).setup_run_environment(env)
+        super().setup_run_environment(env)
 
         for name, value in self.mpi_compiler_wrappers.items():
             env.set(name, value)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -183,7 +183,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
 
         and from setting CC/CXX/F77/FC
         """
-        super(IntelOneapiCompilers, self).setup_run_environment(env)
+        super().setup_run_environment(env)
 
         env.set("CC", self.component_prefix.linux.bin.icx)
         env.set("CXX", self.component_prefix.linux.bin.icpx)
@@ -195,7 +195,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         # install_tree("/opt/intel/oneapi/compiler", self.prefix)
 
         # install cpp
-        super(IntelOneapiCompilers, self).install(spec, prefix)
+        super().install(spec, prefix)
 
         # install fortran
         self.install_component(find("fortran-installer", "*")[0])

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -136,7 +136,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
             return IntelOneApiStaticLibraryList(libs, system_libs)
 
     def setup_run_environment(self, env):
-        super(IntelOneapiMkl, self).setup_run_environment(env)
+        super().setup_run_environment(env)
 
         # Support RPATH injection to the library directories when the '-mkl' or '-qmkl'
         # flag of the Intel compilers are used outside the Spack build environment. We

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -596,7 +596,7 @@ class IntelParallelStudio(IntelPackage):
         )
 
     def setup_run_environment(self, env):
-        super(IntelParallelStudio, self).setup_run_environment(env)
+        super().setup_run_environment(env)
 
         for name, value in self.mpi_compiler_wrappers.items():
             env.set(name, value)

--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -57,7 +57,7 @@ class Kallisto(CMakePackage):
         """Call the original std_cmake_args and then filter the verbose
         setting.
         """
-        a = super(Kallisto, self).std_cmake_args
+        a = super().std_cmake_args
         if self.spec.satisfies("@0.44.0:"):
             args = [i for i in a if i != "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"]
             if self.spec.satisfies("@0.46.2:"):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -347,7 +347,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        entries = super(Lbann, self).initconfig_compiler_entries()
+        entries = super().initconfig_compiler_entries()
         entries.append(cmake_cache_string("CMAKE_CXX_STANDARD", "17"))
         if not spec.satisfies("^cmake@3.23.0"):
             # There is a bug with using Ninja generator in this version
@@ -368,7 +368,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_hardware_entries(self):
         spec = self.spec
-        entries = super(Lbann, self).initconfig_hardware_entries()
+        entries = super().initconfig_hardware_entries()
 
         if "+cuda" in spec:
             if self.spec.satisfies("%clang"):

--- a/var/spack/repos/builtin/packages/libpsl/package.py
+++ b/var/spack/repos/builtin/packages/libpsl/package.py
@@ -29,7 +29,7 @@ class Libpsl(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version >= Version("0.21.1"):
-            return super(Libpsl, self).url_for_version(version)
+            return super().url_for_version(version)
         url_fmt = (
             "https://github.com/rockdaboot/libpsl/releases/download/libpsl-{0}/libpsl-{0}.tar.gz"
         )

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -29,7 +29,7 @@ class LuaImplPackage(MakefilePackage):
     lua_version_override = None
 
     def __init__(self, *args, **kwargs):
-        super(LuaImplPackage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.lua_dir_name = "lua"
         pass
 

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -153,7 +153,7 @@ class Mesa(MesonPackage):
         if self.spec.satisfies("%intel"):
             if name == "cflags":
                 flags.append("-std=c99")
-        return super(Mesa, self).flag_handler(name, flags)
+        return super().flag_handler(name, flags)
 
     @property
     def libglx_headers(self):

--- a/var/spack/repos/builtin/packages/mumax/package.py
+++ b/var/spack/repos/builtin/packages/mumax/package.py
@@ -57,7 +57,7 @@ class Mumax(MakefilePackage, CudaPackage):
         return join_path(self.gopath, "src/github.com/mumax/3")
 
     def do_stage(self, mirror_only=False):
-        super(Mumax, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
         if not os.path.exists(self.mumax_gopath_dir):
             # Need to move source to $GOPATH and then symlink the original
             # stage directory

--- a/var/spack/repos/builtin/packages/munge/package.py
+++ b/var/spack/repos/builtin/packages/munge/package.py
@@ -45,4 +45,4 @@ class Munge(AutotoolsPackage):
 
     def install(self, spec, prefix):
         os.makedirs(os.path.join(prefix, "lib/systemd/system"))
-        super(Munge, self).install(spec, prefix)
+        super().install(spec, prefix)

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -73,7 +73,7 @@ class Openexr(CMakePackage):
     @property
     def build_directory(self):
         if self.spec.satisfies("@3:"):
-            return super(Openexr, self).build_directory
+            return super().build_directory
         else:
             return "."
 

--- a/var/spack/repos/builtin/packages/openjpeg/package.py
+++ b/var/spack/repos/builtin/packages/openjpeg/package.py
@@ -46,7 +46,7 @@ class Openjpeg(CMakePackage):
 
     def url_for_version(self, version):
         if version >= Version("2.1.1"):
-            return super(Openjpeg, self).url_for_version(version)
+            return super().url_for_version(version)
 
         # Before version 2.2.0, release tarballs of the versions like x.y.0
         # did not have the ".0" in their names:

--- a/var/spack/repos/builtin/packages/openloops/get-process-list.py
+++ b/var/spack/repos/builtin/packages/openloops/get-process-list.py
@@ -8,7 +8,7 @@ class my_html_parser(HTMLParser):
         pass
 
     def __init__(self):
-        super(HTMLParser, self).__init__()
+        super().__init__()
         self.state = 0
         self.processes = []
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -207,7 +207,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # source and make everything writeable in the future.
     def do_stage(self, mirror_only=False):
         # Do Spack's regular stage
-        super(Perl, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
         # Add write permissions on file to be patched
         filename = join_path(self.stage.source_path, "pp.c")
         perm = os.stat(filename).st_mode

--- a/var/spack/repos/builtin/packages/photos-f/package.py
+++ b/var/spack/repos/builtin/packages/photos-f/package.py
@@ -26,7 +26,7 @@ class PhotosF(MakefilePackage):
 
     def do_stage(self, mirror_only=False):
         # Fix directory structure - remove extra "<version>" subdirectory
-        super(PhotosF, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
         root = join_path(self.stage.source_path, self.spec.version)
         for fn in os.listdir(root):
             shutil.move(join_path(root, fn), self.stage.source_path)

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -101,7 +101,7 @@ class Postgresql(AutotoolsPackage):
                 with working_dir(os.path.join("src", subdir)):
                     make("install")
         else:
-            super(Postgresql, self).install(spec, prefix)
+            super().install(spec, prefix)
 
     def setup_run_environment(self, env):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -77,7 +77,7 @@ class PyKeras(PythonPackage):
 
     def url_for_version(self, version):
         if version >= Version("2.6"):
-            return super(PyKeras, self).url_for_version(version)
+            return super().url_for_version(version)
         else:
             url = "https://pypi.io/packages/source/K/Keras/Keras-{0}.tar.gz"
             return url.format(version.dotted)

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -89,7 +89,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         ]
 
     def install(self, pkg, spec, prefix):
-        super(CMakeBuilder, self).install(pkg, spec, prefix)
+        super().install(pkg, spec, prefix)
         python_builder = spack.build_systems.python.PythonPipBuilder(pkg)
         python_builder.install(pkg, spec, prefix)
 

--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -54,7 +54,7 @@ class PySip(PythonPackage):
             return "https://www.riverbankcomputing.com/hg/sip/archive/{0}.tar.gz".format(
                 version.dotted
             )
-        return super(PySip, self).url_for_version(version)
+        return super().url_for_version(version)
 
     @when("@:4")
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -109,14 +109,14 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        entries = super(Raja, self).initconfig_compiler_entries()
+        entries = super().initconfig_compiler_entries()
         if "+rocm" in spec:
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
         return entries
 
     def initconfig_hardware_entries(self):
         spec = self.spec
-        entries = super(Raja, self).initconfig_hardware_entries()
+        entries = super().initconfig_hardware_entries()
 
         entries.append(cmake_cache_option("ENABLE_OPENMP", "+openmp" in spec))
 

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -28,7 +28,7 @@ class Sed(AutotoolsPackage, GNUMirrorPackage):
             self.gnu_mirror_path = "sed/sed-{0}.tar.bz2".format(version)
         elif version < Version("4.2"):
             self.gnu_mirror_path = "sed/sed-{0}.tar.gz".format(version)
-        return super(Sed, self).url_for_version(version)
+        return super().url_for_version(version)
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -53,7 +53,7 @@ class SingularityBase(MakefilePackage):
     # Unpack the tarball as usual, then move the src dir into
     # its home within GOPATH.
     def do_stage(self, mirror_only=False):
-        super(SingularityBase, self).do_stage(mirror_only)
+        super().do_stage(mirror_only)
         if not os.path.exists(self.singularity_gopath_dir):
             # Move the expanded source to its destination
             tty.debug(

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -347,7 +347,7 @@ class Spectre(CMakePackage):
     @property
     def archive_files(self):
         # Archive the `BuildInfo.txt` file for debugging builds
-        return super(Spectre, self).archive_files + [
+        return super().archive_files + [
             join_path(self.build_directory, "BuildInfo.txt")
         ]
 

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -347,9 +347,7 @@ class Spectre(CMakePackage):
     @property
     def archive_files(self):
         # Archive the `BuildInfo.txt` file for debugging builds
-        return super().archive_files + [
-            join_path(self.build_directory, "BuildInfo.txt")
-        ]
+        return super().archive_files + [join_path(self.build_directory, "BuildInfo.txt")]
 
     def check(self):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/srcml-identifier-getter-tool/package.py
+++ b/var/spack/repos/builtin/packages/srcml-identifier-getter-tool/package.py
@@ -21,6 +21,6 @@ class SrcmlIdentifierGetterTool(CMakePackage):
     depends_on("lzma")
 
     def install(self, spec, prefix):
-        super(SrcmlIdentifierGetterTool, self).install(spec, prefix)
+        super().install(spec, prefix)
         mkdir(prefix.bin)
         install(join_path(self.build_directory, "bin", "grabidentifiers"), prefix.bin)

--- a/var/spack/repos/builtin/packages/turbomole/package.py
+++ b/var/spack/repos/builtin/packages/turbomole/package.py
@@ -44,7 +44,7 @@ class Turbomole(Package):
     def do_fetch(self, mirror_only=True):
         if "+mpi" in self.spec and "+smp" in self.spec:
             raise InstallError("Can not have both SMP and MPI enabled in the " "same build.")
-        super(Turbomole, self).do_fetch(mirror_only)
+        super().do_fetch(mirror_only)
 
     def get_tm_arch(self):
         if "TURBOMOLE" in os.getcwd():

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -147,7 +147,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_compiler_entries(self):
         spec = self.spec
-        entries = super(Umpire, self).initconfig_compiler_entries()
+        entries = super().initconfig_compiler_entries()
 
         if "+rocm" in spec:
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
@@ -165,7 +165,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_hardware_entries(self):
         spec = self.spec
-        entries = super(Umpire, self).initconfig_hardware_entries()
+        entries = super().initconfig_hardware_entries()
 
         option_prefix = "UMPIRE_" if spec.satisfies("@2022.03.0:") else ""
 

--- a/var/spack/repos/tutorial/packages/netlib-lapack/package.py
+++ b/var/spack/repos/tutorial/packages/netlib-lapack/package.py
@@ -170,19 +170,19 @@ class NetlibLapack(CMakePackage):
     @when("+shared")
     def cmake(self, spec, prefix):
         for self._building_shared in (False, True):
-            super(NetlibLapack, self).cmake(spec, prefix)
+            super().cmake(spec, prefix)
 
     @when("+shared")
     def build(self, spec, prefix):
         for self._building_shared in (False, True):
-            super(NetlibLapack, self).build(spec, prefix)
+            super().build(spec, prefix)
 
     @when("+shared")
     def install(self, spec, prefix):
         for self._building_shared in (False, True):
-            super(NetlibLapack, self).install(spec, prefix)
+            super().install(spec, prefix)
 
     @when("+shared")
     def check(self):
         for self._building_shared in (False, True):
-            super(NetlibLapack, self).check()
+            super().check()


### PR DESCRIPTION
We no longer support Python 2, so there's no reason to use the old syntax.

Just did a simple sed call, might be bugs.