### PR TITLE
ci: Fix broken SPACK_CHECKOUT_VERSION

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1257,20 +1257,11 @@ def generate_gitlab_ci_yaml(
 
         output_object["stages"] = stage_names
 
-        # Capture the version of spack used to generate the pipeline, transform it
-        # into a value that can be passed to "git checkout", and save it in a
-        # global yaml variable
+        # Capture the version of Spack used to generate the pipeline, that can be
+        # passed to `git checkout` for version consistency. If we aren't in a Git
+        # repository, presume we are a Spack release and use the Git tag instead.
         spack_version = spack.main.get_version()
-        version_to_clone = None
-        v_match = re.match(r"^\d+\.\d+\.\d+$", spack_version)
-        if v_match:
-            version_to_clone = "v{0}".format(v_match.group(0))
-        else:
-            v_match = re.match(r"^[^-]+-[^-]+-([a-f\d]+)$", spack_version)
-            if v_match:
-                version_to_clone = v_match.group(1)
-            else:
-                version_to_clone = spack_version
+        version_to_clone = spack.main.get_spack_commit() or f"v{spack.spack_version}"
 
         output_object["variables"] = {
             "SPACK_ARTIFACTS_ROOT": rel_artifacts_root,


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/31952
Quick flip of https://github.com/spack/spack/pull/31963

The generated `.gitlab-ci.yml` contains a variable `SPACK_CHECKOUT_VERSION` that generated child jobs should be able to use to checkout the version of Spack that generated the pipeline. Now that `spack.main.get_spack_commit` exists, use that to get the commit SHA for the variable, falling back to the Git release tag (`v{spack.spack_version}`) if that fails for any reason.

/cc @scottwittenburg 