### PR TITLE
Palace: Updates  for v0.11.2

### DIFF
--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -14,14 +14,12 @@ class Palace(CMakePackage):
     homepage = "https://github.com/awslabs/palace"
     git = "https://github.com/awslabs/palace.git"
 
-    root_cmakelists_dir = "palace"
-
     maintainers("sebastiangrimberg")
 
     version("develop", branch="main")
-    version("0.11.1", tag="v0.11.1")
-    version("0.11.0", tag="v0.11.0")
+    version("0.11.2", tag="v0.11.2")
 
+    variant("shared", default=True, description="Enables the build of shared libraries")
     variant("int64", default=False, description="Use 64 bit integers")
     variant("openmp", default=False, description="Use OpenMP")
     variant(
@@ -44,27 +42,25 @@ class Palace(CMakePackage):
     depends_on("zlib")
     depends_on("nlohmann-json")
     depends_on("fmt")
+    depends_on("eigen")
 
-    depends_on("metis@5:+int64", when="+int64")
-    depends_on("metis@5:~int64", when="~int64")
+    depends_on("metis@5:")
+    depends_on("metis+shared", when="+shared")
+    depends_on("metis~shared", when="~shared")
+    depends_on("metis+int64", when="+int64")
+    depends_on("metis~int64", when="~int64")
 
-    depends_on("hypre+shared")
+    depends_on("hypre~complex")
+    depends_on("hypre+shared", when="+shared")
+    depends_on("hypre~shared", when="~shared")
     depends_on("hypre+mixedint", when="+int64")
     depends_on("hypre~mixedint", when="~int64")
     depends_on("hypre+openmp", when="+openmp")
     depends_on("hypre~openmp", when="~openmp")
 
-    depends_on("petsc+double+complex")
-    depends_on("petsc+int64", when="+int64")
-    depends_on("petsc~int64", when="~int64")
-    depends_on("petsc+openmp", when="+openmp")
-    depends_on("petsc~openmp", when="~openmp")
-
-    depends_on("slepc", when="+slepc")
-    depends_on("arpack-ng+icb@develop", when="+arpack")
-    depends_on("gslib", when="+gslib")
-
     with when("+superlu-dist"):
+        depends_on("superlu-dist+shared", when="+shared")
+        depends_on("superlu-dist~shared", when="~shared")
         depends_on("superlu-dist+int64", when="+int64")
         depends_on("superlu-dist~int64", when="~int64")
         depends_on("superlu-dist+openmp", when="+openmp")
@@ -72,29 +68,48 @@ class Palace(CMakePackage):
 
     with when("+strumpack"):
         depends_on("strumpack+butterflypack+zfp+parmetis")
+        depends_on("strumpack+shared", when="+shared")
+        depends_on("strumpack~shared", when="~shared")
         depends_on("strumpack+openmp", when="+openmp")
         depends_on("strumpack~openmp", when="~openmp")
 
     with when("+mumps"):
         depends_on("mumps+metis+parmetis")
+        depends_on("mumps+shared", when="+shared")
+        depends_on("mumps~shared", when="~shared")
         depends_on("mumps+openmp", when="+openmp")
         depends_on("mumps~openmp", when="~openmp")
 
-    # Conflicts: Palace always builds its own internal MFEM
+    with when("+slepc"):
+        depends_on("slepc ^petsc+mpi+double+complex")
+        depends_on("petsc+shared", when="+shared")
+        depends_on("petsc~shared", when="~shared")
+        depends_on("petsc+int64", when="+int64")
+        depends_on("petsc~int64", when="~int64")
+        depends_on("petsc+openmp", when="+openmp")
+        depends_on("petsc~openmp", when="~openmp")
+
+    with when("+arpack"):
+        depends_on("arpack-ng+mpi+icb@develop")
+        depends_on("arpack-ng+shared", when="+shared")
+        depends_on("arpack-ng~shared", when="~shared")
+
+    # Conflicts: Palace always builds its own internal MFEM, GSLIB
     conflicts("^mfem", msg="Palace builds its own internal MFEM")
+    conflicts("^gslib", msg="Palace builds its own internal GSLIB")
 
     # More dependency variant conflicts
     conflicts("^hypre+int64", msg="Palace uses HYPRE's mixedint option for 64 bit integers")
-    conflicts("^petsc~double", msg="Palace requires PETSc with double precision")
-    conflicts("^petsc~complex", msg="Palace requires PETSc with complex numbers")
-    conflicts("^petsc+metis", msg="Palace requires PETSc without METIS")
-    conflicts("^petsc+hypre", msg="Palace requires PETSc without HYPRE")
-    conflicts("^petsc+superlu-dist", msg="Palace requires PETSc without SuperLU_DIST")
-    conflicts("^slepc+arpack", msg="Palace requires SLEPc without ARPACK")
     conflicts("^mumps+int64", msg="Palace requires MUMPS without 64 bit integers")
+    conflicts("^slepc+arpack", msg="Palace requires SLEPc without ARPACK")
+
+    # No install phase for Palace (always performed during build)
+    phases = ["cmake", "build"]
 
     def cmake_args(self):
         args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("PALACE_WITH_64BIT_INT", "int64"),
             self.define_from_variant("PALACE_WITH_OPENMP", "openmp"),
             self.define_from_variant("PALACE_WITH_GSLIB", "gslib"),
             self.define_from_variant("PALACE_WITH_SUPERLU", "superlu-dist"),
@@ -102,26 +117,25 @@ class Palace(CMakePackage):
             self.define_from_variant("PALACE_WITH_MUMPS", "mumps"),
             self.define_from_variant("PALACE_WITH_SLEPC", "slepc"),
             self.define_from_variant("PALACE_WITH_ARPACK", "arpack"),
-            "-DPALACE_WITH_INTERNAL_JSON=OFF",
-            "-DPALACE_WITH_INTERNAL_FMT=OFF",
+            "-DPALACE_BUILD_EXTERNAL_DEPS=OFF",
         ]
+
+        # HYPRE is always built with external BLAS/LAPACK
+        args += ["-DHYPRE_REQUIRED_PACKAGES=LAPACK;BLAS"]
 
         # MPI compiler wrappers are not required, but MFEM test builds need to know to link
         # against MPI libraries
         if "+superlu-dist" in self.spec:
-            args += ["-DSuperLUDist_REQUIRED_PACKAGES=MPI"]
+            args += ["-DSuperLUDist_REQUIRED_PACKAGES=LAPACK;BLAS;MPI"]
         if "+strumpack" in self.spec:
-            args += ["-DSTRUMPACK_REQUIRED_PACKAGES=MPI;MPI_Fortran"]
+            args += ["-DSTRUMPACK_REQUIRED_PACKAGES=LAPACK;BLAS;MPI;MPI_Fortran"]
         if "+mumps" in self.spec:
-            args += ["-DMUMPS_REQUIRED_PACKAGES=MPI;MPI_Fortran"]
+            args += ["-DMUMPS_REQUIRED_PACKAGES=LAPACK;BLAS;MPI;MPI_Fortran"]
 
         # BLAS/LAPACK linkage
         args += [
             "-DBLAS_LIBRARIES={0}".format(self.spec["blas"].libs.joined(";")),
             "-DLAPACK_LIBRARIES={0}".format(self.spec["lapack"].libs.joined(";")),
         ]
-
-        # HYPRE is always built with external BLAS/LAPACK
-        args += ["-DHYPRE_REQUIRED_PACKAGES=LAPACK;BLAS"]
 
         return args

--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -118,22 +118,20 @@ class Palace(CMakePackage):
         ]
 
         # HYPRE is always built with external BLAS/LAPACK
-        args += ["-DHYPRE_REQUIRED_PACKAGES=LAPACK;BLAS"]
+        args += self.define("HYPRE_REQUIRED_PACKAGES", "LAPACK;BLAS")
 
         # MPI compiler wrappers are not required, but MFEM test builds need to know to link
         # against MPI libraries
         if "+superlu-dist" in self.spec:
-            args += ["-DSuperLUDist_REQUIRED_PACKAGES=LAPACK;BLAS;MPI"]
+            args += self.define("SuperLUDist_REQUIRED_PACKAGES", "LAPACK;BLAS;MPI")
         if "+strumpack" in self.spec:
-            args += ["-DSTRUMPACK_REQUIRED_PACKAGES=LAPACK;BLAS;MPI;MPI_Fortran"]
+            args += self.define("STRUMPACK_REQUIRED_PACKAGES", "LAPACK;BLAS;MPI;MPI_Fortran")
         if "+mumps" in self.spec:
-            args += ["-DMUMPS_REQUIRED_PACKAGES=LAPACK;BLAS;MPI;MPI_Fortran"]
+            args += self.define("MUMPS_REQUIRED_PACKAGES", "LAPACK;BLAS;MPI;MPI_Fortran")
 
         # BLAS/LAPACK linkage
-        args += [
-            "-DBLAS_LIBRARIES={0}".format(self.spec["blas"].libs.joined(";")),
-            "-DLAPACK_LIBRARIES={0}".format(self.spec["lapack"].libs.joined(";")),
-        ]
+        args += self.define("BLAS_LIBRARIES", "{0}".format(self.spec["blas"].libs.joined(";")))
+        args += self.define("LAPACK_LIBRARIES", "{0}".format(self.spec["lapack"].libs.joined(";")))
 
         return args
 

--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -103,9 +103,6 @@ class Palace(CMakePackage):
     conflicts("^mumps+int64", msg="Palace requires MUMPS without 64 bit integers")
     conflicts("^slepc+arpack", msg="Palace requires SLEPc without ARPACK")
 
-    # No install phase for Palace (always performed during build)
-    phases = ["cmake", "build"]
-
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
@@ -117,7 +114,7 @@ class Palace(CMakePackage):
             self.define_from_variant("PALACE_WITH_MUMPS", "mumps"),
             self.define_from_variant("PALACE_WITH_SLEPC", "slepc"),
             self.define_from_variant("PALACE_WITH_ARPACK", "arpack"),
-            "-DPALACE_BUILD_EXTERNAL_DEPS=OFF",
+            self.define("PALACE_BUILD_EXTERNAL_DEPS", False),
         ]
 
         # HYPRE is always built with external BLAS/LAPACK
@@ -139,3 +136,7 @@ class Palace(CMakePackage):
         ]
 
         return args
+
+    def install(self, pkg, spec, prefix):
+        # No install phase for Palace (always performed during build)
+        pass


### PR DESCRIPTION
The recent release of Palace modifies the build system which breaks compatibility with the existing Spack recipe. This PR updates the build recipe for versions >= v0.11.2 (as a rapidly changing pre-1.0 project, I think it is safe to not worry about backward compatibility here).