### PR TITLE
soapdenovo2: strip optimization flags from injected flags

### DIFF
--- a/var/spack/repos/builtin/packages/soapdenovo2/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo2/package.py
@@ -17,6 +17,7 @@ class Soapdenovo2(MakefilePackage):
 
     homepage = "https://github.com/aquaskyline/SOAPdenovo2"
     url = "https://github.com/aquaskyline/SOAPdenovo2/archive/r240.tar.gz"
+    maintainers("snehring")
 
     version("242", sha256="a0043ceb41bc17a1c3fd2b8abe4f9029a60ad3edceb2b15af3c2cfabd36aa11b")
     version("240", sha256="cc9e9f216072c0bbcace5efdead947e1c3f41f09baec5508c7b90f933a090909")

--- a/var/spack/repos/builtin/packages/soapdenovo2/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo2/package.py
@@ -23,9 +23,9 @@ class Soapdenovo2(MakefilePackage):
     version("240", sha256="cc9e9f216072c0bbcace5efdead947e1c3f41f09baec5508c7b90f933a090909")
 
     def flag_handler(self, name, flags):
+        if name.lower() == "cflags" and self.spec.satisfies("%gcc@10:"):
+            flags.append("-fcommon")
         if name.lower() == "cflags" or name.lower() == "cxxflags" or name.lower() == "cppflags":
-            if self.spec.satisfies("%gcc@10:"):
-                flags.append("-fcommon")
             opt_flag = re.compile("-O.*")
             # This package cannot compile with anything other than the -O3
             # specified in the makefile

--- a/var/spack/repos/builtin/packages/soapdenovo2/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo2/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -20,11 +22,13 @@ class Soapdenovo2(MakefilePackage):
     version("240", sha256="cc9e9f216072c0bbcace5efdead947e1c3f41f09baec5508c7b90f933a090909")
 
     def flag_handler(self, name, flags):
-        if self.spec.satisfies("%gcc@10:"):
-            if name == "cflags" or name == "CFLAGS":
+        if name.lower() == "cflags" or name.lower() == "cxxflags" or name.lower() == "cppflags":
+            if self.spec.satisfies("%gcc@10:"):
                 flags.append("-fcommon")
-            if name == "cxxflags" or name == "CXXFLAGS":
-                flags.append("-fcommon")
+            opt_flag = re.compile("-O.*")
+            # This package cannot compile with anything other than the -O3
+            # specified in the makefile
+            flags = [f for f in flags if not opt_flag.match(f)]
         return (flags, None, None)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/soapdenovo2/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo2/package.py
@@ -25,10 +25,10 @@ class Soapdenovo2(MakefilePackage):
     def flag_handler(self, name, flags):
         if name.lower() == "cflags" and self.spec.satisfies("%gcc@10:"):
             flags.append("-fcommon")
-        if name.lower() == "cflags" or name.lower() == "cxxflags" or name.lower() == "cppflags":
+        if name.lower() in ["cflags", "cxxflags", "cppflags"]:
             opt_flag = re.compile("-O.*")
-            # This package cannot compile with anything other than the -O3
-            # specified in the makefile
+            # This package cannot compile with any optimization flag other
+            # than the -O3 specified in the makefile
             flags = [f for f in flags if not opt_flag.match(f)]
         return (flags, None, None)
 


### PR DESCRIPTION
This fixes an issue brought about by the recent change to compiler flag prioritization.