### PR TITLE
Fix conflicts on direct dependencies that don't start with ^

### DIFF
--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -30,7 +30,7 @@ class Canu(MakefilePackage):
     depends_on("perl", type="run")
     # version guessed from include date of vendored boost
     depends_on("boost@1.60.0:+graph")
-    conflicts("boost@1.70.1:", when="@:2.0")
+    conflicts("^boost@1.70.1:", when="@:2.0")
 
     build_directory = "src"
     build_targets = ["clean"]

--- a/var/spack/repos/builtin/packages/cusz/package.py
+++ b/var/spack/repos/builtin/packages/cusz/package.py
@@ -24,9 +24,9 @@ class Cusz(CMakePackage, CudaPackage):
     version("0.3", sha256="0feb4f7fd64879fe147624dd5ad164adf3983f79b2e0383d35724f8d185dcb11")
 
     # these version of Cuda provide the CUB headers, but not CUB cmake configuration that we use.
-    conflicts("cuda@11.0.2:11.2.2")
+    conflicts("^cuda@11.0.2:11.2.2")
 
-    depends_on("cub", when="^ cuda@:10.2.89")
+    depends_on("cub", when="^cuda@:10.2.89")
 
     def cmake_args(self):
         cuda_arch = self.spec.variants["cuda_arch"].value

--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -33,7 +33,7 @@ class Dire(Package):
     depends_on("hepmc")
     depends_on("pythia8@8.226:")
 
-    conflicts("pythia8@8.301:", msg="Dire is included in Pythia8 since version 8.301")
+    conflicts("^pythia8@8.301:", msg="Dire is included in Pythia8 since version 8.301")
 
     def install(self, spec, prefix):
         configure_args = ["--prefix={0}".format(prefix)]

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -73,9 +73,9 @@ class Dyninst(CMakePackage):
 
     # findtbb.cmake in the dynist repo does not work with recent tbb
     # package layout. Need to use tbb provided config instead.
-    conflicts("intel-tbb@2021.1:")
-    conflicts("intel-oneapi-tbb@2021.1:")
-    conflicts("intel-parallel-studio", when="@12.0.0:")
+    conflicts("^intel-tbb@2021.1:")
+    conflicts("^intel-oneapi-tbb@2021.1:")
+    conflicts("^intel-parallel-studio", when="@12.0.0:")
     depends_on("tbb@2018.6.0:", when="@10.0.0:")
 
     depends_on("cmake@3.4.0:", type="build", when="@10.1.0:")

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -141,7 +141,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on("parallel-netcdf+shared", when="+pnetcdf", propagate=["fortran"])
 
     dav_sdk_depends_on("unifyfs", when="+unifyfs ")
-    conflicts("unifyfs@develop")
+    conflicts("^unifyfs@develop")
 
     dav_sdk_depends_on("veloc", when="+veloc")
 
@@ -164,7 +164,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("ascent ^conduit ~hdf5_compat", when="+ascent +hdf5")
     # Disable configuring with @develop. This should be removed after ascent
     # releases 0.8 and ascent can build with conduit@0.8: and vtk-m@1.7:
-    conflicts("ascent@develop", when="+ascent")
+    conflicts("^ascent@develop", when="+ascent")
 
     depends_on("py-cinemasci", when="+cinema")
 
@@ -177,7 +177,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
         propagate=["adios2", "cuda", "hdf5", "rocm"] + amdgpu_target_variants + cuda_arch_variants,
     )
     dav_sdk_depends_on("libcatalyst@2:+mpi", when="+paraview")
-    conflicts("paraview@master", when="+paraview")
+    conflicts("^paraview@master", when="+paraview")
 
     dav_sdk_depends_on("visit+mpi+python+silo", when="+visit", propagate=["hdf5", "adios2"])
 

--- a/var/spack/repos/builtin/packages/flcl/package.py
+++ b/var/spack/repos/builtin/packages/flcl/package.py
@@ -25,7 +25,9 @@ class Flcl(CMakePackage):
     depends_on("cmake@3.17:", type="build", when="@:0.4.0")
     depends_on("cmake@3.19:", type="build", when="@0.5.0:")
 
-    conflicts("kokkos@3.3.00:", when="@:0.4.99", msg="Requires FLCL >= 0.5.0 to use Kokkos >= 3.3")
+    conflicts(
+        "^kokkos@3.3.00:", when="@:0.4.99", msg="Requires FLCL >= 0.5.0 to use Kokkos >= 3.3"
+    )
 
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", self.run_tests)]

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -89,8 +89,8 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     for level in ("low", "medium", "high"):
         depends_on("caliper@2.0.1~adiak~libdw", when="@:1 caliper_detail=%s" % level)
         depends_on("caliper", when="@2.0: caliper_detail=%s" % level)
-        conflicts("caliper@2.6", when="@2.0: caliper_detail=%s" % level)
-        conflicts("caliper@2.7", when="@2.0: caliper_detail=%s" % level)
+        conflicts("^caliper@2.6", when="@2.0: caliper_detail=%s" % level)
+        conflicts("^caliper@2.7", when="@2.0: caliper_detail=%s" % level)
 
     depends_on("graphviz", when="+graphviz")
     depends_on("hdf5+hl+mpi", when="+hdf5")

--- a/var/spack/repos/builtin/packages/freeglut/package.py
+++ b/var/spack/repos/builtin/packages/freeglut/package.py
@@ -23,7 +23,7 @@ class Freeglut(CMakePackage, SourceforgePackage):
     depends_on("glu")
 
     # FreeGLUT does not support OSMesa
-    conflicts("osmesa")
+    conflicts("^osmesa")
 
     # FreeGLUT only works with GLX on linux (cray is also linux)
     with when("platform=linux"):

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -83,7 +83,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
     depends_on("autoconf@2.69", type="build", when="@master:")
     depends_on("automake@1.16:", type="build", when="@master:")
 
-    conflicts("hip@:4.4.0", when="+rocm")
+    conflicts("^hip@:4.4.0", when="+rocm")
 
     def install(self, spec, prefix):
         if spec.satisfies("@master:"):

--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -26,10 +26,10 @@ class Glew(CMakePackage):
         multi=False,
         description="The OpenGL provider to use",
     )
-    conflicts("osmesa", when="gl=glx")
-    conflicts("osmesa", when="gl=other")
-    conflicts("glx", when="gl=osmesa")
-    conflicts("glx", when="gl=other")
+    conflicts("^osmesa", when="gl=glx")
+    conflicts("^osmesa", when="gl=other")
+    conflicts("^glx", when="gl=osmesa")
+    conflicts("^glx", when="gl=other")
 
     depends_on("gl")
     depends_on("osmesa", when="gl=osmesa")

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -61,9 +61,9 @@ class Gptune(CMakePackage):
     depends_on("hypre+gptune@2.19.0", when="+hypre", type=("build", "run"))
 
     depends_on("openmpi@4:", when="+mpispawn", type=("build", "run"))
-    conflicts("mpich", when="+mpispawn")
-    conflicts("spectrum-mpi", when="+mpispawn")
-    conflicts("cray-mpich", when="+mpispawn")
+    conflicts("^mpich", when="+mpispawn")
+    conflicts("^spectrum-mpi", when="+mpispawn")
+    conflicts("^cray-mpich", when="+mpispawn")
     conflicts("%gcc@:7")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -161,7 +161,7 @@ class Gromacs(CMakePackage, CudaPackage):
     conflicts("%intel", when="@2022:", msg="GROMACS %intel support was removed in version 2022")
     conflicts("%gcc@:8", when="@2023:", msg="GROMACS requires GCC 9 or later since version 2023")
     conflicts(
-        "intel-oneapi-mkl@:2021.2",
+        "^intel-oneapi-mkl@:2021.2",
         when="@2023:",
         msg="GROMACS requires oneMKL 2021.3 or later since version 2023",
     )

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -40,7 +40,7 @@ class Hipsycl(CMakePackage):
     depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda")
     # https://github.com/OpenSYCL/OpenSYCL/pull/918 was introduced after 0.9.4
-    conflicts("llvm@16:", when="@:0.9.4")
+    conflicts("^llvm@16:", when="@:0.9.4")
     # LLVM PTX backend requires cuda7:10.1 (https://tinyurl.com/v82k5qq)
     depends_on("cuda@9:10.1", when="@0.8.1: +cuda ^llvm@9")
     depends_on("cuda@9:", when="@0.8.1: +cuda ^llvm@10:")

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -164,7 +164,7 @@ class Hpctoolkit(AutotoolsPackage):
     conflicts("%gcc@:4", when="@:2020", msg="hpctoolkit requires gnu gcc 5.x or later")
 
     conflicts("^binutils@2.35:2.35.1", msg="avoid binutils 2.35 and 2.35.1 (spews errors)")
-    conflicts("xz@5.2.7:5.2.8", msg="avoid xz 5.2.7:5.2.8 (broken symbol versions)")
+    conflicts("^xz@5.2.7:5.2.8", msg="avoid xz 5.2.7:5.2.8 (broken symbol versions)")
 
     conflicts("+cray", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")
     conflicts("+mpi", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -168,15 +168,15 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Certain Asio headers don't compile with nvcc from 1.17.0 onwards with
     # C++17. Starting with CUDA 11.3 they compile again.
-    conflicts("asio@1.17.0:", when="+cuda cxxstd=17 ^cuda@:11.2")
+    conflicts("^asio@1.17.0:", when="+cuda cxxstd=17 ^cuda@:11.2")
 
     # Starting from ROCm 5.0.0 hipcc miscompiles asio 1.17.0 and newer
-    conflicts("asio@1.17.0:", when="+rocm ^hip@5:")
+    conflicts("^asio@1.17.0:", when="+rocm ^hip@5:")
 
     # Boost and HIP don't work together in certain versions:
     # https://github.com/boostorg/config/issues/392. Boost 1.78.0 and HPX 1.8.0
     # both include a fix.
-    conflicts("boost@:1.77.0", when="@:1.7 +rocm")
+    conflicts("^boost@:1.77.0", when="@:1.7 +rocm")
 
     # libstdc++ has a broken valarray in some versions that clang/hipcc refuses
     # to compile:

--- a/var/spack/repos/builtin/packages/mesa-demos/package.py
+++ b/var/spack/repos/builtin/packages/mesa-demos/package.py
@@ -25,10 +25,10 @@ class MesaDemos(AutotoolsPackage):
         multi=False,
         description="The OpenGL provider to use",
     )
-    conflicts("osmesa", when="gl=glx")
-    conflicts("osmesa", when="gl=other")
-    conflicts("glx", when="gl=osmesa")
-    conflicts("glx", when="gl=other")
+    conflicts("^osmesa", when="gl=glx")
+    conflicts("^osmesa", when="gl=other")
+    conflicts("^glx", when="gl=osmesa")
+    conflicts("^glx", when="gl=other")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -25,10 +25,10 @@ class MesaGlu(AutotoolsPackage):
         multi=False,
         description="The OpenGL provider to use",
     )
-    conflicts("osmesa", when="gl=glx")
-    conflicts("osmesa", when="gl=other")
-    conflicts("glx", when="gl=osmesa")
-    conflicts("glx", when="gl=other")
+    conflicts("^osmesa", when="gl=glx")
+    conflicts("^osmesa", when="gl=other")
+    conflicts("^glx", when="gl=osmesa")
+    conflicts("^glx", when="gl=other")
 
     depends_on("gl@3:")
     depends_on("osmesa", when="gl=osmesa")

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -119,7 +119,7 @@ class Neovim(CMakePackage):
     with when("@0.6:"):
         depends_on("cmake@3.10:", type="build")
         depends_on("gperf@3.1:", type="link")
-        conflicts("libiconv@:1.14")
+        conflicts("^libiconv@:1.14")
         depends_on("libtermkey@0.22:", type="link")
         depends_on("libvterm@0.1.4:", type="link")
         depends_on("msgpack-c@3.0.0:", type="link")
@@ -136,7 +136,7 @@ class Neovim(CMakePackage):
     # Support for `libvterm@0.2:` has been added in neovim@0.8.0
     # term: Add support for libvterm >= 0.2 (https://github.com/neovim/neovim/releases/tag/v0.8.0)
     # https://github.com/neovim/neovim/issues/16217#issuecomment-958590493
-    conflicts("libvterm@0.2:", when="@:0.7")
+    conflicts("^libvterm@0.2:", when="@:0.7")
 
     @when("^lua")
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/numactl/package.py
+++ b/var/spack/repos/builtin/packages/numactl/package.py
@@ -31,7 +31,7 @@ class Numactl(AutotoolsPackage):
 
     # Numactl has hardcoded minimum versions for libtool,
     # libtool@develop returns UNKOWN as a version tag and fails
-    conflicts("libtool@develop")
+    conflicts("^libtool@develop")
 
     # Numerous errors when trying to build on darwin
     conflicts("platform=darwin")

--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -36,7 +36,7 @@ class Oce(Package):
     with when("+tbb"):
         depends_on("tbb")
         depends_on("intel-tbb@:2020 build_system=makefile", when="^intel-tbb")
-        conflicts("intel-oneapi-tbb@2021.1:")
+        conflicts("^intel-oneapi-tbb@2021.1:")
 
     # There is a bug in OCE which appears with Clang (version?) or GCC 6.0
     # and has to do with compiler optimization, see

--- a/var/spack/repos/builtin/packages/octave-quaternion/package.py
+++ b/var/spack/repos/builtin/packages/octave-quaternion/package.py
@@ -16,5 +16,5 @@ class OctaveQuaternion(OctavePackage, SourceforgePackage):
     version("2.4.0", sha256="4c2d4dd8f1d213f080519c6f9dfbbdca068087ee0411122b16e377e0f4641610")
     version("2.2.2", sha256="261d51657bc729c8f9fe915532d91e75e48dce2af2b298781e78cc93a5067cbd")
 
-    conflicts("octave@6:")
+    conflicts("^octave@6:")
     extends("octave@3.8.0:5.2.0")

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -63,14 +63,14 @@ class OmegaH(CMakePackage, CudaPackage):
     # Note: '+cuda' and 'cuda_arch' variants are added by the CudaPackage
     depends_on("cuda", when="+cuda")
     conflicts(
-        "cuda@11.2",
+        "^cuda@11.2",
         when="@scorec.10.1.0:",
         msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
     )
     # the sandia repo has a fix for cuda > 11.2 support
     #  see github.com/sandialabs/omega_h/pull/373
     conflicts(
-        "cuda@11.2",
+        "^cuda@11.2",
         when="@:9.34.4",
         msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
     )

--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -136,7 +136,7 @@ class Opencascade(CMakePackage):
     depends_on("tk", when="+tk")
     depends_on("gl")
 
-    conflicts("vtk@9.2", when="@:7.7.0 +vtk")
+    conflicts("^vtk@9.2", when="@:7.7.0 +vtk")
 
     def url_for_version(self, version):
         url = (

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -138,7 +138,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # Restrict zlib-ng to older versions for older Perl
     # See https://github.com/pmqs/Compress-Raw-Zlib/issues/24
     patch("zlib-ng.patch", when="@5.38 ^zlib-ng@2.1.2:")
-    conflicts("zlib-ng@2.1.2:", when="@:5.37")
+    conflicts("^zlib-ng@2.1.2:", when="@:5.37")
 
     # Fix the Time-Local testase http://blogs.perl.org/users/tom_wyant/2020/01/my-y2020-bug.html
     patch(

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -92,8 +92,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("boost@1.71:")
     depends_on("fmt@9:", when="@0.11:")
     # https://github.com/pika-org/pika/issues/686
-    conflicts("fmt@10:", when="@:0.15 +cuda")
-    conflicts("fmt@10:", when="@:0.15 +rocm")
+    conflicts("^fmt@10:", when="@:0.15 +cuda")
+    conflicts("^fmt@10:", when="@:0.15 +rocm")
     depends_on("hwloc@1.11.5:")
 
     depends_on("gperftools", when="malloc=tcmalloc")
@@ -110,7 +110,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocblas", when="+rocm")
     depends_on("rocsolver", when="@0.5: +rocm")
     depends_on("tracy-client", when="+tracy")
-    conflicts("tracy-client@0.9:", when="@:0.9")
+    conflicts("^tracy-client@0.9:", when="@:0.9")
     depends_on("whip@0.1: +rocm", when="@0.9: +rocm")
     depends_on("whip@0.1: +cuda", when="@0.9: +cuda")
 

--- a/var/spack/repos/builtin/packages/py-topiary-asr/package.py
+++ b/var/spack/repos/builtin/packages/py-topiary-asr/package.py
@@ -47,7 +47,7 @@ class PyTopiaryAsr(PythonPackage):
     depends_on("mpi", type="run")
     depends_on("openmpi+legacylaunchers", type="run", when="^openmpi schedulers=slurm")
 
-    conflicts("mpich")
+    conflicts("^mpich")
 
     def patch(self):
         if self.spec.satisfies("^raxml-ng+mpi"):

--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -31,8 +31,8 @@ class Salmon(CMakePackage):
     # 1.8.0 relies on tbb provided config, earlier versions make
     # assumptions about the layout of tbb files that are not true in
     # 2021.1 and later
-    conflicts("intel-tbb@2021.1:", when="@:1.7.0")
-    conflicts("intel-oneapi-tbb@2021.1:", when="@:1.7.0")
+    conflicts("^intel-tbb@2021.1:", when="@:1.7.0")
+    conflicts("^intel-oneapi-tbb@2021.1:", when="@:1.7.0")
     depends_on("tbb")
     depends_on(
         "boost@1.66.0:"

--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -39,7 +39,7 @@ class ScitokensCpp(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
 
-    conflicts("jwt-cpp@0.5:", when="@:0.7")
+    conflicts("^jwt-cpp@0.5:", when="@:0.7")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72
     @when("@0.7.0 ^openssl@3:")

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -80,7 +80,7 @@ class Silo(AutotoolsPackage):
     # API changes in hdf5-1.13 cause breakage
     # See https://github.com/LLNL/Silo/pull/260
     patch("hdf5-113.patch", when="@4.11: +hdf5 ^hdf5@1.13:")
-    conflicts("hdf5@1.13:", when="@:4.10.2-bsd")
+    conflicts("^hdf5@1.13:", when="@:4.10.2-bsd")
 
     # hzip and fpzip are not available in the BSD releases
     conflicts("+hzip", when="@4.10.2-bsd,4.11-bsd")

--- a/var/spack/repos/builtin/packages/ucsc-bedgraphtobigwig/package.py
+++ b/var/spack/repos/builtin/packages/ucsc-bedgraphtobigwig/package.py
@@ -24,7 +24,7 @@ class UcscBedgraphtobigwig(Package):
     # MySQL removed the type my_bool, while mariadb didn't.
     # https://groups.google.com/a/soe.ucsc.edu/g/genome/c/mIT6fe9l99g
     depends_on("mysql-client")
-    conflicts("mysql@8.0.0:")
+    conflicts("^mysql@8.0.0:")
 
     def setup_build_environment(self, env):
         env.set("MYSQLLIBS", "-lmysqlclient")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -116,7 +116,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     depends_on("python@2.7.5:", type=("build", "run"))
 
-    conflicts("hip@:4.4.0", when="+rocm")
+    conflicts("^hip@:4.4.0", when="+rocm")
 
     depends_on("oneapi-level-zero@1.8.0:", when="+level_zero")
 

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -102,13 +102,13 @@ class Xrootd(CMakePackage):
     conflicts("cxxstd=20", when="@5.0:5.5.2")
     conflicts("cxxstd=17", when="@5 ~client_only")
     conflicts("cxxstd=20", when="@5 ~client_only")
-    conflicts("scitokens-cpp", when="@:5.5.2 +client_only")
+    conflicts("^scitokens-cpp", when="@:5.5.2 +client_only")
 
     depends_on("bzip2")
     depends_on("cmake@2.6:", type="build", when="@3.1.0:")
     depends_on("cmake@3.16:", type="build", when="@5.6:")
-    conflicts("cmake@:3.0", when="@5.0.0")
-    conflicts("cmake@:3.15.99", when="@5.5.4:5.5")
+    conflicts("^cmake@:3.0", when="@5.0.0")
+    conflicts("^cmake@:3.15.99", when="@5.5.4:5.5")
     depends_on("davix", when="+davix")
     depends_on("libxml2", when="+http")
     depends_on("uuid", when="@4.11.0:")
@@ -124,7 +124,7 @@ class Xrootd(CMakePackage):
     depends_on("krb5", when="+krb5")
     depends_on("json-c")
     depends_on("scitokens-cpp", when="+scitokens-cpp")
-    conflicts("openssl@3:", when="@:5.3.99")
+    conflicts("^openssl@3:", when="@:5.3.99")
 
     extends("python", when="+python")
 


### PR DESCRIPTION
Extracted from #38748

This is to avoid an excessive number of warnings from built-in once #38447 is merged.