### PR TITLE
Static-analysis-suite: mark versions deprecate for this obsolete package

### DIFF
--- a/var/spack/repos/builtin/packages/static-analysis-suite/package.py
+++ b/var/spack/repos/builtin/packages/static-analysis-suite/package.py
@@ -13,9 +13,21 @@ class StaticAnalysisSuite(CMakePackage):
     homepage = "https://github.com/dpiparo/SAS"
     url = "https://github.com/dpiparo/SAS/archive/0.1.3.tar.gz"
 
-    version("0.2.0", sha256="a369e56f8edc61dbf59ae09dbb11d98bc05fd337c5e47e13af9c913bf7bfc538")
-    version("0.1.4", sha256="9b2a3436efe3c8060ee4882f3ed37d848ee79a63d6055a71a23fad6409559f40")
-    version("0.1.3", sha256="93c3194bb7d518c215e79436bfb43304683832b3cc66bfc838f6195ce4574943")
+    version(
+        "0.2.0",
+        sha256="a369e56f8edc61dbf59ae09dbb11d98bc05fd337c5e47e13af9c913bf7bfc538",
+        deprecated=True,
+    )
+    version(
+        "0.1.4",
+        sha256="9b2a3436efe3c8060ee4882f3ed37d848ee79a63d6055a71a23fad6409559f40",
+        deprecated=True,
+    )
+    version(
+        "0.1.3",
+        sha256="93c3194bb7d518c215e79436bfb43304683832b3cc66bfc838f6195ce4574943",
+        deprecated=True,
+    )
 
     depends_on("python@2.7:")
     depends_on("llvm@3.5:")


### PR DESCRIPTION
This package was developed long time ago in the SFT group at CERN, but since then has been completely obsoleted by new compiler features. Also the source code is no longer available at the given URL. (@dpiparo can confirm)
Thus following the policy laid out in https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions we would like the package to be removed from spack. Either by first deprecating all versions, and remove the package in the next version, or if we can directly remove it?