### PR TITLE
R: fix build on macOS arm64

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -102,6 +102,8 @@ class R(AutotoolsPackage):
     # temporary fix to lower the optimization level.
     patch("change_optflags_tmp.patch", when="%fj@4.1.0")
 
+    build_directory = "spack-build"
+
     # R custom URL version
     def url_for_version(self, version):
         """Handle R's customed URL versions"""


### PR DESCRIPTION
This bug was detected in our ML CI pipeline. For some reason (case-insensitive file system?) R fails to build on macOS arm64 (haven't tested any other platforms) with the following error:
```
make[1]: Nothing to be done for `R'.
make[1]: Nothing to be done for `R'.
cp: ../../doc/html/katex and /var/folders/jv/cgkfvslj6nq1l7cw0c8c_8gm0000gn/T/Adam/spack-stage/spack-stage-r-4.3.0-t5xqwoytdy6supqlabd5jg3g2vziellp/spack-src/doc/html/katex are identical (not copied).
make[3]: *** [install-sources] Error 1
make[2]: *** [R] Error 2
make[1]: *** [R] Error 1
make: *** [R] Error 1
```
Changing the build directory solves this issue.