### PR TITLE
Kokkos: Enable CUDA extended lambdas support by default from version 4 on

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -73,7 +73,6 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "aggressive_vectorization": [False, "Aggressively vectorize loops"],
         "compiler_warnings": [False, "Print all compiler warnings"],
         "cuda_constexpr": [False, "Activate experimental constexpr features"],
-        "cuda_lambda": [False, "Activate experimental lambda features"],
         "cuda_ldg_intrinsic": [False, "Use CUDA LDG intrinsics"],
         "cuda_relocatable_device_code": [False, "Enable RDC for CUDA"],
         "cuda_uvm": [False, "Enable unified virtual memory (UVM) for CUDA"],
@@ -187,6 +186,20 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         dflt, desc = options_variants[opt]
         variant(opt, default=dflt, description=desc)
 
+    conflicts("+cuda_lambda", when="~cuda", msg="Must enable CUDA to use cuda_lambda")
+    variant(
+        "cuda_lambda",
+        default=False,
+        when="@:3",
+        description="Activate experimental lambda features",
+    )
+    variant(
+        "cuda_lambda",
+        default=True,
+        when="@4:",
+        description="Activate experimental lambda features",
+    )
+
     tpls_values = list(tpls_variants.keys())
     for tpl in tpls_values:
         dflt, desc = tpls_variants[tpl]
@@ -284,6 +297,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
             from_variant("CMAKE_CXX_STANDARD", "std"),
             from_variant("BUILD_SHARED_LIBS", "shared"),
+            from_variant("Kokkos_ENABLE_CUDA_LAMBDA", "cuda_lambda"),
         ]
 
         spack_microarches = []


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/5580.
Related to faulures in https://github.com/spack/spack/pull/38802 (https://gitlab.spack.io/spack/spack/-/pipelines/446356, https://gitlab.spack.io/spack/spack/-/jobs/7669468):
```
-- kokkos_launch_compiler is enabled globally. C++ compiler commands
            with -DKOKKOS_DEPENDENCE will be redirected to the appropriate comp
           iler for Kokkos
     19    -- Found Kokkos: /home/software/spack/__spack_path_placeholder__/__s
           pack_path_placeholder__/__spack_path_placeholder__/__spack_path_plac
           eholder__/__spack_path_placeholder__/__spack_path_placeholder__/__sp
           ack_path_placeholder__/__spack_path_placeholder__/__spack_path_place
           h/linux-ubuntu20.04-x86_64_v3/gcc-11.1.0/kokkos-4.0.01-yg7j5hy4l6mug
           c6iyfa5ts6hktjvnhlg/lib/cmake/Kokkos (version "4.0.1")
     20    -- Could NOT find Kokkos_OPTIONS (missing: CUDA_LAMBDA)
  >> 21    CMake Error at /home/software/spack/__spack_path_placeholder__/__spa
           ck_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh
           older__/__spack_path_placeholder__/__spack_path_placeholder__/__spac
           k_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/
           linux-ubuntu20.04-x86_64_v3/gcc-11.1.0/kokkos-4.0.01-yg7j5hy4l6mugc6
           iyfa5ts6hktjvnhlg/lib/cmake/Kokkos/KokkosConfigCommon.cmake:89 (mess
           age):
     22      Kokkos does NOT provide all backends and/or architectures requeste
           d
     23    Call Stack (most recent call first):
     24      CMakeLists.txt:7 (kokkos_check)
```