### PR TITLE
libzmq: Do not treat warnings as errors during compilation.

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -109,7 +109,9 @@ class Libzmq(AutotoolsPackage):
         config_args.extend(self.enable_or_disable("libunwind"))
         # the package won't compile with newer compilers because warnings
         # are converted to errors. Hence, disable such conversion.
-        config_args.append("--disable-Werror")
+        # this option was only added in version 4.2.3.
+        if(self.spec.version >= Version("4.2.3")):
+            config_args.append("--disable-Werror")
 
         if "+libsodium" in self.spec:
             config_args.append("--with-libsodium=" + self.spec["libsodium"].prefix)

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -110,7 +110,7 @@ class Libzmq(AutotoolsPackage):
         # the package won't compile with newer compilers because warnings
         # are converted to errors. Hence, disable such conversion.
         # this option was only added in version 4.2.3.
-        if(self.spec.version >= Version("4.2.3")):
+        if self.spec.version >= Version("4.2.3"):
             config_args.append("--disable-Werror")
 
         if "+libsodium" in self.spec:

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -107,6 +107,9 @@ class Libzmq(AutotoolsPackage):
         config_args.extend(self.enable_or_disable("drafts"))
         config_args.extend(self.enable_or_disable("libbsd"))
         config_args.extend(self.enable_or_disable("libunwind"))
+        # the package won't compile with newer compilers because warnings
+        # are converted to errors. Hence, disable such conversion.
+        config_args.append("--disable-Werror")
 
         if "+libsodium" in self.spec:
             config_args.append("--with-libsodium=" + self.spec["libsodium"].prefix)


### PR DESCRIPTION
The package won't compile with newer compilers because warnings are converted to errors. Hence, disable such conversion.