### PR TITLE
libxc: add kxc and lxc variants

### DIFF
--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -30,8 +30,8 @@ class Libxc(AutotoolsPackage, CudaPackage):
     version("2.2.1", sha256="ade61c1fa4ed238edd56408fd8ee6c2e305a3d5753e160017e2a71817c98fd00")
 
     variant("shared", default=True, description="Build shared libraries")
-    variant("kxc", default=False, when="@5.0:", description="Build with third derivatives")
-    variant("lxc", default=False, when="@5.0:", description="Build with fourth derivatives")
+    variant("kxc", default=False, when="@5:", description="Build with third derivatives")
+    variant("lxc", default=False, when="@5:", description="Build with fourth derivatives")
 
     conflicts("+shared +cuda", msg="Only ~shared supported with +cuda")
     conflicts("+cuda", when="@:4", msg="CUDA support only in libxc 5.0.0 and above")

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -30,6 +30,8 @@ class Libxc(AutotoolsPackage, CudaPackage):
     version("2.2.1", sha256="ade61c1fa4ed238edd56408fd8ee6c2e305a3d5753e160017e2a71817c98fd00")
 
     variant("shared", default=True, description="Build shared libraries")
+    variant("kxc",default=False, description="Build with third derivatives")
+    variant("lxc",default=False, description="Build with fourth derivatives")
 
     conflicts("+shared +cuda", msg="Only ~shared supported with +cuda")
     conflicts("+cuda", when="@:4", msg="CUDA support only in libxc 5.0.0 and above")
@@ -118,6 +120,10 @@ class Libxc(AutotoolsPackage, CudaPackage):
         args = []
         args += self.enable_or_disable("shared")
         args += self.enable_or_disable("cuda")
+        if "+kxc" in self.spec:
+            args.append("--enable-kxc")
+        if "+lxc" in self.spec:
+            args.append("--enable-lxc")
         return args
 
     @run_after("configure")

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -30,8 +30,8 @@ class Libxc(AutotoolsPackage, CudaPackage):
     version("2.2.1", sha256="ade61c1fa4ed238edd56408fd8ee6c2e305a3d5753e160017e2a71817c98fd00")
 
     variant("shared", default=True, description="Build shared libraries")
-    variant("kxc",default=False, description="Build with third derivatives")
-    variant("lxc",default=False, description="Build with fourth derivatives")
+    variant("kxc", default=False, when="@5.0:", description="Build with third derivatives")
+    variant("lxc", default=False, when="@5.0:", description="Build with fourth derivatives")
 
     conflicts("+shared +cuda", msg="Only ~shared supported with +cuda")
     conflicts("+cuda", when="@:4", msg="CUDA support only in libxc 5.0.0 and above")


### PR DESCRIPTION
Recent versions of Libxc ( >= 5.1 ) by default disables compiling for kxc and lxc variants.
KXC and LXC variants  are used for some packages for eg. octopus.
This MR introduces them as a variant.
A test fortran program based on https://gitlab.com/octopus-code/octopus/-/merge_requests/1418 was used to confirm that kxc was installed as expected.: 
Test:
```shell
❯ spack install libxc@6.1.0+kxc+lxc
❯ spack find -lv libxc
-- linux-fedora38-zen3 / gcc@13.1.1 -----------------------------
qbkw5ue libxc@6.1.0~cuda+kxc+lxc+shared build_system=autotools
❯ spack load /qbkw
❯ cat test.f90
program tests
  use xc_f03_lib_m
  implicit none

  integer :: xc_flags
  type(xc_f03_func_t) :: xc_func
  type(xc_f03_func_info_t) :: xc_info

  call xc_f03_func_init(xc_func, XC_GGA_X_B88, XC_UNPOLARIZED)
  xc_info = xc_f03_func_get_info(xc_func)
  xc_flags = xc_f03_func_info_get_flags(xc_info)
  if(IAND(xc_flags, XC_FLAGS_HAVE_KXC) == 0) then
    stop 1
  endif
  call xc_f03_func_end(xc_func)
  print *, "I am working"
end program tests
❯ gfortran $(pkg-config --cflags --libs libxcf03) ./test.f90
❯ LD_LIBRARY_PATH=$(spack location -i /qbk)/lib ./a.out
 I am working
```
