### PR TITLE
qt-base: add conflict for 6.5+ with GCC < 9

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -154,6 +154,9 @@ class QtBase(QtPackage):
 
     # Qt6 requires newer compilers: see https://github.com/spack/spack/issues/34418
     conflicts("%gcc@:7")
+    # The oldest compiler for Qt 6.5 is GCC 9: https://doc.qt.io/qt-6.5/supported-platforms.html
+    with when("@6.5:"):
+        conflicts("%gcc@:8")
 
     # ensure that Qt links against GSS framework on macOS: https://bugreports.qt.io/browse/QTBUG-114537
     with when("@6.3.2:6.5.1"):


### PR DESCRIPTION
Compilation of 6.5 with GCC 8 is not supported and broken: std::filesystem is not found, as it is only available from -lstdc++fs. GCC 9 is the oldest GCC release listed as being supported for Qt 6.5: https://doc.qt.io/qt-6.5/linux.html