### PR TITLE
HACCKernels git repository has changed URL.  Updating.

### DIFF
--- a/var/spack/repos/builtin/packages/hacckernels/package.py
+++ b/var/spack/repos/builtin/packages/hacckernels/package.py
@@ -13,8 +13,8 @@ class Hacckernels(CMakePackage):
     on diverse computing architectures and to scale to millions of
     cores and beyond."""
 
-    homepage = "https://xgitlab.cels.anl.gov/hacc/HACCKernels"
-    git = "https://xgitlab.cels.anl.gov/hacc/HACCKernels.git"
+    homepage = "https://git.cels.anl.gov/hacc/HACCKernels"
+    git = "https://git.cels.anl.gov/hacc/HACCKernels.git"
 
     tags = ["proxy-app"]
 


### PR DESCRIPTION
Change the homepage and git repo URL of hacckernels.