### PR TITLE
spack/util/compression: tar file rename

### DIFF
--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -81,6 +81,7 @@ def _system_untar(archive_file):
     """
     archive_file_no_ext = strip_extension(archive_file)
     outfile = os.path.basename(archive_file_no_ext)
+
     @contextlib.contextmanager
     def tar_name_saftey():
         try:
@@ -97,6 +98,7 @@ def _system_untar(archive_file):
         finally:
             if renamed:
                 shutil.move(archive_file, archive_file_no_ext)
+
     with tar_name_saftey():
         tar = which("tar", required=True)
         tar.add_default_arg("-oxf")

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import contextlib
 import inspect
 import io
 import os

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import contextlib
 import inspect
 import io
 import os
@@ -80,15 +81,26 @@ def _system_untar(archive_file):
     """
     archive_file_no_ext = strip_extension(archive_file)
     outfile = os.path.basename(archive_file_no_ext)
-    if archive_file_no_ext == archive_file:
-        # the archive file has no extension. Tar on windows cannot untar onto itself
-        # archive_file can be a tar file (which causes the problem on windows) but it can
-        # also have other extensions (on Unix) such as tgz, tbz2, ...
-        archive_file = archive_file_no_ext + "-input"
-        shutil.move(archive_file_no_ext, archive_file)
-    tar = which("tar", required=True)
-    tar.add_default_arg("-oxf")
-    tar(archive_file)
+    @contextlib.contextmanager
+    def tar_name_saftey():
+        try:
+            nonlocal archive_file
+            renamed = False
+            if archive_file_no_ext == archive_file:
+                # the archive file has no extension. Tar on windows cannot untar onto itself
+                # archive_file can be a tar file (which causes the problem on windows) but it can
+                # also have other extensions (on Unix) such as tgz, tbz2, ...
+                archive_file = archive_file_no_ext + "-input"
+                shutil.move(archive_file_no_ext, archive_file)
+                renamed = True
+            yield
+        finally:
+            if renamed:
+                shutil.move(archive_file, archive_file_no_ext)
+    with tar_name_saftey():
+        tar = which("tar", required=True)
+        tar.add_default_arg("-oxf")
+        tar(archive_file)
     return outfile
 
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -81,28 +81,10 @@ def _system_untar(archive_file):
     """
     archive_file_no_ext = strip_extension(archive_file)
     outfile = os.path.basename(archive_file_no_ext)
-
-    @contextlib.contextmanager
-    def tar_name_saftey():
-        try:
-            nonlocal archive_file
-            renamed = False
-            if archive_file_no_ext == archive_file:
-                # the archive file has no extension. Tar on windows cannot untar onto itself
-                # archive_file can be a tar file (which causes the problem on windows) but it can
-                # also have other extensions (on Unix) such as tgz, tbz2, ...
-                archive_file = archive_file_no_ext + "-input"
-                shutil.move(archive_file_no_ext, archive_file)
-                renamed = True
-            yield
-        finally:
-            if renamed:
-                shutil.move(archive_file, archive_file_no_ext)
-
-    with tar_name_saftey():
-        tar = which("tar", required=True)
-        tar.add_default_arg("-oxf")
-        tar(archive_file)
+    tar = which("tar", required=True)
+    tar.add_default_arg("-C ..")
+    tar.add_default_arg("-oxf")
+    tar(archive_file)
     return outfile
 
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -81,7 +81,8 @@ def _system_untar(archive_file):
     archive_file_no_ext = strip_extension(archive_file)
     outfile = os.path.basename(archive_file_no_ext)
     tar = which("tar", required=True)
-    tar.add_default_arg("-C ..")
+    parent_dir = os.path.dirname(os.getcwd())
+    tar.add_default_arg(f"-C {parent_dir}")
     tar.add_default_arg("-oxf")
     tar(archive_file)
     return outfile


### PR DESCRIPTION
When a tarfile is being extracted, if it has no extension, it is renamed with a '-input' postfix.
This is done to prevent collisions on Windows, where the system native tar cannot handle extracting a file onto itself.
However, other methods that expect the tarfile's name to be consistent cannot know if the tarfile was renamed. Make the `_system_untar` method responsible for renaming the tarfile after extraction.

Behavior before this PR:
```
[spack] C:\spack_win\spack>spack stage pegtl
==> Using cached archive: C:\spack_win\spack\var\spack\cache\_source-cache\archive\91\91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56.tar.gz
==> Error: [WinError 2] The system cannot find the file specified: 'C:\\spack\\pegtl-3.2.0-lom5yt7\\spack-expanded-archive\\3.2.0'
```

Behavior with these changes:
```
[spack] C:\spack_win\spack>spack stage pegtl
==> Using cached archive: C:\spack_win\spack\var\spack\cache\_source-cache\archive\91\91aa6529ef9e6b57368e7b5b1f04a3bd26a39419d30e35a3c5c66ef073926b56.tar.gz
==> Staged pegtl in C:\spack\pegtl-3.2.0-lom5yt7
```