### PR TITLE
libtiff: fix shared build for old cmake

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -103,6 +103,12 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     # https://gitlab.com/libtiff/libtiff/-/merge_requests/243
     conflicts("platform=darwin", when="@4.3.0")
 
+    # cmake 3.19 and newer turn on pic automatically when shared is enabled
+    # for older cmake versions enabling shared without pic results in
+    # relocation R_X86_64_32 against `.rodata.str1.1' can not
+    # be used when making a shared object; recompile with -fPIC
+    conflicts("~pic", when="+shared ^cmake@:3.18")
+
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler
         if self.spec.satisfies("%nvhpc@:20.11"):


### PR DESCRIPTION
Installing `spack install libtiff+shared` failed with `cmake@:3.18` with the error
```
     252    /usr/bin/ld: CMakeFiles/tiff.dir/tif_aux.c.o: relocation R_X86_64_32 against `.rodata.str1.1' can not 
            be used when making a shared object; recompile with -fPIC
     253    /usr/bin/ld: failed to set dynamic section sizes: bad value
```
Enabling `pic` fixed it.