### PR TITLE
Add a more detailed HTTPError

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import codecs
+import email.message
 import errno
 import multiprocessing.pool
 import os
@@ -16,7 +17,7 @@ import traceback
 import urllib.parse
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import HTTPSHandler, Request, build_opener
 
 import llnl.util.lang
@@ -38,15 +39,42 @@ from spack.util.executable import CommandNotFoundError, which
 from spack.util.path import convert_to_posix_path
 
 
+class DetailedHTTPError(HTTPError):
+    def __init__(self, req: Request, code: int, msg: str, hdrs: email.message.Message, fp) -> None:
+        self.req = req
+        super().__init__(req.get_full_url(), code, msg, hdrs, fp)
+
+    def __str__(self):
+        # Note: HTTPError, is actually a kind of non-seekable response object, so
+        # best not to read the response body here (even if it may include a human-readable
+        # error message).
+        msg = f"{self.req.get_method()} {self.url} returned {self.code}: {self.msg}"
+        if self.hdrs:
+            msg += "\n    Response headers:"
+            for key, value in self.hdrs.items():
+                msg += f"\n    - {key}: {value}"
+        return msg
+
+
+class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
+    def http_error_default(self, req, fp, code, msg, hdrs):
+        raise DetailedHTTPError(req, code, msg, hdrs, fp)
+
+
 def _urlopen():
     s3 = spack.s3_handler.UrllibS3Handler()
     gcs = spack.gcs_handler.GCSHandler()
+    error_handler = SpackHTTPDefaultErrorHandler()
 
     # One opener with HTTPS ssl enabled
-    with_ssl = build_opener(s3, gcs, HTTPSHandler(context=ssl.create_default_context()))
+    with_ssl = build_opener(
+        s3, gcs, HTTPSHandler(context=ssl.create_default_context()), error_handler
+    )
 
     # One opener with HTTPS ssl disabled
-    without_ssl = build_opener(s3, gcs, HTTPSHandler(context=ssl._create_unverified_context()))
+    without_ssl = build_opener(
+        s3, gcs, HTTPSHandler(context=ssl._create_unverified_context()), error_handler
+    )
 
     # And dynamically dispatch based on the config:verify_ssl.
     def dispatch_open(fullurl, data=None, timeout=None):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -48,12 +48,7 @@ class DetailedHTTPError(HTTPError):
         # Note: HTTPError, is actually a kind of non-seekable response object, so
         # best not to read the response body here (even if it may include a human-readable
         # error message).
-        msg = f"{self.req.get_method()} {self.url} returned {self.code}: {self.msg}"
-        if self.hdrs:
-            msg += "\n    Response headers:"
-            for key, value in self.hdrs.items():
-                msg += f"\n    - {key}: {value}"
-        return msg
+        return f"{self.req.get_method()} {self.url} returned {self.code}: {self.msg}"
 
 
 class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):


### PR DESCRIPTION
Before:

```
urllib.error.HTTPError: HTTP Error 404: Not Found
```

After:

```
spack.util.web.DetailedHTTPError: GET https://google.com/does-not-exist returned 404: Not Found
```

What's a bad idea is to read the response body, since you can in fact catch the
error and treat it more or less as a response object, and the file object is not
seekable; we don't want to steal the response.

Notice that the URL _after_ redirect is printed, which is maybe not always useful,
but still it's better than not printing a URL at all. In principle we can customize
the redirect handler and catch errors there, and then print the redirect chain,
but that sounds even more hacky than this PR already is, and this PR is a strict
improvement over the status quo.