### PR TITLE
protobuf: use cxxstd from abseil-cpp to fix C++17 build

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -125,10 +125,11 @@ class Protobuf(CMakePackage):
         ]
 
         if self.spec.satisfies("@3.22:"):
+            cxxstd = self.spec["abseil-cpp"].variants["cxxstd"].value
             args.extend(
                 [
                     self.define("protobuf_ABSL_PROVIDER", "package"),
-                    self.define("CMAKE_CXX_STANDARD", 14),
+                    self.define("CMAKE_CXX_STANDARD", cxxstd),
                 ]
             )
 


### PR DESCRIPTION
Protobuf fails to build if you have the variant `cxxstd=17` by default (or explicitly within the dependency `abseil-cpp`). This correctly sets the cmake flags based on the dependent package.