### PR TITLE
Restrict py-pip version for packages using --install-option

### DIFF
--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -44,6 +44,8 @@ class PyNetworkit(PythonPackage):
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("python@3:", type=("build", "run"))
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
 
     def install_options(self, spec, prefix):
         # Enable ext. core-library + parallel build

--- a/var/spack/repos/builtin/packages/py-pymol/package.py
+++ b/var/spack/repos/builtin/packages/py-pymol/package.py
@@ -21,6 +21,8 @@ class PyPymol(PythonPackage):
 
     depends_on("python+tkinter@2.7:", type=("build", "link", "run"), when="@2.3.0:2.4.0")
     depends_on("python+tkinter@3.6:", type=("build", "link", "run"), when="@2.5.0:")
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
     depends_on("gl")
     depends_on("glew")
     depends_on("libpng")

--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -36,6 +36,8 @@ class PyPyside(PythonPackage):
     depends_on("cmake", type="build")
 
     depends_on("py-setuptools", type="build")
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
     depends_on("py-sphinx", type=("build", "run"))
     depends_on("py-sphinx@:3.5.0", type=("build", "run"), when="@:1.2.2")
     depends_on("qt@4.5:4.9")

--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -42,6 +42,8 @@ class PyPyside2(PythonPackage):
     depends_on("py-wheel", type="build")
     # https://bugreports.qt.io/browse/PYSIDE-1385
     depends_on("py-wheel@:0.34", when="@:5.14", type="build")
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
     depends_on("qt@5.11:+opengl")
 
     depends_on("graphviz", when="+doc", type="build")

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -19,6 +19,8 @@ class PyShiboken(PythonPackage):
     depends_on("cmake", type="build")
 
     depends_on("py-setuptools", type="build")
+    # in newer pip versions --install-option does not exist
+    depends_on("py-pip@:23.0", type="build")
     depends_on("py-sphinx@:3.4", type=("build", "run"))
     depends_on("libxml2")
     depends_on("qt@:4.8")


### PR DESCRIPTION
This is the last bunch of packages that need to have `py-pip` restricted, because, as discussed in #38608, `--install-option` is not available anymore in `py-pip@23.1`.

None of these packages build for me (even before `py-pip` was upgraded):
- `py-networkit`: `libnetworkit` does not build with
    ```
    make[2]: *** No rule to make target 'tlx-NOTFOUND', needed by 'libnetworkit.so'.  Stop.
    ````
- `py-pymol`: cyclic dependencies
- `py-pyside`: with `^python@3.8 ^py-markupsafe@2.0.1` -> `py-pyside@1.2.2` works, but `py-pyside@1.2.4` seems to need `python@:3.5`
- `py-pyside2`: dependency `libtiff` only builds with `libtiff+pic`, but `py-side2` still does not build with:
	```
	fatal: 'GL/gl.h' file not found
	```
- `py-shiboken`: does not build with error
	```
	Failed to query the Qt version with qmake $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/qt-3.3.8b-oml4p5kzdrsv3fnaglseoavti4hir4kw/bin/qmake
	```