### PR TITLE
py-jinja2: add conflict for py-markupsafe@2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-jinja2/package.py
+++ b/var/spack/repos/builtin/packages/py-jinja2/package.py
@@ -41,4 +41,4 @@ class PyJinja2(PythonPackage):
     depends_on("py-babel@0.8:", when="+i18n", type=("build", "run"))
 
     # https://github.com/pallets/jinja/issues/1585
-    conflicts("^py-markupsafe@2.0.2:", when="@:2.11.3")
+    conflicts("^py-markupsafe@2.1:", when="@:2")

--- a/var/spack/repos/builtin/packages/py-jinja2/package.py
+++ b/var/spack/repos/builtin/packages/py-jinja2/package.py
@@ -39,3 +39,6 @@ class PyJinja2(PythonPackage):
     depends_on("py-markupsafe@0.23:", type=("build", "run"))
     depends_on("py-babel@2.7:", when="@3:+i18n", type=("build", "run"))
     depends_on("py-babel@0.8:", when="+i18n", type=("build", "run"))
+
+    # https://github.com/pallets/jinja/issues/1585
+    conflicts("^py-markupsafe@2.0.2:", when="@:2.11.3")


### PR DESCRIPTION
As seen in https://github.com/spack/spack/pull/38886#discussion_r1264151218 building `py-jinja@2.11.3` with `py-markupsafe@2.0.1` results in problem in follow up packages.