### PR TITLE
fzf: add v0.42.0

### DIFF
--- a/var/spack/repos/builtin/packages/fzf/package.py
+++ b/var/spack/repos/builtin/packages/fzf/package.py
@@ -17,6 +17,7 @@ class Fzf(MakefilePackage):
 
     executables = ["^fzf$"]
 
+    version("0.42.0", sha256="743c1bfc7851b0796ab73c6da7db09d915c2b54c0dd3e8611308985af8ed3df2")
     version("0.41.1", sha256="982682eaac377c8a55ae8d7491fcd0e888d6c13915d01da9ebb6b7c434d7f4b5")
     version("0.40.0", sha256="9597f297a6811d300f619fff5aadab8003adbcc1566199a43886d2ea09109a65")
 


### PR DESCRIPTION
Add fzf v0.42.0.

**Summarized Changelog:**
- Added new info style: --info=right
- Added new info style: --info=inline-right
- Added new border style thinblock which uses symbols for legacy computing [one eighth block elements](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing)

Full changelog can be found [here](https://github.com/junegunn/fzf/releases/tag/0.42.0).