### PR TITLE
unzip: fix build with clang16+

### DIFF
--- a/var/spack/repos/builtin/packages/unzip/configure-cflags.patch
+++ b/var/spack/repos/builtin/packages/unzip/configure-cflags.patch
@@ -1,0 +1,37 @@
+--- ./unix/configure.old	2009-04-16 19:25:12.000000000 +0000
++++ ./unix/configure	2023-07-14 09:35:33.735000149 +0000
+@@ -383,7 +383,7 @@
+ do
+   echo Check for $func
+   echo "int main(){ $func(); return 0; }" > conftest.c
+-  $CC $BFLAG -o conftest conftest.c >/dev/null 2>/dev/null
++  $CC $BFLAG $CFLAGS -o conftest conftest.c >/dev/null 2>/dev/null
+   [ $? -ne 0 ] && CFLAGSR="${CFLAGSR} -DNO_`echo $func | tr '[a-z]' '[A-Z]'`"
+ done
+
+@@ -395,14 +395,14 @@
+   echo "int main() { lchmod(\"${temp_file}\", 0666); }" \
+ ) > conftest.c
+ ln -s "${temp_link}" "${temp_file}" && \
+- $CC $BFLAG -o conftest conftest.c >/dev/null 2>/dev/null && \
++ $CC $CFLAGS $BFLAG -o conftest conftest.c >/dev/null 2>/dev/null && \
+  ./conftest
+ [ $? -ne 0 ] && CFLAGSR="${CFLAGSR} -DNO_LCHMOD"
+ rm -f "${temp_file}"
+
+ echo Check for memset
+ echo "int main(){ char k; memset(&k,0,0); return 0; }" > conftest.c
+-$CC -o conftest conftest.c >/dev/null 2>/dev/null
++$CC $CFLAGS -o conftest conftest.c >/dev/null 2>/dev/null
+ [ $? -ne 0 ] && CFLAGSR="${CFLAGSR} -DZMEM"
+
+ echo Check for errno declaration
+@@ -422,7 +422,7 @@
+ int main() { return closedir(opendir(".")); }
+ _EOF_
+
+-$CC -o conftest conftest.c >/dev/null 2>/dev/null
++$CC $CFLAGS -o conftest conftest.c >/dev/null 2>/dev/null
+ if [ $? -ne 0 ]; then
+   OPT=""
+   for lib in ndir dir ucb bsd BSD PW x dirent

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -14,21 +14,33 @@ class Unzip(MakefilePackage):
 
     version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
 
+    patch("configure-cflags.patch", when="%clang@16:")
+
     # The Cray cc wrapper doesn't handle the '-s' flag (strip) cleanly.
     @when("platform=cray")
     def patch(self):
         filter_file(r"^LFLAGS2=.*", "LFLAGS2=", join_path("unix", "configure"))
 
-    make_args = ["-f", join_path("unix", "Makefile"), "LOC=-DLARGE_FILE_SUPPORT"]
+    def get_make_args(self):
+        make_args = ["-f", join_path("unix", "Makefile")]
+
+        cflags = []
+        if self.spec.satisfies("%clang@16:"):
+            cflags.append("-Wno-error=implicit-function-declaration")
+            cflags.append("-Wno-error=implicit-int")
+        cflags.append("-DLARGE_FILE_SUPPORT")
+
+        make_args.append('LOC="{}"'.format(" ".join(cflags)))
+        return make_args
 
     @property
     def build_targets(self):
         target = "macosx" if "platform=darwin" in self.spec else "generic"
-        return self.make_args + [target]
+        return self.get_make_args() + [target]
 
     def url_for_version(self, version):
         return "http://downloads.sourceforge.net/infozip/unzip{0}.tar.gz".format(version.joined)
 
     @property
     def install_targets(self):
-        return self.make_args + ["prefix={0}".format(self.prefix), "install"]
+        return self.get_make_args() + ["prefix={0}".format(self.prefix), "install"]


### PR DESCRIPTION
Clang 16's change to erroring out by default on implicit function declarations and implicit integers causes the build script for unzip to break. Since this project hasn't had a release since 2010, we need to patch it downstream/pass additional flags to get the build to succeed.