### PR TITLE
Remove spec.format call in Database._get_matching_spec_key

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1216,7 +1216,7 @@ class Database:
             match = self.query_one(spec, **kwargs)
             if match:
                 return match.dag_hash()
-            raise KeyError("No such spec in database!")
+            raise NoSuchSpecError(spec)
         return key
 
     @_autospec
@@ -1672,3 +1672,14 @@ class InvalidDatabaseVersionError(SpackError):
     @property
     def database_version_message(self):
         return f"The expected DB version is '{self.expected}', but '{self.found}' was found."
+
+
+class NoSuchSpecError(KeyError):
+    """Raised when a spec is not found in the database."""
+
+    def __init__(self, spec):
+        self.spec = spec
+        super().__init__(spec)
+
+    def __str__(self):
+        return f"No such spec in database: {self.spec}"

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1216,7 +1216,7 @@ class Database:
             match = self.query_one(spec, **kwargs)
             if match:
                 return match.dag_hash()
-            raise KeyError("No such spec in database! %s" % spec)
+            raise KeyError("No such spec in database!")
         return key
 
     @_autospec

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1682,4 +1682,7 @@ class NoSuchSpecError(KeyError):
         super().__init__(spec)
 
     def __str__(self):
+        # This exception is raised frequently, and almost always
+        # caught, so ensure we don't pay the cost of Spec.__str__
+        # unless the exception is actually printed.
         return f"No such spec in database: {self.spec}"


### PR DESCRIPTION
`"%s" % spec` formats the spec with deps included, which produces sometimes KBs of data and is slow to run in pure Python. It can delay otherwise very short-lived read/write locks on the database.

Discovered in #38762 where profile output showed about 2 seconds is spent in `spec.format`, which is significant overhead when using multiprocessing to install from binary cache in parallel (installation often takes <5s for small packages). With this change, `spec.format` no longer shows up in profile output.

(This line hasn't changed since Spack v0.9 ;p)