### PR TITLE
openfoam-org: add precision option(lp)

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -114,11 +114,17 @@ class OpenfoamOrg(Package):
     )
 
     variant("int64", default=False, description="Compile with 64-bit label")
-    variant("float32", default=False, description="Compile with 32-bit scalar (single-precision)")
     variant(
         "source", default=True, description="Install library/application sources and tutorials"
     )
     variant("metis", default=False, description="With metis decomposition")
+    variant(
+        "precision",
+        default="dp",
+        description="Precision option",
+        values=("sp", "dp", conditional("lp", when="@6:")),
+        multi=False,
+    )
 
     depends_on("mpi")
     depends_on("zlib")
@@ -426,6 +432,14 @@ class OpenfoamOrg(Package):
 
 class OpenfoamOrgArch(OpenfoamArch):
     """An openfoam-org variant of OpenfoamArch"""
+
+    def __init__(self, spec, **kwargs):
+        super().__init__(spec, **kwargs)
+        if "precision=lp" in spec:
+            self.precision_option = "LP"
+        elif "precision=sp" in spec:
+            self.precision_option = "SP"
+        self.update_options()
 
     def update_arch(self, spec):
         """Handle differences in WM_ARCH naming"""


### PR DESCRIPTION
From version 6 onwards, OpenFOAM-org introduced support for long double precision (lp). 
(https://github.com/OpenFOAM/OpenFOAM-dev/commit/d82cc36c5af97e799a82fadf455e06d192ae1e65)

This update has been implemented in the variant , and the previous 'float32' choice has been merged into the 'precision' variant.

This PR also ensures similar integration(https://github.com/spack/spack/pull/37736) in the related software, OpenFOAM, which is a similar pacakge.
