### PR TITLE
CMake Package: allow for ~ownlibs

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -19,7 +19,7 @@ class Cmake(Package):
     homepage = "https://www.cmake.org"
     url = "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.tar.gz"
     git = "https://gitlab.kitware.com/cmake/cmake.git"
-    maintainers("chuckatkins")
+    maintainers("chuckatkins", "johnwparent")
 
     tags = ["build-tools", "windows"]
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -215,12 +215,14 @@ class Cmake(Package):
         depends_on("expat")
         depends_on("zlib")
         # expat/zlib are used in CMake/CTest, so why not require them in libarchive.
-        depends_on("libarchive@3.1.0: xar=expat compression=zlib")
-        depends_on("libarchive@3.3.3:", when="@3.15.0:")
-        depends_on("libuv@1.0.0:1.10", when="@3.7.0:3.10.3")
-        depends_on("libuv@1.10.0:1.10", when="@3.11.0:3.11")
-        depends_on("libuv@1.10.0:", when="@3.12.0:")
-        depends_on("rhash", when="@3.8.0:")
+        for plat in ["darwin", "cray", "linux"]:
+            with when("platform=%s" % plat):
+                depends_on("libarchive@3.1.0: xar=expat compression=zlib")
+                depends_on("libarchive@3.3.3:", when="@3.15.0:")
+                depends_on("libuv@1.0.0:1.10", when="@3.7.0:3.10.3")
+                depends_on("libuv@1.10.0:1.10", when="@3.11.0:3.11")
+                depends_on("libuv@1.10.0:", when="@3.12.0:")
+                depends_on("rhash", when="@3.8.0:")
 
     for plat in ["darwin", "linux", "cray"]:
         with when("+ownlibs platform=%s" % plat):
@@ -234,9 +236,6 @@ class Cmake(Package):
         depends_on("python@2.7.11:", type="build")
         depends_on("py-sphinx", type="build")
 
-    # TODO: update curl package to build with Windows SSL implementation
-    # at which point we can build with +ownlibs on Windows
-    conflicts("~ownlibs", when="platform=windows")
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
     patch("intel-c-gnu11.patch", when="@3.6.0:3.6.1")

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -286,9 +286,6 @@ class Curl(NMakePackage, AutotoolsPackage):
     depends_on("libssh", when="+libssh")
     depends_on("krb5", when="+gssapi")
 
-    # curl queries pkgconfig for openssl compilation flags
-    depends_on("pkgconfig", type="build")
-
     # https://github.com/curl/curl/pull/9054
     patch("easy-lock-sched-header.patch", when="@7.84.0")
 
@@ -446,7 +443,7 @@ class NMakeBuilder(NMakeBuilder):
         args.append("WITH_PREFIX=%s" % self.prefix + "\\")
         return args
 
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         # Spack's env CC and CXX values will cause an error
         # if there is a path in the space, and escaping with
         # double quotes raises a syntax issues, instead


### PR DESCRIPTION
Curl support for Windows was introduced in #30169, with that CMake can build without vendored deps on Windows
This PR makes changes to the non-Windows ownlib deps to conflict on the Windows platform and fixes the Curl package, which somehow has had changes introduced that prevent function on Windows.