### PR TITLE
elfutils: remove conflicts with clang after version 0.186

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -89,12 +89,9 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
     # and https://github.com/libarchive/libarchive/issues/1819
     conflicts("^libarchive@3.6.2 +iconv", when="+debuginfod")
 
-    # Elfutils uses nested functions in C code, which is implemented
-    # in gcc, but not in clang. C code compiled with gcc is
-    # binary-compatible with clang, so it should be possible to build
-    # elfutils with gcc, and then link it to clang-built libraries.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=24964
     conflicts("%apple-clang")
-    conflicts("%clang")
+    conflicts("%clang", when="@:0.185")
     conflicts("%cce")
 
     # Elfutils uses -Wall and we don't want to fail the build over a


### PR DESCRIPTION
In late 2021 elfutils was patched to make it build with clang, and these patches ended up in version 0.186. This commit updates the conflicts to specify this so elfutils can be built with clang.