### PR TITLE
Partially fix "spack bootstrap now --dev" on Mac M1

### DIFF
--- a/var/spack/repos/builtin/packages/py-isort/package.py
+++ b/var/spack/repos/builtin/packages/py-isort/package.py
@@ -12,6 +12,7 @@ class PyIsort(PythonPackage):
     homepage = "https://github.com/timothycrosley/isort"
     pypi = "isort/isort-4.2.15.tar.gz"
 
+    version("5.11.5", sha256="6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db")
     version("5.10.1", sha256="e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951")
     version("5.9.3", sha256="9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899")
     version("5.9.1", sha256="83510593e07e433b77bd5bff0f6f607dbafa06d1a89022616f02d8b699cfcd56")


### PR DESCRIPTION
See also: https://github.com/spack/spack/issues/38231

This version of isort resolves the bug in the mentioned issue, and is compatible with Python 3.9

I don't consider the bug fully resolved though, since in my case, once the bootstrapping is complete, my shell input/output is broken (that being said, with this change, you can at least `spack style --fix` after closing and reopening the shell after a `spack bootstrap now --dev`).