### PR TITLE
sombrero: More verbose make rules and use correct C/C++/MPI compilers

### DIFF
--- a/var/spack/repos/builtin/packages/sombrero/package.py
+++ b/var/spack/repos/builtin/packages/sombrero/package.py
@@ -43,6 +43,18 @@ class Sombrero(MakefilePackage):
         sombrero_sh = FileFilter(join_path(self.stage.source_path, "sombrero.sh"))
         sombrero_dir = join_path(prefix.bin, "sombrero")
         sombrero_sh.filter("sombrero/", "{0}/".format(sombrero_dir))
+        # Sombrero makefile forces silent rules (`-s`), but we want them to be
+        # verbose, for easier debugging when something fails.
+        makerules = FileFilter(join_path(self.stage.source_path, "Make", "MkRules"))
+        makerules.filter("-s", "")
+
+    def build(self, spec, prefix):
+        # Pass to make the actual C/C++/MPI compilers.
+        make(
+            "GCC={0}".format(self.compiler.cc),
+            "CXX={0}".format(self.compiler.cxx),
+            "MPICC={0}".format(self.spec["mpi"].mpicc),
+        )
 
     def install(self, spec, prefix):
         sombrero_dir = join_path(prefix.bin, "sombrero")


### PR DESCRIPTION
For reference, the problem is that sombrero forces `gcc`/`g++`/`mpicc` as compilers: https://github.com/sa2c/sombrero/blob/8bbe464ebd61d0c548e86b383e0796e79dc683c1/Make/MkRules#L77-L78, and https://github.com/sa2c/sombrero/blob/8bbe464ebd61d0c548e86b383e0796e79dc683c1/Make/MkFlags.x86-64#L4 