### PR TITLE
hdf5: fix showconfig

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -700,6 +700,27 @@ class Hdf5(CMakePackage):
         return spec_vers_str
 
     @run_after("install")
+    def fix_showconfig(self):
+        # The 'Extra libraries' entry of the 'h5cc -showconfig' command is a space-separated list
+        # of linker flags if the package is installed with Autotools, and a semicolon-separated
+        # list of library names and/or absolute paths to library files if the package is installed
+        # with CMake. There are use cases that rely on the old Autotools behavior. Here, we make
+        # sure that the output of the command looks like it was before we switched to CMake.
+        filter_file(
+            r"^(\s*Extra libraries: )(.*)",
+            lambda match: "{0}{1}".format(
+                match.group(1),
+                " ".join(
+                    lib if os.sep in lib else "-l{0}".format(lib)
+                    for lib in filter(None, match.group(2).split(";"))
+                ),
+            ),
+            self.prefix.lib.join("libhdf5.settings"),
+            backup=False,
+            ignore_absent=True,
+        )
+
+    @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_install(self):
         self.test_check_prog()


### PR DESCRIPTION
This is my second attempt to fix the `Extra libraries` section of the `h5cc -showconfig` command so it looks as if the package was installed with Autotools: a space-separated list of linker flags instead of a semicolon-separated list of library names.

The first attempt was #34920, which was reverted in #37707.

The problem with the first implementation was that it didn't account for possible path entries on the list generated by CMake. This version changes the semicolon-separated list to a space-separated one while keeping entries with the path separator as-is and prepending the `-l` flag otherwise. The assumption is that if there is a path separator, it's an absolute path (as far as I know, CMake makes sure of that) to a library file, which can be simply passed to the linker.

@haampie unfortunately, I can't see [the log](https://gitlab.spack.io/spack/spack/-/jobs/6990446) that you mentioned in #37707 anymore. What was the problem there? Is there a package that actually expects the `Extra libraries` entry to be the original semicolon-separated list?