### PR TITLE
ci: Use newer image version for two service jobs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -220,7 +220,7 @@ protected-publish:
   - /^releases\/v.*/
   - /^v.*/
   - /^develop-[\d]{4}-[\d]{2}-[\d]{2}$/
-  image: "ghcr.io/spack/python-aws-bash:0.0.1"
+  image: "ghcr.io/spack/python-aws-bash:0.0.2"
   tags: ["spack", "public", "medium", "aws", "x86_64"]
   retry:
     max: 2

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -41,7 +41,7 @@ ci:
 
   - copy-job:
       tags: ["service", "x86_64"]
-      image: "ghcr.io/spack/python-aws-bash:0.0.1"
+      image: "ghcr.io/spack/python-aws-bash:0.0.2"
       before_script:
       - - if [[ $CI_COMMIT_TAG == "v"* ]]; then export SPACK_REPLACE_VERSION=$(echo "$CI_COMMIT_TAG" | sed 's/\(v[[:digit:]]\+\.[[:digit:]]\+\).*/releases\/\1/'); fi
         - if [[ $CI_COMMIT_TAG == "develop-"* ]]; then export SPACK_REPLACE_VERSION=develop; fi


### PR DESCRIPTION
The older image contained old versions of awscli and boto3, which we needed when boto3 still had bugs that affected spack buildcache creation in S3.  The bugs have long since been fixed, so this PR moves to an image with the latest versions of awscli and boto3.

This is a draft until the relevant spack/spack-infrastructure [PR](https://github.com/spack/spack-infrastructure/pull/590) is merged and the new image gets built.