### PR TITLE
Ensure the bootstrap store has a padding length of zero

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -155,13 +155,13 @@ def _ensure_bootstrap_configuration() -> Generator:
     with spack.environment.no_active_environment():
         with spack.platforms.prevent_cray_detection(), spack.platforms.use_platform(
             spack.platforms.real_host()
-        ), spack.repo.use_repositories(spack.paths.packages_path), spack.store.use_store(
-            bootstrap_store_path
-        ):
+        ), spack.repo.use_repositories(spack.paths.packages_path):
             # Default configuration scopes excluding command line
             # and builtin but accounting for platform specific scopes
             config_scopes = _bootstrap_config_scopes()
-            with spack.config.use_configuration(*config_scopes):
+            with spack.config.use_configuration(*config_scopes), spack.store.use_store(
+                bootstrap_store_path, extra_data={"padded_length": 0}
+            ):
                 # We may need to compile code from sources, so ensure we
                 # have compilers for the current platform
                 _add_compilers_if_missing()

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -23,20 +23,29 @@ def active_mock_environment(mutable_config, mutable_mock_env_path):
 
 @pytest.mark.regression("22294")
 def test_store_is_restored_correctly_after_bootstrap(mutable_config, tmpdir):
-    # Prepare a custom store path. This should be in a writeable location
-    # since Spack needs to initialize the DB.
+    """Tests that the store is correctly swapped during bootstrapping, and restored afterward."""
     user_path = str(tmpdir.join("store"))
-    # Reassign global variables in spack.store to the value
-    # they would have at Spack startup.
-    spack.store.reinitialize()
-    # Set the custom user path
-    spack.config.set("config:install_tree:root", user_path)
+    with spack.store.use_store(user_path):
+        assert spack.store.root == user_path
+        assert spack.config.config.get("config:install_tree:root") == user_path
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            assert spack.store.root == spack.bootstrap.config.store_path()
+        assert spack.store.root == user_path
+        assert spack.config.config.get("config:install_tree:root") == user_path
 
-    # Test that within the context manager we use the bootstrap store
-    # and that outside we restore the correct location
-    with spack.bootstrap.ensure_bootstrap_configuration():
-        assert spack.store.root == spack.bootstrap.config.store_path()
-    assert spack.store.root == user_path
+
+@pytest.mark.regression("38963")
+def test_store_padding_length_is_zero_during_bootstrapping(mutable_config, tmpdir):
+    """Tests that, even though padded length is set in user config, the bootstrap store maintains
+    a padded length of zero.
+    """
+    user_path = str(tmpdir.join("store"))
+    with spack.store.use_store(user_path, extra_data={"padded_length": 512}):
+        assert spack.config.config.get("config:install_tree:padded_length") == 512
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            assert spack.store.root == spack.bootstrap.config.store_path()
+            assert spack.config.config.get("config:install_tree:padded_length") == 0
+        assert spack.config.config.get("config:install_tree:padded_length") == 512
 
 
 @pytest.mark.parametrize(

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -15,6 +15,7 @@ spack:
   config:
     install_tree:
       root: {{ store_path }}
+      padded_length: 0
 
   packages:
     python:


### PR DESCRIPTION
fixes #38963

Without this PR, padded length was propagating from user configuration to bootstrap configuration, and was causing the issue reported in #38963