### PR TITLE
libffi: Fix build with clang

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -40,7 +40,11 @@ class Libffi(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%oneapi@2023:") or self.spec.satisfies("%arm@23.04:"):
+            if (
+                self.spec.satisfies("%oneapi@2023:")
+                or self.spec.satisfies("%arm@23.04:")
+                or self.spec.satisfies("%clang")
+            ):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)
 


### PR DESCRIPTION
Currently spack cannot build libffi with clang as clang throws an error related to an implicit function declaration, similar to some other compilers. This patch adds clang to the list of compilers for libffi that receive the -Wno-error=implicit-function-declaration flag so that spack can successfully build libffi with clang.