### PR TITLE
ci: limit parallel downloads

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -562,7 +562,7 @@ def ci_rebuild(args):
             "SPACK={}".format(args_to_string(spack_cmd)),
             "SPACK_COLOR=always",
             "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
-            "-j$(nproc)",
+            "-j2",
             "install-deps/{}".format(job_spec.format("{name}-{version}-{hash}")),
         ],
         spack_cmd + ["install"] + root_install_args,

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -503,7 +503,7 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose"]
+    spack_cmd = [SPACK_COMMAND, "-p", "--color=always", "--backtrace", "--verbose"]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:


### PR DESCRIPTION
Install at most two packages from cache in parallel, to reduce the filesystem
stress on power ci, which is potentially the reason it's ultra slow and causing
lock issues:

```
  File "/builds/spack/spack/lib/spack/llnl/util/lock.py", line 344, in _lock
    raise LockTimeoutError(op_str.lower(), self.path, total_wait_time, num_attempts)
llnl.util.lock.LockTimeoutError: Timed out waiting for a write lock after 120.388s.
    Made 280 attempts on file: /root/.spack/cache/providers/.builtin-index.j
son.lock
```
