### PR TITLE
quickjs: make Makefile use correct compiler

### DIFF
--- a/var/spack/repos/builtin/packages/quickjs/package.py
+++ b/var/spack/repos/builtin/packages/quickjs/package.py
@@ -25,12 +25,18 @@ class Quickjs(MakefilePackage):
         "2020-09-06", sha256="0021a3e8cdc6b61e225411d05e2841d2437e1ccf4b4cabb9a5f7685ebfb57717"
     )
 
+    variant("lto", default=True, when="%gcc",
+            description="Enable link-time optimization")
+
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
         makefile.filter("prefix=/usr/local", "prefix={}".format(prefix))
         makefile.filter("lib/quickjs", "lib")
         makefile.filter("CFLAGS=", "CFLAGS+=-fPIC ")
-        makefile.filter("^ *CC=.*", "")
-        makefile.filter("HOST_CC=.*", "HOST_CC=$(CC)")
-        makefile.filter("CONFIG_LTO=y", "")
+        if not "+lto" in spec:
+            makefile.filter("CONFIG_LTO=y", "")
+        cc = self.compiler.cc
+        makefile.filter("^ *CC=.*", "  CC={}".format(cc))
+        makefile.filter("^ *HOST_CC=.*", "  HOST_CC={}".format(cc))
+        makefile.filter("gcc-ar", "{}-ar".format(cc))
 

--- a/var/spack/repos/builtin/packages/quickjs/package.py
+++ b/var/spack/repos/builtin/packages/quickjs/package.py
@@ -29,3 +29,8 @@ class Quickjs(MakefilePackage):
         makefile = FileFilter("Makefile")
         makefile.filter("prefix=/usr/local", "prefix={}".format(prefix))
         makefile.filter("lib/quickjs", "lib")
+        makefile.filter("CFLAGS=", "CFLAGS+=-fPIC ")
+        makefile.filter("^ *CC=.*", "")
+        makefile.filter("HOST_CC=.*", "HOST_CC=$(CC)")
+        makefile.filter("CONFIG_LTO=y", "")
+

--- a/var/spack/repos/builtin/packages/quickjs/package.py
+++ b/var/spack/repos/builtin/packages/quickjs/package.py
@@ -25,8 +25,7 @@ class Quickjs(MakefilePackage):
         "2020-09-06", sha256="0021a3e8cdc6b61e225411d05e2841d2437e1ccf4b4cabb9a5f7685ebfb57717"
     )
 
-    variant("lto", default=True, when="%gcc",
-            description="Enable link-time optimization")
+    variant("lto", default=True, when="%gcc", description="Enable link-time optimization")
 
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
@@ -39,4 +38,3 @@ class Quickjs(MakefilePackage):
         makefile.filter("^ *CC=.*", "  CC={}".format(cc))
         makefile.filter("^ *HOST_CC=.*", "  HOST_CC={}".format(cc))
         makefile.filter("gcc-ar", "{}-ar".format(cc))
-

--- a/var/spack/repos/builtin/packages/quickjs/package.py
+++ b/var/spack/repos/builtin/packages/quickjs/package.py
@@ -32,7 +32,7 @@ class Quickjs(MakefilePackage):
         makefile.filter("prefix=/usr/local", "prefix={}".format(prefix))
         makefile.filter("lib/quickjs", "lib")
         makefile.filter("CFLAGS=", "CFLAGS+=-fPIC ")
-        if not "+lto" in spec:
+        if "+lto" not in spec:
             makefile.filter("CONFIG_LTO=y", "")
         cc = self.compiler.cc
         makefile.filter("^ *CC=.*", "  CC={}".format(cc))


### PR DESCRIPTION
The quickjs package is a Makefile-base package. The Makefile hard-codes "gcc" as compiler (unless it detects that we are on a Darwin platform, in which case it hard-codes "clang"). This PR makes the package's `edit` method edit the Makefile as follows:
- The definition of `CC` is replaced with one that uses `self.compiler.cc`;
- Same for `HOST_CC` (which is the compiler that `qjsc` will use to compile the C files it produces from javascript files);
- LTO is disabled in the Makefile unless the compiler is gcc (the Makefile uses `llvm-ar` for LTO when using clang, but this executable doesn't seem to be present on my Mac, nor on the clang installation on my Ubuntu machine).
- Adds `-fPIC` to the `CFLAGS` (otherwise we the resulting library cannot be linked against PIC code).

I have tested these changes with both gcc and clang on an Ubuntu machine, for all the versions.