### PR TITLE
Prefix conflict messages with package name

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -520,7 +520,8 @@ def conflicts(conflict_spec, when=None, msg=None):
 
         # Save in a list the conflicts and the associated custom messages
         when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
-        when_spec_list.append((when_spec, msg))
+        msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
+        when_spec_list.append((when_spec, msg_with_name))
 
     return _execute_conflicts
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -897,7 +897,8 @@ def requires(*requirement_specs, policy="one_of", when=None, msg=None):
 
         # Save in a list the requirements and the associated custom messages
         when_spec_list = pkg.requirements.setdefault(tuple(requirement_specs), [])
-        when_spec_list.append((when_spec, policy, msg))
+        msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
+        when_spec_list.append((when_spec, policy, msg_with_name))
 
     return _execute_requires
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -956,8 +956,8 @@ class SpackSolverSetup:
         return [fn.attr("node_target_satisfies", spec.name, target)]
 
     def conflict_rules(self, pkg):
-        default_msg = "{0} '{1}' conflicts with '{2}'"
-        no_constraint_msg = "{0} conflicts with '{1}'"
+        default_msg = "{0}: '{1}' conflicts with '{2}'"
+        no_constraint_msg = "{0}: conflicts with '{1}'"
         for trigger, constraints in pkg.conflicts.items():
             trigger_msg = "conflict trigger %s" % str(trigger)
             trigger_id = self.condition(spack.spec.Spec(trigger), name=pkg.name, msg=trigger_msg)


### PR DESCRIPTION
This patch prefixes all conflict messages with the package name to alleviate what was otherwise a very manual process. Note that this patch is a small change but has a fairly outsized impact.