### PR TITLE
e4s oneapi ci: build with latest 2023.2 based image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -334,7 +334,7 @@ gpu-tests-build:
 
 e4s-oneapi-generate:
   extends: [ ".e4s-oneapi", ".generate"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.06.01
+  image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.07.21
 
 e4s-oneapi-build:
   extends: [ ".e4s-oneapi", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -69,12 +69,12 @@ spack:
 
   compilers:
   - compiler:
-      spec: oneapi@2023.1.0
+      spec: oneapi@2023.2.0
       paths:
-        cc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/icx
-        cxx: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/icpx
-        f77: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/ifx
-        fc: /opt/intel/oneapi/compiler/2023.1.0/linux/bin/ifx
+        cc: /opt/intel/oneapi/compiler/2023.2.0/linux/bin/icx
+        cxx: /opt/intel/oneapi/compiler/2023.2.0/linux/bin/icpx
+        f77: /opt/intel/oneapi/compiler/2023.2.0/linux/bin/ifx
+        fc: /opt/intel/oneapi/compiler/2023.2.0/linux/bin/ifx
       flags: {}
       operating_system: ubuntu20.04
       target: x86_64
@@ -82,7 +82,7 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: gcc@11.1.0
+      spec: gcc@11.4.0
       paths:
         cc: /usr/bin/gcc
         cxx: /usr/bin/g++
@@ -245,7 +245,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.06.01
+        image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023.07.21
 
   cdash:
     build-group: E4S OneAPI


### PR DESCRIPTION
E4S OneAPI CI: build using latest `2023.2`-based runner image

CC @rscohn2