### PR TITLE
Add qmake virtual provider

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -49,6 +49,7 @@ packages:
       pbs: [openpbs, torque]
       pil: [py-pillow]
       pkgconfig: [pkgconf, pkg-config]
+      qmake: [qt-base, qt]
       rpc: [libtirpc]
       scalapack: [netlib-scalapack, amdscalapack]
       sycl: [hipsycl]

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -28,7 +28,7 @@ class QMakePackage(spack.package_base.PackageBase):
 
     build_system("qmake")
 
-    depends_on("qt", type="build", when="build_system=qmake")
+    depends_on("qmake", type="build", when="build_system=qmake")
 
 
 @spack.builder.builder("qmake")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -33,6 +33,8 @@ class QtPackage(CMakePackage):
 
     maintainers("wdconinc", "sethrj")
 
+    provides("qmake")
+
     # Default dependencies for all qt-* components
     generator("ninja")
     depends_on("cmake@3.16:", type="build")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -68,6 +68,8 @@ class Qt(Package):
     variant("tools", default=True, description="Build tools, including Qt Designer.")
     variant("webkit", default=False, description="Build the Webkit extension")
 
+    provides("qmake")
+
     # Patches for qt@3
     patch("qt3-accept.patch", when="@3")
     patch("qt3-headers.patch", when="@3")


### PR DESCRIPTION
#29555 introduced a new `qt-base` package for Qt 6. However, many packages support both Qt 5 and 6. This PR introduces a new `qmake` virtual provider so that packages can choose to support both dependencies.

Notes:

* `qmake` might not be the best name, open to alternatives
* I don't think there's an automatic way for `qmake@6.5:` to imply `qt-base@6.5:`? We would have to explicitly specify which versions of qt/qt-base provide which versions of qmake?
* I didn't attempt to update all packages containing `depends_on("qt")` because I'm not able to test all of them. Someone else can do this if they're bored.

P.S. I have not tested this at all. Qt does not build on modern macOS (#34064), so I can only test qt-base.