### PR TITLE
Sundials: Port to support Windows

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/SundialsAddLibrary_no_dup_targets.patch
+++ b/var/spack/repos/builtin/packages/sundials/SundialsAddLibrary_no_dup_targets.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/macros/SundialsAddLibrary.cmake b/cmake/macros/SundialsAddLibrary.cmake
+index 5d734ce..e186b14 100644
+--- a/cmake/macros/SundialsAddLibrary.cmake
++++ b/cmake/macros/SundialsAddLibrary.cmake
+@@ -311,15 +311,21 @@ macro(sundials_add_library target)
+ 
+       # set the correct output name
+       if(sundials_add_library_OUTPUT_NAME)
+-        set_target_properties(${_actual_target_name} PROPERTIES
+-          OUTPUT_NAME ${sundials_add_library_OUTPUT_NAME}
+-          CLEAN_DIRECT_OUTPUT 1
+-        )
++        set(tgt_output_name ${sundials_add_library_OUTPUT_NAME})
+       else()
+-        set_target_properties(${_actual_target_name} PROPERTIES
+-          OUTPUT_NAME ${target}
+-          CLEAN_DIRECT_OUTPUT 1
+-        )
++        set(tgt_output_name ${target})
++      endif()
++
++      if(${_libtype} MATCHES "STATIC")
++          set_target_properties(${_actual_target_name} PROPERTIES
++            OUTPUT_NAME ${tgt_output_name}${_STATIC_LIB_SUFFIX}
++            CLEAN_DIRECT_OUTPUT 1
++          )
++      else()
++          set_target_properties(${_actual_target_name} PROPERTIES
++            OUTPUT_NAME ${tgt_output_name}
++            CLEAN_DIRECT_OUTPUT 1
++          )
+       endif()
+ 
+       # set the library versions

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -289,6 +289,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     patch("remove-links-to-OpenMP-vector.patch", when="@5.5.0:5.7.0")
     # fix issues with exported PETSc target(s) in SUNDIALSConfig.cmake
     patch("sundials-v5.8.0.patch", when="@5.8.0")
+    patch("SundialsAddLibrary_no_dup_targets.patch", when="platform=windows")
 
     # ==========================================================================
     # SUNDIALS Settings

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -289,8 +289,10 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     patch("remove-links-to-OpenMP-vector.patch", when="@5.5.0:5.7.0")
     # fix issues with exported PETSc target(s) in SUNDIALSConfig.cmake
     patch("sundials-v5.8.0.patch", when="@5.8.0")
+    # Fix static and import lib naming clash with ninja generator and MSVC
     patch("SundialsAddLibrary_no_dup_targets.patch", when="platform=windows")
-
+    # Fix lack of link to MPI with MPI dependent targets with MSVC
+    patch("sundials-link-mpi-when-enabled.patch", when="platform=windows")
     # ==========================================================================
     # SUNDIALS Settings
     # ==========================================================================

--- a/var/spack/repos/builtin/packages/sundials/sundials-link-mpi-when-enabled.patch
+++ b/var/spack/repos/builtin/packages/sundials/sundials-link-mpi-when-enabled.patch
@@ -6,7 +6,7 @@ index 96c18b94c..9c2f2a867 100644
        ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_mpimanyvector.h
      INCLUDE_SUBDIR
        nvector
-+    LINK_LIBRARIES MPI::MPI_C
++    LINK_LIBRARIES PUBLIC MPI::MPI_C
      OBJECT_LIBRARIES
        sundials_generic_obj
      COMPILE_DEFINITIONS
@@ -18,7 +18,7 @@ index b6ca27136..b36f525d8 100644
      ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_mpiplusx.h
    INCLUDE_SUBDIR
      nvector
-+  LINK_LIBRARIES MPI::MPI_C
++  LINK_LIBRARIES PUBLIC MPI::MPI_C
    OBJECT_LIBRARIES
      sundials_generic_obj
      sundials_nvecmpimanyvector_obj
@@ -30,7 +30,7 @@ index d5d2e28a5..a1f05db62 100644
      ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_parallel.h
    INCLUDE_SUBDIR
      nvector
-+  LINK_LIBRARIES MPI::MPI_C
++  LINK_LIBRARIES PUBLIC MPI::MPI_C
    OBJECT_LIBRARIES
      sundials_generic_obj
    OUTPUT_NAME

--- a/var/spack/repos/builtin/packages/sundials/sundials-link-mpi-when-enabled.patch
+++ b/var/spack/repos/builtin/packages/sundials/sundials-link-mpi-when-enabled.patch
@@ -1,0 +1,36 @@
+diff --git a/src/nvector/manyvector/CMakeLists.txt b/src/nvector/manyvector/CMakeLists.txt
+index 96c18b94c..9c2f2a867 100644
+--- a/src/nvector/manyvector/CMakeLists.txt
++++ b/src/nvector/manyvector/CMakeLists.txt
+@@ -59,6 +59,7 @@ if(BUILD_NVECTOR_MPIMANYVECTOR)
+       ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_mpimanyvector.h
+     INCLUDE_SUBDIR
+       nvector
++    LINK_LIBRARIES MPI::MPI_C
+     OBJECT_LIBRARIES
+       sundials_generic_obj
+     COMPILE_DEFINITIONS
+diff --git a/src/nvector/mpiplusx/CMakeLists.txt b/src/nvector/mpiplusx/CMakeLists.txt
+index b6ca27136..b36f525d8 100644
+--- a/src/nvector/mpiplusx/CMakeLists.txt
++++ b/src/nvector/mpiplusx/CMakeLists.txt
+@@ -32,6 +32,7 @@ sundials_add_library(sundials_nvecmpiplusx
+     ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_mpiplusx.h
+   INCLUDE_SUBDIR
+     nvector
++  LINK_LIBRARIES MPI::MPI_C
+   OBJECT_LIBRARIES
+     sundials_generic_obj
+     sundials_nvecmpimanyvector_obj
+diff --git a/src/nvector/parallel/CMakeLists.txt b/src/nvector/parallel/CMakeLists.txt
+index d5d2e28a5..a1f05db62 100644
+--- a/src/nvector/parallel/CMakeLists.txt
++++ b/src/nvector/parallel/CMakeLists.txt
+@@ -32,6 +32,7 @@ sundials_add_library(sundials_nvecparallel
+     ${SUNDIALS_SOURCE_DIR}/include/nvector/nvector_parallel.h
+   INCLUDE_SUBDIR
+     nvector
++  LINK_LIBRARIES MPI::MPI_C
+   OBJECT_LIBRARIES
+     sundials_generic_obj
+   OUTPUT_NAME


### PR DESCRIPTION
This PR vendors support for building the Sundials package with MSVC and Ninja on the Windows platform. 
Two patches have been added to the CMake system, one that prevents the duplication of Ninja outputs due to name collision between static and shared libraries, and another that explicitly links targets to MPI that reference MPI symbols.

Changes will be upstreamed to the Sundials repo in the near future.