### PR TITLE
Optional ups deps

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -137,6 +137,7 @@ jobs:
     - name: Setup repo and non-root user
       run: |
           git --version
+          git config --global --add safe.directory /__w/spack/spack
           git fetch --unshallow
           . .github/workflows/setup_git.sh
           useradd spack-test

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Setup repo and non-root user
         run: |
           git --version
+          git config --global --add safe.directory /__w/spack/spack
           git fetch --unshallow
           . .github/workflows/setup_git.sh
           useradd spack-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+    - id: flake8
+#  - repo: https://github.com/psf/black
+#    rev: 22.6.0
+#    hooks:
+#      - id: black

--- a/bin/spack
+++ b/bin/spack
@@ -1,3 +1,4 @@
+#!/usr/bin/python3 -I
 #!/bin/sh
 # -*- python -*-
 #

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -33,7 +33,11 @@ modules:
       - PKG_CONFIG_PATH
     ./:
       - CMAKE_PREFIX_PATH
-
+  # Fermi specific ups files
+  ups:
+    roots:
+      ups_table: $spack/../../..
+      ups_version: $spack/../../..
   # These are configurations for the module set named "default"
   default:
     # Where to install modules

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.20.0.dev0"
+__version__ = "0.20.0"
 spack_version = __version__
 
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.20.0"
+__version__ = "0.20.0-fermi"
 spack_version = __version__
 
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def iter_groups(specs, indent, all_headers):
             spack.spec.architecture_color,
             architecture if architecture else "no arch",
             spack.spec.compiler_color,
-            f"{compiler.name}@{compiler.version}" if compiler else "no compiler",
+            f"{compiler}" if compiler else "no compiler",
         )
 
         # Sometimes we want to display specs that are not yet concretized.

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -347,7 +347,7 @@ def iter_groups(specs, indent, all_headers):
             spack.spec.architecture_color,
             architecture if architecture else "no arch",
             spack.spec.compiler_color,
-            f"{compiler}" if compiler else "no compiler",
+            f"{compiler.display_str}" if compiler else "no compiler",
         )
 
         # Sometimes we want to display specs that are not yet concretized.

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -98,7 +98,7 @@ def compiler_find(args):
         config = spack.config.config
         filename = config.get_config_filename(args.scope, "compilers")
         tty.msg("Added %d new compiler%s to %s" % (n, s, filename))
-        colify(reversed(sorted(c.spec for c in new_compilers)), indent=4)
+        colify(reversed(sorted(c.spec.display_str for c in new_compilers)), indent=4)
     else:
         tty.msg("Found no new compilers")
     tty.msg("Compilers are defined in the following files:")
@@ -112,13 +112,13 @@ def compiler_remove(args):
         tty.die("No compilers match spec %s" % cspec)
     elif not args.all and len(compilers) > 1:
         tty.error("Multiple compilers match spec %s. Choose one:" % cspec)
-        colify(reversed(sorted([c.spec for c in compilers])), indent=4)
+        colify(reversed(sorted([c.spec.display_str for c in compilers])), indent=4)
         tty.msg("Or, use `spack compiler remove -a` to remove all of them.")
         sys.exit(1)
 
     for compiler in compilers:
         spack.compilers.remove_compiler_from_config(compiler.spec, scope=args.scope)
-        tty.msg("Removed compiler %s" % compiler.spec)
+        tty.msg("Removed compiler %s" % compiler.spec.display_str)
 
 
 def compiler_info(args):
@@ -130,7 +130,7 @@ def compiler_info(args):
         tty.die("No compilers match spec %s" % cspec)
     else:
         for c in compilers:
-            print(str(c.spec) + ":")
+            print(c.spec.display_str + ":")
             print("\tpaths:")
             for cpath in ["cc", "cxx", "f77", "fc"]:
                 print("\t\t%s = %s" % (cpath, getattr(c, cpath, None)))
@@ -188,7 +188,7 @@ def compiler_list(args):
             os_str += "-%s" % target
         cname = "%s{%s} %s" % (spack.spec.compiler_color, name, os_str)
         tty.hline(colorize(cname), char="-")
-        colify(reversed(sorted(c.spec for c in compilers)))
+        colify(reversed(sorted(c.spec.display_str for c in compilers)))
 
 
 def compiler(parser, args):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -302,13 +302,16 @@ def env_create(args):
         # the environment should not include a view.
         with_view = None
 
-    _env_create(
+    env = _env_create(
         args.create_env,
         init_file=args.envfile,
         dir=args.dir,
         with_view=with_view,
         keep_relative=args.keep_relative,
     )
+
+    # Generate views, only really useful for environments created from spack.lock files.
+    env.regenerate_views()
 
 
 def _env_create(name_or_path, *, init_file=None, dir=False, with_view=None, keep_relative=False):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -490,7 +490,7 @@ def env_loads_setup_parser(subparser):
     subparser.add_argument(
         "-m",
         "--module-type",
-        choices=("tcl", "lmod"),
+        choices=("tcl", "lmod", "ups_table", "ups_version"),
         help="type of module system to generate loads for",
     )
     spack.cmd.modules.add_loads_arguments(subparser)

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -7,6 +7,8 @@ from typing import Callable, Dict
 
 import spack.cmd.modules.lmod
 import spack.cmd.modules.tcl
+import spack.cmd.modules.ups_table
+import spack.cmd.modules.ups_version
 
 description = "generate/manage module files"
 section = "user environment"
@@ -20,6 +22,8 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="module_command")
     spack.cmd.modules.lmod.add_command(sp, _subcommands)
     spack.cmd.modules.tcl.add_command(sp, _subcommands)
+    spack.cmd.modules.ups_table.add_command(sp, _subcommands)
+    spack.cmd.modules.ups_version.add_command(sp, _subcommands)
 
 
 def module(parser, args):

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -116,21 +116,23 @@ def one_spec_or_raise(specs):
 
 
 def check_module_set_name(name):
-    modules_config = spack.config.get("modules")
-    valid_names = set(
-        [
-            key
-            for key, value in modules_config.items()
-            if isinstance(value, dict) and value.get("enable", [])
-        ]
-    )
-    if "enable" in modules_config and modules_config["enable"]:
-        valid_names.add("default")
+    modules = spack.config.get("modules")
+    if name != "prefix_inspections" and name in modules:
+        return
 
-    if name not in valid_names:
-        msg = "Cannot use invalid module set %s." % name
-        msg += "    Valid module set names are %s" % list(valid_names)
-        raise spack.config.ConfigError(msg)
+    names = [k for k in modules if k != "prefix_inspections"]
+
+    if not names:
+        raise spack.config.ConfigError(
+            f"Module set configuration is missing. Cannot use module set '{name}'"
+        )
+
+    pretty_names = "', '".join(names)
+
+    raise spack.config.ConfigError(
+        f"Cannot use invalid module set '{name}'.",
+        f"Valid module set names are: '{pretty_names}'.",
+    )
 
 
 _missing_modules_warning = (

--- a/lib/spack/spack/cmd/modules/ups_table.py
+++ b/lib/spack/spack/cmd/modules/ups_table.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import functools
+
+import spack.cmd.modules
+
+
+def add_command(parser, command_dict):
+    ups_table_parser = parser.add_parser("ups_table", help="manipulate ups files")
+    spack.cmd.modules.setup_parser(ups_table_parser)
+
+    command_dict["ups_table"] = functools.partial(
+        spack.cmd.modules.modules_cmd, module_type="ups_table"
+    )

--- a/lib/spack/spack/cmd/modules/ups_version.py
+++ b/lib/spack/spack/cmd/modules/ups_version.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import functools
+
+import spack.cmd.modules
+
+
+def add_command(parser, command_dict):
+    ups_version_parser = parser.add_parser("ups_version", help="manipulate ups files")
+    spack.cmd.modules.setup_parser(ups_version_parser)
+
+    command_dict["ups_version"] = functools.partial(
+        spack.cmd.modules.modules_cmd, module_type="ups_version"
+    )

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -25,7 +25,7 @@ level = "long"
 
 
 # tutorial configuration parameters
-tutorial_branch = "releases/v0.19"
+tutorial_branch = "releases/v0.20"
 tutorial_mirror = "file:///mirror"
 tutorial_key = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -30,7 +30,7 @@ fortran_mapping = {
 
 
 def get_valid_fortran_pth(comp_ver):
-    cl_ver = str(comp_ver).split("@")[1]
+    cl_ver = str(comp_ver)
     sort_fn = lambda fc_ver: StrictVersion(fc_ver)
     sort_fc_ver = sorted(list(avail_fc_version), key=sort_fn)
     for ver in sort_fc_ver:
@@ -75,7 +75,7 @@ class Msvc(Compiler):
     # file based on compiler executable path.
 
     def __init__(self, *args, **kwargs):
-        new_pth = [pth if pth else get_valid_fortran_pth(args[0]) for pth in args[3]]
+        new_pth = [pth if pth else get_valid_fortran_pth(args[0].version) for pth in args[3]]
         args[3][:] = new_pth
         super(Msvc, self).__init__(*args, **kwargs)
         if os.getenv("ONEAPI_ROOT"):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -756,6 +756,15 @@ def _add_platform_scope(cfg, scope_type, name, path):
     cfg.push_scope(scope_type(plat_name, plat_path))
 
 
+def _add_os_scope(cfg, scope_type, name, path):
+    """Add an os-specific subdirectory for the current platform."""
+    host_platform = spack.platforms.host()
+    oss = host_platform.operating_system("frontend")
+    os_name = "%s/%s" % (name, oss)
+    os_path = "%s/%s" % (path, oss)
+    cfg.push_scope(scope_type(os_name, os_path))
+
+
 def _add_command_line_scopes(cfg, command_line_scopes):
     """Add additional scopes from the --config-scope argument.
 
@@ -773,6 +782,7 @@ def _add_command_line_scopes(cfg, command_line_scopes):
         name = "cmd_scope_%d" % i
         cfg.push_scope(ImmutableConfigScope(name, path))
         _add_platform_scope(cfg, ImmutableConfigScope, name, path)
+        _add_os_scope(cfg, ImmutableConfigScope, name, path)
 
 
 def _config():
@@ -821,6 +831,7 @@ def _config():
 
         # Each scope can have per-platfom overrides in subdirectories
         _add_platform_scope(cfg, ConfigScope, name, path)
+        _add_os_scope(cfg, ConfigScope, name, path)
 
     # add command-line scopes
     _add_command_line_scopes(cfg, command_line_scopes)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -160,13 +160,15 @@ class ConfigScope(object):
             with open(filename, "w") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, IOError) as e:
-            # for the moment, stubbing this out because spack is trying to
-            # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
-            # (with what is already in there) which keeps you from using
-            # a bootstrap area in cvmfs...  Really need to fix upstream
-            # from here to not update the config file if its already right...
-            #raise ConfigFileError(f"cannot write to '{filename}'") from e
-            pass
+            if hasattr(e, 'errno') and e.errno == 30:
+                tty.warn("Ignoring write error on readonly %s" % filename)
+                # for the moment, stubbing this out because spack is trying to
+                # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
+                # (with what is already in there) which keeps you from using
+                # a bootstrap area in cvmfs...  Really need to fix upstream
+                # from here to not update the config file if its already right...
+            else:
+                raise ConfigFileError(f"cannot write to '{filename}'") from e
 
     def clear(self):
         """Empty cached config information."""

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -160,7 +160,13 @@ class ConfigScope(object):
             with open(filename, "w") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, IOError) as e:
-            raise ConfigFileError(f"cannot write to '{filename}'") from e
+            # for the moment, stubbing this out because spack is trying to
+            # update the bootstrap.yaml in the bootstrap area *all* *the* *time*
+            # (with what is already in there) which keeps you from using
+            # a bootstrap area in cvmfs...  Really need to fix upstream
+            # from here to not update the config file if its already right...
+            #raise ConfigFileError(f"cannot write to '{filename}'") from e
+            pass
 
     def clear(self):
         """Empty cached config information."""

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -824,7 +824,7 @@ def print_setup_info(*info):
     shell_set("_sp_sys_type", str(spack.spec.ArchSpec.default_arch()))
     shell_set("_sp_compatible_sys_types", ":".join(_compatible_sys_types()))
     # print roots for all module systems
-    module_to_roots = {"tcl": list(), "lmod": list()}
+    module_to_roots = {"tcl": list(), "lmod": list(), "ups_table": list(), "ups_version": list()}
     for name in module_to_roots.keys():
         path = spack.modules.common.root_path(name, "default")
         module_to_roots[name].append(path)

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -12,12 +12,21 @@ from __future__ import absolute_import
 from .common import disable_modules, ensure_modules_are_enabled_or_warn
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
+from .ups_table import UpsTableModulefileWriter
+from .ups_version import UpsVersionModulefileWriter
 
 __all__ = [
     "TclModulefileWriter",
     "LmodModulefileWriter",
+    "UpsTableModulefileWriter",
+    "UpsVersionModulefileWriter",
     "disable_modules",
     "ensure_modules_are_enabled_or_warn",
 ]
 
-module_types = {"tcl": TclModulefileWriter, "lmod": LmodModulefileWriter}
+module_types = {
+    "tcl": TclModulefileWriter,
+    "lmod": LmodModulefileWriter,
+    "ups_table": UpsTableModulefileWriter,
+    "ups_version": UpsVersionModulefileWriter,
+}

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -170,17 +170,12 @@ def merge_config_rules(configuration, spec):
     Returns:
         dict: actions to be taken on the spec passed as an argument
     """
-
-    # Get the top-level configuration for the module type we are using
-    module_specific_configuration = copy.deepcopy(configuration)
-
-    # Construct a dictionary with the actions we need to perform on the spec
-    # passed as a parameter
-
+    # Construct a dictionary with the actions we need to perform on the spec passed as a parameter
+    spec_configuration = {}
     # The keyword 'all' is always evaluated first, all the others are
     # evaluated in order of appearance in the module file
-    spec_configuration = module_specific_configuration.pop("all", {})
-    for constraint, action in module_specific_configuration.items():
+    spec_configuration.update(copy.deepcopy(configuration.get("all", {})))
+    for constraint, action in configuration.items():
         if spec.satisfies(constraint):
             if hasattr(constraint, "override") and constraint.override:
                 spec_configuration = {}
@@ -200,14 +195,14 @@ def merge_config_rules(configuration, spec):
     # configuration
 
     # Hash length in module files
-    hash_length = module_specific_configuration.get("hash_length", 7)
+    hash_length = configuration.get("hash_length", 7)
     spec_configuration["hash_length"] = hash_length
 
-    verbose = module_specific_configuration.get("verbose", False)
+    verbose = configuration.get("verbose", False)
     spec_configuration["verbose"] = verbose
 
     # module defaults per-package
-    defaults = module_specific_configuration.get("defaults", [])
+    defaults = configuration.get("defaults", [])
     spec_configuration["defaults"] = defaults
 
     return spec_configuration

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -32,6 +32,7 @@ import contextlib
 import copy
 import datetime
 import inspect
+import os
 import os.path
 import pathlib
 import re
@@ -907,6 +908,7 @@ class BaseModuleFileWriter(object):
         conf_update = self.conf.context
         context.update(conf_update)
 
+        context.update({"os": os})
         # Render the template
         text = template.render(context)
         # Write it to file

--- a/lib/spack/spack/modules/ups_table.py
+++ b/lib/spack/spack/modules/ups_table.py
@@ -1,0 +1,120 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""This module implements the classes necessary to generate TCL
+non-hierarchical modules.
+"""
+import os.path
+import string
+from typing import Any, Dict
+
+import llnl.util.tty as tty
+
+import spack.config
+import spack.tengine as tengine
+
+from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter, root_path
+
+
+def configuration(module_set_name):
+    config_path = "modules:%s:ups_table" % module_set_name
+    config = spack.config.get(config_path, {})
+    if not config and module_set_name == "default":
+        # return old format for backward compatibility
+        return spack.config.get("modules:ups_table", {})
+    return config
+
+
+#: Caches the configuration {spec_hash: configuration}
+configuration_registry: Dict[str, Any] = {}
+
+
+def make_configuration(spec, module_set_name, explicit):
+    """Returns the ups_table configuration for spec"""
+    key = (spec.dag_hash(), module_set_name, explicit)
+    try:
+        return configuration_registry[key]
+    except KeyError:
+        return configuration_registry.setdefault(key, UpsTableConfiguration(spec, module_set_name))
+
+
+def make_layout(spec, module_set_name, explicit):
+    """Returns the layout information for spec"""
+    conf = make_configuration(spec, module_set_name, explicit)
+    return UpsTableFileLayout(conf)
+
+
+def make_context(spec, module_set_name, explicit):
+    """Returns the context information for spec"""
+    conf = make_configuration(spec, module_set_name, explicit)
+    return UpsTableContext(conf)
+
+
+class UpsTableConfiguration(BaseConfiguration):
+    """Configuration class for ups_table module files."""
+
+    @property
+    def conflicts(self):
+        """Conflicts for this module file"""
+        return self.conf.get("conflict", [])
+
+
+class UpsTableFileLayout(BaseFileLayout):
+    """File layout for ups_table module files."""
+
+    extension = "table"
+
+    def dirname(self):
+        return root_path("ups_table", "ups")
+
+    @property
+    def filename(self):
+        """Name of the module file for the current spec."""
+        subdirname = self.spec.format("{name}").replace("-", "_")
+        if not os.access(os.path.join(self.dirname(), subdirname), os.F_OK):
+            os.makedirs(os.path.join(self.dirname(), subdirname))
+        fn = "{}-{}-{}.table".format(self.spec.name, self.spec.version, self.spec._hash)
+        fp = os.path.join(self.dirname(), subdirname, fn.replace("-", "_"))
+        return fp
+
+
+class UpsTableContext(BaseContext):
+    """Context class for ups_table module files."""
+
+    @tengine.context_property
+    def prerequisites(self):
+        """List of modules that needs to be loaded automatically."""
+        return self._create_module_list_of("specs_to_prereq")
+
+    @tengine.context_property
+    def conflicts(self):
+        """List of conflicts for the ups_table module file."""
+        fmts = []
+        f = string.Formatter()
+        for item in self.conf.conflicts:
+            naming_scheme = self.conf["naming_scheme"]
+            if len([x for x in f.parse(item)]) > 1:
+                for naming_dir, conflict_dir in zip(naming_scheme.split("/"), item.split("/")):
+                    if naming_dir != conflict_dir:
+                        message = "conflict scheme does not match naming "
+                        message += "scheme [{spec}]\n\n"
+                        message += 'naming scheme   : "{nformat}"\n'
+                        message += 'conflict scheme : "{cformat}"\n\n'
+                        message += "** You may want to check your "
+                        message += "`modules.yaml` configuration file **\n"
+                        tty.error(
+                            message.format(spec=self.spec, nformat=naming_scheme, cformat=item)
+                        )
+                        raise SystemExit("Module generation aborted.")
+                item = self.spec.format(item)
+            fmts.append(item)
+        # Substitute spec tokens if present
+        return [self.spec.format(x) for x in fmts]
+
+
+class UpsTableModulefileWriter(BaseModuleFileWriter):
+    """Writer class for ups_table module files."""
+
+    default_template = os.path.join("modules", "modulefile.ups_table")

--- a/lib/spack/spack/modules/ups_version.py
+++ b/lib/spack/spack/modules/ups_version.py
@@ -1,0 +1,120 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""This module implements the classes necessary to generate TCL
+non-hierarchical modules.
+"""
+import os.path
+import string
+from typing import Any, Dict
+
+import llnl.util.tty as tty
+
+import spack.config
+import spack.tengine as tengine
+
+from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter, root_path
+
+
+def configuration(module_set_name):
+    config_path = "modules:%s:ups_version" % module_set_name
+    config = spack.config.get(config_path, {})
+    if not config and module_set_name == "default":
+        # return old format for backward compatibility
+        return spack.config.get("modules:ups_version", {})
+    return config
+
+
+#: Caches the configuration {spec_hash: configuration}
+configuration_registry: Dict[str, Any] = {}
+
+
+def make_configuration(spec, module_set_name, explicit):
+    """Returns the ups_version configuration for spec"""
+    key = (spec.dag_hash(), module_set_name, explicit)
+    try:
+        return configuration_registry[key]
+    except KeyError:
+        return configuration_registry.setdefault(
+            key, UpsVersionConfiguration(spec, module_set_name)
+        )
+
+
+def make_layout(spec, module_set_name, explicit):
+    """Returns the layout information for spec"""
+    conf = make_configuration(spec, module_set_name, explicit)
+    return UpsVersionFileLayout(conf)
+
+
+def make_context(spec, module_set_name, explicit):
+    """Returns the context information for spec"""
+    conf = make_configuration(spec, module_set_name, explicit)
+    return UpsVersionContext(conf)
+
+
+class UpsVersionConfiguration(BaseConfiguration):
+    """Configuration class for ups_version module files."""
+
+    @property
+    def conflicts(self):
+        """Conflicts for this module file"""
+        return self.conf.get("conflict", [])
+
+
+class UpsVersionFileLayout(BaseFileLayout):
+    """File layout for ups_version module files."""
+
+    def dirname(self):
+        return root_path("ups_version", "ups")
+
+    @property
+    def filename(self):
+        """Name of the module file for the current spec."""
+        # Just the name of the file
+        filename = os.path.basename(self.use_name)
+        subdirname = self.spec.format("{name}/{version}.version").replace("-", "_")
+        if not os.access(os.path.join(self.dirname(), subdirname), os.F_OK):
+            os.makedirs(os.path.join(self.dirname(), subdirname))
+        return os.path.join(self.dirname(), subdirname, filename)
+
+
+class UpsVersionContext(BaseContext):
+    """Context class for ups_version module files."""
+
+    @tengine.context_property
+    def prerequisites(self):
+        """List of modules that needs to be loaded automatically."""
+        return self._create_module_list_of("specs_to_prereq")
+
+    @tengine.context_property
+    def conflicts(self):
+        """List of conflicts for the ups_version module file."""
+        fmts = []
+        f = string.Formatter()
+        for item in self.conf.conflicts:
+            naming_scheme = self.conf["naming_scheme"]
+            if len([x for x in f.parse(item)]) > 1:
+                for naming_dir, conflict_dir in zip(naming_scheme.split("/"), item.split("/")):
+                    if naming_dir != conflict_dir:
+                        message = "conflict scheme does not match naming "
+                        message += "scheme [{spec}]\n\n"
+                        message += 'naming scheme   : "{nformat}"\n'
+                        message += 'conflict scheme : "{cformat}"\n\n'
+                        message += "** You may want to check your "
+                        message += "`modules.yaml` configuration file **\n"
+                        tty.error(
+                            message.format(spec=self.spec, nformat=naming_scheme, cformat=item)
+                        )
+                        raise SystemExit("Module generation aborted.")
+                item = self.spec.format(item)
+            fmts.append(item)
+        # Substitute spec tokens if present
+        return [self.spec.format(x) for x in fmts]
+
+
+class UpsVersionModulefileWriter(BaseModuleFileWriter):
+    """Writer class for ups_version module files."""
+
+    default_template = os.path.join("modules", "modulefile.ups_version")

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2017,7 +2017,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     # stack instead of from traceback.
                     # The traceback is truncated here, so we can't use it to
                     # traverse the stack.
-                    m = "\n".join(spack.build_environment.get_package_context(tb))
+                    context = spack.build_environment.get_package_context(tb)
+                    m = "\n".join(context) if context else ""
 
                 exc = e  # e is deleted after this block
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1248,6 +1248,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # TODO: allow more than one active extendee.
         if deps:
+            if len(deps) == 2 and repr(deps[0]) == repr(deps[1]):
+                return deps[0]
             assert len(deps) == 1
             return deps[0]
 

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -110,12 +110,17 @@ module_config_properties = {
     "arch_folder": {"type": "boolean"},
     "roots": {
         "type": "object",
-        "properties": {"tcl": {"type": "string"}, "lmod": {"type": "string"}},
+        "properties": {
+            "tcl": {"type": "string"},
+            "lmod": {"type": "string"},
+            "ups_table": {"type": "string"},
+            "ups_version": {"type": "string"},
+        },
     },
     "enable": {
         "type": "array",
         "default": [],
-        "items": {"type": "string", "enum": ["tcl", "lmod"]},
+        "items": {"type": "string", "enum": ["tcl", "lmod", "ups_table", "ups_version"]},
     },
     "lmod": {
         "allOf": [
@@ -150,6 +155,20 @@ module_config_properties = {
             r"^[\w-]*": array_of_strings
         },
     },
+    "ups_table": {
+        "allOf": [
+            # Base configuration
+            module_type_configuration,
+            {},  # Specific UPS table file extensions
+        ]
+    },
+    "ups_version": {
+        "allOf": [
+            # Base configuration
+            module_type_configuration,
+            {},  # Specific UPS version file extensions
+        ]
+    },
 }
 
 
@@ -166,7 +185,21 @@ properties = {
                     # prefix-relative path to be inspected for existence
                     r"^[\w-]*": array_of_strings
                 },
-            }
+            },
+            "ups_table": {
+                "allOf": [
+                    # Base configuration
+                    module_type_configuration,
+                    {},  # Specific tcl extensions
+                ]
+            },
+            "ups_version": {
+                "allOf": [
+                    # Base configuration
+                    module_type_configuration,
+                    {},  # Specific tcl extensions
+                ]
+            },
         },
         "patternProperties": {
             valid_module_set_name: {

--- a/lib/spack/spack/schema/upstreams.py
+++ b/lib/spack/spack/schema/upstreams.py
@@ -18,7 +18,12 @@ properties = {
                     "install_tree": {"type": "string"},
                     "modules": {
                         "type": "object",
-                        "properties": {"tcl": {"type": "string"}, "lmod": {"type": "string"}},
+                        "properties": {
+                            "tcl": {"type": "string"},
+                            "lmod": {"type": "string"},
+                            "ups_table": {"type": "string"},
+                            "ups_version": {"type": "string"},
+                        },
                     },
                 },
             }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -861,9 +861,9 @@ class SpackSolverSetup(object):
     def __init__(self, tests=False):
         self.gen = None  # set by setup()
 
-        self.declared_versions = {}
-        self.possible_versions = {}
-        self.deprecated_versions = {}
+        self.declared_versions = collections.defaultdict(list)
+        self.possible_versions = collections.defaultdict(set)
+        self.deprecated_versions = collections.defaultdict(set)
 
         self.possible_virtuals = None
         self.possible_compilers = []
@@ -1722,10 +1722,6 @@ class SpackSolverSetup(object):
 
     def build_version_dict(self, possible_pkgs):
         """Declare any versions in specs not declared in packages."""
-        self.declared_versions = collections.defaultdict(list)
-        self.possible_versions = collections.defaultdict(set)
-        self.deprecated_versions = collections.defaultdict(set)
-
         packages_yaml = spack.config.get("packages")
         packages_yaml = _normalize_packages_yaml(packages_yaml)
         for pkg_name in possible_pkgs:
@@ -1766,12 +1762,7 @@ class SpackSolverSetup(object):
                 if isinstance(v, vn.GitVersion):
                     version_defs.append(v)
                 else:
-                    satisfying_versions = list(x for x in pkg_class.versions if x.satisfies(v))
-                    if not satisfying_versions:
-                        raise spack.config.ConfigError(
-                            "Preference for version {0} does not match any version "
-                            " defined in {1}".format(str(v), pkg_name)
-                        )
+                    satisfying_versions = self._check_for_defined_matching_versions(pkg_class, v)
                     # Amongst all defined versions satisfying this specific
                     # preference, the highest-numbered version is the
                     # most-preferred: therefore sort satisfying versions
@@ -1783,6 +1774,28 @@ class SpackSolverSetup(object):
                     DeclaredVersion(version=vdef, idx=weight, origin=Provenance.PACKAGES_YAML)
                 )
                 self.possible_versions[pkg_name].add(vdef)
+
+    def _check_for_defined_matching_versions(self, pkg_class, v):
+        """Given a version specification (which may be a concrete version,
+        range, etc.), determine if any package.py version declarations
+        or externals define a version which satisfies it.
+
+        This is primarily for determining whether a version request (e.g.
+        version preferences, which should not themselves define versions)
+        refers to a defined version.
+
+        This function raises an exception if no satisfying versions are
+        found.
+        """
+        pkg_name = pkg_class.name
+        satisfying_versions = list(x for x in pkg_class.versions if x.satisfies(v))
+        satisfying_versions.extend(x for x in self.possible_versions[pkg_name] if x.satisfies(v))
+        if not satisfying_versions:
+            raise spack.config.ConfigError(
+                "Preference for version {0} does not match any version"
+                " defined for {1} (in its package.py or any external)".format(str(v), pkg_name)
+            )
+        return satisfying_versions
 
     def add_concrete_versions_from_specs(self, specs, origin):
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
@@ -2215,14 +2228,6 @@ class SpackSolverSetup(object):
         # get possible compilers
         self.possible_compilers = self.generate_possible_compilers(specs)
 
-        # traverse all specs and packages to build dict of possible versions
-        self.build_version_dict(possible)
-        self.add_concrete_versions_from_specs(specs, Provenance.SPEC)
-        self.add_concrete_versions_from_specs(dev_specs, Provenance.DEV_SPEC)
-
-        req_version_specs = _get_versioned_specs_from_pkg_requirements()
-        self.add_concrete_versions_from_specs(req_version_specs, Provenance.PACKAGE_REQUIREMENT)
-
         self.gen.h1("Concrete input spec definitions")
         self.define_concrete_input_specs(specs, possible)
 
@@ -2249,6 +2254,14 @@ class SpackSolverSetup(object):
         self.provider_defaults()
         self.provider_requirements()
         self.external_packages()
+
+        # traverse all specs and packages to build dict of possible versions
+        self.build_version_dict(possible)
+        self.add_concrete_versions_from_specs(specs, Provenance.SPEC)
+        self.add_concrete_versions_from_specs(dev_specs, Provenance.DEV_SPEC)
+
+        req_version_specs = self._get_versioned_specs_from_pkg_requirements()
+        self.add_concrete_versions_from_specs(req_version_specs, Provenance.PACKAGE_REQUIREMENT)
 
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
@@ -2296,83 +2309,78 @@ class SpackSolverSetup(object):
         if self.concretize_everything:
             self.gen.fact(fn.concretize_everything())
 
+    def _get_versioned_specs_from_pkg_requirements(self):
+        """If package requirements mention versions that are not mentioned
+        elsewhere, then we need to collect those to mark them as possible
+        versions.
+        """
+        req_version_specs = list()
+        config = spack.config.get("packages")
+        for pkg_name, d in config.items():
+            if pkg_name == "all":
+                continue
+            if "require" in d:
+                req_version_specs.extend(self._specs_from_requires(pkg_name, d["require"]))
+        return req_version_specs
 
-def _get_versioned_specs_from_pkg_requirements():
-    """If package requirements mention versions that are not mentioned
-    elsewhere, then we need to collect those to mark them as possible
-    versions.
-    """
-    req_version_specs = list()
-    config = spack.config.get("packages")
-    for pkg_name, d in config.items():
-        if pkg_name == "all":
-            continue
-        if "require" in d:
-            req_version_specs.extend(_specs_from_requires(pkg_name, d["require"]))
-    return req_version_specs
-
-
-def _specs_from_requires(pkg_name, section):
-    """Collect specs from requirements which define versions (i.e. those that
-    have a concrete version). Requirements can define *new* versions if
-    they are included as part of an equivalence (hash=number) but not
-    otherwise.
-    """
-    if isinstance(section, str):
-        spec = spack.spec.Spec(section)
-        if not spec.name:
-            spec.name = pkg_name
-        extracted_specs = [spec]
-    else:
-        spec_strs = []
-        for spec_group in section:
-            if isinstance(spec_group, str):
-                spec_strs.append(spec_group)
-            else:
-                # Otherwise it is an object. The object can contain a single
-                # "spec" constraint, or a list of them with "any_of" or
-                # "one_of" policy.
-                if "spec" in spec_group:
-                    new_constraints = [spec_group["spec"]]
-                else:
-                    key = "one_of" if "one_of" in spec_group else "any_of"
-                    new_constraints = spec_group[key]
-                spec_strs.extend(new_constraints)
-
-        extracted_specs = []
-        for spec_str in spec_strs:
-            spec = spack.spec.Spec(spec_str)
+    def _specs_from_requires(self, pkg_name, section):
+        """Collect specs from requirements which define versions (i.e. those that
+        have a concrete version). Requirements can define *new* versions if
+        they are included as part of an equivalence (hash=number) but not
+        otherwise.
+        """
+        if isinstance(section, str):
+            spec = spack.spec.Spec(section)
             if not spec.name:
                 spec.name = pkg_name
-            extracted_specs.append(spec)
+            extracted_specs = [spec]
+        else:
+            spec_strs = []
+            for spec_group in section:
+                if isinstance(spec_group, str):
+                    spec_strs.append(spec_group)
+                else:
+                    # Otherwise it is an object. The object can contain a single
+                    # "spec" constraint, or a list of them with "any_of" or
+                    # "one_of" policy.
+                    if "spec" in spec_group:
+                        new_constraints = [spec_group["spec"]]
+                    else:
+                        key = "one_of" if "one_of" in spec_group else "any_of"
+                        new_constraints = spec_group[key]
+                    spec_strs.extend(new_constraints)
 
-    version_specs = []
-    for spec in extracted_specs:
-        if spec.versions.concrete:
-            # Note: this includes git versions
-            version_specs.append(spec)
-            continue
+            extracted_specs = []
+            for spec_str in spec_strs:
+                spec = spack.spec.Spec(spec_str)
+                if not spec.name:
+                    spec.name = pkg_name
+                extracted_specs.append(spec)
 
-        # Prefer spec's name if it exists, in case the spec is
-        # requiring a specific implementation inside of a virtual section
-        # e.g. packages:mpi:require:openmpi@4.0.1
-        pkg_class = spack.repo.path.get_pkg_class(spec.name or pkg_name)
-        satisfying_versions = list(v for v in pkg_class.versions if v.satisfies(spec.versions))
-        if not satisfying_versions:
-            raise spack.config.ConfigError(
-                "{0} assigns a version that is not defined in"
-                " the associated package.py".format(str(spec))
+        version_specs = []
+        for spec in extracted_specs:
+            if spec.versions.concrete:
+                # Note: this includes git versions
+                version_specs.append(spec)
+                continue
+
+            # Prefer spec's name if it exists, in case the spec is
+            # requiring a specific implementation inside of a virtual section
+            # e.g. packages:mpi:require:openmpi@4.0.1
+            pkg_class = spack.repo.path.get_pkg_class(spec.name or pkg_name)
+            satisfying_versions = self._check_for_defined_matching_versions(
+                pkg_class, spec.versions
             )
 
-        # Version ranges ("@1.3" without the "=", "@1.2:1.4") and lists
-        # will end up here
-        ordered_satisfying_versions = sorted(satisfying_versions, reverse=True)
-        vspecs = list(spack.spec.Spec("@{0}".format(x)) for x in ordered_satisfying_versions)
-        version_specs.extend(vspecs)
+            # Version ranges ("@1.3" without the "=", "@1.2:1.4") and lists
+            # will end up here
+            ordered_satisfying_versions = sorted(satisfying_versions, reverse=True)
+            vspecs = list(spack.spec.Spec("@{0}".format(x)) for x in ordered_satisfying_versions)
+            version_specs.extend(vspecs)
 
-    for spec in version_specs:
-        spec.attach_git_version_lookup()
-    return version_specs
+        for spec in version_specs:
+            spec.attach_git_version_lookup()
+        return version_specs
 
 
 class SpecBuilder(object):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2789,11 +2789,11 @@ class Spec(object):
         # Also record all patches required on dependencies by
         # depends_on(..., patch=...)
         for dspec in root.traverse_edges(deptype=all, cover="edges", root=False):
-            pkg_deps = dspec.parent.package_class.dependencies
-            if dspec.spec.name not in pkg_deps:
+            if dspec.spec.concrete:
                 continue
 
-            if dspec.spec.concrete:
+            pkg_deps = dspec.parent.package_class.dependencies
+            if dspec.spec.name not in pkg_deps:
                 continue
 
             patches = []

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -679,6 +679,16 @@ class CompilerSpec(object):
         d = d["compiler"]
         return CompilerSpec(d["name"], vn.VersionList.from_dict(d))
 
+    @property
+    def display_str(self):
+        """Equivalent to {compiler.name}{@compiler.version} for Specs, without extra
+        @= for readability."""
+        if self.concrete:
+            return f"{self.name}@{self.version}"
+        elif self.versions != vn.any_version:
+            return f"{self.name}@{self.versions}"
+        return self.name
+
     def __str__(self):
         out = self.name
         if self.versions and self.versions != vn.any_version:
@@ -1730,14 +1740,14 @@ class Spec(object):
     def short_spec(self):
         """Returns a version of the spec with the dependencies hashed
         instead of completely enumerated."""
-        spec_format = "{name}{@version}{%compiler}"
+        spec_format = "{name}{@version}{%compiler.name}{@compiler.version}"
         spec_format += "{variants}{arch=architecture}{/hash:7}"
         return self.format(spec_format)
 
     @property
     def cshort_spec(self):
         """Returns an auto-colorized version of ``self.short_spec``."""
-        spec_format = "{name}{@version}{%compiler}"
+        spec_format = "{name}{@version}{%compiler.name}{@compiler.version}"
         spec_format += "{variants}{arch=architecture}{/hash:7}"
         return self.cformat(spec_format)
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -204,8 +204,8 @@ def test_compiler_find_mixed_suffixes(no_compilers_yaml, working_env, clangdir):
     os.environ["PATH"] = str(clangdir)
     output = compiler("find", "--scope=site")
 
-    assert "clang@=11.0.0" in output
-    assert "gcc@=8.4.0" in output
+    assert "clang@11.0.0" in output
+    assert "gcc@8.4.0" in output
 
     config = spack.compilers.get_compiler_config("site", False)
     clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")
@@ -246,8 +246,8 @@ def test_compiler_find_prefer_no_suffix(no_compilers_yaml, working_env, clangdir
     os.environ["PATH"] = str(clangdir)
     output = compiler("find", "--scope=site")
 
-    assert "clang@=11.0.0" in output
-    assert "gcc@=8.4.0" in output
+    assert "clang@11.0.0" in output
+    assert "gcc@8.4.0" in output
 
     config = spack.compilers.get_compiler_config("site", False)
     clang = next(c["compiler"] for c in config if c["compiler"]["spec"] == "clang@=11.0.0")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3299,3 +3299,22 @@ def test_environment_created_in_users_location(mutable_config, tmpdir):
     assert dir_name in out
     assert env_dir in ev.root(dir_name)
     assert os.path.isdir(os.path.join(env_dir, dir_name))
+
+
+def test_environment_created_from_lockfile_has_view(mock_packages, tmpdir):
+    """When an env is created from a lockfile, a view should be generated for it"""
+    env_a = str(tmpdir.join("a"))
+    env_b = str(tmpdir.join("b"))
+
+    # Create an environment and install a package in it
+    env("create", "-d", env_a)
+    with ev.Environment(env_a):
+        add("libelf")
+        install("--fake")
+
+    # Create another environment from the lockfile of the first environment
+    env("create", "-d", env_b, os.path.join(env_a, "spack.lock"))
+
+    # Make sure the view was created
+    with ev.Environment(env_b) as e:
+        assert os.path.isdir(e.view_path_default)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -906,7 +906,7 @@ packages:
   mpileaks:
     version: ["2.2"]
   libelf:
-    version: ["0.8.11"]
+    version: ["0.8.10"]
 """
         )
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -357,3 +357,18 @@ def test_find_loaded(database, working_env):
     output = find("--loaded")
     expected = find()
     assert output == expected
+
+
+@pytest.mark.regression("37712")
+def test_environment_with_version_range_in_compiler_doesnt_fail(tmp_path):
+    """Tests that having an active environment with a root spec containing a compiler constrained
+    by a version range (i.e. @X.Y rather the single version than @=X.Y) doesn't result in an error
+    when invoking "spack find".
+    """
+    test_environment = ev.create_in_dir(tmp_path)
+    test_environment.add("zlib %gcc@12.1.0")
+    test_environment.write()
+
+    with test_environment:
+        output = find()
+    assert "zlib%gcc@12.1.0" in output

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -319,3 +319,17 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     spack.cmd.common.arguments.sanitize_reporter_options(args)
     filename = spack.cmd.test.report_filename(args, suite)
     assert filename != "https://blahblah/submit.php?project=debugging"
+
+
+def test_test_output_multiple_specs(
+    mock_test_stage, mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config
+):
+    """Ensure proper reporting for suite with skipped, failing, and passed tests."""
+    install("test-error", "simple-standalone-test@0.9", "simple-standalone-test@1.0")
+    out = spack_test("run", "test-error", "simple-standalone-test", fail_on_error=False)
+
+    # Note that a spec with passing *and* skipped tests is still considered
+    # to have passed at this level. If you want to see the spec-specific
+    # part result summaries, you'll have to look at the "test-out.txt" files
+    # for each spec.
+    assert "1 failed, 2 passed of 3 specs" in out

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -66,6 +66,28 @@ class V(Package):
 )
 
 
+_pkgt = (
+    "t",
+    """\
+class T(Package):
+    version('2.1')
+    version('2.0')
+
+    depends_on('u', when='@2.1:')
+""",
+)
+
+
+_pkgu = (
+    "u",
+    """\
+class U(Package):
+    version('1.1')
+    version('1.0')
+""",
+)
+
+
 @pytest.fixture
 def create_test_repo(tmpdir, mutable_config):
     repo_path = str(tmpdir)
@@ -79,7 +101,7 @@ repo:
         )
 
     packages_dir = tmpdir.join("packages")
-    for pkg_name, pkg_str in [_pkgx, _pkgy, _pkgv]:
+    for pkg_name, pkg_str in [_pkgx, _pkgy, _pkgv, _pkgt, _pkgu]:
         pkg_dir = packages_dir.ensure(pkg_name, dir=True)
         pkg_file = pkg_dir.join("package.py")
         with open(str(pkg_file), "w") as f:
@@ -142,6 +164,45 @@ packages:
     update_packages_config(conf_str)
     with pytest.raises(UnsatisfiableSpecError):
         Spec("x@1.1").concretize()
+
+
+def test_require_undefined_version(concretize_scope, test_repo):
+    """If a requirement specifies a numbered version that isn't in
+    the associated package.py and isn't part of a Git hash
+    equivalence (hash=number), then Spack should raise an error
+    (it is assumed this is a typo, and raising the error here
+    avoids a likely error when Spack attempts to fetch the version).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration requirements")
+
+    conf_str = """\
+packages:
+  x:
+    require: "@1.2"
+"""
+    update_packages_config(conf_str)
+    with pytest.raises(spack.config.ConfigError):
+        Spec("x").concretize()
+
+
+def test_require_truncated(concretize_scope, test_repo):
+    """A requirement specifies a version range, with satisfying
+    versions defined in the package.py. Make sure we choose one
+    of the defined versions (vs. allowing the requirement to
+    define a new version).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration requirements")
+
+    conf_str = """\
+packages:
+  x:
+    require: "@1"
+"""
+    update_packages_config(conf_str)
+    xspec = Spec("x").concretized()
+    assert xspec.satisfies("@1.1")
 
 
 def test_git_user_supplied_reference_satisfaction(
@@ -218,6 +279,40 @@ packages:
     # Make sure the git commit info is retained
     assert isinstance(s1.version, spack.version.GitVersion)
     assert s1.version.ref == a_commit_hash
+
+
+def test_requirement_adds_version_satisfies(
+    concretize_scope, test_repo, mock_git_version_info, monkeypatch
+):
+    """Make sure that new versions added by requirements are factored into
+    conditions. In this case create a new version that satisfies a
+    depends_on condition and make sure it is triggered (i.e. the
+    dependency is added).
+    """
+    if spack.config.get("config:concretizer") == "original":
+        pytest.skip("Original concretizer does not support configuration" " requirements")
+
+    repo_path, filename, commits = mock_git_version_info
+    monkeypatch.setattr(
+        spack.package_base.PackageBase, "git", path_to_file_url(repo_path), raising=False
+    )
+
+    # Sanity check: early version of T does not include U
+    s0 = Spec("t@2.0").concretized()
+    assert not ("u" in s0)
+
+    conf_str = """\
+packages:
+  t:
+    require: "@{0}=2.2"
+""".format(
+        commits[0]
+    )
+    update_packages_config(conf_str)
+
+    s1 = Spec("t").concretized()
+    assert "u" in s1
+    assert s1.satisfies("@2.2")
 
 
 def test_requirement_adds_git_hash_version(

--- a/lib/spack/spack/test/data/modules/lmod/complex_hierarchy.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/complex_hierarchy.yaml
@@ -4,7 +4,7 @@ lmod:
   hash_length: 0
 
   core_compilers:
-    - 'clang@3.3'
+    - 'clang@12.0.0'
 
   core_specs:
     - 'mpich@3.0.1'

--- a/lib/spack/spack/test/data/modules/lmod/core_compilers.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/core_compilers.yaml
@@ -1,0 +1,5 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@12.0.0'

--- a/lib/spack/spack/test/data/modules/lmod/core_compilers_at_equal.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/core_compilers_at_equal.yaml
@@ -1,0 +1,5 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@=12.0.0'

--- a/lib/spack/spack/test/data/modules/ups_table/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/alter_environment.yaml
@@ -1,0 +1,22 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    filter:
+      environment_blacklist':
+        - CMAKE_PREFIX_PATH
+    environment:
+      set:
+        '{name}_ROOT': '{prefix}'
+
+  'platform=test target=x86_64':
+    environment:
+      set:
+        FOO: 'foo'
+        OMPI_MCA_mpi_leave_pinned: '1'
+      unset:
+        - BAR
+
+  'platform=test target=x86_32':
+    load:
+      - 'foo/bar'

--- a/lib/spack/spack/test/data/modules/ups_table/autoload_all.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/autoload_all.yaml
@@ -1,0 +1,6 @@
+enable:
+  - ups_table
+ups_table:
+  verbose: true
+  all:
+    autoload: 'all'

--- a/lib/spack/spack/test/data/modules/ups_table/autoload_direct.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/autoload_direct.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_table/autoload_with_constraints.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/autoload_with_constraints.yaml
@@ -1,0 +1,8 @@
+enable:
+  - ups_table
+ups_table:
+  ^mpich2:
+    autoload: 'direct'
+
+  ^python:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_table/blacklist.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/blacklist.yaml
@@ -1,0 +1,10 @@
+enable:
+  - ups_table
+ups_table:
+  whitelist:
+    - zmpi
+  blacklist:
+    - callpath
+    - mpi
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_table/blacklist_implicits.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/blacklist_implicits.yaml
@@ -1,0 +1,6 @@
+enable:
+  - ups_table
+ups_table:
+  blacklist_implicits: true
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_table/conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/conflicts.yaml
@@ -1,0 +1,8 @@
+enable:
+  - ups_table
+ups_table:
+  naming_scheme: '{name}/{version}-{compiler.name}'
+  all:
+    conflict:
+      - '{name}'
+      - 'intel/14.0.1'

--- a/lib/spack/spack/test/data/modules/ups_table/invalid_naming_scheme.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/invalid_naming_scheme.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_table
+ups_table:
+  # {variants} is not allowed in the naming scheme, see #2884
+  naming_scheme: '{name}/{version}-{compiler.name}-{variants}'

--- a/lib/spack/spack/test/data/modules/ups_table/invalid_token_in_env_var_name.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/invalid_token_in_env_var_name.yaml
@@ -1,0 +1,21 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    filter:
+      environment_blacklist':
+        - CMAKE_PREFIX_PATH
+    environment:
+      set:
+        '{name}_ROOT_{prefix}': '{prefix}'
+
+  'platform=test target=x86_64':
+    environment:
+      set:
+        FOO_{variants}: 'foo'
+      unset:
+        - BAR
+
+  'platform=test target=x86_32':
+    load:
+      - 'foo/bar'

--- a/lib/spack/spack/test/data/modules/ups_table/override_template.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/override_template.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    template: 'override_from_modules.txt'

--- a/lib/spack/spack/test/data/modules/ups_table/prerequisites_all.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/prerequisites_all.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    prerequisites: 'all'

--- a/lib/spack/spack/test/data/modules/ups_table/prerequisites_direct.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/prerequisites_direct.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_table
+ups_table:
+  all:
+    prerequisites: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_table/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/suffix.yaml
@@ -1,0 +1,7 @@
+enable:
+  - ups_table
+ups_table:
+  mpileaks:
+    suffixes:
+      '+debug': foo
+      '~debug': bar

--- a/lib/spack/spack/test/data/modules/ups_table/wrong_conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/ups_table/wrong_conflicts.yaml
@@ -1,0 +1,7 @@
+enable:
+  - ups_table
+ups_table:
+  naming_scheme: '{name}/{version}-{compiler.name}'
+  all:
+    conflict:
+      - '{name}/{compiler.name}'

--- a/lib/spack/spack/test/data/modules/ups_version/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/alter_environment.yaml
@@ -1,0 +1,22 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    filter:
+      environment_blacklist':
+        - CMAKE_PREFIX_PATH
+    environment:
+      set:
+        '{name}_ROOT': '{prefix}'
+
+  'platform=test target=x86_64':
+    environment:
+      set:
+        FOO: 'foo'
+        OMPI_MCA_mpi_leave_pinned: '1'
+      unset:
+        - BAR
+
+  'platform=test target=x86_32':
+    load:
+      - 'foo/bar'

--- a/lib/spack/spack/test/data/modules/ups_version/autoload_all.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/autoload_all.yaml
@@ -1,0 +1,6 @@
+enable:
+  - ups_version
+ups_version:
+  verbose: true
+  all:
+    autoload: 'all'

--- a/lib/spack/spack/test/data/modules/ups_version/autoload_direct.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/autoload_direct.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_version/autoload_with_constraints.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/autoload_with_constraints.yaml
@@ -1,0 +1,8 @@
+enable:
+  - ups_version
+ups_version:
+  ^mpich2:
+    autoload: 'direct'
+
+  ^python:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_version/blacklist.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/blacklist.yaml
@@ -1,0 +1,10 @@
+enable:
+  - ups_version
+ups_version:
+  whitelist:
+    - zmpi
+  blacklist:
+    - callpath
+    - mpi
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_version/blacklist_implicits.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/blacklist_implicits.yaml
@@ -1,0 +1,6 @@
+enable:
+  - ups_version
+ups_version:
+  blacklist_implicits: true
+  all:
+    autoload: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_version/conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/conflicts.yaml
@@ -1,0 +1,8 @@
+enable:
+  - ups_version
+ups_version:
+  naming_scheme: '{name}/{version}-{compiler.name}'
+  all:
+    conflict:
+      - '{name}'
+      - 'intel/14.0.1'

--- a/lib/spack/spack/test/data/modules/ups_version/invalid_naming_scheme.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/invalid_naming_scheme.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_version
+ups_version:
+  # {variants} is not allowed in the naming scheme, see #2884
+  naming_scheme: '{name}/{version}-{compiler.name}-{variants}'

--- a/lib/spack/spack/test/data/modules/ups_version/invalid_token_in_env_var_name.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/invalid_token_in_env_var_name.yaml
@@ -1,0 +1,21 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    filter:
+      environment_blacklist':
+        - CMAKE_PREFIX_PATH
+    environment:
+      set:
+        '{name}_ROOT_{prefix}': '{prefix}'
+
+  'platform=test target=x86_64':
+    environment:
+      set:
+        FOO_{variants}: 'foo'
+      unset:
+        - BAR
+
+  'platform=test target=x86_32':
+    load:
+      - 'foo/bar'

--- a/lib/spack/spack/test/data/modules/ups_version/override_template.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/override_template.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    template: 'override_from_modules.txt'

--- a/lib/spack/spack/test/data/modules/ups_version/prerequisites_all.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/prerequisites_all.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    prerequisites: 'all'

--- a/lib/spack/spack/test/data/modules/ups_version/prerequisites_direct.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/prerequisites_direct.yaml
@@ -1,0 +1,5 @@
+enable:
+  - ups_version
+ups_version:
+  all:
+    prerequisites: 'direct'

--- a/lib/spack/spack/test/data/modules/ups_version/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/suffix.yaml
@@ -1,0 +1,7 @@
+enable:
+  - ups_version
+ups_version:
+  mpileaks:
+    suffixes:
+      '+debug': foo
+      '~debug': bar

--- a/lib/spack/spack/test/data/modules/ups_version/wrong_conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/ups_version/wrong_conflicts.yaml
@@ -1,0 +1,7 @@
+enable:
+  - ups_version
+ups_version:
+  naming_scheme: '{name}/{version}-{compiler.name}'
+  all:
+    conflict:
+      - '{name}/{compiler.name}'

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -63,7 +63,7 @@ def test_modules_written_with_proper_permissions(
     assert mock_package_perms & os.stat(mock_module_filename).st_mode == mock_package_perms
 
 
-@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+@pytest.mark.parametrize("module_type", ["tcl", "lmod", "ups_table", "ups_version"])
 def test_modules_default_symlink(
     module_type, mock_packages, mock_module_filename, mock_module_defaults, config
 ):

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -45,6 +45,18 @@ def provider(request):
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestLmod(object):
+    @pytest.mark.regression("37788")
+    @pytest.mark.parametrize("modules_config", ["core_compilers", "core_compilers_at_equal"])
+    def test_layout_for_specs_compiled_with_core_compilers(
+        self, modules_config, module_configuration, factory
+    ):
+        """Tests that specs compiled with core compilers are in the 'Core' folder. Also tests that
+        we can use both ``compiler@version`` and ``compiler@=version`` to specify a core compiler.
+        """
+        module_configuration(modules_config)
+        module, spec = factory("libelf%clang@12.0.0")
+        assert "Core" in module.layout.available_path_parts
+
     def test_file_layout(self, compiler, provider, factory, module_configuration):
         """Tests the layout of files in the hierarchy is the one expected."""
         module_configuration("complex_hierarchy")
@@ -61,7 +73,7 @@ class TestLmod(object):
         # is transformed to r"Core" if the compiler is listed among core
         # compilers
         # Check that specs listed as core_specs are transformed to "Core"
-        if compiler == "clang@=3.3" or spec_string == "mpich@3.0.1":
+        if compiler == "clang@=12.0.0" or spec_string == "mpich@3.0.1":
             assert "Core" in layout.available_path_parts
         else:
             assert compiler.replace("@=", "/") in layout.available_path_parts

--- a/lib/spack/spack/test/modules/ups_table.py
+++ b/lib/spack/spack/test/modules/ups_table.py
@@ -1,0 +1,246 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+import spack.modules.common
+import spack.modules.ups_table
+import spack.spec
+
+mpich_spec_string = "mpich@3.0.4"
+mpich_product_line = "PRODUCT = mpich"
+mpileaks_spec_string = "mpileaks"
+libdwarf_spec_string = "libdwarf arch=x64-linux"
+
+#: Class of the writer tested in this module
+writer_cls = spack.modules.ups_table.UpsTableModulefileWriter
+
+
+@pytest.mark.usefixtures("config", "mock_packages")
+class TestUpsTable(object):
+    def test_simple_case(self, modulefile_content, module_configuration):
+        """Tests the generation of a simple ups_table module file."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content(mpich_spec_string)
+
+        assert "FILE = Table" in content
+
+    def test_autoload_direct(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of direct dependencies."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content(mpileaks_spec_string)
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+        # The configuration file sets the verbose keyword to False
+        messages = [x for x in content if 'puts stderr "Autoloading' in x]
+        assert len(messages) == 0
+
+    def test_autoload_all(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of all dependencies."""
+
+        module_configuration("autoload_all")
+        content = modulefile_content(mpileaks_spec_string)
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+        assert len([x for x in content if "setupRequired" in x]) == 3
+
+    def test_prerequisites_direct(self, modulefile_content, module_configuration):
+        """Tests asking direct dependencies as prerequisites."""
+
+        module_configuration("prerequisites_direct")
+        content = modulefile_content("mpileaks arch=x86-linux")
+
+        assert len([x for x in content if "setupRequired(" in x]) == 2
+
+    def test_prerequisites_all(self, modulefile_content, module_configuration):
+        """Tests asking all dependencies as prerequisites."""
+
+        module_configuration("prerequisites_all")
+        content = modulefile_content("mpileaks arch=x86-linux")
+
+        assert len([x for x in content if "setupRequired(" in x]) == 2
+
+    def test_alter_environment(self, modulefile_content, module_configuration):
+        """Tests modifications to run-time environment."""
+
+        module_configuration("alter_environment")
+        content = modulefile_content("mpileaks platform=test target=x86_64")
+
+        assert len([x for x in content if x.startswith("PathPrepend(CMAKE_PREFIX_PATH")]) == 0
+        assert len([x for x in content if 'EnvSet(FOO, "foo"' in x]) == 1
+        assert len([x for x in content if 'EnvSet(OMPI_MCA_mpi_leave_pinned, "1"' in x]) == 1
+        assert len([x for x in content if 'EnvSet(OMPI_MCA_MPI_LEAVE_PINNED, "1"' in x]) == 0
+        assert len([x for x in content if "EnvSet(MPILEAKS_ROOT" in x]) == 1
+
+        content = modulefile_content("libdwarf %clang platform=test target=x86_32")
+
+        assert len([x for x in content if x.startswith("PathPrepend(CMAKE_PREFIX_PATH")]) == 0
+        assert len([x for x in content if 'EnvSet(FOO, "foo"' in x]) == 0
+        assert len([x for x in content if "unEnvSet(BAR" in x]) == 0
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+        assert len([x for x in content if "EnvSet(LIBDWARF_ROOT" in x]) == 1
+
+    def test_blacklist(self, modulefile_content, module_configuration):
+        """Tests blacklisting the generation of selected modules."""
+
+        module_configuration("blacklist")
+        content = modulefile_content("mpileaks ^zmpi")
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+        # Returns a StringIO instead of a string as no module file was written
+        with pytest.raises(AttributeError):
+            modulefile_content("callpath arch=x86-linux")
+
+        content = modulefile_content("zmpi arch=x86-linux")
+
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+    def test_naming_scheme(self, factory, module_configuration):
+        """Tests reading the correct naming scheme."""
+
+        # This configuration has no error, so check the conflicts directives
+        # are there
+        module_configuration("conflicts")
+
+        # Test we read the expected configuration for the naming scheme
+        writer, _ = factory("mpileaks")
+        expected = "{name}/{version}-{compiler.name}"
+
+        assert writer.conf.naming_scheme == expected
+
+    def test_invalid_naming_scheme(self, factory, module_configuration):
+        """Tests the evaluation of an invalid naming scheme."""
+
+        module_configuration("invalid_naming_scheme")
+
+        # Test that having invalid tokens in the naming scheme raises
+        # a RuntimeError
+        writer, _ = factory("mpileaks")
+        with pytest.raises(RuntimeError):
+            writer.layout.use_name
+
+    def test_invalid_token_in_env_name(self, factory, module_configuration):
+        """Tests setting environment variables with an invalid name."""
+
+        module_configuration("invalid_token_in_env_var_name")
+
+        writer, _ = factory("mpileaks")
+        with pytest.raises(RuntimeError):
+            writer.write()
+
+    def test_module_index(self, module_configuration, factory, tmpdir_factory):
+        module_configuration("suffix")
+
+        w1, s1 = factory("mpileaks")
+        w2, s2 = factory("callpath")
+
+        test_root = str(tmpdir_factory.mktemp("module-root"))
+
+        spack.modules.common.generate_module_index(test_root, [w1, w2])
+
+        index = spack.modules.common.read_module_index(test_root)
+
+        assert index[s1.dag_hash()].use_name == w1.layout.use_name
+        assert index[s2.dag_hash()].path == w2.layout.filename
+
+    def test_suffixes(self, module_configuration, factory):
+        """Tests adding suffixes to module file name."""
+        module_configuration("suffix")
+
+        writer, spec = factory("mpileaks+debug arch=x86-linux")
+        assert "foo" in writer.layout.use_name
+
+        writer, spec = factory("mpileaks~debug arch=x86-linux")
+        assert "bar" in writer.layout.use_name
+
+    def test_setup_environment(self, modulefile_content, module_configuration):
+        """Tests the internal set-up of run-time environment."""
+
+        module_configuration("suffix")
+        content = modulefile_content("mpileaks")
+
+        assert len([x for x in content if "EnvSet(FOOBAR" in x]) == 1
+        assert len([x for x in content if 'EnvSet(FOOBAR, "mpileaks"' in x]) == 1
+
+        spec = spack.spec.Spec("mpileaks")
+        spec.concretize()
+        content = modulefile_content(str(spec["callpath"]))
+
+        assert len([x for x in content if "EnvSet(FOOBAR" in x]) == 1
+        assert len([x for x in content if 'EnvSet(FOOBAR, "callpath"' in x]) == 1
+
+    def test_override_template_in_package(self, modulefile_content, module_configuration):
+        """Tests overriding a template from and attribute in the package."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content("override-module-templates")
+
+        assert "PRODUCT = override-module-templates" in content
+
+    def test_override_template_in_modules_yaml(self, modulefile_content, module_configuration):
+        """Tests overriding a template from `modules.yaml`"""
+        module_configuration("override_template")
+
+        content = modulefile_content("override-module-templates")
+        assert "Override even better!" in content
+
+        content = modulefile_content("mpileaks arch=x86-linux")
+        assert "Override even better!" in content
+
+    @pytest.mark.regression("4400")
+    @pytest.mark.db
+    def test_blacklist_implicits(self, modulefile_content, module_configuration, database):
+        module_configuration("blacklist_implicits")
+
+        # mpileaks has been installed explicitly when setting up
+        # the tests database
+        mpileaks_specs = database.query("mpileaks")
+        for item in mpileaks_specs:
+            writer = writer_cls(item)
+            assert not writer.conf.blacklisted
+
+        # callpath is a dependency of mpileaks, and has been pulled
+        # in implicitly
+        callpath_specs = database.query("callpath")
+        for item in callpath_specs:
+            writer = writer_cls(item)
+            assert writer.conf.blacklisted
+
+    @pytest.mark.regression("9624")
+    @pytest.mark.db
+    def test_autoload_with_constraints(self, modulefile_content, module_configuration, database):
+        """Tests the automatic loading of direct dependencies."""
+
+        module_configuration("autoload_with_constraints")
+
+        # Test the mpileaks that should have the autoloaded dependencies
+        content = modulefile_content("mpileaks ^mpich2")
+        assert len([x for x in content if "FILE = Table" in x]) == 1
+
+        # Test the mpileaks that should NOT have the autoloaded dependencies
+        content = modulefile_content("mpileaks ^mpich")
+        assert len([x for x in content if "FILE = Table" in x]) == 1

--- a/lib/spack/spack/test/modules/ups_version.py
+++ b/lib/spack/spack/test/modules/ups_version.py
@@ -1,0 +1,205 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+import spack.modules.common
+import spack.modules.tcl
+import spack.spec
+
+mpich_spec_string = "mpich@3.0.4"
+mpileaks_spec_string = "mpileaks"
+libdwarf_spec_string = "libdwarf arch=x64-linux"
+
+#: Class of the writer tested in this module
+writer_cls = spack.modules.ups_version.UpsVersionModulefileWriter
+
+
+@pytest.mark.usefixtures("config", "mock_packages")
+class TestTcl(object):
+    def test_simple_case(self, modulefile_content, module_configuration):
+        """Tests the generation of a simple TCL module file."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content(mpich_spec_string)
+
+        assert "PRODUCT = mpich" in content
+
+    def test_autoload_direct(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of direct dependencies."""
+
+        module_configuration("autoload_direct")
+        content = modulefile_content(mpileaks_spec_string)
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        # The configuration file sets the verbose keyword to False
+        messages = [x for x in content if 'puts stderr "Autoloading' in x]
+        assert len(messages) == 0
+
+    def test_autoload_all(self, modulefile_content, module_configuration):
+        """Tests the automatic loading of all dependencies."""
+
+        module_configuration("autoload_all")
+        content = modulefile_content(mpileaks_spec_string)
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        # dtbuild1 has
+        # - 1 ('run',) dependency
+        # - 1 ('build','link') dependency
+        # - 1 ('build',) dependency
+        # Just make sure the 'build' dependency is not there
+        content = modulefile_content("dtbuild1")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+    def test_prerequisites_direct(self, modulefile_content, module_configuration):
+        """Tests asking direct dependencies as prerequisites."""
+
+        module_configuration("prerequisites_direct")
+        content = modulefile_content("mpileaks arch=x86-linux")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+    def test_prerequisites_all(self, modulefile_content, module_configuration):
+        """Tests asking all dependencies as prerequisites."""
+
+        module_configuration("prerequisites_all")
+        content = modulefile_content("mpileaks arch=x86-linux")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+    def test_alter_environment(self, modulefile_content, module_configuration):
+        """Tests modifications to run-time environment."""
+
+        module_configuration("alter_environment")
+        content = modulefile_content("mpileaks platform=test target=x86_64")
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        content = modulefile_content("libdwarf %clang platform=test target=x86_32")
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+    def test_blacklist(self, modulefile_content, module_configuration):
+        """Tests blacklisting the generation of selected modules."""
+
+        module_configuration("blacklist")
+        content = modulefile_content("mpileaks ^zmpi")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        # Returns a StringIO instead of a string as no module file was written
+        with pytest.raises(AttributeError):
+            modulefile_content("callpath arch=x86-linux")
+
+        content = modulefile_content("zmpi arch=x86-linux")
+
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+    def test_naming_scheme(self, factory, module_configuration):
+        """Tests reading the correct naming scheme."""
+
+        # This configuration has no error, so check the conflicts directives
+        # are there
+        module_configuration("conflicts")
+
+        # Test we read the expected configuration for the naming scheme
+        writer, _ = factory("mpileaks")
+        expected = "{name}/{version}-{compiler.name}"
+
+        assert writer.conf.naming_scheme == expected
+
+    def test_invalid_naming_scheme(self, factory, module_configuration):
+        """Tests the evaluation of an invalid naming scheme."""
+
+        module_configuration("invalid_naming_scheme")
+
+        # Test that having invalid tokens in the naming scheme raises
+        # a RuntimeError
+        writer, _ = factory("mpileaks")
+        with pytest.raises(RuntimeError):
+            writer.layout.use_name
+
+    def test_invalid_token_in_env_name(self, factory, module_configuration):
+        """Tests setting environment variables with an invalid name."""
+
+        module_configuration("invalid_token_in_env_var_name")
+
+        writer, _ = factory("mpileaks")
+        with pytest.raises(RuntimeError):
+            writer.write()
+
+    def test_module_index(self, module_configuration, factory, tmpdir_factory):
+        module_configuration("suffix")
+
+        w1, s1 = factory("mpileaks")
+        w2, s2 = factory("callpath")
+
+        test_root = str(tmpdir_factory.mktemp("module-root"))
+
+        spack.modules.common.generate_module_index(test_root, [w1, w2])
+
+        index = spack.modules.common.read_module_index(test_root)
+
+        assert index[s1.dag_hash()].use_name == w1.layout.use_name
+        assert index[s2.dag_hash()].path == w2.layout.filename
+
+    def test_suffixes(self, module_configuration, factory):
+        """Tests adding suffixes to module file name."""
+        module_configuration("suffix")
+
+        writer, spec = factory("mpileaks+debug arch=x86-linux")
+        assert "foo" in writer.layout.use_name
+
+        writer, spec = factory("mpileaks~debug arch=x86-linux")
+        assert "bar" in writer.layout.use_name
+
+    def test_setup_environment(self, modulefile_content, module_configuration):
+        """Tests the internal set-up of run-time environment."""
+
+        module_configuration("suffix")
+        spec = spack.spec.Spec("mpileaks")
+        spec.concretize()
+
+    def test_override_template_in_modules_yaml(self, modulefile_content, module_configuration):
+        """Tests overriding a template from `modules.yaml`"""
+        module_configuration("override_template")
+
+        content = modulefile_content("override-module-templates")
+        assert "Override even better!" in content
+
+        content = modulefile_content("mpileaks arch=x86-linux")
+        assert "Override even better!" in content
+
+    def test_extend_context(self, modulefile_content, module_configuration):
+        """Tests using a package defined context"""
+        module_configuration("autoload_direct")
+        content = modulefile_content("override-context-templates")
+
+        assert "PRODUCT = override-context-templates" in content
+
+    @pytest.mark.regression("9624")
+    @pytest.mark.db
+    def test_autoload_with_constraints(self, modulefile_content, module_configuration, database):
+        """Tests the automatic loading of direct dependencies."""
+
+        module_configuration("autoload_with_constraints")
+
+        # Test the mpileaks that should have the autoloaded dependencies
+        content = modulefile_content("mpileaks ^mpich2")
+        assert len([x for x in content if "FILE = version" in x]) == 1
+
+        # Test the mpileaks that should NOT have the autoloaded dependencies
+        content = modulefile_content("mpileaks ^mpich")
+        assert len([x for x in content if "FILE = version" in x]) == 1

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -22,6 +22,7 @@ from llnl.util.lang import dedupe
 
 import spack.platforms
 import spack.spec
+import spack.target
 
 from .executable import Executable, which
 from .path import path_to_os_path, system_path_filter
@@ -37,7 +38,7 @@ if sys.platform == "win32":
     SUFFIXES = []
 else:
     SYSTEM_PATHS = ["/", "/usr", "/usr/local"]
-    SUFFIXES = ["bin", "bin64", "include", "lib", "lib64"]
+    SUFFIXES = ["bin64", "bin", "include", "lib64", "lib"]
 
 SYSTEM_DIRS = [os.path.join(p, s) for s in SUFFIXES for p in SYSTEM_PATHS] + SYSTEM_PATHS
 
@@ -116,11 +117,31 @@ def filter_system_paths(paths: List[Path]) -> List[Path]:
     return [p for p in paths if not is_system_path(p)]
 
 
-def deprioritize_system_paths(paths: List[Path]) -> List[Path]:
+target_64bit_re = re.compile(r"(?<!\d)64(?=\D|$)")
+
+
+def deprioritize_system_paths(
+    paths: List[Path], target: Optional[Union[str, spack.target.Target]] = None
+) -> List[Path]:
     """Reorders input paths by putting system paths at the end of the list, otherwise
     preserving order.
     """
-    return list(sorted(paths, key=is_system_path))
+    result = sorted(paths, key=is_system_path)
+    # If we are building for a 64-bit target, move e.g. *64 system paths to
+    # the front of the system paths; otherwise remove them
+    if target is None:
+        ref_target = spack.platforms.host().target("default_target")
+    elif not isinstance(target, spack.target.Target):
+        ref_target = spack.target.Target(target)
+    else:
+        ref_target = target
+    if target_64bit_re.search(ref_target.microarchitecture.family.name):
+        result.sort(key=lambda path: is_system_path(path) and not path.endswith("64"))
+    else:
+        result = list(
+            filter(lambda path: not (is_system_path(path) and path.endswith("64")), result)
+        )
+    return result
 
 
 def prune_duplicate_paths(paths: List[Path]) -> List[Path]:
@@ -416,13 +437,37 @@ class RemovePath(NameValueModifier):
         env[self.name] = self.separator.join(directories)
 
 
+class RemoveSystemPaths(NameModifier):
+    def execute(self, env: MutableMapping[str, str]):
+        tty.debug(f"RemoveSystemPaths: {self.name}", level=3)
+        environment_value = env.get(self.name, "")
+        directories = environment_value.split(self.separator) if environment_value else []
+        directories = filter_system_paths(
+            [path_to_os_path(os.path.normpath(x)).pop() for x in directories]
+        )
+        env[self.name] = self.separator.join(directories)
+
+
 class DeprioritizeSystemPaths(NameModifier):
+    __slots__ = ("target",)
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        separator: str = os.pathsep,
+        trace: Optional[Trace] = None,
+        target: Optional[Union[str, spack.target.Target]] = None,
+    ):
+        super().__init__(name, separator=separator, trace=trace)
+        self.target = target
+
     def execute(self, env: MutableMapping[str, str]):
         tty.debug(f"DeprioritizeSystemPaths: {self.name}", level=3)
         environment_value = env.get(self.name, "")
         directories = environment_value.split(self.separator) if environment_value else []
         directories = deprioritize_system_paths(
-            [path_to_os_path(os.path.normpath(x)).pop() for x in directories]
+            [path_to_os_path(os.path.normpath(x)).pop() for x in directories], self.target
         )
         env[self.name] = self.separator.join(directories)
 
@@ -585,7 +630,23 @@ class EnvironmentModifications:
         self.env_modifications.append(item)
 
     @system_env_normalize
-    def deprioritize_system_paths(self, name: str, separator: str = os.pathsep):
+    def remove_system_paths(self, name: str, separator: str = os.pathsep):
+        """Stores a request to remove system paths from a list of paths.
+
+        Args:
+            name: name of the environment variable
+            separator: separator for the paths (default: os.pathsep)
+        """
+        item = RemoveSystemPaths(name, separator=separator, trace=self._trace())
+        self.env_modifications.append(item)
+
+    @system_env_normalize
+    def deprioritize_system_paths(
+        self,
+        name: str,
+        separator: str = os.pathsep,
+        target: Optional[Union[str, spack.target.Target]] = None,
+    ):
         """Stores a request to deprioritize system paths in a path list,
         otherwise preserving the order.
 
@@ -593,7 +654,9 @@ class EnvironmentModifications:
             name: name of the environment variable
             separator: separator for the paths (default: os.pathsep)
         """
-        item = DeprioritizeSystemPaths(name, separator=separator, trace=self._trace())
+        item = DeprioritizeSystemPaths(
+            name, separator=separator, trace=self._trace(), target=target
+        )
         self.env_modifications.append(item)
 
     @system_env_normalize

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -24,4 +24,4 @@ spack:
   mirrors: { "mirror": "s3://spack-binaries/develop/build_systems" }
 
   cdash:
-    build-group: Build tests for different build systems
+    build-group: Build Systems

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -6,9 +6,9 @@ spack:
     mesa:
       require: "+glx +osmesa +opengl ~opengles +llvm"
     libosmesa:
-      require: ^mesa +osmesa
+      require: "mesa +osmesa"
     libglx:
-      require: ^mesa +glx
+      require: "mesa +glx"
     ospray:
       require: "@2.8.0 +denoiser +mpi"
     llvm:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -269,6 +269,10 @@ spack:
     pipeline-gen:
     - build-job:
         image: ecpe4s/ubuntu20.04-runner-x86_64-oneapi:2023-01-01
+        before_script:
+        - - . /bootstrap/runner/view/lmod/lmod/init/bash
+          - module use /opt/intel/oneapi/modulefiles
+          - module load compiler
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -1,0 +1,60 @@
+FILE = Table
+PRODUCT = {{spec.name|replace("-", "_")}}
+
+FLAVOR=ANY
+
+{% if   (spec.compiler|string).find('gcc@9.3.0')==0   %}{%set upscompquals = 'e20' %}
+{% elif (spec.compiler|string).find('gcc@8.2.0')==0   %}{%set upscompquals = 'e19' %}
+{% elif (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
+{% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e15' %}
+{% elif (spec.compiler|string).find('gcc@6.3.0')==0   %}{%set upscompquals = 'e14' %}
+{% elif (spec.compiler|string).find('gcc@4.9.3')==0   %}{%set upscompquals = 'e10' %}
+{% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e17' %}
+{% elif (spec.compiler|string).find('clang@5.0.1')==0 %}{%set upscompquals = 'c2' %}
+{% endif %}
+
+{% if (spec.compiler_flags|string).find('-g')>0 %}{%set upsdebugquals="debug"%}
+{%else%}{%set upsdebugquals="opt"%}
+{%endif%}
+
+{%if  upscompquals  %}
+QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}"
+{%else%}
+QUALIFIERS=""
+{%endif%}
+
+
+{%set spack_root = os.environ['SPACK_ROOT'] %}
+{%set install_root =  spack_root[0:spack_root.find('/spack/')] %}
+{%if spec.prefix[0:spec.prefix.find('/'+spec.name)] == install_root %}
+
+Action = setup
+    prodDir()
+    setupEnv()
+{% for package in spec._dependencies.keys() %}
+    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+{% endfor %}
+
+{% block environment %}
+{% for command_name, cmd in environment_modifications %}
+{# A non-standard separator is required #}
+{% if command_name == 'PrependPath' %}
+    PathPrepend({{ cmd.name }}, "{{ cmd.value|replace(spec.prefix,'${UPS_PROD_DIR}') }}", "{{cmd.separator}}")
+{% elif command_name == 'AppendPath' %}
+    PathAppend({{ cmd.name }}, "{{ cmd.value|replace(spec.prefix,'${UPS_PROD_DIR}') }}", "{{cmd.separator}}")
+{% elif command_name == 'RemovePath' %}
+    PathRemove({{ cmd.name }}, "{{ cmd.value|replace(spec.prefix,'${UPS_PROD_DIR}') }}", "{{ cmd.separator }}")
+{% elif command_name == 'SetEnv' %}
+    EnvSet({{ cmd.name }}, "{{ cmd.value|replace(spec.prefix,'${UPS_PROD_DIR}') }}")
+{% elif command_name == 'UnsetEnv' %}
+    EnvUnset({{ cmd.name }})
+{% endif %}
+{#  #}
+{% endfor %}
+{% endblock %}
+
+{%endif%}
+
+{% block footer %}
+{# In case he module needs to be extended with custom TCL code #}
+{% endblock %}

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -33,7 +33,7 @@ Action = setup
     setupEnv()
 {% for package in spec._dependencies.keys() %}
    {% if spec[package].prefix != "/usr" %}
-    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+    setupOptional({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
    {% endif %}
 {% endfor %}
 

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -32,7 +32,9 @@ Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
+  {%if spec[package].prefix != "/usr" %}
     setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+  {%endif%}
 {% endfor %}
 
 {% block environment %}

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -26,15 +26,15 @@ QUALIFIERS=""
 
 {%set spack_root = os.environ['SPACK_ROOT'] %}
 {%set install_root =  spack_root[0:spack_root.find('/spack/')] %}
-{%if spec.prefix[0:spec.prefix.find('/'+spec.name)] == install_root %}
+{%if spec.prefix.startswith(install_root) %}
 
 Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
-  {%if spec[package].prefix != "/usr" %}
-    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
-  {%endif%}
+   {% if spec[package].prefix != "/usr" %}
+    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@=')[0] == package%}{{c.split('@=')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+   {% endif %}
 {% endfor %}
 
 {% block environment %}

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -1,0 +1,57 @@
+FILE = version
+PRODUCT = {{spec.name|replace("-","_")}}
+VERSION = {{spec.version}}
+
+{% if   (spec.architecture|string).find('i686')>0   %}{%set upsbits = '' %}
+{% elif (spec.architecture|string).find('x86_64')>0 %}{%set upsbits = '64bit' %}
+{% else  %}{%set upsbits = '64bit' %}
+{% endif %}
+
+{% if   (spec.architecture|string).find('darwin')>=0 %}{%set upsos = 'Darwin' %}
+{% elif (spec.architecture|string).find('linux')>=0   %}{%set upsos = 'Linux' %}
+{% else %} {% set upsos = 'Linux' %}
+{% endif %}
+
+{% if   (spec.architecture|string).find('scientific5')>0 %}{%set upsrelglibc = '+2.6-2.5' %}
+{% elif (spec.architecture|string).find('scientific6')>0 %}{%set upsrelglibc = '+2.6-2.12' %}
+{% elif (spec.architecture|string).find('scientific7')>0 %}{%set upsrelglibc = '+3.10-2.17' %}
+{% elif (spec.architecture|string).find('rhel5')>0 %}{%set upsrelglibc = '+2.6-2.5' %}
+{% elif (spec.architecture|string).find('rhel6')>0 %}{%set upsrelglibc = '+2.6-2.12' %}
+{% elif (spec.architecture|string).find('rhel7')>0 %}{%set upsrelglibc = '+3.10-2.17' %}
+{% elif (spec.architecture|string).find('maverics')>0    %}{%set upsrelglibc = '+13' %}
+{% elif (spec.architecture|string).find('yosemite')>0    %}{%set upsrelglibc = '+14' %}
+{% elif (spec.architecture|string).find('elcapitan')>0   %}{%set upsrelglibc = '+15' %}
+{% elif (spec.architecture|string).find('sierra')>0      %}{%set upsrelglibc = '+16' %}
+{% elif (spec.architecture|string).find('highsierra')>0  %}{%set upsrelglibc = '+17' %}
+{% elif (spec.architecture|string).find('mojave')>0      %}{%set upsrelglibc = '+18' %}
+{% else %}{%set upsrelglibc = '' %}
+{% endif %}
+
+
+{% if   (spec.compiler|string).find('gcc@9.3.0')==0   %}{%set upscompquals = 'e20' %}
+{% elif (spec.compiler|string).find('gcc@8.2.0')==0   %}{%set upscompquals = 'e19' %}
+{% elif (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
+{% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e15' %}
+{% elif (spec.compiler|string).find('gcc@6.3.0')==0   %}{%set upscompquals = 'e14' %}
+{% elif (spec.compiler|string).find('gcc@4.9.3')==0   %}{%set upscompquals = 'e10' %}
+{% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e17' %}
+{% elif (spec.compiler|string).find('clang@5.0.1')==0 %}{%set upscompquals = 'c2' %}
+{% endif %}
+
+{% if (spec.compiler_flags|string).find('-g')>0 %}{%set upsdebugquals="debug"%}
+{%else%}{%set upsdebugquals="opt"%}
+{%endif%}
+
+FLAVOR="{{upsos}}{{upsbits}}{{upsrelglibc}}"
+{%if  upscompquals  %}
+QUALIFIERS="{{upscompquals}}:{{upsdebugquals}}"
+{%else%}
+QUALIFIERS=""
+{%endif%}
+
+  DECLARER = {{username}}
+  DECLARED = {{timestamp}}
+  MODIFIER = {{username}}
+  MODIFIED = {{timestamp}}
+  PROD_DIR = {{spec.prefix}}
+  TABLE_FILE = {{spec.name|replace("-","_")}}_{{spec.version}}_{{spec._hash}}.table

--- a/var/spack/repos/builtin.mock/packages/python/package.py
+++ b/var/spack/repos/builtin.mock/packages/python/package.py
@@ -14,6 +14,7 @@ class Python(Package):
 
     extendable = True
 
+    version("3.7.1", md5="aaabbbcccdddeeefffaaabbbcccddd12")
     version("3.5.1", md5="be78e48cdfc1a7ad90efff146dce6cfe")
     version("3.5.0", md5="a56c0c0b45d75a0ec9c6dee933c41c36")
     version("2.7.11", md5="6b6076ec9e93f05dd63e47eb9c15728b", preferred=True)

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -7,16 +7,24 @@ from spack.package import *
 
 
 class SimpleStandaloneTest(Package):
-    """This package has a simple stand-alone test features."""
+    """This package has simple stand-alone test features."""
 
     homepage = "http://www.example.com/simple_test"
     url = "http://www.unit-test-should-replace-this-url/simple_test-1.0.tar.gz"
 
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("1.0", md5="123456789abcdef0123456789abcdefg")
+    version("0.9", md5="0123456789abcdef0123456789abcdef")
 
-    provides("standalone-test")
+    provides("standalone-ifc")
 
     def test_echo(self):
         """simple stand-alone test"""
         echo = which("echo")
         echo("testing echo", output=str.split, error=str.split)
+
+    def test_skip(self):
+        """simple skip test"""
+        if self.spec.satisfies("@1.0:"):
+            raise SkipTest("This test is not available from v1.0 on")
+
+        print("Ran test_skip")

--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -19,6 +19,7 @@ class Catch2(CMakePackage):
     version("develop", branch="devel")
 
     # Releases
+    version("3.3.2", sha256="8361907f4d9bff3ae7c1edb027f813659f793053c99b67837a0c0375f065bae2")
     version("3.0.1", sha256="8c4173c68ae7da1b5b505194a0c2d6f1b2aef4ec1e3e7463bde451f26bbaf4e7")
     version(
         "3.0.0-preview4", sha256="2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee"

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -26,6 +26,7 @@ class Cmake(Package):
     executables = ["^cmake[0-9]*$"]
 
     version("master", branch="master")
+    version("3.26.4", sha256="313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208")
     version("3.26.3", sha256="bbd8d39217509d163cb544a40d6428ac666ddc83e22905d3e52c925781f0f659")
     version("3.26.2", sha256="d54f25707300064308ef01d4d21b0f98f508f52dda5d527d882b9d88379f89a8")
     version("3.26.1", sha256="f29964290ad3ced782a1e58ca9fda394a82406a647e24d6afd4e6c32e42c412f")

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -28,6 +28,9 @@ class Davix(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    variant('thirdparty',default=False)
+    depends_on('gsoap', when='+thirdparty')
+
     depends_on("pkgconfig", type="build")
     depends_on("libxml2")
     depends_on("uuid")
@@ -35,6 +38,13 @@ class Davix(CMakePackage):
 
     def cmake_args(self):
         cmake_args = ["-DCMAKE_CXX_STANDARD={0}".format(self.spec.variants["cxxstd"].value)]
+
+        if self.spec.variants['thirdparty']:
+            cmake_args.append('-DENABLE_THIRD_PARTY_COPY=ON')
+        else:
+            cmake_args.append('-DENABLE_THIRD_PARTY_COPY=OFF')
+
         if "darwin" in self.spec.architecture:
             cmake_args.append("-DCMAKE_MACOSX_RPATH=ON")
+
         return cmake_args

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -17,6 +17,7 @@ class G4ndl(Package):
 
     maintainers("drbenmorgan")
 
+    version("4.6", sha256="9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408")
     version("4.7", sha256="7e7d3d2621102dc614f753ad928730a290d19660eed96304a9d24b453d670309")
     version("4.6", sha256="9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408")
     version("4.5", sha256="cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e")

--- a/var/spack/repos/builtin/packages/genie/GENIE-Generator.patch
+++ b/var/spack/repos/builtin/packages/genie/GENIE-Generator.patch
@@ -1,0 +1,31 @@
+diff -Naur GENIE-Generator/src/Framework/Messenger/Messenger.h GENIE-Generator/src/Framework/Messenger/Messenger.h
+--- GENIE-Generator/src/Framework/Messenger/Messenger.h	2023-03-10 08:40:23.000000000 -0600
++++ GENIE-Generator/src/Framework/Messenger/Messenger.h	2023-03-20 18:44:11.213250122 -0500
+@@ -109,6 +109,7 @@
+ */
+ #ifndef HIDE_GENIE_MSG_LOG_MACROS
+ 
++#ifndef HIDE_GENIE_LOG_XXX
+ #define LOG_FATAL(stream) \
+           (*Messenger::Instance())(stream) \
+                << log4cpp::Priority::FATAL << "[n] <" \
+@@ -148,6 +149,7 @@
+           (*Messenger::Instance())(stream) \
+                << log4cpp::Priority::DEBUG << "[n] <" \
+                << __FILE__ << "::" << __FUNCTION__ << " (" << __LINE__ << ")> : "
++#endif
+ 
+ #endif // HIDE_GENIE_MSG_LOG_MACROS
+ 
+diff -Naur GENIE-Generator/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx GENIE-Generator/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx
+--- GENIE-Generator/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx	2023-03-10 08:40:23.000000000 -0600
++++ GENIE-Generator/src/Physics/NuclearDeExcitation/NucDeExcitationSim.cxx	2023-03-20 18:45:07.995827324 -0500
+@@ -410,7 +410,7 @@
+     //>
+     double p32Elv = 0.0020;
+     //>
+-    int ns12 = 8;
++    const int ns12 = 8;
+     double s12Elv[ns12] = {0.0005, 0.0007, 0.0017, 0.0021, 0.0033, 0.0035, 0.0047, 0.0063};
+     //double s12Plv[ns12] = {0.21, 0.295, 0.14, 0.26, 0.14, 0.2, 0.03, 0.03};
+     // the above multiply by 0.2

--- a/var/spack/repos/builtin/packages/genie/GENIE-Reweight.patch
+++ b/var/spack/repos/builtin/packages/genie/GENIE-Reweight.patch
@@ -1,0 +1,10 @@
+--- GENIE-Reweight/src/RwCalculators/GReWeightINuke.h
++++ GENIE-Reweight/src/RwCalculators/GReWeightINuke.h
+@@ -47,6 +47,7 @@
+ 
+ namespace genie {
+ 
++ class GHepParticle;
+  class HAIntranuke2018;
+ 
+ namespace rew   {

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -58,6 +58,8 @@ class Genie(Package):
     # GENIE Makefile's think that the spack compiler is invalid.
     # Disables this check.
     patch("genie_disable_gopt_with_compiler_check.patch", level=0, when="@2.11:")
+    patch("GENIE-Generator.patch")
+    patch("GENIE-Reweight.patch")
 
     # Flags for GENIE"s optional but disabled by default features
     variant(

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -209,7 +209,11 @@ class Glib(Package):
 
         # arguments for older versions
         if self.spec.satisfies("@:2.72"):
-            args.append("-Dgettext=external")
+            if self.spec["iconv"].name == "libc":
+                args.append("-Dgettext=libc")
+            else:
+                args.append("-Dgettext=external")
+
         if self.spec.satisfies("@:2.74"):
             if self.spec["iconv"].name == "libc":
                 args.append("-Diconv=libc")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -185,6 +185,14 @@ class Hdf5(CMakePackage):
 
     variant("hl", default=False, description="Enable the high-level library")
     variant("cxx", default=False, description="Enable C++ support")
+    variant(
+        "cxxstd", 
+        default="11", 
+        values=("11","14","17","20","23"), 
+        multi=False, 
+        sticky=True, 
+        description="C++ standard",
+    )
     variant("map", when="@1.14:", default=False, description="Enable MAP API support")
     variant("fortran", default=False, description="Enable Fortran support")
     variant("java", when="@1.10:", default=False, description="Enable Java support")
@@ -582,6 +590,9 @@ class Hdf5(CMakePackage):
                 # are enabled but the tests are disabled.
                 spec.satisfies("@1.8.22+shared+tools"),
             ),
+            self.define("CXX_STANDARD_REQUIRED", True),
+            self.define("CMAKE_CXX_FLAGS", "-std=c++{0}".format(self.spec.variants["cxxstd"].value)),
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("HDF5_ENABLE_MAP_API", "map"),
             self.define("HDF5_ENABLE_Z_LIB_SUPPORT", True),
             self.define_from_variant("HDF5_ENABLE_SZIP_SUPPORT", "szip"),

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -38,6 +38,14 @@ class Hepmc3(CMakePackage):
         default=False,
         description="Install interfaces for some Monte-Carlo Event Gens",
     )
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", "20", "23"),
+        multi=False,
+        sticky=True,
+        description="C++ standard",
+    )
 
     depends_on("cmake@2.8.9:", type="build")
     depends_on("root", when="+rootio")
@@ -52,6 +60,9 @@ class Hepmc3(CMakePackage):
             "-DHEPMC3_ENABLE_PYTHON={0}".format(spec.satisfies("+python")),
             "-DHEPMC3_ENABLE_ROOTIO={0}".format(spec.satisfies("+rootio")),
             "-DHEPMC3_INSTALL_INTERFACES={0}".format(spec.satisfies("+interfaces")),
+            self.define("HEPMC_CXX_STANDARD",spec.variants["cxxstd"].value),
+            self.define("CMAKE_CXX_STANDARD",spec.variants["cxxstd"].value),
+            self.define("CMAKE_CXX_FLAGS", "-std=c++{}".format(spec.variants["cxxstd"].value)),
         ]
 
         if self.spec.satisfies("+python"):

--- a/var/spack/repos/builtin/packages/jwt-cpp/package.py
+++ b/var/spack/repos/builtin/packages/jwt-cpp/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class JwtCpp(CMakePackage):
+    """A header only library for creating and validating JSON Web Tokens in C++11."""
+
+    homepage = "https://thalhammer.github.io/jwt-cpp/"
+    url = "https://github.com/Thalhammer/jwt-cpp/archive/refs/tags/v0.4.0.tar.gz"
+
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
+
+    version("0.6.0", sha256="0227bd6e0356b211341075c7997c837f0b388c01379bd256aa525566a5553f03")
+    version("0.5.2", sha256="d3188f9611597eb1bb285169879e1d87202bf10a08e4e7734c9f2097bfd4a850")
+    version("0.5.1", sha256="d8f5ffb361824630b3b6f4aad26c730c915081071040c232ac57947d6177ef4f")
+    version("0.5.0", sha256="079a273f070dd11213e301712319a65881e51ab81535cc436d5313191df852a2")
+    version("0.4.0", sha256="f0dcc7b0e8bef8f9c3f434e7121f9941145042c9fe3055a5bdd709085a4f2be4")
+
+    # TODO: jwt-cpp>=0.6.0 supports wolfSSL for which there is currently
+    # no Spack recipe.
+    variant(
+        "ssl",
+        default="openssl",
+        values=("openssl", "libressl"),
+        multi=False,
+        when="@0.5.0:",
+        description="SSL library to use",
+    )
+
+    depends_on("openssl@1.0.2:", when="@0.4.0:0.4.99")
+    depends_on("openssl@1.0.2:", when="@0.5.0:0.5.99 ssl=openssl")
+    depends_on("openssl@1.0.1:", when="@0.6.0: ssl=openssl")
+    depends_on("libressl@3:", when="@0.5.0: ssl=libressl")
+
+    def cmake_args(self):
+        spec = self.spec
+        define = self.define
+        args = []
+        if spec.satisfies("@0.5.0:"):
+            ssl_library_dict = {"openssl": "OpenSSL", "libressl": "LibreSSL"}
+            args.append(define("JWT_SSL_LIBRARY", ssl_library_dict[spec.variants["ssl"].value]))
+            args += [define("JWT_BUILD_TESTS", False), define("JWT_BUILD_EXAMPLES", False)]
+        else:
+            args.append(define("BUILD_TESTS", False))
+        return args

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -46,3 +46,8 @@ class Libgd(AutotoolsPackage):
             "configure",
             string=True,
         )
+        filter_file(
+            "#include<string.h>", 
+            "#include<string.h>\n#include<limits.h>",
+            "src/gd_gd2.c"
+        )

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -47,7 +47,7 @@ class Libgd(AutotoolsPackage):
             string=True,
         )
         filter_file(
-            "#include<string.h>", 
-            "#include<string.h>\n#include<limits.h>",
+            "#include *<string.h>",
+            "#include <string.h>\n#include <limits.h>",
             "src/gd_gd2.c"
         )

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -21,6 +21,7 @@ class Lmod(AutotoolsPackage):
     homepage = "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod"
     url = "https://github.com/TACC/Lmod/archive/8.5.6.tar.gz"
 
+    version("8.7.24", sha256="8451267652059b6507b652e1b563929ecf9b689ffb20830642085eb6a55bd539")
     version("8.7.20", sha256="c04deff7d2ca354610a362459a7aa9a1c642a095e45a4b0bb2471bb3254e85f4")
     version("8.7.2", sha256="5f44f3783496d2d597ced7531e1714c740dbb2883a7d16fde362135fb0b0fd96")
     version("8.6.18", sha256="3db1c665c35fb8beb78c02e40d56accd361d82b715df70b2a995bcb10fbc2c80")
@@ -54,6 +55,8 @@ class Lmod(AutotoolsPackage):
     depends_on("lua-luaposix", type=("build", "run"))
     depends_on("lua-luafilesystem", type=("build", "run"))
     depends_on("tcl", type=("build", "link", "run"))
+
+    depends_on("bc", type="build", when="@8.7.10:")
 
     variant("auto_swap", default=True, description="Auto swapping of compilers, etc.")
     variant(

--- a/var/spack/repos/builtin/packages/py-pytest-regressions/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-regressions/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestRegressions(PythonPackage):
+    """Easy to use fixtures to write regression tests."""
+
+    homepage = "https://github.com/ESSS/pytest-regressions"
+    pypi = "pytest-regressions/pytest-regressions-2.3.1.tar.gz"
+
+    maintainers("chissg", "gartung", "marcmengel", "vitodb")
+
+    version("2.3.1", sha256="b3ec4cdb34e8f627606275d8b834c65e60e1a3073e326bb3727a427273d0221d")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pytest@3.5:", type=("build", "run"))
+    depends_on("python@3.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-basic-ng/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-basic-ng/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxBasicNg(PythonPackage):
+    """A modern skeleton for Sphinx themes."""
+
+    homepage = "https://github.com/pradyunsg/sphinx-basic-ng"
+    documentation = "https://rtfd.io/sphinx-basic-ng/"
+    pypi = "sphinx_basic_ng/sphinx_basic_ng-0.0.1a12.tar.gz"
+
+    maintainers("chissg", "gartung", "marcmengel", "vitodb")
+    version("0.0.1a12", sha256="cffffb14914ddd26c94b1330df1d72dab5a42e220aaeb5953076a40b9c50e801")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxBookTheme(PythonPackage):
+
+    """An interactive book theme for Sphinx."""
+
+    homepage = "https://pypi.org/project/sphinx-book-theme/"
+    pypi = "sphinx_book_theme/sphinx_book_theme-0.3.3.tar.gz"
+
+    maintainers("chissg", "gartung", "marcmengel", "vitodb")
+
+    version("0.3.3", sha256="0ec36208ff14c6d6bf8aee1f1f8268e0c6e2bfa3cef6e41143312b25275a6217")

--- a/var/spack/repos/builtin/packages/py-sphinx-design/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-design/package.py
@@ -22,3 +22,7 @@ class PySphinxDesign(PythonPackage):
     depends_on("py-flit-core@3.4:3", type=("build"))
     depends_on("py-sphinx@4:5", when="@0.3", type=("build", "run"))
     depends_on("py-sphinx@4:6", when="@0.4:", type=("build", "run"))
+    depends_on("py-pytest@7.1:", type="test")
+    depends_on("py-pytest-cov", type="test")
+    depends_on("py-pytest-regressions", type="test")
+    depends_on("py-myst-parser@0.18.0:", type="test")

--- a/var/spack/repos/builtin/packages/py-sphinx-immaterial/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-immaterial/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -13,6 +13,7 @@ class PySphinxRtdTheme(PythonPackage):
     pypi = "sphinx-rtd-theme/sphinx_rtd_theme-0.5.1.tar.gz"
 
     version("1.2.0", sha256="a0d8bd1a2ed52e0b338cbe19c4b2eef3c5e7a048769753dac6a9f059c7b641b8")
+    version("1.1.1", sha256="6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103")
     version("1.0.0", sha256="eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c")
     version("0.5.2", sha256="32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a")
     version("0.5.1", sha256="eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5")
@@ -21,8 +22,10 @@ class PySphinxRtdTheme(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-sphinx", when="@0.4.1:", type=("build", "run"))
-    depends_on("py-sphinx@1.6:6", when="@1:", type=("build", "run"))
-    depends_on("python@2.7:2.8,3.4:", when="@1:", type=("build", "run"))
+    depends_on("py-sphinx@1.6:5", when="@1:1.1.99", type=("build", "run"))
+    depends_on("py-sphinx@1.6:6", when="@1.2:", type=("build", "run"))
+    depends_on("python@2.7:2.8,3.4:", when="@1:1.1.99", type=("build", "run"))
+    depends_on("python@3.6:", when="@1.2:", type=("build", "run"))
     depends_on("py-docutils@:0.16", when="@0.5.2:0", type=("build", "run"))
     depends_on("py-docutils@:0.17", when="@1:1.1", type=("build", "run"))
     depends_on("py-docutils@:0.18", when="@1.2:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-theme-builder/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-theme-builder/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxThemeBuilder(PythonPackage):
+    """A tool for authoring Sphinx themes with a simple (opinionated) workflow."""
+
+    homepage = "https://github.com/pradyunsg/sphinx-theme-builder"
+    pypi = "sphinx-theme-builder/sphinx-theme-builder-0.2.0b1.tar.gz"
+
+    maintainers("chissg", "gartung", "marcmengel", "vitodb")
+
+    version("0.2.0b2", sha256="e9cd98c2bb35bf414fe721469a043cdcc10f0808d1ffcf606acb4a6282a6f288")
+    version("0.2.0b1", sha256="e9bb4a0a8516bab8769b9ddf003b70e5878611113319eb1fdb690af84a3a595f")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-flit-core@3.2:3", type="build")
+
+    depends_on("py-pyproject-metadata", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"))
+    depends_on("py-rich", type=("build", "run"))
+    depends_on("py-nodeenv", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-tomli", when="^python@:3.10", type=("build", "run"))
+    depends_on("py-typing-extensions", when="^python@3.7", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -14,6 +14,7 @@ class PySphinx(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("7.0.1", sha256="61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d")
     version("7.0.0", sha256="283c44aa28922bb4223777b44ac0d59af50a279ac7690dfe945bb2b9575dc41b")
 
     version("6.2.1", sha256="6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b")
@@ -88,7 +89,8 @@ class PySphinx(PythonPackage):
     depends_on("py-pygments@2.13:", when="@6.0.1:", type=("build", "run"))
     depends_on("py-pygments@2.12:", when="@5.2:", type=("build", "run"))
     depends_on("py-pygments@2:", type=("build", "run"))
-    depends_on("py-docutils@0.18.1:0.19", when="@6.2:", type=("build", "run"))
+    depends_on("py-docutils@0.18.1:0.20", when="@7.0.1:", type=("build", "run"))
+    depends_on("py-docutils@0.18.1:0.19", when="@6.2:7.0.0", type=("build", "run"))
     depends_on("py-docutils@0.18:0.19", when="@6.0:6.1", type=("build", "run"))
     depends_on("py-docutils@0.14:0.19", when="@5.1:5", type=("build", "run"))
     depends_on("py-docutils@0.14:0.18", when="@5.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
@@ -20,6 +20,7 @@ class PySphinxcontribApplehelp(PythonPackage):
     # import any modules for this package.
     import_modules: List[str] = []
 
+    version("1.0.4", sha256="828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e")
     version("1.0.2", sha256="a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58")
     version("1.0.1", sha256="edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897")
 

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
@@ -19,6 +19,7 @@ class PySphinxcontribHtmlhelp(PythonPackage):
     # import any modules.
     import_modules: List[str] = []
 
+    version("2.0.1", sha256="0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff")
     version("2.0.0", sha256="f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2")
     version("1.0.2", sha256="4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422")
 

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-moderncmakedomain/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxcontribModerncmakedomain(PythonPackage):
+    """Sphinx Domain for Modern CMake."""
+
+    homepage = "https://github.com/scikit-build/moderncmakedomain"
+    pypi = "sphinxcontrib_moderncmakedomain/sphinxcontrib_moderncmakedomain-3.25.0.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    version("3.25.0", sha256="4138e4d3f60e5c4b3982caa10033693bfc1009cdd851766754d5990d9d1e992a")
+
+    conflicts("python@:3.5")
+
+    depends_on("py-hatchling", type="build")
+
+    depends_on("py-sphinx", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-versioning/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-versioning/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxcontribVersioning(PythonPackage):
+    """Sphinx extension that allows building versioned docs for self-hosting."""
+
+    homepage = "https://github.com/Robpol86/sphinxcontrib-versioning"
+    pypi = "sphinxcontrib-versioning/sphinxcontrib-versioning-2.2.1.tar.gz"
+
+    maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
+
+    version("2.2.1", sha256="1a5fe9b4e36020488d0d037fccc0b21aaf71b80425cad42ef4a5e5c3c193d3cd")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-click", type=("build", "run"))
+    depends_on("py-colorclass", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -154,7 +154,7 @@ class Python(Package):
     if sys.platform != "win32":
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2")
+        depends_on("iconv", when="~libxml2")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -40,6 +40,8 @@ class Python(Package):
     install_targets = ["install"]
     build_targets: List[str] = []
 
+    version("3.11.4", sha256="85c37a265e5c9dd9f75b35f954e31fbfc10383162417285e30ad25cc073a0d63")
+
     version("3.11.2", sha256="2411c74bda5bbcfcddaf4531f66d1adc73f247f529aee981b029513aefdbf849")
     version("3.11.1", sha256="baed518e26b337d4d8105679caf68c5c32630d702614fc174e98cb95c46bdfa4")
     version("3.11.0", sha256="64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb")

--- a/var/spack/repos/builtin/packages/range-v3/package.py
+++ b/var/spack/repos/builtin/packages/range-v3/package.py
@@ -23,6 +23,7 @@ class RangeV3(CMakePackage):
     maintainers("greenc-FNAL")
 
     version("master", branch="master")
+    version("0.12.0", sha256="015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb")
     version("0.11.0", sha256="376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c")
     version("0.10.0", sha256="5a1cd44e7315d0e8dcb1eee4df6802221456a9d1dbeac53da02ac7bd4ea150cd")
     version("0.5.0", sha256="32e30b3be042246030f31d40394115b751431d9d2b4e0f6d58834b2fd5594280")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -228,6 +228,7 @@ class Root(CMakePackage):
 
     # X-Graphics
     depends_on("libx11", when="+x")
+    depends_on("xproto", when="+x")
     depends_on("libxext", when="+x")
     depends_on("libxft", when="+x")
     depends_on("libxpm", when="+x")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -232,6 +232,9 @@ class Root(CMakePackage):
     depends_on("libxft", when="+x")
     depends_on("libxpm", when="+x")
     depends_on("libsm", when="+x")
+    depends_on("fontconfig", when="+x")
+    depends_on("xextproto", when="+x @:6.08")
+    depends_on("xextproto", when="+x @6.22:")
 
     # OpenGL
     depends_on("ftgl@2.4.0:", when="+opengl")

--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -13,20 +13,47 @@ class ScitokensCpp(CMakePackage):
     homepage = "https://github.com/scitokens/scitokens-cpp"
     url = "https://github.com/scitokens/scitokens-cpp/archive/refs/tags/v0.7.0.tar.gz"
 
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb")
+
     version("1.0.1", sha256="d4660521fa17189e7a7858747d066052dd8ea8f430ce7649911c157d4423c412")
     version("1.0.0", sha256="88376c5cd065aac8d92445184a02ccf5186dc4890ccd7518e88be436978675c0")
+    version("0.7.3", sha256="7d3c438596588cd74cf1af8255c55f44ca86a34293b81415ee24b33de64f886a")
+    version("0.7.2", sha256="594eee5f80463cd501e9b4c17b6ea6dcae47a42ef4947406ce8b157e15d50d5b")
     version("0.7.1", sha256="44a1bca188897b1e97645149d1f6bc187cd0e482ad36159ca376834f028ce5ef")
     version("0.7.0", sha256="72600cf32523b115ec7abf4ac33fa369e0a655b3d3b390e1f68363e6c4e961b6")
+
+    variant(
+        "cxxstd",
+        default="11",
+        values=("11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+    )
 
     depends_on("cmake@2.6:")
     depends_on("cmake@3.10:", when="@0.7.1:")
     depends_on("openssl")
     depends_on("sqlite")
     depends_on("curl")
+    depends_on("jwt-cpp", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
+
+    conflicts("jwt-cpp@0.5:", when="@:0.7")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72
     @when("@0.7.0 ^openssl@3:")
     def patch(self):
         filter_file(" -Werror", "", "CMakeLists.txt")
+
+    def cmake_args(self):
+        define = self.define
+        define_from_variant = self.define_from_variant
+        args = [
+            define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            define("CMAKE_CXX_STANDARD_REQUIRED", True),
+        ]
+        return args
+
+    def setup_build_environment(self, env):
+        env.set("JWC_CPP_DIR", self.spec["jwt-cpp"].prefix)

--- a/var/spack/repos/builtin/packages/xrootd/no-systemd-5.5.2.patch
+++ b/var/spack/repos/builtin/packages/xrootd/no-systemd-5.5.2.patch
@@ -1,0 +1,17 @@
+--- a/cmake/XRootDFindLibs.cmake	2021-07-29 12:22:48.000000000 +0000
++++ b/cmake/XRootDFindLibs.cmake	2021-10-25 18:26:07.308918231 +0000
+@@ -30,10 +30,10 @@
+   add_definitions( -DHAVE_XML2 )
+ endif()
+ 
+-find_package( systemd )
+-if( SYSTEMD_FOUND )
+-  add_definitions( -DHAVE_SYSTEMD )
+-endif()
++#find_package( systemd )
++#if( SYSTEMD_FOUND )
++#  add_definitions( -DHAVE_SYSTEMD )
++#endif()
+ 
+ find_package( CURL )
+ 

--- a/var/spack/repos/builtin/packages/xrootd/no-systemd-pre-5.5.2.patch
+++ b/var/spack/repos/builtin/packages/xrootd/no-systemd-pre-5.5.2.patch
@@ -1,0 +1,17 @@
+--- a/cmake/XRootDFindLibs.cmake	2021-07-29 12:22:48.000000000 +0000
++++ b/cmake/XRootDFindLibs.cmake	2021-10-25 18:26:07.308918231 +0000
+@@ -26,10 +26,10 @@
+   add_definitions( -DHAVE_XML2 )
+ endif()
+ 
+-find_package( Systemd )
+-if( SYSTEMD_FOUND )
+-  add_definitions( -DHAVE_SYSTEMD )
+-endif()
++#find_package( Systemd )
++#if( SYSTEMD_FOUND )
++#  add_definitions( -DHAVE_SYSTEMD )
++#endif()
+ 
+ find_package( CURL )
+ 

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -15,8 +15,9 @@ class Xrootd(CMakePackage):
     url = "https://xrootd.slac.stanford.edu/download/v5.5.1/xrootd-5.5.1.tar.gz"
     list_url = "https://xrootd.slac.stanford.edu/dload.html"
 
-    maintainers("wdconinc")
+    maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb", "wdconinc")
 
+    version("5.5.5", sha256="0710caae527082e73d3bf8f9d1dffe95808afd3fcaaaa15ab0b937b8b226bc1f")
     version("5.5.4", sha256="41a8557ea2d118b1950282b17abea9230b252aa5ee1a5959173e2534b7d611d3")
     version("5.5.3", sha256="703829c2460204bd3c7ba8eaa23911c3c9a310f6d436211ba0af487ef7f6a980")
     version("5.5.2", sha256="ec4e0490b8ee6a3254a4ea4449342aa364bc95b78dc9a8669151be30353863c6")
@@ -49,35 +50,69 @@ class Xrootd(CMakePackage):
     version("4.4.0", sha256="f066e7488390c0bc50938d23f6582fb154466204209ca92681f0aa06340e77c8")
     version("4.3.0", sha256="d34865772d975b5d58ad80bb05312bf49aaf124d5431e54dc8618c05a0870e3c")
 
+    variant("davix", default=True, description="Build with Davix")
     variant("http", default=True, description="Build with HTTP support")
-
+    variant("krb5", default=False, description="Build with KRB5 support")
     variant("python", default=False, description="Build pyxroot Python extension")
-
     variant("readline", default=True, description="Use readline")
 
-    variant("krb5", default=False, description="Build with KRB5 support")
+    variant(
+        "cxxstd",
+        default="98",
+        values=("98", "11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+        when="@:4.5.99",
+    )
 
     variant(
         "cxxstd",
         default="11",
-        values=("98", "11", "14", "17"),
+        values=("98", "11", "14", "17", "20"),
         multi=False,
-        description="Use the specified C++ standard when building.",
+        description="Use the specified C++ standard when building",
+        when="@4.6.0:5.1.99",
+    )
+
+    variant(
+        "cxxstd",
+        default="14",
+        values=("98", "11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building",
+        when="@5.2.0:",
     )
 
     variant(
         "scitokens-cpp", default=False, when="@5.1.0:", description="Enable support for SciTokens"
     )
 
+    variant(
+        "client_only", default=False, description="Build and install client only", when="@4.10.0:"
+    )
+
     conflicts("cxxstd=98", when="@4.7.0:")
+    # C++ standard is not honored without
+    # https://github.com/xrootd/xrootd/pull/1929
+    # Related: C++>14 causes compilation errors with ~client_only. See
+    # also https://github.com/xrootd/xrootd/pull/1933.
+    conflicts("cxxstd=17", when="@5.0:5.5.2")
+    conflicts("cxxstd=20", when="@5.0:5.5.2")
+    conflicts("cxxstd=17", when="@5 ~client_only")
+    conflicts("cxxstd=20", when="@5 ~client_only")
+    conflicts("scitokens-cpp", when="@:5.5.2 +client_only")
 
     depends_on("bzip2")
-    depends_on("cmake@2.6:", type="build")
+    depends_on("cmake@2.6:", type="build", when="@3.1.0:")
+    conflicts("cmake@:3.0", when="@5.0.0")
+    conflicts("cmake@:3.15.99", when="@5.5.4:")
+    depends_on("davix", when="+davix")
     depends_on("libxml2", when="+http")
     depends_on("uuid", when="@4.11.0:")
     depends_on("openssl@:1", when="@:5.4")
     depends_on("openssl")
     depends_on("python", when="+python")
+    depends_on("py-setuptools", type="build", when="+python")
     depends_on("readline", when="+readline")
     depends_on("xz")
     depends_on("zlib")
@@ -85,6 +120,7 @@ class Xrootd(CMakePackage):
     depends_on("krb5", when="+krb5")
     depends_on("json-c")
     depends_on("scitokens-cpp", when="+scitokens-cpp")
+    conflicts("openssl@3:", when="@:5.3.99")
 
     extends("python", when="+python")
     patch("python-support.patch", level=1, when="@:4.8+python")
@@ -94,35 +130,73 @@ class Xrootd(CMakePackage):
         sha256="2655e2d609d80bf9c9ab58557f4f6940408a1af9c686e7aa214ac0348c89c8fa",
         when="@5.5.1",
     )
+    # https://github.com/xrootd/xrootd/pull/1930
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/1930.patch?full_index=1",
+        sha256="969f8b07edff42449ad76b02f3e57d93b8d6c829be1ba14bccf831c27bc971e1",
+        when="@5.5.3",
+    )
 
+    # do not use systemd
+    patch("no-systemd-pre-5.5.2.patch", when="@:5.5.1")
+    patch("no-systemd-5.5.2.patch", when="@5.5.2:")
+
+    @when("@4.7.0:5.1.99")
     def patch(self):
-        # Do not use systemd
-        filter_file(
-            r"(add_definitions\(\s*-DHAVE_SYSTEMD\s*\))", r"#\1", "cmake/XRootDFindLibs.cmake"
-        )
+        """Remove hardcoded -std=c++0x flag"""
+        filter_file(r"\-std=c\+\+0x", r"", "cmake/XRootDOSDefs.cmake")
 
-        # Remove hardcoded -std=c++0x flag
-        if self.spec.satisfies("@4.7.0:"):
-            filter_file(r"\-std=c\+\+0x", r"", "cmake/XRootDOSDefs.cmake")
+    @when("@5.2.0:5 +client_only")
+    def patch(self):
+        """Allow CMAKE_CXX_STANDARD to be set in cache"""
+        # See https://github.com/xrootd/xrootd/pull/1929
+        filter_file(
+            r"^(\s+(?i:set)\s*\(\s*CMAKE_CXX_STANDARD\s+\d+)(\s*\).*)$",
+            r'\1 CACHE STRING "C++ Standard"\2',
+            "cmake/XRootDOSDefs.cmake",
+        )
 
     def cmake_args(self):
         spec = self.spec
-        options = [
-            "-DENABLE_HTTP:BOOL={0}".format("ON" if "+http" in spec else "OFF"),
-            "-DENABLE_PYTHON:BOOL={0}".format("ON" if "+python" in spec else "OFF"),
-            "-DENABLE_READLINE:BOOL={0}".format("ON" if "+readline" in spec else "OFF"),
-            "-DENABLE_KRB5:BOOL={0}".format("ON" if "+krb5" in spec else "OFF"),
-            "-DENABLE_CEPH:BOOL=OFF",
+        define = self.define
+        define_from_variant = self.define_from_variant
+        options = []
+        if spec.satisfies("@5.2.0: +client_only") or spec.satisfies("@6:"):
+            options += [
+                define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+                define("CMAKE_CXX_STANDARD_REQUIRED", True),
+            ]
+
+        options += [
+            define_from_variant("ENABLE_HTTP", "http"),
+            define_from_variant("ENABLE_XRDCLHTTP", "davix"),
+            define_from_variant("ENABLE_PYTHON", "python"),
+            define_from_variant("ENABLE_READLINE", "readline"),
+            define_from_variant("ENABLE_KRB5", "krb5"),
+            define_from_variant("ENABLE_SCITOKENS", "scitokens-cpp"),
+            define_from_variant("XRDCL_ONLY", "client_only"),
+            define("ENABLE_CEPH", False),
+            define("ENABLE_CRYPTO", True),
+            define("ENABLE_FUSE", False),
+            define("ENABLE_MACAROONS", False),
+            define("ENABLE_VOMS", False),
+            define("FORCE_ENABLED", True),
         ]
         # see https://github.com/spack/spack/pull/11581
         if "+python" in self.spec:
-            options.append("-DPYTHON_EXECUTABLE=%s" % spec["python"].command.path)
+            options.extend(
+                [
+                    define("PYTHON_EXECUTABLE", spec["python"].command.path),
+                    define("XRD_PYTHON_REQ_VERSION", spec["python"].version.up_to(2)),
+                ]
+            )
 
         if "+scitokens-cpp" in self.spec:
             options.append("-DSCITOKENS_CPP_DIR=%s" % spec["scitokens-cpp"].prefix)
 
         return options
 
+    @when("@:5.1.99")
     def setup_build_environment(self, env):
         cxxstdflag = ""
         if self.spec.variants["cxxstd"].value == "98":


### PR DESCRIPTION
Make dependencies in the ups-compatible table files optional.   This helps avoid errors due to dependencies that may not have table files, etc.