### PR TITLE
mruby: added mruby package

### DIFF
--- a/var/spack/repos/builtin/packages/mruby/config.rb
+++ b/var/spack/repos/builtin/packages/mruby/config.rb
@@ -1,0 +1,83 @@
+MRuby::Build.new do |conf|
+  # load specific toolchain settings
+  conf.toolchain
+  if ENV.key?('MRUBY_ENABLE_CXX_EXCEPTION')
+    conf.enable_cxx_exception
+  end
+
+  # Use mrbgems
+  # conf.gem 'examples/mrbgems/ruby_extension_example'
+  # conf.gem 'examples/mrbgems/c_extension_example' do |g|
+  #   g.cc.flags << '-g' # append cflags in this gem
+  # end
+  # conf.gem 'examples/mrbgems/c_and_ruby_extension_example'
+  # conf.gem :core => 'mruby-eval'
+  # conf.gem :mgem => 'mruby-onig-regexp'
+  # conf.gem :github => 'mattn/mruby-onig-regexp'
+  # conf.gem :git => 'git@github.com:mattn/mruby-onig-regexp.git', :branch => 'master', :options => '-v'
+
+  # include the GEM box
+  conf.gembox 'full-core'
+
+  # C compiler settings
+  # conf.cc do |cc|
+  #   cc.command = ENV['CC'] || 'gcc'
+  #   cc.flags = [ENV['CFLAGS'] || %w()]
+  #   cc.include_paths = ["#{root}/include"]
+  #   cc.defines = %w()
+  #   cc.option_include_path = %q[-I"%s"]
+  #   cc.option_define = '-D%s'
+  #   cc.compile_options = %Q[%{flags} -MMD -o "%{outfile}" -c "%{infile}"]
+  # end
+
+  # mrbc settings
+  # conf.mrbc do |mrbc|
+  #   mrbc.compile_options = "-g -B%{funcname} -o-" # The -g option is required for line numbers
+  # end
+
+  # Linker settings
+  # conf.linker do |linker|
+  #   linker.command = ENV['LD'] || 'gcc'
+  #   linker.flags = [ENV['LDFLAGS'] || []]
+  #   linker.flags_before_libraries = []
+  #   linker.libraries = %w()
+  #   linker.flags_after_libraries = []
+  #   linker.library_paths = []
+  #   linker.option_library = '-l%s'
+  #   linker.option_library_path = '-L%s'
+  #   linker.link_options = "%{flags} -o "%{outfile}" %{objs} %{libs}"
+  # end
+
+  # Archiver settings
+  # conf.archiver do |archiver|
+  #   archiver.command = ENV['AR'] || 'ar'
+  #   archiver.archive_options = 'rs "%{outfile}" %{objs}'
+  # end
+
+  # Parser generator settings
+  # conf.yacc do |yacc|
+  #   yacc.command = ENV['YACC'] || 'bison'
+  #   yacc.compile_options = %q[-o "%{outfile}" "%{infile}"]
+  # end
+
+  # gperf settings
+  # conf.gperf do |gperf|
+  #   gperf.command = 'gperf'
+  #   gperf.compile_options = %q[-L ANSI-C -C -p -j1 -i 1 -g -o -t -N mrb_reserved_word -k"1,3,$" "%{infile}" > "%{outfile}"]
+  # end
+
+  # file extensions
+  # conf.exts do |exts|
+  #   exts.object = '.o'
+  #   exts.executable = '' # '.exe' if Windows
+  #   exts.library = '.a'
+  # end
+
+  # file separator
+  # conf.file_separator = '/'
+
+  # Turn on `enable_debug` for better debugging
+  # conf.enable_debug
+  conf.enable_bintest
+  conf.enable_test
+end

--- a/var/spack/repos/builtin/packages/mruby/package.py
+++ b/var/spack/repos/builtin/packages/mruby/package.py
@@ -40,7 +40,7 @@ class Mruby(Package):
     def install(self, spec, prefix):
         import os
         rb = spec["ruby"]
-        env["MRUBY_CONFIG"] = "build_config/spack.rb"
+        env["MRUBY_CONFIG"] = os.path.join("build_config", "spack.rb")
         env["GEM_PATH"] = os.path.join(
             rb.prefix, "lib", "ruby", "gems", str(rb.version.up_to(2)) + ".0")
         if "+cxx_exception" in spec:

--- a/var/spack/repos/builtin/packages/mruby/package.py
+++ b/var/spack/repos/builtin/packages/mruby/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Mruby(Package):
+    """mruby is the lightweight implementation of the Ruby language complying
+    to (part of) the ISO standard. Its syntax is Ruby 2.x compatible."""
+
+    homepage = "https://mruby.org/"
+    url      = "https://github.com/mruby/mruby/archive/refs/tags/3.0.0.tar.gz"
+    git      = "https://github.com/mruby/mruby.git"
+
+    maintainers = ["mdorier"]
+
+    version("master", branch="master")
+    version("3.2.0", sha256="3c198e4a31d31fe8524013066fac84a67fe6cd6067d92c25a1c79089744cb608")
+    version("3.1.0", sha256="64ce0a967028a1a913d3dfc8d3f33b295332ab73be6f68e96d0f675f18c79ca8")
+    version("3.0.0", sha256="95b798cdd931ef29d388e2b0b267cba4dc469e8722c37d4ef8ee5248bc9075b0")
+    version("2.1.2", sha256="4dc0017e36d15e81dc85953afb2a643ba2571574748db0d8ede002cefbba053b")
+    version("2.1.1", sha256="bb27397ee9cb7e0ddf4ff51caf5b0a193d636b7a3c52399684c8c383b41c362a")
+    version("2.1.0", sha256="d6733742a07e553c52ab71df08b0604b3b571768bbc0c2729fbf0389d1bb5d13")
+
+    variant("cxx_exception", description="Enable C++ exceptions",
+            default=False, when="@3.1.0:")
+
+    depends_on("ruby@3.0.0:", type=("build"))
+    depends_on("bison", type=("build"))
+
+    def patch(self):
+        """Create a config.rb file for rake to use"""
+        import os
+        here = os.path.dirname(os.path.abspath(__file__))
+        copy(os.path.join(here, "config.rb"),
+             os.path.join("build_config", "spack.rb"))
+
+    def install(self, spec, prefix):
+        import os
+        rb = spec["ruby"]
+        env["MRUBY_CONFIG"] = "build_config/spack.rb"
+        env["GEM_PATH"] = os.path.join(
+            rb.prefix, "lib", "ruby", "gems", str(rb.version.up_to(2)) + ".0")
+        if "+cxx_exception" in spec:
+            env["MRUBY_ENABLE_CXX_EXCEPTION"] = "ON"
+        rake()
+        build_path = os.path.join("build", "host")
+        for d in ["include", "lib", "bin", "mrblib", "mrbgems"]:
+            prefix_d = os.path.join(prefix, d)
+            build_path_d = os.path.join(build_path, d)
+            mkdirp(prefix_d)
+            install_tree(build_path_d, prefix_d)
+        install_tree("include", prefix.include)

--- a/var/spack/repos/builtin/packages/mruby/package.py
+++ b/var/spack/repos/builtin/packages/mruby/package.py
@@ -11,8 +11,8 @@ class Mruby(Package):
     to (part of) the ISO standard. Its syntax is Ruby 2.x compatible."""
 
     homepage = "https://mruby.org/"
-    url      = "https://github.com/mruby/mruby/archive/refs/tags/3.0.0.tar.gz"
-    git      = "https://github.com/mruby/mruby.git"
+    url = "https://github.com/mruby/mruby/archive/refs/tags/3.0.0.tar.gz"
+    git = "https://github.com/mruby/mruby.git"
 
     maintainers = ["mdorier"]
 
@@ -24,8 +24,7 @@ class Mruby(Package):
     version("2.1.1", sha256="bb27397ee9cb7e0ddf4ff51caf5b0a193d636b7a3c52399684c8c383b41c362a")
     version("2.1.0", sha256="d6733742a07e553c52ab71df08b0604b3b571768bbc0c2729fbf0389d1bb5d13")
 
-    variant("cxx_exception", description="Enable C++ exceptions",
-            default=False, when="@3.1.0:")
+    variant("cxx_exception", description="Enable C++ exceptions", default=False, when="@3.1.0:")
 
     depends_on("ruby@3.0.0:", type=("build"))
     depends_on("bison", type=("build"))
@@ -34,15 +33,16 @@ class Mruby(Package):
         """Create a config.rb file for rake to use"""
         import os
         here = os.path.dirname(os.path.abspath(__file__))
-        copy(os.path.join(here, "config.rb"),
-             os.path.join("build_config", "spack.rb"))
+        copy(os.path.join(here, "config.rb"), os.path.join("build_config", "spack.rb"))
 
     def install(self, spec, prefix):
         import os
+
         rb = spec["ruby"]
         env["MRUBY_CONFIG"] = os.path.join("build_config", "spack.rb")
         env["GEM_PATH"] = os.path.join(
-            rb.prefix, "lib", "ruby", "gems", str(rb.version.up_to(2)) + ".0")
+            rb.prefix, "lib", "ruby", "gems", str(rb.version.up_to(2)) + ".0"
+        )
         if "+cxx_exception" in spec:
             env["MRUBY_ENABLE_CXX_EXCEPTION"] = "ON"
         rake()

--- a/var/spack/repos/builtin/packages/mruby/package.py
+++ b/var/spack/repos/builtin/packages/mruby/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Mruby(Package):
@@ -32,6 +32,7 @@ class Mruby(Package):
     def patch(self):
         """Create a config.rb file for rake to use"""
         import os
+
         here = os.path.dirname(os.path.abspath(__file__))
         copy(os.path.join(here, "config.rb"), os.path.join("build_config", "spack.rb"))
 


### PR DESCRIPTION
This PR adds the mruby package. Building mruby requires writing a config.rb file for rake. The package provides a default config.rb, which is copied over to the source directory by the patch function. This config builds all the gems shipped with the mruby source. Should someone need a different config (e.g. with a restricted list of gems to reduce the size in an embedded context, or with external gems), we should find a way for the user to be able to provide such a file. Right now the user may simply override the package in another namespace to provide a different config.rb and a different patch function.