### PR TITLE
WarpX 23.07

### DIFF
--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -11,27 +11,20 @@ class PyPicmistandard(PythonPackage):
 
     homepage = "https://picmi-standard.github.io"
     git = "https://github.com/picmi-standard/picmi.git"
-    pypi = "picmistandard/picmistandard-0.0.18.tar.gz"
+    pypi = "picmistandard/picmistandard-0.25.0.tar.gz"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
 
     version("develop", branch="master")
-    version("0.25.0", sha256="0a78b3b17054d0861626287ace1fb9321469a9c95795b92981103b27d7797f67")
+    version("0.25.0", sha256="3fe6a524822d382e52bfc9d3378249546075d28620969954c5ffb43e7968fb02")
     version("0.24.0", sha256="55a82adcc14b41eb612caf0d9e47b0e2a56ffc196a58b41fa0cc395c6924be9a")
-    version("0.23.2", sha256="e6b4c46b23520d0a97b904df90d53ff6a3209b2b6b2fa741f684c594429a591c")
-    version("0.23.1", sha256="90ad1d3d2759d910cfdb88484516b7d0434ec98e881af46961b7e2faa534434d")
+    version("0.23.2", sha256="2853fcfaf2f226a88bb6063ae564832b7e69965294fd652cd2ac04756fa4599a")
+    version("0.23.1", sha256="c7375010b7a3431b519bc0accf097f2aafdb520e2a0126f42895cb96dcc7dcf1")
     version("0.0.22", sha256="e234a431274254b22cd70be64d6555b383d98426b2763ea0c174cf77bf4d0890")
     version("0.0.21", sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b")
     version("0.0.20", sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905")
     version("0.0.19", sha256="4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a")
     version("0.0.18", sha256="68c208c0c54b4786e133bb13eef0dd4824998da4906285987ddee84e6d195e71")
-    # 0.15 - 0.17 have broken install logic: missing requirements.txt on pypi
-    version(
-        "0.0.16",
-        sha256="b7eefdae1c43119984226b2df358c86fdeef7495084e47b3575e3d07e790ba30",
-        url="https://github.com/picmi-standard/picmi/archive/refs/tags/0.0.14.tar.gz",
-    )
-    version("0.0.14", sha256="8f83b25b281fc0309a0c4f75c7605afd5fa0ef4df3b3ac115069478c119bc8c3")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-numpy@1.15:1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -46,15 +46,6 @@ class PyWarpx(PythonPackage):
     version("22.03", sha256="ddbef760c8000f2f827dfb097ca3359e7aecbea8766bec5c3a91ee28d3641564")
     version("22.02", sha256="d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42")
     version("22.01", sha256="e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28")
-    version("21.12", sha256="847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1")
-    version("21.11", sha256="ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b")
-    version("21.10", sha256="d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454")
-    version("21.09", sha256="861a65f11846541c803564db133c8678b9e8779e69902ef1637b21399d257eab")
-    version("21.08", sha256="6128a32cfd075bc63d08eebea6d4f62d33ce0570f4fd72330a71023ceacccc86")
-    version("21.07", sha256="a8740316d813c365715f7471201499905798b50bd94950d33f1bd91478d49561")
-    version("21.06", sha256="a26039dc4061da45e779dd5002467c67a533fc08d30841e01e7abb3a890fbe30")
-    version("21.05", sha256="f835f0ae6c5702550d23191aa0bb0722f981abb1460410e3d8952bc3d945a9fc")
-    version("21.04", sha256="51d2d8b4542eada96216e8b128c0545c4b7527addc2038efebe586c32c4020a0")
 
     variant("mpi", default=True, description="Enable MPI support")
 
@@ -78,15 +69,6 @@ class PyWarpx(PythonPackage):
         "22.03",
         "22.02",
         "22.01",
-        "21.12",
-        "21.11",
-        "21.10",
-        "21.09",
-        "21.08",
-        "21.07",
-        "21.06",
-        "21.05",
-        "21.04",
         "develop",
     ]:
         depends_on("warpx@{0}".format(v), when="@{0}".format(v), type=["build", "link"])
@@ -96,8 +78,6 @@ class PyWarpx(PythonPackage):
     depends_on("py-numpy@1.15.0:1", type=("build", "run"))
     depends_on("py-mpi4py@2.1.0:", type=("build", "run"), when="+mpi")
     depends_on("py-periodictable@1.5:1", type=("build", "run"))
-    depends_on("py-picmistandard@0.0.14", type=("build", "run"), when="@21.03:21.11")
-    depends_on("py-picmistandard@0.0.16", type=("build", "run"), when="@21.12")
     depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
     depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
     depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.06.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.07.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
@@ -27,6 +27,7 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version("develop", branch="development")
+    version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
     version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
     version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
     version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")
@@ -58,6 +59,7 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
+        "23.07",
         "23.06",
         "23.05",
         "23.04",
@@ -101,7 +103,8 @@ class PyWarpx(PythonPackage):
     depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")
     depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:23.03")
     depends_on("py-picmistandard@0.23.2", type=("build", "run"), when="@23.04:23.05")
-    depends_on("py-picmistandard@0.24.0", type=("build", "run"), when="@23.06:")
+    depends_on("py-picmistandard@0.24.0", type=("build", "run"), when="@23.06")
+    depends_on("py-picmistandard@0.25.0", type=("build", "run"), when="@23.07:")
     depends_on("py-setuptools@42:", type="build")
     # Since we use PYWARPX_LIB_DIR to pull binaries out of the
     # 'warpx' spack package, we don't need py-cmake as declared

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.06.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.07.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "MaxThevenet", "RemiLehe")
@@ -25,6 +25,7 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
+    version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
     version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
     version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
     version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")


### PR DESCRIPTION
Update WarpX and related Python packages to the lastest releases.