### PR TITLE
package import: remove magic import line

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1266,12 +1266,8 @@ def get_package_context(traceback, context=3):
     # Point out the location in the install method where we failed.
     filename = inspect.getfile(frame.f_code)
     lineno = frame.f_lineno
-    if os.path.basename(filename) == "package.py":
-        # subtract 1 because we inject a magic import at the top of package files.
-        # TODO: get rid of the magic import.
-        lineno -= 1
 
-    lines = ["{0}:{1:d}, in {2}:".format(filename, lineno, frame.f_code.co_name)]
+    lines = [f"{filename}:{lineno:d}, in {frame.f_code.co_name}:"]
 
     # Build a message showing context in the install method.
     sourcelines, start = inspect.getsourcelines(frame)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -78,17 +78,6 @@ def namespace_from_fullname(fullname):
     return namespace
 
 
-class RepoLoader(importlib.machinery.SourceFileLoader):
-    """Loads a Python module associated with a package in specific repository"""
-
-    def __init__(self, fullname, repo, package_name):
-        self.repo = repo
-        self.package_name = package_name
-        self.package_py = repo.filename_for_package_name(package_name)
-        self.fullname = fullname
-        super().__init__(self.fullname, self.package_py)
-
-
 class SpackNamespaceLoader:
     def create_module(self, spec):
         return SpackNamespace(spec.name)
@@ -129,7 +118,9 @@ class ReposFinder:
                 # With 2 nested conditionals we can call "repo.real_name" only once
                 package_name = repo.real_name(module_name)
                 if package_name:
-                    return RepoLoader(fullname, repo, package_name)
+                    return importlib.machinery.SourceFileLoader(
+                        fullname, repo.filename_for_package_name(package_name)
+                    )
 
             # We are importing a full namespace like 'spack.pkg.builtin'
             if fullname == repo.full_namespace:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1206,7 +1206,7 @@ class Repo:
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             if isinstance(e, NameError):
-                msg += ". This usually means it's missing `from spack.package import *`."
+                msg += ". This usually means `from spack.package import *` is missing at the top of the package.py file."
             raise RepoError(msg) from e
 
         cls = getattr(module, class_name)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1214,6 +1214,8 @@ class Repo:
             raise UnknownPackageError(fullname)
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
+            if isinstance(e, NameError):
+                msg += ". This usually means it's missing `from spack.package import *`."
             raise RepoError(msg) from e
 
         cls = getattr(module, class_name)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -78,41 +78,15 @@ def namespace_from_fullname(fullname):
     return namespace
 
 
-class _PrependFileLoader(importlib.machinery.SourceFileLoader):
-    def __init__(self, fullname, path, prepend=None):
-        super(_PrependFileLoader, self).__init__(fullname, path)
-        self.prepend = prepend
-
-    def path_stats(self, path):
-        stats = super(_PrependFileLoader, self).path_stats(path)
-        if self.prepend:
-            stats["size"] += len(self.prepend) + 1
-        return stats
-
-    def get_data(self, path):
-        data = super(_PrependFileLoader, self).get_data(path)
-        if path != self.path or self.prepend is None:
-            return data
-        else:
-            return self.prepend.encode() + b"\n" + data
-
-
-class RepoLoader(_PrependFileLoader):
+class RepoLoader(importlib.machinery.SourceFileLoader):
     """Loads a Python module associated with a package in specific repository"""
-
-    #: Code in ``_package_prepend`` is prepended to imported packages.
-    #:
-    #: Spack packages are expected to call `from spack.package import *`
-    #: themselves, but we are allowing a deprecation period before breaking
-    #: external repos that don't do this yet.
-    _package_prepend = "from spack.package import *"
 
     def __init__(self, fullname, repo, package_name):
         self.repo = repo
         self.package_name = package_name
         self.package_py = repo.filename_for_package_name(package_name)
         self.fullname = fullname
-        super().__init__(self.fullname, self.package_py, prepend=self._package_prepend)
+        super().__init__(self.fullname, self.package_py)
 
 
 class SpackNamespaceLoader:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1206,7 +1206,10 @@ class Repo:
         except Exception as e:
             msg = f"cannot load package '{pkg_name}' from the '{self.namespace}' repository: {e}"
             if isinstance(e, NameError):
-                msg += ". This usually means `from spack.package import *` is missing at the top of the package.py file."
+                msg += (
+                    ". This usually means `from spack.package import *` "
+                    "is missing at the top of the package.py file."
+                )
             raise RepoError(msg) from e
 
         cls = getattr(module, class_name)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -145,6 +145,8 @@ repo:
 
     packages_dir = repo_dir.ensure("packages", dir=True)
     root_pkg_str = """
+from spack.package import *
+
 class Root(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/root-1.0.tar.gz"
@@ -157,6 +159,8 @@ class Root(Package):
     packages_dir.join("root", "package.py").write(root_pkg_str, ensure=True)
 
     changing_template = """
+from spack.package import *
+
 class Changing(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/changing-1.0.tar.gz"

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -29,6 +29,8 @@ def update_packages_config(conf_str):
 _pkgx = (
     "x",
     """\
+from spack.package import *
+
 class X(Package):
     version("1.1")
     version("1.0")
@@ -45,6 +47,8 @@ class X(Package):
 _pkgy = (
     "y",
     """\
+from spack.package import *
+
 class Y(Package):
     version("2.5")
     version("2.4")
@@ -59,6 +63,8 @@ class Y(Package):
 _pkgv = (
     "v",
     """\
+from spack.package import *
+
 class V(Package):
     version("2.1")
     version("2.0")
@@ -69,6 +75,8 @@ class V(Package):
 _pkgt = (
     "t",
     """\
+from spack.package import *
+
 class T(Package):
     version('2.1')
     version('2.0')
@@ -81,6 +89,8 @@ class T(Package):
 _pkgu = (
     "u",
     """\
+from spack.package import *
+
 class U(Package):
     version('1.1')
     version('1.0')

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 import pytest
 
@@ -334,6 +335,9 @@ class OldPackage(Package):
     with spack.repo.use_repositories(str(tmpdir)) as repo:
         with pytest.raises(
             spack.repo.RepoError,
-            match=r"This usually means it's missing `from spack.package import \*`.",
+            match=re.escape(
+                "This usually means `from spack.package import *` "
+                "is missing at the top of the package.py file."
+            ),
         ):
             repo.get_pkg_class("old-package")

--- a/share/spack/templates/mock-repository/package.pyt
+++ b/share/spack/templates/mock-repository/package.pyt
@@ -1,3 +1,5 @@
+from spack.package import *
+
 class {{ cls_name }}(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/root-1.0.tar.gz"


### PR DESCRIPTION
Deprecated in #30404 (Spack v0.19.0), the opaque automatic import line can probably safely be removed by now.

To be nice, Spack suggests adding `from spack.package import *` when `NameError` is raised on import.