### PR TITLE
Fix typo in documentation about arch spec usage

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -733,7 +733,7 @@ named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on
    spack:
      definitions:
        - compilers: ['%gcc', '%clang']
-       - when: arch.satisfies('x86_64:')
+       - when: arch.satisfies('arch=x86_64:')
          compilers: ['%intel']
 
 .. note::


### PR DESCRIPTION
Fix typo about usage of `arch` in spack environments `spack:definitions:when`.

See #17056,
