### PR TITLE
cmake: make most variants sticky

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -212,9 +212,7 @@ class Cmake(Package):
         "See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135",
     )
 
-    # Vendored dependencies do not build with nvhpc; it's also more
-    # transparent to patch Spack's versions of CMake's dependencies.
-    conflicts("+ownlibs %nvhpc")
+    requires("~ownlibs", when="%nvhpc", msg="vendored dependencies do not build with nvhpc")
 
     with when("~ownlibs"):
         depends_on("curl")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -184,11 +184,17 @@ class Cmake(Package):
     # build, and CMake is built frequently. Also, CMake is almost always
     # a build dependency, and its libs will not interfere with others in
     # the build.
-    variant("ownlibs", default=True, description="Use CMake-provided third-party libraries")
-    variant("qt", default=False, description="Enables the build of cmake-gui")
+    variant(
+        "ownlibs",
+        default=True,
+        sticky=True,
+        description="Use CMake-provided third-party libraries",
+    )
+    variant("qt", default=False, sticky=True, description="Enables the build of cmake-gui")
     variant(
         "doc",
         default=False,
+        sticky=True,
         description="Enables the generation of html and man page documentation",
     )
     variant(


### PR DESCRIPTION
closes #38644 

This means `clingo` can't flip them at will, and an explicit request from the user is needed.