### PR TITLE
Add checksum CI test (and verify with `glab` and `gh`)

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -23,12 +23,29 @@ jobs:
         operating_system: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # @v2
+      with:
+        fetch-depth: 2
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # @v2
       with:
-        python-version: ${{inputs.python_version}}
+        python-version: ${{ inputs.python_version }}
     - name: Install Python packages
       run: |
         pip install --upgrade pip setuptools pytest coverage[toml]
+    - name: Verify new package checksums
+      run: |
+        . share/spack/setup-env.sh
+        files=($(git diff --name-only -r HEAD^1 HEAD -- var/spack/repos/builtin/packages/*))
+        for file in ${files[@]}; do
+            package=$(basename $(dirname $file))
+            versions=($(git diff -r HEAD^1 HEAD -- $file | \
+            grep -E "^\+    version\(" | \
+            sed -E "s/^\+    version\(\"//g" | \
+            sed -E "s/\".*\)//g"))
+            if [ ${#versions[@]} -ne 0 ]; then
+                 printf "> spack checksum --verify $package ${versions[@]}"
+                 $(which spack) checksum --verify $package ${versions[@]}
+            fi
+        done
     - name: Package audits (with coverage)
       if: ${{ inputs.with_coverage == 'true' }}
       run: |

--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -14,6 +14,7 @@ class Gh(Package):
 
     maintainers("lcnzg")
 
+    version("2.32.1", sha256="1d569dc82eb6520e6a8959568c2db84fea3bbaab2604c8dd5901849d320e1eae")
     version("2.28.0", sha256="cf3c0fb7f601d717d8b5177707a197c49fd426f5dc3c9aa52a932e96ba7166af")
     version("2.25.1", sha256="d3b28da03f49600697d2e80c2393425bd382e340040c34641bf3569593c7fbe8")
     version("2.25.0", sha256="b445dbb863643d30cc7991b134c694ea14492e7fac363a9e2648f245f67184f7")

--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -14,7 +14,9 @@ class Glab(Package):
 
     maintainers("alecbcs")
 
+    version("1.31.0", sha256="5648e88e7d6cc993227f5a4e80238af189bed09c7aed1eb12be7408e9a042747")
     version("1.30.0", sha256="d3c1a9ba723d94a0be10fc343717cf7b61732644f5c42922f1c8d81047164b99")
+    version("1.29.4", sha256="f6c628d376ea2db9872b1df20abc886281ba58b7bdf29f19dc179c541958640b")
     version("1.28.1", sha256="243a0f15e4400aab7b4d27ec71c6ae650bf782473c47520ffccd57af8d939c90")
     version("1.28.0", sha256="9a0b433c02033cf3d257405d845592e2b7c2e38741027769bb97a8fd763aeeac")
     version("1.27.0", sha256="26bf5fe24eeaeb0f861c89b31129498f029441ae11cc9958e14ad96ec1356d51")


### PR DESCRIPTION
Adding a CI check to use `spack checksum --verify $version` on new package updates. Testing this functionality with an added version to glab.