### PR TITLE
py-cython: add v3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -12,12 +12,14 @@ class PyCython(PythonPackage):
     homepage = "https://github.com/cython/cython"
     pypi = "cython/Cython-0.29.21.tar.gz"
 
-    version("3.0.0a9", sha256="23931c45877432097cef9de2db2dc66322cbc4fc3ebbb42c476bb2c768cecff0")
+    version("3.0.0", sha256="350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82")
     version(
-        "0.29.35",
-        sha256="6e381fa0bf08b3c26ec2f616b19ae852c06f5750f4290118bf986b6f85c8c527",
-        preferred=True,
+        "3.0.0a9",
+        sha256="23931c45877432097cef9de2db2dc66322cbc4fc3ebbb42c476bb2c768cecff0",
+        deprecated=True,
     )
+    version("0.29.36", sha256="41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f")
+    version("0.29.35", sha256="6e381fa0bf08b3c26ec2f616b19ae852c06f5750f4290118bf986b6f85c8c527")
     version("0.29.34", sha256="1909688f5d7b521a60c396d20bba9e47a1b2d2784bfb085401e1e1e7d29a29a8")
     version("0.29.33", sha256="5040764c4a4d2ce964a395da24f0d1ae58144995dab92c6b96f44c3f4d72286a")
     version("0.29.32", sha256="8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7")
@@ -41,9 +43,6 @@ class PyCython(PythonPackage):
     version("0.25.2", sha256="f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306")
     version("0.23.5", sha256="0ae5a5451a190e03ee36922c4189ca2c88d1df40a89b4f224bc842d388a0d1b6")
     version("0.23.4", sha256="fec42fecee35d6cc02887f1eef4e4952c97402ed2800bfe41bbd9ed1a0730d8e")
-
-    depends_on("python@2.7:2,3.4:", when="@3:", type=("build", "link", "run"))
-    depends_on("python@2.6:2,3.3:", type=("build", "link", "run"))
 
     # https://github.com/cython/cython/commit/1cd24026e9cf6d63d539b359f8ba5155fd48ae21
     # collections.Iterable was removed in Python 3.10

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -23,7 +23,7 @@ class PyGevent(PythonPackage):
     depends_on("py-setuptools@40.8:", when="@20.5.1:", type=("build", "run"))
     depends_on("py-setuptools@40.8:", when="@1.5:", type="build")
     depends_on("py-setuptools@24.2:", when="@:1.4", type="build")
-    depends_on("py-cython@3.0.0a9:", when="@20.5.1:", type="build")
+    depends_on("py-cython@3:", when="@20.5.1:", type="build")
     depends_on("py-cython@0.29.14:", when="@1.5:", type="build")
     depends_on("py-cython@0.27:", when="@:1.4", type="build")
     depends_on("py-cython@0.27:", when="@:1.4", type="build")
@@ -35,6 +35,9 @@ class PyGevent(PythonPackage):
     depends_on("py-greenlet@0.4.13:", when="@:1.4", type=("build", "run"))
     depends_on("py-zope-event", when="@20.5.1:", type=("build", "run"))
     depends_on("py-zope-interface", when="@20.5.1:", type=("build", "run"))
+
+    # https://github.com/gevent/gevent/issues/1599
+    conflicts("^py-cython@3:", when="@:20.5.0")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="%intel")

--- a/var/spack/repos/builtin/packages/py-pycocotools/package.py
+++ b/var/spack/repos/builtin/packages/py-pycocotools/package.py
@@ -22,3 +22,5 @@ class PyPycocotools(PythonPackage):
     depends_on("py-setuptools@18.0:", when="@:2.0.3", type=("build", "run"))
     depends_on("py-matplotlib@2.1.0:", type=("build", "run"))
     depends_on("py-numpy", type=("build", "link", "run"))
+
+    conflicts("^py-cython@3:", when="@:2.0.4")

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -34,6 +34,9 @@ class PyPyyaml(PythonPackage):
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:5.3")
 
+    # https://github.com/yaml/pyyaml/issues/601
+    conflicts("^py-cython@3:")
+
     @property
     def import_modules(self):
         modules = ["yaml"]


### PR DESCRIPTION
Cython has finally finished their migration to v3.0.0!

This release is highly backwards-incompatible, and I've already noticed issues building older versions of pycocotools. I'm excited to see how many other packages break. Most of the mainstream packages have an explicit `<2`, but many smaller packages are likely to break with this change. I'm personally of the mindset that we should make 3.0.0 the default (as it is with pip) and add conflicts as we discover them. Let's see how many packages require modification for the pipeline to pass.