### PR TITLE
Extract prefix locks and failure markers from Database

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -125,7 +125,7 @@ def clean(parser, args):
 
     if args.failures:
         tty.msg("Removing install failure marks")
-        spack.installer.clear_failures()
+        spack.store.STORE.clear_all_failures()
 
     if args.misc_cache:
         tty.msg("Removing cached information on repositories")

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -17,6 +17,7 @@ import spack.cmd.test
 import spack.config
 import spack.repo
 import spack.stage
+import spack.store
 import spack.util.path
 from spack.paths import lib_path, var_path
 
@@ -125,7 +126,7 @@ def clean(parser, args):
 
     if args.failures:
         tty.msg("Removing install failure marks")
-        spack.store.STORE.clear_all_failures()
+        spack.store.STORE.failure_tracker.clear_all_failures()
 
     if args.misc_cache:
         tty.msg("Removing cached information on repositories")

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -126,7 +126,7 @@ def clean(parser, args):
 
     if args.failures:
         tty.msg("Removing install failure marks")
-        spack.store.STORE.failure_tracker.clear_all_failures()
+        spack.store.STORE.failure_tracker.clear_all()
 
     if args.misc_cache:
         tty.msg("Removing cached information on repositories")

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -25,7 +25,7 @@ import pathlib
 import socket
 import sys
 import time
-from typing import Dict, Generator, List, NamedTuple, Set, Type, Union
+from typing import Any, Callable, Dict, Generator, List, NamedTuple, Set, Type, Union
 
 try:
     import uuid
@@ -359,11 +359,20 @@ def prefix_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
     return pathlib.Path(root_dir) / _DB_DIRNAME / "prefix_lock"
 
 
+def failures_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
+    """Returns the path of the failures lock file, given the root directory.
+
+    Args:
+        root_dir: root directory containing the database directory
+    """
+    return pathlib.Path(root_dir) / _DB_DIRNAME / "prefix_failures"
+
+
 class SpecLocker:
     """Manages acquiring and releasing read or write locks on concrete specs."""
 
-    #: Maps (lockfile, spec.dag_hash()) to the corresponding lock object
-    locks: Dict[Tuple[str, str], lk.Lock] = {}
+    #: Maps (lockfile, spec.dag_hash(), spec.name) to the corresponding lock object
+    locks: Dict[Tuple[str, str, str], lk.Lock] = {}
 
     def __init__(self, lock_path: Union[str, pathlib.Path], default_timeout: Optional[float]):
         self.lock_path = pathlib.Path(lock_path)
@@ -382,21 +391,34 @@ class SpecLocker:
         """
         assert spec.concrete, "cannot lock a non-concrete spec"
         timeout = timeout or self.default_timeout
-        key = (str(self.lock_path), spec.dag_hash())
+        key = self._lock_key(spec)
 
         if key not in self.locks:
-            self.locks[key] = lk.Lock(
-                str(self.lock_path),
-                start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
-                length=1,
-                default_timeout=timeout,
-                desc=spec.name,
-            )
+            self.locks[key] = self.raw_lock(spec, timeout=timeout)
 
         if timeout != self.locks[key].default_timeout:
             self.locks[key].default_timeout = timeout
 
         return self.locks[key]
+
+    def raw_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.Lock:
+        """Returns a raw lock for a Spec, but doesn't keep track of it."""
+        return lk.Lock(
+            str(self.lock_path),
+            start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
+            length=1,
+            default_timeout=timeout,
+            desc=spec.name,
+        )
+
+    def has_lock(self, spec: "spack.spec.Spec") -> bool:
+        """Returns True if the spec is already managed by this spec locker"""
+        key = self._lock_key(spec)
+        return key in self.locks
+
+    def _lock_key(self, spec: "spack.spec.Spec") -> Tuple[str, str, str]:
+        key = (str(self.lock_path), spec.dag_hash(), spec.name)
+        return key
 
     @contextlib.contextmanager
     def read_lock(self, spec: "spack.spec.Spec") -> Generator["SpecLocker", None, None]:
@@ -432,11 +454,153 @@ class SpecLocker:
         else:
             lock.release_write()
 
+    def clear(self, spec: "spack.spec.Spec") -> Tuple[bool, Optional[lk.Lock]]:
+        key = self._lock_key(spec)
+        if key in self.locks:
+            lock = self.locks.pop(key)
+            return True, lock
+        return False, None
+
+    def clear_all(self, clear_fn: Optional[Callable[[lk.Lock], Any]] = None) -> None:
+        for key in self.all_keys():
+            lock = self.locks.pop(key)
+            if clear_fn is not None:
+                clear_fn(lock)
+
+    def all_keys(self) -> List[Tuple[str, str, str]]:
+        return [key for key in self.locks if key[0] == str(self.lock_path)]
+
+
+class FailureTracker:
+    """Tracks installation failures.
+
+    Prefix failure marking takes the form of a byte range lock on the nth
+    byte of a file for coordinating between concurrent parallel build
+    processes and a persistent file, named with the full hash and
+    containing the spec, in a subdirectory of the database to enable
+    persistence across overlapping but separate related build processes.
+
+    The failure lock file lives alongside the install DB.
+
+    ``n`` is the sys.maxsize-bit prefix of the associated DAG hash to make
+    the likelihood of collision very low with no cleanup required.
+    """
+
+    def __init__(self, root_dir: Union[str, pathlib.Path], default_timeout: Optional[float]):
+        #: Ensure a persistent location for dealing with parallel installation
+        #: failures (e.g., across near-concurrent processes).
+        self.failure_dir = pathlib.Path(root_dir) / _DB_DIRNAME / "failures"
+        self.failure_dir.mkdir(parents=True, exist_ok=True)
+
+        self.failures_lock = SpecLocker(
+            failures_lock_path(root_dir), default_timeout=default_timeout
+        )
+
+    def clear_failure(self, spec: "spack.spec.Spec", force: bool = False) -> None:
+        """Removes any persistent and cached failure tracking for the spec.
+
+        see `mark_failed()`.
+
+        Args:
+            spec: the spec whose failure indicators are being removed
+            force: True if the failure information should be cleared when a failure lock
+                exists for the file, or False if the failure should not be cleared (e.g.,
+                it may be associated with a concurrent build)
+        """
+        failure_locked = self.prefix_failure_locked(spec)
+        if failure_locked and not force:
+            tty.msg(f"Retaining failure marking for {spec.name} due to lock")
+            return
+
+        if failure_locked:
+            tty.warn(f"Removing failure marking despite lock for {spec.name}")
+
+        succeeded, lock = self.failures_lock.clear(spec)
+        if succeeded and lock is not None:
+            lock.release_write()
+
+        if self.prefix_failure_marked(spec):
+            path = self._failed_spec_path(spec)
+            tty.debug(f"Removing failure marking for {spec.name}")
+            try:
+                path.unlink()
+            except OSError as err:
+                tty.warn(
+                    f"Unable to remove failure marking for {spec.name} ({str(path)}): {str(err)}"
+                )
+
+    def clear_all_failures(self) -> None:
+        """Force remove install failure tracking files."""
+        tty.debug("Releasing prefix failure locks")
+        self.failures_lock.clear_all(
+            clear_fn=lambda x: x.release_write() if x.is_write_locked() else True
+        )
+
+        tty.debug("Removing prefix failure tracking files")
+        try:
+            for fail_mark in os.listdir(str(self.failure_dir)):
+                try:
+                    (self.failure_dir / fail_mark).unlink()
+                except OSError as exc:
+                    tty.warn(f"Unable to remove failure marking file {fail_mark}: {str(exc)}")
+        except OSError as exc:
+            tty.warn(f"Unable to remove failure marking files: {str(exc)}")
+
+    def mark_failed(self, spec: "spack.spec.Spec") -> lk.Lock:
+        """Marks a spec as failing to install.
+
+        Args:
+            spec: spec that failed to install
+        """
+        # Dump the spec to the failure file for (manual) debugging purposes
+        path = self._failed_spec_path(spec)
+        path.write_text(spec.to_json())
+
+        # Also ensure a failure lock is taken to prevent cleanup removal
+        # of failure status information during a concurrent parallel build.
+        if not self.failures_lock.has_lock(spec):
+            try:
+                mark = self.failures_lock.lock(spec)
+                mark.acquire_write()
+            except lk.LockTimeoutError:
+                # Unlikely that another process failed to install at the same
+                # time but log it anyway.
+                tty.debug(f"PID {os.getpid()} failed to mark install failure for {spec.name}")
+                tty.warn(f"Unable to mark {spec.name} as failed.")
+
+        return self.failures_lock.lock(spec)
+
+    def prefix_failed(self, spec: "spack.spec.Spec") -> bool:
+        """Return True if the prefix (installation) is marked as failed."""
+        # The failure was detected in this process.
+        if self.failures_lock.has_lock(spec):
+            return True
+
+        # The failure was detected by a concurrent process (e.g., an srun),
+        # which is expected to be holding a write lock if that is the case.
+        if self.prefix_failure_locked(spec):
+            return True
+
+        # Determine if the spec may have been marked as failed by a separate
+        # spack build process running concurrently.
+        return self.prefix_failure_marked(spec)
+
+    def prefix_failure_locked(self, spec: "spack.spec.Spec") -> bool:
+        """Return True if a process has a failure lock on the spec."""
+        check = self.failures_lock.raw_lock(spec)
+        return check.is_write_locked()
+
+    def prefix_failure_marked(self, spec: "spack.spec.Spec") -> bool:
+        """Determine if the spec has a persistent failure marking."""
+        return self._failed_spec_path(spec).exists()
+
+    def _failed_spec_path(self, spec: "spack.spec.Spec") -> pathlib.Path:
+        """Return the path to the spec's failure file, which may not exist."""
+        assert spec.concrete, "concrete spec required for failure path"
+        return self.failure_dir / f"{spec.name}-{spec.dag_hash()}"
+
 
 class Database:
-    #: Per-process failure (lock) objects for each install prefix
-    _prefix_failures: Dict[str, lk.Lock] = {}
-
     #: Fields written for each install record
     record_fields: Tuple[str, ...] = DEFAULT_INSTALL_RECORD_FIELDS
 
@@ -474,20 +638,15 @@ class Database:
         self._verifier_path = os.path.join(self.database_directory, "index_verifier")
         self._lock_path = os.path.join(self.database_directory, "lock")
 
-        # Ensure a persistent location for dealing with parallel installation
-        # failures (e.g., across near-concurrent processes).
-        self._failure_dir = os.path.join(self.database_directory, "failures")
-
-        # Support special locks for handling parallel installation failures
-        # of a spec.
-        self.prefix_fail_path = os.path.join(self.database_directory, "prefix_failures")
-
         # Create needed directories and files
         if not is_upstream and not os.path.exists(self.database_directory):
             fs.mkdirp(self.database_directory)
 
-        if not is_upstream and not os.path.exists(self._failure_dir):
-            fs.mkdirp(self._failure_dir)
+        self.failure_tracker = None
+        if not is_upstream:
+            self.failure_tracker = FailureTracker(
+                self.root, default_timeout=lock_cfg.package_timeout
+            )
 
         self.is_upstream = is_upstream
         self.last_seen_verifier = ""
@@ -505,12 +664,6 @@ class Database:
         self.package_lock_timeout = lock_cfg.package_timeout
 
         tty.debug("DATABASE LOCK TIMEOUT: {0}s".format(str(self.db_lock_timeout)))
-        timeout_format_str = (
-            "{0}s".format(str(self.package_lock_timeout))
-            if self.package_lock_timeout
-            else "No timeout"
-        )
-        tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
 
         self.lock: Union[ForbiddenLock, lk.Lock]
         if self.is_upstream:
@@ -550,147 +703,22 @@ class Database:
         """Get a read lock context manager for use in a `with` block."""
         return self._read_transaction_impl(self.lock, acquire=self._read)
 
-    def _failed_spec_path(self, spec):
-        """Return the path to the spec's failure file, which may not exist."""
-        if not spec.concrete:
-            raise ValueError("Concrete spec required for failure path for {0}".format(spec.name))
-
-        return os.path.join(self._failure_dir, "{0}-{1}".format(spec.name, spec.dag_hash()))
-
     def clear_all_failures(self) -> None:
         """Force remove install failure tracking files."""
-        tty.debug("Releasing prefix failure locks")
-        for pkg_id in list(self._prefix_failures.keys()):
-            lock = self._prefix_failures.pop(pkg_id, None)
-            if lock:
-                lock.release_write()
-
-        # Remove all failure markings (aka files)
-        tty.debug("Removing prefix failure tracking files")
-        for fail_mark in os.listdir(self._failure_dir):
-            try:
-                os.remove(os.path.join(self._failure_dir, fail_mark))
-            except OSError as exc:
-                tty.warn(
-                    "Unable to remove failure marking file {0}: {1}".format(fail_mark, str(exc))
-                )
+        assert self.failure_tracker is not None
+        self.failure_tracker.clear_all_failures()
 
     def clear_failure(self, spec: "spack.spec.Spec", force: bool = False) -> None:
-        """
-        Remove any persistent and cached failure tracking for the spec.
-
-        see `mark_failed()`.
-
-        Args:
-            spec: the spec whose failure indicators are being removed
-            force: True if the failure information should be cleared when a prefix failure
-                lock exists for the file, or False if the failure should not be cleared (e.g.,
-                it may be associated with a concurrent build)
-        """
-        failure_locked = self.prefix_failure_locked(spec)
-        if failure_locked and not force:
-            tty.msg("Retaining failure marking for {0} due to lock".format(spec.name))
-            return
-
-        if failure_locked:
-            tty.warn("Removing failure marking despite lock for {0}".format(spec.name))
-
-        lock = self._prefix_failures.pop(spec.prefix, None)
-        if lock:
-            lock.release_write()
-
-        if self.prefix_failure_marked(spec):
-            try:
-                path = self._failed_spec_path(spec)
-                tty.debug("Removing failure marking for {0}".format(spec.name))
-                os.remove(path)
-            except OSError as err:
-                tty.warn(
-                    "Unable to remove failure marking for {0} ({1}): {2}".format(
-                        spec.name, path, str(err)
-                    )
-                )
+        assert self.failure_tracker is not None
+        self.failure_tracker.clear_failure(spec, force)
 
     def mark_failed(self, spec: "spack.spec.Spec") -> lk.Lock:
-        """
-        Mark a spec as failing to install.
-
-        Prefix failure marking takes the form of a byte range lock on the nth
-        byte of a file for coordinating between concurrent parallel build
-        processes and a persistent file, named with the full hash and
-        containing the spec, in a subdirectory of the database to enable
-        persistence across overlapping but separate related build processes.
-
-        The failure lock file, ``spack.store.STORE.db.prefix_failures``, lives
-        alongside the install DB. ``n`` is the sys.maxsize-bit prefix of the
-        associated DAG hash to make the likelihood of collision very low with
-        no cleanup required.
-        """
-        # Dump the spec to the failure file for (manual) debugging purposes
-        path = self._failed_spec_path(spec)
-        with open(path, "w") as f:
-            spec.to_json(f)
-
-        # Also ensure a failure lock is taken to prevent cleanup removal
-        # of failure status information during a concurrent parallel build.
-        err = "Unable to mark {0.name} as failed."
-
-        prefix = spec.prefix
-        if prefix not in self._prefix_failures:
-            mark = lk.Lock(
-                self.prefix_fail_path,
-                start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
-                length=1,
-                default_timeout=self.package_lock_timeout,
-                desc=spec.name,
-            )
-
-            try:
-                mark.acquire_write()
-            except lk.LockTimeoutError:
-                # Unlikely that another process failed to install at the same
-                # time but log it anyway.
-                tty.debug(
-                    "PID {0} failed to mark install failure for {1}".format(os.getpid(), spec.name)
-                )
-                tty.warn(err.format(spec))
-
-            # Whether we or another process marked it as a failure, track it
-            # as such locally.
-            self._prefix_failures[prefix] = mark
-
-        return self._prefix_failures[prefix]
+        assert self.failure_tracker is not None
+        return self.failure_tracker.mark_failed(spec)
 
     def prefix_failed(self, spec: "spack.spec.Spec") -> bool:
-        """Return True if the prefix (installation) is marked as failed."""
-        # The failure was detected in this process.
-        if spec.prefix in self._prefix_failures:
-            return True
-
-        # The failure was detected by a concurrent process (e.g., an srun),
-        # which is expected to be holding a write lock if that is the case.
-        if self.prefix_failure_locked(spec):
-            return True
-
-        # Determine if the spec may have been marked as failed by a separate
-        # spack build process running concurrently.
-        return self.prefix_failure_marked(spec)
-
-    def prefix_failure_locked(self, spec: "spack.spec.Spec") -> bool:
-        """Return True if a process has a failure lock on the spec."""
-        check = lk.Lock(
-            self.prefix_fail_path,
-            start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
-            length=1,
-            default_timeout=self.package_lock_timeout,
-            desc=spec.name,
-        )
-
-        return check.is_write_locked()
-
-    def prefix_failure_marked(self, spec: "spack.spec.Spec") -> bool:
-        """Determine if the spec has a persistent failure marking."""
-        return os.path.exists(self._failed_spec_path(spec))
+        assert self.failure_tracker is not None
+        return self.failure_tracker.prefix_failed(spec)
 
     def _write_to_file(self, stream):
         """Write out the database in JSON format to the stream passed

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -142,22 +142,23 @@ class InstallStatuses:
     def canonicalize(cls, query_arg):
         if query_arg is True:
             return [cls.INSTALLED]
-        elif query_arg is False:
+        if query_arg is False:
             return [cls.MISSING]
-        elif query_arg is any:
+        if query_arg is any:
             return [cls.INSTALLED, cls.DEPRECATED, cls.MISSING]
-        elif isinstance(query_arg, InstallStatus):
+        if isinstance(query_arg, InstallStatus):
             return [query_arg]
-        else:
-            try:  # Try block catches if it is not an iterable at all
-                if any(type(x) != InstallStatus for x in query_arg):
-                    raise TypeError
-            except TypeError:
-                raise TypeError(
-                    "installation query must be `any`, boolean, "
-                    "InstallStatus, or iterable of InstallStatus"
-                )
-            return query_arg
+        try:
+            statuses = list(query_arg)
+            if all(isinstance(x, InstallStatus) for x in statuses):
+                return statuses
+        except TypeError:
+            pass
+
+        raise TypeError(
+            "installation query must be `any`, boolean, "
+            "InstallStatus, or iterable of InstallStatus"
+        )
 
 
 class InstallRecord:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -519,11 +519,12 @@ def _try_install_from_binary_cache(
     )
 
 
+# FIXME (failure tracking): This masks using a global
 def clear_failures() -> None:
     """
     Remove all failure tracking markers for the Spack instance.
     """
-    spack.store.STORE.db.clear_all_failures()
+    spack.store.STORE.clear_all_failures()
 
 
 def combine_phase_logs(phase_log_files: List[str], log_path: str) -> None:
@@ -1287,7 +1288,7 @@ class PackageInstaller:
             dep_id = package_id(dep_pkg)
 
             # Check for failure since a prefix lock is not required
-            if spack.store.STORE.db.prefix_failed(dep):
+            if spack.store.STORE.prefix_failed(dep):
                 action = "'spack install' the dependency"
                 msg = "{0} is marked as an install failure: {1}".format(dep_id, action)
                 raise InstallError(err.format(request.pkg_id, msg), pkg=dep_pkg)
@@ -1627,12 +1628,12 @@ class PackageInstaller:
                 # Clear any persistent failure markings _unless_ they are
                 # associated with another process in this parallel build
                 # of the spec.
-                spack.store.STORE.db.clear_failure(dep, force=False)
+                spack.store.STORE.clear_failure(dep, force=False)
 
         install_package = request.install_args.get("install_package")
         if install_package and request.pkg_id not in self.build_tasks:
             # Be sure to clear any previous failure
-            spack.store.STORE.db.clear_failure(request.spec, force=True)
+            spack.store.STORE.clear_failure(request.spec, force=True)
 
             # If not installing dependencies, then determine their
             # installation status before proceeding
@@ -1888,7 +1889,7 @@ class PackageInstaller:
         err = "" if exc is None else ": {0}".format(str(exc))
         tty.debug("Flagging {0} as failed{1}".format(pkg_id, err))
         if mark:
-            self.failed[pkg_id] = spack.store.STORE.db.mark_failed(task.pkg.spec)
+            self.failed[pkg_id] = spack.store.STORE.mark_failed(task.pkg.spec)
         else:
             self.failed[pkg_id] = None
         task.status = STATUS_FAILED
@@ -2074,7 +2075,7 @@ class PackageInstaller:
 
             # Flag a failed spec.  Do not need an (install) prefix lock since
             # assume using a separate (failed) prefix lock file.
-            if pkg_id in self.failed or spack.store.STORE.db.prefix_failed(spec):
+            if pkg_id in self.failed or spack.store.STORE.prefix_failed(spec):
                 term_status.clear()
                 tty.warn("{0} failed to install".format(pkg_id))
                 self._update_failed(task)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -519,14 +519,6 @@ def _try_install_from_binary_cache(
     )
 
 
-# FIXME (failure tracking): This masks using a global
-def clear_failures() -> None:
-    """
-    Remove all failure tracking markers for the Spack instance.
-    """
-    spack.store.STORE.clear_all_failures()
-
-
 def combine_phase_logs(phase_log_files: List[str], log_path: str) -> None:
     """
     Read set or list of logs and combine them into one file.
@@ -1127,15 +1119,13 @@ class PackageInstaller:
     instance.
     """
 
-    def __init__(self, installs: List[Tuple["spack.package_base.PackageBase", dict]] = []):
+    def __init__(self, installs: List[Tuple["spack.package_base.PackageBase", dict]] = []) -> None:
         """Initialize the installer.
 
         Args:
             installs (list): list of tuples, where each
                 tuple consists of a package (PackageBase) and its associated
                  install arguments (dict)
-        Return:
-            PackageInstaller: instance
         """
         # List of build requests
         self.build_requests = [BuildRequest(pkg, install_args) for pkg, install_args in installs]

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1502,7 +1502,7 @@ class PackageInstaller:
             if lock is None:
                 tty.debug(msg.format("Acquiring", desc, pkg_id, pretty_seconds(timeout or 0)))
                 op = "acquire"
-                lock = spack.store.STORE.db.prefix_lock(pkg.spec, timeout)
+                lock = spack.store.STORE.prefix_lock(pkg.spec, timeout)
                 if timeout != lock.default_timeout:
                     tty.warn(
                         "Expected prefix lock timeout {0}, not {1}".format(

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1278,7 +1278,7 @@ class PackageInstaller:
             dep_id = package_id(dep_pkg)
 
             # Check for failure since a prefix lock is not required
-            if spack.store.STORE.failure_tracker.failed(dep):
+            if spack.store.STORE.failure_tracker.has_failed(dep):
                 action = "'spack install' the dependency"
                 msg = "{0} is marked as an install failure: {1}".format(dep_id, action)
                 raise InstallError(err.format(request.pkg_id, msg), pkg=dep_pkg)
@@ -1618,12 +1618,12 @@ class PackageInstaller:
                 # Clear any persistent failure markings _unless_ they are
                 # associated with another process in this parallel build
                 # of the spec.
-                spack.store.STORE.failure_tracker.clear_failure(dep, force=False)
+                spack.store.STORE.failure_tracker.clear(dep, force=False)
 
         install_package = request.install_args.get("install_package")
         if install_package and request.pkg_id not in self.build_tasks:
             # Be sure to clear any previous failure
-            spack.store.STORE.failure_tracker.clear_failure(request.spec, force=True)
+            spack.store.STORE.failure_tracker.clear(request.spec, force=True)
 
             # If not installing dependencies, then determine their
             # installation status before proceeding
@@ -1879,7 +1879,7 @@ class PackageInstaller:
         err = "" if exc is None else ": {0}".format(str(exc))
         tty.debug("Flagging {0} as failed{1}".format(pkg_id, err))
         if mark:
-            self.failed[pkg_id] = spack.store.STORE.failure_tracker.mark_failed(task.pkg.spec)
+            self.failed[pkg_id] = spack.store.STORE.failure_tracker.mark(task.pkg.spec)
         else:
             self.failed[pkg_id] = None
         task.status = STATUS_FAILED
@@ -2065,7 +2065,7 @@ class PackageInstaller:
 
             # Flag a failed spec.  Do not need an (install) prefix lock since
             # assume using a separate (failed) prefix lock file.
-            if pkg_id in self.failed or spack.store.STORE.failure_tracker.failed(spec):
+            if pkg_id in self.failed or spack.store.STORE.failure_tracker.has_failed(spec):
                 term_status.clear()
                 tty.warn("{0} failed to install".format(pkg_id))
                 self._update_failed(task)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1278,7 +1278,7 @@ class PackageInstaller:
             dep_id = package_id(dep_pkg)
 
             # Check for failure since a prefix lock is not required
-            if spack.store.STORE.prefix_failed(dep):
+            if spack.store.STORE.failure_tracker.failed(dep):
                 action = "'spack install' the dependency"
                 msg = "{0} is marked as an install failure: {1}".format(dep_id, action)
                 raise InstallError(err.format(request.pkg_id, msg), pkg=dep_pkg)
@@ -1493,7 +1493,7 @@ class PackageInstaller:
             if lock is None:
                 tty.debug(msg.format("Acquiring", desc, pkg_id, pretty_seconds(timeout or 0)))
                 op = "acquire"
-                lock = spack.store.STORE.prefix_lock(pkg.spec, timeout)
+                lock = spack.store.STORE.prefix_locker.lock(pkg.spec, timeout)
                 if timeout != lock.default_timeout:
                     tty.warn(
                         "Expected prefix lock timeout {0}, not {1}".format(
@@ -1618,12 +1618,12 @@ class PackageInstaller:
                 # Clear any persistent failure markings _unless_ they are
                 # associated with another process in this parallel build
                 # of the spec.
-                spack.store.STORE.clear_failure(dep, force=False)
+                spack.store.STORE.failure_tracker.clear_failure(dep, force=False)
 
         install_package = request.install_args.get("install_package")
         if install_package and request.pkg_id not in self.build_tasks:
             # Be sure to clear any previous failure
-            spack.store.STORE.clear_failure(request.spec, force=True)
+            spack.store.STORE.failure_tracker.clear_failure(request.spec, force=True)
 
             # If not installing dependencies, then determine their
             # installation status before proceeding
@@ -1879,7 +1879,7 @@ class PackageInstaller:
         err = "" if exc is None else ": {0}".format(str(exc))
         tty.debug("Flagging {0} as failed{1}".format(pkg_id, err))
         if mark:
-            self.failed[pkg_id] = spack.store.STORE.mark_failed(task.pkg.spec)
+            self.failed[pkg_id] = spack.store.STORE.failure_tracker.mark_failed(task.pkg.spec)
         else:
             self.failed[pkg_id] = None
         task.status = STATUS_FAILED
@@ -2065,7 +2065,7 @@ class PackageInstaller:
 
             # Flag a failed spec.  Do not need an (install) prefix lock since
             # assume using a separate (failed) prefix lock file.
-            if pkg_id in self.failed or spack.store.STORE.prefix_failed(spec):
+            if pkg_id in self.failed or spack.store.STORE.failure_tracker.failed(spec):
                 term_status.clear()
                 tty.warn("{0} failed to install".format(pkg_id))
                 self._update_failed(task)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2209,7 +2209,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             pkg = None
 
         # Pre-uninstall hook runs first.
-        with spack.store.STORE.db.prefix_write_lock(spec):
+        with spack.store.STORE.prefix_write_lock(spec):
             if pkg is not None:
                 try:
                     spack.hooks.pre_uninstall(spec)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2209,7 +2209,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             pkg = None
 
         # Pre-uninstall hook runs first.
-        with spack.store.STORE.prefix_write_lock(spec):
+        with spack.store.STORE.prefix_locker.write_lock(spec):
             if pkg is not None:
                 try:
                     spack.hooks.pre_uninstall(spec)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -326,7 +326,7 @@ class Stage:
         self.keep = keep
 
         # File lock for the stage directory.  We use one file for all
-        # stage locks. See spack.database.Database.prefix_lock for
+        # stage locks. See spack.database.Database.prefix_locker.lock for
         # details on this approach.
         self._lock = None
         if lock:

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -170,6 +170,12 @@ class Store:
         self.upstreams = upstreams
         self.lock_cfg = lock_cfg
         self.db = spack.database.Database(root, upstream_dbs=upstreams, lock_cfg=lock_cfg)
+
+        timeout_format_str = (
+            f"{str(lock_cfg.package_timeout)}s" if lock_cfg.package_timeout else "No timeout"
+        )
+        tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
+
         self.prefix_locker = spack.database.SpecLocker(
             spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
         )

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -135,18 +135,21 @@ def parse_install_tree(config_dict):
 class Store:
     """A store is a path full of installed Spack packages.
 
-    Stores consist of packages installed according to a
-    ``DirectoryLayout``, along with an index, or _database_ of their
-    contents.  The directory layout controls what paths look like and how
-    Spack ensures that each unique spec gets its own unique directory (or
-    not, though we don't recommend that). The database is a single file
-    that caches metadata for the entire Spack installation.  It prevents
-    us from having to spider the install tree to figure out what's there.
+    Stores consist of packages installed according to a ``DirectoryLayout``, along with a database
+    of their contents.
+
+    The directory layout controls what paths look like and how Spack ensures that each unique spec
+    gets its own unique directory (or not, though we don't recommend that).
+
+    The database is a single file that caches metadata for the entire Spack installation. It
+    prevents us from having to spider the install tree to figure out what's there.
+
+    The store is also able to lock installation prefixes, and to mark installation failures.
 
     Args:
         root: path to the root of the install tree
-        unpadded_root: path to the root of the install tree without padding.
-            The sbang script has to be installed here to work with padded roots
+        unpadded_root: path to the root of the install tree without padding. The sbang script has
+            to be installed here to work with padded roots
         projections: expression according to guidelines that describes how to construct a path to
             a package prefix in this store
         hash_length: length of the hashes used in the directory layout. Spec hash suffixes will be
@@ -189,17 +192,27 @@ class Store:
         )
 
     def clear_all_failures(self) -> None:
-        """Force remove install failure tracking files."""
+        """Removes all the install failure tracking files."""
         self.failure_tracker.clear_all_failures()
 
     def clear_failure(self, spec: "spack.spec.Spec", force: bool = False) -> None:
+        """Clears a failure for a single spec.
+
+        Args:
+            spec: spec to be cleared
+            force: True if the failure information should be cleared when a failure lock
+                exists for the file, or False if the failure should not be cleared (e.g.,
+                it may be associated with a concurrent build)
+        """
         self.failure_tracker.clear_failure(spec, force)
 
     def mark_failed(self, spec: "spack.spec.Spec") -> lock.Lock:
+        """Marks a spec installation as failed"""
         return self.failure_tracker.mark_failed(spec)
 
     def prefix_failed(self, spec: "spack.spec.Spec") -> bool:
-        return self.failure_tracker.prefix_failed(spec)
+        """True if the installation of the spec failed."""
+        return self.failure_tracker.failed(spec)
 
     def prefix_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lock.Lock:
         return self.prefix_locker.lock(spec, timeout=timeout)

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -32,6 +32,7 @@ import spack.database
 import spack.directory_layout
 import spack.error
 import spack.paths
+import spack.spec
 import spack.util.path
 from spack.util import lock
 
@@ -216,13 +217,6 @@ class Store:
 
     def prefix_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lock.Lock:
         return self.prefix_locker.lock(spec, timeout=timeout)
-
-    @contextlib.contextmanager
-    def prefix_read_lock(
-        self, spec: "spack.spec.Spec"
-    ) -> Generator[spack.database.SpecLocker, None, None]:
-        with self.prefix_locker.read_lock(spec) as locker:
-            yield locker
 
     @contextlib.contextmanager
     def prefix_write_lock(

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -34,7 +34,6 @@ import spack.error
 import spack.paths
 import spack.spec
 import spack.util.path
-from spack.util import lock
 
 #: default installation root, relative to the Spack install path
 DEFAULT_INSTALL_TREE_ROOT = os.path.join(spack.paths.opt_path, "spack")
@@ -191,39 +190,6 @@ class Store:
         self.layout = spack.directory_layout.DirectoryLayout(
             root, projections=projections, hash_length=hash_length
         )
-
-    def clear_all_failures(self) -> None:
-        """Removes all the install failure tracking files."""
-        self.failure_tracker.clear_all_failures()
-
-    def clear_failure(self, spec: "spack.spec.Spec", force: bool = False) -> None:
-        """Clears a failure for a single spec.
-
-        Args:
-            spec: spec to be cleared
-            force: True if the failure information should be cleared when a failure lock
-                exists for the file, or False if the failure should not be cleared (e.g.,
-                it may be associated with a concurrent build)
-        """
-        self.failure_tracker.clear_failure(spec, force)
-
-    def mark_failed(self, spec: "spack.spec.Spec") -> lock.Lock:
-        """Marks a spec installation as failed"""
-        return self.failure_tracker.mark_failed(spec)
-
-    def prefix_failed(self, spec: "spack.spec.Spec") -> bool:
-        """True if the installation of the spec failed."""
-        return self.failure_tracker.failed(spec)
-
-    def prefix_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lock.Lock:
-        return self.prefix_locker.lock(spec, timeout=timeout)
-
-    @contextlib.contextmanager
-    def prefix_write_lock(
-        self, spec: "spack.spec.Spec"
-    ) -> Generator[spack.database.SpecLocker, None, None]:
-        with self.prefix_locker.write_lock(spec) as locker:
-            yield locker
 
     def reindex(self) -> None:
         """Convenience function to reindex the store DB with its own layout."""

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -33,7 +33,7 @@ def mock_calls_for_clean(monkeypatch):
     monkeypatch.setattr(spack.stage, "purge", Counter("stages"))
     monkeypatch.setattr(spack.caches.fetch_cache, "destroy", Counter("downloads"), raising=False)
     monkeypatch.setattr(spack.caches.misc_cache, "destroy", Counter("caches"))
-    monkeypatch.setattr(spack.installer, "clear_failures", Counter("failures"))
+    monkeypatch.setattr(spack.store.STORE, "clear_all_failures", Counter("failures"))
     monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
 
     yield counts

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -10,9 +10,11 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.caches
+import spack.cmd.clean
 import spack.main
 import spack.package_base
 import spack.stage
+import spack.store
 
 clean = spack.main.SpackCommand("clean")
 
@@ -33,7 +35,9 @@ def mock_calls_for_clean(monkeypatch):
     monkeypatch.setattr(spack.stage, "purge", Counter("stages"))
     monkeypatch.setattr(spack.caches.fetch_cache, "destroy", Counter("downloads"), raising=False)
     monkeypatch.setattr(spack.caches.misc_cache, "destroy", Counter("caches"))
-    monkeypatch.setattr(spack.store.STORE, "clear_all_failures", Counter("failures"))
+    monkeypatch.setattr(
+        spack.store.STORE.failure_tracker, "clear_all_failures", Counter("failures")
+    )
     monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
 
     yield counts

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -35,9 +35,7 @@ def mock_calls_for_clean(monkeypatch):
     monkeypatch.setattr(spack.stage, "purge", Counter("stages"))
     monkeypatch.setattr(spack.caches.fetch_cache, "destroy", Counter("downloads"), raising=False)
     monkeypatch.setattr(spack.caches.misc_cache, "destroy", Counter("caches"))
-    monkeypatch.setattr(
-        spack.store.STORE.failure_tracker, "clear_all_failures", Counter("failures")
-    )
+    monkeypatch.setattr(spack.store.STORE.failure_tracker, "clear_all", Counter("failures"))
     monkeypatch.setattr(spack.cmd.clean, "remove_python_cache", Counter("python_cache"))
 
     yield counts

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -705,7 +705,6 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
     assert "was not installed" in out
 
     # Check that failure prefix locks are still cached
-    # FIXME: (failure tracker)
     failed_packages = [
         key[2] for key in spack.store.STORE.failure_tracker.failures_lock.all_keys()
     ]

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -707,7 +707,7 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
     # Check that failure prefix locks are still cached
     # FIXME: (failure tracker)
     failed_packages = [
-        key[2] for key in spack.store.STORE.db.failure_tracker.failures_lock.all_keys()
+        key[2] for key in spack.store.STORE.failure_tracker.failures_lock.all_keys()
     ]
     assert "libelf" in failed_packages
     assert "libdwarf" in failed_packages

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -705,9 +705,12 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
     assert "was not installed" in out
 
     # Check that failure prefix locks are still cached
-    failure_lock_prefixes = ",".join(spack.store.STORE.db._prefix_failures.keys())
-    assert "libelf" in failure_lock_prefixes
-    assert "libdwarf" in failure_lock_prefixes
+    # FIXME: (failure tracker)
+    failed_packages = [
+        key[2] for key in spack.store.STORE.db.failure_tracker.failures_lock.all_keys()
+    ]
+    assert "libelf" in failed_packages
+    assert "libdwarf" in failed_packages
 
 
 def test_install_only_dependencies(tmpdir, mock_fetch, install_mockery):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -23,6 +23,7 @@ import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.package_base
+import spack.store
 import spack.util.executable
 from spack.error import SpackError
 from spack.main import SpackCommand
@@ -706,7 +707,8 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
 
     # Check that failure prefix locks are still cached
     failed_packages = [
-        key[2] for key in spack.store.STORE.failure_tracker.failures_lock.all_keys()
+        pkg_name
+        for dag_hash, pkg_name in spack.store.STORE.failure_tracker.failures_lock.locks.keys()
     ]
     assert "libelf" in failed_packages
     assert "libdwarf" in failed_packages

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -707,8 +707,7 @@ def test_cache_only_fails(tmpdir, mock_fetch, install_mockery, capfd):
 
     # Check that failure prefix locks are still cached
     failed_packages = [
-        pkg_name
-        for dag_hash, pkg_name in spack.store.STORE.failure_tracker.failures_lock.locks.keys()
+        pkg_name for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
     ]
     assert "libelf" in failed_packages
     assert "libdwarf" in failed_packages

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -956,15 +956,8 @@ def install_mockery(temporary_store, mutable_config, mock_packages):
     with spack.config.override("config:checksum", False):
         yield
 
-    # Also wipe out any cached prefix failure locks (associated with
-    # the session-scoped mock archive).
-    for pkg_id in list(temporary_store.db._prefix_failures.keys()):
-        lock = spack.store.STORE.db._prefix_failures.pop(pkg_id, None)
-        if lock:
-            try:
-                lock.release_write()
-            except Exception:
-                pass
+    # Wipe out any cached prefix failure locks (associated with the session-scoped mock archive)
+    temporary_store.db.failure_tracker.clear_all_failures()
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -957,7 +957,7 @@ def install_mockery(temporary_store, mutable_config, mock_packages):
         yield
 
     # Wipe out any cached prefix failure locks (associated with the session-scoped mock archive)
-    temporary_store.db.failure_tracker.clear_all_failures()
+    temporary_store.clear_all_failures()
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -950,14 +950,14 @@ def disable_compiler_execution(monkeypatch, request):
 
 
 @pytest.fixture(scope="function")
-def install_mockery(temporary_store, mutable_config, mock_packages):
+def install_mockery(temporary_store: spack.store.Store, mutable_config, mock_packages):
     """Hooks a fake install directory, DB, and stage directory into Spack."""
     # We use a fake package, so temporarily disable checksumming
     with spack.config.override("config:checksum", False):
         yield
 
     # Wipe out any cached prefix failure locks (associated with the session-scoped mock archive)
-    temporary_store.clear_all_failures()
+    temporary_store.failure_tracker.clear_all_failures()
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -957,7 +957,7 @@ def install_mockery(temporary_store: spack.store.Store, mutable_config, mock_pac
         yield
 
     # Wipe out any cached prefix failure locks (associated with the session-scoped mock archive)
-    temporary_store.failure_tracker.clear_all_failures()
+    temporary_store.failure_tracker.clear_all()
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -808,7 +808,7 @@ def test_failed_spec_path_error(database):
     """Ensure spec not concrete check is covered."""
     s = spack.spec.Spec("a")
     with pytest.raises(AssertionError, match="concrete spec required"):
-        spack.store.STORE.db.mark_failed(s)
+        spack.store.STORE.mark_failed(s)
 
 
 @pytest.mark.db
@@ -823,7 +823,7 @@ def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
     monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_locked", _is)
 
     s = spack.spec.Spec("a").concretized()
-    spack.store.STORE.db.clear_failure(s)
+    spack.store.STORE.clear_failure(s)
     out = capfd.readouterr()[0]
     assert "Retaining failure marking" in out
 
@@ -841,7 +841,7 @@ def test_clear_failure_forced(default_mock_concretization, mutable_database, mon
     monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_marked", _is)
 
     s = default_mock_concretization("a")
-    spack.store.STORE.db.clear_failure(s, force=True)
+    spack.store.STORE.clear_failure(s, force=True)
     out = capfd.readouterr()[1]
     assert "Removing failure marking despite lock" in out
     assert "Unable to remove failure marking" in out
@@ -859,12 +859,12 @@ def test_mark_failed(default_mock_concretization, mutable_database, monkeypatch,
 
     with tmpdir.as_cwd():
         s = default_mock_concretization("a")
-        spack.store.STORE.db.mark_failed(s)
+        spack.store.STORE.mark_failed(s)
 
         out = str(capsys.readouterr()[1])
         assert "Unable to mark a as failed" in out
 
-    spack.store.STORE.db.clear_all_failures()
+    spack.store.STORE.clear_all_failures()
 
 
 @pytest.mark.db
@@ -877,19 +877,19 @@ def test_prefix_failed(default_mock_concretization, mutable_database, monkeypatc
     s = default_mock_concretization("a")
 
     # Confirm the spec is not already marked as failed
-    assert not spack.store.STORE.db.prefix_failed(s)
+    assert not spack.store.STORE.prefix_failed(s)
 
     # Check that a failure entry is sufficient
-    spack.store.STORE.db.mark_failed(s)
-    assert spack.store.STORE.db.prefix_failed(s)
+    spack.store.STORE.mark_failed(s)
+    assert spack.store.STORE.prefix_failed(s)
 
     # Remove the entry and check again
-    spack.store.STORE.db.clear_failure(s)
-    assert not spack.store.STORE.db.prefix_failed(s)
+    spack.store.STORE.clear_failure(s)
+    assert not spack.store.STORE.prefix_failed(s)
 
     # Now pretend that the prefix failure is locked
     monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_locked", _is)
-    assert spack.store.STORE.db.prefix_failed(s)
+    assert spack.store.STORE.prefix_failed(s)
 
 
 def test_prefix_read_lock_error(default_mock_concretization, mutable_database, monkeypatch):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -905,7 +905,7 @@ def test_prefix_read_lock_error(default_mock_concretization, mutable_database, m
     monkeypatch.setattr(lk.Lock, "acquire_read", _raise)
 
     with pytest.raises(Exception):
-        with spack.store.STORE.db.prefix_read_lock(s):
+        with spack.store.STORE.prefix_read_lock(s):
             assert False
 
 
@@ -921,7 +921,7 @@ def test_prefix_write_lock_error(default_mock_concretization, mutable_database, 
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise)
 
     with pytest.raises(Exception):
-        with spack.store.STORE.db.prefix_write_lock(s):
+        with spack.store.STORE.prefix_write_lock(s):
             assert False
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -818,9 +818,8 @@ def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
     def _is(self, spec):
         return True
 
-    # FIXME (failure tracker)
     # Pretend the spec has been failure locked
-    monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_locked", _is)
+    monkeypatch.setattr(spack.database.FailureTracker, "failure_lock_taken", _is)
 
     s = spack.spec.Spec("a").concretized()
     spack.store.STORE.clear_failure(s)
@@ -836,9 +835,9 @@ def test_clear_failure_forced(default_mock_concretization, mutable_database, mon
         return True
 
     # Pretend the spec has been failure locked
-    monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_locked", _is)
+    monkeypatch.setattr(spack.database.FailureTracker, "failure_lock_taken", _is)
     # Ensure raise OSError when try to remove the non-existent marking
-    monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_marked", _is)
+    monkeypatch.setattr(spack.database.FailureTracker, "persistent_failure_mark", _is)
 
     s = default_mock_concretization("a")
     spack.store.STORE.clear_failure(s, force=True)
@@ -888,7 +887,7 @@ def test_prefix_failed(default_mock_concretization, mutable_database, monkeypatc
     assert not spack.store.STORE.prefix_failed(s)
 
     # Now pretend that the prefix failure is locked
-    monkeypatch.setattr(spack.database.FailureTracker, "prefix_failure_locked", _is)
+    monkeypatch.setattr(spack.database.FailureTracker, "failure_lock_taken", _is)
     assert spack.store.STORE.prefix_failed(s)
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -891,22 +891,6 @@ def test_prefix_failed(default_mock_concretization, mutable_database, monkeypatc
     assert spack.store.STORE.prefix_failed(s)
 
 
-def test_prefix_read_lock_error(default_mock_concretization, mutable_database, monkeypatch):
-    """Cover the prefix read lock exception."""
-
-    def _raise(db, spec):
-        raise lk.LockError("Mock lock error")
-
-    s = default_mock_concretization("a")
-
-    # Ensure subsequent lock operations fail
-    monkeypatch.setattr(lk.Lock, "acquire_read", _raise)
-
-    with pytest.raises(Exception):
-        with spack.store.STORE.prefix_read_lock(s):
-            assert False
-
-
 def test_prefix_write_lock_error(default_mock_concretization, mutable_database, monkeypatch):
     """Cover the prefix write lock exception."""
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -159,7 +159,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
         s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
         # must clear failure markings for the package before re-installing it
-        spack.store.STORE.db.clear_failure(s, True)
+        spack.store.STORE.clear_failure(s, True)
 
         s.package.set_install_succeed()
         s.package.stage = MockStage(s.package.stage)
@@ -354,7 +354,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.db.clear_failure(s, True)
+    spack.store.STORE.clear_failure(s, True)
 
     s.package.set_install_succeed()
     s.package.stage = MockStage(s.package.stage)

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -159,7 +159,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
         s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
         # must clear failure markings for the package before re-installing it
-        spack.store.STORE.failure_tracker.clear_failure(s, True)
+        spack.store.STORE.failure_tracker.clear(s, True)
 
         s.package.set_install_succeed()
         s.package.stage = MockStage(s.package.stage)
@@ -354,7 +354,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear_failure(s, True)
+    spack.store.STORE.failure_tracker.clear(s, True)
 
     s.package.set_install_succeed()
     s.package.stage = MockStage(s.package.stage)

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -159,7 +159,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
         s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
         # must clear failure markings for the package before re-installing it
-        spack.store.STORE.clear_failure(s, True)
+        spack.store.STORE.failure_tracker.clear_failure(s, True)
 
         s.package.set_install_succeed()
         s.package.stage = MockStage(s.package.stage)
@@ -354,7 +354,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.clear_failure(s, True)
+    spack.store.STORE.failure_tracker.clear_failure(s, True)
 
     s.package.set_install_succeed()
     s.package.stage = MockStage(s.package.stage)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -619,6 +619,7 @@ def test_clear_failures_success(install_mockery):
         assert os.path.isfile(spack.database.failures_lock_path(spack.store.STORE.root))
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="chmod does not prevent removal on Win")
 def test_clear_failures_errs(install_mockery, capsys):
     """Test the clear_failures exception paths."""
     s = spack.spec.Spec("a").concretized()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -432,7 +432,7 @@ def test_ensure_locked_new_lock(install_mockery, tmpdir, lock_type, reads, write
 
 
 def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir, capsys):
-    orig_pl = spack.database.Database.prefix_lock
+    orig_pl = spack.store.Store.prefix_lock
 
     def _pl(db, spec, timeout):
         lock = orig_pl(db, spec, timeout)
@@ -444,7 +444,7 @@ def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir, capsys):
     installer = create_installer(const_arg)
     spec = installer.build_requests[0].pkg.spec
 
-    monkeypatch.setattr(spack.database.Database, "prefix_lock", _pl)
+    monkeypatch.setattr(spack.store.Store, "prefix_lock", _pl)
 
     lock_type = "read"
     ltype, lock = installer._ensure_locked(lock_type, spec.package)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -606,7 +606,7 @@ def test_clear_failures_success(install_mockery):
     assert spack.store.STORE.prefix_failed(s)
 
     # Now clear failure tracking
-    inst.clear_failures()
+    spack.store.STORE.clear_all_failures()
 
     # Ensure there are no cached failure locks or failure marks
     assert len(spack.store.STORE.failure_tracker.failures_lock.all_keys()) == 0
@@ -628,7 +628,7 @@ def test_clear_failures_errs(install_mockery, capsys):
     spack.store.STORE.failure_tracker.failure_dir.chmod(0o000)
 
     # Clear failure tracking
-    inst.clear_failures()
+    spack.store.STORE.clear_all_failures()
 
     # Ensure expected warning generated
     out = str(capsys.readouterr()[1])
@@ -678,7 +678,7 @@ def test_combine_phase_logs_does_not_care_about_encoding(tmpdir):
         assert f.read() == data * 2
 
 
-def test_check_deps_status_install_failure(install_mockery, monkeypatch):
+def test_check_deps_status_install_failure(install_mockery):
     """Tests that checking the dependency status on a request to install
     'a' fails, if we mark the dependency as failed.
     """

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -364,7 +364,7 @@ def test_ensure_locked_err(install_mockery, monkeypatch, tmpdir, capsys):
     """Test _ensure_locked when a non-lock exception is raised."""
     mock_err_msg = "Mock exception error"
 
-    def _raise(lock, timeout):
+    def _raise(lock, timeout=None):
         raise RuntimeError(mock_err_msg)
 
     const_arg = installer_args(["trivial-install-test-package"], {})

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -19,6 +19,7 @@ import spack.binary_distribution
 import spack.compilers
 import spack.concretize
 import spack.config
+import spack.database
 import spack.installer as inst
 import spack.package_base
 import spack.package_prefs as prefs
@@ -609,7 +610,7 @@ def test_clear_failures_success(install_mockery):
     spack.store.STORE.clear_all_failures()
 
     # Ensure there are no cached failure locks or failure marks
-    assert len(spack.store.STORE.failure_tracker.failures_lock.all_keys()) == 0
+    assert len(spack.store.STORE.failure_tracker.failures_lock.locks) == 0
     assert len(os.listdir(spack.store.STORE.failure_tracker.failure_dir)) == 0
 
     # Ensure the core directory and failure lock file still exist


### PR DESCRIPTION
# Summary
This PR extracts two responsibilities from the `Database` class:
1. Managing locks for prefixes during an installation
2. Marking installation failures

and pushes them into their own class (`SpecLocker` and `FailureMarker`). These responsibilities are also pushed up into the `Store`, leaving to `Database` only the duty to manage `index.json` files.

## Locking

`SpecLocker` classes no longer share a global list of locks, but locks are per instance. Their identifier is simply `(dag hash, package name)`, and not the spec prefix path, to avoid circular dependencies across Store / Database / Spec.