### PR TITLE
modules: no --delim option if separator is colon character

### DIFF
--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -133,9 +133,9 @@ class TestTcl:
         module_configuration("module_path_separator")
         content = modulefile_content("module-path-separator")
 
-        assert len([x for x in content if "append-path --delim {:} COLON {foo}" in x]) == 1
-        assert len([x for x in content if "prepend-path --delim {:} COLON {foo}" in x]) == 1
-        assert len([x for x in content if "remove-path --delim {:} COLON {foo}" in x]) == 1
+        assert len([x for x in content if "append-path COLON {foo}" in x]) == 1
+        assert len([x for x in content if "prepend-path COLON {foo}" in x]) == 1
+        assert len([x for x in content if "remove-path COLON {foo}" in x]) == 1
         assert len([x for x in content if "append-path --delim {;} SEMICOLON {bar}" in x]) == 1
         assert len([x for x in content if "prepend-path --delim {;} SEMICOLON {bar}" in x]) == 1
         assert len([x for x in content if "remove-path --delim {;} SEMICOLON {bar}" in x]) == 1
@@ -150,37 +150,23 @@ class TestTcl:
 
         # no manpath set by module
         content = modulefile_content("mpileaks")
-        assert len([x for x in content if "append-path --delim {:} MANPATH {}" in x]) == 0
+        assert len([x for x in content if "append-path MANPATH {}" in x]) == 0
 
         # manpath set by module with prepend-path
         content = modulefile_content("module-manpath-prepend")
-        assert (
-            len([x for x in content if "prepend-path --delim {:} MANPATH {/path/to/man}" in x])
-            == 1
-        )
-        assert (
-            len(
-                [
-                    x
-                    for x in content
-                    if "prepend-path --delim {:} MANPATH {/path/to/share/man}" in x
-                ]
-            )
-            == 1
-        )
-        assert len([x for x in content if "append-path --delim {:} MANPATH {}" in x]) == 1
+        assert len([x for x in content if "prepend-path MANPATH {/path/to/man}" in x]) == 1
+        assert len([x for x in content if "prepend-path MANPATH {/path/to/share/man}" in x]) == 1
+        assert len([x for x in content if "append-path MANPATH {}" in x]) == 1
 
         # manpath set by module with append-path
         content = modulefile_content("module-manpath-append")
-        assert (
-            len([x for x in content if "append-path --delim {:} MANPATH {/path/to/man}" in x]) == 1
-        )
-        assert len([x for x in content if "append-path --delim {:} MANPATH {}" in x]) == 1
+        assert len([x for x in content if "append-path MANPATH {/path/to/man}" in x]) == 1
+        assert len([x for x in content if "append-path MANPATH {}" in x]) == 1
 
         # manpath set by module with setenv
         content = modulefile_content("module-manpath-setenv")
         assert len([x for x in content if "setenv MANPATH {/path/to/man}" in x]) == 1
-        assert len([x for x in content if "append-path --delim {:} MANPATH {}" in x]) == 0
+        assert len([x for x in content if "append-path MANPATH {}" in x]) == 0
 
     @pytest.mark.regression("29578")
     def test_setenv_raw_value(self, modulefile_content, module_configuration):

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -54,11 +54,23 @@ conflict {{ name }}
 {% block environment %}
 {% for command_name, cmd in environment_modifications %}
 {% if command_name == 'PrependPath' %}
+{% if cmd.separator == ':' %}
+prepend-path {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% else %}
 prepend-path --delim {{ '{' }}{{ cmd.separator }}{{ '}' }} {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% endif %}
 {% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
+{% if cmd.separator == ':' %}
+append-path {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% else %}
 append-path --delim {{ '{' }}{{ cmd.separator }}{{ '}' }} {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% endif %}
 {% elif command_name in ('RemovePath', 'RemoveFlagsEnv') %}
+{% if cmd.separator == ':' %}
+remove-path {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% else %}
 remove-path --delim {{ '{' }}{{ cmd.separator }}{{ '}' }} {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
+{% endif %}
 {% elif command_name == 'SetEnv' %}
 setenv {{ cmd.name }} {{ '{' }}{{ cmd.value }}{{ '}' }}
 {% elif command_name == 'UnsetEnv' %}
@@ -68,7 +80,7 @@ unsetenv {{ cmd.name }}
 {% endfor %}
 {# Make sure system man pages are enabled by appending trailing delimiter to MANPATH #}
 {% if has_manpath_modifications %}
-append-path --delim {{ '{' }}:{{ '}' }} MANPATH {{ '{' }}{{ '}' }}
+append-path MANPATH {{ '{' }}{{ '}' }}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Update Tcl modulefile template to simplify generated `append-path`, `prepend-path` and `remove-path` commands and improve their readability.

If path element delimiter is colon character, do not set the `--delim` option as it is the default delimiter value.