### PR TITLE
package:py-wand add build env var, add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-wand/package.py
+++ b/var/spack/repos/builtin/packages/py-wand/package.py
@@ -21,9 +21,6 @@ class PyWand(PythonPackage):
     depends_on("py-setuptools", type="build")
     # provides libmagickwand
     depends_on("imagemagick")
-    depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
-
-    depends_on("py-sphinx@1:", type="build", when="+docs")
 
     def setup_build_environment(self, env):
         env.set('MAGICK_HOME', self.spec['imagemagick'].prefix)

--- a/var/spack/repos/builtin/packages/py-wand/package.py
+++ b/var/spack/repos/builtin/packages/py-wand/package.py
@@ -16,8 +16,6 @@ class PyWand(PythonPackage):
     version("0.5.6", sha256="d06b59f36454024ce952488956319eb542d5dc65f1e1b00fead71df94dbfcf88")
     version("0.4.2", sha256="a0ded99a9824ddd82617a4b449164e2c5c93853aaff96f9e0bab8b405d62ca7c")
 
-    variant("docs", default=False, description="Build docs")
-
     depends_on("py-setuptools", type="build")
     # provides libmagickwand
     depends_on("imagemagick")

--- a/var/spack/repos/builtin/packages/py-wand/package.py
+++ b/var/spack/repos/builtin/packages/py-wand/package.py
@@ -26,4 +26,4 @@ class PyWand(PythonPackage):
     depends_on("py-sphinx@1:", type="build", when="+docs")
 
     def setup_build_environment(self, env):
-        env.set('MAGICK_HOME', self.spec['imagemagick'].prefix)
+        env.set("MAGICK_HOME", self.spec["imagemagick"].prefix)

--- a/var/spack/repos/builtin/packages/py-wand/package.py
+++ b/var/spack/repos/builtin/packages/py-wand/package.py
@@ -25,6 +25,5 @@ class PyWand(PythonPackage):
 
     depends_on("py-sphinx@1:", type="build", when="+docs")
 
-
     def setup_build_environment(self, env):
         env.set('MAGICK_HOME', self.spec['imagemagick'].prefix)

--- a/var/spack/repos/builtin/packages/py-wand/package.py
+++ b/var/spack/repos/builtin/packages/py-wand/package.py
@@ -12,6 +12,7 @@ class PyWand(PythonPackage):
     homepage = "https://docs.wand-py.org"
     pypi = "Wand/Wand-0.5.6.tar.gz"
 
+    version("0.6.11", sha256="b661700da9f8f1e931e52726e4fc643a565b9514f5883d41b773e3c37c9fa995")
     version("0.5.6", sha256="d06b59f36454024ce952488956319eb542d5dc65f1e1b00fead71df94dbfcf88")
     version("0.4.2", sha256="a0ded99a9824ddd82617a4b449164e2c5c93853aaff96f9e0bab8b405d62ca7c")
 
@@ -23,3 +24,7 @@ class PyWand(PythonPackage):
     depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
 
     depends_on("py-sphinx@1:", type="build", when="+docs")
+
+
+    def setup_build_environment(self, env):
+        env.set('MAGICK_HOME', self.spec['imagemagick'].prefix)


### PR DESCRIPTION
it turns out py-wand fail to build if system installation of imagemagick is removed, hence the need for this PR. Also add new version (which still seems to be compatible with python@2.7 and python@3.3:)