### PR TITLE
py-minkowskiengine: add missing openblas dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -19,6 +19,9 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-pybind11", type="link")
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
+    depends_on("openblas")
 
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-torch", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
+++ b/var/spack/repos/builtin/packages/py-minkowskiengine/package.py
@@ -21,6 +21,8 @@ class PyMinkowskiengine(PythonPackage, CudaPackage):
     depends_on("py-pybind11", type="link")
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
+    # According to the documentation other BLAS should be possible too, but
+    # they didn't work, see https://github.com/spack/spack/pull/38742
     depends_on("openblas")
 
     depends_on("py-numpy", type=("build", "run"))


### PR DESCRIPTION
Installation failed with the error `fatal error: cblas.h: No such file or directory`, adding a missing openblas dependency fixed that for me.

In addition as discussed in #38608 the py-pip version has to be restricted to 23.0 for `--install-option` to work.