### PR TITLE
mesa-glu: Patch register long to long

### DIFF
--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -36,6 +36,10 @@ class MesaGlu(AutotoolsPackage):
 
     provides("glu@1.3")
 
+    # When using -std=c++17, using register long will throw an error. This
+    # patch switches all instances of register long to long to fix this.
+    patch("register-long.patch")
+
     def configure_args(self):
         args = ["--disable-libglvnd"]
 

--- a/var/spack/repos/builtin/packages/mesa-glu/register-long.patch
+++ b/var/spack/repos/builtin/packages/mesa-glu/register-long.patch
@@ -1,0 +1,28 @@
+From e5b42317078a1dbbf7ef9f1431ef6dcb711c7026 Mon Sep 17 00:00:00 2001
+From: Aiden Grossman <agrossman154@yahoo.com>
+Date: Mon, 10 Jul 2023 17:59:18 -0700
+Subject: [PATCH] Change register long to long to fix compile error
+
+When using -std=c++17, using register long will throw an error. This
+patch switches all instances of register long to long to fix this.
+---
+ src/libnurbs/internals/varray.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libnurbs/internals/varray.cc b/src/libnurbs/internals/varray.cc
+index 1cb2354..41b3b18 100644
+--- a/src/libnurbs/internals/varray.cc
++++ b/src/libnurbs/internals/varray.cc
+@@ -73,8 +73,8 @@ Varray::~Varray( void )
+ inline void
+ Varray::update( Arc_ptr arc, long dir[2], REAL val )
+ {
+-    register long ds = sgn(arc->tail()[0] - arc->prev->tail()[0]);
+-    register long dt = sgn(arc->tail()[1] - arc->prev->tail()[1]);
++    long ds = sgn(arc->tail()[0] - arc->prev->tail()[0]);
++    long dt = sgn(arc->tail()[1] - arc->prev->tail()[1]);
+
+     if( dir[0] != ds || dir[1] != dt ) {
+ 	dir[0] = ds;
+--
+2.29.1


### PR DESCRIPTION
mesa-glu still has a couple instances of the register keyword which causes build failures with clang on my platform. This patch removes the register keyword which doesn't have any impact on correctness.