### PR TITLE
Win/remodel oneapi msvc vcintegration

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -41,7 +41,6 @@ class CmdCall:
         self._cmds = cmds
 
     def __call__(self):
-        import pdb; pdb.set_trace()
         out = subprocess.check_output(self.cmd_line, stderr=subprocess.STDOUT)  # novermin
         return out.decode("utf-16le", errors="replace")  # novermin
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -170,10 +170,14 @@ class Msvc(Compiler):
             # If this found, it sets all the vars
             oneapi_root = os.getenv("ONEAPI_ROOT")
             oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
-            oneapi_version_setvars = os.path.join(oneapi_root, "compiler", str(self.ifx_version), "env", "vars.bat")
+            oneapi_version_setvars = os.path.join(
+                oneapi_root, "compiler", str(self.ifx_version), "env", "vars.bat"
+            )
             # order matters here, the specific version env must be invoked first, otherwise it will be
             # ignored if the root setvars sets up the oneapi env first
-            env_cmds.extend([VarsInvocation(oneapi_version_setvars), VarsInvocation(oneapi_root_setvars)])
+            env_cmds.extend(
+                [VarsInvocation(oneapi_version_setvars), VarsInvocation(oneapi_root_setvars)]
+            )
         self.msvc_compiler_environment = CmdCall(*env_cmds)
 
     @property
@@ -208,7 +212,9 @@ class Msvc(Compiler):
         return Version(
             re.search(
                 Msvc.version_regex,
-                spack.compiler.get_compiler_version_output(compiler, version_arg=None, ignore_errors=True),
+                spack.compiler.get_compiler_version_output(
+                    compiler, version_arg=None, ignore_errors=True
+                ),
             ).group(1)
         )
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -177,11 +177,11 @@ class Msvc(Compiler):
         # file must be invoked before useage.
         env_cmds = []
         compiler_root = os.path.join(self.cc, "../../../../../../..")
-        self.vcvarsall = os.path.join(compiler_root, "Auxiliary", "Build", "vcvars64.bat")
+        vcvars_script_path = os.path.join(compiler_root, "Auxiliary", "Build", "vcvars64.bat")
         # get current platform architecture and format for vcvars argument
         arch = spack.platforms.real_host().default.lower()
         arch = arch.replace("-", "_")
-        self.vcvars_call = VCVarsInvocation(self.vcvarsall, arch, self.msvc_version)
+        self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, self.msvc_version)
         env_cmds.append(self.vcvars_call)
         # Below is a check for a valid fortran path
         # paths has c, cxx, fc, and f77 paths in that order

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -29,6 +29,78 @@ fortran_mapping = {
 }
 
 
+class CmdCall:
+    def __init__(self, *cmds):
+        self._cmds = cmds
+
+    def __call__(self):
+        if not self._cmds:
+            raise RuntimeError(
+                """Attempting to run commands from CMD without specifying commands.
+                Please add commands to be run."""
+            )
+        out = subprocess.check_output(self.cmd_line, stderr=subprocess.STDOUT)  # novermin
+        return out.decode("utf-16le", errors="replace")  # novermin
+
+    @property
+    def cmd_line(self):
+        base_call = "cmd /u /c "
+        commands = " && ".join([str(x) for x in self._cmds])
+        # If multiple commands are being invoked by a single subshell
+        # they must be encapsulated by a double quote. Always double
+        # quote to be sure of proper handling
+        # cmd will properly resolve nested double quotes as needed
+        #
+        # `set`` writes out the active env to the subshell stdout,
+        # and in this context we are always trying to obtain env
+        # state so it should always be appended
+        return base_call + f'"{commands} && set"'
+
+    def add_command(self, cmd):
+        self._cmds.append(cmd)
+
+
+class VarsInvocation:
+    def __init__(self, script):
+        self._script = script
+
+    def __str__(self):
+        return f'"{self._script}"'
+
+    @property
+    def script(self):
+        return self._script
+
+
+class VCVarsInvocation(VarsInvocation):
+    def __init__(self, script, arch, msvc_version):
+        super(VCVarsInvocation, self).__init__(script)
+        self._arch = arch
+        self._msvc_version = msvc_version
+
+    @property
+    def sdk_ver(self):
+        if getattr(self, "_sdk_ver", None):
+            return self._sdk_ver + ".0"
+        return ""
+
+    @sdk_ver.setter
+    def sdk_ver(self, val):
+        self._sdk_ver = val
+
+    @property
+    def arch(self):
+        return self._arch
+
+    @property
+    def vcvars_ver(self):
+        return f"-vcvars_ver={self._msvc_version}"
+
+    def __str__(self):
+        script = super(VCVarsInvocation, self).__str__()
+        return f"{script} {self.arch} {self.sdk_ver} {self.vcvars_ver}"
+
+
 def get_valid_fortran_pth(comp_ver):
     cl_ver = str(comp_ver)
     sort_fn = lambda fc_ver: StrictVersion(fc_ver)
@@ -78,19 +150,31 @@ class Msvc(Compiler):
         new_pth = [pth if pth else get_valid_fortran_pth(args[0].version) for pth in args[3]]
         args[3][:] = new_pth
         super().__init__(*args, **kwargs)
-        if os.getenv("ONEAPI_ROOT"):
+        # To use the MSVC compilers, VCVARS must be invoked
+        # VCVARS is located at a fixed location, referencable
+        # idiomatically by the following relative path from the
+        # compiler.
+        # Spack first finds the compilers via VSWHERE
+        # and stores their path, but their respective VCVARS
+        # file must be invoked before useage.
+        env_cmds = []
+        compiler_root = os.path.join(self.cc, "../../../../../../..")
+        self.vcvarsall = os.path.join(compiler_root, "Auxiliary", "Build", "vcvars64.bat")
+        # get current platform architecture and format for vcvars argument
+        arch = spack.platforms.real_host().default.lower()
+        arch = arch.replace("-", "_")
+        self.vcvars_call = VCVarsInvocation(self.vcvarsall, arch, self.msvc_version)
+        env_cmds.append(self.vcvars_call)
+        # Below is a check for a valid fortran path
+        if args[3][2]:
             # If this found, it sets all the vars
-            self.setvarsfile = os.path.join(os.getenv("ONEAPI_ROOT"), "setvars.bat")
-        else:
-            # To use the MSVC compilers, VCVARS must be invoked
-            # VCVARS is located at a fixed location, referencable
-            # idiomatically by the following relative path from the
-            # compiler.
-            # Spack first finds the compilers via VSWHERE
-            # and stores their path, but their respective VCVARS
-            # file must be invoked before useage.
-            self.setvarsfile = os.path.abspath(os.path.join(self.cc, "../../../../../../.."))
-            self.setvarsfile = os.path.join(self.setvarsfile, "Auxiliary", "Build", "vcvars64.bat")
+            oneapi_root = os.getenv("ONEAPI_ROOT")
+            oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
+            oneapi_version_setvars = os.path.join(oneapi_root, "compiler", str(self.ifx_version), "env", "vars.bat")
+            # order matters here, the specific version env must be invoked first, otherwise it will be
+            # ignored if the root setvars sets up the oneapi env first
+            env_cmds.extend([VarsInvocation(oneapi_version_setvars), VarsInvocation(oneapi_root_setvars)])
+        self.msvc_compiler_environment = CmdCall(*env_cmds)
 
     @property
     def msvc_version(self):
@@ -119,15 +203,24 @@ class Msvc(Compiler):
         """
         return self.msvc_version[:2].joined.string[:3]
 
-    @property
-    def cl_version(self):
-        """Cl toolset version"""
+    def _compiler_version(self, compiler):
+        """Returns version object for given compiler"""
         return Version(
             re.search(
                 Msvc.version_regex,
-                spack.compiler.get_compiler_version_output(self.cc, version_arg=None),
+                spack.compiler.get_compiler_version_output(compiler, version_arg=None, ignore_errors=True),
             ).group(1)
         )
+
+    @property
+    def cl_version(self):
+        """Cl toolset version"""
+        return self._compiler_version(self.cc)
+
+    @property
+    def ifx_version(self):
+        """Ifx compiler version associated with this version of MSVC"""
+        return self._compiler_version(self.fc)
 
     @property
     def vs_root(self):
@@ -146,27 +239,12 @@ class Msvc(Compiler):
         # output, sort into dictionary, use that to make the build
         # environment.
 
-        # get current platform architecture and format for vcvars argument
-        arch = spack.platforms.real_host().default.lower()
-        arch = arch.replace("-", "_")
         # vcvars can target specific sdk versions, force it to pick up concretized sdk
         # version, if needed by spec
-        sdk_ver = (
-            ""
-            if "win-sdk" not in pkg.spec or pkg.name == "win-sdk"
-            else pkg.spec["win-sdk"].version.string + ".0"
-        )
-        # provide vcvars with msvc version selected by concretization,
-        # not whatever it happens to pick up on the system (highest available version)
-        out = subprocess.check_output(  # novermin
-            'cmd /u /c "{}" {} {} {} && set'.format(
-                self.setvarsfile, arch, sdk_ver, "-vcvars_ver=%s" % self.msvc_version
-            ),
-            stderr=subprocess.STDOUT,
-        )
-        if sys.version_info[0] >= 3:
-            out = out.decode("utf-16le", errors="replace")  # novermin
+        if pkg.name != "win-sdk" and "win-sdk" in pkg.spec:
+            self.vcvars_call.sdk_ver = pkg.spec["win-sdk"].version.string
 
+        out = self.msvc_compiler_environment()
         int_env = dict(
             (key, value)
             for key, _, value in (line.partition("=") for line in out.splitlines())

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -79,6 +79,19 @@ class VCVarsInvocation(VarsInvocation):
 
     @property
     def sdk_ver(self):
+        """Accessor for Windows SDK version property
+
+        Note: This property may not be set by
+        the calling context and as such this property will
+        return an empty string
+
+        This property will ONLY be set if the SDK package
+        is a dependency somewhere in the Spack DAG of the package
+        for which we are constructing an MSVC compiler env.
+        Otherwise this property should be unset to allow the VCVARS
+        script to use its internal heuristics to determine appropriate
+        SDK version
+        """
         if getattr(self, "_sdk_ver", None):
             return self._sdk_ver + ".0"
         return ""

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -41,6 +41,7 @@ class CmdCall:
         self._cmds = cmds
 
     def __call__(self):
+        import pdb; pdb.set_trace()
         out = subprocess.check_output(self.cmd_line, stderr=subprocess.STDOUT)  # novermin
         return out.decode("utf-16le", errors="replace")  # novermin
 
@@ -96,7 +97,7 @@ class VCVarsInvocation(VarsInvocation):
         return f"-vcvars_ver={self._msvc_version}"
 
     def command_str(self):
-        script = super(VCVarsInvocation, self).__str__()
+        script = super(VCVarsInvocation, self).command_str()
         return f"{script} {self.arch} {self.sdk_ver} {self.vcvars_ver}"
 
 


### PR DESCRIPTION
Currently, OneAPI's `setvars` scripts effectively disregard any argument's we're passing to the MSVC vcvars env setup script, and additionally, completely ignore the requested version of OneAPI, defaulting to whatever the latest installed on the system is. 
This leads to a scenario where we have improperly constructed Windows native development environments, with potentially multiple versions of MSVC and OneAPI being loaded or called in the same env. Obviously this is far from ideal and leads to some fairly inscrutable errors such as overlapping header files between MSVC and OneAPI and a different version of OneAPI being called than the env was setup for. 

This PR solves this issue by creating a structured invocation of each relevant script in an order that ensures the correct values are set in the resultant build env.

The order needs to be: 
1. MSVC vcvarsall - the oneapi script checks to see if this has been invoked, and if so, does not attempt to reestablish an MSVC env
2. The compiler specific env.bat script for the relevant version of the oneapi compiler we're looking for. The root setvars scripts seems to respect this as well, although it is less explicit
3. The root oneapi setvars script, which sets up everything else the oneapi env needs and seems to respect previous env invocations.