### PR TITLE
mpich: fix building with NVHPC

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/mpich32_411_CFI_configure.patch
+++ b/var/spack/repos/builtin/packages/mpich/mpich32_411_CFI_configure.patch
@@ -1,0 +1,10 @@
+--- a/configure
++++ b/configure
+@@ -39449,6 +39449,7 @@ int foo_c(CFI_cdesc_t * a_desc, CFI_cdesc_t * b_desc)
+ 
+ void test_assumed_rank_async_impl_c(CFI_cdesc_t * a_desc)
+ {
++	CFI_is_contiguous(a_desc);
+ 	return;
+ }
+ 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -210,6 +210,18 @@ with '-Wl,-commons,use_dylibs' and without
         patch("mpich34_yaksa_hindexed.patch", when="datatype-engine=yaksa")
         patch("mpich34_yaksa_hindexed.patch", when="datatype-engine=auto device=ch4")
 
+    # Fix false positive result of the configure time check for CFI support
+    # https://github.com/pmodels/mpich/pull/6537
+    # https://github.com/pmodels/mpich/issues/6505
+    with when("@3.2.2:4.1.1"):
+        # Apply the patch from the upstream repo in case we have to run the autoreconf stage:
+        patch(
+            "https://github.com/pmodels/mpich/commit/d901a0b731035297dd6598888c49322e2a05a4e0.patch?full_index=1",
+            sha256="de0de41ec42ac5f259ea02f195eea56fba84d72b0b649a44c947eab6632995ab",
+        )
+        # Apply the changes to the configure script to skip the autoreconf stage if possible:
+        patch("mpich32_411_CFI_configure.patch")
+
     depends_on("findutils", type="build")
     depends_on("pkgconfig", type="build")
 
@@ -486,6 +498,7 @@ with '-Wl,-commons,use_dylibs' and without
     def configure_args(self):
         spec = self.spec
         config_args = [
+            "--disable-maintainer-mode",
             "--disable-silent-rules",
             "--enable-shared",
             "--with-pm={0}".format("hydra" if "+hydra" in spec else "no"),


### PR DESCRIPTION
This applies patches to `mpich` to fix the issue reported in https://github.com/pmodels/mpich/issues/6505. The issue is fixed upstream starting version `4.1.2`, which we don't have in Spack yet (I'd leave it to someone else to add it). The patch for `aclocal_fc.m4` from the upstream is applied in case some other patch requires the `autoreconf` stage. An extra patch `mpich32_411_CFI_configure.patch` is added to fix the `configure` script directly to avoid the `autoreconf` stage if possible. The `--disable-maintainer-mode` configure option is added to suppress the reconfiguration at the `build` stage due to the modified timestamp of the `m4` file. An alternative solution that could look like the following would require too many comments, so I dropped it.
```python
def patch(self):
    if self.spec.satisfies("@3.2.2:4.1.1"):
        x = FileFilter("configure", join_path("confdb", "aclocal_fc.m4"))
        with keep_modification_time(*x.filenames):
            x.filter(
                regex="{",
                string=True,
                repl="{\n\tCFI_is_contiguous(a_desc);",
                start_at="void test_assumed_rank_async_impl_c(CFI_cdesc_t * a_desc)",
                stop_at="return;",
            )
```