### PR TITLE
ci: fix stack mirror url

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -255,6 +255,11 @@ protected-publish:
 # you should inlclude your custom definitions at the end of the of the
 # extends list.
 #
+# Also note that if extending .base-job, the mirror url given in your
+# spack.yaml should take the form:
+#
+#     s3://spack-binaries/develop/${SPACK_CI_STACK_NAME}
+#
 ########################################
 # My Super Cool Pipeline
 ########################################

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -92,7 +92,7 @@ spack:
   # - py-vector-quantize-pytorch  # py-torch
   # - r-xgboost                   # r
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/ml-darwin-aarch64-cpu" }
+  mirrors: { "mirror": "s3://spack-binaries/develop/ml-darwin-aarch64-mps" }
 
   ci:
     pipeline-gen:


### PR DESCRIPTION
Noticed the `ml-darwin-aarch64-mps` stack rebuilding a lot of specs, and it turned out to be due to a mismatch between the stack name and the mirror url.  Added a note in the example stack making this requirement clear.