### PR TITLE
Fix for #39113 --- add glib version constraint for @1.76.1:

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -42,6 +42,9 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("glib@2.49.2:", when="@1.49.2:")
     # version 1.48.0 build fails with glib 2.49.4
     depends_on("glib@2.48.1", when="@1.48.0")
+    # version 1.76.1 build fails with glib < 2.76.0 
+    # https://github.com/spack/spack/issues/39113
+    depends_on("glib@2.76.0", when="@1.76.1:")
     depends_on("libffi")
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -44,7 +44,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("glib@2.48.1", when="@1.48.0")
     # version 1.76.1 build fails with glib < 2.76.0
     # https://github.com/spack/spack/issues/39113
-    depends_on("glib@2.76.0", when="@1.76.1:")
+    depends_on("glib@2.76.0:", when="@1.76.1:")
     depends_on("libffi")
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -42,7 +42,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("glib@2.49.2:", when="@1.49.2:")
     # version 1.48.0 build fails with glib 2.49.4
     depends_on("glib@2.48.1", when="@1.48.0")
-    # version 1.76.1 build fails with glib < 2.76.0 
+    # version 1.76.1 build fails with glib < 2.76.0
     # https://github.com/spack/spack/issues/39113
     depends_on("glib@2.76.0", when="@1.76.1:")
     depends_on("libffi")


### PR DESCRIPTION
Require glib@2.76.0: for gobject-introspection@21.76.1:

Should fix issue #39113, at least to the point of bringing the issue from build stage to spec/concretization stage