### PR TITLE
Add `keep_werror = "specific"` to mpich

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -25,6 +25,8 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
     executables = ["^mpichversion$"]
 
+    keep_werror = "specific"
+
     version("develop", submodules=True)
     version("4.1.1", sha256="ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2")
     version("4.1", sha256="8b1ec63bc44c7caa2afbb457bc5b3cd4a70dbe46baba700123d67c48dc5ab6a0")


### PR DESCRIPTION
Adding `keep_werror = "specific"` so that once https://github.com/pmodels/mpich/pull/6581 makes it into an mpich release mpich built with clang will no longer trigger bogus warnings in dependent projects because of a misdetected compiler attribute (https://github.com/pmodels/mpich/issues/6496).