### PR TITLE
Correctly specify build dependency on CMake when building with internal ParallelIO

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -96,6 +96,7 @@ class Esmf(MakefilePackage):
     depends_on("parallelio@2.5.9: ~mpi", when="@8.4.0:8.4.99+external-parallelio~mpi")
     depends_on("parallelio@2.5.10: +mpi", when="@8.5.0:+external-parallelio+mpi")
     depends_on("parallelio@2.5.10: ~mpi", when="@8.5.0:+external-parallelio~mpi")
+    depends_on("cmake@3.5.2:", type="build", when="~external-parallelio")
 
     # Testing dependencies
     depends_on("perl", type="test")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/39278