### PR TITLE
Remove qt variant in cmake

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -186,7 +186,6 @@ class Cmake(Package):
     # a build dependency, and its libs will not interfere with others in
     # the build.
     variant("ownlibs", default=True, description="Use CMake-provided third-party libraries")
-    variant("qt", default=False, description="Enables the build of cmake-gui")
     variant(
         "doc",
         default=False,
@@ -233,7 +232,6 @@ class Cmake(Package):
         depends_on("libuv@1.10.0:", when="@3.12.0:")
         depends_on("rhash", when="@3.8.0:")
 
-    depends_on("qt", when="+qt")
     depends_on("ncurses", when="+ncurses")
 
     with when("+doc"):
@@ -276,8 +274,6 @@ class Cmake(Package):
         sha256="b48396c0e4f61756248156b6cebe9bc0d7a22228639b47b5aa77c9330588ce88",
         when="@3.19.0:3.19",
     )
-
-    conflicts("+qt", when="^qt@5.4.0")  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166
     conflicts("%intel", when="@3.11.0:3.11.4")
@@ -358,11 +354,7 @@ class Cmake(Package):
 
             # Whatever +/~ownlibs, use system curl.
             args.append("--system-curl")
-
-            if "+qt" in spec:
-                args.append("--qt-gui")
-            else:
-                args.append("--no-qt-gui")
+            args.append("--no-qt-gui")
 
             if "+doc" in spec:
                 args.append("--sphinx-html")


### PR DESCRIPTION
`cmake+qt` depends on `qt`, which depends on `libmng`, which is a CMake
package, and has been for 4 years. Nobody ever complained about
`cmake+qt` not concretizing... so why pay the ~8x solve cost for nothing?


Before:

```
    setup          3.779s
    load           0.018s
    ground         2.625s
    solve          4.511s
    total         11.236s
```

After:

```
    setup          3.734s
    load           0.018s
    ground         0.468s
    solve          0.560s
    total          5.080s
```