### PR TITLE
hdf: fix build with clang16+

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -144,6 +144,14 @@ class Hdf(AutotoolsPackage):
             elif name == "fflags":
                 flags.append(self.compiler.f77_pic_flag)
 
+        if name == "cflags":
+            # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
+            if self.spec.satisfies("@:4.2.15 %apple-clang") or self.spec.satisfies("%clang@16:"):
+                flags.append("-Wno-error=implicit-function-declaration")
+
+            if self.spec.satisfies("%clang@16:"):
+                flags.append("-Wno-error=implicit-int")
+
         return flags, None, None
 
     def configure_args(self):
@@ -177,10 +185,6 @@ class Hdf(AutotoolsPackage):
             config_args.extend(
                 ["FFLAGS=-fallow-argument-mismatch", "FCFLAGS=-fallow-argument-mismatch"]
             )
-
-        # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
-        if self.spec.satisfies("@:4.2.15 %apple-clang"):
-            config_args.append("CFLAGS=-Wno-error=implicit-function-declaration")
 
         return config_args
 


### PR DESCRIPTION
With the release of clang 16, clang now treats implicit function declarations and implicit integers as errors rather than warnings, causing the build to fail. This patch adds flags to prevent build failures.