### PR TITLE
restore config locks

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -31,7 +31,8 @@ def misc_cache_location():
 
 def _misc_cache():
     path = misc_cache_location()
-    return spack.util.file_cache.FileCache(path)
+    lock_enable = spack.config.get("config:locks", True)
+    return spack.util.file_cache.FileCache(path, lock_enable = lock_enable)
 
 
 #: Spack's cache for small data

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -173,7 +173,8 @@ class Store:
         self.hash_length = hash_length
         self.upstreams = upstreams
         self.lock_cfg = lock_cfg
-        self.db = spack.database.Database(root, upstream_dbs=upstreams, lock_cfg=lock_cfg)
+        db_root = spack.config.get("config:database_root", root)
+        self.db = spack.database.Database(db_root, upstream_dbs=upstreams, lock_cfg=lock_cfg)
 
         timeout_format_str = (
             f"{str(lock_cfg.package_timeout)}s" if lock_cfg.package_timeout else "No timeout"
@@ -184,7 +185,7 @@ class Store:
             spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
         )
         self.failure_tracker = spack.database.FailureTracker(
-            self.root, default_timeout=lock_cfg.package_timeout
+            db_root, default_timeout=lock_cfg.package_timeout
         )
 
         self.layout = spack.directory_layout.DirectoryLayout(

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -25,7 +25,7 @@ class FileCache:
 
     """
 
-    def __init__(self, root, timeout=120):
+    def __init__(self, root, timeout = 120, lock_enable = True):
         """Create a file cache object.
 
         This will create the cache directory if it does not exist yet.
@@ -43,6 +43,7 @@ class FileCache:
 
         self._locks = {}
         self.lock_timeout = timeout
+        self.lock_enable = lock_enable
 
     def destroy(self):
         """Remove all files under the cache root."""
@@ -67,7 +68,7 @@ class FileCache:
     def _get_lock(self, key):
         """Create a lock for a key, if necessary, and return a lock object."""
         if key not in self._locks:
-            self._locks[key] = Lock(self._lock_path(key), default_timeout=self.lock_timeout)
+            self._locks[key] = Lock(self._lock_path(key), default_timeout=self.lock_timeout, enable=self.lock_enable)
         return self._locks[key]
 
     def init_entry(self, key):


### PR DESCRIPTION
fixes https://github.com/flatironinstitute/nixpack/issues/40

With https://github.com/spack/spack/commit/53ae969aa008c8fb358f33b9b961beb5512999ff, config:locks is no longer used to create Lock. This patch restores this and allow to create database locks to a custom directory.

Database locks have been introduced by https://github.com/spack/spack/commit/53ae969aa008c8fb358f33b9b961beb5512999ff
We could either use config:locks on them or create the lock in a custom directory. To avoid much trouble, the later has been chosen.

@alalazo @haampie 