### PR TITLE
disable fortran in openblas for darwin ci, fix variant default value

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -20,6 +20,8 @@ spack:
       variants: +mps~cuda~rocm
     mpi:
       require: openmpi
+    openblas:
+      require: ~fortran
 
   specs:
   # Hugging Face

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -53,7 +53,7 @@ class Openblas(MakefilePackage):
 
     variant(
         "fortran",
-        default="True",
+        default=True,
         when="@0.3.21:",
         description="w/o a Fortran compiler, OpenBLAS will build an f2c-converted LAPACK",
     )


### PR DESCRIPTION
In CI there are no Fortran compilers.