### PR TITLE
DLA-Future: ensure umpire~cuda~rocm when ~cuda~rocm

### DIFF
--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -30,7 +30,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapackpp@2022.05.00:")
 
     depends_on("umpire~examples")
-    depends_on("umpire~cuda~rocm", when="~cuda~rocm")
+    depends_on("umpire~cuda", when="~cuda")
+    depends_on("umpire~rocm", when="~rocm")
     depends_on("umpire+cuda~shared", when="+cuda")
     depends_on("umpire+rocm~shared", when="+rocm")
     depends_on("umpire@4.1.0:")

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -29,7 +29,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blaspp@2022.05.00:")
     depends_on("lapackpp@2022.05.00:")
 
-    depends_on("umpire~examples")
+    depends_on("umpire~examples~cuda~rocm", when="~cuda~rocm")
     depends_on("umpire+cuda~shared", when="+cuda")
     depends_on("umpire+rocm~shared", when="+rocm")
     depends_on("umpire@4.1.0:")

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -29,7 +29,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blaspp@2022.05.00:")
     depends_on("lapackpp@2022.05.00:")
 
-    depends_on("umpire~examples~cuda~rocm", when="~cuda~rocm")
+    depends_on("umpire~examples")
+    depends_on("umpire~cuda~rocm", when="~cuda~rocm")
     depends_on("umpire+cuda~shared", when="+cuda")
     depends_on("umpire+rocm~shared", when="+rocm")
     depends_on("umpire@4.1.0:")


### PR DESCRIPTION
Ensure `umpire~cuda~rocm` is used when `~cuda~rocm`.

Related to https://github.com/LLNL/Umpire/pull/827.