### PR TITLE
Fix package.py error handling minor bug

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1256,9 +1256,8 @@ def get_package_context(traceback, context=3):
             func = getattr(obj, tb.tb_frame.f_code.co_name, "")
             if func:
                 typename, *_ = func.__qualname__.partition(".")
-
-            if isinstance(obj, CONTEXT_BASES) and typename not in basenames:
-                break
+                if isinstance(obj, CONTEXT_BASES) and typename not in basenames:
+                    break
     else:
         return None
 


### PR DESCRIPTION
Fix one of the issue of #39016.

When walking a recipe error trackback, the `typename` variable was used while not set under some conditions.

Both this PR and #39015 fixes the freeze seen in #39016, but they actually fix 2 different bugs.

I think the bug was introduced in #37655.
