### PR TITLE
Attempt to fix compilation of intel packages with `threads=openmp`

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -699,11 +699,7 @@ class IntelPackage(Package):
             omp_libs = LibraryList(omp_lib_path.strip())
 
         elif "%clang" in self.spec:
-            with self.compiler.compiler_environment():
-                omp_lib_path = Executable(self.compiler.cc)(
-                    "--print-file-name", "libomp.%s" % dso_suffix, output=str
-                )
-            omp_libs = LibraryList(omp_lib_path.strip())
+            omp_libs = LibraryList("-fopenmp=libomp")
 
         if len(omp_libs) < 1:
             raise_lib_error("Cannot locate OpenMP libraries:", omp_libnames)


### PR DESCRIPTION
I'm porting over the proposed patch from https://github.com/spack/spack/issues/38509 into a PR. I'm only applying it for `%clang` for fear of breaking other things. I'm hoping CI will tell me if this is a very bad idea or just a bad idea.