### PR TITLE
mvapich2: Add patch to avoid segmentation fault in `MPIR_Attr_delete_list`

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/mpir_attr_delete_list_segfault.patch
+++ b/var/spack/repos/builtin/packages/mvapich2/mpir_attr_delete_list_segfault.patch
@@ -1,0 +1,18 @@
+--- a/src/mpi/attr/attrutil.c
++++ b/src/mpi/attr/attrutil.c
+@@ -266,6 +266,7 @@
+ 	   corresponding keyval */
+ 	/* Still to do: capture any error returns but continue to 
+ 	   process attributes */
++    if (p->keyval) {
+ 	mpi_errno = MPIR_Call_attr_delete( handle, p );
+ 
+ 	/* We must also remove the keyval reference.  If the keyval
+@@ -282,6 +283,7 @@
+ 		MPIU_Handle_obj_free( &MPID_Keyval_mem, p->keyval );
+ 	    }
+ 	}
++	}
+ 	
+ 	MPIU_Handle_obj_free( &MPID_Attr_mem, p );
+ 	

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -133,6 +133,10 @@ class Mvapich2(AutotoolsPackage):
     depends_on("libfabric", when="fabrics=nemesisofi")
     depends_on("slurm", when="process_managers=slurm")
 
+    # Fix segmentation fault in `MPIR_Attr_delete_list`:
+    # <https://lists.osu.edu/pipermail/mvapich-discuss/2023-January/010695.html>.
+    patch("mpir_attr_delete_list_segfault.patch", when="@2.3.7")
+
     conflicts("fabrics=psm2", when="@:2.1")  # psm2 support was added at version 2.2
 
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")


### PR DESCRIPTION
In [`MPI.jl`](https://github.com/JuliaParallel/MPI.jl) we discovered a segmentation fault in mvapich2, which is fixed by the attached patch, suggested at https://lists.osu.edu/pipermail/mvapich-discuss/2023-January/010695.html but it's not included in any version of mvapich v2.*.  We'd like to use Spack to build mvapich2 for testing it in CI in `MPI.jl`, but at the moment this is consistently segfaulting because of this bug, so it'd be great to have a fixed version in Spack.  PR in `MPI.jl` showing that this works: https://github.com/JuliaParallel/MPI.jl/pull/751