### PR TITLE
Add w3emc 2.10.0 and update variants, run env logic

### DIFF
--- a/var/spack/repos/builtin/packages/w3emc/package.py
+++ b/var/spack/repos/builtin/packages/w3emc/package.py
@@ -17,11 +17,16 @@ class W3emc(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
+    version("2.10.0", sha256="366b55a0425fc3e729ecb9f3b236250349399fe4c8e19f325500463043fd2f18")
     version("2.9.3", sha256="9ca1b08dd13dfbad4a955257ae0cf38d2e300ccd8d983606212bc982370a29bc")
     version("2.9.2", sha256="eace811a1365f69b85fdf2bcd93a9d963ba72de5a7111e6fa7c0e6578b69bfbc")
     version("2.9.1", sha256="d3e705615bdd0b76a40751337d943d5a1ea415636f4e5368aed058f074b85df4")
     version("2.9.0", sha256="994f59635ab91e34e96cab5fbaf8de54389d09461c7bac33b3104a1187e6c98a")
     version("2.7.3", sha256="eace811a1365f69b85fdf2bcd93a9d963ba72de5a7111e6fa7c0e6578b69bfbc")
+
+    variant("bufr", default=False, description="Build with BUFR routines", when="@2.10:")
+
+    depends_on("bufr", when="@2.10: +bufr")
 
     depends_on("bacio", when="@2.9.2:")
 
@@ -31,9 +36,17 @@ class W3emc(CMakePackage):
     depends_on("netcdf-fortran", when="@2.7.3")
 
     def setup_run_environment(self, env):
-        for suffix in ("4", "8", "d"):
+        suffixes = ["4", "d"]
+        if self.spec.satisfies("@:2.9"):
+            suffixes += ["8"]
+        for suffix in suffixes:
             lib = find_libraries(
                 "libw3emc_" + suffix, root=self.prefix, shared=False, recursive=True
             )
             env.set("W3EMC_LIB" + suffix, lib[0])
             env.set("W3EMC_INC" + suffix, join_path(self.prefix, "include_" + suffix))
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_WITH_BUFR", "bufr"))
+        return args


### PR DESCRIPTION
This PR updates w3emc to include the latest version, along with the necessary tweaks to the build logic.