### PR TITLE
py-pytest-html: Add version 3.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytest-html/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-html/package.py
@@ -22,7 +22,7 @@ class PyPytestHtml(PythonPackage):
     depends_on("py-setuptools-scm", type="build")
     depends_on("py-pytest@5.0:5,6.0.1:", type=("build", "run"))
     depends_on("py-pytest-metadata", type=("build", "run"))
-    depends_on("py-py", when="^py-pytest@7.2.0:", type=("build", "run"))
+    depends_on("py-py@1.8.2:", when="^py-pytest@7.2.0:", type=("build", "run"))
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-pytest-html/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-html/package.py
@@ -14,6 +14,7 @@ class PyPytestHtml(PythonPackage):
     homepage = "https://github.com/pytest-dev/pytest-html"
     pypi = "pytest-html/pytest-html-3.1.1.tar.gz"
 
+    version("3.2.0", sha256="c4e2f4bb0bffc437f51ad2174a8a3e71df81bbc2f6894604e604af18fbe687c3")
     version("3.1.1", sha256="3ee1cf319c913d19fe53aeb0bc400e7b0bc2dbeb477553733db1dad12eb75ee3")
 
     depends_on("python@3.6:", type=("build", "run"))
@@ -21,3 +22,11 @@ class PyPytestHtml(PythonPackage):
     depends_on("py-setuptools-scm", type="build")
     depends_on("py-pytest@5.0:5,6.0.1:", type=("build", "run"))
     depends_on("py-pytest-metadata", type=("build", "run"))
+    depends_on("py-py", when="^py-pytest@7.2.0:", type=("build", "run"))
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def check_build(self):
+        # Simplest test: pytest will load pytest-html plugin
+        output = python("-m", "pytest", "-VV", output=str, error=str)
+        assert self.prefix in output, f"Missing pytest-html in {output!r}"

--- a/var/spack/repos/builtin/packages/py-pytest-html/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-html/package.py
@@ -25,7 +25,13 @@ class PyPytestHtml(PythonPackage):
     depends_on("py-wheel@0.33.6:", type="build")
     depends_on("py-pytest@5.0:5,6.0.1:", type=("build", "run"))
     depends_on("py-pytest-metadata", type=("build", "run"))
-    depends_on("py-py@1.8.2:", type=("build", "run"))
+
+    # https://github.com/spack/spack/pull/38989
+    # py-pytest@7.2 removed py-py dependency, but now py-pytest conflicts with py-py. And
+    # py-pytest-htm@:3 requires py-py.
+    # One workaround is to always add py-py *before* py-pytest in PYTHONPATH, but we cannot ensure
+    # that. So don't allow this configuration, pending py-pytest-html@4.
+    conflicts("^py-pytest@7.2:", when="@:3")
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-pytest-html/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-html/package.py
@@ -18,11 +18,13 @@ class PyPytestHtml(PythonPackage):
     version("3.1.1", sha256="3ee1cf319c913d19fe53aeb0bc400e7b0bc2dbeb477553733db1dad12eb75ee3")
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm", type="build")
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm+toml@3.5.0:", type="build")
+    depends_on("py-setuptools-scm-git-archive@1.1:", type="build")
+    depends_on("py-wheel@0.33.6:", type="build")
     depends_on("py-pytest@5.0:5,6.0.1:", type=("build", "run"))
     depends_on("py-pytest-metadata", type=("build", "run"))
-    depends_on("py-py@1.8.2:", when="^py-pytest@7.2.0:", type=("build", "run"))
+    depends_on("py-py@1.8.2:", type=("build", "run"))
 
     @run_after("install")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-pytest-html/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-html/package.py
@@ -13,6 +13,7 @@ class PyPytestHtml(PythonPackage):
 
     homepage = "https://github.com/pytest-dev/pytest-html"
     pypi = "pytest-html/pytest-html-3.1.1.tar.gz"
+    git = "https://github.com/pytest-dev/pytest-html.git"
 
     version("3.2.0", sha256="c4e2f4bb0bffc437f51ad2174a8a3e71df81bbc2f6894604e604af18fbe687c3")
     version("3.1.1", sha256="3ee1cf319c913d19fe53aeb0bc400e7b0bc2dbeb477553733db1dad12eb75ee3")


### PR DESCRIPTION
Add py-pytest-html 3.2.0.

Add conflict with `py-pytest@7.2:`, due to conflicting `py` python modules (see PR comments). A reliable fix should come with [py-pytest-html 4](https://github.com/pytest-dev/pytest-html/blob/master/docs/deprecations.rst#py-module) (not released yet).

For the record, here is the errors you'd get with a conflicting `py`  python module:

```console
$ python3 -m pytest --version
[...]
  File "/.../spack/linux-ubuntu22.04-skylake/gcc-11.3.0/py-pytest-html-3.1.1-hhlwraizrwicneboermmg6ft7p37544k/lib/python3.10/site-packages/pytest_html/plugin.py", line 22, in <module>
    from py.xml import html
ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package
```

Or

```console
$ python3 -m pytest --version
[...]
  File "/.../spack/linux-ubuntu22.04-skylake/gcc-12.1.0/py-pytest-html-3.2.0-gujzhqzf4cjuahf4chqz5dtitohihzn2/lib/python3.10/site-packages/pytest_html/html_report.py", line 11, in <module>
    from py.xml import html
ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package
```
