### PR TITLE
Fix default construction of locks

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -344,7 +344,7 @@ def lock_configuration(configuration):
     return LockConfiguration(
         enable=configuration.get("config:locks", True),
         database_timeout=configuration.get("config:db_lock_timeout"),
-        package_timeout=configuration.get("config:db_lock_timeout"),
+        package_timeout=configuration.get("config:package_lock_timeout"),
     )
 
 


### PR DESCRIPTION
This fixes a typo introduced in #33495 