### PR TITLE
Windows: fixup pwsh env activate; deactivate, load;unload

### DIFF
--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -40,6 +40,13 @@ function Read-SpackArgs {
 }
 
 function Set-SpackEnv {
+    # This method is responsible
+    # for processing the return from $(spack <command>)
+    # which are returned as System.Object[]'s containing
+    # a list of env commands
+    # Invoke-Expression can only handle one command at a time
+    # so we iterate over the list to invoke the env modification
+    # expressions one at a time
     foreach($envop in $args[0]){
         Invoke-Expression $envop
     }

--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -41,9 +41,7 @@ function Read-SpackArgs {
 
 function Set-SpackEnv {
     foreach($envop in $args[0]){
-        $envop = $envop.Trim("`$")
-        $path, $value = $envop -split "="
-        Set-Item -Path $path -Value $value
+        Invoke-Expression $envop
     }
 }
 
@@ -116,6 +114,7 @@ function Invoke-SpackLoad {
         python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
     }
     else {
+        # python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand "--pwsh" $SpackSubCommandArgs
         $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand "--pwsh" $SpackSubCommandArgs)
         Set-SpackEnv $SpackEnv
     }

--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -41,20 +41,12 @@ function Read-SpackArgs {
 
 function Set-SpackEnv {
     foreach($envop in $args[0]){
-        $envop = $envop -replace '[$]',""
+        $envop = $envop.Trim("`$")
         $path, $value = $envop -split "="
         Set-Item -Path $path -Value $value
     }
 }
 
-function Remove-SpackEnv {
-    $args[1]
-    foreach($envop in $args[0]) {
-        $envop
-        "`n"
-        $ExecutionContext.InvokeCommand.InvokeScript("$envop")
-    }
-}
 
 function Invoke-SpackCD {
     if (Compare-CommonArgs $SpackSubCommandArgs) {
@@ -108,7 +100,7 @@ function Invoke-SpackEnv {
                 }
                 else {
                     $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params env deactivate "--pwsh")
-                    Remove-SpackEnv $SpackEnv
+                    Set-SpackEnv $SpackEnv
                 }
             }
             default {python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs}
@@ -129,19 +121,6 @@ function Invoke-SpackLoad {
     }
 }
 
-function Invoke-SpackUnLoad {
-    if (Compare-CommonArgs $SpackSubCommandArgs) {
-        python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
-    }
-    elseif ([bool]($SpackSubCommandArgs.Where({($_ -eq "--pwsh")}))) {
-        python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs
-    }
-    else {
-        $SpackEnv = $(python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand "--pwsh" $SpackSubCommandArgs)
-        Remove-SpackEnv $SpackEnv
-    }
-}
-
 
 $SpackCMD_params, $SpackSubCommand, $SpackSubCommandArgs = Read-SpackArgs $args
 
@@ -157,6 +136,6 @@ switch($SpackSubCommand)
     "cd"     {Invoke-SpackCD}
     "env"    {Invoke-SpackEnv}
     "load"   {Invoke-SpackLoad}
-    "unload" {Invoke-SpackUnLoad}
+    "unload" {Invoke-SpackLoad}
     default  {python $Env:SPACK_ROOT/bin/spack $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs}
 }

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -239,6 +239,13 @@ def env_deactivate_setup_parser(subparser):
         const="bat",
         help="print bat commands to activate the environment",
     )
+    shells.add_argument(
+        "--pwsh",
+        action="store_const",
+        dest="shell",
+        const="pwsh",
+        help="print pwsh commands to activate the environment",
+    )
 
 
 def env_deactivate(args):

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -52,6 +52,13 @@ def setup_parser(subparser):
         const="bat",
         help="print bat commands to load the package",
     )
+    shells.add_argument(
+        "--pwsh",
+        action="store_const",
+        dest="shell",
+        const="pwsh",
+        help="print pwsh commands to load the package",
+    )
 
     subparser.add_argument(
         "--first",

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -51,6 +51,13 @@ def setup_parser(subparser):
         const="bat",
         help="print bat commands to load the package",
     )
+    shells.add_argument(
+        "--pwsh",
+        action="store_const",
+        dest="shell",
+        const="pwsh",
+        help="print pwsh commands to load the package",
+    )
 
     subparser.add_argument(
         "-a", "--all", action="store_true", help="unload all loaded Spack packages"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -82,7 +82,7 @@ def deactivate_header(shell):
         # TODO: despacktivate
         # TODO: prompt
     elif shell == "pwsh":
-        cmds += "Remove-Item Env:SPACK_ENV"
+        cmds += "$Env:SPACK_ENV=\n"
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"
         cmds += "unset SPACK_ENV; export SPACK_ENV;\n"

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -43,7 +43,7 @@ def activate_header(env, shell, prompt=None):
         # TODO: despacktivate
         # TODO: prompt
     elif shell == "pwsh":
-        cmds += "$Env:SPACK_ENV=%s\n" % env.path
+        cmds += "$Env:SPACK_ENV='%s'\n" % env.path
     else:
         if "color" in os.getenv("TERM", "") and prompt:
             prompt = colorize("@G{%s}" % prompt, color=True, enclose=True)
@@ -82,7 +82,7 @@ def deactivate_header(shell):
         # TODO: despacktivate
         # TODO: prompt
     elif shell == "pwsh":
-        cmds += "$Env:SPACK_ENV=\n"
+        cmds += "Set-Item -Path Env:SPACK_ENV\n"
     else:
         cmds += "if [ ! -z ${SPACK_ENV+x} ]; then\n"
         cmds += "unset SPACK_ENV; export SPACK_ENV;\n"

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -173,7 +173,7 @@ def test_escape_double_quotes_in_shell_modifications():
         assert r'set "QUOTED_VAR="MY_VAL"' in cmds
         cmds = to_validate.shell_modifications(shell="pwsh")
         assert "$Env:VAR='$PATH;$ANOTHER_PATH'" in cmds
-        assert '$Env:QUOTED_VAR=\'"MY_VAL"\'' in cmds
+        assert "$Env:QUOTED_VAR='\"MY_VAL\"'" in cmds
     else:
         cmds = to_validate.shell_modifications()
         assert 'export VAR="$PATH:$ANOTHER_PATH"' in cmds

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -172,8 +172,8 @@ def test_escape_double_quotes_in_shell_modifications():
         assert r'set "VAR=$PATH;$ANOTHER_PATH"' in cmds
         assert r'set "QUOTED_VAR="MY_VAL"' in cmds
         cmds = to_validate.shell_modifications(shell="pwsh")
-        assert r"$Env:VAR=$PATH;$ANOTHER_PATH" in cmds
-        assert r'$Env:QUOTED_VAR="MY_VAL"' in cmds
+        assert "$Env:VAR='$PATH;$ANOTHER_PATH'" in cmds
+        assert '$Env:QUOTED_VAR=\'"MY_VAL"\'' in cmds
     else:
         cmds = to_validate.shell_modifications()
         assert 'export VAR="$PATH:$ANOTHER_PATH"' in cmds

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -56,8 +56,7 @@ _SHELL_UNSET_STRINGS = {
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
     "bat": 'set "{0}="\n',
-    # "pwsh": "Remove-Item Env:{0}\n",
-     "pwsh": "$Env:{0}=\n",
+    "pwsh": "$Env:{0}=\n",
 }
 
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -443,10 +443,7 @@ class RemovePath(NameValueModifier):
         # being unset here, clear out the variable to
         # indicate it should be unset entirely
         env_path = self.separator.join(directories)
-        if env_path:
-            env[self.name] = env_path
-        else:
-            env.pop(self.name)
+        env[self.name] = env_path
 
 
 class DeprioritizeSystemPaths(NameModifier):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -47,7 +47,7 @@ _SHELL_SET_STRINGS = {
     "csh": "setenv {0} {1};\n",
     "fish": "set -gx {0} {1};\n",
     "bat": 'set "{0}={1}"\n',
-    "pwsh": "$Env:{0}={1}\n",
+    "pwsh": "$Env:{0}='{1}'\n",
 }
 
 
@@ -56,7 +56,7 @@ _SHELL_UNSET_STRINGS = {
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
     "bat": 'set "{0}="\n',
-    "pwsh": "$Env:{0}=\n",
+    "pwsh": "Set-Item -Path Env:{0}\n",
 }
 
 
@@ -429,21 +429,13 @@ class RemovePath(NameValueModifier):
     def execute(self, env: MutableMapping[str, str]):
         tty.debug(f"RemovePath: {self.name}-{str(self.value)}", level=3)
         environment_value = env.get(self.name, "")
-        # Short circuit here, if there is no env value for the modification
-        # we are trying to make, we shouldn't continue trying to modify
-        if not environment_value:
-            return
         directories = environment_value.split(self.separator)
         directories = [
             path_to_os_path(os.path.normpath(x)).pop()
             for x in directories
             if x != path_to_os_path(os.path.normpath(self.value)).pop()
         ]
-        # If the path only has a single value that is the value
-        # being unset here, clear out the variable to
-        # indicate it should be unset entirely
-        env_path = self.separator.join(directories)
-        env[self.name] = env_path
+        env[self.name] = self.separator.join(directories)
 
 
 class DeprioritizeSystemPaths(NameModifier):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -732,11 +732,10 @@ class EnvironmentModifications:
                     cmds += _SHELL_UNSET_STRINGS[shell].format(name)
                 else:
                     if sys.platform != "win32":
-                        cmd = _SHELL_SET_STRINGS[shell].format(
-                            name, double_quote_escape(new_env[name])
-                        )
+                        new_env_name = double_quote_escape(new_env[name])
                     else:
-                        cmd = _SHELL_SET_STRINGS[shell].format(name, new_env[name])
+                        new_env_name = new_env[name]
+                    cmd = _SHELL_SET_STRINGS[shell].format(name, new_env_name)
                     cmds += cmd
         return cmds
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -56,7 +56,8 @@ _SHELL_UNSET_STRINGS = {
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
     "bat": 'set "{0}="\n',
-    "pwsh": "Remove-Item Env:{0}\n",
+    # "pwsh": "Remove-Item Env:{0}\n",
+     "pwsh": "$Env:{0}=\n",
 }
 
 
@@ -439,7 +440,7 @@ class RemovePath(NameValueModifier):
             for x in directories
             if x != path_to_os_path(os.path.normpath(self.value)).pop()
         ]
-        # If the path only has a single value, that is the value
+        # If the path only has a single value that is the value
         # being unset here, clear out the variable to
         # indicate it should be unset entirely
         env_path = self.separator.join(directories)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -942,7 +942,7 @@ _spack_env_activate() {
 }
 
 _spack_env_deactivate() {
-    SPACK_COMPREPLY="-h --help --sh --csh --fish --bat"
+    SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh"
 }
 
 _spack_env_create() {
@@ -1234,7 +1234,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --first --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --only --list"
     else
         _installed_packages
     fi
@@ -1852,7 +1852,7 @@ _spack_unit_test() {
 _spack_unload() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat -a --all"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh -a --all"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1396,7 +1396,7 @@ complete -c spack -n '__fish_spack_using_command env activate' -s d -l dir -r -f
 complete -c spack -n '__fish_spack_using_command env activate' -s d -l dir -r -d 'activate the environment in this directory'
 
 # spack env deactivate
-set -g __fish_spack_optspecs_spack_env_deactivate h/help sh csh fish bat
+set -g __fish_spack_optspecs_spack_env_deactivate h/help sh csh fish bat pwsh
 complete -c spack -n '__fish_spack_using_command env deactivate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env deactivate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l sh -f -a shell
@@ -1407,6 +1407,8 @@ complete -c spack -n '__fish_spack_using_command env deactivate' -l fish -f -a s
 complete -c spack -n '__fish_spack_using_command env deactivate' -l fish -d 'print fish commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command env deactivate' -l bat -d 'print bat commands to activate the environment'
+complete -c spack -n '__fish_spack_using_command env deactivate' -l pwsh -f -a shell
+complete -c spack -n '__fish_spack_using_command env deactivate' -l pwsh -d 'print pwsh commands to activate the environment'
 
 # spack env create
 set -g __fish_spack_optspecs_spack_env_create h/help d/dir keep-relative without-view with-view=
@@ -1926,7 +1928,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat first only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first only= list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -1938,6 +1940,8 @@ complete -c spack -n '__fish_spack_using_command load' -l fish -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l fish -d 'print fish commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l bat -d 'print bat commands to load the package'
+complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell
+complete -c spack -n '__fish_spack_using_command load' -l pwsh -d 'print pwsh commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_first
 complete -c spack -n '__fish_spack_using_command load' -l first -d 'load the first match if multiple packages match the spec'
 complete -c spack -n '__fish_spack_using_command load' -l only -r -f -a 'package dependencies'
@@ -2799,7 +2803,7 @@ complete -c spack -n '__fish_spack_using_command unit-test' -l showlocals -f -a 
 complete -c spack -n '__fish_spack_using_command unit-test' -l showlocals -d 'show local variable values in tracebacks'
 
 # spack unload
-set -g __fish_spack_optspecs_spack_unload h/help sh csh fish bat a/all
+set -g __fish_spack_optspecs_spack_unload h/help sh csh fish bat pwsh a/all
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 unload' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command unload' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command unload' -s h -l help -d 'show this help message and exit'
@@ -2811,6 +2815,8 @@ complete -c spack -n '__fish_spack_using_command unload' -l fish -f -a shell
 complete -c spack -n '__fish_spack_using_command unload' -l fish -d 'print fish commands to load the package'
 complete -c spack -n '__fish_spack_using_command unload' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command unload' -l bat -d 'print bat commands to load the package'
+complete -c spack -n '__fish_spack_using_command unload' -l pwsh -f -a shell
+complete -c spack -n '__fish_spack_using_command unload' -l pwsh -d 'print pwsh commands to load the package'
 complete -c spack -n '__fish_spack_using_command unload' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command unload' -s a -l all -d 'unload all loaded Spack packages'
 


### PR DESCRIPTION
Commands mentioned in PR subject are currently broken on powershell with Windows due to improper use of the `InvokeCommand` commandlet and a lack of direct support for the `--pwsh` argument in `spack load`, `spack unload`, and `spack env deactivate`.

(EDIT: this PR can now set the env variable to be empty) ~Additionally the `RemovePath` environmental modifier, if attempting to remove a path that does not exist, or would be empty after removal, adds the env variable back as an empty string, which breaks environmental modifications on Windows Powershell.~