### PR TITLE
gftl-shared: new version 1.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -23,6 +23,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.6.1", sha256="0e3e1e0c7e0c3f1576e296b3b199dcae4bbaad055fc8fe929c34e52d4b07b02c")
     version("1.6.0", sha256="90245b83aea9854bc5b9fbd553a68cf73ab12f6ed5a14753a9c84092047e8cb0")
     version("1.5.1", sha256="353d07cc22678d1a79b19dbf53d8ba54b889e424a15e315cc4f035b72eedb83a")
     version("1.5.0", sha256="c19b8197cc6956d4a51a16f98b38b63c7bc9f784f1fd38f8e3949be3ea792356")


### PR DESCRIPTION
This PR adds gFTL-shared v1.6.1