### PR TITLE
eccodes: fixups

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -321,6 +321,9 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
+            self.define(
+                "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
+            ),
             self.define_from_variant("ENABLE_FORTRAN", "fortran"),
             self.define("BUILD_SHARED_LIBS", "BOTH" if "+shared" in self.spec else "OFF"),
             self.define("ENABLE_TESTS", self.run_tests),

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -335,15 +335,14 @@ class Eccodes(CMakePackage):
         ]
 
         if "+netcdf" in self.spec:
-            args.extend(
-                [
-                    # Prevent possible overriding by environment variables
-                    # NETCDF_ROOT, NETCDF_DIR, and NETCDF_PATH:
-                    self.define("NETCDF_PATH", self.spec["netcdf-c"].prefix),
-                    # Prevent overriding by environment variable HDF5_ROOT:
-                    self.define("HDF5_ROOT", self.spec["hdf5"].prefix),
-                ]
-            )
+            # Prevent possible overriding by environment variables NETCDF_ROOT, NETCDF_DIR, and
+            # NETCDF_PATH:
+            args.append(self.define("NETCDF_PATH", self.spec["netcdf-c"].prefix))
+            # Prevent overriding by environment variable HDF5_ROOT (starting version 2.14.0,
+            # ecCodes is shipped with ecBuild 3.1.0+, which does not seem to rely on the HDF5_ROOT
+            # variable):
+            if self.spec.satisfies("@:2.13"):
+                args.append(self.define("HDF5_ROOT", self.spec["hdf5"].prefix))
 
         if jp2k == "openjpeg":
             args.append(self.define("OPENJPEG_PATH", self.spec["openjpeg"].prefix))

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -354,7 +354,7 @@ class Eccodes(CMakePackage):
             # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
             args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
 
-        if "^python" in self.spec:
+        if "+memfs" in self.spec:
             args.append(self.define("PYTHON_EXECUTABLE", python.path))
 
         definitions = self.spec.variants["definitions"].value


### PR DESCRIPTION
1. Explicitly disable the Python 2 interface (fixup for #33898).
2. Do not set unused cmake argument `HDF5_ROOT` starting version `2.14.0`.
3. Set `PYTHON_EXECUTABLE` only when needed (fixes #38871).