### PR TITLE
gcoff: fix build with clang 16+

### DIFF
--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -88,3 +88,9 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies("+x"):
             dir = join_path(self.prefix.lib, "X11", "app-defaults")
             env.set_path("XFILESEARCHPATH", dir)
+
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%clang@16:"):
+                flags.append("-Wno-register")
+        return (flags, None, None)


### PR DESCRIPTION
gcoff uses the register keyword in a couple different places which causes errors when building with c++17, which is the default in clang
16. This patch adds the -Wno-register flag to ignore these errors when when building with clang 16.