### PR TITLE
Add conflict for `hpx ~generic_coroutines` on ARM

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -195,8 +195,13 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/spack/spack/pull/17654
     # https://github.com/STEllAR-GROUP/hpx/issues/4829
     depends_on("boost+context", when="+generic_coroutines")
-    _msg_generic_coroutines = "This platform requires +generic_coroutines"
-    conflicts("~generic_coroutines", when="platform=darwin", msg=_msg_generic_coroutines)
+
+    _msg_generic_coroutines_platform = "This platform requires +generic_coroutines"
+    conflicts("~generic_coroutines", when="platform=darwin", msg=_msg_generic_coroutines_platform)
+
+    _msg_generic_coroutines_target = "This target requires +generic_coroutines"
+    conflicts("~generic_coroutines", when="target=aarch64:", msg=_msg_generic_coroutines_target)
+    conflicts("~generic_coroutines", when="target=arm:", msg=_msg_generic_coroutines_target)
 
     # Patches APEX
     patch("git_external.patch", when="@1.3.0 instrumentation=apex")


### PR DESCRIPTION
Fix #38796 by adding a conflict for `hpx ~generic_coroutines` on ARM microarchitectures. The conflict is currently version-independent. A fix in HPX may later relax the conflict: https://github.com/STEllAR-GROUP/hpx/issues/6298.