### PR TITLE
serf: add 1.3.10

### DIFF
--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -15,6 +15,7 @@ class Serf(SConsPackage):
 
     maintainers("cosmicexplorer")
 
+    version("1.3.10", sha256="be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6")
     version("1.3.9", sha256="549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc")
     version("1.3.8", sha256="e0500be065dbbce490449837bb2ab624e46d64fc0b090474d9acaa87c82b2590")
 
@@ -30,7 +31,7 @@ class Serf(SConsPackage):
     depends_on("uuid")
     depends_on("zlib")
 
-    patch("py3syntax.patch")
+    patch("py3syntax.patch", when="@:1.3.9")
     patch("py3-hashbang.patch")
 
     def build_args(self, spec, prefix):


### PR DESCRIPTION
`subversion` did not build for me with the error
```
  >> 902    /usr/bin/ld: $spack/opt/spack/linux-fedora37-x86_64/gcc-12.3.1/serf-1.3.9-
            27df6tjnlqrx5u3iomfjd5eez2uoype3/lib/libserf-1.so: undefined reference to `ERR_GET_FUNC
```
Updating `serf` solved the issue for me.