### PR TITLE
py-sphinx-rtd-theme: avoid concretizing 0.5 with Sphinx 7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -22,8 +22,8 @@ class PySphinxRtdTheme(PythonPackage):
 
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-sphinx@1.6:6", when="@:1.2", type=("build", "run"))
-    depends_on("py-sphinx", when="@0.4.1:", type=("build", "run"))
+    depends_on("py-sphinx@1.6:6", when="@1:", type=("build", "run"))
+    depends_on("py-sphinx@:6", when="@0", type=("build", "run"))
     depends_on("py-docutils@:0.18", when="@1.2:", type=("build", "run"))
     depends_on("py-docutils@:0.17", when="@1:1.1", type=("build", "run"))
     depends_on("py-docutils@:0.16", when="@0.5.2:0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -22,7 +22,7 @@ class PySphinxRtdTheme(PythonPackage):
 
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-sphinx@1.6:6", when="@1:", type=("build", "run"))
+    depends_on("py-sphinx@1.6:6", when="@:1.2", type=("build", "run"))
     depends_on("py-sphinx", when="@0.4.1:", type=("build", "run"))
     depends_on("py-docutils@:0.18", when="@1.2:", type=("build", "run"))
     depends_on("py-docutils@:0.17", when="@1:1.1", type=("build", "run"))


### PR DESCRIPTION
A missing constraint in the Sphinx RTD package allows spack to combine a super-new version of sphinx with a super-old version of the theme. Sphinx 7 support is planned for the 1.3 release: https://github.com/readthedocs/sphinx_rtd_theme/issues/1463 .