### PR TITLE
Fix Tiled-MM package

### DIFF
--- a/var/spack/repos/builtin/packages/tiled-mm/package.py
+++ b/var/spack/repos/builtin/packages/tiled-mm/package.py
@@ -10,10 +10,11 @@ class TiledMm(CMakePackage, CudaPackage, ROCmPackage):
     """Matrix multiplication on GPUs for matrices stored on a CPU. Similar to cublasXt,
     but ported to both NVIDIA and AMD GPUs."""
 
-    maintainers = ["mtaillefumier", "simonpintarelli"]
     homepage = "https://github.com/eth-cscs/Tiled-MM/"
     url = "https://github.com/eth-cscs/Tiled-MM/archive/refs/tags/v2.0.tar.gz"
     git = "https://github.com/eth-cscs/Tiled-MM.git"
+
+    maintainers("mtaillefumier", "simonpintarelli", "RMeli")
 
     version("master", branch="master")
     version("2.2", sha256="6d0b49c9588ece744166822fd44a7bc5bec3dc666b836de8bf4bf1a7bb675aac")
@@ -33,8 +34,8 @@ class TiledMm(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("TIELDMM_WITH_EXAMPLES", "examples"),
-            self.define_from_variant("TIELDMM_WITH_TESTS", "tests"),
+            self.define_from_variant("TILEDMM_WITH_EXAMPLES", "examples"),
+            self.define_from_variant("TILEDMM_WITH_TESTS", "tests"),
         ]
 
         if "+rocm" in self.spec:


### PR DESCRIPTION
Fix typos in CMake variables, causing the following error:

```
1 error found in build log:
     13    -- Looking for pthread_create in pthreads
     14    -- Looking for pthread_create in pthreads - not found
     15    -- Looking for pthread_create in pthread
     16    -- Looking for pthread_create in pthread - found
     17    -- Found Threads: TRUE
     18    TILEDMM_EXTERNAL_LIBRARIES
  >> 19    CMake Error at CMakeLists.txt:89 (find_package):
     20      By not providing "Findcxxopts.cmake" in CMAKE_MODULE_PATH this project has
     21      asked CMake to find a package configuration file provided by "cxxopts", but
     22      CMake did not find one.
     23    
     24      Could not find a package configuration file provided by "cxxopts" with any
     25      of the following names:
```