### PR TITLE
Trilinos: fix @13.2: +python

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -941,7 +941,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         # https://github.com/trilinos/Trilinos/issues/866
         # A workaround is to remove PyTrilinos from the COMPONENTS_LIST
         # and to remove -lpytrilonos from Makefile.export.Trilinos
-        if "+python" in self.spec and self.spec.satisfies("@:13.0.1"):
+        if self.spec.satisfies("@:13.0.1 +python"):
             filter_file(
                 r"(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)",
                 (r"\1\3"),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -941,7 +941,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         # https://github.com/trilinos/Trilinos/issues/866
         # A workaround is to remove PyTrilinos from the COMPONENTS_LIST
         # and to remove -lpytrilonos from Makefile.export.Trilinos
-        if "+python" in self.spec:
+        if "+python" in self.spec and self.spec.satisfies("@:13.0.1"):
             filter_file(
                 r"(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)",
                 (r"\1\3"),


### PR DESCRIPTION
filter_python function is a workaround until trilinos@13.0.1 and from 13.2.0 its failing with this error:
```
==> Error: FileNotFoundError: [Errno 2] No such file or directory: '/scratch/pawsey0001/ddeeptimahanti/2023.07/software/linux-sles15-zen3/gcc-12.2.0/trilinos-13.2.0-fj6zvkm6xyqmn2msc2r6lkkw6lciuxyw/include/Makefile.export.Trilinos'

/scratch/pawsey0001/ddeeptimahanti/2023.07/spack/var/spack/repos/pawsey/packages/trilinos/package.py:956, in filter_python:
        953                (r"\1\3"),
        954                "%s/cmake/Trilinos/TrilinosConfig.cmake" % self.prefix.lib,
        955            )
  >>    956            filter_file(r"-lpytrilinos", "", "%s/Makefile.export.Trilinos" % self.prefix.include)
```
So, this fix will resolve this issue.