### PR TITLE
dcmtk: new version and pic configuration

### DIFF
--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -13,6 +13,7 @@ class Dcmtk(CMakePackage):
     homepage = "https://dicom.offis.de"
     url = "https://github.com/DCMTK/dcmtk/archive/DCMTK-3.6.3.tar.gz"
 
+    version("3.6.7", sha256="17705dcdb2047d1266bb4e92dbf4aa6d4967819e8e3e94f39b7df697661b4860")
     version("3.6.6", sha256="117097da6d50ddbad0e48bb1e6cdc61468e82ba1d32001dd8e2366b445133a8c")
     version("3.6.5", sha256="37dad355d5513b4de4a86b5b7b0c3e9ec059860d88781b80916bba2a04e6d5b8")
     version("3.6.4", sha256="e4b1de804a3fef38fe8cb9edd00262c3cbbd114b305511c14479dd888a9337d2")
@@ -43,6 +44,8 @@ class Dcmtk(CMakePackage):
 
     variant("cxx11", default=False, description="Enable c++11 features")
     variant("stl", default=True, description="Use native STL implementation")
+
+    conflicts("platform=darwin", when="@:3.6.6")
 
     def patch(self):
         # Backport 3.6.4

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -67,5 +67,7 @@ class Dcmtk(CMakePackage):
         args += ["-DDCMTK_WITH_ICONV={0}".format("ON" if "+iconv" in self.spec else "OFF")]
         args += ["-DDCMTK_ENABLE_CXX11={0}".format("ON" if "+cxx11" in self.spec else "OFF")]
         args += ["-DDCMTK_ENABLE_STL={0}".format("ON" if "+stl" in self.spec else "OFF")]
-        args += ["-DCMAKE_POSITION_INDEPENDENT_CODE={0}".format("ON" if "+pic" in self.spec else "OFF")]
+        args += [
+            "-DCMAKE_POSITION_INDEPENDENT_CODE={0}".format("ON" if "+pic" in self.spec else "OFF")
+        ]
         return args

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -42,6 +42,7 @@ class Dcmtk(CMakePackage):
     variant("iconv", default=True, description="Charset conversion support (iconv)")
     depends_on("iconv", type=("build", "link"))
 
+    variant("pic", default=False, description="Produce position-independent code")
     variant("cxx11", default=False, description="Enable c++11 features")
     variant("stl", default=True, description="Use native STL implementation")
 
@@ -66,4 +67,5 @@ class Dcmtk(CMakePackage):
         args += ["-DDCMTK_WITH_ICONV={0}".format("ON" if "+iconv" in self.spec else "OFF")]
         args += ["-DDCMTK_ENABLE_CXX11={0}".format("ON" if "+cxx11" in self.spec else "OFF")]
         args += ["-DDCMTK_ENABLE_STL={0}".format("ON" if "+stl" in self.spec else "OFF")]
+        args += ["-DCMAKE_POSITION_INDEPENDENT_CODE={0}".format("ON" if "+pic" in self.spec else "OFF")]
         return args

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -46,7 +46,7 @@ class Dcmtk(CMakePackage):
     variant("cxx11", default=False, description="Enable c++11 features")
     variant("stl", default=True, description="Use native STL implementation")
 
-    conflicts("platform=darwin", when="@:3.6.6")
+    conflicts("platform=darwin target=aarch64:", when="@:3.6.6")
 
     def patch(self):
         # Backport 3.6.4

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -59,15 +59,15 @@ class Dcmtk(CMakePackage):
             )
 
     def cmake_args(self):
-        args = ["-DDCMTK_WITH_OPENSSL={0}".format("ON" if "+ssl" in self.spec else "OFF")]
-        args += ["-DDCMTK_WITH_ZLIB={0}".format("ON" if "+zlib" in self.spec else "OFF")]
-        args += ["-DDCMTK_WITH_TIFF={0}".format("ON" if "+tiff" in self.spec else "OFF")]
-        args += ["-DDCMTK_WITH_PNG={0}".format("ON" if "+png" in self.spec else "OFF")]
-        args += ["-DDCMTK_WITH_XML={0}".format("ON" if "+xml" in self.spec else "OFF")]
-        args += ["-DDCMTK_WITH_ICONV={0}".format("ON" if "+iconv" in self.spec else "OFF")]
-        args += ["-DDCMTK_ENABLE_CXX11={0}".format("ON" if "+cxx11" in self.spec else "OFF")]
-        args += ["-DDCMTK_ENABLE_STL={0}".format("ON" if "+stl" in self.spec else "OFF")]
-        args += [
-            "-DCMAKE_POSITION_INDEPENDENT_CODE={0}".format("ON" if "+pic" in self.spec else "OFF")
+        args = [
+            self.define_from_variant("DCMTK_WITH_OPENSSL", "ssl"),
+            self.define_from_variant("DCMTK_WITH_ZLIB", "zlib"),
+            self.define_from_variant("DCMTK_WITH_TIFF", "tiff"),
+            self.define_from_variant("DCMTK_WITH_PNG", "png"),
+            self.define_from_variant("DCMTK_WITH_XML", "xml"),
+            self.define_from_variant("DCMTK_WITH_ICONV", "iconv"),
+            self.define_from_variant("DCMTK_ENABLE_CXX11", "cxx11"),
+            self.define_from_variant("DCMTK_ENABLE_STL", "stl"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         return args


### PR DESCRIPTION
pic variant is required if the DICOM I/O support plugin for OpenSceneGraph should be built