### PR TITLE
OpenMPI: only requires one Fortran compiler

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -897,7 +897,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to
         # avoid delayed build errors in dependents.
-        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+        if (self.compiler.f77 is None) and (self.compiler.fc is None):
             raise InstallError("OpenMPI requires both C and Fortran compilers!")
 
     @when("@main")


### PR DESCRIPTION
Currently, https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/openmpi/package.py#L900-L901 has logic requiring definition of both self.compiler.f77 and self.compiler.fc.

```py
        if (self.compiler.f77 is None) or (self.compiler.fc is None):
            raise InstallError("OpenMPI requires both C and Fortran compilers!")
```

Based on the raised InstallError, it looks like self.compiler.fc may be a mistake and should instead be self.compiler.cc. However, the function it is defined in is `def die_without_fortran`, and from this name and the comments above it, it looks like the intention could just be to find a fortran compiler.

This PR proposes changing this line (or -> and) to:
```py
        if (self.compiler.f77 is None) and (self.compiler.fc is None):
            raise InstallError("OpenMPI requires both C and Fortran compilers!")
```

which will be satisfied if either f77 or fc is defined, rather than requiring both be defined. 

@tgamblin @davydden