### PR TITLE
mkl support for cray mpich

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -176,7 +176,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         libs.append("libmkl_core")
 
         if self.spec.satisfies("+cluster"):
-            if any(self.spec.satisfies(m) for m in ["^intel-oneapi-mpi", "^intel-mpi", "^mpich"]):
+            if any(self.spec.satisfies(m) for m in ["^intel-oneapi-mpi", "^intel-mpi", "^mpich", "^cray-mpich"]):
                 libs.append(self._xlp64_lib("libmkl_blacs_intelmpi"))
             elif self.spec.satisfies("^openmpi"):
                 libs.append(self._xlp64_lib("libmkl_blacs_openmpi"))

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -176,7 +176,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         libs.append("libmkl_core")
 
         if self.spec.satisfies("+cluster"):
-            if any(self.spec.satisfies(m) for m in ["^intel-oneapi-mpi", "^intel-mpi", "^mpich", "^cray-mpich"]):
+            if any(
+                self.spec.satisfies(m)
+                for m in ["^intel-oneapi-mpi", "^intel-mpi", "^mpich", "^cray-mpich"]
+            ):
                 libs.append(self._xlp64_lib("libmkl_blacs_intelmpi"))
             elif self.spec.satisfies("^openmpi"):
                 libs.append(self._xlp64_lib("libmkl_blacs_openmpi"))


### PR DESCRIPTION
Addresses issue noted in #38554 for supporting cray mpich. The link line advisor doesn't say it supports cray-mpich, but I expect that this will work. I am unable to install cray mpich on my system, so hoping someone can test that it works. 
```
==> cray-pmi: Executing phase: 'install'
==> Error: AttributeError: 'super' object has no attribute 'install'

The 'cray-pmi' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package\ format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also repo\
rt the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure

/localdisk/work/rscohn1/projects/spack/spack/lib/spack/spack/builder.py:145, in __getattr__:
        144        def __getattr__(self, item):
  >>    145            result = getattr(super(type(self.root_builder), self.root_builder), item)
        146            if item in super(type(self.root_builder), self.root_builder).phases:
        147                result = _PhaseAdapter(self.root_builder, result)
        148            return result

```