### PR TITLE
py-urllib3: new versions 2.*

### DIFF
--- a/var/spack/repos/builtin/packages/py-brotlicffi/package.py
+++ b/var/spack/repos/builtin/packages/py-brotlicffi/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBrotlicffi(PythonPackage):
+    """BrotliCFFI contains Python CFFI bindings for the reference Brotli
+    encoder/decoder."""
+
+    homepage = "https://github.com/python-hyper/brotlicffi"
+    pypi = "brotlicffi/brotlicffi-1.0.9.2.tar.gz"
+
+    version("1.0.9.2", sha256="0c248a68129d8fc6a217767406c731e498c3e19a7be05ea0a90c3c86637b7d96")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cffi@1.0.0:", type=("build", "run"))
+
+    # TODO: Builds against internal copy of headers, doesn't seem to be a way
+    # to use external brotli installation
+    # depends_on('brotli')

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -51,4 +51,4 @@ class PyUrllib3(PythonPackage):
     depends_on("py-brotlipy@0.6:", when="+brotli @:1")
     depends_on("py-brotlicffi@1.0.9:", when="+brotli @2:")
 
-    depends_on("zstd@0.18.0:", when="+zstd @2:")
+    depends_on("py-zstandard@0.18.0:", when="+zstd @2:")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -14,7 +14,11 @@ class PyUrllib3(PythonPackage):
     pypi = "urllib3/urllib3-1.25.6.tar.gz"
 
     version("2.0.3", sha256="bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825")
-    version("1.26.16", sha256="8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14", preferred=True)
+    version(
+        "1.26.16",
+        sha256="8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14",
+        preferred=True,
+    )
     version("1.26.12", sha256="3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e")
     version("1.26.6", sha256="f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f")
     version("1.25.9", sha256="3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -13,6 +13,8 @@ class PyUrllib3(PythonPackage):
     homepage = "https://urllib3.readthedocs.io/"
     pypi = "urllib3/urllib3-1.25.6.tar.gz"
 
+    version("2.0.3", sha256="bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825")
+    version("1.26.16", sha256="8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14", preferred=True)
     version("1.26.12", sha256="3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e")
     version("1.26.6", sha256="f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f")
     version("1.25.9", sha256="3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527")
@@ -26,15 +28,20 @@ class PyUrllib3(PythonPackage):
     variant("socks", default=False, description="SOCKS and HTTP proxy support")
     variant("secure", default=False, description="Add SSL/TLS support")
     variant("brotli", default=False, description="Add Brotli support")
+    variant("zstd", default=False, description="Add Zstandard support", when="@2:")
 
     depends_on("python@2.7:2.8,3.4:", when="@:1.25", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@1.26.6", type=("build", "run"))
     depends_on("python@2.7:2.8,3.6:3", when="@1.26.12:", type=("build", "run"))
+    depends_on("python@3.7:3", when="@2:", type=("build", "run"))
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", when="@1", type="build")
+    depends_on("py-hatchling@1.6.0:1", when="@2", type="build")
 
     depends_on("py-pyopenssl@0.14:", when="+secure")
+    depends_on("py-pyopenssl@17.1.0:", when="+secure @2:")
     depends_on("py-cryptography@1.3.4:", when="+secure")
+    depends_on("py-cryptography@1.9:", when="+secure @2:")
     depends_on("py-idna@2:", when="+secure")
     depends_on("py-certifi", when="+secure")
     depends_on("py-urllib3-secure-extra", when="+secure @1.26.12:")
@@ -42,3 +49,6 @@ class PyUrllib3(PythonPackage):
     depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks")
 
     depends_on("py-brotlipy@0.6:", when="+brotli")
+    depends_on("py-brotlipy@1.0.9:", when"+brotli @2:")
+
+    depends_on("zstd@0.18.0:", when="+zstd @2:")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -26,7 +26,7 @@ class PyUrllib3(PythonPackage):
     version("1.14", sha256="dd4fb13a4ce50b18338c7e4d665b21fd38632c5d4b1d9f1a1379276bd3c08d37")
 
     variant("socks", default=False, description="SOCKS and HTTP proxy support")
-    variant("secure", default=False, description="Add SSL/TLS support")
+    variant("secure", default=False, description="Add SSL/TLS support", when="@:2.0")
     variant("brotli", default=False, description="Add Brotli support")
     variant("zstd", default=False, description="Add Zstandard support", when="@2:")
 

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -49,6 +49,6 @@ class PyUrllib3(PythonPackage):
     depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks")
 
     depends_on("py-brotlipy@0.6:", when="+brotli")
-    depends_on("py-brotlipy@1.0.9:", when="+brotli @2:")
+    depends_on("py-brotlicffi@1.0.9:", when="+brotli @2:")
 
     depends_on("zstd@0.18.0:", when="+zstd @2:")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -14,11 +14,7 @@ class PyUrllib3(PythonPackage):
     pypi = "urllib3/urllib3-1.25.6.tar.gz"
 
     version("2.0.3", sha256="bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825")
-    version(
-        "1.26.16",
-        sha256="8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14",
-        preferred=True,
-    )
+    version("1.26.16", sha256="8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14")
     version("1.26.12", sha256="3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e")
     version("1.26.6", sha256="f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f")
     version("1.25.9", sha256="3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -49,6 +49,6 @@ class PyUrllib3(PythonPackage):
     depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks")
 
     depends_on("py-brotlipy@0.6:", when="+brotli")
-    depends_on("py-brotlipy@1.0.9:", when"+brotli @2:")
+    depends_on("py-brotlipy@1.0.9:", when="+brotli @2:")
 
     depends_on("zstd@0.18.0:", when="+zstd @2:")

--- a/var/spack/repos/builtin/packages/py-urllib3/package.py
+++ b/var/spack/repos/builtin/packages/py-urllib3/package.py
@@ -48,7 +48,7 @@ class PyUrllib3(PythonPackage):
 
     depends_on("py-pysocks@1.5.6,1.5.8:1", when="+socks")
 
-    depends_on("py-brotlipy@0.6:", when="+brotli")
+    depends_on("py-brotlipy@0.6:", when="+brotli @:1")
     depends_on("py-brotlicffi@1.0.9:", when="+brotli @2:")
 
     depends_on("zstd@0.18.0:", when="+zstd @2:")

--- a/var/spack/repos/builtin/packages/py-zstandard/package.py
+++ b/var/spack/repos/builtin/packages/py-zstandard/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyZstandard(PythonPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://github.com/indygreg/python-zstandard"
+    pypi = "zstandard/zstandard-0.21.0.tar.gz"
+
+    version("0.21.0", sha256="f08e3a10d01a247877e4cb61a82a319ea746c356a3786558bed2481e6c405546")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cffi@1.11:", type=("build", "run"))
+    depends_on("zstd")
+
+    def global_options(self, spec, prefix):
+        options = ["--system-zstd"]
+        return options

--- a/var/spack/repos/builtin/packages/py-zstandard/package.py
+++ b/var/spack/repos/builtin/packages/py-zstandard/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class PyZstandard(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """Zstandard bindings for Python."""
 
     homepage = "https://github.com/indygreg/python-zstandard"
     pypi = "zstandard/zstandard-0.21.0.tar.gz"


### PR DESCRIPTION
This adds a new bugfix release in the 1.26 series (https://github.com/urllib3/urllib3/compare/1.26.12...1.26.16, no changes to dependency versions), and the first version in the 2.* series, which brings a switch to hatchling. New variant for `zstd` support. Default remains the most recent 1.26.* release.

TODO:
- [x] The `secure` variant is deprecated (https://github.com/urllib3/urllib3/issues/2680) and will be removed in 2.1. Do we have a way of marking variants as deprecated?
- [x] Figure out what to do with `py-brotlipy` which doesn't have a recent enough version, and there's some duplication with `brotli` maybe.