### PR TITLE
audit: ensure conflicts are on declared dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/memkind/package.py
+++ b/var/spack/repos/builtin/packages/memkind/package.py
@@ -40,7 +40,7 @@ class Memkind(AutotoolsPackage):
 
     # memkind includes a copy of jemalloc; see
     # <https://github.com/memkind/memkind#jemalloc>.
-    conflicts("jemalloc")
+    # conflicts("jemalloc")
 
     # https://github.com/spack/spack/issues/37292
     parallel = False

--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -95,8 +95,8 @@ class Palace(CMakePackage):
         depends_on("arpack-ng~shared", when="~shared")
 
     # Conflicts: Palace always builds its own internal MFEM, GSLIB
-    conflicts("^mfem", msg="Palace builds its own internal MFEM")
-    conflicts("^gslib", msg="Palace builds its own internal GSLIB")
+    # conflicts("^mfem", msg="Palace builds its own internal MFEM")
+    # conflicts("^gslib", msg="Palace builds its own internal GSLIB")
 
     # More dependency variant conflicts
     conflicts("^hypre+int64", msg="Palace uses HYPRE's mixedint option for 64 bit integers")

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -52,4 +52,4 @@ class PyNumba(PythonPackage):
 
     # Version 6.0.0 of llvm had a hidden symbol which breaks numba at runtime.
     # See https://reviews.llvm.org/D44140
-    conflicts("^llvm@6.0.0")
+    # conflicts("^llvm@6.0.0")

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -70,8 +70,8 @@ class Scotch(CMakePackage, MakefilePackage):
 
     # Vendored dependency of METIS/ParMETIS conflicts with standard
     # installations
-    conflicts("^metis", when="+metis")
-    conflicts("^parmetis", when="+metis")
+    # conflicts("^metis", when="+metis")
+    # conflicts("^parmetis", when="+metis")
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/votca/package.py
+++ b/var/spack/repos/builtin/packages/votca/package.py
@@ -28,9 +28,9 @@ class Votca(CMakePackage):
         "new-gmx", default=False, description="Build against gromacs>2019 - no tabulated kernels"
     )
     variant("xtp", default=True, description="Build xtp parts of votca")
-    conflicts("votca-tools")
-    conflicts("votca-csg")
-    conflicts("votca-xtp")
+    # conflicts("votca-tools")
+    # conflicts("votca-csg")
+    # conflicts("votca-xtp")
 
     depends_on("cmake@3.13:", type="build")
     depends_on("expat")


### PR DESCRIPTION
At the moment, we don't impose restrictions on which spec can appear in `conflicts` directives - which means in principle a package can declare conflicts with any other unrelated package. 

As part of the performance analysis in #38447 it turned out though that we could speed-up grounding and solving if we assume that a package could query or impose conditions only to its possible direct dependencies. This assumption  currently holds for the vast majority of packages.

Here we add an audit to verify that the property continues to hold. Failed audits would result in errors similar to:
![Screenshot from 2023-07-06 11-31-59](https://github.com/spack/spack/assets/4199709/f6ec1d00-2641-411d-97c1-83c2f2cb1208)

We also fix a few packages that have been marked by the new audit:
- https://github.com/spack/spack/pull/38748/commits/a2c9eda6996daeadd1318e186b34695051885b45 removes a conflict condition from a base package (`ROCmPackage`), and moves it to the 6 packages that really need it
- https://github.com/spack/spack/pull/38748/commits/448e73e5571bba6d9e592259f483e309bffbbfcc fixes a few conflicts missing a `^` before a dependency
- 4d3be79f434e47b85553c5a2a316586da883186f fixes other bugs related to wrong package names in conflicts

The only legitimate use case so far is represented by the packages in https://github.com/spack/spack/pull/38748/commits/837adf7b10c99b2fd065a03585e0199f7d0dc7ce, where the `conflicts` directive is abused to express that a package `vendors` another. I think that use case should be solved by adding a `vendors` directive.