### PR TITLE
gperf: patch usage of register keyword

### DIFF
--- a/var/spack/repos/builtin/packages/gperf/package.py
+++ b/var/spack/repos/builtin/packages/gperf/package.py
@@ -20,4 +20,10 @@ class Gperf(AutotoolsPackage, GNUMirrorPackage):
     version("3.1", sha256="588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2")
     version("3.0.4", sha256="767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e")
 
+    # This patch removes all instances of the register keyword within gperf
+    # which is necessary to build gperf with recent compilers that default to
+    # c++17 where using the register keyword results in a compile-time error.
+    # This has no impact on correctness.
+    patch("register.patch")
+
     # NOTE: `make check` is known to fail tests

--- a/var/spack/repos/builtin/packages/gperf/register.patch
+++ b/var/spack/repos/builtin/packages/gperf/register.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/getline.cc b/lib/getline.cc
+index ecc3e85..2d97644 100644 (file)
+--- a/lib/getline.cc
++++ b/lib/getline.cc
+@@ -55,7 +55,7 @@ getstr (char **lineptr, size_t *n, FILE *stream, char terminator, size_t offset)
+ 
+   for (;;)
+     {
+-      register int c = getc (stream);
++      int c = getc (stream);
+ 
+       /* We always want at least one char left in the buffer, since we
+          always (unless we get an error while reading the first char)


### PR DESCRIPTION
gperf still uses the register keyword in one place which makes compilation fail with c++17. This patch adds in a patch file to remove the usage of the reigster keyword so that it compiles properly.