### PR TITLE
AMD AOCL 4.1

### DIFF
--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -24,6 +24,7 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1")
     version("4.0")
     version("3.2")
     version("3.1")
@@ -32,7 +33,7 @@ class AmdAocl(BundlePackage):
 
     variant("openmp", default=False, description="Enable OpenMP support.")
 
-    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0"]:
+    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1"]:
         depends_on("amdblis@{0} threads=openmp".format(vers), when="@{0} +openmp".format(vers))
         depends_on("amdblis@{0} threads=none".format(vers), when="@{0} ~openmp".format(vers))
         depends_on("amdfftw@{0} +openmp".format(vers), when="@{0} +openmp".format(vers))

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -32,6 +32,7 @@ class Amdblis(BlisBase):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="a05c6c7d359232580d1d599696053ad0beeedf50f3b88d5d22ee7d34375ab577")
     version("4.0", sha256="cddd31176834a932753ac0fc4c76332868feab3e9ac607fa197d8b44c1e74a41")
     version("3.2", sha256="5a400ee4fc324e224e12f73cc37b915a00f92b400443b15ce3350278ad46fff6")
     version("3.1", sha256="2891948925b9db99eec02a1917d9887a7bee9ad2afc5421c9ba58602a620f2bf")

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -37,6 +37,7 @@ class Amdfftw(FftwBase):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="f1cfecfcc0729f96a5bd61c6b26f3fa43bb0662d3fff370d4f73490c60cf4e59")
     version("4.0", sha256="5f02cb05f224bd86bd88ec6272b294c26dba3b1d22c7fb298745fd7b9d2271c0")
     version("3.2", sha256="31cab17a93e03b5b606e88dd6116a1055b8f49542d7d0890dbfcca057087b8d0")
     version("3.1", sha256="3e777f3acef13fa1910db097e818b1d0d03a6a36ef41186247c6ab1ab0afc132")

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -138,7 +138,7 @@ class Amdfftw(FftwBase):
 
     conflicts(
         "+amd-dynamic-dispatcher",
-        when="%aocc",
+        when="@:4.0 %aocc",
         msg="dynamic-dispatcher is not supported by AOCC clang compiler",
     )
 

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -44,6 +44,7 @@ class Amdlibflame(LibflameBase):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="8aed69c60d11cc17e058cabcb8a931cee4f343064ade3e73d3392b7214624b61")
     version("4.0", sha256="bcb05763aa1df1e88f0da5e43ff86d956826cbea1d9c5ff591d78a3e091c66a4")
     version("3.2", sha256="6b5337fb668b82d0ed0a4ab4b5af4e2f72e4cedbeeb4a8b6eb9a3ef057fb749a")
     version("3.1", sha256="4520fb93fcc89161f65a40810cae0fa1f87cecb242da4a69655f502545a53426")

--- a/var/spack/repos/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/builtin/packages/amdlibm/package.py
@@ -29,6 +29,7 @@ class Amdlibm(SConsPackage):
     url = "https://github.com/amd/aocl-libm-ose/archive/refs/tags/3.0.tar.gz"
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="5bbbbc6bc721d9a775822eab60fbc11eb245e77d9f105b4fcb26a54d01456122")
     version("4.0", sha256="038c1eab544be77598eccda791b26553d3b9e2ee4ab3f5ad85fdd2a77d015a7d")
     version("3.2", sha256="c75b287c38a3ce997066af1f5c8d2b19fc460d5e56678ea81f3ac33eb79ec890")
     version("3.1", sha256="dee487cc2d89c2dc93508be2c67592670ffc1d02776c017e8907317003f48845")

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -30,6 +30,7 @@ class Amdscalapack(ScalapackBase):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="b2e51c3604e5869d1faaef2e52c92071fcb3de1345aebb2ea172206622067ad9")
     version("4.0", sha256="f02913b5984597b22cdb9a36198ed61039a1bf130308e778dc31b2a7eb88b33b")
     version("3.2", sha256="9e00979bb1be39d627bdacb01774bc043029840d542fafc934d16fec3e3b0892")
     version("3.1", sha256="4c2ee2c44644a0feec0c6fc1b1a413fa9028f14d7035d43a398f5afcfdbacb98")

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -28,6 +28,7 @@ class AoclSparse(CMakePackage):
 
     maintainers("amd-toolchain-support")
 
+    version("4.1", sha256="35ef437210bc25fdd802b462eaca830bfd928f962569b91b592f2866033ef2bb")
     version("4.0", sha256="68524e441fdc7bb923333b98151005bed39154d9f4b5e8310b5c37de1d69c2c3")
     version("3.2", sha256="db7d681a8697d6ef49acf3e97e8bec35b048ce0ad74549c3b738bbdff496618f")
     version("3.1", sha256="8536f06095c95074d4297a3d2910654085dd91bce82e116c10368a9f87e9c7b9")

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -55,7 +55,8 @@ class AoclSparse(CMakePackage):
 
     depends_on("boost", when="+benchmarks")
     depends_on("boost", when="@2.2")
-    depends_on("cmake@3.5:", type="build")
+    depends_on("cmake@3.5:", type="build", when="@:4.0")
+    depends_on("cmake@3.11:", type="build", when="@4.1:")
 
     @property
     def build_directory(self):


### PR DESCRIPTION
- Checksums for version 4.1 of `amdblis`, `amdlibflame`, `amdscalapack`, `amdfftw` and `aocl-sparse`
- Updated `aocl-sparse@4.1` CMake requirements
- `amdfftw@4.1` now supports `%aocc +dynamic-dispatch`

`amdlibm` 4.1 hasn't been released on github yet so both that package and `amd-aocl` are pending.