### PR TITLE
HiPACE++ 23.07

### DIFF
--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -39,7 +39,7 @@ class Hipace(CMakePackage):
         description="Floating point precision (single/double)",
     )
 
-    depends_on("cmake@3.18.0:", type="build", when="@23.07:")
+    depends_on("cmake@3.18.0:", type="build", when="@23.05:")
     depends_on("cmake@3.15.0:", type="build")
     depends_on("mpi", when="+mpi")
     with when("+openpmd"):

--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -39,12 +39,12 @@ class Hipace(CMakePackage):
         description="Floating point precision (single/double)",
     )
 
-    depends_on("cmake@3.15.0:", type="build")
     depends_on("cmake@3.18.0:", type="build", when="@23.07:")
+    depends_on("cmake@3.15.0:", type="build")
     depends_on("mpi", when="+mpi")
     with when("+openpmd"):
-        depends_on("openpmd-api@0.14.2:")
         depends_on("openpmd-api@0.15.1:", when="@23.07:")
+        depends_on("openpmd-api@0.14.2:")
         depends_on("openpmd-api ~mpi", when="~mpi")
         depends_on("openpmd-api +mpi", when="+mpi")
     with when("compute=noacc"):
@@ -58,12 +58,12 @@ class Hipace(CMakePackage):
         depends_on("pkgconfig", type="build")
         depends_on("llvm-openmp", when="%apple-clang")
     with when("compute=cuda"):
-        depends_on("cuda@9.2.88:")
         depends_on("cuda@:12.1", when="%gcc@:12.2")
         depends_on("cuda@:12.0", when="%gcc@:12.1")
         depends_on("cuda@:12.1", when="%gcc@:12.2")
         depends_on("cuda@:11.8", when="%gcc@:9")
         depends_on("cuda@:10", when="%gcc@:8")
+        depends_on("cuda@9.2.88:")
     with when("compute=hip"):
         depends_on("rocfft")
         depends_on("rocprim")

--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -43,7 +43,7 @@ class Hipace(CMakePackage):
     depends_on("cmake@3.15.0:", type="build")
     depends_on("mpi", when="+mpi")
     with when("+openpmd"):
-        depends_on("openpmd-api@0.15.1:", when="@23.07:")
+        depends_on("openpmd-api@0.15.1:", when="@23.05:")
         depends_on("openpmd-api@0.14.2:")
         depends_on("openpmd-api ~mpi", when="~mpi")
         depends_on("openpmd-api +mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -42,13 +42,6 @@ class Hipace(CMakePackage):
     depends_on("cmake@3.15.0:", type="build")
     depends_on("cmake@3.18.0:", type="build", when="@23.07:")
     depends_on("mpi", when="+mpi")
-    with when("compute=cuda"):
-        depends_on("cuda@9.2.88:")
-        depends_on("cuda@:12.1", when="%gcc@:12.2")
-        depends_on("cuda@:12.0", when="%gcc@:12.1")
-        depends_on("cuda@:12.1", when="%gcc@:12.2")
-        depends_on("cuda@:11.8", when="%gcc@:9")
-        depends_on("cuda@:10", when="%gcc@:8")
     with when("+openpmd"):
         depends_on("openpmd-api@0.14.2:")
         depends_on("openpmd-api@0.15.1:", when="@23.07:")
@@ -64,6 +57,13 @@ class Hipace(CMakePackage):
         depends_on("fftw +mpi", when="+mpi")
         depends_on("pkgconfig", type="build")
         depends_on("llvm-openmp", when="%apple-clang")
+    with when("compute=cuda"):
+        depends_on("cuda@9.2.88:")
+        depends_on("cuda@:12.1", when="%gcc@:12.2")
+        depends_on("cuda@:12.0", when="%gcc@:12.1")
+        depends_on("cuda@:12.1", when="%gcc@:12.2")
+        depends_on("cuda@:11.8", when="%gcc@:9")
+        depends_on("cuda@:10", when="%gcc@:8")
     with when("compute=hip"):
         depends_on("rocfft")
         depends_on("rocprim")

--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -12,12 +12,14 @@ class Hipace(CMakePackage):
     """
 
     homepage = "https://hipace.readthedocs.io"
-    url = "https://github.com/Hi-PACE/hipace/archive/refs/tags/v21.09.tar.gz"
+    url = "https://github.com/Hi-PACE/hipace/archive/refs/tags/v23.07.tar.gz"
     git = "https://github.com/Hi-PACE/hipace.git"
 
     maintainers("ax3l", "MaxThevenet", "SeverinDiederichs")
 
     version("develop", branch="development")
+    version("23.07", sha256="2b1f61c91d2543d7ee360eba3630c864107e29f7bcfd0221451beea88f414f21")
+    version("23.05", sha256="33a15cfeada3ca16c2a3af1538caa7ff731df13b48b884045a0fe7974382fcd1")
     version("21.09", sha256="5d27824fe6aac47ce26ca69759140ab4d7844f9042e436c343c03ea4852825f1")
 
     variant(
@@ -38,10 +40,18 @@ class Hipace(CMakePackage):
     )
 
     depends_on("cmake@3.15.0:", type="build")
-    depends_on("cuda@9.2.88:", when="compute=cuda")
+    depends_on("cmake@3.18.0:", type="build", when="@23.07:")
     depends_on("mpi", when="+mpi")
+    with when("compute=cuda"):
+        depends_on("cuda@9.2.88:")
+        depends_on("cuda@:12.1", when="%gcc@:12.2")
+        depends_on("cuda@:12.0", when="%gcc@:12.1")
+        depends_on("cuda@:12.1", when="%gcc@:12.2")
+        depends_on("cuda@:11.8", when="%gcc@:9")
+        depends_on("cuda@:10", when="%gcc@:8")
     with when("+openpmd"):
         depends_on("openpmd-api@0.14.2:")
+        depends_on("openpmd-api@0.15.1:", when="@23.07:")
         depends_on("openpmd-api ~mpi", when="~mpi")
         depends_on("openpmd-api +mpi", when="+mpi")
     with when("compute=noacc"):


### PR DESCRIPTION
Update the package, in particular:
- Add recent versions 23.07 and 23.05 (so far only 21.09 is available)
- Update minimal CMake version
- Update minimal openPMD-api version
- Enforce compatible GCC/CUDA versions to build HiPACE++