### PR TITLE
py-shiboken: fix build by restricting dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -28,8 +28,6 @@ class PyShiboken(PythonPackage):
     depends_on("libxml2")
     depends_on("qt@4.6:4.8")
 
-    # Fails to query the Qt version with qmake with qt@3
-    conflicts("^qt@3")
     # to prevent ImportError: cannot import name 'soft_unicode' from 'markupsafe'
     conflicts("^py-markupsafe@2.0.2:")
 

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -18,12 +18,20 @@ class PyShiboken(PythonPackage):
 
     depends_on("cmake", type="build")
 
+    # to prevent error: 'PyTypeObject' {aka 'struct _typeobject'} has no member
+    # named 'tp_print'
+    depends_on("python@:3.8", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
     depends_on("py-sphinx@:3.4", type=("build", "run"))
     depends_on("libxml2")
     depends_on("qt@:4.8")
+
+    # Fails to query the Qt version with qmake with qt@3
+    conflicts("^qt@3")
+    # to prevent ImportError: cannot import name 'soft_unicode' from 'markupsafe'
+    conflicts("^py-markupsafe@2.0.2:")
 
     # subprocess.mswindows was renamed to subprocess._mswindows in Python 3.5
     patch("python-3.5.patch", when="^python@3.5:")

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -28,9 +28,6 @@ class PyShiboken(PythonPackage):
     depends_on("libxml2")
     depends_on("qt@4.6:4.8")
 
-    # to prevent ImportError: cannot import name 'soft_unicode' from 'markupsafe'
-    conflicts("^py-markupsafe@2.0.2:")
-
     # subprocess.mswindows was renamed to subprocess._mswindows in Python 3.5
     patch("python-3.5.patch", when="^python@3.5:")
 

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -16,7 +16,7 @@ class PyShiboken(PythonPackage):
 
     version("1.2.2", sha256="0baee03c6244ab56e42e4200d0cb5e234682b11cc296ed0a192fe457d054972f")
 
-    depends_on("cmake", type="build")
+    depends_on("cmake@2.6:", type="build")
 
     # to prevent error: 'PyTypeObject' {aka 'struct _typeobject'} has no member
     # named 'tp_print'

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -26,7 +26,7 @@ class PyShiboken(PythonPackage):
     depends_on("py-pip@:23.0", type="build")
     depends_on("py-sphinx@:3.4", type=("build", "run"))
     depends_on("libxml2")
-    depends_on("qt@:4.8")
+    depends_on("qt@4.6:4.8")
 
     # Fails to query the Qt version with qmake with qt@3
     conflicts("^qt@3")


### PR DESCRIPTION
For some reason the concretizer chooses `qt@3` and not the newer `qt@4` which let the build fail. I have added a conflict as a workaround. 

Similar to `py-pyside` this package also needs some restrictions on `python` and `py-markupsafe` to work.