### PR TITLE
Respect custom user store when bootstrapping

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -150,6 +150,7 @@ def _add_compilers_if_missing() -> None:
 
 @contextlib.contextmanager
 def _ensure_bootstrap_configuration() -> Generator:
+    spack.store.ensure_singleton_created()
     bootstrap_store_path = store_path()
     user_configuration = _read_and_sanitize_configuration()
     with spack.environment.no_active_environment():

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -326,6 +326,11 @@ def specfile_matches(filename: str, **kwargs) -> List["spack.spec.Spec"]:
     return spack.store.find(query, **kwargs)
 
 
+def ensure_singleton_created() -> None:
+    """Ensures the lazily evaluated singleton is created"""
+    _ = STORE.db
+
+
 @contextlib.contextmanager
 def use_store(
     path: Union[str, pathlib.Path], extra_data: Optional[Dict[str, Any]] = None
@@ -349,7 +354,7 @@ def use_store(
         data.update(extra_data)
 
     # Swap the store with the one just constructed and return it
-    _ = STORE.db
+    ensure_singleton_created()
     spack.config.config.push_scope(
         spack.config.InternalConfigScope(name=scope_name, data={"config": {"install_tree": data}})
     )

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -47,6 +47,25 @@ def test_store_padding_length_is_zero_during_bootstrapping(mutable_config, tmpdi
         assert spack.config.config.get("config:install_tree:padded_length") == 512
 
 
+@pytest.mark.regression("38963")
+def test_install_tree_customization_is_respected(mutable_config, tmp_path):
+    """Tests that a custom user store is respected when we exit the bootstrapping
+    environment.
+    """
+    spack.store.reinitialize()
+    store_dir = tmp_path / "store"
+    spack.config.config.set("config:install_tree:root", str(store_dir))
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert spack.store.STORE.root == spack.bootstrap.config.store_path()
+        assert (
+            spack.config.config.get("config:install_tree:root")
+            == spack.bootstrap.config.store_path()
+        )
+        assert spack.config.config.get("config:install_tree:padded_length") == 0
+    assert spack.config.config.get("config:install_tree:root") == str(store_dir)
+    assert spack.store.STORE.root == str(store_dir)
+
+
 @pytest.mark.parametrize(
     "config_value,expected",
     [


### PR DESCRIPTION
The user store is lazily evaluated. The change in #38975 made it such that the first evaluation was happening in the middle of swapping to bootstrap configuration. Ensure we construct the user store before that.