### PR TITLE
mtn: add mtn package

### DIFF
--- a/var/spack/repos/builtin/packages/mtn/package.py
+++ b/var/spack/repos/builtin/packages/mtn/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Mtn(MakefilePackage):
+    """Movie Thumbnailer is CLI thumbnail generator using FFmpeg."""
+
+    homepage = "https://gitlab.com/movie_thumbnailer/mtn"
+    url = "https://gitlab.com/movie_thumbnailer/mtn/-/archive/v3.4.2/mtn-v3.4.2.tar.gz"
+
+    maintainers("ledif")
+
+    version("3.4.2", sha256="19b2076c00f5b0ad70c2467189b17f335c6e7ece5d1a01ed8910779f6a5ca52a")
+
+    depends_on("ffmpeg")
+    depends_on("libgd")
+
+    def build(self, spec, prefix):
+        src_dir = join_path(self.build_directory, "src")
+        with working_dir(src_dir):
+            make()
+
+    def install(self, spec, prefix):
+        src_dir = join_path(self.build_directory, "src")
+        with working_dir(src_dir):
+            make(f"PREFIX={prefix}", "install")


### PR DESCRIPTION
Description of package from https://gitlab.com/movie_thumbnailer/mtn:
> Movie Thumbnailer (mtn) saves thumbnails (screenshots) of movie or video files to image files (jpg, png). It uses FFmpeg's libavcodec as its engine, so it supports all popular codecs, e.g. h.265/hevc, h.264, mpeg1, mpeg2, mp4, vc1, wmv, xvid, divx...  
mtn was originaly developed by tuit (tuitfun); though most of its magic is actually done by FFmpeg libraries.