### PR TITLE
Bugfix/ltrace: Add missing elf dependency

### DIFF
--- a/var/spack/repos/builtin/packages/ltrace/package.py
+++ b/var/spack/repos/builtin/packages/ltrace/package.py
@@ -18,6 +18,8 @@ class Ltrace(AutotoolsPackage):
 
     conflicts("platform=darwin", msg="ltrace runs only on Linux.")
 
+    depends_on("elf", type="link")
+
     def configure_args(self):
         # Disable -Werror since some functions used by ltrace
         # have been deprecated in recent version of glibc


### PR DESCRIPTION
It appears there are some situations (e.g., a container) that reveal a dependency on `elf`.

This has been manually tested when built with `libelf` and `elfutils`.