### PR TITLE
Debug libsearch

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1750,16 +1750,17 @@ def find(root, files, recursive=True):
     Returns:
         list: The files that have been found
     """
-    tty.debug("Find (enter): {0} {1}".format(root, str(files)))
     if isinstance(files, str):
         files = [files]
 
     if recursive:
+        tty.debug(f"Find (recursive): {root} {str(files)}")
         result = _find_recursive(root, files)
     else:
+        tty.debug(f"Find (not recursive): {root} {str(files)}")
         result = _find_non_recursive(root, files)
 
-    tty.debug("Find (leave): {0} {1}".format(root, str(files)))
+    tty.debug(f"Find complete: {root} {str(files)}")
     return result
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1750,13 +1750,17 @@ def find(root, files, recursive=True):
     Returns:
         list: The files that have been found
     """
+    tty.debug("Find (enter): {0} {1}".format(root, str(files)))
     if isinstance(files, str):
         files = [files]
 
     if recursive:
-        return _find_recursive(root, files)
+        result = _find_recursive(root, files)
     else:
-        return _find_non_recursive(root, files)
+        result = _find_non_recursive(root, files)
+
+    tty.debug("Find (leave): {0} {1}".format(root, str(files)))
+    return result
 
 
 @system_path_filter


### PR DESCRIPTION
We output debug messages when Spack's core code searches for libraries, because in some cases improperly formatted externals (e.g. saying an external exists when it doesn't) can unintentionally lead to very long search times (recursive search for a file that doesn't exist in a low-level prefix like "usr/").

We also provide functions like `find_libraries` that can be used in `package.py` files, which may also run into this problem. This PR adds a lower level debugging statement in `find` to help diagnose similar cases where users call `find` directly.