### PR TITLE
update luajit and fix link on neovim to allow luajit to work on linux aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
+++ b/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
@@ -13,10 +13,13 @@ class LuaLuajitOpenresty(LuaImplPackage):
     """Flast flexible JITed lua - OpenResty maintained fork"""
 
     homepage = "https://openresty.org/en/luajit.html"
-    url = "https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20220111.tar.gz"
+    url = "https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20230410.tar.gz"
 
     version(
         "2.1-20220111", sha256="1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
+    )
+    version(
+        "2.1-20230410", sha256="77bbcbb24c3c78f51560017288f3118d995fe71240aa379f5818ff6b166712ff"
     )
 
     variant(

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -86,7 +86,7 @@ class Neovim(CMakePackage):
 
     # dependencies to allow regular lua to work
     depends_on("lua-ffi", when="^lua", type=("link", "run"))
-    depends_on("lua-bitlib", type="link", when="^lua")
+    depends_on("lua-bitlib", type=("link", "run"), when="^lua")
 
     # base dependencies
     depends_on("cmake@3.0:", type="build")


### PR DESCRIPTION
This is a package bump for luajit and a tweak for neovim to allow it to build and run correctly on aarch64.