### PR TITLE
Fixed broken calls to _if_ninja_target_execute

### DIFF
--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -209,5 +209,5 @@ class MesonBuilder(BaseBuilder):
     def check(self):
         """Search Meson-generated files for the target ``test`` and run it if found."""
         with fs.working_dir(self.build_directory):
-            self._if_ninja_target_execute("test")
-            self._if_ninja_target_execute("check")
+            self.pkg._if_ninja_target_execute("test")
+            self.pkg._if_ninja_target_execute("check")


### PR DESCRIPTION
closes #39361

At some point between 0.18.1 and 0.19.2, there was a change in the Meson build system that added the MesonBuilder class. The check(self) function wasn't updated to be compatible with those changes and was producing issues when trying to build packages.