### PR TITLE
hdfview: add v3.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -15,6 +15,11 @@ class Hdfview(Package):
     homepage = "https://www.hdfgroup.org/downloads/hdfview/"
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.4/src/hdfview-3.1.4.tar.gz"
 
+    version(
+        "3.1.3",
+        sha256='566807495305a32d3da65539a529f268fcfc375e6da32ed07c2b5723b9aa0c66',
+        url='https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.3/src/hdfview-3.1.3.tar.gz'
+    )
     version("3.3.0", sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430")
     version("3.2.0", sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8")
     version("3.1.4", sha256="898fcd5227d4e7b697efde5e5a969405f96b72517f9dfbdbdce2991290fd56a0")
@@ -29,12 +34,8 @@ class Hdfview(Package):
     patch("fix_build.patch", when="@3.1.1")
 
     depends_on("ant", type="build")
-    depends_on("hdf5 +java")
+    depends_on("hdf5@1.10.9 +java")
     depends_on("hdf +java -external-xdr +shared")
-
-    depends_on("hdf5@1.10", when="@:3.1")
-    depends_on("hdf5@1.12:", when="@3.2")
-    depends_on("hdf5@1.14:", when="@3.3:")
 
     def install(self, spec, prefix):
         ant = which("ant")
@@ -55,4 +56,5 @@ class Hdfview(Package):
     def setup_build_environment(self, env):
         env.set("HDF5LIBS", self.spec["hdf5"].prefix)
         env.set("HDFLIBS", self.spec["hdf"].prefix)
+        env.set("JAVA_HOME", self.spec["java"].prefix)
         env.set("ANT_HOME", self.spec["ant"].prefix)

--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -17,8 +17,8 @@ class Hdfview(Package):
 
     version(
         "3.1.3",
-        sha256='566807495305a32d3da65539a529f268fcfc375e6da32ed07c2b5723b9aa0c66',
-        url='https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.3/src/hdfview-3.1.3.tar.gz'
+        sha256="566807495305a32d3da65539a529f268fcfc375e6da32ed07c2b5723b9aa0c66",
+        url="https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.3/src/hdfview-3.1.3.tar.gz",
     )
     version("3.3.0", sha256="0916161861c21fa8dd354b445b48eff5a53d80a5c0b383e79eb64b7b108e2430")
     version("3.2.0", sha256="d3c0deff2cbd959508c4da9c712da72fb204ff6818a3434f00a7071f8e8cf2b8")


### PR DESCRIPTION
This PR fixes #39267 however that is for spack v0.20.1 which is what I run whereas here I am creating the PR for develop which has introduced some changes of syntax which I am struggling to keep up with. The patch that I fully understand and it's guaranteed to work is the following, as I said against v0.20.1 (should I make a separate PR against that for a possible .2 release, or is it a moot point?)

```
--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -15,6 +15,8 @@ class Hdfview(Package):
     homepage = "https://www.hdfgroup.org/downloads/hdfview/"
     url = "https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz"

+    version('3.1.3', sha256='566807495305a32d3da65539a529f268fcfc375e6da32ed07c2b5723b9aa0c66',
+                        url='https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-3.1.3/src/hdfview-3.1.3.tar.gz')
     version(
         "3.1.1",
         sha256="1cfd127ebb4c3b0ab1cfe54649a410fc7a1c2d73f45564697d3729f4aa6b0ba3",
@@ -26,12 +28,14 @@ class Hdfview(Package):
     patch("fix_build.patch", when="@3.1.1")

     depends_on("ant", type="build")
-    depends_on("hdf5 +java")
+    depends_on("hdf5@1.10.9 +java")
     depends_on("hdf +java -external-xdr +shared")

     def install(self, spec, prefix):
         env["HDF5LIBS"] = spec["hdf5"].prefix
         env["HDFLIBS"] = spec["hdf"].prefix
+        env["JAVA_HOME"] = spec["java"].prefix
+        env["ANT_HOME"] = spec["ant"].prefix
```

Even with this patch, HDFView compiles with spack, but does not work out of the box because for some reason it does not create the `lib` directory with all its content in the way that its developers envisioned (which should include a java install, an approach that I don't like and that probably the spack developers stripped? however as is it does not work).

This other problem can be solved in v0.20.1 by manually editing the `hdfview` script and setting the `JAVABIN` fully qualified path to the location of the spack-installed java (which concretized to `openjdk-11.0.17_8` for me, YMMV) and moreover by manually going into the hdfview install directory and running the following otherwise it cannot find the `jar`s.

```
# ln -s . ext
# mkdir lib
# cd lib
# ln -s ../ app
```

I know I could make a patch for this, but it's been quite a tour de force figuring out all of these, and I'm now too tired for doing it now.