### PR TITLE
lcov: add version2, embed perl path in binaries

### DIFF
--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -13,15 +13,15 @@ class Lcov(MakefilePackage):
     supports statement, function and branch coverage measurement."""
 
     homepage = "http://ltp.sourceforge.net/coverage/lcov.php"
-    url = "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz"
+    url = "https://github.com/linux-test-project/lcov/releases/download/v2.0/lcov-2.0.tar.gz"
     maintainers("KineticTheory")
 
+    version("2.0", sha256="1857bb18e27abe8bcec701a907d5c47e01db4d4c512fc098d1a6acd29267bf46")
     version("1.16", sha256="987031ad5528c8a746d4b52b380bc1bffe412de1f2b9c2ba5224995668e3240b")
     version("1.15", sha256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a")
     version("1.14", sha256="14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a")
 
-    depends_on("perl")
-
+    depends_on("perl", type=("build", "run"))
     def install(self, spec, prefix):
         make(
             "LCOV_PERL_PATH=%s" % self.spec["perl"].command.path,
@@ -29,3 +29,4 @@ class Lcov(MakefilePackage):
             "PREFIX=%s" % prefix,
             "install",
         )
+

--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -21,8 +21,8 @@ class Lcov(MakefilePackage):
     version("1.15", sha256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a")
     version("1.14", sha256="14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a")
 
-    #dependencies from
-    #https://github.com/linux-test-project/lcov/blob/02ece21d54ccd16255d74f8b00f8875b6c15653a/README#L91-L111
+    # dependencies from
+    # https://github.com/linux-test-project/lcov/blob/02ece21d54ccd16255d74f8b00f8875b6c15653a/README#L91-L111
     depends_on("perl", type=("build", "run"))
     depends_on("perl-capture-tiny", type=("run"))
     depends_on("perl-devel-cover", type=("run"))
@@ -32,6 +32,7 @@ class Lcov(MakefilePackage):
     depends_on("perl-json", type=("run"))
     depends_on("perl-memory-process", type=("run"))
     depends_on("perl-time-hires", type=("run"))
+
     def install(self, spec, prefix):
         make(
             "LCOV_PERL_PATH=%s" % self.spec["perl"].command.path,
@@ -39,4 +40,3 @@ class Lcov(MakefilePackage):
             "PREFIX=%s" % prefix,
             "install",
         )
-

--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -21,7 +21,17 @@ class Lcov(MakefilePackage):
     version("1.15", sha256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a")
     version("1.14", sha256="14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a")
 
+    #dependencies from
+    #https://github.com/linux-test-project/lcov/blob/02ece21d54ccd16255d74f8b00f8875b6c15653a/README#L91-L111
     depends_on("perl", type=("build", "run"))
+    depends_on("perl-capture-tiny", type=("run"))
+    depends_on("perl-devel-cover", type=("run"))
+    depends_on("perl-datetime", type=("run"))
+    depends_on("perl-digest-md5", type=("run"))
+    depends_on("perl-file-spec", type=("run"))
+    depends_on("perl-json", type=("run"))
+    depends_on("perl-memory-process", type=("run"))
+    depends_on("perl-time-hires", type=("run"))
     def install(self, spec, prefix):
         make(
             "LCOV_PERL_PATH=%s" % self.spec["perl"].command.path,

--- a/var/spack/repos/builtin/packages/perl-datetime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDatetime(PerlPackage):
+    """DateTime - A date and time object for Perl"""
+
+    homepage = "https://metacpan.org/pod/DateTime"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-1.63.tar.gz"
+
+    version("1.63", sha256="1b11e49ec6e184ae2a10eccd05eda9534f32458fc644c12ab710c29a3a816f6f")

--- a/var/spack/repos/builtin/packages/perl-datetime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime/package.py
@@ -13,3 +13,5 @@ class PerlDatetime(PerlPackage):
     url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-1.63.tar.gz"
 
     version("1.63", sha256="1b11e49ec6e184ae2a10eccd05eda9534f32458fc644c12ab710c29a3a816f6f")
+
+    depends_on("perl-namespace-autoclean", type=("run"))

--- a/var/spack/repos/builtin/packages/perl-devel-cover/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-cover/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDevelCover(PerlPackage):
+    """Devel::Cover - Perl extension for code coverage metrics"""
+
+    homepage = "https://metacpan.org/pod/Devel::Cover"
+    url = "https://cpan.metacpan.org/authors/id/P/PJ/PJCJ/Devel-Cover-1.40.tar.gz"
+
+    version("1.40", sha256="26e2f431fbcf7bff3851f352f83b84067c09ff206f40ab975cad8d2bafe711a8")

--- a/var/spack/repos/builtin/packages/perl-file-spec/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-spec/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlFileSpec(PerlPackage):
+    """File::Spec - Perl extension for portably performing operations on file names"""
+
+    homepage = "https://metacpan.org/pod/File::Spec"
+    url = "https://cpan.metacpan.org/authors/id/K/KW/KWILLIAMS/File-Spec-0.90.tar.gz"
+
+    version("0.90", sha256="695a34604e1b6a98327fe2b374504329735b07c2c45db9f55df1636e4c29bf79")

--- a/var/spack/repos/builtin/packages/perl-memory-process/package.py
+++ b/var/spack/repos/builtin/packages/perl-memory-process/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMemoryProcess(PerlPackage):
+    """Memory::Process - Perl class to determine actual memory usage"""
+
+    homepage = "https://metacpan.org/pod/Memory::Process"
+    url = "https://cpan.metacpan.org/authors/id/S/SK/SKIM/Memory-Process-0.06.tar.gz"
+
+    version("0.06", sha256="35814488ffd29c97621625ea3b3d700afbfa60ed055bd759d4e58d9c8fd44e4e")

--- a/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlNamespaceAutoclean(PerlPackage):
+    """Namespace::Autoclean - Keep imports out of your namespace"""
+
+    homepage = "https://metacpan.org/pod/namespace::autoclean"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/namespace-autoclean-0.29.tar.gz"
+
+    version("0.29", sha256="45ebd8e64a54a86f88d8e01ae55212967c8aa8fed57e814085def7608ac65804")


### PR DESCRIPTION
This PR:
- adds version 2.0
- embeds the perl path in the installed utilities which fixes issues where the system default perl is too old for lcov
