### PR TITLE
Python: fix library/header error msg format

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1021,8 +1021,8 @@ print(json.dumps(config))
                 return lib
 
         raise spack.error.NoLibrariesError(
-            "Unable to find {} libraries with the following names:\n\n* ".format(self.name) +
-            "\n* ".join(candidates),
+            "Unable to find {} libraries with the following names:\n\n* ".format(self.name)
+            + "\n* ".join(candidates)
         )
 
     @property
@@ -1047,8 +1047,8 @@ print(json.dumps(config))
                 break
         else:
             raise spack.error.NoHeadersError(
-                "Unable to locate {} headers in any of these locations:\n\n* ".format(self.name) +
-                "\n* ".join(candidates),
+                "Unable to locate {} headers in any of these locations:\n\n* ".format(self.name)
+                + "\n* ".join(candidates)
             )
 
         headers.directories = [os.path.dirname(config_h)]

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1021,8 +1021,8 @@ print(json.dumps(config))
                 return lib
 
         raise spack.error.NoLibrariesError(
-            "Unable to find {} libraries with the following names:".format(self.name),
-            "\n".join(candidates),
+            "Unable to find {} libraries with the following names:\n\n* ".format(self.name) +
+            "\n* ".join(candidates),
         )
 
     @property
@@ -1047,8 +1047,8 @@ print(json.dumps(config))
                 break
         else:
             raise spack.error.NoHeadersError(
-                "Unable to locate {} headers in any of these locations:".format(self.name),
-                "\n".join(candidates),
+                "Unable to locate {} headers in any of these locations:\n\n* ".format(self.name) +
+                "\n* ".join(candidates),
             )
 
         headers.directories = [os.path.dirname(config_h)]


### PR DESCRIPTION
### Before

Duplicated text from error class:
```
spack.error.NoLibrariesError: Unable to locate Unable to find python libraries with the following names: libraries in libpython3.10.dylib
libpython3.10.a
```
Incorrect indentation:
```
spack.error.NoHeadersError: Unable to locate python headers in any of these locations:
    /Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/include/python3.10
/Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/include/3.10
/Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/Headers
```

### After

```
spack.error.NoLibrariesError: Unable to find python libraries with the following names:

* libpython3.10.dylib
* libpython3.10.a
```
```
spack.error.NoHeadersError: Unable to locate python headers in any of these locations:

* /Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/include/python3.10
* /Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/include/3.10
* /Users/Adam/spack/opt/spack/darwin-ventura-m2/apple-clang-14.0.3/python-3.10.10-6ubk3rmf65n54msvgm2m2cnya7qbegdu/Headers
```
Can replace bullet points with tabs if you want.