### PR TITLE
octopus: specify the scalapack library not the directory

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -192,8 +192,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         if "+scalapack" in spec:
             args.extend(
                 [
-                    "--with-blacs=%s" % spec["scalapack"].libs,
-                    "--with-scalapack=%s" % spec["scalapack"].libs,
+                    "--with-blacs=-L%s -lscalapack" % spec["scalapack"].libs,
+                    "--with-scalapack=-L%s -lscalapack" % spec["scalapack"].libs,
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -192,8 +192,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         if "+scalapack" in spec:
             args.extend(
                 [
-                    "--with-blacs=-L%s -lscalapack" % spec["scalapack"].libs,
-                    "--with-scalapack=-L%s -lscalapack" % spec["scalapack"].libs,
+                    f"--with-blacs={spec['scalapack'].libs.ld_flags}",
+                    f"--with-scalapack={spec['scalapack'].libs.ld_flags}",
                 ]
             )
 


### PR DESCRIPTION
Octopus `configure` expects the library for blacs and scalapack and not the directory itself.
```console
configure --help
...
  --with-blacs=<lib>      use BLACS library <lib>
  --with-scalapack=<lib>  use SCALAPACK library <lib>
  --with-elpa-prefix=DIR  Directory where elpa was installed.
...
```
This MR specifies the right library when the `scalapack` variant is chosen.
Previously the `scalapack` would have not been picked up even when the `+scalapack` variant was chosen.
This MR fixes that:
Here is an output from the compiled octopus:
```
❯ octopus --config
maxdim3 openmp mpi sse2 avx libxc5 libxc_fxc metis scalapack
```