### PR TITLE
Drop Python 2 object subclassing

### DIFF
--- a/lib/spack/external/ctest_log_parser.py
+++ b/lib/spack/external/ctest_log_parser.py
@@ -208,7 +208,7 @@ _file_line_matches = [
 ]
 
 
-class LogEvent(object):
+class LogEvent:
     """Class representing interesting events (e.g., errors) in a build log."""
     def __init__(self, text, line_no,
                  source_file=None, source_line_no=None,
@@ -345,7 +345,7 @@ def _parse_unpack(args):
     return _parse(*args)
 
 
-class CTestLogParser(object):
+class CTestLogParser:
     """Log file parser that extracts errors and warnings."""
     def __init__(self, profile=False):
         # whether to record timing information

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -402,7 +402,7 @@ def filter_file(
                 os.remove(backup_filename)
 
 
-class FileFilter(object):
+class FileFilter:
     """Convenience class for calling ``filter_file`` a lot."""
 
     def __init__(self, *filenames):
@@ -1336,7 +1336,7 @@ def lexists_islink_isdir(path):
     return True, is_link, is_dir
 
 
-class BaseDirectoryVisitor(object):
+class BaseDirectoryVisitor:
     """Base class and interface for :py:func:`visit_directory_tree`."""
 
     def visit_file(self, root, rel_path, depth):
@@ -2352,7 +2352,7 @@ def find_all_libraries(root, recursive=False):
     )
 
 
-class WindowsSimulatedRPath(object):
+class WindowsSimulatedRPath:
     """Class representing Windows filesystem rpath analog
 
     One instance of this class is associated with a package (only on Windows)

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -769,7 +769,7 @@ class RequiredAttributeError(ValueError):
         super(RequiredAttributeError, self).__init__(message)
 
 
-class ObjectWrapper(object):
+class ObjectWrapper:
     """Base class that wraps an object. Derived classes can add new behavior
     while staying undercover.
 
@@ -796,7 +796,7 @@ class ObjectWrapper(object):
         self.__dict__ = wrapped_object.__dict__
 
 
-class Singleton(object):
+class Singleton:
     """Simple wrapper for lazily initialized singleton objects."""
 
     def __init__(self, factory):
@@ -843,7 +843,7 @@ class Singleton(object):
         return repr(self.instance)
 
 
-class LazyReference(object):
+class LazyReference:
     """Lazily evaluated reference to part of a singleton."""
 
     def __init__(self, ref_function):
@@ -941,7 +941,7 @@ def star(func):
     return _wrapper
 
 
-class Devnull(object):
+class Devnull:
     """Null stream with less overhead than ``os.devnull``.
 
     See https://stackoverflow.com/a/2929954.
@@ -1058,7 +1058,7 @@ class TypedMutableSequence(collections.abc.MutableSequence):
         return str(self.data)
 
 
-class GroupedExceptionHandler(object):
+class GroupedExceptionHandler:
     """A generic mechanism to coalesce multiple exceptions and preserve tracebacks."""
 
     def __init__(self):
@@ -1089,7 +1089,7 @@ class GroupedExceptionHandler(object):
         return "due to the following failures:\n{0}".format("\n".join(each_exception_message))
 
 
-class GroupedExceptionForwarder(object):
+class GroupedExceptionForwarder:
     """A contextmanager to capture exceptions and forward them to a
     GroupedExceptionHandler."""
 
@@ -1109,7 +1109,7 @@ class GroupedExceptionForwarder(object):
         return True
 
 
-class classproperty(object):
+class classproperty:
     """Non-data descriptor to evaluate a class-level property. The function that performs
     the evaluation is injected at creation time and take an instance (could be None) and
     an owner (i.e. the class that originated the instance)

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -285,7 +285,7 @@ class DestinationMergeVisitor(BaseDirectoryVisitor):
         self.visit_file(root, rel_path, depth)
 
 
-class LinkTree(object):
+class LinkTree:
     """Class to create trees of symbolic links from a source directory.
 
     LinkTree objects are constructed with a source root.  Their

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -39,7 +39,7 @@ __all__ = [
 true_fn = lambda: True
 
 
-class OpenFile(object):
+class OpenFile:
     """Record for keeping track of open lockfiles (with reference counting).
 
     There's really only one ``OpenFile`` per inode, per process, but we record the
@@ -53,7 +53,7 @@ class OpenFile(object):
         self.refs = 0
 
 
-class OpenFileTracker(object):
+class OpenFileTracker:
     """Track open lockfiles, to minimize number of open file descriptors.
 
     The ``fcntl`` locks that Spack uses are associated with an inode and a process.
@@ -169,7 +169,7 @@ def _attempts_str(wait_time, nattempts):
     return " after {} and {}".format(pretty_seconds(wait_time), attempts)
 
 
-class LockType(object):
+class LockType:
     READ = 0
     WRITE = 1
 
@@ -192,7 +192,7 @@ class LockType(object):
         return op == LockType.READ or op == LockType.WRITE
 
 
-class Lock(object):
+class Lock:
     """This is an implementation of a filesystem lock using Python's lockf.
 
     In Python, ``lockf`` actually calls ``fcntl``, so this should work with
@@ -681,7 +681,7 @@ class Lock(object):
         )
 
 
-class LockTransaction(object):
+class LockTransaction:
     """Simple nested transaction context manager that uses a file lock.
 
     Arguments:

--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -203,7 +203,7 @@ def color_when(value):
     set_color_when(old_value)
 
 
-class match_to_ansi(object):
+class match_to_ansi:
     def __init__(self, color=True, enclose=False):
         self.color = _color_when_value(color)
         self.enclose = enclose
@@ -319,7 +319,7 @@ def cescape(string):
     return string
 
 
-class ColorStream(object):
+class ColorStream:
     def __init__(self, stream, color=None):
         self._stream = stream
         self._color = color

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -65,7 +65,7 @@ def _strip(line):
     return _escape.sub("", line)
 
 
-class keyboard_input(object):
+class keyboard_input:
     """Context manager to disable line editing and echoing.
 
     Use this with ``sys.stdin`` for keyboard input, e.g.::
@@ -242,7 +242,7 @@ class keyboard_input(object):
                 signal.signal(signum, old_handler)
 
 
-class Unbuffered(object):
+class Unbuffered:
     """Wrapper for Python streams that forces them to be unbuffered.
 
     This is implemented by forcing a flush after each write.
@@ -287,7 +287,7 @@ def _file_descriptors_work(*streams):
         return False
 
 
-class FileWrapper(object):
+class FileWrapper:
     """Represents a file. Can be an open stream, a path to a file (not opened
     yet), or neither. When unwrapped, it returns an open file (or file-like)
     object.
@@ -329,7 +329,7 @@ class FileWrapper(object):
             self.file.close()
 
 
-class MultiProcessFd(object):
+class MultiProcessFd:
     """Return an object which stores a file descriptor and can be passed as an
     argument to a function run with ``multiprocessing.Process``, such that
     the file descriptor is available in the subprocess."""
@@ -429,7 +429,7 @@ def log_output(*args, **kwargs):
         return nixlog(*args, **kwargs)
 
 
-class nixlog(object):
+class nixlog:
     """
     Under the hood, we spawn a daemon and set up a pipe between this
     process and the daemon.  The daemon writes our output to both the
@@ -750,7 +750,7 @@ class StreamWrapper:
                 os.close(self.saved_stream)
 
 
-class winlog(object):
+class winlog:
     """
     Similar to nixlog, with underlying
     functionality ported to support Windows.

--- a/lib/spack/llnl/util/tty/pty.py
+++ b/lib/spack/llnl/util/tty/pty.py
@@ -34,7 +34,7 @@ except ImportError:
     pass
 
 
-class ProcessController(object):
+class ProcessController:
     """Wrapper around some fundamental process control operations.
 
     This allows one process (the controller) to drive another (the
@@ -155,7 +155,7 @@ class ProcessController(object):
         self.wait(lambda: "T" not in self.proc_status())
 
 
-class PseudoShell(object):
+class PseudoShell:
     """Sets up controller and minion processes with a PTY.
 
     You can create a ``PseudoShell`` if you want to test how some

--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -13,7 +13,7 @@ from spack.spec import CompilerSpec
 from spack.util.executable import Executable, ProcessError
 
 
-class ABI(object):
+class ABI:
     """This class provides methods to test ABI compatibility between specs.
     The current implementation is rather rough and could be improved."""
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -60,7 +60,7 @@ CALLBACKS = {}
 GROUPS = collections.defaultdict(list)
 
 
-class Error(object):
+class Error:
     """Information on an error reported in a test."""
 
     def __init__(self, summary, details):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -87,7 +87,7 @@ class ListMirrorSpecsError(spack.error.SpackError):
     """Raised when unable to retrieve list of specs from the mirror"""
 
 
-class BinaryCacheIndex(object):
+class BinaryCacheIndex:
     """
     The BinaryCacheIndex tracks what specs are available on (usually remote)
     binary caches.
@@ -2337,7 +2337,7 @@ def download_single_spec(concrete_spec, destination, mirror_url=None):
     return download_buildcache_entry(files_to_fetch, mirror_url)
 
 
-class BinaryCacheQuery(object):
+class BinaryCacheQuery:
     """Callable object to query if a spec is in a binary cache"""
 
     def __init__(self, all_architectures):

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -175,7 +175,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
         return find_libraries("*", root=lib_path, shared=True, recursive=True)
 
 
-class IntelOneApiStaticLibraryList(object):
+class IntelOneApiStaticLibraryList:
     """Provides ld_flags when static linking is needed
 
     Oneapi puts static and dynamic libraries in the same directory, so

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -63,7 +63,7 @@ def create(pkg):
     return _BUILDERS[id(pkg)]
 
 
-class _PhaseAdapter(object):
+class _PhaseAdapter:
     def __init__(self, builder, phase_fn):
         self.builder = builder
         self.phase_fn = phase_fn
@@ -115,7 +115,7 @@ def _create(pkg):
     # package. The semantic should be the same as the method in the base builder were still
     # present in the base class of the package.
 
-    class _ForwardToBaseBuilder(object):
+    class _ForwardToBaseBuilder:
         def __init__(self, wrapped_pkg_object, root_builder):
             self.wrapped_package_object = wrapped_pkg_object
             self.root_builder = root_builder
@@ -388,7 +388,7 @@ class _PackageAdapterMeta(BuilderMeta):
         return super(_PackageAdapterMeta, mcs).__new__(mcs, name, bases, attr_dict)
 
 
-class InstallationPhase(object):
+class InstallationPhase:
     """Manages a single phase of the installation.
 
     This descriptor stores at creation time the name of the method it should

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -58,7 +58,7 @@ def _fetch_cache():
     return spack.fetch_strategy.FsCache(path)
 
 
-class MirrorCache(object):
+class MirrorCache:
     def __init__(self, root, skip_unstable_versions):
         self.root = os.path.abspath(root)
         self.skip_unstable_versions = skip_unstable_versions

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -57,7 +57,7 @@ spack_compiler = spack.main.SpackCommand("compiler")
 PushResult = namedtuple("PushResult", "success url")
 
 
-class TemporaryDirectory(object):
+class TemporaryDirectory:
     def __init__(self):
         self.temporary_directory = tempfile.mkdtemp()
 
@@ -471,7 +471,7 @@ def _unpack_script(script_section, op=_noop):
     return script
 
 
-class RebuildDecision(object):
+class RebuildDecision:
     def __init__(self):
         self.rebuild = True
         self.mirrors = []
@@ -2128,7 +2128,7 @@ def run_standalone_tests(**kwargs):
     tty.debug("spack test exited {0}".format(exit_code))
 
 
-class CDashHandler(object):
+class CDashHandler:
     """
     Class for managing CDash data and processing.
     """

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -147,7 +147,7 @@ def get_command(cmd_name):
     return getattr(get_module(cmd_name), pname)
 
 
-class _UnquotedFlags(object):
+class _UnquotedFlags:
     """Use a heuristic in `.extract()` to detect whether the user is trying to set
     multiple flags like the docker ENV attribute allows (e.g. 'cflags=-Os -pipe').
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -69,7 +69,7 @@ class {class_name}({base_class_name}):
 '''
 
 
-class BundlePackageTemplate(object):
+class BundlePackageTemplate:
     """
     Provides the default values to be used for a bundle package file template.
     """

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -418,7 +418,7 @@ def env_list(args):
     colify(color_names, indent=4)
 
 
-class ViewAction(object):
+class ViewAction:
     regenerate = "regenerate"
     enable = "enable"
     disable = "disable"

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -71,7 +71,7 @@ def variant(s):
     return spack.spec.enabled_variant_color + s + plain_format
 
 
-class VariantFormatter(object):
+class VariantFormatter:
     def __init__(self, variants):
         self.variants = variants
         self.headers = ("Name [Default]", "When", "Allowed values", "Description")

--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -100,7 +100,7 @@ license_line_regexes = [
 ]
 
 
-class LicenseError(object):
+class LicenseError:
     def __init__(self):
         self.error_counts = defaultdict(int)
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -60,7 +60,7 @@ def is_package(f):
 
 
 #: decorator for adding tools to the list
-class tool(object):
+class tool:
     def __init__(self, name, required=False):
         self.name = name
         self.required = required

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -288,7 +288,7 @@ def url_stats(args):
     # dictionary of issue type -> package -> descriptions
     issues = defaultdict(lambda: defaultdict(lambda: []))
 
-    class UrlStats(object):
+    class UrlStats:
         def __init__(self):
             self.total = 0
             self.schemes = defaultdict(lambda: 0)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -189,7 +189,7 @@ def in_system_subdirectory(path):
     return any(path_contains_subdirectory(path, x) for x in system_dirs)
 
 
-class Compiler(object):
+class Compiler:
     """This class encapsulates a Spack "compiler", which includes C,
     C++, and Fortran compilers.  Subclasses should implement
     support for specific compilers, their possible names, arguments,

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -369,7 +369,7 @@ def compiler_specs_for_arch(arch_spec, scope=None):
     return [c.spec for c in compilers_for_arch(arch_spec, scope)]
 
 
-class CacheReference(object):
+class CacheReference:
     """This acts as a hashable reference to any object (regardless of whether
     the object itself is hashable) and also prevents the object from being
     garbage-collected (so if two CacheReference objects are equal, they

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -48,7 +48,7 @@ _abi: Union[spack.abi.ABI, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(
 
 
 @functools.total_ordering
-class reverse_order(object):
+class reverse_order:
     """Helper for creating key functions.
 
     This is a wrapper that inverts the sense of the natural
@@ -65,7 +65,7 @@ class reverse_order(object):
         return other.value < self.value
 
 
-class Concretizer(object):
+class Concretizer:
     """You can subclass this class to override some of the default
     concretization strategies, or you can override all of them.
     """

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -111,7 +111,7 @@ scopes_metavar = "{defaults,system,site,user}[/PLATFORM] or env:ENVIRONMENT"
 overrides_base_name = "overrides-"
 
 
-class ConfigScope(object):
+class ConfigScope:
     """This class represents a configuration scope.
 
     A scope is one directory containing named configuration files.
@@ -382,7 +382,7 @@ def _config_mutator(method):
     return _method
 
 
-class Configuration(object):
+class Configuration:
     """A full Spack configuration, from a hierarchy of config files.
 
     This class makes it easy to add a new scope on top of an existing one.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -135,7 +135,7 @@ class InstallStatus(str):
     pass
 
 
-class InstallStatuses(object):
+class InstallStatuses:
     INSTALLED = InstallStatus("installed")
     DEPRECATED = InstallStatus("deprecated")
     MISSING = InstallStatus("missing")
@@ -162,7 +162,7 @@ class InstallStatuses(object):
             return query_arg
 
 
-class InstallRecord(object):
+class InstallRecord:
     """A record represents one installation in the DB.
 
     The record keeps track of the spec for the installation, its
@@ -253,7 +253,7 @@ class ForbiddenLockError(SpackError):
     """Raised when an upstream DB attempts to acquire a lock"""
 
 
-class ForbiddenLock(object):
+class ForbiddenLock:
     def __getattribute__(self, name):
         raise ForbiddenLockError("Cannot access attribute '{0}' of lock".format(name))
 
@@ -307,7 +307,7 @@ _query_docstring = """
         """
 
 
-class Database(object):
+class Database:
 
     """Per-process lock objects for each install prefix."""
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -224,7 +224,7 @@ def _windows_drive():
     return drive
 
 
-class WindowsCompilerExternalPaths(object):
+class WindowsCompilerExternalPaths:
     @staticmethod
     def find_windows_compiler_root_paths():
         """Helper for Windows compiler installation root discovery
@@ -260,7 +260,7 @@ class WindowsCompilerExternalPaths(object):
         )
 
 
-class WindowsKitExternalPaths(object):
+class WindowsKitExternalPaths:
     if sys.platform == "win32":
         plat_major_ver = str(winOs.windows_version()[0])
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -37,7 +37,7 @@ def _check_concrete(spec):
         raise ValueError("Specs passed to a DirectoryLayout must be concrete!")
 
 
-class DirectoryLayout(object):
+class DirectoryLayout:
     """A directory layout is used to associate unique paths with specs.
     Different installations are going to want different layouts for their
     install, and they can use this to customize the nesting structure of

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -93,7 +93,7 @@ def fetcher(cls):
     return cls
 
 
-class FetchStrategy(object):
+class FetchStrategy:
     """Superclass of all fetch strategies."""
 
     #: The URL attribute must be specified either at the package class
@@ -1652,7 +1652,7 @@ def from_list_url(pkg):
             tty.msg("Could not determine url from list_url.")
 
 
-class FsCache(object):
+class FsCache:
     def __init__(self, root):
         self.root = os.path.abspath(root)
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -126,7 +126,7 @@ def inverse_view_func_parser(view_type):
     return link_name
 
 
-class FilesystemView(object):
+class FilesystemView:
     """
     Governs a filesystem view that is located at certain root-directory.
 

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -10,7 +10,7 @@ import spack.repo
 hashes = []
 
 
-class SpecHashDescriptor(object):
+class SpecHashDescriptor:
     """This class defines how hashes are generated on Spec objects.
 
     Spec hashes in Spack are generated from a serialized (e.g., with

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -33,7 +33,7 @@ from llnl.util.lang import ensure_last, list_modules
 import spack.paths
 
 
-class _HookRunner(object):
+class _HookRunner:
     #: Stores all hooks on first call, shared among
     #: all HookRunner objects
     _hooks = None

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -86,7 +86,7 @@ STATUS_DEQUEUED = "dequeued"
 STATUS_REMOVED = "removed"
 
 
-class InstallAction(object):
+class InstallAction:
     #: Don't perform an install
     NONE = 0
     #: Do a standard install
@@ -657,7 +657,7 @@ def package_id(pkg):
     return "{0}-{1}-{2}".format(pkg.name, pkg.version, pkg.spec.dag_hash())
 
 
-class TermTitle(object):
+class TermTitle:
     def __init__(self, pkg_count):
         # Counters used for showing status information in the terminal title
         self.pkg_num = 0
@@ -683,7 +683,7 @@ class TermTitle(object):
         sys.stdout.flush()
 
 
-class TermStatusLine(object):
+class TermStatusLine:
     """
     This class is used in distributed builds to inform the user that other packages are
     being installed by another process.
@@ -727,7 +727,7 @@ class TermStatusLine(object):
         sys.stdout.flush()
 
 
-class PackageInstaller(object):
+class PackageInstaller:
     """
     Class for managing the install process for a Spack instance based on a
     bottom-up DAG approach.
@@ -1867,7 +1867,7 @@ class PackageInstaller(object):
             )
 
 
-class BuildProcessInstaller(object):
+class BuildProcessInstaller:
     """This class implements the part installation that happens in the child process."""
 
     def __init__(self, pkg, install_args):
@@ -2091,7 +2091,7 @@ def build_process(pkg, install_args):
         return installer.run()
 
 
-class OverwriteInstall(object):
+class OverwriteInstall:
     def __init__(self, installer, database, task):
         self.installer = installer
         self.database = database
@@ -2122,7 +2122,7 @@ class OverwriteInstall(object):
             raise e.inner_exception
 
 
-class BuildTask(object):
+class BuildTask:
     """Class for representing the build task for a package."""
 
     def __init__(self, pkg, request, compiler, start, attempts, status, installed):
@@ -2338,7 +2338,7 @@ class BuildTask(object):
         return len(self.uninstalled_deps)
 
 
-class BuildRequest(object):
+class BuildRequest:
     """Class for representing an installation request."""
 
     def __init__(self, pkg, install_args):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -651,7 +651,7 @@ def _invoke_command(command, parser, args, unknown_args):
     return 0 if return_val is None else return_val
 
 
-class SpackCommand(object):
+class SpackCommand:
     """Callable object that invokes a spack command (for testing).
 
     Example usage::

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -62,7 +62,7 @@ def _url_or_path_to_url(url_or_path: str) -> str:
     return url_util.path_to_file_url(spack.util.path.canonicalize_path(url_or_path))
 
 
-class Mirror(object):
+class Mirror:
     """Represents a named location for storing source tarballs and binary
     packages.
 
@@ -371,7 +371,7 @@ Spack not to expand it with the following syntax:
     return ext
 
 
-class MirrorReference(object):
+class MirrorReference:
     """A ``MirrorReference`` stores the relative paths where you can store a
     package/resource in a mirror directory.
 
@@ -597,7 +597,7 @@ def remove(name, scope):
     tty.msg("Removed mirror %s." % name)
 
 
-class MirrorStats(object):
+class MirrorStats:
     def __init__(self):
         self.present = {}
         self.new = {}

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -294,7 +294,7 @@ def read_module_indices():
     return module_indices
 
 
-class UpstreamModuleIndex(object):
+class UpstreamModuleIndex:
     """This is responsible for taking the individual module indices of all
     upstream Spack installations and locating the module for a given spec
     based on which upstream install it is located in."""
@@ -388,7 +388,7 @@ def get_module(module_type, spec, get_full_path, module_set_name="default", requ
             return writer.layout.use_name
 
 
-class BaseConfiguration(object):
+class BaseConfiguration:
     """Manipulates the information needed to generate a module file to make
     querying easier. It needs to be sub-classed for specific module types.
     """
@@ -551,7 +551,7 @@ class BaseConfiguration(object):
         return self.conf.get("verbose")
 
 
-class BaseFileLayout(object):
+class BaseFileLayout:
     """Provides information on the layout of module files. Needs to be
     sub-classed for specific module types.
     """
@@ -821,7 +821,7 @@ def ensure_modules_are_enabled_or_warn():
     warnings.warn(msg)
 
 
-class BaseModuleFileWriter(object):
+class BaseModuleFileWriter:
     def __init__(self, spec, module_set_name, explicit=None):
         self.spec = spec
 

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -52,7 +52,7 @@ class MultiMethodMeta(type):
         super(MultiMethodMeta, cls).__init__(name, bases, attr_dict)
 
 
-class SpecMultiMethod(object):
+class SpecMultiMethod:
     """This implements a multi-method for Spack specs.  Packages are
     instantiated with a particular spec, and you may want to
     execute different versions of methods based on what the spec
@@ -153,7 +153,7 @@ class SpecMultiMethod(object):
         )
 
 
-class when(object):
+class when:
     def __init__(self, condition):
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.

--- a/lib/spack/spack/operating_systems/_operating_system.py
+++ b/lib/spack/spack/operating_systems/_operating_system.py
@@ -8,7 +8,7 @@ import spack.util.spack_yaml as syaml
 
 
 @llnl.util.lang.lazy_lexicographic_ordering
-class OperatingSystem(object):
+class OperatingSystem:
     """Base class for all the Operating Systems.
 
     On a multiple architecture machine, the architecture spec field can be set to

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -125,7 +125,7 @@ def preferred_version(pkg):
     return max(pkg.versions, key=key_fn)
 
 
-class WindowsRPath(object):
+class WindowsRPath:
     """Collection of functionality surrounding Windows RPATH specific features
 
     This is essentially meaningless for all other platforms
@@ -175,7 +175,7 @@ class WindowsRPath(object):
 detectable_packages = collections.defaultdict(list)
 
 
-class DetectablePackageMeta(object):
+class DetectablePackageMeta:
     """Check if a package is detectable and add default implementations
     for the detection function.
     """
@@ -365,7 +365,7 @@ def on_package_attributes(**attr_dict):
     return _execute_under_condition
 
 
-class PackageViewMixin(object):
+class PackageViewMixin:
     """This collects all functionality related to adding installed Spack
     package to views. Packages can customize how they are added to views by
     overriding these functions.

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -19,7 +19,7 @@ def _spec_type(component):
     return _lesser_spec_types.get(component, spack.spec.Spec)
 
 
-class PackagePrefs(object):
+class PackagePrefs:
     """Defines the sort order for a set of specs.
 
     Spack's package preference implementation uses PackagePrefss to

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -51,7 +51,7 @@ def apply_patch(stage, patch_path, level=1, working_dir="."):
         patch("-s", "-p", str(level), "-i", patch_path, "-d", working_dir)
 
 
-class Patch(object):
+class Patch:
     """Base class for patches.
 
     Arguments:
@@ -310,7 +310,7 @@ def from_dict(dictionary, repository=None):
         raise ValueError("Invalid patch dictionary: %s" % dictionary)
 
 
-class PatchCache(object):
+class PatchCache:
     """Index of patches used in a repository, by sha256 hash.
 
     This allows us to look up patches without loading all packages.  It's

--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -35,7 +35,7 @@ real_host = _host
 host = _host
 
 
-class _PickleableCallable(object):
+class _PickleableCallable:
     """Class used to pickle a callable that may substitute either
     _platform or _all_platforms. Lambda or nested functions are
     not pickleable.

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -16,7 +16,7 @@ class NoPlatformError(spack.error.SpackError):
 
 
 @llnl.util.lang.lazy_lexicographic_ordering
-class Platform(object):
+class Platform:
     """Platform is an abstract class extended by subclasses.
 
     To add a new type of platform (such as cray_xe), create a subclass and set all the

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -38,7 +38,7 @@ def _cross_provider_maps(lmap, rmap):
     return result
 
 
-class _IndexBase(object):
+class _IndexBase:
     #: This is a dict of dicts used for finding providers of particular
     #: virtual dependencies. The dict of dicts looks like:
     #:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -117,7 +117,7 @@ class RepoLoader(_PrependFileLoader):
         )
 
 
-class SpackNamespaceLoader(object):
+class SpackNamespaceLoader:
     def create_module(self, spec):
         return SpackNamespace(spec.name)
 
@@ -125,7 +125,7 @@ class SpackNamespaceLoader(object):
         module.__loader__ = self
 
 
-class ReposFinder(object):
+class ReposFinder:
     """MetaPathFinder class that loads a Python module corresponding to a Spack package
 
     Return a loader based on the inspection of the current global repository list.
@@ -542,7 +542,7 @@ class PatchIndexer(Indexer):
         self.index.update_package(pkg_fullname)
 
 
-class RepoIndex(object):
+class RepoIndex:
     """Container class that manages a set of Indexers for a Repo.
 
     This class is responsible for checking packages in a repository for
@@ -641,7 +641,7 @@ class RepoIndex(object):
         return indexer.index
 
 
-class RepoPath(object):
+class RepoPath:
     """A RepoPath is a list of repos that function as one.
 
     It functions exactly like a Repo, but it operates on the combined
@@ -903,7 +903,7 @@ class RepoPath(object):
         return self.exists(pkg_name)
 
 
-class Repo(object):
+class Repo:
     """Class representing a package repository in the filesystem.
 
     Each package repository must have a top-level configuration file
@@ -1421,7 +1421,7 @@ def use_repositories(*paths_and_repos, **kwargs):
         path = saved
 
 
-class MockRepositoryBuilder(object):
+class MockRepositoryBuilder:
     """Build a mock repository in a directory"""
 
     def __init__(self, root_directory, namespace=None):

--- a/lib/spack/spack/resource.py
+++ b/lib/spack/spack/resource.py
@@ -11,7 +11,7 @@ package to enable optional features.
 """
 
 
-class Resource(object):
+class Resource:
     """Represents an optional resource to be fetched by a package.
 
     Aggregates a name, a fetcher, a destination and a placement.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -247,7 +247,7 @@ def specify(spec):
     return spack.spec.Spec(spec)
 
 
-class AspObject(object):
+class AspObject:
     """Object representing a piece of ASP code."""
 
 
@@ -313,7 +313,7 @@ class AspFunction(AspObject):
         return str(self)
 
 
-class AspFunctionBuilder(object):
+class AspFunctionBuilder:
     def __getattr__(self, name):
         return AspFunction(name)
 
@@ -355,7 +355,7 @@ def check_packages_exist(specs):
                 raise spack.repo.UnknownPackageError(str(s.fullname))
 
 
-class Result(object):
+class Result:
     """Result of an ASP solve."""
 
     def __init__(self, specs, asp=None):
@@ -655,7 +655,7 @@ RequirementRule = collections.namedtuple(
 )
 
 
-class PyclingoDriver(object):
+class PyclingoDriver:
     def __init__(self, cores=True):
         """Driver for the Python clingo interface.
 
@@ -853,7 +853,7 @@ class PyclingoDriver(object):
         return result, timer, self.control.statistics
 
 
-class SpackSolverSetup(object):
+class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
     def __init__(self, tests=False):
@@ -1536,7 +1536,7 @@ class SpackSolverSetup(object):
         clauses = []
 
         # TODO: do this with consistent suffixes.
-        class Head(object):
+        class Head:
             node = fn.attr("node")
             virtual_node = fn.attr("virtual_node")
             node_platform = fn.attr("node_platform_set")
@@ -1550,7 +1550,7 @@ class SpackSolverSetup(object):
             node_flag_propagate = fn.attr("node_flag_propagate")
             variant_propagate = fn.attr("variant_propagate")
 
-        class Body(object):
+        class Body:
             node = fn.attr("node")
             virtual_node = fn.attr("virtual_node")
             node_platform = fn.attr("node_platform")
@@ -2381,7 +2381,7 @@ class SpackSolverSetup(object):
         return version_specs
 
 
-class SpecBuilder(object):
+class SpecBuilder:
     """Class with actions to rebuild a spec from ASP results."""
 
     #: Regex for attributes that don't need actions b/c they aren't used to construct specs.
@@ -2696,7 +2696,7 @@ def _develop_specs_from_env(spec, env):
     spec.constrain(dev_info["spec"])
 
 
-class Solver(object):
+class Solver:
     """This is the main external interface class for solving.
 
     It manages solver configuration and preferences in one place. It sets up the solve

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -205,7 +205,7 @@ def colorize_spec(spec):
 
 
 @lang.lazy_lexicographic_ordering
-class ArchSpec(object):
+class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
 
     @staticmethod
@@ -567,7 +567,7 @@ class ArchSpec(object):
 
 
 @lang.lazy_lexicographic_ordering
-class CompilerSpec(object):
+class CompilerSpec:
     """The CompilerSpec field represents the compiler or range of compiler
     versions that a package should be built with.  CompilerSpecs have a
     name and a version list."""
@@ -1169,7 +1169,7 @@ def _libs_default_handler(descriptor, spec, cls):
     raise spack.error.NoLibrariesError(msg.format(spec.name, home))
 
 
-class ForwardQueryToPackage(object):
+class ForwardQueryToPackage:
     """Descriptor used to forward queries from Spec to Package"""
 
     def __init__(self, attribute_name, default_handler=None):
@@ -1311,7 +1311,7 @@ class SpecBuildInterface(lang.ObjectWrapper):
 
 
 @lang.lazy_lexicographic_ordering(set_hash=False)
-class Spec(object):
+class Spec:
     #: Cache for spec's prefix, computed lazily in the corresponding property
     _prefix = None
     abstract_hash = None

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -10,7 +10,7 @@ from spack.error import SpackError
 from spack.spec import Spec
 
 
-class SpecList(object):
+class SpecList:
     def __init__(self, name="specs", yaml_list=None, reference=None):
         # Normalize input arguments
         yaml_list = yaml_list or []

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -199,7 +199,7 @@ def _mirror_roots():
     ]
 
 
-class Stage(object):
+class Stage:
     """Manages a temporary stage directory for building.
 
     A Stage object is a context manager that handles a directory where
@@ -790,7 +790,7 @@ class StageComposite(pattern.Composite):
         return self[0].archive_file
 
 
-class DIYStage(object):
+class DIYStage:
     """
     Simple class that allows any directory to be a spack stage.  Consequently,
     it does not expect or require that the source path adhere to the standard

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -126,7 +126,7 @@ def parse_install_tree(config_dict):
     return (root, unpadded_root, projections)
 
 
-class Store(object):
+class Store:
     """A store is a path full of installed Spack packages.
 
     Stores consist of packages installed according to a

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -47,7 +47,7 @@ def serialize(obj):
     return serialized_obj
 
 
-class SpackTestProcess(object):
+class SpackTestProcess:
     def __init__(self, fn):
         self.fn = fn
 
@@ -60,7 +60,7 @@ class SpackTestProcess(object):
         return multiprocessing.Process(target=self._restore_and_run, args=(self.fn, test_state))
 
 
-class PackageInstallContext(object):
+class PackageInstallContext:
     """Captures the in-memory process state of a package installation that
     needs to be transmitted to a child process.
     """
@@ -85,7 +85,7 @@ class PackageInstallContext(object):
         return pkg
 
 
-class TestState(object):
+class TestState:
     """Spack tests may modify state that is normally read from disk in memory;
     this object is responsible for properly serializing that state to be
     applied to a subprocess. This isn't needed outside of a testing environment
@@ -116,7 +116,7 @@ class TestState(object):
             self.test_patches.restore()
 
 
-class TestPatches(object):
+class TestPatches:
     def __init__(self, module_patches, class_patches):
         self.module_patches = list((x, y, serialize(z)) for (x, y, z) in module_patches)
         self.class_patches = list((x, y, serialize(z)) for (x, y, z) in class_patches)

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -32,7 +32,7 @@ def _ensure_other_is_target(method):
     return _impl
 
 
-class Target(object):
+class Target:
     def __init__(self, name, module_name=None):
         """Target models microarchitectures and their compatibility.
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -103,7 +103,7 @@ def ensure_env_variables(config, mock_packages, monkeypatch, working_env):
 
 @pytest.fixture
 def mock_module_cmd(monkeypatch):
-    class Logger(object):
+    class Logger:
         def __init__(self, fn=None):
             self.fn = fn
             self.calls = []

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -46,7 +46,7 @@ def test_dir(tmpdir):
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "working_env")
-class TestTargets(object):
+class TestTargets:
     @pytest.mark.parametrize(
         "input_dir", glob.iglob(os.path.join(DATA_PATH, "make", "affirmative", "*"))
     )
@@ -94,7 +94,7 @@ class TestTargets(object):
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestAutotoolsPackage(object):
+class TestAutotoolsPackage:
     def test_with_or_without(self, default_mock_concretization):
         s = default_mock_concretization("a")
         options = s.package.with_or_without("foo")
@@ -257,7 +257,7 @@ spack:
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestCMakePackage(object):
+class TestCMakePackage:
     def test_cmake_std_args(self, default_mock_concretization):
         # Call the function on a CMakePackage instance
         s = default_mock_concretization("cmake-client")
@@ -313,7 +313,7 @@ class TestCMakePackage(object):
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestDownloadMixins(object):
+class TestDownloadMixins:
     """Test GnuMirrorPackage, SourceforgePackage, SourcewarePackage and XorgPackage."""
 
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -46,7 +46,7 @@ def test_import_signing_key(mock_gnupghome):
     ci.import_signing_key(signing_key)
 
 
-class FakeWebResponder(object):
+class FakeWebResponder:
     def __init__(self, response_code=200, content_to_read=[]):
         self._resp_code = response_code
         self._content = content_to_read
@@ -153,7 +153,7 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
     assert not ret
     assert "requires git" in err
 
-    class mock_git_cmd(object):
+    class mock_git_cmd:
         def __init__(self, *args, **kwargs):
             self.returncode = 0
             self.check = None

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on
 def mock_calls_for_clean(monkeypatch):
     counts = {}
 
-    class Counter(object):
+    class Counter:
         def __init__(self, name):
             self.name = name
             counts[name] = 0

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on
 
 
 @pytest.mark.usefixtures("mutable_mock_env_path", "mock_packages", "mock_fetch", "config")
-class TestDevelop(object):
+class TestDevelop:
     def check_develop(self, env, spec, path=None):
         path = path or spec.name
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -78,7 +78,7 @@ def test_mirror_skip_unstable(tmpdir_factory, mock_packages, config, source_for_
     )
 
 
-class MockMirrorArgs(object):
+class MockMirrorArgs:
     def __init__(
         self,
         specs=None,
@@ -260,7 +260,7 @@ def test_mirror_destroy(
 
 
 @pytest.mark.usefixtures("mock_packages")
-class TestMirrorCreate(object):
+class TestMirrorCreate:
     @pytest.mark.regression("31736", "31985")
     def test_all_specs_with_all_versions_dont_concretize(self):
         args = MockMirrorArgs(exclude_file=None, exclude_specs=None)

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -18,7 +18,7 @@ uninstall = SpackCommand("uninstall")
 install = SpackCommand("install")
 
 
-class MockArgs(object):
+class MockArgs:
     def __init__(self, packages, all=False, force=False, dependents=False):
         self.packages = packages
         self.all = all
@@ -207,7 +207,7 @@ def test_in_memory_consistency_when_uninstalling(mutable_database, monkeypatch):
 # Note: I want to use https://docs.pytest.org/en/7.1.x/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 # the style formatter insists on separating these two lines.
 @pytest.mark.skipif(sys.platform == "win32", reason="Envs unsupported on Windows")
-class TestUninstallFromEnv(object):
+class TestUninstallFromEnv:
     """Tests an installation with two environments e1 and e2, which each have
     shared package installations:
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -23,7 +23,7 @@ from spack.util.executable import ProcessError
 @pytest.fixture()
 def make_args_for_version(monkeypatch):
     def _factory(version, path="/usr/bin/gcc"):
-        class MockOs(object):
+        class MockOs:
             pass
 
         compiler_name = "gcc"
@@ -838,7 +838,7 @@ def test_apple_clang_setup_environment(mock_executable, monkeypatch):
     Xcode on MacOS.
     """
 
-    class MockPackage(object):
+    class MockPackage:
         use_xcode = False
 
     apple_clang_cls = spack.compilers.class_for_compiler_name("apple-clang")
@@ -937,7 +937,7 @@ def test_xcode_not_available(xcode_select_output, mock_executable, monkeypatch):
     )
     env = spack.util.environment.EnvironmentModifications()
 
-    class MockPackage(object):
+    class MockPackage:
         use_xcode = True
 
     pkg = MockPackage()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -179,7 +179,7 @@ class Changing(Package):
 
     with spack.repo.use_repositories(str(repo_dir), override=False) as repository:
 
-        class _ChangingPackage(object):
+        class _ChangingPackage:
             default_context = [
                 ("delete_version", True),
                 ("delete_variant", False),
@@ -224,7 +224,7 @@ class Changing(Package):
 # adjusting_default_target_based_on_compiler uses the current_host fixture,
 # which changes the config.
 @pytest.mark.usefixtures("mutable_config", "mock_packages")
-class TestConcretize(object):
+class TestConcretize:
     def test_concretize(self, spec):
         check_concretize(spec)
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -61,7 +61,7 @@ def assert_variant_values(spec, **variants):
 
 
 @pytest.mark.usefixtures("concretize_scope", "mock_packages")
-class TestConcretizePreferences(object):
+class TestConcretizePreferences:
     @pytest.mark.parametrize(
         "package_name,variant_value,expected_results",
         [

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -116,7 +116,7 @@ def test_repo(create_test_repo, monkeypatch, mock_stage):
         yield mock_repo_path
 
 
-class MakeStage(object):
+class MakeStage:
     def __init__(self, stage):
         self.stage = stage
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -313,7 +313,7 @@ def test_write_list_in_memory(mock_low_high_config):
     assert config == repos_high["repos"] + repos_low["repos"]
 
 
-class MockEnv(object):
+class MockEnv:
     def __init__(self, path):
         self.path = path
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -462,7 +462,7 @@ def check_for_leftover_stage_files(request, mock_stage, ignore_stage_files):
         assert not files_in_stage
 
 
-class MockCache(object):
+class MockCache:
     def store(self, copy_cmd, relative_dest):
         pass
 
@@ -470,7 +470,7 @@ class MockCache(object):
         return MockCacheFetcher()
 
 
-class MockCacheFetcher(object):
+class MockCacheFetcher:
     def fetch(self):
         raise FetchError("Mock cache always fails for tests")
 
@@ -998,7 +998,7 @@ def mock_fetch(mock_archive, monkeypatch):
     monkeypatch.setattr(spack.package_base.PackageBase, "fetcher", mock_fetcher)
 
 
-class MockLayout(object):
+class MockLayout:
     def __init__(self, root):
         self.root = root
 
@@ -1021,7 +1021,7 @@ def gen_mock_layout(tmpdir):
     yield create_layout
 
 
-class MockConfig(object):
+class MockConfig:
     def __init__(self, configuration, writer_key):
         self._configuration = configuration
         self.writer_key = writer_key
@@ -1033,7 +1033,7 @@ class MockConfig(object):
         return self.configuration(module_set_name)[self.writer_key]
 
 
-class ConfigUpdate(object):
+class ConfigUpdate:
     def __init__(self, root_for_conf, writer_mod, writer_key, monkeypatch):
         self.root_for_conf = root_for_conf
         self.writer_mod = writer_mod
@@ -1646,7 +1646,7 @@ repo:
 ##########
 
 
-class MockBundle(object):
+class MockBundle:
     has_code = False
     name = "mock-bundle"
 
@@ -1785,7 +1785,7 @@ def mock_curl_configs(mock_config_data, monkeypatch):
     """
     config_data_dir, config_files = mock_config_data
 
-    class MockCurl(object):
+    class MockCurl:
         def __init__(self):
             self.returncode = None
 

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -71,7 +71,7 @@ example_compiler_entry = """\
 """
 
 
-class JsonSpecEntry(object):
+class JsonSpecEntry:
     def __init__(self, name, hash, prefix, version, arch, compiler, dependencies, parameters):
         self.name = name
         self.hash = hash
@@ -98,7 +98,7 @@ class JsonSpecEntry(object):
         return (self.name, {"hash": self.hash, "type": list(deptypes)})
 
 
-class JsonArchEntry(object):
+class JsonArchEntry:
     def __init__(self, platform, os, target):
         self.platform = platform
         self.os = os
@@ -108,7 +108,7 @@ class JsonArchEntry(object):
         return {"platform": self.platform, "platform_os": self.os, "target": {"name": self.target}}
 
 
-class JsonCompilerEntry(object):
+class JsonCompilerEntry:
     def __init__(self, name, version, arch=None, executables=None):
         self.name = name
         self.version = version

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -531,7 +531,7 @@ def test_026_reindex_after_deprecate(mutable_database):
     _check_db_sanity(mutable_database)
 
 
-class ReadModify(object):
+class ReadModify:
     """Provide a function which can execute in a separate process that removes
     a spec from the database.
     """

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -29,7 +29,7 @@ def add_o3_to_build_system_cflags(pkg, name, flags):
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestFlagHandlers(object):
+class TestFlagHandlers:
     def test_no_build_system_flags(self, temp_env):
         # Test that both autotools and cmake work getting no build_system flags
         s1 = spack.spec.Spec("cmake-client").concretized()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -108,7 +108,7 @@ def mock_remove_prefix(*args):
     raise MockInstallError("Intentional error", "Mock remove_prefix method intentionally fails")
 
 
-class RemovePrefixChecker(object):
+class RemovePrefixChecker:
     def __init__(self, wrapped_rm_prefix):
         self.removed = False
         self.wrapped_rm_prefix = wrapped_rm_prefix
@@ -118,7 +118,7 @@ class RemovePrefixChecker(object):
         self.wrapped_rm_prefix()
 
 
-class MockStage(object):
+class MockStage:
     def __init__(self, wrapped_stage):
         self.wrapped_stage = wrapped_stage
         self.test_destroyed = False

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -66,7 +66,7 @@ plat_shared_ext = "dll" if sys.platform == "win32" else "so"
 plat_apple_shared_ext = "dylib"
 
 
-class TestLibraryList(object):
+class TestLibraryList:
     def test_repr(self, library_list):
         x = eval(repr(library_list))
         assert library_list == x
@@ -156,7 +156,7 @@ class TestLibraryList(object):
         assert type(pylist + library_list) == type(library_list)
 
 
-class TestHeaderList(object):
+class TestHeaderList:
     def test_repr(self, header_list):
         x = eval(repr(header_list))
         assert header_list == x

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -179,12 +179,12 @@ def test_key_ordering():
     with pytest.raises(TypeError):
 
         @llnl.util.lang.key_ordering
-        class ClassThatHasNoCmpKeyMethod(object):
+        class ClassThatHasNoCmpKeyMethod:
             # this will raise b/c it does not define _cmp_key
             pass
 
     @llnl.util.lang.key_ordering
-    class KeyComparable(object):
+    class KeyComparable:
         def __init__(self, t):
             self.t = t
 

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -266,7 +266,7 @@ def mpi_multiproc_test(*functions):
     include = comm.rank < len(functions)
     subcomm = comm.Split(include)
 
-    class subcomm_barrier(object):
+    class subcomm_barrier:
         """Stand-in for multiproc barrier for MPI-parallel jobs."""
 
         def wait(self):
@@ -296,7 +296,7 @@ multiproc_test = mpi_multiproc_test if mpi else local_multiproc_test
 #
 # Process snippets below can be composed into tests.
 #
-class AcquireWrite(object):
+class AcquireWrite:
     def __init__(self, lock_path, start=0, length=0):
         self.lock_path = lock_path
         self.start = start
@@ -313,7 +313,7 @@ class AcquireWrite(object):
         barrier.wait()  # hold the lock until timeout in other procs.
 
 
-class AcquireRead(object):
+class AcquireRead:
     def __init__(self, lock_path, start=0, length=0):
         self.lock_path = lock_path
         self.start = start
@@ -330,7 +330,7 @@ class AcquireRead(object):
         barrier.wait()  # hold the lock until timeout in other procs.
 
 
-class TimeoutWrite(object):
+class TimeoutWrite:
     def __init__(self, lock_path, start=0, length=0):
         self.lock_path = lock_path
         self.start = start
@@ -348,7 +348,7 @@ class TimeoutWrite(object):
         barrier.wait()
 
 
-class TimeoutRead(object):
+class TimeoutRead:
     def __init__(self, lock_path, start=0, length=0):
         self.lock_path = lock_path
         self.start = start
@@ -691,7 +691,7 @@ def test_upgrade_read_to_write_fails_with_readonly_file(private_lock_path):
         lk.file_tracker.release_by_stat(os.stat(private_lock_path))
 
 
-class ComplexAcquireAndRelease(object):
+class ComplexAcquireAndRelease:
     def __init__(self, lock_path):
         self.lock_path = lock_path
 
@@ -987,7 +987,7 @@ def test_transaction_with_context_manager(lock_path, transaction, type):
             assert vals["entered_ctx"]
             assert vals["exited_ctx"]
 
-    class TestContextManager(object):
+    class TestContextManager:
         def __enter__(self):
             vals["entered_ctx"] = True
 
@@ -1188,7 +1188,7 @@ def test_nested_reads(lock_path):
                     assert vals["read"] == 1
 
 
-class LockDebugOutput(object):
+class LockDebugOutput:
     def __init__(self, lock_path):
         self.lock_path = lock_path
         self.host = socket.gethostname()

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -246,7 +246,7 @@ def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
         )
 
 
-class MockFetcher(object):
+class MockFetcher:
     """Mock fetcher object which implements the necessary functionality for
     testing MirrorCache
     """

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -82,7 +82,7 @@ def test_modules_default_symlink(
     assert not os.path.lexists(link_path)
 
 
-class MockDb(object):
+class MockDb:
     def __init__(self, db_ids, spec_hash_to_db):
         self.upstream_dbs = db_ids
         self.spec_hash_to_db = spec_hash_to_db
@@ -91,7 +91,7 @@ class MockDb(object):
         return self.spec_hash_to_db.get(spec_hash)
 
 
-class MockSpec(object):
+class MockSpec:
     def __init__(self, unique_id):
         self.unique_id = unique_id
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -44,7 +44,7 @@ def provider(request):
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestLmod(object):
+class TestLmod:
     @pytest.mark.regression("37788")
     @pytest.mark.parametrize("modules_config", ["core_compilers", "core_compilers_at_equal"])
     def test_layout_for_specs_compiled_with_core_compilers(

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on
 
 
 @pytest.mark.usefixtures("config", "mock_packages", "mock_module_filename")
-class TestTcl(object):
+class TestTcl:
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple Tcl module file."""
 

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -23,7 +23,7 @@ def pkg_factory(name):
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestPackage(object):
+class TestPackage:
     def test_load_package(self):
         spack.repo.path.get_pkg_class("mpich")
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -62,7 +62,7 @@ def sbang_line():
     yield "#!/bin/sh %s/bin/sbang\n" % spack.store.layout.root
 
 
-class ScriptDirectory(object):
+class ScriptDirectory:
     """Directory full of test scripts to run sbang instrumentation on."""
 
     def __init__(self, sbang_line):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -177,7 +177,7 @@ def test_conditional_dep_with_user_constraints(tmpdir, spec_str, expr_str, expec
 
 
 @pytest.mark.usefixtures("mutable_mock_repo", "config")
-class TestSpecDag(object):
+class TestSpecDag:
     def test_conflicting_package_constraints(self, set_dependency):
         set_dependency("mpileaks", "mpich@1.0")
         set_dependency("callpath", "mpich@2.0")

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -10,7 +10,7 @@ from spack.spec import Spec
 from spack.spec_list import SpecList
 
 
-class TestSpecList(object):
+class TestSpecList:
     default_input = ["mpileaks", "$mpis", {"matrix": [["hypre"], ["$gccs", "$clangs"]]}, "libelf"]
 
     default_reference = {

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -24,7 +24,7 @@ from spack.variant import (
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
-class TestSpecSemantics(object):
+class TestSpecSemantics:
     """Test satisfies(), intersects(), constrain() and other semantic operations on specs."""
 
     @pytest.mark.parametrize(
@@ -754,7 +754,7 @@ class TestSpecSemantics(object):
     def test_errors_in_variant_directive(self):
         variant = spack.directives.variant.__wrapped__
 
-        class Pkg(object):
+        class Pkg:
             name = "PKG"
 
         # We can't use names that are reserved by Spack

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -340,7 +340,7 @@ def failing_fetch_strategy():
 def search_fn():
     """Returns a search function that always succeeds."""
 
-    class _Mock(object):
+    class _Mock:
         performed_search = False
 
         def __call__(self):
@@ -385,7 +385,7 @@ def check_stage_dir_perms(prefix, path):
 
 
 @pytest.mark.usefixtures("mock_packages")
-class TestStage(object):
+class TestStage:
     stage_name = "spack-test-stage"
 
     def test_setup_and_destroy_name_with_tmp(self, mock_stage_archive):

--- a/lib/spack/spack/test/tengine.py
+++ b/lib/spack/spack/test/tengine.py
@@ -11,7 +11,7 @@ import spack.tengine as tengine
 from spack.util.path import canonicalize_path
 
 
-class TestContext(object):
+class TestContext:
     class A(tengine.Context):
         @tengine.context_property
         def foo(self):
@@ -66,7 +66,7 @@ class TestContext(object):
 
 
 @pytest.mark.usefixtures("config")
-class TestTengineEnvironment(object):
+class TestTengineEnvironment:
     def test_template_retrieval(self):
         """Tests the template retrieval mechanism hooked into config files"""
         # Check the directories are correct

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -401,7 +401,7 @@ def test_url_missing_curl(tmpdir, monkeypatch):
 
 
 def test_url_fetch_text_urllib_bad_returncode(tmpdir, monkeypatch):
-    class response(object):
+    class response:
         def getcode(self):
             return 404
 

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -9,7 +9,7 @@ from io import StringIO
 import spack.util.timer as timer
 
 
-class Tick(object):
+class Tick:
     """Timer that increments the seconds passed by 1
     everytime tick is called."""
 

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -23,7 +23,7 @@ from spack.variant import (
 )
 
 
-class TestMultiValuedVariant(object):
+class TestMultiValuedVariant:
     def test_initialization(self):
         # Basic properties
         a = MultiValuedVariant("foo", "bar,baz")
@@ -198,7 +198,7 @@ class TestMultiValuedVariant(object):
         assert a.yaml_entry() == expected
 
 
-class TestSingleValuedVariant(object):
+class TestSingleValuedVariant:
     def test_initialization(self):
         # Basic properties
         a = SingleValuedVariant("foo", "bar")
@@ -356,7 +356,7 @@ class TestSingleValuedVariant(object):
         assert a.yaml_entry() == expected
 
 
-class TestBoolValuedVariant(object):
+class TestBoolValuedVariant:
     def test_initialization(self):
         # Basic properties - True value
         for v in (True, "True", "TRUE", "TrUe"):
@@ -534,7 +534,7 @@ def test_from_node_dict():
     assert type(a) == BoolValuedVariant
 
 
-class TestVariant(object):
+class TestVariant:
     def test_validation(self):
         a = Variant(
             "foo", default="", description="", values=("bar", "baz", "foobar"), multi=False
@@ -584,7 +584,7 @@ class TestVariant(object):
         assert a.allowed_values == "bar, baz, foobar"
 
 
-class TestVariantMapTest(object):
+class TestVariantMapTest:
     def test_invalid_values(self):
         # Value with invalid type
         a = VariantMap(None)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -222,12 +222,12 @@ def test_list_url(tmpdir):
     assert list_url(True) == ["dir/another-file.txt", "file-0.txt", "file-1.txt", "file-2.txt"]
 
 
-class MockPages(object):
+class MockPages:
     def search(self, *args, **kwargs):
         return [{"Key": "keyone"}, {"Key": "keytwo"}, {"Key": "keythree"}]
 
 
-class MockPaginator(object):
+class MockPaginator:
     def paginate(self, *args, **kwargs):
         return MockPages()
 
@@ -240,7 +240,7 @@ class MockClientError(Exception):
         }
 
 
-class MockS3Client(object):
+class MockS3Client:
     def get_paginator(self, *args, **kwargs):
         return MockPaginator()
 

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -22,7 +22,7 @@ def sort_edges(edges):
     return edges
 
 
-class BaseVisitor(object):
+class BaseVisitor:
     """A simple visitor that accepts all edges unconditionally and follows all
     edges to dependencies of a given ``deptype``."""
 
@@ -46,7 +46,7 @@ class BaseVisitor(object):
         return sort_edges(item.edge.spec.edges_to_dependencies(deptype=self.deptype))
 
 
-class ReverseVisitor(object):
+class ReverseVisitor:
     """A visitor that reverses the arrows in the DAG, following dependents."""
 
     def __init__(self, visitor, deptype="all"):
@@ -65,7 +65,7 @@ class ReverseVisitor(object):
         )
 
 
-class CoverNodesVisitor(object):
+class CoverNodesVisitor:
     """A visitor that traverses each node once."""
 
     def __init__(self, visitor, key=id, visited=None):
@@ -88,7 +88,7 @@ class CoverNodesVisitor(object):
         return self.visitor.neighbors(item)
 
 
-class CoverEdgesVisitor(object):
+class CoverEdgesVisitor:
     """A visitor that traverses all edges once."""
 
     def __init__(self, visitor, key=id, visited=None):
@@ -110,7 +110,7 @@ class CoverEdgesVisitor(object):
         return self.visitor.neighbors(item)
 
 
-class TopoVisitor(object):
+class TopoVisitor:
     """Visitor that can be used in :py:func:`depth-first traversal
     <spack.traverse.traverse_depth_first_with_visitor>` to generate
     a topologically ordered list of specs.

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -25,7 +25,7 @@ _deprecated_hash_algorithms = ["md5"]
 _hash_functions: Dict[str, Callable[[], Any]] = {}
 
 
-class DeprecatedHash(object):
+class DeprecatedHash:
     def __init__(self, hash_alg, alert_fn, disable_security_check):
         self.hash_alg = hash_alg
         self.alert_fn = alert_fn
@@ -92,7 +92,7 @@ def checksum(hashlib_algo, filename, **kwargs):
     return hasher.hexdigest()
 
 
-class Checker(object):
+class Checker:
     """A checker checks files against one particular hex digest.
     It will automatically determine what hashing algorithm
     to used based on the length of the digest it's initialized

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -75,7 +75,7 @@ class ELF_CONSTANTS:
     SHT_STRTAB = 3
 
 
-class ElfFile(object):
+class ElfFile:
     """Parsed ELF file."""
 
     __slots__ = [

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -17,7 +17,7 @@ from spack.util.path import Path, format_os_path, path_to_os_path, system_path_f
 __all__ = ["Executable", "which", "ProcessError"]
 
 
-class Executable(object):
+class Executable:
     """Class representing a program that can be run on the command line."""
 
     def __init__(self, name):

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -13,7 +13,7 @@ from spack.error import SpackError
 from spack.util.lock import Lock, ReadTransaction, WriteTransaction
 
 
-class FileCache(object):
+class FileCache:
     """This class manages cached data in the filesystem.
 
     - Cache files are fetched and stored by unique keys.  Keys can be relative
@@ -126,7 +126,7 @@ class FileCache(object):
         # TODO: is pretty hard to reason about in llnl.util.lock. At some
         # TODO: point we should just replace it with functions and simplify
         # TODO: the locking code.
-        class WriteContextManager(object):
+        class WriteContextManager:
             def __enter__(cm):
                 cm.orig_filename = self.cache_path(key)
                 cm.orig_file = None

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -34,7 +34,7 @@ def gcs_client():
     return storage_client
 
 
-class GCSBucket(object):
+class GCSBucket:
     """GCS Bucket Object
     Create a wrapper object for a GCS Bucket. Provides methods to wrap spack
     related tasks, such as destroy.
@@ -153,7 +153,7 @@ class GCSBucket(object):
             sys.exit(1)
 
 
-class GCSBlob(object):
+class GCSBlob:
     """GCS Blob object
 
     Wraps some blob methods for spack functionality

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -177,8 +177,8 @@ class InvalidFullyQualifiedModuleNameError(spack.error.SpackError):
         self.name = name
 
 
-class NamespaceTrie(object):
-    class Element(object):
+class NamespaceTrie:
+    class Element:
         def __init__(self, value):
             self.value = value
 

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -11,7 +11,7 @@ import traceback
 from .cpus import cpus_available
 
 
-class ErrorFromWorker(object):
+class ErrorFromWorker:
     """Wrapper class to report an error from a worker process"""
 
     def __init__(self, exc_cls, exc, tb):
@@ -37,7 +37,7 @@ class ErrorFromWorker(object):
         return self.error_message
 
 
-class Task(object):
+class Task:
     """Wrapped task that trap every Exception and return it as an
     ErrorFromWorker object.
 

--- a/lib/spack/spack/util/pattern.py
+++ b/lib/spack/spack/util/pattern.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 
 
-class Delegate(object):
+class Delegate:
     def __init__(self, name, container):
         self.name = name
         self.container = container
@@ -69,7 +69,7 @@ def composite(interface=None, method_list=None, container=list):
         # Patch the behavior of each of the methods in the previous list.
         # This is done associating an instance of the descriptor below to
         # any method that needs to be patched.
-        class IterateOver(object):
+        class IterateOver:
             """Decorator used to patch methods in a composite.
 
             It iterates over all the items in the instance containing the
@@ -120,7 +120,7 @@ def composite(interface=None, method_list=None, container=list):
     return cls_decorator
 
 
-class Bunch(object):
+class Bunch:
     """Carries a bunch of named attributes (from Alex Martelli bunch)"""
 
     def __init__(self, **kwargs):

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -25,7 +25,7 @@ Interval = collections.namedtuple("Interval", ("begin", "end"))
 global_timer_name = "_global"
 
 
-class NullTimer(object):
+class NullTimer:
     """Timer interface that does nothing, useful in for "tell
     don't ask" style code when timers are optional."""
 
@@ -57,7 +57,7 @@ class NullTimer(object):
 NULL_TIMER = NullTimer()
 
 
-class Timer(object):
+class Timer:
     """Simple interval timer"""
 
     def __init__(self, now=time.time):

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -17,7 +17,7 @@ if sys.platform == "win32":
     import winreg
 
 
-class RegistryValue(object):
+class RegistryValue:
     """
     Class defining a Windows registry entry
     """
@@ -28,7 +28,7 @@ class RegistryValue(object):
         self.key = parent_key
 
 
-class RegistryKey(object):
+class RegistryKey:
     """
     Class wrapping a Windows registry key
     """
@@ -115,7 +115,7 @@ class _HKEY_CONSTANT(RegistryKey):
         return self._handle
 
 
-class HKEY(object):
+class HKEY:
     """
     Predefined, open registry HKEYs
     From the Microsoft docs:
@@ -133,7 +133,7 @@ class HKEY(object):
     HKEY_PERFORMANCE_DATA = _HKEY_CONSTANT("HKEY_PERFORMANCE_DATA")
 
 
-class WindowsRegistryView(object):
+class WindowsRegistryView:
     """
     Interface to provide access, querying, and searching to Windows registry entries.
     This class represents a single key entrypoint into the Windows registry

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -23,7 +23,7 @@ from spack.util.string import comma_or
 special_variant_values = [None, "none", "*"]
 
 
-class Variant(object):
+class Variant:
     """Represents a variant in a package, as declared in the
     variant directive.
     """
@@ -230,7 +230,7 @@ def _flatten(values):
 
 
 @lang.lazy_lexicographic_ordering
-class AbstractVariant(object):
+class AbstractVariant:
     """A variant that has not yet decided who it wants to be. It behaves like
     a multi valued variant which **could** do things.
 
@@ -864,7 +864,7 @@ def disjoint_sets(*sets):
 
 
 @functools.total_ordering
-class Value(object):
+class Value:
     """Conditional value that might be used in variants."""
 
     def __init__(self, value, when):

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -177,7 +177,7 @@ def check_spec_manifest(spec):
     return results
 
 
-class VerificationResults(object):
+class VerificationResults:
     def __init__(self):
         self.errors = {}
 

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -52,7 +52,7 @@ infinity_versions = ["stable", "trunk", "head", "master", "main", "develop"]
 iv_min_len = min(len(s) for s in infinity_versions)
 
 
-class VersionStrComponent(object):
+class VersionStrComponent:
     __slots__ = ["data"]
 
     def __init__(self, data):
@@ -1158,7 +1158,7 @@ class VersionLookupError(VersionError):
     """Raised for errors looking up git commits as versions."""
 
 
-class CommitLookup(object):
+class CommitLookup:
     """An object for cached lookups of git commits
 
     CommitLookup objects delegate to the misc_cache for locking. CommitLookup objects may

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -116,7 +116,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         change_sed_delimiter("@", ";", "src/Makefile.in")
 
 
-class SetupEnvironment(object):
+class SetupEnvironment:
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -184,7 +184,7 @@ class IntelTbb(CMakePackage, MakefilePackage):
         return find_libraries("libtbb*", root=self.prefix, shared=shared, recursive=True)
 
 
-class SetupEnvironment(object):
+class SetupEnvironment:
     # We set OS here in case the user has it set to something else
     # that TBB doesn't expect.
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -185,7 +185,7 @@ class Libxml2(AutotoolsPackage, NMakePackage):
             xmllint("--dtdvalid", dtd_path, data_dir.join("info.xml"))
 
 
-class RunAfter(object):
+class RunAfter:
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def import_module_test(self):

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -76,7 +76,7 @@ class Metis(CMakePackage, MakefilePackage):
             )
 
 
-class SetupEnvironment(object):
+class SetupEnvironment:
     def setup_build_environment(self, env):
         # Ignore warnings/errors re unrecognized omp pragmas on %intel
         if "%intel@14:" in self.spec:

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -881,7 +881,7 @@ class Openfoam(Package):
 # -----------------------------------------------------------------------------
 
 
-class OpenfoamArch(object):
+class OpenfoamArch:
     """OpenfoamArch represents architecture/compiler settings for OpenFOAM.
     The string representation is WM_OPTIONS.
 

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -101,7 +101,7 @@ class Ruby(AutotoolsPackage, NMakePackage):
         module.rake = Executable(self.prefix.bin.rake)
 
 
-class SetupEnvironment(object):
+class SetupEnvironment:
     def setup_dependent_build_environment(self, env, dependent_spec):
         # TODO: do this only for actual extensions.
         # Set GEM_PATH to include dependent gem directories

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -62,7 +62,7 @@ class Zlib(MakefilePackage, Package):
         return find_libraries(["libz"], root=self.prefix, recursive=True, shared=shared)
 
 
-class SetupEnvironment(object):
+class SetupEnvironment:
     def setup_build_environment(self, env):
         if "+pic" in self.spec:
             env.append_flags("CFLAGS", self.pkg.compiler.cc_pic_flag)


### PR DESCRIPTION
We no longer support Python 2, so there's no reason to use the old syntax.

Just did a simple sed call, might be bugs.