### PR TITLE
Remove "node_compiler" from the list of unknown atoms

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2391,6 +2391,7 @@ class SpecBuilder:
                 r"^.*_propagate$",
                 r"^.*_satisfies$",
                 r"^.*_set$",
+                r"^node_compiler$",
                 r"^package_hash$",
                 r"^root$",
                 r"^virtual_node$",


### PR DESCRIPTION
Currently, if we run in `debug` mode, we get spurious output:
```console
$ spack -d spec zlib
==> [2023-07-06-14:38:49.224351] Imported spec from built-in commands
==> [2023-07-06-14:38:49.224983] Imported spec from built-in commands
[ ... ]
==> [2023-07-06-14:38:51.367106] Reading config from file /home/culpo/.spack/linux/compilers.yaml
==> [2023-07-06-14:38:51.487494] UNKNOWN SYMBOL: attr("node_compiler", zlib, gcc)
[ ... ]
```
This PR removes the spurious `UNKOWN SYMBOL` line.