### PR TITLE
e4s cray sles ci: expand spec list

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -36,12 +36,24 @@ spack:
     elfutils:
       variants: +bzip2 ~nls +xz
       require: '%gcc'
+    unzip:
+      require: '%gcc'
 
   specs:
+  - adios2
+  - amrex  
   - butterflypack
+  - conduit
+  - flux-core
+  - h5bench
+  - hdf5-vol-async
+  - hdf5-vol-cache
+  - hdf5-vol-log  
   - hypre
   - kokkos
   - kokkos-kernels
+  - legion
+  - mfem
   - raja
   - superlu-dist
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -44,7 +44,6 @@ spack:
   - amrex  
   - butterflypack
   - conduit
-  - flux-core
   - h5bench
   - hdf5-vol-async
   - hdf5-vol-cache
@@ -56,6 +55,7 @@ spack:
   - mfem
   - raja
   - superlu-dist
+  # - flux-core # python cray sles issue
 
   mirrors: { "mirror": "s3://spack-binaries-cray/develop/e4s-cray-sles" }
 


### PR DESCRIPTION
Taking advantage of unused Cray SLES cycles by expanding the `E4S Cray SLES` CI stack.

