### PR TITLE
legion@23.03.0 +rocm: patch FindHIP.cmake

### DIFF
--- a/var/spack/repos/builtin/packages/legion/find-hip.patch
+++ b/var/spack/repos/builtin/packages/legion/find-hip.patch
@@ -1,0 +1,17 @@
+diff -ruN spack-src/cmake/FindHIP.cmake spack-src-patched/cmake/FindHIP.cmake
+--- spack-src/cmake/FindHIP.cmake	2023-07-09 13:15:38.406950154 -0700
++++ spack-src-patched/cmake/FindHIP.cmake	2023-07-09 13:17:12.374845175 -0700
+@@ -22,7 +22,12 @@
+       set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to where HIP has been installed")
+   endif()
+ endif()
+-include(${HIP_PATH}/cmake/FindHIP.cmake)
++if(EXISTS ${HIP_PATH}/lib/cmake/hip/FindHIP.cmake)
++  # ROCM >= 5.3.0
++  include(${HIP_PATH}/lib/cmake/hip/FindHIP.cmake)
++else()
++  include(${HIP_PATH}/cmake/FindHIP.cmake)
++endif()
+ 
+ if(NOT HIP_INCLUDE_DIRS)
+   list(APPEND HIP_INCLUDE_DIRS

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -72,6 +72,7 @@ class Legion(CMakePackage, ROCmPackage):
 
     # https://github.com/spack/spack/issues/37232#issuecomment-1553376552
     patch("hip-offload-arch.patch", when="@23.03.0 +rocm")
+    patch("find-hip.patch", when="@23.03.0 +rocm")
 
     # HIP specific
     variant(


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/37232

If we want to merge this we should make sure to extend its application to include the new `legion@23.06.0 +rocm` being added:
* https://github.com/spack/spack/pull/38759

CC @elliottslaughter @wspear