### PR TITLE
FIX libfabric module file

### DIFF
--- a/var/spack/repos/builtin/packages/aws-ofi-rccl/package.py
+++ b/var/spack/repos/builtin/packages/aws-ofi-rccl/package.py
@@ -35,12 +35,12 @@ class AwsOfiRccl(AutotoolsPackage):
     # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
     def setup_run_environment(self, env):
         aws_ofi_rccl_home = self.spec["aws-ofi-rccl"].prefix
-        env.append_path("LD_LIBRARY_PATH", aws_ofi_rccl_home.lib)
+        env.prepend_path("LD_LIBRARY_PATH", aws_ofi_rccl_home.lib)
 
     # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
     def setup_dependent_run_environment(self, env, dependent_spec):
         aws_ofi_rccl_home = self.spec["aws-ofi-rccl"].prefix
-        env.append_path("LD_LIBRARY_PATH", aws_ofi_rccl_home.lib)
+        env.prepend_path("LD_LIBRARY_PATH", aws_ofi_rccl_home.lib)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -153,12 +153,12 @@ class Libfabric(AutotoolsPackage):
         if self.run_tests:
             env.prepend_path("PATH", self.prefix.bin)
 
-    # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
+    # To enable this package add it to the LD_LIBRARY_PATH
     def setup_run_environment(self, env):
         libfabric_home = self.spec["libfabric"].prefix
         env.prepend_path("LD_LIBRARY_PATH", libfabric_home.lib)
 
-    # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
+    # To enable this package add it to the LD_LIBRARY_PATH
     def setup_dependent_run_environment(self, env, dependent_spec):
         libfabric_home = self.spec["libfabric"].prefix
         env.prepend_path("LD_LIBRARY_PATH", libfabric_home.lib)

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -153,6 +153,16 @@ class Libfabric(AutotoolsPackage):
         if self.run_tests:
             env.prepend_path("PATH", self.prefix.bin)
 
+    # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
+    def setup_run_environment(self, env):
+        libfabric_home = self.spec["libfabric"].prefix
+        env.prepend_path("LD_LIBRARY_PATH", libfabric_home.lib)
+
+    # To enable this plug-in to work with RCCL add it to the LD_LIBRARY_PATH
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        libfabric_home = self.spec["libfabric"].prefix
+        env.prepend_path("LD_LIBRARY_PATH", libfabric_home.lib)
+
     @when("@main")
     def autoreconf(self, spec, prefix):
         bash = which("bash")


### PR DESCRIPTION
Add support to export the LD_LIBRARY_PATH for the libfabric package
and subsequent module files.

Fix the AWS OFI RCCL package so that it prepends the enviornment variables.