### PR TITLE
Add style tool to fix fish file formatting

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -36,6 +36,7 @@ class BootstrapEnvironment(spack.environment.Environment):
             mypy_root_spec(),
             black_root_spec(),
             flake8_root_spec(),
+            fish_root_spec(),
             pytest_root_spec(),
         ]
 
@@ -176,6 +177,12 @@ def black_root_spec() -> str:
 def flake8_root_spec() -> str:
     """Return the root spec used to bootstrap flake8"""
     return _root_spec("py-flake8@3.8.2:")
+
+
+def fish_root_spec() -> str:
+    """Return the root spec used to bootstrap fish"""
+    # fish 3.2.0 introduces the `--check` flag to `fish_indent`
+    return _root_spec("fish@3.2:")
 
 
 def pytest_root_spec() -> str:

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -123,7 +123,7 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None):
 
         for f in files:
             # Ignore files in the exclude locations
-            if any(os.path.realpath(f).startswith(e) for e in excludes):
+            if not f or any(os.path.realpath(f).startswith(e) for e in excludes):
                 continue
 
             changed.add(f)

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -36,7 +36,7 @@ exclude_directories = [os.path.relpath(spack.paths.external_path, spack.paths.pr
 #: double-check the results of other tools (if, e.g., --fix was provided)
 #: The list maps an executable name to a method to ensure the tool is
 #: bootstrapped or present in the environment.
-tool_names = ["isort", "black", "flake8", "mypy"]
+tool_names = ["isort", "black", "flake8", "mypy", "fish_indent"]
 
 #: tools we run in spack style
 tools = {}
@@ -61,12 +61,13 @@ def is_package(f):
 
 #: decorator for adding tools to the list
 class tool:
-    def __init__(self, name, required=False):
+    def __init__(self, name, required=False, suffix=".py"):
         self.name = name
         self.required = required
+        self.suffix = suffix
 
     def __call__(self, fun):
-        tools[self.name] = (fun, self.required)
+        tools[self.name] = (fun, self.required, self.suffix)
         return fun
 
 
@@ -121,10 +122,6 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None):
         files = git(*arg_list, output=str).split("\n")
 
         for f in files:
-            # Ignore non-Python files
-            if not (f.endswith(".py") or f == "bin/spack"):
-                continue
-
             # Ignore files in the exclude locations
             if any(os.path.realpath(f).startswith(e) for e in excludes):
                 continue
@@ -352,6 +349,22 @@ def run_black(black_cmd, file_list, args):
     return returncode
 
 
+@tool("fish_indent", suffix=".fish")
+def run_fish_indent(fish_indent_cmd, file_list, args):
+    if args.fix:
+        fish_indent_args = ["--write"]
+    else:
+        fish_indent_args = ["--check"]
+
+    output = fish_indent_cmd(*fish_indent_args, *file_list, fail_on_error=False, output=str)
+    returncode = fish_indent_cmd.returncode
+
+    rewrite_and_print_output(output, args)
+    print_tool_result("fish_indent", returncode)
+
+    return returncode
+
+
 def validate_toolset(arg_value):
     """Validate --tool and --skip arguments (sets of optionally comma-separated tools)."""
     tools = set(",".join(arg_value).split(","))  # allow args like 'isort,flake8'
@@ -417,9 +430,11 @@ def style(parser, args):
 
         print_style_header(file_list, args, tools_to_run)
         for tool_name in tools_to_run:
-            run_function, required = tools[tool_name]
+            run_function, required, suffix = tools[tool_name]
             print_tool_header(tool_name)
-            return_code |= run_function(which(tool_name), file_list, args)
+            file_subset = [f for f in file_list if f.endswith(suffix)]
+            if file_subset:
+                return_code |= run_function(which(tool_name), file_subset, args)
 
     if return_code == 0:
         tty.msg(color.colorize("@*{spack style checks were clean}"))

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -56,7 +56,7 @@ def flake8_package_with_errors(scope="function"):
     """A flake8 package with errors."""
     repo = spack.repo.Repo(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("flake8")
-    tmp = filename + ".tmp"
+    tmp = filename.replace("package.py", "package2.py")
 
     shutil.copy(filename, tmp)
     package = FileFilter(tmp)
@@ -64,11 +64,12 @@ def flake8_package_with_errors(scope="function"):
     # this is a black error (quote style and spacing before/after operator)
     package.filter('state = "unmodified"', "state    =    'modified'", string=True)
 
-    # this is an isort error (orderign) and a flake8 error (unused import)
+    # this is an isort error (ordering) and a flake8 error (unused import)
     package.filter(
         "from spack.package import *", "from spack.package import *\nimport os", string=True
     )
     yield tmp
+    os.remove(tmp)
 
 
 def test_changed_files_from_git_rev_base(git, tmpdir, capfd):
@@ -213,6 +214,7 @@ def test_fix_style(external_style_root):
 @pytest.mark.skipif(not which("isort"), reason="isort is not installed.")
 @pytest.mark.skipif(not which("mypy"), reason="mypy is not installed.")
 @pytest.mark.skipif(not which("black"), reason="black is not installed.")
+@pytest.mark.skipif(not which("fish_indent"), reason="fish is not installed.")
 def test_external_root(external_style_root, capfd):
     """Ensure we can run in a separate root directory w/o configuration files."""
     tmpdir, py_file = external_style_root
@@ -285,5 +287,5 @@ def test_style_with_black(flake8_package_with_errors):
 
 
 def test_skip_tools():
-    output = style("--skip", "isort,mypy,black,flake8")
+    output = style("--skip", "isort,mypy,black,flake8,fish_indent")
     assert "Nothing to run" in output

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -66,548 +66,548 @@ end
 function spack -d "wrapper for the `spack` command"
 
 
-#
-# DEFINE SUPPORT FUNCTIONS HERE
-#
+    #
+    # DEFINE SUPPORT FUNCTIONS HERE
+    #
 
 
-#
-# ALLOCATE_SP_SHARED, and DELETE_SP_SHARED allocate (and delete) temporary
-# global variables
-#
+    #
+    # ALLOCATE_SP_SHARED, and DELETE_SP_SHARED allocate (and delete) temporary
+    # global variables
+    #
 
 
-function allocate_sp_shared -d "allocate shared (global variables)"
-    set -gx __sp_remaining_args
-    set -gx __sp_subcommand_args
-    set -gx __sp_module_args
-    set -gx __sp_stat
-    set -gx __sp_stdout
-    set -gx __sp_stderr
-end
-
-
-
-function delete_sp_shared -d "deallocate shared (global variables)"
-    set -e __sp_remaining_args
-    set -e __sp_subcommand_args
-    set -e __sp_module_args
-    set -e __sp_stat
-    set -e __sp_stdout
-    set -e __sp_stderr
-end
-
-
-
-
-#
-# STREAM_ARGS and SHIFT_ARGS: helper functions manipulating the `argv` array:
-#   -> STREAM_ARGS: echos the `argv` array element-by-element
-#   -> SHIFT_ARGS:  echos the `argv` array element-by-element starting with the
-#                   second element. If `argv` has only one element, echo the
-#                   empty string `""`.
-# NOTE: while `stream_args` is not strictly necessary, it adds a nice symmetry
-#       to `shift_args`
-#
-
-function stream_args -d "echos args as a stream"
-    # return the elements of `$argv` as an array
-    #  -> since we want to be able to call it as part of `set x (shift_args
-    #     $x)`, we return these one-at-a-time using echo... this means that the
-    #     sub-command stream will correctly concatenate the output into an array
-    for elt in $argv
-        echo $elt
+    function allocate_sp_shared -d "allocate shared (global variables)"
+        set -gx __sp_remaining_args
+        set -gx __sp_subcommand_args
+        set -gx __sp_module_args
+        set -gx __sp_stat
+        set -gx __sp_stdout
+        set -gx __sp_stderr
     end
-end
 
 
-function shift_args -d "simulates bash shift"
+
+    function delete_sp_shared -d "deallocate shared (global variables)"
+        set -e __sp_remaining_args
+        set -e __sp_subcommand_args
+        set -e __sp_module_args
+        set -e __sp_stat
+        set -e __sp_stdout
+        set -e __sp_stderr
+    end
+
+
+
+
     #
-    # Returns argv[2..-1] (as an array)
-    #  -> if argv has only 1 element, then returns the empty string. This
-    #     simulates the behavior of bash `shift`
+    # STREAM_ARGS and SHIFT_ARGS: helper functions manipulating the `argv` array:
+    #   -> STREAM_ARGS: echos the `argv` array element-by-element
+    #   -> SHIFT_ARGS:  echos the `argv` array element-by-element starting with the
+    #                   second element. If `argv` has only one element, echo the
+    #                   empty string `""`.
+    # NOTE: while `stream_args` is not strictly necessary, it adds a nice symmetry
+    #       to `shift_args`
     #
 
-    if test -z "$argv[2]"
-        # there are no more element, returning the empty string
-        echo ""
-    else
-        # return the next elements `$argv[2..-1]` as an array
+    function stream_args -d "echos args as a stream"
+        # return the elements of `$argv` as an array
         #  -> since we want to be able to call it as part of `set x (shift_args
-        #     $x)`, we return these one-at-a-time using echo... this means that
-        #     the sub-command stream will correctly concatenate the output into
-        #     an array
-        for elt in $argv[2..-1]
+        #     $x)`, we return these one-at-a-time using echo... this means that the
+        #     sub-command stream will correctly concatenate the output into an array
+        for elt in $argv
             echo $elt
         end
     end
 
-end
 
+    function shift_args -d "simulates bash shift"
+        #
+        # Returns argv[2..-1] (as an array)
+        #  -> if argv has only 1 element, then returns the empty string. This
+        #     simulates the behavior of bash `shift`
+        #
 
-
-
-#
-# CAPTURE_ALL: helper function used to capture stdout, stderr, and status
-#   -> CAPTURE_ALL: there is a bug in fish, that prevents stderr re-capture
-#                   from nested command substitution:
-#                   https://github.com/fish-shell/fish-shell/issues/6459
-#
-
-function capture_all
-    begin;
-        begin;
-            eval $argv[1]
-            set $argv[2] $status  # read sets the `status` flag => capture here
-        end 2>| read -z __err
-    end 1>| read -z __out
-
-    # output arrays
-    set $argv[3] (echo $__out | string split \n)
-    set $argv[4] (echo $__err | string split \n)
-
-    return 0
-end
-
-
-
-
-#
-# GET_SP_FLAGS, and GET_MOD_ARGS: support functions for extracting arguments and
-# flags. Note bash's `shift` operation is simulated by the `__sp_remaining_args`
-# array which is roughly equivalent to `$@` in bash.
-#
-
-function get_sp_flags -d "return leading flags"
-    #
-    # Accumulate initial flags for main spack command. NOTE: Sets the external
-    # array: `__sp_remaining_args` containing all unprocessed arguments.
-    #
-
-    # initialize argument counter
-    set -l i 1
-
-    # iterate over elements (`elt`) in `argv` array
-    for elt in $argv
-
-        # match element `elt` of `argv` array to check if it has a leading dash
-        if echo $elt | string match -r -q "^-"
-            # by echoing the current `elt`, the calling stream accumulates list
-            # of valid flags. NOTE that this can also be done by adding to an
-            # array, but fish functions can only return integers, so this is the
-            # most elegant solution.
-            echo $elt
+        if test -z "$argv[2]"
+            # there are no more element, returning the empty string
+            echo ""
         else
-            # bash compatibility: stop when the match first fails. Upon failure,
-            # we pack the remainder of `argv` into a global `__sp_remaining_args`
-            # array (`i` tracks the index of the next element).
-            set __sp_remaining_args (stream_args $argv[$i..-1])
+            # return the next elements `$argv[2..-1]` as an array
+            #  -> since we want to be able to call it as part of `set x (shift_args
+            #     $x)`, we return these one-at-a-time using echo... this means that
+            #     the sub-command stream will correctly concatenate the output into
+            #     an array
+            for elt in $argv[2..-1]
+                echo $elt
+            end
+        end
+
+    end
+
+
+
+
+    #
+    # CAPTURE_ALL: helper function used to capture stdout, stderr, and status
+    #   -> CAPTURE_ALL: there is a bug in fish, that prevents stderr re-capture
+    #                   from nested command substitution:
+    #                   https://github.com/fish-shell/fish-shell/issues/6459
+    #
+
+    function capture_all
+        begin
+            begin
+                eval $argv[1]
+                set $argv[2] $status # read sets the `status` flag => capture here
+            end 2>| read -z __err
+        end 1>| read -z __out
+
+        # output arrays
+        set $argv[3] (echo $__out | string split \n)
+        set $argv[4] (echo $__err | string split \n)
+
+        return 0
+    end
+
+
+
+
+    #
+    # GET_SP_FLAGS, and GET_MOD_ARGS: support functions for extracting arguments and
+    # flags. Note bash's `shift` operation is simulated by the `__sp_remaining_args`
+    # array which is roughly equivalent to `$@` in bash.
+    #
+
+    function get_sp_flags -d "return leading flags"
+        #
+        # Accumulate initial flags for main spack command. NOTE: Sets the external
+        # array: `__sp_remaining_args` containing all unprocessed arguments.
+        #
+
+        # initialize argument counter
+        set -l i 1
+
+        # iterate over elements (`elt`) in `argv` array
+        for elt in $argv
+
+            # match element `elt` of `argv` array to check if it has a leading dash
+            if echo $elt | string match -r -q "^-"
+                # by echoing the current `elt`, the calling stream accumulates list
+                # of valid flags. NOTE that this can also be done by adding to an
+                # array, but fish functions can only return integers, so this is the
+                # most elegant solution.
+                echo $elt
+            else
+                # bash compatibility: stop when the match first fails. Upon failure,
+                # we pack the remainder of `argv` into a global `__sp_remaining_args`
+                # array (`i` tracks the index of the next element).
+                set __sp_remaining_args (stream_args $argv[$i..-1])
+                return
+            end
+
+            # increment argument counter: used in place of bash's `shift` command
+            set -l i (math $i+1)
+
+        end
+
+        # if all elements in `argv` are matched, make sure that `__sp_remaining_args`
+        # is deleted (this might be overkill...).
+        set -e __sp_remaining_args
+    end
+
+
+
+    #
+    # CHECK_SP_FLAGS, CONTAINS_HELP_FLAGS, CHECK_ENV_ACTIVATE_FLAGS, and
+    # CHECK_ENV_DEACTIVATE_FLAGS: support functions for checking arguments and flags.
+    #
+
+    function check_sp_flags -d "check spack flags for h/V flags"
+        #
+        # Check if inputs contain h or V flags.
+        #
+
+        # combine argument array into single string (space seperated), to be passed
+        # to regular expression matching (`string match -r`)
+        set -l _a "$argv"
+
+        # skip if called with blank input. Notes: [1] (cf. EOF)
+        if test -n "$_a"
+            if echo $_a | string match -r -q ".*h.*"
+                return 0
+            end
+            if echo $_a | string match -r -q ".*V.*"
+                return 0
+            end
+        end
+
+        return 1
+    end
+
+
+
+    function match_flag -d "checks all combinations of flags ocurring inside of a string"
+
+        # Remove leading and trailing spaces -- but we need to insert a "guard" (x)
+        # so that eg. `string trim -h` doesn't trigger the help string for `string trim`
+        set -l _a (string sub -s 2 (string trim "x$argv[1]"))
+        set -l _b (string sub -s 2 (string trim "x$argv[2]"))
+
+        if test -z "$_a"; or test -z "$_b"
+            return 0
+        end
+
+        # surrounded by spaced
+        if echo "$_a" | string match -r -q " +$_b +"
+            return 0
+        end
+
+        # beginning of string + trailing space
+        if echo "$_a" | string match -r -q "^$_b +"
+            return 0
+        end
+
+        # end of string + leadingg space
+        if echo "$_a" | string match -r -q " +$_b\$"
+            return 0
+        end
+
+        # entire string
+        if echo "$_a" | string match -r -q "^$_b\$"
+            return 0
+        end
+
+        return 1
+
+    end
+
+
+
+    function check_env_activate_flags -d "check spack env subcommand flags for -h, --sh, --csh, or --fish"
+        #
+        # Check if inputs contain -h/--help, --sh, --csh, or --fish
+        #
+
+        # combine argument array into single string (space seperated), to be passed
+        # to regular expression matching (`string match -r`)
+        set -l _a "$argv"
+
+        # skip if called with blank input. Notes: [1] (cf. EOF)
+        if test -n "$_a"
+
+            # looks for a single `-h`
+            if match_flag $_a -h
+                return 0
+            end
+
+            # looks for a single `--help`
+            if match_flag $_a --help
+                return 0
+            end
+
+            # looks for a single `--sh`
+            if match_flag $_a --sh
+                return 0
+            end
+
+            # looks for a single `--csh`
+            if match_flag $_a --csh
+                return 0
+            end
+
+            # looks for a single `--fish`
+            if match_flag $_a --fish
+                return 0
+            end
+
+            # looks for a single `--list`
+            if match_flag $_a --list
+                return 0
+            end
+
+        end
+
+        return 1
+    end
+
+
+    function check_env_deactivate_flags -d "check spack env subcommand flags for --sh, --csh, or --fish"
+        #
+        # Check if inputs contain --sh, --csh, or --fish
+        #
+
+        # combine argument array into single string (space seperated), to be passed
+        # to regular expression matching (`string match -r`)
+        set -l _a "$argv"
+
+        # skip if called with blank input. Notes: [1] (cf. EOF)
+        if test -n "$_a"
+
+            # looks for a single `--sh`
+            if match_flag $_a --sh
+                return 0
+            end
+
+            # looks for a single `--csh`
+            if match_flag $_a --csh
+                return 0
+            end
+
+            # looks for a single `--fish`
+            if match_flag $_a --fish
+                return 0
+            end
+
+        end
+
+        return 1
+    end
+
+
+
+
+    #
+    # SPACK RUNNER function, this does all the work!
+    #
+
+
+    function spack_runner -d "Runner function for the `spack` wrapper"
+        # Store DYLD_* variables from spack shell function
+        # This is necessary because MacOS System Integrity Protection clears
+        # variables that affect dyld on process start.
+        for var in DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
+            if set -q $var
+                set -gx SPACK_$var $$var
+            end
+        end
+
+        #
+        # Accumulate initial flags for main spack command
+        #
+
+        set __sp_remaining_args # remaining (unparsed) arguments
+        set -l sp_flags (get_sp_flags $argv) # sets __sp_remaining_args
+
+
+        #
+        # h and V flags don't require further output parsing.
+        #
+
+        if check_sp_flags $sp_flags
+            command spack $sp_flags $__sp_remaining_args
             return
         end
 
-        # increment argument counter: used in place of bash's `shift` command
-        set -l i (math $i+1)
 
-    end
+        #
+        # Isolate subcommand and subcommand specs. Notes: [1] (cf. EOF)
+        #
 
-    # if all elements in `argv` are matched, make sure that `__sp_remaining_args`
-    # is deleted (this might be overkill...).
-    set -e __sp_remaining_args
-end
+        set -l sp_subcommand ""
 
-
-
-#
-# CHECK_SP_FLAGS, CONTAINS_HELP_FLAGS, CHECK_ENV_ACTIVATE_FLAGS, and
-# CHECK_ENV_DEACTIVATE_FLAGS: support functions for checking arguments and flags.
-#
-
-function check_sp_flags -d "check spack flags for h/V flags"
-    #
-    # Check if inputs contain h or V flags.
-    #
-
-    # combine argument array into single string (space seperated), to be passed
-    # to regular expression matching (`string match -r`)
-    set -l _a "$argv"
-
-    # skip if called with blank input. Notes: [1] (cf. EOF)
-    if test -n "$_a"
-        if echo $_a | string match -r -q ".*h.*"
-            return 0
-        end
-        if echo $_a | string match -r -q ".*V.*"
-            return 0
-        end
-    end
-
-    return 1
-end
-
-
-
-function match_flag -d "checks all combinations of flags ocurring inside of a string"
-
-    # Remove leading and trailing spaces -- but we need to insert a "guard" (x)
-    # so that eg. `string trim -h` doesn't trigger the help string for `string trim`
-    set -l _a (string sub -s 2 (string trim "x$argv[1]"))
-    set -l _b (string sub -s 2 (string trim "x$argv[2]"))
-
-    if test -z "$_a"; or test -z "$_b"
-        return 0
-    end
-
-    # surrounded by spaced
-    if echo "$_a" | string match -r -q " +$_b +"
-        return 0
-    end
-
-    # beginning of string + trailing space
-    if echo "$_a" | string match -r -q "^$_b +"
-        return 0
-    end
-
-    # end of string + leadingg space
-    if echo "$_a" | string match -r -q " +$_b\$"
-        return 0
-    end
-
-    # entire string
-    if echo "$_a" | string match -r -q "^$_b\$"
-        return 0
-    end
-
-    return 1
-
-end
-
-
-
-function check_env_activate_flags -d "check spack env subcommand flags for -h, --sh, --csh, or --fish"
-    #
-    # Check if inputs contain -h/--help, --sh, --csh, or --fish
-    #
-
-    # combine argument array into single string (space seperated), to be passed
-    # to regular expression matching (`string match -r`)
-    set -l _a "$argv"
-
-    # skip if called with blank input. Notes: [1] (cf. EOF)
-    if test -n "$_a"
-
-        # looks for a single `-h`
-        if match_flag $_a "-h"
-            return 0
+        if test -n "$__sp_remaining_args[1]"
+            set sp_subcommand $__sp_remaining_args[1]
+            set __sp_remaining_args (shift_args $__sp_remaining_args) # simulates bash shift
         end
 
-        # looks for a single `--help`
-        if match_flag $_a "--help"
-            return 0
-        end
-
-        # looks for a single `--sh`
-        if match_flag $_a "--sh"
-            return 0
-        end
-
-        # looks for a single `--csh`
-        if match_flag $_a "--csh"
-            return 0
-        end
-
-        # looks for a single `--fish`
-        if match_flag $_a "--fish"
-            return 0
-        end
-
-        # looks for a single `--list`
-        if match_flag $_a "--list"
-            return 0
-        end
-
-    end
-
-    return 1
-end
+        set -l sp_spec $__sp_remaining_args
 
 
-function check_env_deactivate_flags -d "check spack env subcommand flags for --sh, --csh, or --fish"
-    #
-    # Check if inputs contain --sh, --csh, or --fish
-    #
+        #
+        # Filter out cd, env, and load and unload. For any other commands, just run
+        # the spack command as is.
+        #
 
-    # combine argument array into single string (space seperated), to be passed
-    # to regular expression matching (`string match -r`)
-    set -l _a "$argv"
+        switch $sp_subcommand
 
-    # skip if called with blank input. Notes: [1] (cf. EOF)
-    if test -n "$_a"
+            # CASE: spack subcommand is `cd`: if the sub command arg is `-h`, nothing
+            # further needs to be done. Otherwise, test the location referring the
+            # subcommand and cd there (if it exists).
 
-        # looks for a single `--sh`
-        if match_flag $_a "--sh"
-            return 0
-        end
+            case cd
 
-        # looks for a single `--csh`
-        if match_flag $_a "--csh"
-            return 0
-        end
+                set -l sp_arg ""
 
-        # looks for a single `--fish`
-        if match_flag $_a "--fish"
-            return 0
-        end
-
-    end
-
-    return 1
-end
-
-
-
-
-#
-# SPACK RUNNER function, this does all the work!
-#
-
-
-function spack_runner -d "Runner function for the `spack` wrapper"
-    # Store DYLD_* variables from spack shell function
-    # This is necessary because MacOS System Integrity Protection clears
-    # variables that affect dyld on process start.
-    for var in DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
-        if set -q $var
-            set -gx SPACK_$var $$var
-        end
-    end
-
-    #
-    # Accumulate initial flags for main spack command
-    #
-
-    set __sp_remaining_args # remaining (unparsed) arguments
-    set -l sp_flags (get_sp_flags $argv) # sets __sp_remaining_args
-
-
-    #
-    # h and V flags don't require further output parsing.
-    #
-
-    if check_sp_flags $sp_flags
-        command spack $sp_flags $__sp_remaining_args
-        return
-    end
-
-
-    #
-    # Isolate subcommand and subcommand specs. Notes: [1] (cf. EOF)
-    #
-
-    set -l sp_subcommand ""
-
-    if test -n "$__sp_remaining_args[1]"
-        set sp_subcommand $__sp_remaining_args[1]
-        set __sp_remaining_args (shift_args $__sp_remaining_args)  # simulates bash shift
-    end
-
-    set -l sp_spec $__sp_remaining_args
-
-
-    #
-    # Filter out cd, env, and load and unload. For any other commands, just run
-    # the spack command as is.
-    #
-
-    switch $sp_subcommand
-
-        # CASE: spack subcommand is `cd`: if the sub command arg is `-h`, nothing
-        # further needs to be done. Otherwise, test the location referring the
-        # subcommand and cd there (if it exists).
-
-        case "cd"
-
-            set -l sp_arg ""
-
-            # Extract the first subcommand argument. Notes: [1] (cf. EOF)
-            if test -n "$__sp_remaining_args[1]"
-                set sp_arg $__sp_remaining_args[1]
-                set __sp_remaining_args (shift_args $__sp_remaining_args) # simulates bash shift
-            end
-
-            # Notes: [2] (cf. EOF)
-            if test "x$sp_arg" = "x-h"; or test "x$sp_arg" = "x--help"
-                # nothing more needs to be done for `-h` or `--help`
-                command spack cd -h
-                return
-            else
-                # extract location using the subcommand (fish `(...)`)
-                set -l LOC (command spack location $sp_arg $__sp_remaining_args)
-
-                # test location and cd if exists:
-                if test -d "$LOC"
-                    cd $LOC
-                    return
-                else
-                    return 1
+                # Extract the first subcommand argument. Notes: [1] (cf. EOF)
+                if test -n "$__sp_remaining_args[1]"
+                    set sp_arg $__sp_remaining_args[1]
+                    set __sp_remaining_args (shift_args $__sp_remaining_args) # simulates bash shift
                 end
 
-            end
+                # Notes: [2] (cf. EOF)
+                if test "x$sp_arg" = x-h; or test "x$sp_arg" = x--help
+                    # nothing more needs to be done for `-h` or `--help`
+                    command spack cd -h
+                    return
+                else
+                    # extract location using the subcommand (fish `(...)`)
+                    set -l LOC (command spack location $sp_arg $__sp_remaining_args)
+
+                    # test location and cd if exists:
+                    if test -d "$LOC"
+                        cd $LOC
+                        return
+                    else
+                        return 1
+                    end
+
+                end
 
 
-        # CASE: spack subcommand is `env`. Here we get the spack runtime to
-        # supply the appropriate shell commands for setting the environment
-        # varibles. These commands are then run by fish (using the `capture_all`
-        # function, instead of a command substitution).
+                # CASE: spack subcommand is `env`. Here we get the spack runtime to
+                # supply the appropriate shell commands for setting the environment
+                # varibles. These commands are then run by fish (using the `capture_all`
+                # function, instead of a command substitution).
 
-        case "env"
+            case env
 
-            set -l sp_arg ""
+                set -l sp_arg ""
 
-            # Extract the first subcommand argument.  Notes: [1] (cf. EOF)
-            if test -n "$__sp_remaining_args[1]"
-                set sp_arg $__sp_remaining_args[1]
-                set __sp_remaining_args (shift_args $__sp_remaining_args) # simulates bash shift
-            end
+                # Extract the first subcommand argument.  Notes: [1] (cf. EOF)
+                if test -n "$__sp_remaining_args[1]"
+                    set sp_arg $__sp_remaining_args[1]
+                    set __sp_remaining_args (shift_args $__sp_remaining_args) # simulates bash shift
+                end
 
-            # Notes: [2] (cf. EOF)
-            if test "x$sp_arg" = "x-h"; or test "x$sp_arg" = "x--help"
-                # nothing more needs to be done for `-h` or `--help`
-                command spack env -h
-                return
-            else
-                switch $sp_arg
-                    case "activate"
-                        set -l _a (stream_args $__sp_remaining_args)
+                # Notes: [2] (cf. EOF)
+                if test "x$sp_arg" = x-h; or test "x$sp_arg" = x--help
+                    # nothing more needs to be done for `-h` or `--help`
+                    command spack env -h
+                    return
+                else
+                    switch $sp_arg
+                        case activate
+                            set -l _a (stream_args $__sp_remaining_args)
 
-                        if check_env_activate_flags $_a
-                            # no args or args contain -h/--help, --sh, or --csh: just execute
-                            command spack env activate $_a
-                            return
-                        else
-                            # actual call to activate: source the output
-                            set -l sp_env_cmd "command spack $sp_flags env activate --fish $__sp_remaining_args"
-                            capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
-                            eval $__sp_stdout
-                            if test -n "$__sp_stderr"
-                                echo -s \n$__sp_stderr 1>&2  # current fish bug: handle stderr manually
-                            end
-                            return $__sp_stat
-                        end
-
-                    case "deactivate"
-                        set -l _a (stream_args $__sp_remaining_args)
-
-                        if check_env_deactivate_flags $_a
-                            # just  execute the command if --sh, --csh, or --fish are provided
-                            command spack env deactivate $_a
-                            return
-
-                        # Test of further (unparsed arguments). Any other
-                        # arguments are an error or help, so just run help
-                        # -> TODO: This should throw and error but leave as is
-                        #    for compatibility with setup-env.sh
-                        # -> Notes: [1] (cf. EOF).
-                        else if test -n "$__sp_remaining_args"
-                            command spack env deactivate -h
-                            return
-                        else
-                            # no args: source the output of the command
-                            set -l sp_env_cmd "command spack $sp_flags env deactivate --fish"
-                            capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
-                            if test $__sp_stat -ne 0
+                            if check_env_activate_flags $_a
+                                # no args or args contain -h/--help, --sh, or --csh: just execute
+                                command spack env activate $_a
+                                return
+                            else
+                                # actual call to activate: source the output
+                                set -l sp_env_cmd "command spack $sp_flags env activate --fish $__sp_remaining_args"
+                                capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
+                                eval $__sp_stdout
                                 if test -n "$__sp_stderr"
-                                    echo -s \n$__sp_stderr 1>&2  # current fish bug: handle stderr manually
+                                    echo -s \n$__sp_stderr 1>&2 # current fish bug: handle stderr manually
                                 end
                                 return $__sp_stat
                             end
-                            eval $__sp_stdout
-                        end
 
-                    case "*"
-                        # if $__sp_remaining_args is empty, then don't include it
-                        # as argument (otherwise it will be confused as a blank
-                        # string input!)
-                        if test -n "$__sp_remaining_args"
-                            command spack env $sp_arg $__sp_remaining_args
-                            return
-                        else
-                            command spack env $sp_arg
-                            return
-                        end
-                end
-            end
+                        case deactivate
+                            set -l _a (stream_args $__sp_remaining_args)
 
+                            if check_env_deactivate_flags $_a
+                                # just  execute the command if --sh, --csh, or --fish are provided
+                                command spack env deactivate $_a
+                                return
 
-        # CASE: spack subcommand is either `load`, or `unload`. These statements
-        # deal with the technical details of actually using modules. Especially
-        # to deal with the substituting latest version numbers to the module
-        # command.
+                                # Test of further (unparsed arguments). Any other
+                                # arguments are an error or help, so just run help
+                                # -> TODO: This should throw and error but leave as is
+                                #    for compatibility with setup-env.sh
+                                # -> Notes: [1] (cf. EOF).
+                            else if test -n "$__sp_remaining_args"
+                                command spack env deactivate -h
+                                return
+                            else
+                                # no args: source the output of the command
+                                set -l sp_env_cmd "command spack $sp_flags env deactivate --fish"
+                                capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
+                                if test $__sp_stat -ne 0
+                                    if test -n "$__sp_stderr"
+                                        echo -s \n$__sp_stderr 1>&2 # current fish bug: handle stderr manually
+                                    end
+                                    return $__sp_stat
+                                end
+                                eval $__sp_stdout
+                            end
 
-        case "load" or "unload"
-
-            set -l _a (stream_args $__sp_remaining_args)
-
-            if check_env_activate_flags $_a
-                # no args or args contain -h/--help, --sh, or --csh: just execute
-                command spack $sp_flags $sp_subcommand $__sp_remaining_args
-                return
-            else
-                # actual call to activate: source the output
-                set -l sp_env_cmd "command spack $sp_flags $sp_subcommand --fish $__sp_remaining_args"
-                capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
-                if test $__sp_stat -ne 0
-                    if test -n "$__sp_stderr"
-                        echo -s \n$__sp_stderr 1>&2  # current fish bug: handle stderr manually
+                        case "*"
+                            # if $__sp_remaining_args is empty, then don't include it
+                            # as argument (otherwise it will be confused as a blank
+                            # string input!)
+                            if test -n "$__sp_remaining_args"
+                                command spack env $sp_arg $__sp_remaining_args
+                                return
+                            else
+                                command spack env $sp_arg
+                                return
+                            end
                     end
-                    return $__sp_stat
                 end
-                eval $__sp_stdout
-            end
 
 
-        # CASE: Catch-all
+                # CASE: spack subcommand is either `load`, or `unload`. These statements
+                # deal with the technical details of actually using modules. Especially
+                # to deal with the substituting latest version numbers to the module
+                # command.
 
-        case "*"
-            command spack $argv
-            return
+            case load or unload
+
+                set -l _a (stream_args $__sp_remaining_args)
+
+                if check_env_activate_flags $_a
+                    # no args or args contain -h/--help, --sh, or --csh: just execute
+                    command spack $sp_flags $sp_subcommand $__sp_remaining_args
+                    return
+                else
+                    # actual call to activate: source the output
+                    set -l sp_env_cmd "command spack $sp_flags $sp_subcommand --fish $__sp_remaining_args"
+                    capture_all $sp_env_cmd __sp_stat __sp_stdout __sp_stderr
+                    if test $__sp_stat -ne 0
+                        if test -n "$__sp_stderr"
+                            echo -s \n$__sp_stderr 1>&2 # current fish bug: handle stderr manually
+                        end
+                        return $__sp_stat
+                    end
+                    eval $__sp_stdout
+                end
+
+
+                # CASE: Catch-all
+
+            case "*"
+                command spack $argv
+                return
+        end
     end
-end
 
 
 
 
-#
-# RUN SPACK_RUNNER HERE
-#
+    #
+    # RUN SPACK_RUNNER HERE
+    #
 
 
-#
-# Allocate temporary global variables used for return extra arguments from
-# functions. NOTE: remember to call delete_sp_shared whenever returning from
-# this function.
-#
+    #
+    # Allocate temporary global variables used for return extra arguments from
+    # functions. NOTE: remember to call delete_sp_shared whenever returning from
+    # this function.
+    #
 
-allocate_sp_shared
-
-
-#
-# Run spack command using the spack_runner.
-#
-
-spack_runner $argv
-# Capture state of spack_runner (returned below)
-set -l stat $status
+    allocate_sp_shared
 
 
-#
-# Delete temprary global variabels allocated in `allocated_sp_shared`.
-#
+    #
+    # Run spack command using the spack_runner.
+    #
 
-delete_sp_shared
+    spack_runner $argv
+    # Capture state of spack_runner (returned below)
+    set -l stat $status
+
+
+    #
+    # Delete temprary global variabels allocated in `allocated_sp_shared`.
+    #
+
+    delete_sp_shared
 
 
 
-return $stat
+    return $stat
 
 end
 
@@ -681,7 +681,7 @@ end
 #
 # Figure out where this file is. Below code only needs to work in fish
 #
-set -l sp_source_file (status -f)  # name of current file
+set -l sp_source_file (status -f) # name of current file
 
 
 
@@ -711,8 +711,8 @@ set -xg SPACK_ROOT $sp_prefix
 #
 # No need to determine which shell is being used (obviously it's fish)
 #
-set -xg SPACK_SHELL "fish"
-set -xg _sp_shell "fish"
+set -xg SPACK_SHELL fish
+set -xg _sp_shell fish
 
 
 
@@ -721,9 +721,9 @@ if test -z "$SPACK_SKIP_MODULES"
     #
     # Check whether we need environment-variables (module) <= `use` is not available
     #
-    set -l need_module "no"
+    set -l need_module no
     if not functions -q use; and not functions -q module
-        set need_module "yes"
+        set need_module yes
     end
 
 
@@ -742,7 +742,7 @@ if test -z "$SPACK_SKIP_MODULES"
     end
 
 
-    if test "$need_module" = "yes"
+    if test "$need_module" = yes
         set -l sp_shell_vars (command spack --print-shell-vars sh,modules)
 
         for sp_var_expr in $sp_shell_vars
@@ -750,7 +750,7 @@ if test -z "$SPACK_SKIP_MODULES"
         end
 
         # _sp_module_prefix is set by spack --print-sh-vars
-        if test "$_sp_module_prefix" != "not_installed"
+        if test "$_sp_module_prefix" != not_installed
             set -xg MODULE_PREFIX $_sp_module_prefix
             spack_pathadd PATH "$MODULE_PREFIX/bin"
         end
@@ -765,7 +765,7 @@ if test -z "$SPACK_SKIP_MODULES"
 
     end
 
-    if test "$need_module" = "yes"
+    if test "$need_module" = yes
         function module -d "wrapper for the `module` command to point at Spack's modules instance" --inherit-variable MODULE_PREFIX
             eval $MODULE_PREFIX/bin/modulecmd $SPACK_SHELL $argv
         end

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2627,9 +2627,9 @@ complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format a
 complete -c spack -n '__fish_spack_using_command style' -l root -r -f -a root
 complete -c spack -n '__fish_spack_using_command style' -l root -r -d 'style check a different spack instance'
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -f -a tool
-complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: isort,black,flake8,mypy)'
+complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: isort,black,flake8,mypy,fish_indent)'
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a skip
-complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from isort,black,flake8,mypy)'
+complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from isort,black,flake8,mypy,fish_indent)'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all


### PR DESCRIPTION
Spack now contains 3 fish files. Fish comes with a [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) tool to automatically format your code. We should use it.