### PR TITLE
Better detection of Python libs/headers

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -318,9 +318,12 @@ class PythonPackage(PythonExtension):
     def headers(self):
         """Discover header files in platlib."""
 
+        # Remove py- prefix in package name
+        name = self.spec.name[3:]
+
         # Headers may be in either location
-        include = self.prefix.join(self.spec["python"].package.include)
-        platlib = self.prefix.join(self.spec["python"].package.platlib)
+        include = self.prefix.join(self.spec["python"].package.include).join(name)
+        platlib = self.prefix.join(self.spec["python"].package.platlib).join(name)
         headers = fs.find_all_headers(include) + fs.find_all_headers(platlib)
 
         if headers:
@@ -334,13 +337,14 @@ class PythonPackage(PythonExtension):
         """Discover libraries in platlib."""
 
         # Remove py- prefix in package name
-        library = "lib" + self.spec.name[3:].replace("-", "?")
-        root = self.prefix.join(self.spec["python"].package.platlib)
+        name = self.spec.name[3:]
 
-        for shared in [True, False]:
-            libs = fs.find_libraries(library, root, shared=shared, recursive=True)
-            if libs:
-                return libs
+        root = self.prefix.join(self.spec["python"].package.platlib).join(name)
+
+        libs = fs.find_all_libraries(root, recursive=True)
+
+        if libs:
+            return libs
 
         msg = "Unable to recursively locate {} libraries in {}"
         raise NoLibrariesError(msg.format(self.spec.name, root))


### PR DESCRIPTION
Follow-up to #28527 and #32970.

Our first draft of Python library detection mostly followed the same design we use for all other packages: look for `lib<name>` but in platlib instead of lib/lib64. However, this doesn't work for many packages. For example, numpy has no libnumpy.so file:

<details>
  <summary>numpy libraries</summary>
  
```console
> find . -name '*.so'
./lib/python3.9/site-packages/numpy/core/_operand_flag_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_multiarray_umath.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_simd.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_rational_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_umath_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_struct_ufunc_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_multiarray_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/linalg/lapack_lite.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/linalg/_umath_linalg.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/fft/_pocketfft_internal.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/bit_generator.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/mtrand.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_generator.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_pcg64.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_sfc64.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_mt19937.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_philox.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_bounded_integers.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_common.cpython-39-darwin.so
> find . -name '*.a'
./lib/python3.9/site-packages/numpy/core/lib/libnpymath.a
./lib/python3.9/site-packages/numpy/random/lib/libnpyrandom.a
```
</details>

Also, the header detection can accidentally pick up headers from other packages if they are installed in a shared conda installation. Note that numpy also stores all of its headers in the numpy subdirectory:

<details>
  <summary>numpy headers</summary>
  
```console
> find . -name '*.h'
./lib/python3.9/site-packages/numpy/core/include/numpy/ndarrayobject.h
./lib/python3.9/site-packages/numpy/core/include/numpy/utils.h
./lib/python3.9/site-packages/numpy/core/include/numpy/__multiarray_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/oldnumeric.h
./lib/python3.9/site-packages/numpy/core/include/numpy/experimental_dtype_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/libdivide/libdivide.h
./lib/python3.9/site-packages/numpy/core/include/numpy/old_defines.h
./lib/python3.9/site-packages/numpy/core/include/numpy/ufuncobject.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_common.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_cpu.h
./lib/python3.9/site-packages/numpy/core/include/numpy/ndarraytypes.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_no_deprecated_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_3kcompat.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_os.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_endian.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_interrupt.h
./lib/python3.9/site-packages/numpy/core/include/numpy/_numpyconfig.h
./lib/python3.9/site-packages/numpy/core/include/numpy/_neighborhood_iterator_imp.h
./lib/python3.9/site-packages/numpy/core/include/numpy/numpyconfig.h
./lib/python3.9/site-packages/numpy/core/include/numpy/__ufunc_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/arrayscalars.h
./lib/python3.9/site-packages/numpy/core/include/numpy/random/distributions.h
./lib/python3.9/site-packages/numpy/core/include/numpy/random/bitgen.h
./lib/python3.9/site-packages/numpy/core/include/numpy/npy_math.h
./lib/python3.9/site-packages/numpy/core/include/numpy/halffloat.h
./lib/python3.9/site-packages/numpy/core/include/numpy/arrayobject.h
./lib/python3.9/site-packages/numpy/core/include/numpy/_dtype_api.h
./lib/python3.9/site-packages/numpy/core/include/numpy/noprefix.h
./lib/python3.9/site-packages/numpy/f2py/src/fortranobject.h
```
</details>

This PR instead searches for ALL libs/headers, but only in the `<name>` subdirectory of platlib/include. This should be less likely to detect no libs/headers or the wrong libs/headers. Each package can of course override this property, this is simply the default.