### PR TITLE
Don't add `.spack/binary_distribution` twice to the tarball when re-distributing

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1210,7 +1210,7 @@ def tar_add_metadata(tar: tarfile.TarFile, path: str, data: dict):
 
 def deterministic_tarinfo_without_buildinfo(tarinfo: tarfile.TarInfo):
     """Skip buildinfo file when creating a tarball, and normalize other tarinfo fields."""
-    if tarinfo.name.endswith(".spack/binary_distribution"):
+    if tarinfo.name.endswith("/.spack/binary_distribution"):
         return None
 
     return deterministic_tarinfo(tarinfo)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1208,9 +1208,17 @@ def tar_add_metadata(tar: tarfile.TarFile, path: str, data: dict):
     tar.addfile(deterministic_tarinfo(tarinfo), io.BytesIO(bstring))
 
 
-def _do_create_tarball(tarfile_path, binaries_dir, pkg_dir, buildinfo):
+def deterministic_tarinfo_without_buildinfo(tarinfo: tarfile.TarInfo):
+    """Skip buildinfo file when creating a tarball, and normalize other tarinfo fields."""
+    if tarinfo.name.endswith(".spack/binary_distribution"):
+        return None
+
+    return deterministic_tarinfo(tarinfo)
+
+
+def _do_create_tarball(tarfile_path: str, binaries_dir: str, pkg_dir: str, buildinfo: dict):
     with gzip_compressed_tarfile(tarfile_path) as tar:
-        tar.add(name=binaries_dir, arcname=pkg_dir, filter=deterministic_tarinfo)
+        tar.add(name=binaries_dir, arcname=pkg_dir, filter=deterministic_tarinfo_without_buildinfo)
         tar_add_metadata(tar, buildinfo_file_name(pkg_dir), buildinfo)
 
 


### PR DESCRIPTION
Extracted from #38358 

When pushing a package to a buildcache which was fetched from another
buildcache, spack would add the metadata file `.spack/binary_distribution`
twice.

