### PR TITLE
mypy: add more ignored modules to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,23 @@ ignore_missing_imports = true
   # arguments, which don't work in 3.7, which causes mypy to bail out early if you have
   # numpy installed.
   [[tool.mypy.overrides]]
-  module = 'numpy'
+  module = [
+      'IPython',
+      'altgraph',
+      'attr',
+      'boto3',
+      'botocore',
+      'distro',
+      'jinja2',
+      'jsonschema',
+      'macholib',
+      'markupsafe',
+      'numpy',
+      'pyristent',
+      'pytest',
+      'ruamel.yaml',
+      'six',
+  ]
   follow_imports = 'skip'
   follow_imports_for_stubs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,11 @@ ignore_missing_imports = true
   ignore_errors = true
   ignore_missing_imports = true
 
-  # pytest (which we depend on) optionally imports numpy, which requires Python 3.8 in
-  # recent versions. mypy still imports its .pyi file, which has positional-only
-  # arguments, which don't work in 3.7, which causes mypy to bail out early if you have
-  # numpy installed.
+  # Spack imports a number of external packages, and they *may* require Python 3.8 or
+  # higher in recent versions. This can cause mypy to fail because we check for 3.7
+  # compatibility. We could restrict mypy to run for the oldest supported version (3.7),
+  # but that means most developers won't be able to run mypy, which means it'll fail
+  # more in CI. Instead, we exclude these imported packages from mypy checking.
   [[tool.mypy.overrides]]
   module = [
       'IPython',


### PR DESCRIPTION
Fixes #38704.

`mypy` will check *all* imported packages, even optional dependencies outside your project, and this can cause issues if you are targeting python versions *older* than the one you're running in. `mypy` will report issues in the latest versions of dependencies as errors even if installing on some older python would have installed an older version of the dependency.

We saw this problem before with `numpy` in #34732. We've started seeing it with IPython in #38704. This fixes the issue by exempting `IPython` and a number of other imports of Spack's from `mypy` checking.