### PR TITLE
add wrf4.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -70,6 +70,11 @@ class Wrf(Package):
     tags = ["windows"]
 
     version(
+        "4.5.1",
+        sha256="9d557c34c105db4d41e727843ecb19199233c7cf82c5369b34a2ce8efe65e2d1",
+        url="https://github.com/wrf-model/WRF/releases/download/v4.5.1/v4.5.1.tar.gz",
+    )
+    version(
         "4.5.0",
         sha256="14fd78abd4e32c1d99e2e97df0370030a5c58ec84c343591bdc5e74f163c5525",
         url="https://github.com/wrf-model/WRF/releases/download/v4.5/v4.5.tar.gz",


### PR DESCRIPTION
Add support for [wrf 4.5.1](https://github.com/wrf-model/WRF/releases/tag/v4.5.1).  Have been tested with gcc-9.5.0 and oneapi-2023.2.0