### PR TITLE
Lua: Port Windows support

### DIFF
--- a/var/spack/repos/builtin/packages/lua/lua_cmake.patch
+++ b/var/spack/repos/builtin/packages/lua/lua_cmake.patch
@@ -1,0 +1,141 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..4e39ba4
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,41 @@
++cmake_minimum_required(VERSION 3.12)
++
++project(Lua C)
++set(Lua_VERSION_MAJOR 5)
++set(Lua_VERSION_MINOR 4)
++set(Lua_VERSION_PATCH 6)
++
++option(BUILD_SHARED_LIBS "If true, CMake will build and install a shared library" ON)
++
++add_subdirectory(src)
++
++# Intallation
++
++# Install man pages
++install(FILES doc/lua.1 doc/luac.1 DESTINATION man)
++
++# Export installation
++install(EXPORT LuaTargets
++    FILE LuaTargets.cmake
++    DESTINATION lib/cmake/Lua
++)
++include(CMakePackageConfigHelpers)
++configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/LuaConfig.cmake.in
++  "${CMAKE_CURRENT_BINARY_DIR}/LuaConfig.cmake"
++  INSTALL_DESTINATION "lib/cmake/Lua"
++  NO_SET_AND_CHECK_MACRO
++  NO_CHECK_REQUIRED_COMPONENTS_MACRO
++)
++write_basic_package_version_file(
++  "${CMAKE_CURRENT_BINARY_DIR}/LuaConfigVersion.cmake"
++  VERSION "${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}.${Lua_VERSION_PATCH}"
++  COMPATIBILITY AnyNewerVersion
++)
++install(FILES
++  ${CMAKE_CURRENT_BINARY_DIR}/LuaConfig.cmake
++  ${CMAKE_CURRENT_BINARY_DIR}/LuaConfigVersion.cmake
++  DESTINATION lib/cmake/Lua
++)
++export(EXPORT LuaTargets
++  FILE "${CMAKE_CURRENT_BINARY_DIR}/LuaTargets.cmake"
++)
+diff --git a/cmake/LuaConfig.cmake.in b/cmake/LuaConfig.cmake.in
+new file mode 100644
+index 0000000..dfd53b7
+--- /dev/null
++++ b/cmake/LuaConfig.cmake.in
+@@ -0,0 +1,3 @@
++@PACKAGE_INIT@
++
++include ( "${CMAKE_CURRENT_LIST_DIR}/LuaTargets.cmake" )
+\ No newline at end of file
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+new file mode 100644
+index 0000000..6cba945
+--- /dev/null
++++ b/src/CMakeLists.txt
+@@ -0,0 +1,78 @@
++set(LUA_LIB_SOURCES lapi.c
++                    lcode.c
++                    lctype.c
++                    ldebug.c
++                    ldo.c
++                    ldump.c
++                    lfunc.c
++                    lgc.c
++                    llex.c
++                    lmem.c
++                    lobject.c
++                    lopcodes.c
++                    lparser.c
++                    lstate.c
++                    lstring.c
++                    ltable.c
++                    ltm.c
++                    lundump.c
++                    lvm.c
++                    lzio.c
++                    lauxlib.c
++                    lbaselib.c
++                    lcorolib.c
++                    ldblib.c
++                    liolib.c
++                    lmathlib.c
++                    loadlib.c
++                    loslib.c
++                    lstrlib.c
++                    ltablib.c
++                    lutf8lib.c
++                    linit.c
++    )
++
++
++# Create object library shared between all libs so we only need to compile sources once
++add_library(luaobj OBJECT ${LUA_LIB_SOURCES})
++# Lua static library - liblua
++add_library(liblua_static STATIC $<TARGET_OBJECTS:luaobj>)
++set_target_properties(liblua_static
++    PROPERTIES OUTPUT_NAME liblua
++)
++list(APPEND LuaExportTargets liblua_static)
++# If enabled, shared lua library lua
++if(BUILD_SHARED_LIBS)
++    add_library(liblua SHARED $<TARGET_OBJECTS:luaobj>)
++    target_compile_definitions(liblua PUBLIC $<$<BOOL:WIN32>:LUA_BUILD_AS_DLL>)
++    set_target_properties(liblua
++        PROPERTIES OUTPUT_NAME lua
++    )
++    list(APPEND LuaExportTargets liblua)
++endif()
++
++# Lua interpreter - lua
++add_executable(lua lua.c)
++target_link_libraries(lua PUBLIC liblua_static)
++list(APPEND LuaExportTargets lua)
++
++# Lua compiler - luac
++add_executable(luac luac.c)
++target_link_libraries(luac PRIVATE liblua_static)
++list(APPEND LuaExportTargets luac)
++
++# install header files
++install(FILES lua.h
++              luaconf.h
++              lauxlib.h
++              lua.hpp
++        DESTINATION include
++)
++# install targets defined in this scope
++install(TARGETS ${LuaExportTargets}
++    EXPORT LuaTargets
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib
++    INCLUDES DESTINATION include
++)

--- a/var/spack/repos/builtin/packages/lua/lua_cmake.patch
+++ b/var/spack/repos/builtin/packages/lua/lua_cmake.patch
@@ -60,7 +60,7 @@ new file mode 100644
 index 0000000..6cba945
 --- /dev/null
 +++ b/src/CMakeLists.txt
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,81 @@
 +set(LUA_LIB_SOURCES lapi.c
 +                    lcode.c
 +                    lctype.c
@@ -101,11 +101,14 @@ index 0000000..6cba945
 +# Lua static library - liblua
 +add_library(liblua_static STATIC $<TARGET_OBJECTS:luaobj>)
 +set_target_properties(liblua_static
-+    PROPERTIES OUTPUT_NAME liblua
++    PROPERTIES OUTPUT_NAME lua_static
 +)
 +list(APPEND LuaExportTargets liblua_static)
 +# If enabled, shared lua library lua
 +if(BUILD_SHARED_LIBS)
++    if(WIN32)
++       set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
++    endif(WIN32)
 +    add_library(liblua SHARED $<TARGET_OBJECTS:luaobj>)
 +    target_compile_definitions(liblua PUBLIC $<$<BOOL:WIN32>:LUA_BUILD_AS_DLL>)
 +    set_target_properties(liblua

--- a/var/spack/repos/builtin/packages/lua/lua_cmake.patch
+++ b/var/spack/repos/builtin/packages/lua/lua_cmake.patch
@@ -60,7 +60,7 @@ new file mode 100644
 index 0000000..6cba945
 --- /dev/null
 +++ b/src/CMakeLists.txt
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,79 @@
 +set(LUA_LIB_SOURCES lapi.c
 +                    lcode.c
 +                    lctype.c
@@ -101,18 +101,16 @@ index 0000000..6cba945
 +# Lua static library - liblua
 +add_library(liblua_static STATIC $<TARGET_OBJECTS:luaobj>)
 +set_target_properties(liblua_static
-+    PROPERTIES OUTPUT_NAME lua_static
++    PROPERTIES OUTPUT_NAME lua
 +)
 +list(APPEND LuaExportTargets liblua_static)
 +# If enabled, shared lua library lua
 +if(BUILD_SHARED_LIBS)
-+    if(WIN32)
-+       set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
-+    endif(WIN32)
 +    add_library(liblua SHARED $<TARGET_OBJECTS:luaobj>)
 +    target_compile_definitions(liblua PUBLIC $<$<BOOL:WIN32>:LUA_BUILD_AS_DLL>)
 +    set_target_properties(liblua
-+        PROPERTIES OUTPUT_NAME lua
++        PROPERTIES
++                   WINDOWS_EXPORT_ALL_SYMBOLS $<BOOL:WIN32>
 +    )
 +    list(APPEND LuaExportTargets liblua)
 +endif()

--- a/var/spack/repos/builtin/packages/lua/lua_cmake.patch
+++ b/var/spack/repos/builtin/packages/lua/lua_cmake.patch
@@ -60,7 +60,7 @@ new file mode 100644
 index 0000000..6cba945
 --- /dev/null
 +++ b/src/CMakeLists.txt
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,80 @@
 +set(LUA_LIB_SOURCES lapi.c
 +                    lcode.c
 +                    lctype.c
@@ -129,6 +129,7 @@ index 0000000..6cba945
 +install(FILES lua.h
 +              luaconf.h
 +              lauxlib.h
++              lualib.h
 +              lua.hpp
 +        DESTINATION include
 +)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -8,6 +8,8 @@ import os
 
 import spack.build_environment
 from spack.package import *
+import spack.build_systems.cmake
+import spack.build_systems.makefile
 from spack.util.executable import Executable
 
 
@@ -194,7 +196,7 @@ class LuaImplPackage(MakefilePackage):
         module.luarocks = Executable(self.spec.prefix.bin.luarocks)
 
 
-class Lua(LuaImplPackage):
+class Lua(LuaImplPackage, CMakePackage, MakefilePackage):
     """The Lua programming language interpreter and library."""
 
     homepage = "https://www.lua.org"
@@ -231,12 +233,16 @@ class Lua(LuaImplPackage):
     depends_on("ncurses+termlib")
     depends_on("readline")
 
+    build_system("cmake", "makefile", default="makefile")
+
     patch(
         "http://lua.2524044.n2.nabble.com/attachment/7666421/0/pkg-config.patch",
         sha256="208316c2564bdd5343fa522f3b230d84bd164058957059838df7df56876cb4ae",
         when="+pcfile @:5.3.9999",
     )
 
+
+class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def build(self, spec, prefix):
         if spec.satisfies("platform=darwin"):
             target = "macosx"
@@ -290,3 +296,6 @@ class Lua(LuaImplPackage):
                 join_path(self.prefix.lib, "pkgconfig", versioned_pc_file_name),
                 join_path(self.prefix.lib, "pkgconfig", "lua.pc"),
             )
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    """"""

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -7,9 +7,9 @@ import glob
 import os
 
 import spack.build_environment
-from spack.package import *
 import spack.build_systems.cmake
 import spack.build_systems.makefile
+from spack.package import *
 from spack.util.executable import Executable
 
 
@@ -298,6 +298,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
                 join_path(self.prefix.lib, "pkgconfig", versioned_pc_file_name),
                 join_path(self.prefix.lib, "pkgconfig", "lua.pc"),
             )
+
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -13,10 +13,9 @@ from spack.package import *
 from spack.util.executable import Executable
 
 
-
-
 class LuaBaseMixin(MakefilePackage):
     """Base class defining common Lua implementation package details"""
+
     extendable = True
 
     variant(
@@ -201,8 +200,7 @@ class LuaBuilderMixin:
         env.prepend_path("LUA_CPATH", ";".join(lua_cpatterns), separator=";")
 
 
-
-class LuaImplPackage(LuaBaseMixin, LuaBuilderMixin, ):
+class LuaImplPackage(LuaBaseMixin, LuaBuilderMixin):
     """Specialized class for lua *implementations*
 
     This exists to ensure that lua, luajit and luajit-openresty all initialize extension

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -196,7 +196,9 @@ class LuaBuilderMixin:
         # This can be invoked from either the builder or package context
         # this circuitous routing ensures it works from both
         # without this method needing to understand its calling context
-        lua_patterns, lua_cpatterns = self.spec.package._setup_dependent_env_helper(env, dependent_spec)
+        lua_patterns, lua_cpatterns = self.spec.package._setup_dependent_env_helper(
+            env, dependent_spec
+        )
 
         env.prepend_path("LUA_PATH", ";".join(lua_patterns), separator=";")
         env.prepend_path("LUA_CPATH", ";".join(lua_cpatterns), separator=";")


### PR DESCRIPTION
Lua has no Windows native compatible buildsystem, so I wrote a CMake system (Windows only for the moment) and patched it in.
Additionally a number (nearly all) of Lua's base deps are not needed on Windows according to the Lua tutorial for Windows, so those have been conflicted for now. I foresee having to undo that down the line to potentially open up some more behavior but for now things remain as is on other platforms and this vendors new support for Windows.

Additionally this PR enables the installation of packages like `lua-sol2` for free, simply by virtue of being able to install Lua. 