### PR TITLE
Fix multiple quadratic complexity issues in environments

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1956,7 +1956,7 @@ class Environment:
         return [root for _, root in self.concretized_specs()]
 
     def get_by_hash(self, dag_hash: str) -> List[Spec]:
-        # If it's not a prefix we can early exit
+        # If it's not a partial hash prefix we can early exit
         early_exit = len(dag_hash) == 32
         matches = []
         for spec in traverse.traverse_nodes(

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1978,10 +1978,14 @@ class Environment:
 
     def all_matching_specs(self, *specs: spack.spec.Spec) -> List[Spec]:
         """Returns all concretized specs in the environment satisfying any of the input specs"""
+        # Look up abstract hashes ahead of time, to avoid O(n^2) traversal.
+        specs = [s.lookup_hash() for s in specs]
+
+        # Avoid double lookup by directly calling _satisfies.
         return [
             s
             for s in traverse.traverse_nodes(self.concrete_roots(), key=traverse.by_dag_hash)
-            if any(s.satisfies(t) for t in specs)
+            if any(s._satisfies(t) for t in specs)
         ]
 
     @spack.repo.autospec

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -396,17 +396,16 @@ def test_dev_build_rebuild_on_source_changes(
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                """\
+                f"""\
 spack:
   specs:
-  - %s@0.0.0
+  - {test_spec}@0.0.0
 
   develop:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
-      path: %s
+      path: {build_dir}
 """
-                % (test_spec, build_dir)
             )
 
         env("create", "test", "./spack.yaml")

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -554,3 +554,8 @@ def traverse_tree(specs, cover="nodes", deptype="all", key=id, depth_first=True)
         return traverse_breadth_first_tree_nodes(None, edges)
 
     return traverse_edges(specs, order="pre", cover=cover, deptype=deptype, key=key, depth=True)
+
+
+def by_dag_hash(s: "spack.spec.Spec") -> str:
+    """Used very often as a key function for traversals."""
+    return s.dag_hash()


### PR DESCRIPTION
This fixes two performance regressions discovered in #38762 where every
`spack install` task would spend about 5 seconds installing a package, but
two minutes starting... And since we rely on process parallelism for parallel
fetching of binaries, this would result in multiple dozens of minutes of installation
time for very trivial packages :(

For example, https://gitlab.spack.io/spack/spack/-/jobs/7594245 took almost
an hour to install a package in 1m 8.49s. The profile data shows one spack
process to install a dependency  (5s) took in total 843.703 seconds (?!) spending
559.736 seconds in traversal :man_facepalming: 

1. #35042 introduced a regression where looking up specs by abstract hash in an
   environment caused nested iteration of the entire environment in
   `x.satisfies(y) for x in env`
2. #27167 also caused nested iteration (collect all specs in an environment,
   and traverse each to find a child with `dev_path`)

Fixes are respectively:

1. Do standard "lookup" ahead of time (which causes full env traversal), and
   then run satisfies(...) on each env spec. This is still inefficient but at
   least it's O(2n) instead of O(n^2).
2. For dev specs: just find them once in O(n) and then loop over the installed
   parents in O(n), so this is also O(2n).

Extra small optmization I've added is to early exit when finding specs by full
hash in an env, cause then we know there's only one unique spec anyways. Prefix
search still collects all.

