### PR TITLE
py-torchmetrics: add v1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchmetrics/package.py
+++ b/var/spack/repos/builtin/packages/py-torchmetrics/package.py
@@ -14,6 +14,7 @@ class PyTorchmetrics(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("1.0.2", sha256="537989d02337814e621a45232eeb1eacfd4700a66c2b5161d19ca2158246e075")
     version("0.11.4", sha256="1fe45a14b44dd65d90199017dd5a4b5a128d56a8a311da7916c402c18c671494")
     version("0.11.3", sha256="6a2bcc17361f0e4c1668c92595b12ef30ccf9ef1d03263bee7c6136a882afe30")
     version("0.11.2", sha256="5a1f5fff9b1fb695bbcab6442d768e2e9b9535d00f4b4dea9ce03d40c866be07")
@@ -32,11 +33,21 @@ class PyTorchmetrics(PythonPackage):
     version("0.3.1", sha256="78f4057db53f7c219fdf9ec9eed151adad18dd43488a44e5c780806d218e3f1d")
     version("0.2.0", sha256="481a28759acd2d77cc088acba6bc7dc4a356c7cb767da2e1495e91e612e2d548")
 
+    # pyproject.toml
+    depends_on("python@3.8:", when="@1:", type=("build", "run"))
+
+    # setup.py
     depends_on("py-setuptools", type="build")
+
+    # requirements.txt (upper bound is removed during processing)
+    depends_on("py-numpy@1.20.1:", when="@1:", type=("build", "run"))
     depends_on("py-numpy@1.17.2:", when="@0.4:", type=("build", "run"))
     depends_on("py-numpy", when="@0.3:", type=("build", "run"))
     depends_on("py-torch@1.8.1:", when="@0.11:", type=("build", "run"))
     depends_on("py-torch@1.3.1:", type=("build", "run"))
-    depends_on("py-pydeprecate@0.3", when="@0.7:0.8", type=("build", "run"))
-    depends_on("py-packaging", when="@0.3:", type=("build", "run"))
     depends_on("py-typing-extensions", when="@0.9: ^python@:3.8", type=("build", "run"))
+    depends_on("py-packaging", when="@0.3:", type=("build", "run"))
+    depends_on("py-lightning-utilities@0.7:", when="@1:", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("py-pydeprecate@0.3", when="@0.7:0.8", type=("build", "run"))


### PR DESCRIPTION
https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.0.2

1.0.0 and 1.0.1 aren't available as sdists on PyPI for reasons so I didn't add them.