### PR TITLE
py-astropy: fix import tests and restrict py-pip version

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -15,6 +15,7 @@ class PyAstropy(PythonPackage):
 
     homepage = "https://astropy.org/"
     pypi = "astropy/astropy-4.0.1.post1.tar.gz"
+    git = "https://github.com/astropy/astropy.git"
 
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
     version(
@@ -29,13 +30,11 @@ class PyAstropy(PythonPackage):
 
     # Required dependencies
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
-    depends_on("python@3.6:", when="@4.0:", type=("build", "run"))
-    depends_on("python@3.5:", when="@3.0:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", when="@2.0:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.3:", when="@1.2:", type=("build", "run"))
-    depends_on("python@2.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.13:", type="build")
+    # in newer pip versions --install-options does not exist
+    depends_on("py-pip@:23.0", type="build")
+
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@4.0:", type=("build", "run"))
     depends_on("py-numpy@1.13:", when="@3.1:", type=("build", "run"))
@@ -50,6 +49,12 @@ class PyAstropy(PythonPackage):
     depends_on("py-cython@0.29.30", when="@5.1:", type="build")
     depends_on("py-extension-helpers", when="@5.1:", type="build")
     depends_on("pkgconfig", type="build")
+
+    depends_on("py-pytest@7:", type="test")
+    depends_on("py-pytest-doctestplus@0.12:", type="test")
+    depends_on("py-pytest-astropy-header@0.2.1:", type="test")
+    depends_on("py-pytest-astropy@0.10:", type="test")
+    depends_on("py-pytest-xdist", type="test")
 
     # Optional dependencies
     depends_on("py-scipy@0.18:", when="+extras", type=("build", "run"))
@@ -100,3 +105,12 @@ class PyAstropy(PythonPackage):
     def install_test(self):
         with working_dir("spack-test", create=True):
             python("-c", "import astropy; astropy.test()")
+
+    @property
+    def skip_modules(self):
+        modules = []
+
+        if self.spec.satisfies("~extras"):
+            modules.append("astropy.visualization.wcsaxes")
+
+        return modules

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -32,7 +32,7 @@ class PyAstropy(PythonPackage):
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.13:", type="build")
-    # in newer pip versions --install-options does not exist
+    # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
 
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -26,7 +26,7 @@ class PyAstropy(PythonPackage):
     version("1.1.2", sha256="6f0d84cd7dfb304bb437dda666406a1d42208c16204043bc920308ff8ffdfad1")
     version("1.1.post1", sha256="64427ec132620aeb038e4d8df94d6c30df4cc8b1c42a6d8c5b09907a31566a21")
 
-    variant("extras", default=False, description="Enable extra functionality")
+    variant("all", default=False, when="@3.2:", description="Enable all functionality")
 
     # Required dependencies
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
@@ -57,23 +57,41 @@ class PyAstropy(PythonPackage):
     depends_on("py-pytest-xdist", type="test")
 
     # Optional dependencies
-    depends_on("py-scipy@0.18:", when="+extras", type=("build", "run"))
-    depends_on("py-h5py", when="+extras", type=("build", "run"))
-    depends_on("py-beautifulsoup4", when="+extras", type=("build", "run"))
-    depends_on("py-html5lib", when="+extras", type=("build", "run"))
-    depends_on("py-bleach", when="+extras", type=("build", "run"))
-    depends_on("py-pyyaml", when="+extras", type=("build", "run"))
-    depends_on("py-pandas", when="+extras", type=("build", "run"))
-    depends_on("py-bintrees", when="+extras", type=("build", "run"))
-    depends_on("py-sortedcontainers", when="+extras", type=("build", "run"))
-    depends_on("py-pytz", when="+extras", type=("build", "run"))
-    depends_on("py-jplephem", when="+extras", type=("build", "run"))
-    depends_on("py-matplotlib@2.0:", when="+extras", type=("build", "run"))
-    depends_on("py-scikit-image", when="+extras", type=("build", "run"))
-    depends_on("py-mpmath", when="+extras", type=("build", "run"))
-    depends_on("py-asdf@2.3:", when="+extras", type=("build", "run"))
-    depends_on("py-bottleneck", when="+extras", type=("build", "run"))
-    depends_on("py-pytest", when="+extras", type=("build", "run"))
+    with when("+all"):
+        depends_on("py-scipy@1.3:", when="@5:", type=("build", "run"))
+        depends_on("py-scipy@0.18:", type=("build", "run"))
+        depends_on("py-matplotlib@3.1:", when="@5:", type=("build", "run"))
+        depends_on("py-matplotlib@2.1:", when="@4:", type=("build", "run"))
+        depends_on("py-matplotlib@2.0:", type=("build", "run"))
+        depends_on("py-certifi", when="@4.3:", type=("build", "run"))
+        depends_on("py-dask+array", when="@4.1:", type=("build", "run"))
+        depends_on("py-h5py", type=("build", "run"))
+        # py-pyarrow only builds when parquet variant enabled
+        depends_on("py-pyarrow+parquet@5:", when="@5:", type=("build", "run"))
+        depends_on("py-beautifulsoup4", type=("build", "run"))
+        depends_on("py-html5lib", type=("build", "run"))
+        depends_on("py-bleach", type=("build", "run"))
+        depends_on("py-pandas", type=("build", "run"))
+        depends_on("py-sortedcontainers", type=("build", "run"))
+        depends_on("py-pytz", type=("build", "run"))
+        depends_on("py-jplephem", type=("build", "run"))
+        depends_on("py-mpmath", type=("build", "run"))
+        depends_on("py-asdf@2.10:", when="@5.1:", type=("build", "run"))
+        depends_on("py-asdf@2.5:", when="@4.0.1post1:", type=("build", "run"))
+        depends_on("py-asdf@2.3:", type=("build", "run"))
+        depends_on("py-bottleneck", type=("build", "run"))
+        depends_on("py-ipython@4.2:", when="@4.3:", type=("build", "run"))
+        depends_on("py-ipython", type=("build", "run"))
+        depends_on("py-pytest@7:", when="@5.0.2:", type=("build", "run"))
+        depends_on("py-pytest", type=("build", "run"))
+        depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:", type=("build", "run"))
+
+        # Historical optional dependencies
+        depends_on("py-pyyaml", when="@:5", type=("build", "run"))
+        depends_on("py-scikit-image", when="@:4.0", type=("build", "run"))
+        depends_on("py-bintrees", when="@:3.2.1", type=("build", "run"))
+
+        conflicts("^py-matplotlib@3.4.0,3.5.2")
 
     # System dependencies
     depends_on("erfa")

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -66,8 +66,7 @@ class PyAstropy(PythonPackage):
         depends_on("py-certifi", when="@4.3:", type=("build", "run"))
         depends_on("py-dask+array", when="@4.1:", type=("build", "run"))
         depends_on("py-h5py", type=("build", "run"))
-        # py-pyarrow only builds when parquet variant enabled
-        depends_on("py-pyarrow+parquet@5:", when="@5:", type=("build", "run"))
+        depends_on("py-pyarrow@5:", when="@5:", type=("build", "run"))
         depends_on("py-beautifulsoup4", type=("build", "run"))
         depends_on("py-html5lib", type=("build", "run"))
         depends_on("py-bleach", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-astropy-header/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-astropy-header/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestAstropyHeader(PythonPackage):
+    """pytest plugin to add diagnostic information to the header of the test output."""
+
+    homepage = "https://github.com/astropy/pytest-astropy-header"
+    pypi = "pytest-astropy-header/pytest-astropy-header-0.2.2.tar.gz"
+
+    version("0.2.2", sha256="77891101c94b75a8ca305453b879b318ab6001b370df02be2c0b6d1bb322db10")
+
+    depends_on("py-setuptools@30.3.0:", type="build")
+    depends_on("py-setuptools-scm", type="build")
+
+    depends_on("py-pytest@4.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-astropy/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestAstropy(PythonPackage):
+    """Meta-package containing dependencies for testing."""
+
+    homepage = "https://github.com/astropy/pytest-astropy"
+    pypi = "pytest-astropy/pytest-astropy-0.10.0.tar.gz"
+
+    version("0.10.0", sha256="85e3c66ceede4ce668f473b3cf377fcb2aa3c48e24f28aaa377ae86004cce211")
+
+    depends_on("py-setuptools@30.3:", type="build")
+    depends_on("py-setuptools-scm", type="build")
+
+    depends_on("py-pytest@4.6:", type=("build", "run"))
+    depends_on("py-pytest-doctestplus@0.11:", type=("build", "run"))
+    depends_on("py-pytest-remotedata@0.3.1:", type=("build", "run"))
+    depends_on("py-pytest-openfiles@0.3.1:", type=("build", "run"))
+    depends_on("py-pytest-astropy-header@0.1.2:", type=("build", "run"))
+    depends_on("py-pytest-arraydiff@0.1:", type=("build", "run"))
+    depends_on("py-pytest-filter-subpackage@0.1:", type=("build", "run"))
+    depends_on("py-pytest-cov@2.3.1:", type=("build", "run"))
+    depends_on("py-pytest-mock@2:", type=("build", "run"))
+    depends_on("py-attrs@19.2:", type=("build", "run"))
+    depends_on("py-hypothesis@5.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-doctestplus/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-doctestplus/package.py
@@ -10,12 +10,14 @@ from spack.package import *
 class PyPytestDoctestplus(PythonPackage):
     """Pytest plugin with advanced doctest features."""
 
-    homepage = "https://www.astropy.org/"
+    homepage = "https://github.com/astropy/pytest-doctestplus"
     pypi = "pytest-doctestplus/pytest-doctestplus-0.8.0.tar.gz"
 
+    version("0.13.0", sha256="f884e2231fe5378cc8e5d1a272d19b01ebd352df0591a5add55ff50adac2d2d0")
     version("0.9.0", sha256="6fe747418461d7b202824a3486ba8f4fa17a9bd0b1eddc743ba1d6d87f03391a")
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@30.3.0:", type=("build", "run"))
     depends_on("py-setuptools-scm", type="build")
+
     depends_on("py-pytest@4.6:", type=("build", "run"))
+    depends_on("py-packaging@17:", when="@0.10:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-filter-subpackage/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-filter-subpackage/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestFilterSubpackage(PythonPackage):
+    """Pytest plugin for filtering based on sub-packages."""
+
+    homepage = "https://github.com/astropy/pytest-filter-subpackage"
+    pypi = "pytest-filter-subpackage/pytest-filter-subpackage-0.1.2.tar.gz"
+
+    version("0.1.2", sha256="1faea36717803e524588d6c109d26d20d3b34422e8d6a96812758977dca01782")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")
+
+    depends_on("py-pytest@3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest-remotedata/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-remotedata/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestRemotedata(PythonPackage):
+    """Pytest plugin for controlling remote data access."""
+
+    homepage = "https://github.com/astropy/pytest-remotedata"
+    pypi = "pytest-remotedata/pytest-remotedata-0.4.0.tar.gz"
+
+    version("0.4.0", sha256="be21c558e34d7c11b0f6aeb50956c09520bffcd02b7fce9c6f8e8531a401a1c8")
+
+    depends_on("py-setuptools@30.3:", type="build")
+    depends_on("py-setuptools-scm", type="build")
+
+    depends_on("py-pytest@4.6:", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -29,7 +29,7 @@ class PyTomopy(PythonPackage):
     depends_on("ninja", type=("build"))
     depends_on("py-setuptools-scm", type=("build"))
     depends_on("py-setuptools-scm-git-archive", type=("build"))
-    # in newer pip versions --install-options does not exist
+    # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
     # Note: The module name of py-scikit-build is skbuild:
     depends_on("py-scikit-build", type=("build"))

--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -29,6 +29,8 @@ class PyTomopy(PythonPackage):
     depends_on("ninja", type=("build"))
     depends_on("py-setuptools-scm", type=("build"))
     depends_on("py-setuptools-scm-git-archive", type=("build"))
+    # in newer pip versions --install-options does not exist
+    depends_on("py-pip@:23.0", type="build")
     # Note: The module name of py-scikit-build is skbuild:
     depends_on("py-scikit-build", type=("build"))
     depends_on("py-scikit-image@0.17:", type=("build", "run"))


### PR DESCRIPTION
Fix `spack install --test=root` for py-astropy and due to #38608 the `py-pip` version has to be restricted

https://github.com/astropy/astropy/tree/v5.1

https://github.com/scientific-python/pytest-doctestplus/tree/v0.13.0 
I am not sure why setuptools has to be a run dependency but it is listed in `install_requires`

https://github.com/astropy/pytest-astropy-header/tree/v0.2.2
https://github.com/astropy/pytest-astropy/tree/v0.10.0
https://github.com/astropy/pytest-filter-subpackage/tree/v0.1.2
https://github.com/astropy/pytest-remotedata/tree/v0.4.0

Also restrict `py-pip` version of `py-tomopy` here because it has a dependency on `py-astropy`