### PR TITLE
pkgconf: Update to new upstream URL

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -14,7 +14,7 @@ class Pkgconf(AutotoolsPackage):
 
     homepage = "http://pkgconf.org/"
     # URL must remain http:// so Spack can bootstrap curl
-    url = "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.6.3.tar.xz"
+    url = "https://distfiles.ariadne.space/pkgconf/pkgconf-1.6.3.tar.xz"
 
     version("1.9.5", sha256="1ac1656debb27497563036f7bffc281490f83f9b8457c0d60bcfb638fb6b6171")
     version("1.8.0", sha256="ef9c7e61822b7cb8356e6e9e1dca58d9556f3200d78acab35e4347e9d4c2bbaf")


### PR DESCRIPTION
`pkgconf` is no longer hosted at https://distfiles.dereferenced.org/pkgconf/, the site is defunct. The release tarballs are now located at https://distfiles.ariadne.space/pkgconf/.

See https://github.com/pkgconf/pkgconf/commit/437c2a3218bfcb1cae7fa38a4ccd0cb29575ff07