### PR TITLE
openmpi: add openshmem variant

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -495,6 +495,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     # Variants to use internal packages
     variant("internal-hwloc", default=False, description="Use internal hwloc")
     variant("internal-pmix", default=False, description="Use internal pmix")
+    variant("openshmem", default=False, description="Enable building OpenSHMEM")
 
     provides("mpi")
     provides("mpi@:2.2", when="@1.6.5")
@@ -1038,6 +1039,9 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         if spec.satisfies("%nvhpc@:20.11"):
             # Workaround compiler issues
             config_args.append("CFLAGS=-O1")
+
+        if "+openshmem" in spec:
+            config_args.append("--enable-oshmem")
 
         if "+wrapper-rpath" in spec:
             config_args.append("--enable-wrapper-rpath")


### PR DESCRIPTION
Building `nvshmem`  with  `+ shmem` on an NVIDIA A100 requires `openshmem oshcc`compiler wrapper.  We added the `openshmem` `openmpi` variant in `package.py`.  Libraries such as [Kokkos-Remote-Spaces](https://github.com/kokkos/kokkos-remote-spaces) requires `nvshmem` on NVIDIA. @janciesko, @crtrott, @csiefer2 - making `openshmem` install capabilities across machines easy for Kokkos-Remote-Spaces usage.       

