### PR TITLE
CachedCMakePackage: remove CMAKE_GENERATOR from the host-config

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -162,17 +162,6 @@ class CachedCMakeBuilder(CMakeBuilder):
                 libs_string = libs_format_string.format(lang)
                 entries.append(cmake_cache_string(libs_string, libs_flags))
 
-        # Set the generator in the cached config
-        if self.spec.satisfies("generator=make"):
-            entries.append(cmake_cache_string("CMAKE_GENERATOR", "Unix Makefiles"))
-        if self.spec.satisfies("generator=ninja"):
-            entries.append(cmake_cache_string("CMAKE_GENERATOR", "Ninja"))
-            entries.append(
-                cmake_cache_string(
-                    "CMAKE_MAKE_PROGRAM", "{0}/ninja".format(spec["ninja"].prefix.bin)
-                )
-            )
-
         return entries
 
     def initconfig_mpi_entries(self):


### PR DESCRIPTION
Unfortunately CMake doesn't allow you to override this setting after it is initially set and the parent class `CMakePackage` sets this on the command line anyways during the Spack build.

Host-config/Initial cache:

```
set(CMAKE_GENERATOR "Unix Makefiles" CACHE STRING "")
```

CMakeLists.txt:

```
cmake_minimum_required(3.10)
project(test)
```

Command line showing error:

```
[build]$ rm -rf *; cmake -C ../host-config.cmake -G Ninja ..
loading initial cache file ../host-config.cmake
CMake Error: Error: generator : Ninja
Does not match the generator used previously: Unix Makefiles
Either remove the CMakeCache.txt file and CMakeFiles directory or choose a different binary directory.
```

Notice that this clears the build directory before running the `cmake` command and it still complains you need to remove the `CMakeCache.txt`.

@samuelpmishLLNL 
https://github.com/LLNL/serac/issues/963