### PR TITLE
Update gsi-ncdiag/1.1.1 sha256

### DIFF
--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -14,7 +14,7 @@ class GsiNcdiag(CMakePackage):
 
     maintainers("ulmononian")
 
-    version("1.1.1", sha256="29ac8c22d2bbf11d5b437cbd53168aef99cdaa2c17d9a9c30b49fae4f7c6b1f2")
+    version("1.1.1", sha256="26fc10cf448dd62daa1385e38921d338778416342956c478337e6c6d1b20bf8c")
     version("1.1.0", sha256="9195801301209d6f93890944d58ffee4e24a4e35502ab27560a8c440ee53df4c")
     version("1.0.0", sha256="7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51")
 


### PR DESCRIPTION
The gsi-ncdiag version 1.1.1 tag was recut after updating the version number in the cmake script.  This just updates the sha256 value for that tag.