### PR TITLE
nextdenovo: new package @2.5.2 (and py-paralleltask)

### DIFF
--- a/var/spack/repos/builtin/packages/nextdenovo/package.py
+++ b/var/spack/repos/builtin/packages/nextdenovo/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Nextdenovo(MakefilePackage):
+    """NextDenovo is a string graph-based de novo assembler for long reads."""
+
+    homepage = "https://nextdenovo.readthedocs.io/en/latest/index.html"
+    url = "https://github.com/Nextomics/NextDenovo/archive/refs/tags/2.5.2.tar.gz"
+
+    version("2.5.2", sha256="f1d07c9c362d850fd737c41e5b5be9d137b1ef3f1aec369dc73c637790611190")
+
+    depends_on("python", type="run")
+    depends_on("py-paralleltask", type="run")
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter(r"^TOP_DIR.*",  "TOP_DIR={0}".format(self.build_directory))
+        runfile = FileFilter("nextDenovo")
+        runfile.filter(r"^SCRIPT_PATH.*", "SCRIPT_PATH = '{0}'".format(prefix))
+
+    def install(self, spec, prefix):
+        install_tree("bin", prefix.bin)
+        install("nextDenovo", prefix.bin)
+        install_tree("lib", prefix.lib)

--- a/var/spack/repos/builtin/packages/nextdenovo/package.py
+++ b/var/spack/repos/builtin/packages/nextdenovo/package.py
@@ -19,7 +19,7 @@ class Nextdenovo(MakefilePackage):
 
     def edit(self, spec, prefix):
         makefile = FileFilter("Makefile")
-        makefile.filter(r"^TOP_DIR.*",  "TOP_DIR={0}".format(self.build_directory))
+        makefile.filter(r"^TOP_DIR.*", "TOP_DIR={0}".format(self.build_directory))
         runfile = FileFilter("nextDenovo")
         runfile.filter(r"^SCRIPT_PATH.*", "SCRIPT_PATH = '{0}'".format(prefix))
 

--- a/var/spack/repos/builtin/packages/py-paralleltask/package.py
+++ b/var/spack/repos/builtin/packages/py-paralleltask/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyParalleltask(PythonPackage):
+    """Paralleltask is a simple and lightweight parallel task engine. It can launch a given
+    number of tasks from a batch of independent tasks, and keep this number of running tasks
+    until all tasks are completed."""
+
+    homepage = "https://github.com/moold/ParallelTask"
+    pypi = "Paralleltask/Paralleltask-0.2.2.tar.gz"
+
+    version("0.2.2", sha256="f00945e2bd5b6aff9cdc48fbd92aa7b48d23bb530d7f6643ac966fea11a7a9d5")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-paralleltask/package.py
+++ b/var/spack/repos/builtin/packages/py-paralleltask/package.py
@@ -17,4 +17,4 @@ class PyParalleltask(PythonPackage):
     version("0.2.2", sha256="f00945e2bd5b6aff9cdc48fbd92aa7b48d23bb530d7f6643ac966fea11a7a9d5")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-psutil", type="run")
+    depends_on("py-psutil", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-paralleltask/package.py
+++ b/var/spack/repos/builtin/packages/py-paralleltask/package.py
@@ -17,3 +17,4 @@ class PyParalleltask(PythonPackage):
     version("0.2.2", sha256="f00945e2bd5b6aff9cdc48fbd92aa7b48d23bb530d7f6643ac966fea11a7a9d5")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-psutil", type="run")


### PR DESCRIPTION
Adding `nextdenovo` long read assembler and its (sole) dependency `py-paralleltask`. The latter says it has no dependencies but it lies - it needs `py-psutil`.