### PR TITLE
libelf: fix build with clang16+

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -50,3 +50,10 @@ class Libelf(AutotoolsPackage):
 
     def install(self, spec, prefix):
         make("install", parallel=False)
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%clang@16:"):
+                flags.append("-Wno-error=implicit-int")
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)


### PR DESCRIPTION
libelf fails to build with clang16+ due to Wimplicit-int and Wimplicit-function-declarations becoming errors by default. This breaks the configuration stage, so no build takes place. This patch fixes this by passing -Wno-error=implicit-int and
-Wno-error=implicit-function-declarations as cflags.