### PR TITLE
freeglut: set correct library name

### DIFF
--- a/var/spack/repos/builtin/packages/freeglut/package.py
+++ b/var/spack/repos/builtin/packages/freeglut/package.py
@@ -71,3 +71,7 @@ class Freeglut(CMakePackage, SourceforgePackage):
         ]
 
         return args
+
+    @property
+    def libs(self):
+        return find_libraries(["libglut"], root=self.prefix, recursive=True)


### PR DESCRIPTION
freeglut provides a library named e.g. libglut.so in linux and not libfreeglut.so.