### PR TITLE
Ensure that user config is not readable by other users

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2858,3 +2858,16 @@ class FindFirstFile:
                 if self.match(file):
                     return os.path.join(dirpath, file)
         return None
+
+
+@contextmanager
+def temporary_umask(mask: Optional[int]):
+    """Temporarily set the umask to the given value."""
+    if mask is None:
+        yield
+        return
+    old_mask = os.umask(mask)
+    try:
+        yield
+    finally:
+        os.umask(old_mask)

--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
+from typing import Callable
 
 from ._functions import _host, by_name, platforms, prevent_cray_detection, reset
 from ._platform import Platform
@@ -32,7 +33,7 @@ real_host = _host
 
 #: The current platform used by Spack. May be swapped by the use_platform
 #: context manager.
-host = _host
+host: Callable[[], Platform] = _host
 
 
 class _PickleableCallable:

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -2,11 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from typing import Optional
+from typing import Dict, Optional
 
 import llnl.util.lang
 
 import spack.error
+import spack.operating_systems
+import spack.target
 
 
 class NoPlatformError(spack.error.SpackError):
@@ -55,9 +57,9 @@ class Platform:
     reserved_targets = ["default_target", "frontend", "fe", "backend", "be"]
     reserved_oss = ["default_os", "frontend", "fe", "backend", "be"]
 
-    def __init__(self, name):
-        self.targets = {}
-        self.operating_sys = {}
+    def __init__(self, name: str):
+        self.targets: Dict[str, spack.target.Target] = {}
+        self.operating_sys: Dict[str, spack.operating_systems.OperatingSystem] = {}
         self.name = name
 
     def add_target(self, name, target):


### PR DESCRIPTION
Files such as `~/.spack/mirrors.yaml` may contain secrets, so follow `~/.ssh` best practices of `0o600` file permissions.

This PR sets umask `0o077` when creating the user config.