### PR TITLE
Push conflict between rocm and blt down to packages that actually use blt

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -140,8 +140,6 @@ class ROCmPackage(PackageBase):
     depends_on("hsa-rocr-dev", when="+rocm")
     depends_on("hip +rocm", when="+rocm")
 
-    conflicts("^blt@:0.3.6", when="+rocm")
-
     # need amd gpu type for rocm builds
     conflicts("amdgpu_target=none", when="+rocm")
 

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -163,6 +163,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("+openmp", when="+rocm")
     conflicts("+cuda", when="+rocm")
 
+    conflicts("^blt@:0.3.6", when="+rocm")
+
     def flag_handler(self, name, flags):
         if self.spec.satisfies("%cce") and name == "fflags":
             flags.append("-ef")

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -55,6 +55,8 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("blt")
 
+    conflicts("^blt@:0.3.6", when="+rocm")
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -34,6 +34,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("blt@0.4.0:", type="build", when="@0.3.1:")
     depends_on("blt@:0.3.6", type="build", when="@:0.3.0")
+    conflicts("^blt@:0.3.6", when="+rocm")
 
     depends_on("camp")
     depends_on("umpire@develop")

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -52,6 +52,7 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.4.1:", type="build", when="@2.4.0:")
     depends_on("blt@0.4.0:", type="build", when="@2.3.0")
     depends_on("blt@0.3.6:", type="build", when="@:2.2.2")
+    conflicts("^blt@:0.3.6", when="+rocm")
 
     depends_on("umpire")
     depends_on("umpire@2022.03.0:", when="@2022.03.0:")

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -30,12 +30,12 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     variant("caliper", default=False, description="Build with Caliper support enabled.")
 
     depends_on("mpi", when="+mpi")
-    depends_on("blt")
-    depends_on("cmake")
+    depends_on("blt", type="build")
     depends_on("caliper", when="+caliper")
     depends_on("chai~examples+raja")
     depends_on("raja~exercises~examples")
     depends_on("umpire~examples")
+    conflicts("^blt@:0.3.6", when="+rocm")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -55,11 +55,12 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant("tests", default=False, description="Build tests")
 
-    depends_on("blt")
+    depends_on("blt", type="build")
     depends_on("blt@0.5.0:", type="build", when="@0.14.1:")
     depends_on("blt@0.4.1", type="build", when="@0.14.0")
     depends_on("blt@0.4.0:", type="build", when="@0.13.0")
     depends_on("blt@0.3.6:", type="build", when="@:0.12.0")
+    conflicts("^blt@:0.3.6", when="+rocm")
 
     depends_on("camp@0.2.2:0.2.3", when="@0.14.0")
     depends_on("camp@0.1.0", when="@0.10.0:0.13.0")

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -90,6 +90,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("blt@0.4.1", type="build", when="@6.0.0")
     depends_on("blt@0.4.0:", type="build", when="@4.1.3:5.0.1")
     depends_on("blt@0.3.6:", type="build", when="@:4.1.2")
+    conflicts("^blt@:0.3.6", when="+rocm")
 
     depends_on("camp", when="@5.0.0:")
     depends_on("camp@0.2.2:0.2.3", when="@6.0.0")


### PR DESCRIPTION
Extracted from #38748 

A lot of packages inherit from `RocmPackage`, but only a few use `blt`.