### PR TITLE
py-triangle: restrict Python version

### DIFF
--- a/var/spack/repos/builtin/packages/py-triangle/package.py
+++ b/var/spack/repos/builtin/packages/py-triangle/package.py
@@ -14,7 +14,9 @@ class PyTriangle(PythonPackage):
 
     version("20200424", sha256="fc207641f8f39986f7d2bee1b91688a588cd235d2e67777422f94e61fece27e9")
 
+    depends_on("python@:3.9", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-cython", type="build")
+
     depends_on("triangle", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-cython", type=("build"))


### PR DESCRIPTION
With Python@10 building fails with the error
```
  triangle/core.c: In function '__pyx_tp_dealloc_array':
  triangle/core.c:19390:5: error: lvalue required as increment operand
  19390 |     ++Py_REFCNT(o);
        |     ^~
  triangle/core.c:19392:5: error: lvalue required as decrement operand
  19392 |     --Py_REFCNT(o);
        |     ^~
  triangle/core.c: In function '__pyx_tp_dealloc_memoryview':
  triangle/core.c:19701:5: error: lvalue required as increment operand
  19701 |     ++Py_REFCNT(o);
        |     ^~
  triangle/core.c:19703:5: error: lvalue required as decrement operand
  19703 |     --Py_REFCNT(o);
        |     ^~
...
```
With python@3.9 it installs fine with `--test=root` on Fedora37 and gcc@12.3.1