### PR TITLE
Fix issue preventing setup-env.sh to be sourced

### DIFF
--- a/lib/spack/spack/operating_systems/cray_backend.py
+++ b/lib/spack/spack/operating_systems/cray_backend.py
@@ -86,7 +86,7 @@ class CrayBackend(LinuxDistro):
             # distro.linux_distribution, while still calling __init__
             # methods further up the MRO, we skip LinuxDistro in the MRO and
             # call the OperatingSystem superclass __init__ method
-            super().__init__(name, version)
+            super(LinuxDistro, self).__init__(name, version)
         else:
             super().__init__()
         self.modulecmd = module


### PR DESCRIPTION
PR #38718 introduced an issue preventing to source `setup-env.sh` on Cray systems. This PR revert only one change, but since `sed` was used in #38718 there might be similar issues elsewhere.

https://github.com/spack/spack/pull/38718#discussion_r1263470785

---

```
$ . spack-daint/share/spack/setup-env.sh
Traceback (most recent call last):
  File "/users/rmeli/spack-daint/lib/spack/llnl/util/lang.py", line 191, in _memoized_function
    return func.cache[key]
KeyError: ()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/users/rmeli/spack-daint/bin/spack", line 52, in <module>
    sys.exit(main())
  File "/users/rmeli/spack-daint/lib/spack/spack_installable/main.py", line 35, in main
    import spack.main  # noqa: E402
  File "/users/rmeli/spack-daint/lib/spack/spack/main.py", line 34, in <module>
    import spack.cmd
  File "/users/rmeli/spack-daint/lib/spack/spack/cmd/__init__.py", line 21, in <module>
    import spack.environment as ev
  File "/users/rmeli/spack-daint/lib/spack/spack/environment/__init__.py", line 339, in <module>
    from .environment import (
  File "/users/rmeli/spack-daint/lib/spack/spack/environment/environment.py", line 42, in <module>
    import spack.user_environment as uenv
  File "/users/rmeli/spack-daint/lib/spack/spack/user_environment.py", line 8, in <module>
    import spack.build_environment
  File "/users/rmeli/spack-daint/lib/spack/spack/build_environment.py", line 52, in <module>
    import spack.build_systems.cmake
  File "/users/rmeli/spack-daint/lib/spack/spack/build_systems/cmake.py", line 18, in <module>
    import spack.package_base
  File "/users/rmeli/spack-daint/lib/spack/spack/package_base.py", line 56, in <module>
    from spack.filesystem_view import YamlFilesystemView
  File "/users/rmeli/spack-daint/lib/spack/spack/filesystem_view.py", line 36, in <module>
    import spack.relocate
  File "/users/rmeli/spack-daint/lib/spack/spack/relocate.py", line 30, in <module>
    is_macos = str(spack.platforms.real_host()) == "darwin"
  File "/users/rmeli/spack-daint/lib/spack/llnl/util/lang.py", line 193, in _memoized_function
    ret = func(*args, **kwargs)
  File "/users/rmeli/spack-daint/lib/spack/spack/platforms/_functions.py", line 26, in _host
    return platform_cls()
  File "/users/rmeli/spack-daint/lib/spack/spack/platforms/cray.py", line 84, in __init__
    back_distro = CrayBackend()
  File "/users/rmeli/spack-daint/lib/spack/spack/operating_systems/cray_backend.py", line 89, in __init__
    super().__init__(name, version)
TypeError: __init__() takes 1 positional argument but 3 were given
```