### PR TITLE
PAPI misc fixes

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -91,6 +91,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
             env.set("PAPI_CUDA_ROOT", spec["cuda"].prefix)
         if "+rocm" in spec:
             env.set("PAPI_ROCM_ROOT", spec["hsa-rocr-dev"].prefix)
+            env.set("HSA_TOOLS_LIB", "%s/librocprofiler64.so" % spec["rocprofiler-dev"].prefix.lib)
             env.append_flags("CFLAGS", "-I%s/rocprofiler/include" % spec["rocprofiler-dev"].prefix)
             env.set(
                 "ROCP_METRICS", "%s/rocprofiler/lib/metrics.xml" % spec["rocprofiler-dev"].prefix
@@ -98,9 +99,6 @@ class Papi(AutotoolsPackage, ROCmPackage):
             env.set("ROCPROFILER_LOG", "1")
             env.set("HSA_VEN_AMD_AQLPROFILE_LOG", "1")
             env.set("AQLPROFILE_READ_API", "1")
-            # Setting HSA_TOOLS_LIB=librocprofiler64.so (as recommended) doesn't work
-            # due to a conflict between the spack and system-installed versions.
-            env.set("HSA_TOOLS_LIB", "unset")
         if "+rocm_smi" in spec:
             env.append_flags("CFLAGS", "-I%s/rocm_smi" % spec["rocm-smi-lib"].prefix.include)
         #

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -54,6 +54,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
     variant("shared", default=True, description="Build shared libraries")
     # PAPI requires building static libraries, so there is no "static" variant
     variant("static_tools", default=False, description="Statically link the PAPI tools")
+    variant("debug", default=False, description="Enable debug symbols in PAPI")
     # The PAPI configure option "--with-shlib-tools" is deprecated
     # and therefore not implemented here
 
@@ -145,6 +146,9 @@ class Papi(AutotoolsPackage, ROCmPackage):
 
         if "+static_tools" in spec:
             options.append("--with-static-tools")
+
+        if "+debug" in spec:
+            options.append("--with-debug=yes")
 
         return options
 


### PR DESCRIPTION
This PR introduces two changes:

1. Add a "debug" variant to allow building PAPI with debug symbols
2. Set the HSA_TOOLS_LIB variable to the full pathname for librocprofiler64.so  