### PR TITLE
librsvg: add 2.56.2 and rust upper version limit for 2.51

### DIFF
--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -22,15 +22,27 @@ class Librsvg(AutotoolsPackage):
 
     depends_on("gobject-introspection", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("rust", type="build", when="@2.41:")
+    # rust minimal version from NEWS file and upper bound because "Unaligned
+    # references to packed fields are a hard error" starting from 1.69
+    depends_on("rust@1.40:1.68", when="@2.50:", type="build")
+    depends_on("rust", when="@2.41:", type="build")
     depends_on("gtk-doc", type="build", when="+doc")
-    depends_on("cairo+gobject")
-    depends_on("gdk-pixbuf")
-    depends_on("glib")
-    depends_on("libcroco")
-    depends_on("pango")
+
+    # requirements according to `configure` file
+    depends_on("cairo@1.16:+gobject", when="@2.50:")
+    depends_on("cairo@1.15.12:+gobject", when="@2.44.14:")
+    depends_on("cairo@1.2.0:+gobject")
+    depends_on("libcroco@0.6.1:", when="@:2.44.14")
+    depends_on("gdk-pixbuf@2.20:")
+    depends_on("glib@2.50:", when="@2.50:")
+    depends_on("glib@2.48:", when="@2.44.14:")
+    depends_on("glib@2.12:")
+    depends_on("harfbuzz@2:", when="@2.50:")
+    depends_on("libxml2@2.9:")
+    depends_on("pango@1.46:", when="@2.51:")
+    depends_on("pango@1.38:")
+
     depends_on("libffi")
-    depends_on("libxml2")
     depends_on("shared-mime-info")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -12,6 +12,7 @@ class Librsvg(AutotoolsPackage):
     homepage = "https://wiki.gnome.org/Projects/LibRsvg"
     url = "https://download.gnome.org/sources/librsvg/2.44/librsvg-2.44.14.tar.xz"
 
+    version("2.56.2", sha256="3ec3c4d8f73e0ba4b9130026969e8371c092b734298d36e2fdb3eb4afcec1200")
     version("2.51.0", sha256="89d32e38445025e1b1d9af3dd9d3aeb9f6fce527aeecbecf38b369b34c80c038")
     version("2.50.2", sha256="6211f271ce4cd44a7318190d36712e9cea384a933d3e3570004edeb210a056d3")
     version("2.50.0", sha256="b3fadba240f09b9c9898ab20cb7311467243e607cf8f928b7c5f842474ee3df4")
@@ -22,9 +23,11 @@ class Librsvg(AutotoolsPackage):
 
     depends_on("gobject-introspection", type="build")
     depends_on("pkgconfig", type="build")
-    # rust minimal version from NEWS file and upper bound because "Unaligned
-    # references to packed fields are a hard error" starting from 1.69
-    depends_on("rust@1.40:1.68", when="@2.50:", type="build")
+    # rust minimal version from NEWS file
+    depends_on("rust@1.65:", when="@2.56.1:", type="build")
+    # upper bound because "Unaligned references to packed fields are a hard
+    # error" starting from 1.69
+    depends_on("rust@1.40:1.68", when="@2.50:2.51", type="build")
     depends_on("rust", when="@2.41:", type="build")
     depends_on("gtk-doc", type="build", when="+doc")
 


### PR DESCRIPTION
`librsvg` did not build anymore with the error:
```
error[E0793]: reference to packed field is unaligned
   --> $spack-stage/spack-stage-librsvg-2.51.0-dh25kyl2eni3gzdhzxlm6lkoioz2u6g6/spack-src/vendor/tendril/src/tendril.rs:241:20
    |
241 |                 if (*header).refcount.decrement() == 1 {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)

error[E0793]: reference to packed field is unaligned
   --> $spack-stage/spack-stage-librsvg-2.51.0-dh25kyl2eni3gzdhzxlm6lkoioz2u6g6/spack-src/vendor/tendril/src/tendril.rs:958:9
    |
958 |         (*self.header()).refcount.increment();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
```

The reason for this error was this change in  `rust@1.69:`: "Unaligned references to packed fields are now a hard error" (see [Release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-1)). So limiting rust to `@:1.68` fixed it.

While I was at it, I also added the minimal version requirements for the dependencies according to the configure file.