### PR TITLE
Fix broken assertion

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -143,7 +143,7 @@ class OpenFileTracker:
     def release_by_stat(self, stat):
         key = (stat.st_dev, stat.st_ino, os.getpid())
         open_file = self._descriptors.get(key)
-        assert open_file, "Attempted to close non-existing inode: %s" % stat.st_inode
+        assert open_file, "Attempted to close non-existing inode: %s" % stat.st_ino
 
         open_file.refs -= 1
         if not open_file.refs:


### PR DESCRIPTION
This assertion will never be triggered, except when using file system locks in threads instead of multiple processes, since these globals are not thread safe. This is how I ran into the bug.