### PR TITLE
py-python-hostlist: package addition

### DIFF
--- a/var/spack/repos/builtin/packages/py-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-hostlist/package.py
@@ -16,7 +16,7 @@ class PyHostlist(PythonPackage):
     version(
         "1.23",
         sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
-        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz"
+        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz",
     )
 
     # build dependencies

--- a/var/spack/repos/builtin/packages/py-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-hostlist/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHostlist(PythonPackage):
+    """Hostlist expands and collects LLNL hostlists."""
+
+    pypi = "python-hostlist/python-hostlist-1.23.0.tar.gz"
+    git = "https://github.com/LLNL/py-hostlist.git"
+
+    version("master", branch="master")
+    version(
+            "1.23",
+            sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
+            url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz"
+    )
+
+    # build dependencies
+    depends_on("python@3.5.0:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-hostlist/package.py
@@ -9,6 +9,7 @@ from spack.package import *
 class PyHostlist(PythonPackage):
     """Hostlist expands and collects LLNL hostlists."""
 
+    homepage = "https://www.nsc.liu.se/~kent/python-hostlist/"
     pypi = "python-hostlist/python-hostlist-1.23.0.tar.gz"
     git = "https://github.com/LLNL/py-hostlist.git"
 
@@ -16,9 +17,8 @@ class PyHostlist(PythonPackage):
     version(
         "1.23",
         sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
-        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz",
+        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.0.tar.gz",
     )
 
     # build dependencies
-    depends_on("python@3.5.0:", type=("build", "run"))
     depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-hostlist/package.py
@@ -14,9 +14,9 @@ class PyHostlist(PythonPackage):
 
     version("master", branch="master")
     version(
-            "1.23",
-            sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
-            url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz"
+        "1.23",
+        sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
+        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.tar.gz"
     )
 
     # build dependencies

--- a/var/spack/repos/builtin/packages/py-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-hostlist/package.py
@@ -14,11 +14,7 @@ class PyHostlist(PythonPackage):
     git = "https://github.com/LLNL/py-hostlist.git"
 
     version("master", branch="master")
-    version(
-        "1.23",
-        sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219",
-        url="https://www.nsc.liu.se/~kent/python-hostlist/python-hostlist-1.23.0.tar.gz",
-    )
+    version("1.23.0", sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219")
 
     # build dependencies
     depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-python-hostlist/package.py
+++ b/var/spack/repos/builtin/packages/py-python-hostlist/package.py
@@ -6,12 +6,12 @@
 from spack.package import *
 
 
-class PyHostlist(PythonPackage):
-    """Hostlist expands and collects LLNL hostlists."""
+class PyPythonHostlist(PythonPackage):
+    """The hostlist.py module knows how to expand and collect hostlist expressions."""
 
     homepage = "https://www.nsc.liu.se/~kent/python-hostlist/"
     pypi = "python-hostlist/python-hostlist-1.23.0.tar.gz"
-    git = "https://github.com/LLNL/py-hostlist.git"
+    git = "git://www.nsc.liu.se/~kent/python-hostlist.git"
 
     version("master", branch="master")
     version("1.23.0", sha256="56e0156b501f792c078114f07324f34f37827041581ee5d1ffdce89cca533219")


### PR DESCRIPTION
This package is hosted on [github](https://github.com/TACC/pylauncher/blob/master/hostlist.py), [nsc's website](https://www.nsc.liu.se/~kent/python-hostlist/) and [pypi](https://pypi.org/project/python-hostlist/#files).

It knows how to expand and collect hostlist expressions.

Note: this package is used by py-melissa-core (see https://github.com/spack/spack/pull/38654).