### PR TITLE
lm-sensors: respect compiler choice

### DIFF
--- a/var/spack/repos/builtin/packages/lm-sensors/package.py
+++ b/var/spack/repos/builtin/packages/lm-sensors/package.py
@@ -31,6 +31,14 @@ class LmSensors(MakefilePackage):
     depends_on("flex", type="build")
     depends_on("perl", type="run")
 
+    @property
+    def build_targets(self):
+        targets = []
+
+        targets.append("CC={0}".format(spack_cc))
+
+        return targets
+
     def install(self, spec, prefix):
         make("install", "PREFIX={0}".format(prefix), "ETCDIR={0}/etc".format(prefix))
 


### PR DESCRIPTION
Currently lm-sensors defaults to the compiler specified in the Makefile (gcc) rather than the one specified in the spec. This patch appends the CC flag to the make invocation with the spec compiler to fix this behavior.