### PR TITLE
llvm: remove build type comment

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -78,10 +78,6 @@ class Llvm(CMakePackage, CudaPackage):
     version("5.0.1", sha256="84ca454abf262579814a2a2b846569f6e0cb3e16dc33ca3642b4f1dff6fbafd3")
     version("5.0.0", sha256="1f1843315657a4371d8ca37f01265fa9aae17dbcf46d2d0a95c1fdb3c6a4bab6")
 
-    # NOTE: The debug version of LLVM is an order of magnitude larger than
-    # the release version, and may take up 20-30 GB of space. If you want
-    # to save space, build with `build_type=Release`.
-
     variant(
         "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
     )


### PR DESCRIPTION
The message is now outdated after
https://github.com/spack/spack/pull/36679 which could lead to some confusion.

I've removed the entire message here as after the change listed above I don't think it is really relevant, but if other reviewers are interested in keeping a partial message and only eliminating the last sentence, that would probably be a good option as well.