### PR TITLE
picard: add variant with jvm arguments

### DIFF
--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -172,7 +172,10 @@ class Picard(Package):
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
 
-        script_sh = join_path(os.path.dirname(__file__), "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh" )
+        script_sh = join_path(
+                os.path.dirname(__file__),
+                "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh",
+        )
 
         script = prefix.bin.picard
         install(script_sh, script)

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -156,6 +156,8 @@ class Picard(Package):
     )
     version("1.140", sha256="0d27287217413db6b846284c617d502eaa578662dcb054a7017083eab9c54438")
 
+    variant("parameters", default=False, description="get java parameters in the adapter script")
+
     depends_on("java@17:", type="run", when="@3.0.0:")
     depends_on("java@8:", type="run", when="@:2.27.5")
 
@@ -169,7 +171,9 @@ class Picard(Package):
 
         # Set up a helper script to call java on the jar file,
         # explicitly codes the path for java and the jar file.
-        script_sh = join_path(os.path.dirname(__file__), "picard.sh")
+
+        script_sh = join_path(os.path.dirname(__file__), "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh" )
+
         script = prefix.bin.picard
         install(script_sh, script)
         set_executable(script)

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -174,7 +174,7 @@ class Picard(Package):
 
         script_sh = join_path(
             os.path.dirname(__file__),
-            "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh",
+            "picard_with_parameters.sh" if "+parameters" in spec else "picard.sh",
         )
 
         script = prefix.bin.picard

--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -173,8 +173,8 @@ class Picard(Package):
         # explicitly codes the path for java and the jar file.
 
         script_sh = join_path(
-                os.path.dirname(__file__),
-                "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh",
+            os.path.dirname(__file__),
+            "picard_with_parameters.sh" if "+parameters" in self.variants else "picard.sh",
         )
 
         script = prefix.bin.picard

--- a/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
+++ b/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Picard executable shell script
+set -eu -o pipefail
+
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resolving symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+ENV_PREFIX="$(dirname $(dirname $DIR))"
+# Use Java installed with Anaconda to ensure correct version
+#java="$ENV_PREFIX/bin/java"
+
+# if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
+#if [ -n "${JAVA_HOME:=}" ]; then
+  #if [ -e "$JAVA_HOME/bin/java" ]; then
+      #java="$JAVA_HOME/bin/java"
+  #fi
+#fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx2g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+                then
+                    pass_args="$arg"
+            else
+                    pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
+            fi
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]:=} == org* ]]
+then
+    java $jvm_mem_opts $jvm_prop_opts -cp picard.jar $pass_args
+else
+    java $jvm_mem_opts $jvm_prop_opts -jar picard.jar $pass_args
+fi
+exit

--- a/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
+++ b/var/spack/repos/builtin/packages/picard/picard_with_parameters.sh
@@ -17,14 +17,14 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 JAR_DIR=$DIR
 ENV_PREFIX="$(dirname $(dirname $DIR))"
 # Use Java installed with Anaconda to ensure correct version
-#java="$ENV_PREFIX/bin/java"
+java="$ENV_PREFIX/bin/java"
 
 # if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
-#if [ -n "${JAVA_HOME:=}" ]; then
-  #if [ -e "$JAVA_HOME/bin/java" ]; then
-      #java="$JAVA_HOME/bin/java"
-  #fi
-#fi
+if [ -n "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
+fi
 
 # extract memory and system property Java arguments from the list of provided arguments
 # http://java.dzone.com/articles/better-java-shell-script
@@ -61,8 +61,8 @@ fi
 pass_arr=($pass_args)
 if [[ ${pass_arr[0]:=} == org* ]]
 then
-    java $jvm_mem_opts $jvm_prop_opts -cp picard.jar $pass_args
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/picard.jar" $pass_args
 else
-    java $jvm_mem_opts $jvm_prop_opts -jar picard.jar $pass_args
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/picard.jar" $pass_args
 fi
 exit


### PR DESCRIPTION
Bioconda uses a useful script to control jvm arguments in its wrapper script [1]. This PR adds this script to picard spack recipe as a variant

[1] https://github.com/bioconda/bioconda-recipes/blob/master/recipes/picard/picard.sh