### PR TITLE
hh-suite: patching for %gcc@13:

### DIFF
--- a/var/spack/repos/builtin/packages/hh-suite/gcc13.patch
+++ b/var/spack/repos/builtin/packages/hh-suite/gcc13.patch
@@ -1,0 +1,10 @@
+--- src/a3m_compress.h	2020-08-17 00:16:36.000000000 +0100
++++ src/a3m_compress.h.patched	2023-07-28 19:31:38.599795859 +0100
+@@ -16,6 +16,7 @@
+ #include <algorithm>
+ #include <cstring>
+ #include <climits>
++#include <cstdint>
+ 
+ extern "C" {
+   #include <ffindex.h>     // fast index-based database reading

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -24,6 +24,9 @@ class HhSuite(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("mpi", when="+mpi")
 
+    # patch to fix include requirements for gcc13
+    patch("gcc13.patch", level=0, when="%gcc@13:")
+
     def build_args(self, spec, prefix):
         args = []
         if "+mpi" in self.spec:


### PR DESCRIPTION
Patching `hh-suite` to allow compilation with `gcc@13:`.