### PR TITLE
sgpp: fix build issues

### DIFF
--- a/var/spack/repos/builtin/packages/sgpp/disable_disutils_deprecation_warning.patch
+++ b/var/spack/repos/builtin/packages/sgpp/disable_disutils_deprecation_warning.patch
@@ -1,0 +1,23 @@
+diff --git a/site_scons/SGppConfigure.py b/site_scons/SGppConfigure.py
+index e5f54931f..2b0adc82a 100644
+--- a/site_scons/SGppConfigure.py
++++ b/site_scons/SGppConfigure.py
+@@ -3,7 +3,8 @@
+ # use, please see the copyright notice provided with SG++ or at
+ # sgpp.sparsegrids.org
+ 
+-
++import warnings
++warnings.filterwarnings("ignore", category=DeprecationWarning) 
+ import distutils.sysconfig
+ import errno
+ import os
+@@ -311,6 +312,8 @@ def checkPython(config):
+         raise Exception("Python 3 is required for SGpp python support!")
+       
+     pythonpath = getOutput(["python3", "-c",
++          "import warnings; "
++          "warnings.filterwarnings(\"ignore\", category=DeprecationWarning); " 
+           "import distutils.sysconfig; "
+           "print(distutils.sysconfig.get_python_inc())"])
+     package = "python3-dev"

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -22,6 +22,10 @@ class Sgpp(SConsPackage):
     version("3.4.0", sha256="450d4002850b0a48c561abe221b634261ca44eee111ca605c3e80797182f40b3")
     version("3.3.0", sha256="ca4d5b79f315b425ce69b04940c141451a76848bf1bd7b96067217304c68e2d4")
     version("3.2.0", sha256="dab83587fd447f92ed8546eacaac6b8cbe65b8db5e860218c0fa2e42f776962d")
+    # Note: Older versions of SGpp required Python 2 (and offered Python 2 bindings) and have 
+    # thus been removed from this list as Spack now requires Python 3.
+    # The last spack release with support for Python 2 is v0.19 - there, the spack package
+    # still supports SGpp versions 3.1.0 and 3.0.0 if required.
 
     # Patches with bugfixes that are necessary to build old SGpp versions
     # with spack. Patches are submitted upstream, but need to applied
@@ -43,11 +47,12 @@ class Sgpp(SConsPackage):
     # Fixed in SGpp in PR https://github.com/SGpp/SGpp/pull/229
     patch("avx512_datadriven_compilation.patch", when="@:3.3.0+datadriven")
     # Continue despite distutils deprecation warning!
-    # distutils will be removed in future SGpp versions
+    # distutils will be removed in future SGpp versions. See
+    # https://github.com/SGpp/SGpp/issues/263 for associated issue!
     # TODO Once distutils is removed from SGpp, limit patch to @:3.4.0
     patch("disable_disutils_deprecation_warning.patch", when="^python@3.10:3.11")
 
-    variant("python", default=True, description="Provide Python bindings for SGpp", when="@3.2:")
+    variant("python", default=True, description="Provide Python bindings for SGpp")
     variant("optimization", default=True, description="Builds the optimization module of SGpp")
     variant("pde", default=True, description="Builds the datadriven module of SGpp")
     variant("quadrature", default=True, description="Builds the datadriven module of SGpp")
@@ -59,12 +64,6 @@ class Sgpp(SConsPackage):
         "opencl", default=False, description="Enables support for OpenCL accelerated operations"
     )
     variant("mpi", default=False, description="Enables support for MPI-distributed operations")
-
-    # Java variant deactivated due to spack issue #987
-    # variant('java', default=False,
-    #         description='Provide Java bindings for SGpp')
-    # depends_on('swig@3:', when='+java', type=('build'))
-    # extends('openjdk', when='+java')
 
     # Mandatory dependencies
     depends_on("scons@3:", type=("build"))
@@ -110,7 +109,6 @@ class Sgpp(SConsPackage):
     conflicts("+misc", when="-solver")
     conflicts("+misc", when="-optimization")
     conflicts("+misc", when="-pde")
-    conflicts("+misc", when="@1.0.0:3.1.0", msg="The misc module was introduced in version 3.2.0")
     # Combigrid module requirements (for 3.2.0 or older)
     # newer combigrids have no dependencies
     conflicts("+combigrid", when="@1.0.0:3.2.0~optimization")
@@ -143,9 +141,7 @@ class Sgpp(SConsPackage):
         # Generate swig bindings?
         self.args.append("SG_PYTHON={0}".format("1" if "+python" in spec else "0"))
 
-        # Java variant deactivated due to spack issue #987
-        # self.args.append('SG_JAVA={0}'.format(
-        #     '1' if '+java' in spec else '0'))
+        # Java bindings are now deprecated within SGpp 
         self.args.append("SG_JAVA=0")
 
         # Which modules to build?
@@ -155,10 +151,7 @@ class Sgpp(SConsPackage):
         self.args.append("SG_DATADRIVEN={0}".format("1" if "+datadriven" in spec else "0"))
         self.args.append("SG_COMBIGRID={0}".format("1" if "+combigrid" in spec else "0"))
         self.args.append("SG_SOLVER={0}".format("1" if "+solver" in spec else "0"))
-
-        # Misc flag did not exist in older versions
-        if not spec.satisfies("@1.0.0:3.2.0"):
-            self.args.append("SG_MISC={0}".format("1" if "+misc" in spec else "0"))
+        self.args.append("SG_MISC={0}".format("1" if "+misc" in spec else "0"))
 
         # SIMD scons parameter (pick according to simd spec)
         if "avx512" in self.spec.target:

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -181,6 +181,10 @@ class Sgpp(SConsPackage):
 
         return self.args
 
+    def install_args(self, spec, prefix):
+        # SGpp expects the same args for the install and build commands
+        return self.args
+
     @run_after("install")
     def python_install(self):
         if "+python" in self.spec:

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -22,7 +22,7 @@ class Sgpp(SConsPackage):
     version("3.4.0", sha256="450d4002850b0a48c561abe221b634261ca44eee111ca605c3e80797182f40b3")
     version("3.3.0", sha256="ca4d5b79f315b425ce69b04940c141451a76848bf1bd7b96067217304c68e2d4")
     version("3.2.0", sha256="dab83587fd447f92ed8546eacaac6b8cbe65b8db5e860218c0fa2e42f776962d")
-    # Note: Older versions of SGpp required Python 2 (and offered Python 2 bindings) and have 
+    # Note: Older versions of SGpp required Python 2 (and offered Python 2 bindings) and have
     # thus been removed from this list as Spack now requires Python 3.
     # The last spack release with support for Python 2 is v0.19 - there, the spack package
     # still supports SGpp versions 3.1.0 and 3.0.0 if required.
@@ -141,7 +141,7 @@ class Sgpp(SConsPackage):
         # Generate swig bindings?
         self.args.append("SG_PYTHON={0}".format("1" if "+python" in spec else "0"))
 
-        # Java bindings are now deprecated within SGpp 
+        # Java bindings are now deprecated within SGpp
         self.args.append("SG_JAVA=0")
 
         # Which modules to build?

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -42,6 +42,10 @@ class Sgpp(SConsPackage):
     # Fixes compilation with AVX512 and datadriven
     # Fixed in SGpp in PR https://github.com/SGpp/SGpp/pull/229
     patch("avx512_datadriven_compilation.patch", when="@:3.3.0+datadriven")
+    # Continue despite distutils deprecation warning!
+    # distutils will be removed in future SGpp versions
+    # TODO Once distutils is removed from SGpp, limit patch to @:3.4.0
+    patch("disable_disutils_deprecation_warning.patch", when="^python@3.10:3.11")
 
     variant("python", default=True, description="Provide Python bindings for SGpp", when="@3.2:")
     variant("optimization", default=True, description="Builds the optimization module of SGpp")
@@ -63,15 +67,16 @@ class Sgpp(SConsPackage):
     # extends('openjdk', when='+java')
 
     # Mandatory dependencies
-    depends_on("scons", type=("build"))
-    depends_on("scons@3:", when="@3.2.0:", type=("build"))
+    depends_on("scons@3:", type=("build"))
     depends_on("zlib-api", type=("link"))
     # Python dependencies
     extends("python", when="+python")
     depends_on("py-pip", when="+python", type="build")
     depends_on("py-wheel", when="+python", type="build")
-    depends_on("py-setuptools", when="+python", type=("build"))
-    depends_on("python@3.7:", when="+python", type=("build", "run"))
+    # TODO allow newer versions once distutils is removed from SGpp
+    depends_on("py-setuptools@:59", type=("build"))
+    # TODO allow newer versions once distutils is removed from SGpp
+    depends_on("python@3.7:3.11", type=("build", "run"))
     depends_on("swig@3:", when="+python", type=("build"))
     depends_on("py-numpy@1.17:", when="+python", type=("build", "run"))
     depends_on("py-scipy@1.3:", when="+python", type=("build", "run"))


### PR DESCRIPTION
I have noticed some issues with the sgpp package that this PR fixes:
- SGpp expects the same flags for the install and  the build scons commands - otherwise build issues can occur for some variants (notably I noticed it with the -python variant). The removal of the install_args method in #27798 hence caused problems for these variants. This is easily fixed by re-adding the method, returning the args!
- The deprecation of distutils caused some issues, as the deprecation warning itself caused the internal SGpp Python.h header check to fail when using Python >= 3.10. I have added a small workaround patch silencing the deprecation warning, allowing us to use Python@3.10 and 3.11 until distutils can be completely removed from SGpp. I will update the package once this is done (and https://github.com/SGpp/SGpp/issues/263 is resolved), however until then, this PR will keep the sgpp spack package functional!