### PR TITLE
Add colon escape logic to config add

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -892,7 +892,6 @@ def add(fullpath, scope=None):
         path += "::"
 
     if has_existing_value:
-        value = syaml.load_config(value)
         existing = get(path, scope=scope)
 
     # append values to lists

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -889,7 +889,7 @@ def add(fullpath, scope=None):
             break
 
     if has_existing_value:
-        path, value , _ = fullpath.rpartition(components[-1])
+        path, value, _ = fullpath.rpartition(components[-1])
         # Breaking down path in this way leaves a dangling
         # separator, remove it
         path, *_ = path.rpartition(":")

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1241,7 +1241,8 @@ def process_config_path(path):
     Note: quoted value path components will be processed as a single value (escaping colons)
         quoted path components outside of the value will be considered ill formed and will
         raise.
-        e.g.: `this:is:a:path:'value:with:colon'` will yield:
+        e.g. `this:is:a:path:'value:with:colon'` will yield:
+
             [this, is, a, path, value:with:colon]
     """
     result = []

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -863,6 +863,7 @@ def add(fullpath, scope=None):
     has_existing_value = True
     path = ""
     override = False
+    value = syaml.load_config(components[-1])
     for idx, name in enumerate(components[:-1]):
         # First handle double colons in constructing path
         colon = "::" if override else ":" if path else ""
@@ -883,7 +884,6 @@ def add(fullpath, scope=None):
             existing = get_valid_type(path)
 
             # construct value from this point down
-            value = syaml.load_config(components[-1])
             for component in reversed(components[idx + 1 : -1]):
                 value = {component: value}
             break

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -432,7 +432,7 @@ class Configuration:
         return [
             s
             for s in self.scopes.values()
-            if (type(s) is ConfigScope or type(s) is SingleFileScope)
+            if (isinstance(s, ConfigScope) or isinstance(s, SingleFileScope))
         ]
 
     def highest_precedence_scope(self) -> ConfigScope:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1266,9 +1266,9 @@ def interp_escapes(path):
 def escape_colons(path):
     """Replaces colon characters with hex representation
     in config path arguments so long as the colon is properly escaped
-    with respect to yaml syntax (between two double quotes)"""
+    with respect to yaml syntax (between two single quotes)"""
     # Indicator that we are parsing within the context of a potential escape sequence
-    # However, standalone double quotes are not an escape character and they
+    # However, standalone single quotes are not an escape character and they
     # should be ignored here
     escaped_colon_idx = 0
     inside_escape = False

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -889,9 +889,12 @@ def add(fullpath, scope=None):
             break
 
     if has_existing_value:
-        *path, value = components
+        path, value , _ = fullpath.rpartition(components[-1])
+        # Breaking down path in this way leaves a dangling
+        # separator, remove it
+        path, *_ = path.rpartition(":")
         value = syaml.load_config(value)
-        existing = get(":".join(path), scope=scope)
+        existing = get(path, scope=scope)
 
     # append values to lists
     if isinstance(existing, list) and not isinstance(value, list):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1298,7 +1298,6 @@ def escape_colons(path):
 # trailing ':')
 #
 def process_config_path(path):
-    import pdb; pdb.set_trace()
     path = escape_colons(path)
     result = []
     if path.startswith(":"):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -432,7 +432,7 @@ class Configuration:
         return [
             s
             for s in self.scopes.values()
-            if (isinstance(s, ConfigScope) or isinstance(s, SingleFileScope))
+            if (type(s) is ConfigScope or type(s) is SingleFileScope)
         ]
 
     def highest_precedence_scope(self) -> ConfigScope:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1241,7 +1241,7 @@ def interp_escapes(path):
     i = 0
     path_len = len(path)
     while i < path_len:
-        if path[i] == "%":
+        if path[i] == "\a":
             # processing a potential replacement character
             hex_chars = path[i + 1 : i + 3]
             try:
@@ -1280,7 +1280,7 @@ def escape_colons(path):
             token = ""
         elif current_char == "'" and not (token and token[-1] == "\\"):
             if inside_escape:
-                token = "%3a".join(path_tokens[escaped_colon_idx:] + [token])
+                token = "\a3a".join(path_tokens[escaped_colon_idx:] + [token])
                 path_tokens[escaped_colon_idx:] = ""
                 inside_escape = False
             else:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -889,9 +889,9 @@ def add(fullpath, scope=None):
             break
 
     if has_existing_value:
-        path, _, value = escape_colons(fullpath).rpartition(":")
-        value = syaml.load_config(interp_escapes(value))
-        existing = get(interp_escapes(path), scope=scope)
+        *path, value = components
+        value = syaml.load_config(value)
+        existing = get(":".join(path), scope=scope)
 
     # append values to lists
     if isinstance(existing, list) and not isinstance(value, list):
@@ -1231,74 +1231,16 @@ def merge_yaml(dest, source, prepend=False, append=False):
     return copy.copy(source)
 
 
-def interp_escapes(path):
-    """Interpolate escaped characters based on their hex value
-    when found in the scheme %<hex>"""
-    # local method `set` eclipses builtin python class here
-    # so construct set via direct reference to class
-    known_escape_vals = {58}
-    interped_path = ""
-    i = 0
-    path_len = len(path)
-    while i < path_len:
-        if path[i] == "\a":
-            # processing a potential replacement character
-            hex_chars = path[i + 1 : i + 3]
-            try:
-                esc_int = int(hex_chars, base=16)
-                # valid hex may just be coincidence, ensure
-                # value is one of expected escapes
-                if esc_int in known_escape_vals:
-                    rep_text = chr(esc_int)
-                    interped_path = interped_path + rep_text
-                    i += 3
-                    continue
-            except ValueError:
-                # processed characters are not valid hex
-                # and as such not a valid replacement
-                interped_path = interped_path + path[i]
-        else:
-            interped_path = interped_path + path[i]
-        i += 1
-    return interped_path
-
-
-def escape_colons(path):
-    """Replaces colon characters with hex representation
-    in config path arguments so long as the colon is properly escaped
-    with respect to yaml syntax (between two single quotes)"""
-    # Indicator that we are parsing within the context of a potential escape sequence
-    # However, standalone single quotes are not an escape character and they
-    # should be ignored here
-    escaped_colon_idx = 0
-    inside_escape = False
-    path_tokens = []
-    token = ""
-    for current_char in path:
-        if current_char == ":":
-            path_tokens.append(token)
-            token = ""
-        elif current_char == "'" and not (token and token[-1] == "\\"):
-            if inside_escape:
-                token = "\a3a".join(path_tokens[escaped_colon_idx:] + [token])
-                path_tokens[escaped_colon_idx:] = ""
-                inside_escape = False
-            else:
-                escaped_colon_idx = len(path_tokens)
-                inside_escape = True
-            token += current_char
-        else:
-            token += current_char
-    path_tokens.append(token)
-    return ":".join(path_tokens)
-
-
-#
-# Process a path argument to config.set() that may contain overrides ('::' or
-# trailing ':')
-#
 def process_config_path(path):
-    path = escape_colons(path)
+    """Process a path argument to config.set() that may contain overrides ('::' or
+    trailing ':')
+
+    Note: quoted value path components will be processed as a single value (escaping colons)
+        quoted path components outside of the value will be considered ill formed and will
+        raise.
+        e.g.: `this:is:a:path:'value:with:colon'` will yield:
+            [this, is, a, path, value:with:colon]
+    """
     result = []
     if path.startswith(":"):
         raise syaml.SpackYAMLError("Illegal leading `:' in path `{0}'".format(path), "")
@@ -1325,7 +1267,17 @@ def process_config_path(path):
             front = syaml.syaml_str(front)
             front.append = True
 
-        result.append(interp_escapes(front))
+        quote = "['\"]"
+        not_quote = "[^'\"]"
+
+        if re.match(f"^{quote}", path):
+            m = re.match(rf"^{quote}({not_quote}+){quote}$", path)
+            if not m:
+                raise ValueError("Quotes indicate value, but there are additional path entries")
+            result.append(m.group(1))
+            break
+
+        result.append(front)
     return result
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -888,11 +888,10 @@ def add(fullpath, scope=None):
                 value = {component: value}
             break
 
+    if override:
+        path += "::"
+
     if has_existing_value:
-        path, value, _ = fullpath.rpartition(components[-1])
-        # Breaking down path in this way leaves a dangling
-        # separator, remove it
-        path, *_ = path.rpartition(":")
         value = syaml.load_config(value)
         existing = get(path, scope=scope)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1278,7 +1278,7 @@ def escape_colons(path):
         if current_char == ":":
             path_tokens.append(token)
             token = ""
-        elif current_char == '"' and not (token and token[-1] == "\\"):
+        elif current_char == "'" and not (token and token[-1] == "\\"):
             if inside_escape:
                 token = "%3a".join(path_tokens[escaped_colon_idx:] + [token])
                 path_tokens[escaped_colon_idx:] = ""
@@ -1298,6 +1298,7 @@ def escape_colons(path):
 # trailing ':')
 #
 def process_config_path(path):
+    import pdb; pdb.set_trace()
     path = escape_colons(path)
     result = []
     if path.startswith(":"):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -255,48 +255,6 @@ def test_write_to_same_priority_file(mock_low_high_config, compiler_specs):
     check_compiler_config(b_comps["compilers"], *compiler_specs.b)
 
 
-# Test config path escaping and interpolating
-
-
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        # note: Windows path used below as example but since the method
-        # has no understanding of "paths" this is sufficently generic
-        (
-            'config:install_tree:root:"C:/example/path"',
-            'config:install_tree:root:"C%3a/example/path"',
-        ),
-        ('config:path_entry:"key:with:colons"', 'config:path_entry:"key%3awith%3acolons"'),
-        ('"colons:first":test:path', '"colons%3afirst":test:path'),
-        ('config:with:escaped:\\"quotes:test\\"', 'config:with:escaped:\\"quotes:test\\"'),
-        ('config:with:"single:double_quote', 'config:with:"single:double_quote'),
-    ],
-)
-def test_escape_colons(path, expected):
-    escaped_path = spack.config.escape_colons(path)
-    assert escaped_path == expected
-
-
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        # note: Windows path used below as example but since the method
-        # has no understanding of "paths" this is sufficently generic
-        (
-            'config:install_tree:root:"C%3a/example/path"',
-            'config:install_tree:root:"C:/example/path"',
-        ),
-        ('config:path_entry:"key%3awith%3acolons"', 'config:path_entry:"key:with:colons"'),
-        ('"colons%3afirst":test:path', '"colons:first":test:path'),
-        ("config:with:%random:percent", "config:with:%random:percent"),
-    ],
-)
-def test_interpolate_escape_characters(path, expected):
-    interped_path = spack.config.interp_escapes(path)
-    assert interped_path == expected
-
-
 #
 # Sample repo data and tests
 #


### PR DESCRIPTION
`process_config_path` disregards typical yaml escape syntax, and as such, Windows paths containing drives are broken down by the yaml separator `:`, which is also the drive separator. This PR implements a parser that respects yaml quoting escapes and replaces any ':' characters within the quotes with a placeholder character, which is replaced post processing. 

Verified that this works for the CI.