### PR TITLE
Conduit: add conflict for parmetis being on when MPI is off

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -184,6 +184,8 @@ class Conduit(CMakePackage):
     depends_on("py-sphinx-rtd-theme", when="+python+doc", type="build")
     depends_on("doxygen", when="+doc+doxygen")
 
+    conflicts("+parmetis", when="~mpi", msg="Parmetis support requires MPI")
+
     # Tentative patch for fj compiler
     # Cmake will support fj compiler and this patch will be removed
     patch("fj_flags.patch", when="%fj")


### PR DESCRIPTION
The following spec doesn't make sense.

```
conduit~mpi+parmetis
```

It causes a build failure in Conduit (which I put up a PR to error early for) but parmetis fundamentally requires MPI.