### PR TITLE
Fix build of CentOS stream docker image

### DIFF
--- a/share/spack/templates/container/centos_stream.dockerfile
+++ b/share/spack/templates/container/centos_stream.dockerfile
@@ -23,7 +23,7 @@ RUN dnf update -y \
         python3.11-setuptools \
         unzip \
  && python3.11 -m ensurepip \
- && pip3 install boto3 \
+ && pip3.11 install boto3 \
  && rm -rf /var/cache/dnf \
  && dnf clean all
 {% endblock %}

--- a/share/spack/templates/container/centos_stream.dockerfile
+++ b/share/spack/templates/container/centos_stream.dockerfile
@@ -19,10 +19,10 @@ RUN dnf update -y \
         iproute \
         make \
         patch \
-        python38 \
-        python38-pip \
-        python38-setuptools \
+        python3.11 \
+        python3.11-setuptools \
         unzip \
+ && python3.11 -m ensurepip \
  && pip3 install boto3 \
  && rm -rf /var/cache/dnf \
  && dnf clean all


### PR DESCRIPTION
Quick fix for `pip` not being available in PATH on CentOS stream 