### PR TITLE
e4s cray: expand spec list

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
@@ -90,7 +90,6 @@ spack:
   - amrex
   - butterflypack
   - conduit
-  - datatransferkit
   - flux-core
   - h5bench
   - hdf5-vol-async

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
@@ -84,11 +84,23 @@ spack:
         - cray-libsci/23.02.1.1
 
   specs:
+  - adios2
+  - amrex
   - butterflypack
+  - conduit
+  - datatransferkit
+  - flux-core
+  - h5bench
+  - hdf5-vol-async
+  - hdf5-vol-cache
+  - hdf5-vol-log
   - hypre
   - kokkos
   - kokkos-kernels
+  - legion
+  - mfem
   - petsc
+  - py-petsc4py
   - raja
   - slepc
   - superlu-dist

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray/spack.yaml
@@ -66,6 +66,8 @@ spack:
     elfutils:
       variants: +bzip2 ~nls +xz
       require: '%gcc'
+    unzip:
+      require: '%gcc'
 
     # EXTERNALS
     cray-mpich:


### PR DESCRIPTION
The last three days have seen only ~100 builds sent to our Cray box which is much below what we believe it can handle. This PR expands the list of specs in the E4S Cray CI stack, hopefully without overdoing it.