### PR TITLE
py-plotext: package addition

### DIFF
--- a/var/spack/repos/builtin/packages/py-plotext/package.py
+++ b/var/spack/repos/builtin/packages/py-plotext/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPlotext(PythonPackage):
+    """Plotext plots directly on terminal."""
+
+    pypi = "plotext/plotext-5.2.8.tar.gz"
+    git = "https://github.com/piccolomo/plotext.git"
+
+    version("master", branch="master")
+    version("5.2.8", sha256="319a287baabeb8576a711995f973a2eba631c887aa6b0f33ab016f12c50ffebe")
+
+    # build dependencies
+    depends_on("python@3.5.0:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build"))


### PR DESCRIPTION
This package is hosted on [github](https://github.com/piccolomo/plotext/tree/master) and [pypi](https://pypi.org/project/plotext/#files).

It plots various kind of graph formats in the terminal.

**Note**: this package is used by **py-melissa-core** (see [this active PR](https://github.com/spack/spack/pull/38654)).