### PR TITLE
py-pyarrow: disable dataset variant by default

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -26,7 +26,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
     version("0.11.0", sha256="07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead")
     version("0.9.0", sha256="7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242")
 
-    variant("parquet", default=True, description="Build with Parquet support")
+    variant("parquet", default=False, description="Build with Parquet support")
     variant("orc", default=False, description="Build with orc support")
     variant("dataset", default=True, description="Build with Dataset support")
 

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -30,6 +30,8 @@ class PyPyarrow(PythonPackage, CudaPackage):
     variant("orc", default=False, description="Build with orc support")
     variant("dataset", default=True, description="Build with Dataset support")
 
+    conflicts("~parquet", when="+dataset")
+
     depends_on("cmake@3.0.0:", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("python@3.5:", type=("build", "run"), when="@0.17:")

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -14,6 +14,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
 
     homepage = "https://arrow.apache.org"
     pypi = "pyarrow/pyarrow-0.17.1.tar.gz"
+    git = "https://github.com/apache/arrow"
 
     version("10.0.1", sha256="1a14f57a5f472ce8234f2964cd5184cccaa8df7e04568c64edc33b23eb285dd5")
     version("8.0.0", sha256="4a18a211ed888f1ac0b0ebcb99e2d9a3e913a481120ee9b1fe33d3fedb945d4e")
@@ -28,7 +29,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
 
     variant("parquet", default=False, description="Build with Parquet support")
     variant("orc", default=False, description="Build with orc support")
-    variant("dataset", default=True, description="Build with Dataset support")
+    variant("dataset", default=False, description="Build with Dataset support")
 
     conflicts("~parquet", when="+dataset")
 

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -26,7 +26,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
     version("0.11.0", sha256="07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead")
     version("0.9.0", sha256="7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242")
 
-    variant("parquet", default=False, description="Build with Parquet support")
+    variant("parquet", default=True, description="Build with Parquet support")
     variant("orc", default=False, description="Build with orc support")
     variant("dataset", default=True, description="Build with Dataset support")
 


### PR DESCRIPTION
`py-pyarrow@10.0.1` fails to build with

```
  CMake Error at $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/cmake-3.26.3-6yimixzo6nsao5w4jwvgdgrfyxlaiwqa/share/cmake-3.26/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
    By not providing "FindParquet.cmake" in CMAKE_MODULE_PATH this project has
    asked CMake to find a package configuration file provided by "Parquet", but
    CMake did not find one.

    Could not find a package configuration file provided by "Parquet" with any
    of the following names:

      ParquetConfig.cmake
      parquet-config.cmake

    Add the installation prefix of "Parquet" to CMAKE_PREFIX_PATH or set
    "Parquet_DIR" to a directory containing one of the above files.  If
    "Parquet" provides a separate development package or SDK, be sure it has
    been installed.
  Call Stack (most recent call first):
    $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/arrow-10.0.1-dumla4czul3anpgjtw4427ztpwkyum6x/lib64/cmake/ArrowDataset/ArrowDatasetConfig.cmake:55 (find_dependency)
    CMakeLists.txt:121 (find_package)
```

Also `py-pyarrow@8` fails with

```
  -- Could NOT find ArrowDataset (missing: ArrowDataset_DIR)
  -- Checking for module 'arrow-dataset'
  --   Package 'parquet', required by 'arrow-dataset', not found
  CMake Error at $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/cmake-3.26.3-6yimixzo6nsao5w4jwvgdgrfyxlaiwqa/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find ArrowDataset (missing: ARROW_DATASET_INCLUDE_DIR
    ARROW_DATASET_LIB_DIR) (found version "8.0.0")
  Call Stack (most recent call first):
    $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/cmake-3.26.3-6yimixzo6nsao5w4jwvgdgrfyxlaiwqa/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
    cmake_modules/FindArrowDataset.cmake:76 (find_package_handle_standard_args)
    CMakeLists.txt:435 (find_package)
```

but both install fine with `+parquet` enabled.