### PR TITLE
`spack deconcretize` command

### DIFF
--- a/lib/spack/spack/cmd/common/confirmation.py
+++ b/lib/spack/spack/cmd/common/confirmation.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+from typing import List
+
+import llnl.util.tty as tty
+
+import spack.cmd
+
+
+display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
+
+
+def confirm_action(specs: List[spack.spec.Spec], participle: str, noun: str):
+    """Display the list of specs to be acted on and ask for confirmation.
+
+    Args:
+        specs: specs to be removed
+        participle: action expressed as a participle, e.g. "uninstalled"
+        noun: action expressed as a noun, e.g. "uninstallation"
+    """
+    tty.msg(f"The following {len(specs)} packages will be {participle}:\n")
+    spack.cmd.display_specs(specs, **display_args)
+    print("")
+    answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
+    if not answer:
+        tty.msg(f"Aborting {noun}")
+        sys.exit(0)

--- a/lib/spack/spack/cmd/common/confirmation.py
+++ b/lib/spack/spack/cmd/common/confirmation.py
@@ -10,7 +10,6 @@ import llnl.util.tty as tty
 
 import spack.cmd
 
-
 display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
 
 

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -64,9 +64,9 @@ def find_matching_specs(
     has_errors = False
     for spec in specs:
         if spec is any:
-            matching = [s for _, s in env.concretized_specs()]
+            matching = list(env.all_specs())
         else:
-            matching = [s for _, s in env.concretized_specs() if s.satisfies(spec)]
+            matching = [s for s in env.all_specs() if s.satisfies(spec)]
 
         if not allow_multiple_matches and len(matching) > 1:
             tty.error(f"{spec} matches multiple concrete specs:")

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -4,16 +4,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
-from typing import List
 
 import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.cmd.common.confirmation as confirmation
-import spack.environment as ev
 import spack.spec
-import spack.traverse as traverse
 
 description = "remove specs from the concretized lockfile of an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -17,13 +17,7 @@ import spack.traverse as traverse
 
 description = "remove specs from the concretized lockfile of an environment"
 section = "environments"
-level = "short"
-
-error_message = """You can either:
-    a) use a more specific spec, or
-    b) specify the spec by its hash (e.g. `spack deconcretize /hash`), or
-    c) use `spack deconcretize --all` to deconcretize ALL matching specs.
-"""
+level = "long"
 
 # Arguments for display_specs when we find ambiguity
 display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
@@ -31,99 +25,48 @@ display_args = {"long": True, "show_flags": False, "variants": False, "indent": 
 
 def setup_parser(subparser):
     subparser.add_argument(
-        "-f",
-        "--force",
+        "--root",
         action="store_true",
-        dest="force",
-        help="remove regardless of whether other packages or environments " "depend on this one",
+        help="Deconcretize only environment roots. Additional roots that depend on matching specs"
+        " will be ignored",
     )
-    arguments.add_common_arguments(subparser, ["recurse_dependents", "yes_to_all", "specs"])
+    arguments.add_common_arguments(subparser, ["yes_to_all", "specs"])
     subparser.add_argument(
         "-a",
         "--all",
         action="store_true",
         dest="all",
-        help="deconcretize ALL specs that match each supplied spec",
+        help="Deconcretize ALL specs that match each supplied spec",
     )
 
 
-def find_matching_specs(
-    env: ev.Environment, specs: List[spack.spec.Spec], allow_multiple_matches: bool = False
-):
-    """Returns a list of concrete specs in the environment matching the abstract specs from CLI
+def get_deconcretize_list(args, specs, env):
+    env_specs = [s for _, s in env.concretized_specs()]
+    to_deconcretize = []
+    errors = []
 
-    Args:
-        env: active environment
-        specs: list of specs to be matched against concrete environment
-        allow_multiple_matches: if True mulitple matches are permitted
-
-    Return:
-        list: list of specs
-    """
-    matching_specs = []
-    has_errors = False
-    for spec in specs:
-        if spec is any:
-            matching = list(env.all_specs())
+    for s in specs:
+        if args.root:
+            to_deconc = [e for e in env_specs if e.satisfies(s)]
         else:
-            matching = [s for s in env.all_specs() if s.satisfies(spec)]
+            to_deconc = [e for e in env_specs if any(d.satisfies(s) for d in e.traverse())]
 
-        if not allow_multiple_matches and len(matching) > 1:
+        if len(to_deconc) < 1:
+            tty.warn(f"No matching specs to deconcretize for {s}")
+
+        elif len(to_deconc) > 1 and not args.all:
+            errors.append((s, to_deconc))
+
+        to_deconcretize.extend(to_deconc)
+
+    if errors:
+        for spec, matching in errors:
             tty.error(f"{spec} matches multiple concrete specs:")
             sys.stderr.write("\n")
             spack.cmd.display_specs(matching, output=sys.stderr, **display_args)
             sys.stderr.write("\n")
             sys.stderr.flush()
-            has_errors = True
-
-        if len(matching) == 0 and spec is not any:
-            tty.die(f"{spec} does not match any concrete spec.")
-
-        matching_specs.extend(matching)
-
-    if has_errors:
-        tty.die(error_message)
-
-    return matching_specs
-
-
-def concrete_dependents(
-    specs: List[spack.spec.Spec], env: ev.Environment
-) -> List[spack.spec.Spec]:
-    # Note this traversal will not return any spec in the original list
-    return [
-        spec
-        for spec in traverse.traverse_nodes(
-            specs,
-            root=False,
-            order="breadth",
-            cover="nodes",
-            direction="parents",
-            key=lambda s: s.dag_hash(),
-        )
-        if spec.dag_hash() in env.concretized_order
-    ]
-
-
-def get_deconcretize_list(args, specs, env):
-    matching_specs = find_matching_specs(env, specs, args.all)
-    dependent_specs = concrete_dependents(matching_specs, env)
-    to_deconcretize = matching_specs + dependent_specs if args.dependents else matching_specs
-
-    dangling_dependents = dependent_specs and not args.dependents
-    has_error = not args.force and dangling_dependents
-
-    if has_error:
-        tty.info("Refusing to deconcretize the following specs")
-        spack.cmd.display_specs(matching_specs, **display_args)
-        print()
-        tty.info("The following dependents are still concrete in the environment:")
-        spack.cmd.display_specs(dependent_specs, **display_args)
-        tty.die(
-            "There are still dependents.",
-            "use `spack deconcretize --dependents` to deconcretize dependents too",
-            "use `spack deconcretize --force` to override",
-        )
+        tty.die("Use '--all' to deconcretize all matching specs, or be more specific")
 
     return to_deconcretize
 
@@ -131,11 +74,10 @@ def get_deconcretize_list(args, specs, env):
 def deconcretize_specs(args, specs):
     env = spack.cmd.require_active_env(cmd_name="deconcretize")
 
-    deconcretize_list = get_deconcretize_list(args, specs, env)
-
-    if not deconcretize_list:
-        tty.warn("There are no concrete specs to deconcretize.")
-        return
+    if args.specs:
+        deconcretize_list = get_deconcretize_list(args, specs, env)
+    else:
+        deconcretize_list = [s for _, s in env.concretized_specs()]
 
     if not args.yes_to_all:
         confirmation.confirm_action(deconcretize_list, "deconcretized", "deconcretization")

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -24,7 +24,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         "--root",
         action="store_true",
-        help="Deconcretize only environment roots. Additional roots that depend on matching specs"
+        help="deconcretize only environment roots. additional roots that depend on matching specs"
         " will be ignored",
     )
     arguments.add_common_arguments(subparser, ["yes_to_all", "specs"])
@@ -33,7 +33,7 @@ def setup_parser(subparser):
         "--all",
         action="store_true",
         dest="all",
-        help="Deconcretize ALL specs that match each supplied spec",
+        help="deconcretize ALL specs that match each supplied spec",
     )
 
 

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
-from typing import List, Optional
+from typing import List
 
 import llnl.util.tty as tty
 

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -1,0 +1,157 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+from typing import List, Optional
+
+import llnl.util.tty as tty
+
+import spack.cmd
+import spack.cmd.common.arguments as arguments
+import spack.cmd.common.confirmation as confirmation
+import spack.environment as ev
+import spack.spec
+import spack.traverse as traverse
+
+description = "remove specs from the concretized lockfile of an environment"
+section = "environments"
+level = "short"
+
+error_message = """You can either:
+    a) use a more specific spec, or
+    b) specify the spec by its hash (e.g. `spack deconcretize /hash`), or
+    c) use `spack deconcretize --all` to deconcretize ALL matching specs.
+"""
+
+# Arguments for display_specs when we find ambiguity
+display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        dest="force",
+        help="remove regardless of whether other packages or environments " "depend on this one",
+    )
+    arguments.add_common_arguments(subparser, ["recurse_dependents", "yes_to_all", "specs"])
+    subparser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        dest="all",
+        help="deconcretize ALL specs that match each supplied spec",
+    )
+
+
+def find_matching_specs(
+    env: ev.Environment, specs: List[spack.spec.Spec], allow_multiple_matches: bool = False
+):
+    """Returns a list of concrete specs in the environment matching the abstract specs from CLI
+
+    Args:
+        env: active environment
+        specs: list of specs to be matched against concrete environment
+        allow_multiple_matches: if True mulitple matches are permitted
+
+    Return:
+        list: list of specs
+    """
+    matching_specs = []
+    has_errors = False
+    for spec in specs:
+        if spec is any:
+            matching = [s for _, s in env.concretized_specs()]
+        else:
+            matching = [s for _, s in env.concretized_specs() if s.satisfies(spec)]
+
+        if not allow_multiple_matches and len(matching) > 1:
+            tty.error(f"{spec} matches multiple concrete specs:")
+            sys.stderr.write("\n")
+            spack.cmd.display_specs(matching, output=sys.stderr, **display_args)
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+            has_errors = True
+
+        if len(matching) == 0 and spec is not any:
+            tty.die(f"{spec} does not match any concrete spec.")
+
+        matching_specs.extend(matching)
+
+    if has_errors:
+        tty.die(error_message)
+
+    return matching_specs
+
+
+def concrete_dependents(
+    specs: List[spack.spec.Spec], env: ev.Environment
+) -> List[spack.spec.Spec]:
+    # Note this traversal will not return any spec in the original list
+    return [
+        spec
+        for spec in traverse.traverse_nodes(
+            specs,
+            root=False,
+            order="breadth",
+            cover="nodes",
+            direction="parents",
+            key=lambda s: s.dag_hash(),
+        )
+        if spec.dag_hash() in env.concretized_order
+    ]
+
+
+def get_deconcretize_list(args, specs, env):
+    matching_specs = find_matching_specs(env, specs, args.all)
+    dependent_specs = concrete_dependents(matching_specs, env)
+    to_deconcretize = matching_specs + dependent_specs if args.dependents else matching_specs
+
+    dangling_dependents = dependent_specs and not args.dependents
+    has_error = not args.force and dangling_dependents
+
+    if has_error:
+        tty.info("Refusing to deconcretize the following specs")
+        spack.cmd.display_specs(matching_specs, **display_args)
+        print()
+        tty.info("The following dependents are still concrete in the environment:")
+        spack.cmd.display_specs(dependent_specs, **display_args)
+        tty.die(
+            "There are still dependents.",
+            "use `spack deconcretize --dependents` to deconcretize dependents too",
+            "use `spack deconcretize --force` to override",
+        )
+
+    return to_deconcretize
+
+
+def deconcretize_specs(args, specs):
+    env = spack.cmd.require_active_env(cmd_name="deconcretize")
+
+    deconcretize_list = get_deconcretize_list(args, specs, env)
+
+    if not deconcretize_list:
+        tty.warn("There are no concrete specs to deconcretize.")
+        return
+
+    if not args.yes_to_all:
+        confirmation.confirm_action(deconcretize_list, "deconcretized", "deconcretization")
+
+    with env.write_transaction():
+        for spec in deconcretize_list:
+            env.deconcretize(spec)
+        env.write()
+
+
+def deconcretize(parser, args):
+    if not args.specs and not args.all:
+        tty.die(
+            "deconcretize requires at least one spec argument.",
+            " Use `spack deconcretize --all` to deconcretize ALL specs.",
+        )
+
+    specs = spack.cmd.parse_specs(args.specs) if args.specs else [any]
+    deconcretize_specs(args, specs)

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -6,6 +6,7 @@
 import llnl.util.tty as tty
 
 import spack.cmd.common.arguments
+import spack.cmd.common.confirmation
 import spack.cmd.uninstall
 import spack.environment as ev
 import spack.store
@@ -41,6 +42,6 @@ def gc(parser, args):
         return
 
     if not args.yes_to_all:
-        spack.cmd.uninstall.confirm_removal(specs)
+        spack.cmd.common.confirmation.confirm_action(specs, "uninstalled", "uninstallation")
 
     spack.cmd.uninstall.do_uninstall(specs, force=False)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -11,10 +11,9 @@ from llnl.util.tty.colify import colify
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.confirmation as confirmation
 import spack.environment as ev
-import spack.error
 import spack.package_base
-import spack.repo
 import spack.spec
 import spack.store
 import spack.traverse as traverse
@@ -278,7 +277,7 @@ def uninstall_specs(args, specs):
         return
 
     if not args.yes_to_all:
-        confirm_removal(uninstall_list)
+        confirmation.confirm_action(uninstall_list, "uninstalled", "uninstallation")
 
     # Uninstall everything on the list
     do_uninstall(uninstall_list, args.force)
@@ -290,21 +289,6 @@ def uninstall_specs(args, specs):
             env.write()
 
         env.regenerate_views()
-
-
-def confirm_removal(specs: List[spack.spec.Spec]):
-    """Display the list of specs to be removed and ask for confirmation.
-
-    Args:
-        specs: specs to be removed
-    """
-    tty.msg("The following {} packages will be uninstalled:\n".format(len(specs)))
-    spack.cmd.display_specs(specs, **display_args)
-    print("")
-    answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
-    if not answer:
-        tty.msg("Aborting uninstallation")
-        sys.exit(0)
 
 
 def uninstall(parser, args):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1367,7 +1367,10 @@ class Environment:
 
         # If this was the only user spec that concretized to this concrete spec, remove it
         if dag_hash not in self.concretized_order:
-            del self.specs_by_hash[dag_hash]
+            # if we deconcretized a dependency that doesn't correspond to a root, it
+            # won't be here.
+            if dag_hash in self.specs_by_hash:
+                del self.specs_by_hash[dag_hash]
 
     def _get_specs_to_concretize(
         self,

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -1,0 +1,78 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+import spack.environment as ev
+from spack.main import SpackCommand, SpackCommandError
+
+deconcretize = SpackCommand("deconcretize")
+
+
+@pytest.fixture(scope="function")
+def test_env(mutable_mock_env_path, config, mock_packages):
+    ev.create("test")
+    with ev.read("test") as e:
+        e.add("a@2.0 foobar=bar ^b@1.0")
+        e.add("a@1.0 foobar=bar ^b@0.9")
+        e.concretize()
+        e.write()
+
+
+def test_deconcretize_dep(test_env):
+    with ev.read("test") as e:
+        deconcretize("-y", "b@1.0")
+        specs = [s for s, _ in e.concretized_specs()]
+
+    assert len(specs) == 1
+    assert specs[0].satisfies("a@1.0")
+
+
+def test_deconcretize_all_dep(test_env):
+    with ev.read("test") as e:
+        with pytest.raises(SpackCommandError):
+            deconcretize("-y", "b")
+        deconcretize("-y", "--all", "b")
+        specs = [s for s, _ in e.concretized_specs()]
+
+    assert len(specs) == 0
+
+
+def test_deconcretize_root(test_env):
+    with ev.read("test") as e:
+        output = deconcretize("-y", "--root", "b@1.0")
+        assert "No matching specs to deconcretize" in output
+        assert len(e.concretized_order) == 2
+
+        deconcretize("-y", "--root", "a@2.0")
+        specs = [s for s, _ in e.concretized_specs()]
+
+    assert len(specs) == 1
+    assert specs[0].satisfies("a@1.0")
+
+
+def test_deconcretize_all_root(test_env):
+    with ev.read("test") as e:
+        with pytest.raises(SpackCommandError):
+            deconcretize("-y", "--root", "a")
+
+        output = deconcretize("-y", "--root", "--all", "b")
+        assert "No matching specs to deconcretize" in output
+        assert len(e.concretized_order) == 2
+
+        deconcretize("-y", "--root", "--all", "a")
+        specs = [s for s, _ in e.concretized_specs()]
+
+    assert len(specs) == 0
+
+
+def test_deconcretize_all(test_env):
+    with ev.read("test") as e:
+        with pytest.raises(SpackCommandError):
+            deconcretize()
+        deconcretize("-y", "--all")
+        specs = [s for s, _ in e.concretized_specs()]
+
+    assert len(specs) == 0

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -401,7 +401,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -935,6 +935,15 @@ _spack_debug_create_db_tarball() {
 
 _spack_debug_report() {
     SPACK_COMPREPLY="-h --help"
+}
+
+_spack_deconcretize() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --root -y --yes-to-all -a --all"
+    else
+        _all_packages
+    fi
 }
 
 _spack_dependencies() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1281,11 +1281,11 @@ complete -c spack -n '__fish_spack_using_command_pos_remainder 0 deconcretize' -
 complete -c spack -n '__fish_spack_using_command deconcretize' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command deconcretize' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command deconcretize' -l root -f -a root
-complete -c spack -n '__fish_spack_using_command deconcretize' -l root -d 'Deconcretize only environment roots. Additional roots that depend on matching specs will be ignored'
+complete -c spack -n '__fish_spack_using_command deconcretize' -l root -d 'deconcretize only specific environment roots'
 complete -c spack -n '__fish_spack_using_command deconcretize' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command deconcretize' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 complete -c spack -n '__fish_spack_using_command deconcretize' -s a -l all -f -a all
-complete -c spack -n '__fish_spack_using_command deconcretize' -s a -l all -d 'Deconcretize ALL specs that match each supplied spec'
+complete -c spack -n '__fish_spack_using_command deconcretize' -s a -l all -d 'deconcretize ALL specs that match each supplied spec'
 
 # spack dependencies
 set -g __fish_spack_optspecs_spack_dependencies h/help i/installed t/transitive deptype= V/no-expand-virtuals

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -371,6 +371,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a containerize -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a containerise -d 'creates recipes to build images for different container runtimes'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a create -d 'create a new package file'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a debug -d 'debugging commands for troubleshooting Spack'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a deconcretize -d 'remove specs from the concretized lockfile of an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dependencies -d 'show dependencies of a package'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dependents -d 'show packages that depend on another'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a deprecate -d 'replace one package with another via symlinks'
@@ -1273,6 +1274,18 @@ complete -c spack -n '__fish_spack_using_command debug create-db-tarball' -s h -
 set -g __fish_spack_optspecs_spack_debug_report h/help
 complete -c spack -n '__fish_spack_using_command debug report' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command debug report' -s h -l help -d 'show this help message and exit'
+
+# spack deconcretize
+set -g __fish_spack_optspecs_spack_deconcretize h/help root y/yes-to-all a/all
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 deconcretize' -f -k -a '(__fish_spack_specs)'
+complete -c spack -n '__fish_spack_using_command deconcretize' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command deconcretize' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command deconcretize' -l root -f -a root
+complete -c spack -n '__fish_spack_using_command deconcretize' -l root -d 'Deconcretize only environment roots. Additional roots that depend on matching specs will be ignored'
+complete -c spack -n '__fish_spack_using_command deconcretize' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command deconcretize' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
+complete -c spack -n '__fish_spack_using_command deconcretize' -s a -l all -f -a all
+complete -c spack -n '__fish_spack_using_command deconcretize' -s a -l all -d 'Deconcretize ALL specs that match each supplied spec'
 
 # spack dependencies
 set -g __fish_spack_optspecs_spack_dependencies h/help i/installed t/transitive deptype= V/no-expand-virtuals


### PR DESCRIPTION
We have two ways to concretize now:
* `spack concretize` concretizes only the root specs that are not concrete in the environment.
* `spack concretize -f` eliminates all cached concretization data and reconcretizes the *entire* environment.

This PR adds `spack deconcretize`, which eliminates cached concretization data for a spec.  This allows
users greater control over what is preserved from their `spack.lock` file and what is reused when not
using `spack concretize -f`.  If you want to update a spec installed in your environment, you can call
`spack deconcretize` on it, and that spec and any relevant dependents will be removed from the lock file.

`spack concretize` has two options:
* `--root`: limits deconcretized specs to *specific* roots in the environment. You can use this to deconcretize exactly one root in a `unify: false` environment.  i.e., if `foo` root is a dependent of `bar`, both roots, `spack deconcretize bar` will *not* deconcretize `foo`.
* `--all`: deconcretize *all* specs that match the input spec. By default `spack deconcretize` will complain about multiple matches, like `spack uninstall`.
