### PR TITLE
mvapich2@2.3.7-1: add torque patch

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/fix-torque.patch
+++ b/var/spack/repos/builtin/packages/mvapich2/fix-torque.patch
@@ -1,0 +1,27 @@
+diff -ruN spack-src/src/pm/hydra/configure.ac spack-src-patched/src/pm/hydra/configure.ac
+--- spack-src/src/pm/hydra/configure.ac	2022-05-16 16:58:22.000000000 +0000
++++ spack-src-patched/src/pm/hydra/configure.ac	2023-07-20 15:23:21.802299913 +0000
+@@ -306,15 +306,16 @@
+ 		    available_launchers="$available_launchers pbs"
+ 		    PAC_APPEND_FLAG([-ltorque],[WRAPPER_LIBS])
+                 fi
+-		PAC_SET_HEADER_LIB_PATH(pbs)
+ 		PAC_PUSH_FLAG(LIBS)
+-		PAC_CHECK_HEADER_LIB(tm.h, pbs, tm_init, have_pbs_launcher=yes,
++                if test "have_pbs_launcher" = "no" ; then
++		  PAC_CHECK_HEADER_LIB(tm.h, pbs, tm_init, have_pbs_launcher=yes,
+ 					   have_pbs_launcher=no)
+-		PAC_POP_FLAG(LIBS)
+-                if test "$have_pbs_launcher" = "yes" ; then
+-		    available_launchers="$available_launchers pbs"
+-		    PAC_APPEND_FLAG([-lpbs],[WRAPPER_LIBS])
+-                    AC_DEFINE(HAVE_PBS_PRO, 1, [Define if PBS Pro support is enabled])
++		  PAC_POP_FLAG(LIBS)
++                  if test "$have_pbs_launcher" = "yes" ; then
++		      available_launchers="$available_launchers pbs"
++		      PAC_APPEND_FLAG([-lpbs],[WRAPPER_LIBS])
++                      AC_DEFINE(HAVE_PBS_PRO, 1, [Define if PBS Pro support is enabled])
++                  fi
+                 fi
+ 		available_rmks="$available_rmks pbs"
+ 		;;

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -117,6 +117,7 @@ class Mvapich2(AutotoolsPackage):
         values=auto_or_any_combination_of("lustre", "gpfs", "nfs", "ufs"),
     )
 
+    depends_on("automake@1.15", type="build")  # needed for torque patch
     depends_on("findutils", type="build")
     depends_on("bison", type="build")
     depends_on("pkgconfig", type="build")
@@ -134,6 +135,8 @@ class Mvapich2(AutotoolsPackage):
     depends_on("slurm", when="process_managers=slurm")
 
     conflicts("fabrics=psm2", when="@:2.1")  # psm2 support was added at version 2.2
+
+    patch("fix-torque.patch", when="@2.3.7-1")
 
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
 


### PR DESCRIPTION
This patch fixes mvapich2 + torque build. Fixes https://github.com/spack/spack/issues/37016

@harisubramoni @natshineman @ndcontini @nchaimov @sameershende 