### PR TITLE
flux-sched: add v0.28.0

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -20,6 +20,7 @@ class FluxSched(AutotoolsPackage):
     maintainers("grondo")
 
     version("master", branch="master")
+    version("0.28.0", sha256="9431c671bed5d76fd95b4a4a7f36224d4bf76f416a2a1a5c4908f3ca790d434d")
     version("0.27.0", sha256="1e131924440c904fa0c925b7aa14c47b97f4e67b43af7efd2ebc0ef7ce90eb7c")
     version("0.26.0", sha256="184faec800cf45952ef79bda113f710bf91a05be584034d36a3234627d4a54c7")
     version("0.25.0", sha256="a984b238d8b6968ef51f1948a550bf57887bf3da8002dcd1734ce26afc4bff07")


### PR DESCRIPTION
New release of flux-sched - hot out of the oven! :bread: Title per request of @alecbcs (hope I did OK this time!)

:avocado: Release notes: https://flux-framework.org/release/2023/07/11/flux-sched-0.28.0.html
:avocado: Passing build: https://github.com/flux-framework/spack/actions/runs/5527043621/jobs/10082399547
:avocado: Props and nice work to @garlick @grondo @trws @chu11 @milroy and @jameshcorbett !