### PR TITLE
compiler bootstrapping: match against compiler package versions

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -109,9 +109,10 @@ config:
   suppress_gpg_warnings: false
 
 
-  # If set to true, Spack will attempt to build any compiler on the spec
-  # that is not already available. If set to False, Spack will only use
-  # compilers already configured in compilers.yaml
+  # If set to true, Spack is allowed to bootstrap compilers that are
+  # not available on the system. This influences both concretization
+  # and installation. If set to False, Spack will only use compilers
+  # already configured in compilers.yaml
   install_missing_compilers: false
 
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -702,7 +702,7 @@ def generate_gitlab_ci_yaml(
             criteria.  Spack protected pipelines populate different mirrors based
             on branch name, facilitated by this option.
     """
-    with spack.concretize.disable_compiler_existence_check():
+    with spack.concretize.require_compiler_in_config(False):
         with env.write_transaction():
             env.concretize()
             env.write()

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -702,10 +702,9 @@ def generate_gitlab_ci_yaml(
             criteria.  Spack protected pipelines populate different mirrors based
             on branch name, facilitated by this option.
     """
-    with spack.concretize.require_compiler_in_config(False):
-        with env.write_transaction():
-            env.concretize()
-            env.write()
+    with cfg.override("config:install_missing_compilers", True), env.write_transaction():
+        env.concretize()
+        env.write()
 
     yaml_root = env.manifest[ev.TOP_LEVEL_KEY]
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -331,7 +331,7 @@ def extend_with_dependencies(specs):
 
 def concrete_specs_from_cli_or_file(args):
     tty.msg("Concretizing input specs")
-    with spack.concretize.disable_compiler_existence_check():
+    with spack.concretize.require_compiler_in_config(False):
         if args.specs:
             specs = spack.cmd.parse_specs(args.specs, concretize=True)
             if not specs:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -331,7 +331,7 @@ def extend_with_dependencies(specs):
 
 def concrete_specs_from_cli_or_file(args):
     tty.msg("Concretizing input specs")
-    with spack.concretize.require_compiler_in_config(False):
+    with spack.config.override("config:install_missing_compilers", True):
         if args.specs:
             specs = spack.cmd.parse_specs(args.specs, concretize=True)
             if not specs:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -17,7 +17,6 @@ TODO: make this customizable and allow users to configure
 import functools
 import platform
 import tempfile
-from contextlib import contextmanager
 from itertools import chain
 from typing import Union
 
@@ -70,15 +69,10 @@ class Concretizer:
     concretization strategies, or you can override all of them.
     """
 
-    #: Controls whether we check that compiler versions actually exist
-    #: during concretization. Used for testing and for mirror creation
-    require_compiler_in_config = None
-
     def __init__(self, abstract_spec=None):
-        if Concretizer.require_compiler_in_config is None:
-            Concretizer.require_compiler_in_config = not spack.config.get(
-                "config:install_missing_compilers", False
-            )
+        self.require_compiler_in_config = not spack.config.get(
+            "config:install_missing_compilers", False
+        )
         self.abstract_spec = abstract_spec
         self._adjust_target_answer_generator = None
 
@@ -662,14 +656,6 @@ class Concretizer:
                 raise
 
         return False
-
-
-@contextmanager
-def require_compiler_in_config(enabled=True):
-    saved = Concretizer.require_compiler_in_config
-    Concretizer.require_compiler_in_config = enabled
-    yield
-    Concretizer.require_compiler_in_config = saved
 
 
 def find_spec(spec, condition, default=None):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,7 +25,7 @@ import textwrap
 import time
 import traceback
 import warnings
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
@@ -516,7 +516,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     # Declare versions dictionary as placeholder for values.
     # This allows analysis tools to correctly interpret the class attributes.
-    versions: dict
+    versions: Dict[Union[GitVersion, StandardVersion], dict]
 
     #: By default, packages are not virtual
     #: Virtual packages override this attribute

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -12,7 +12,7 @@ import pprint
 import re
 import types
 import warnings
-from typing import List
+from typing import List, Tuple, Union
 
 import archspec.cpu
 
@@ -600,6 +600,19 @@ def extract_args(model, predicate_name):
     their stringified arguments as tuples.
     """
     return [stringify(sym.arguments) for sym in model if sym.name == predicate_name]
+
+
+def by_preference(version_and_info: Tuple[Union[vn.StandardVersion, vn.GitVersion], dict]):
+    """Concretization order imposed on the set of defined versions in package.py.
+    The order is preferred > non-preferred, non-deprecated > deprecated, finite > develop,
+    otherwise standard version ordering."""
+    version, info = version_and_info
+    return (
+        info.get("preferred", False),
+        not info.get("deprecated", False),
+        not version.isdevelop(),
+        version,
+    )
 
 
 class ErrorHandler:
@@ -1724,24 +1737,11 @@ class SpackSolverSetup:
         packages_yaml = spack.config.get("packages")
         packages_yaml = _normalize_packages_yaml(packages_yaml)
         for pkg_name in possible_pkgs:
-            pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+            pkg_cls: spack.package_base.PackageBase = spack.repo.PATH.get_pkg_class(pkg_name)
 
-            # All the versions from the corresponding package.py file. Since concepts
-            # like being a "develop" version or being preferred exist only at a
-            # package.py level, sort them in this partial list here
-            def key_fn(item):
-                version, info = item
-                # When COMPARING VERSIONS, the '@develop' version is always
-                # larger than other versions. BUT when CONCRETIZING, the largest
-                # NON-develop version is selected by default.
-                return (
-                    info.get("preferred", False),
-                    not info.get("deprecated", False),
-                    not version.isdevelop(),
-                    version,
-                )
-
-            for idx, item in enumerate(sorted(pkg_cls.versions.items(), key=key_fn, reverse=True)):
+            for idx, item in enumerate(
+                sorted(pkg_cls.versions.items(), key=by_preference, reverse=True)
+            ):
                 v, version_info = item
                 self.possible_versions[pkg_name].add(v)
                 self.declared_versions[pkg_name].append(
@@ -2003,29 +2003,50 @@ class SpackSolverSetup:
 
         cspecs = set([c.spec for c in compilers])
 
-        # add compiler specs from the input line to possibilities if we
-        # don't require compilers to exist.
-        strict = spack.concretize.Concretizer().check_for_compiler_existence
         for s in spack.traverse.traverse_nodes(specs):
+            s: spack.spec.Spec
+
             # we don't need to validate compilers for already-built specs
             if s.concrete or not s.compiler:
                 continue
 
-            version = s.compiler.versions.concrete
-
-            if not version or any(c.satisfies(s.compiler) for c in cspecs):
+            if any(c.satisfies(s.compiler) for c in cspecs):
                 continue
 
-            # Error when a compiler is not found and strict mode is enabled
-            if strict:
+            # Error when a compiler cannot be found in config but should be
+            if spack.concretize.Concretizer.require_compiler_in_config:
                 raise spack.concretize.UnavailableCompilerVersionError(s.compiler)
 
             # Make up a compiler matching the input spec. This is for bootstrapping.
-            compiler_cls = spack.compilers.class_for_compiler_name(s.compiler.name)
-            compilers.append(
-                compiler_cls(s.compiler, operating_system=None, target=None, paths=[None] * 4)
+            concrete_compiler_spec = spack.spec.CompilerSpec(s.compiler.name)
+            compiler_pkg: spack.package_base.PackageBase = spack.repo.PATH.get_pkg_class(
+                spack.compilers.pkg_spec_for_compiler(concrete_compiler_spec).name
             )
-            self.gen.fact(fn.allow_compiler(s.compiler.name, version))
+            # Pick the latest the greatest matching compiler, this is a greedy choice
+            # and can be made non-greedy once its modelled in the solver.
+            try:
+                greedy_compiler_version, _ = max(
+                    (
+                        v
+                        for v in compiler_pkg.versions.items()
+                        if v[0].satisfies(s.compiler.versions)
+                    ),
+                    key=by_preference,
+                )
+            except ValueError:
+                # No version of the compiler is compatible with the spec
+                raise spack.concretize.UnavailableCompilerVersionError(s.compiler, bootstrap=True)
+            concrete_compiler_spec.versions = vn.VersionList([greedy_compiler_version])
+            compiler_cls = spack.compilers.class_for_compiler_name(s.compiler.name)
+
+            compilers.append(
+                compiler_cls(
+                    concrete_compiler_spec, operating_system=None, target=None, paths=[None] * 4
+                )
+            )
+            self.gen.fact(
+                fn.allow_compiler(concrete_compiler_spec.name, concrete_compiler_spec.version)
+            )
 
         return list(
             sorted(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2003,9 +2003,8 @@ class SpackSolverSetup:
 
         cspecs = set([c.spec for c in compilers])
 
+        s: spack.spec.Spec
         for s in spack.traverse.traverse_nodes(specs):
-            s: spack.spec.Spec
-
             # we don't need to validate compilers for already-built specs
             if s.concrete or not s.compiler:
                 continue
@@ -2014,7 +2013,7 @@ class SpackSolverSetup:
                 continue
 
             # Error when a compiler cannot be found in config but should be
-            if spack.concretize.Concretizer.require_compiler_in_config:
+            if not spack.config.get("config:install_missing_compilers", False):
                 raise spack.concretize.UnavailableCompilerVersionError(s.compiler)
 
             # Make up a compiler matching the input spec. This is for bootstrapping.

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -213,7 +213,7 @@ def test_concretize_target_ranges(root_target_range, dep_target_range, result, m
         dep_target_range,
     )
     spec = spack.spec.Spec(spec_str)
-    with spack.concretize.disable_compiler_existence_check():
+    with spack.concretize.require_compiler_in_config(False):
         spec.concretize()
 
     assert str(spec).count("arch=test-debian6-%s" % result) == 2

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -10,6 +10,7 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.concretize
+import spack.config
 import spack.operating_systems
 import spack.platforms
 import spack.spec
@@ -213,7 +214,7 @@ def test_concretize_target_ranges(root_target_range, dep_target_range, result, m
         dep_target_range,
     )
     spec = spack.spec.Spec(spec_str)
-    with spack.concretize.require_compiler_in_config(False):
+    with spack.config.override("config:install_missing_compilers", True):
         spec.concretize()
 
     assert str(spec).count("arch=test-debian6-%s" % result) == 2

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1415,13 +1415,13 @@ def test_ci_generate_with_workarounds(
             """\
 spack:
   specs:
-    - callpath%gcc@=9.5
+    - callpath%gcc@12
   mirrors:
     some-mirror: https://my.fake.mirror
   ci:
     pipeline-gen:
     - submapping:
-      - match: ['%gcc@9.5']
+      - match: ['%gcc@12']
         build-job:
           tags:
             - donotcare

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -966,9 +966,7 @@ def test_compiler_bootstrap(
     assert not any(c.satisfies(compiler) for c in compilers.all_compiler_specs())
 
     # Test succeeds if it does not raise an error
-    with spack.concretize.require_compiler_in_config(False), spack.config.override(
-        "config:install_missing_compilers", True
-    ):
+    with spack.config.override("config:install_missing_compilers", True):
         install(f"a%{compiler}")
 
 
@@ -989,9 +987,7 @@ def test_compiler_bootstrap_greedy_match(
     assert not any(c.satisfies(compiler) for c in compilers.all_compiler_specs())
 
     # Test succeeds if it does not raise an error
-    with spack.concretize.require_compiler_in_config(False), spack.config.override(
-        "config:install_missing_compilers", True
-    ):
+    with spack.config.override("config:install_missing_compilers", True):
         install(f"a%{compiler}")
 
     # Picks the preferred version greedily (at least in the clingo case)
@@ -1034,9 +1030,7 @@ def test_compiler_bootstrap_from_binary_mirror(
     # Now make sure that when the compiler is installed from binary mirror,
     # it also gets configured as a compiler.  Test succeeds if it does not
     # raise an error
-    with spack.concretize.require_compiler_in_config(False), spack.config.override(
-        "config:install_missing_compilers", True
-    ):
+    with spack.config.override("config:install_missing_compilers", True):
         install("--no-check-signature", "--cache-only", "--only", "dependencies", f"b%{compiler}")
         install("--no-cache", "--only", "package", f"b%{compiler}")
 
@@ -1057,9 +1051,7 @@ def test_compiler_bootstrap_already_installed(
     assert not any(c.satisfies(compiler) for c in compilers.all_compiler_specs())
 
     # Test succeeds if it does not raise an error
-    with spack.concretize.require_compiler_in_config(False), spack.config.override(
-        "config:install_missing_compilers", True
-    ):
+    with spack.config.override("config:install_missing_compilers", True):
         install(compiler)
         install(f"a%{compiler}")
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -469,7 +469,7 @@ class TestConcretize:
     def test_no_matching_compiler_specs(self, enable_bootstrapping, mock_low_high_config):
         # There's not gcc@999 configured, and there's no bootstrappable version in gcc/package.py
         with pytest.raises(spack.concretize.UnavailableCompilerVersionError) as e:
-            with spack.concretize.require_compiler_in_config(not enable_bootstrapping):
+            with spack.config.override("config:install_missing_compilers", enable_bootstrapping):
                 Spec("a %gcc@999").concretize()
 
         assert ("no matching compiler can be bootstrapped" in str(e.value)) == enable_bootstrapping

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -278,16 +278,6 @@ class TestConcretize:
         concrete = check_concretize("mpileaks   ^mpich2@1.3.1:1.4")
         assert concrete["mpich2"].satisfies("mpich2@1.3.1:1.4")
 
-    def test_concretize_enable_disable_compiler_existence_check(self):
-        with spack.concretize.enable_compiler_existence_check():
-            with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
-                check_concretize("dttop %gcc@=100.100")
-
-        with spack.concretize.disable_compiler_existence_check():
-            spec = check_concretize("dttop %gcc@=100.100")
-            assert spec.satisfies("%gcc@100.100")
-            assert spec["dtlink3"].satisfies("%gcc@100.100")
-
     def test_concretize_with_provides_when(self):
         """Make sure insufficient versions of MPI are not in providers list when
         we ask for some advanced version.
@@ -475,12 +465,14 @@ class TestConcretize:
 
         assert spec.satisfies("^openblas+shared")
 
-    def test_no_matching_compiler_specs(self, mock_low_high_config):
-        # only relevant when not building compilers as needed
-        with spack.concretize.enable_compiler_existence_check():
-            s = Spec("a %gcc@=0.0.0")
-            with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
-                s.concretize()
+    @pytest.mark.parametrize("enable_bootstrapping", [True, False])
+    def test_no_matching_compiler_specs(self, enable_bootstrapping, mock_low_high_config):
+        # There's not gcc@999 configured, and there's no bootstrappable version in gcc/package.py
+        with pytest.raises(spack.concretize.UnavailableCompilerVersionError) as e:
+            with spack.concretize.require_compiler_in_config(not enable_bootstrapping):
+                Spec("a %gcc@999").concretize()
+
+        assert ("no matching compiler can be bootstrapped" in str(e.value)) == enable_bootstrapping
 
     def test_no_compilers_for_arch(self):
         s = Spec("a arch=linux-rhel0-x86_64")
@@ -745,23 +737,41 @@ class TestConcretize:
     @pytest.mark.skipif(sys.platform == "win32", reason="Not supported on Windows (yet)")
     # Include targets to prevent regression on 20537
     @pytest.mark.parametrize(
-        "spec, best_achievable",
+        "spec_str, best_achievable",
         [
-            ("mpileaks%gcc@=4.4.7 ^dyninst@=10.2.1 target=x86_64:", "core2"),
-            ("mpileaks%gcc@=4.8 target=x86_64:", "haswell"),
-            ("mpileaks%gcc@=5.3.0 target=x86_64:", "broadwell"),
-            ("mpileaks%apple-clang@=5.1.0 target=x86_64:", "x86_64"),
+            ("mpileaks%gcc@4.4.7 ^dyninst@=10.2.1 target=x86_64:", "core2"),
+            ("mpileaks%gcc@4.8 target=x86_64:", "haswell"),
+            ("mpileaks%gcc@5.3.0 target=x86_64:", "broadwell"),
+            ("mpileaks%apple-clang@5.1.0 target=x86_64:", "x86_64"),
         ],
     )
     @pytest.mark.regression("13361", "20537")
     def test_adjusting_default_target_based_on_compiler(
-        self, spec, best_achievable, current_host, mock_targets
+        self, spec_str, best_achievable, current_host, mock_targets
     ):
-        best_achievable = archspec.cpu.TARGETS[best_achievable]
-        expected = best_achievable if best_achievable < current_host else current_host
-        with spack.concretize.disable_compiler_existence_check():
-            s = Spec(spec).concretized()
-            assert str(s.architecture.target) == str(expected)
+        spec = Spec(spec_str)
+        with spack.config.override(
+            "compilers",
+            [
+                {
+                    "compiler": {
+                        "spec": str(spec.compiler),
+                        "operating_system": "debian6",
+                        "paths": {
+                            "cc": "/path/to/cc",
+                            "cxx": "/path/to/c++",
+                            "f77": None,
+                            "fc": None,
+                        },
+                        "modules": None,
+                        "target": "x86_64",
+                    }
+                }
+            ],
+        ):
+            best_achievable = archspec.cpu.TARGETS[best_achievable]
+            expected = best_achievable if best_achievable < current_host else current_host
+            assert str(spec.concretized().architecture.target) == str(expected)
 
     def test_compiler_version_matches_any_entry_in_compilers_yaml(self):
         # The behavior here has changed since #8735 / #14730. Now %gcc@10.2 is an abstract

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -535,9 +535,7 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
 def test_bootstrapping_compilers_with_different_names_from_spec(
     install_mockery, mutable_config, mock_fetch, archspec_host_is_spack_test_host
 ):
-    with spack.config.override(
-        "config:install_missing_compilers", True
-    ), spack.concretize.require_compiler_in_config(False):
+    with spack.config.override("config:install_missing_compilers", True):
         spack.spec.Spec("trivial-install-test-package%oneapi@3").concretized().package.do_install()
         assert any(c.satisfies("oneapi@3") for c in spack.compilers.all_compiler_specs())
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -535,14 +535,11 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
 def test_bootstrapping_compilers_with_different_names_from_spec(
     install_mockery, mutable_config, mock_fetch, archspec_host_is_spack_test_host
 ):
-    with spack.config.override("config:install_missing_compilers", True):
-        with spack.concretize.disable_compiler_existence_check():
-            spec = spack.spec.Spec("trivial-install-test-package%oneapi@=22.2.0").concretized()
-            spec.package.do_install()
-
-            assert (
-                spack.spec.CompilerSpec("oneapi@=22.2.0") in spack.compilers.all_compiler_specs()
-            )
+    with spack.config.override(
+        "config:install_missing_compilers", True
+    ), spack.concretize.require_compiler_in_config(False):
+        spack.spec.Spec("trivial-install-test-package%oneapi@3").concretized().package.do_install()
+        assert any(c.satisfies("oneapi@3") for c in spack.compilers.all_compiler_specs())
 
 
 def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):

--- a/var/spack/repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/gcc/package.py
@@ -12,9 +12,11 @@ class Gcc(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/gcc-1.0.tar.gz"
 
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
-    version("2.0", md5="abcdef0123456789abcdef0123456789")
+    version("12.2.0", md5="0123456789abcdef0123456789abcdef")
+    version("12.1.0", md5="abcdef0123456789abcdef0123456789", preferred=True)
     version("3.0", md5="def0123456789abcdef0123456789abc")
+    version("2.0", md5="abcdef0123456789abcdef0123456789")
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     depends_on("conflict", when="@3.0")
 


### PR DESCRIPTION
When installing `x %gcc@y`, greedily take the best matching `gcc@y` from
the `gcc` package, and define it.

That way `spack -c config:install_missing_compilers:true install pkg%gcc@13`
would concretize to `pkg%gcc@13.2.0` if no matching `gcc@13` is defined in
config.

Note: the compiler is concretized under the same config as the package,
so I'm a reluctant to also automatically define compilers based on require
rules, since you either end up with recursion or unmet deps: `gcc@=x %gcc@=x`.

I've taken the liberty to get rid of double globals that toggle concretization
and installation of compilers, that depend on each other in ways that are
hard to understand. Now there's just the `config:install_missing_compilers`
global which affects both concretization and installation.