### PR TITLE
In-place buildcache tar file creation

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1299,6 +1299,15 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
     # create info for later relocation and create tar
     buildinfo = get_buildinfo_dict(spec)
 
+    remote_url = urllib.parse.urlparse(out_url)
+    if remote_url.scheme == "file":
+        # If we're writing to a filesystem location, we can do everything in
+        # place.
+        tarfile_path = url_util.local_file_path(remote_spackfile_path)
+        specfile_path = url_util.local_file_path(remote_specfile_path)
+        mkdirp(os.path.dirname(tarfile_path))
+        mkdirp(os.path.dirname(specfile_path))
+
     _do_create_tarball(tarfile_path, binaries_dir, pkg_dir, buildinfo)
 
     # get the sha256 checksum of the tarball
@@ -1327,13 +1336,14 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
         key = select_signing_key(options.key)
         sign_specfile(key, options.force, specfile_path)
 
-    # push tarball and signed spec json to remote mirror
-    web_util.push_to_url(spackfile_path, remote_spackfile_path, keep_original=False)
-    web_util.push_to_url(
-        signed_specfile_path if not options.unsigned else specfile_path,
-        remote_signed_specfile_path if not options.unsigned else remote_specfile_path,
-        keep_original=False,
-    )
+    if remote_url.scheme != "file":
+        # push tarball and signed spec json to remote mirror
+        web_util.push_to_url(spackfile_path, remote_spackfile_path, keep_original=False)
+        web_util.push_to_url(
+            signed_specfile_path if not options.unsigned else specfile_path,
+            remote_signed_specfile_path if not options.unsigned else remote_specfile_path,
+            keep_original=False,
+        )
 
     # push the key to the build cache's _pgp directory so it can be
     # imported


### PR DESCRIPTION
Currently when writing to a filesystem buildcache, a tar file is created and then moved or copied into the specified location. The tar file is only copied if it is across a file-system boundary, but disk-less nodes with a buildcache on permanent networked storage is not that uncommon of a configuration in HPC environments. Not writing the tar file directly to the buildcache can consume large amounts of memory for some applications (also dependent upon build flags), sometimes even causing OOM errors. This patch makes spack write the packaged spec directly to the buildcache avoiding unnecessary disk usage and a potentially expensive copy operation.