### PR TITLE
spack.repo: uppercase the global PATH variable

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -286,7 +286,7 @@ def _check_build_test_callbacks(pkgs, error_cls):
     """Ensure stand-alone test method is not included in build-time callbacks"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         test_callbacks = getattr(pkg_cls, "build_time_test_callbacks", None)
 
         # TODO (post-34236): "test*"->"test_*" once remove deprecated methods
@@ -312,7 +312,7 @@ def _check_patch_urls(pkgs, error_cls):
 
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         for condition, patches in pkg_cls.patches.items():
             for patch in patches:
                 if not isinstance(patch, spack.patch.UrlPatch):
@@ -342,7 +342,7 @@ def _search_for_reserved_attributes_names_in_packages(pkgs, error_cls):
     errors = []
     for pkg_name in pkgs:
         name_definitions = collections.defaultdict(list)
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
         for cls_item in inspect.getmro(pkg_cls):
             for name in RESERVED_NAMES:
@@ -383,7 +383,7 @@ def _ensure_packages_are_pickeleable(pkgs, error_cls):
     """Ensure that package objects are pickleable"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         pkg = pkg_cls(spack.spec.Spec(pkg_name))
         try:
             pickle.dumps(pkg)
@@ -424,7 +424,7 @@ def _ensure_all_versions_can_produce_a_fetcher(pkgs, error_cls):
     """Ensure all versions in a package can produce a fetcher"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         pkg = pkg_cls(spack.spec.Spec(pkg_name))
         try:
             spack.fetch_strategy.check_pkg_attributes(pkg)
@@ -449,7 +449,7 @@ def _ensure_docstring_and_no_fixme(pkgs, error_cls):
     ]
     for pkg_name in pkgs:
         details = []
-        filename = spack.repo.path.filename_for_package_name(pkg_name)
+        filename = spack.repo.PATH.filename_for_package_name(pkg_name)
         with open(filename, "r") as package_file:
             for i, line in enumerate(package_file):
                 pattern = next((r for r in fixme_regexes if r.search(line)), None)
@@ -461,7 +461,7 @@ def _ensure_docstring_and_no_fixme(pkgs, error_cls):
             error_msg = "Package '{}' contains boilerplate that need to be removed"
             errors.append(error_cls(error_msg.format(pkg_name), details))
 
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         if not pkg_cls.__doc__:
             error_msg = "Package '{}' miss a docstring"
             errors.append(error_cls(error_msg.format(pkg_name), []))
@@ -474,7 +474,7 @@ def _ensure_all_packages_use_sha256_checksums(pkgs, error_cls):
     """Ensure no packages use md5 checksums"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         if pkg_cls.manual_download:
             continue
 
@@ -511,7 +511,7 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
     """Ensure that methods modifying the build environment are ported to builder classes."""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         buildsystem_variant, _ = pkg_cls.variants["build_system"]
         buildsystem_names = [getattr(x, "value", x) for x in buildsystem_variant.values]
         builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in buildsystem_names]
@@ -538,7 +538,7 @@ def _linting_package_file(pkgs, error_cls):
     """Check for correctness of links"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
         # Does the homepage have http, and if so, does https work?
         if pkg_cls.homepage.startswith("http://"):
@@ -562,7 +562,7 @@ def _unknown_variants_in_directives(pkgs, error_cls):
     """Report unknown or wrong variants in directives for this package"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
         # Check "conflicts" directive
         for conflict, triggers in pkg_cls.conflicts.items():
@@ -628,15 +628,15 @@ def _unknown_variants_in_dependencies(pkgs, error_cls):
     """Report unknown dependencies and wrong variants for dependencies"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
-        filename = spack.repo.path.filename_for_package_name(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        filename = spack.repo.PATH.filename_for_package_name(pkg_name)
         for dependency_name, dependency_data in pkg_cls.dependencies.items():
             # No need to analyze virtual packages
-            if spack.repo.path.is_virtual(dependency_name):
+            if spack.repo.PATH.is_virtual(dependency_name):
                 continue
 
             try:
-                dependency_pkg_cls = spack.repo.path.get_pkg_class(dependency_name)
+                dependency_pkg_cls = spack.repo.PATH.get_pkg_class(dependency_name)
             except spack.repo.UnknownPackageError:
                 # This dependency is completely missing, so report
                 # and continue the analysis
@@ -675,7 +675,7 @@ def _ensure_variant_defaults_are_parsable(pkgs, error_cls):
     """Ensures that variant defaults are present and parsable from cli"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         for variant_name, entry in pkg_cls.variants.items():
             variant, _ = entry
             default_is_parsable = (
@@ -714,7 +714,7 @@ def _ensure_variants_have_descriptions(pkgs, error_cls):
     """Ensures that all variants have a description."""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         for variant_name, entry in pkg_cls.variants.items():
             variant, _ = entry
             if not variant.description:
@@ -729,13 +729,13 @@ def _version_constraints_are_satisfiable_by_some_version_in_repo(pkgs, error_cls
     """Report if version constraints used in directives are not satisfiable"""
     errors = []
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
-        filename = spack.repo.path.filename_for_package_name(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        filename = spack.repo.PATH.filename_for_package_name(pkg_name)
         dependencies_to_check = []
         for dependency_name, dependency_data in pkg_cls.dependencies.items():
             # Skip virtual dependencies for the time being, check on
             # their versions can be added later
-            if spack.repo.path.is_virtual(dependency_name):
+            if spack.repo.PATH.is_virtual(dependency_name):
                 continue
 
             dependencies_to_check.extend([edge.spec for edge in dependency_data.values()])
@@ -744,7 +744,7 @@ def _version_constraints_are_satisfiable_by_some_version_in_repo(pkgs, error_cls
         for s in dependencies_to_check:
             dependency_pkg_cls = None
             try:
-                dependency_pkg_cls = spack.repo.path.get_pkg_class(s.name)
+                dependency_pkg_cls = spack.repo.PATH.get_pkg_class(s.name)
                 # Some packages have hacks that might cause failures on some platform
                 # Allow to explicitly set conditions to skip version checks in that case
                 skip_conditions = getattr(dependency_pkg_cls, "skip_version_audit", [])
@@ -787,7 +787,7 @@ def _analyze_variants_in_directive(pkg, constraint, directive, error_cls):
         except variant_exceptions as e:
             summary = pkg.name + ': wrong variant in "{0}" directive'
             summary = summary.format(directive)
-            filename = spack.repo.path.filename_for_package_name(pkg.name)
+            filename = spack.repo.PATH.filename_for_package_name(pkg.name)
 
             error_msg = str(e).strip()
             if isinstance(e, KeyError):

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -476,13 +476,13 @@ def ensure_executables_in_path_or_raise(
 def _add_externals_if_missing() -> None:
     search_list = [
         # clingo
-        spack.repo.path.get_pkg_class("cmake"),
-        spack.repo.path.get_pkg_class("bison"),
+        spack.repo.PATH.get_pkg_class("cmake"),
+        spack.repo.PATH.get_pkg_class("bison"),
         # GnuPG
-        spack.repo.path.get_pkg_class("gawk"),
+        spack.repo.PATH.get_pkg_class("gawk"),
     ]
     if IS_WINDOWS:
-        search_list.append(spack.repo.path.get_pkg_class("winbison"))
+        search_list.append(spack.repo.PATH.get_pkg_class("winbison"))
     detected_packages = spack.detection.by_executable(search_list)
     spack.detection.update_configuration(detected_packages, scope="bootstrap")
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -201,7 +201,7 @@ class PythonExtension(spack.package_base.PackageBase):
             else:
                 python = self.get_external_python_for_prefix()
                 if not python.concrete:
-                    repo = spack.repo.path.repo_for_pkg(python)
+                    repo = spack.repo.PATH.repo_for_pkg(python)
                     python.namespace = repo.namespace
 
                     # Ensure architecture information is present
@@ -301,7 +301,7 @@ class PythonPackage(PythonExtension):
             return python_externals_configured[0]
 
         python_externals_detection = spack.detection.by_executable(
-            [spack.repo.path.get_pkg_class("python")], path_hints=[self.spec.external_path]
+            [spack.repo.PATH.get_pkg_class("python")], path_hints=[self.spec.external_path]
         )
 
         python_externals_detected = [

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1504,7 +1504,7 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
         return
 
     try:
-        pkg_cls = spack.repo.path.get_pkg_class(job_spec.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(job_spec.name)
         job_pkg = pkg_cls(job_spec)
         tty.debug("job package: {0}".format(job_pkg))
     except AssertionError:

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -535,7 +535,7 @@ class SpackCI:
         """Compute the name of a named job with appropriate suffix.
         Valid suffixes are either '-remove' or empty string or None
         """
-        assert type(name) == str
+        assert isinstance(name, str)
 
         jname = name
         if suffix:
@@ -885,7 +885,7 @@ def generate_gitlab_ci_yaml(
         cli_scopes = [
             os.path.relpath(s.path, concrete_env_dir)
             for s in cfg.scopes().values()
-            if type(s) == cfg.ImmutableConfigScope
+            if isinstance(s, cfg.ImmutableConfigScope)
             and s.path not in env_includes
             and os.path.exists(s.path)
         ]

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -47,7 +47,7 @@ def configs(parser, args):
 
 
 def packages(parser, args):
-    pkgs = args.name or spack.repo.path.all_package_names()
+    pkgs = args.name or spack.repo.PATH.all_package_names()
     reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)
     _process_reports(reports)
 
@@ -57,7 +57,7 @@ def packages_https(parser, args):
     if not args.check_all and not args.name:
         tty.die("Please specify one or more packages to audit, or --all.")
 
-    pkgs = args.name or spack.repo.path.all_package_names()
+    pkgs = args.name or spack.repo.PATH.all_package_names()
     reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)
     _process_reports(reports)
 

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -126,7 +126,7 @@ def blame(parser, args):
             blame_file = path
 
     if not blame_file:
-        pkg_cls = spack.repo.path.get_pkg_class(args.package_or_file)
+        pkg_cls = spack.repo.PATH.get_pkg_class(args.package_or_file)
         blame_file = pkg_cls.module.__file__.rstrip("c")  # .pyc -> .py
 
     # get git blame for the package

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -83,7 +83,7 @@ def checksum(parser, args):
         tty.die("`spack checksum` accepts package names, not URLs.")
 
     # Get the package we're going to generate checksums for
-    pkg_cls = spack.repo.path.get_pkg_class(args.package)
+    pkg_cls = spack.repo.PATH.get_pkg_class(args.package)
     pkg = pkg_cls(spack.spec.Spec(args.package))
 
     # Build a list of versions to checksum
@@ -210,7 +210,7 @@ def add_versions_to_package(pkg: PackageBase, version_lines: str):
 
     """
     # Get filename and path for package
-    filename = spack.repo.path.filename_for_package_name(pkg.name)
+    filename = spack.repo.PATH.filename_for_package_name(pkg.name)
     num_versions_added = 0
 
     version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -915,11 +915,11 @@ def get_repository(args, name):
             )
     else:
         if spec.namespace:
-            repo = spack.repo.path.get_repo(spec.namespace, None)
+            repo = spack.repo.PATH.get_repo(spec.namespace, None)
             if not repo:
                 tty.die("Unknown namespace: '{0}'".format(spec.namespace))
         else:
-            repo = spack.repo.path.first_repo()
+            repo = spack.repo.PATH.first_repo()
 
     # Set the namespace on the spec if it's not there already
     if not spec.namespace:

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -47,14 +47,14 @@ def inverted_dependencies():
     actual dependents.
     """
     dag = {}
-    for pkg_cls in spack.repo.path.all_package_classes():
+    for pkg_cls in spack.repo.PATH.all_package_classes():
         dag.setdefault(pkg_cls.name, set())
         for dep in pkg_cls.dependencies:
             deps = [dep]
 
             # expand virtuals if necessary
-            if spack.repo.path.is_virtual(dep):
-                deps += [s.name for s in spack.repo.path.providers_for(dep)]
+            if spack.repo.PATH.is_virtual(dep):
+                deps += [s.name for s in spack.repo.PATH.providers_for(dep)]
 
             for d in deps:
                 dag.setdefault(d, set()).add(pkg_cls.name)

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -98,7 +98,7 @@ def dev_build(self, args):
         tty.die("spack dev-build only takes one spec.")
 
     spec = specs[0]
-    if not spack.repo.path.exists(spec.name):
+    if not spack.repo.PATH.exists(spec.name):
         tty.die(
             "No package for '{0}' was found.".format(spec.name),
             "  Use `spack create` to create a new package",

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -31,9 +31,9 @@ def edit_package(name, repo_path, namespace):
     if repo_path:
         repo = spack.repo.Repo(repo_path)
     elif namespace:
-        repo = spack.repo.path.get_repo(namespace)
+        repo = spack.repo.PATH.get_repo(namespace)
     else:
-        repo = spack.repo.path
+        repo = spack.repo.PATH
     path = repo.filename_for_package_name(name)
 
     spec = Spec(name)

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -58,7 +58,7 @@ def extensions(parser, args):
 
         extendable_pkgs = []
         for name in spack.repo.all_package_names():
-            pkg_cls = spack.repo.path.get_pkg_class(name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(name)
             if pkg_cls.extendable:
                 extendable_pkgs.append(name)
 
@@ -81,7 +81,7 @@ def extensions(parser, args):
 
     if args.show in ("packages", "all"):
         # List package names of extensions
-        extensions = spack.repo.path.extensions_for(spec)
+        extensions = spack.repo.PATH.extensions_for(spec)
         if not extensions:
             tty.msg("%s has no extensions." % spec.cshort_spec)
         else:

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -133,9 +133,9 @@ def external_find(args):
 
     # Add the packages that have been required explicitly
     if args.packages:
-        pkg_cls_to_check = [spack.repo.path.get_pkg_class(pkg) for pkg in args.packages]
+        pkg_cls_to_check = [spack.repo.PATH.get_pkg_class(pkg) for pkg in args.packages]
         if args.tags:
-            allowed = set(spack.repo.path.packages_with_tags(*args.tags))
+            allowed = set(spack.repo.PATH.packages_with_tags(*args.tags))
             pkg_cls_to_check = [x for x in pkg_cls_to_check if x.name in allowed]
 
     if args.tags and not pkg_cls_to_check:
@@ -144,15 +144,15 @@ def external_find(args):
         # Since tags are cached it's much faster to construct what we need
         # to search directly, rather than filtering after the fact
         pkg_cls_to_check = [
-            spack.repo.path.get_pkg_class(pkg_name)
+            spack.repo.PATH.get_pkg_class(pkg_name)
             for tag in args.tags
-            for pkg_name in spack.repo.path.packages_with_tags(tag)
+            for pkg_name in spack.repo.PATH.packages_with_tags(tag)
         ]
         pkg_cls_to_check = list(set(pkg_cls_to_check))
 
     # If the list of packages is empty, search for every possible package
     if not args.tags and not pkg_cls_to_check:
-        pkg_cls_to_check = list(spack.repo.path.all_package_classes())
+        pkg_cls_to_check = list(spack.repo.PATH.all_package_classes())
 
     # If the user specified any packages to exclude from external find, add them here
     if args.exclude:
@@ -239,7 +239,7 @@ def _collect_and_consume_cray_manifest_files(
 
 def external_list(args):
     # Trigger a read of all packages, might take a long time.
-    list(spack.repo.path.all_package_classes())
+    list(spack.repo.PATH.all_package_classes())
     # Print all the detectable packages
     tty.msg("Detectable packages per repository")
     for namespace, pkgs in sorted(spack.package_base.detectable_packages.items()):

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -268,7 +268,7 @@ def find(parser, args):
 
     # If tags have been specified on the command line, filter by tags
     if args.tags:
-        packages_with_tags = spack.repo.path.packages_with_tags(*args.tags)
+        packages_with_tags = spack.repo.PATH.packages_with_tags(*args.tags)
         results = [x for x in results if x.name in packages_with_tags]
 
     if args.loaded:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -349,7 +349,7 @@ def print_virtuals(pkg):
 
 def info(parser, args):
     spec = spack.spec.Spec(args.package)
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     pkg = pkg_cls(spec)
 
     # Output core package information

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -107,7 +107,7 @@ def filter_by_name(pkgs, args):
                 if f.match(p):
                     return True
 
-                pkg_cls = spack.repo.path.get_pkg_class(p)
+                pkg_cls = spack.repo.PATH.get_pkg_class(p)
                 if pkg_cls.__doc__:
                     return f.match(pkg_cls.__doc__)
                 return False
@@ -159,7 +159,7 @@ def get_dependencies(pkg):
 @formatter
 def version_json(pkg_names, out):
     """Print all packages with their latest versions."""
-    pkg_classes = [spack.repo.path.get_pkg_class(name) for name in pkg_names]
+    pkg_classes = [spack.repo.PATH.get_pkg_class(name) for name in pkg_names]
 
     out.write("[\n")
 
@@ -201,7 +201,7 @@ def html(pkg_names, out):
     """
 
     # Read in all packages
-    pkg_classes = [spack.repo.path.get_pkg_class(name) for name in pkg_names]
+    pkg_classes = [spack.repo.PATH.get_pkg_class(name) for name in pkg_names]
 
     # Start at 2 because the title of the page from Sphinx is id1.
     span_id = 2
@@ -313,13 +313,13 @@ def list(parser, args):
 
     # If tags have been specified on the command line, filter by tags
     if args.tags:
-        packages_with_tags = spack.repo.path.packages_with_tags(*args.tags)
+        packages_with_tags = spack.repo.PATH.packages_with_tags(*args.tags)
         sorted_packages = [p for p in sorted_packages if p in packages_with_tags]
 
     if args.update:
         # change output stream if user asked for update
         if os.path.exists(args.update):
-            if os.path.getmtime(args.update) > spack.repo.path.last_mtime():
+            if os.path.getmtime(args.update) > spack.repo.PATH.last_mtime():
                 tty.msg("File is up to date: %s" % args.update)
                 return
 

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -109,7 +109,7 @@ def location(parser, args):
         return
 
     if args.packages:
-        print(spack.repo.path.first_repo().root)
+        print(spack.repo.PATH.first_repo().root)
         return
 
     if args.stages:
@@ -135,7 +135,7 @@ def location(parser, args):
 
     # Package dir just needs the spec name
     if args.package_dir:
-        print(spack.repo.path.dirname_for_package_name(spec.name))
+        print(spack.repo.PATH.dirname_for_package_name(spec.name))
         return
 
     # Either concretize or filter from already concretized environment

--- a/lib/spack/spack/cmd/maintainers.py
+++ b/lib/spack/spack/cmd/maintainers.py
@@ -54,11 +54,11 @@ def setup_parser(subparser):
 
 def packages_to_maintainers(package_names=None):
     if not package_names:
-        package_names = spack.repo.path.all_package_names()
+        package_names = spack.repo.PATH.all_package_names()
 
     pkg_to_users = defaultdict(lambda: set())
     for name in package_names:
-        cls = spack.repo.path.get_pkg_class(name)
+        cls = spack.repo.PATH.get_pkg_class(name)
         for user in cls.maintainers:
             pkg_to_users[name].add(user)
 
@@ -67,8 +67,8 @@ def packages_to_maintainers(package_names=None):
 
 def maintainers_to_packages(users=None):
     user_to_pkgs = defaultdict(lambda: [])
-    for name in spack.repo.path.all_package_names():
-        cls = spack.repo.path.get_pkg_class(name)
+    for name in spack.repo.PATH.all_package_names():
+        cls = spack.repo.PATH.get_pkg_class(name)
         for user in cls.maintainers:
             lower_users = [u.lower() for u in users]
             if not users or user.lower() in lower_users:
@@ -80,8 +80,8 @@ def maintainers_to_packages(users=None):
 def maintained_packages():
     maintained = []
     unmaintained = []
-    for name in spack.repo.path.all_package_names():
-        cls = spack.repo.path.get_pkg_class(name)
+    for name in spack.repo.PATH.all_package_names():
+        cls = spack.repo.PATH.get_pkg_class(name)
         if cls.maintainers:
             maintained.append(name)
         else:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -474,7 +474,7 @@ def create_mirror_for_all_specs(path, skip_unstable_versions, selection_fn):
         path, skip_unstable_versions=skip_unstable_versions
     )
     for candidate in mirror_specs:
-        pkg_cls = spack.repo.path.get_pkg_class(candidate.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(candidate.name)
         pkg_obj = pkg_cls(spack.spec.Spec(candidate))
         mirror_stats.next_spec(pkg_obj.spec)
         spack.mirror.create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats)

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -309,7 +309,7 @@ def refresh(module_type, specs, args):
 
     # Skip unknown packages.
     writers = [
-        cls(spec, args.module_set_name) for spec in specs if spack.repo.path.exists(spec.name)
+        cls(spec, args.module_set_name) for spec in specs if spack.repo.PATH.exists(spec.name)
     ]
 
     # Filter excluded packages early
@@ -377,7 +377,7 @@ callbacks = {"refresh": refresh, "rm": rm, "find": find, "loads": loads}
 def modules_cmd(parser, args, module_type, callbacks=callbacks):
     # Qualifiers to be used when querying the db for specs
     constraint_qualifiers = {
-        "refresh": {"installed": True, "known": lambda x: not spack.repo.path.exists(x)}
+        "refresh": {"installed": True, "known": lambda x: not spack.repo.PATH.exists(x)}
     }
     query_args = constraint_qualifiers.get(args.subparser_name, {})
 

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -143,7 +143,7 @@ def pkg_source(args):
         tty.die("spack pkg source requires exactly one spec")
 
     spec = specs[0]
-    filename = spack.repo.path.filename_for_package_name(spec.name)
+    filename = spack.repo.PATH.filename_for_package_name(spec.name)
 
     # regular source dump -- just get the package and print its contents
     if args.canonical:
@@ -184,7 +184,7 @@ def pkg_grep(args, unknown_args):
     grouper = lambda e: e[0] // 500
 
     # set up iterator and save the first group to ensure we don't end up with a group of size 1
-    groups = itertools.groupby(enumerate(spack.repo.path.all_package_paths()), grouper)
+    groups = itertools.groupby(enumerate(spack.repo.PATH.all_package_paths()), grouper)
     if not groups:
         return 0  # no packages to search
 

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -24,7 +24,7 @@ def setup_parser(subparser):
 
 
 def providers(parser, args):
-    valid_virtuals = sorted(spack.repo.path.provider_index.providers.keys())
+    valid_virtuals = sorted(spack.repo.PATH.provider_index.providers.keys())
 
     buffer = io.StringIO()
     isatty = sys.stdout.isatty()
@@ -53,5 +53,5 @@ def providers(parser, args):
     for spec in specs:
         if sys.stdout.isatty():
             print("{0}:".format(spec))
-        spack.cmd.display_specs(sorted(spack.repo.path.providers_for(spec)))
+        spack.cmd.display_specs(sorted(spack.repo.PATH.providers_for(spec)))
         print("")

--- a/lib/spack/spack/cmd/resource.py
+++ b/lib/spack/spack/cmd/resource.py
@@ -29,7 +29,7 @@ def setup_parser(subparser):
 
 def _show_patch(sha256):
     """Show a record from the patch index."""
-    patches = spack.repo.path.patch_index.index
+    patches = spack.repo.PATH.patch_index.index
     data = patches.get(sha256)
 
     if not data:
@@ -47,7 +47,7 @@ def _show_patch(sha256):
         owner = rec["owner"]
 
         if "relative_path" in rec:
-            pkg_dir = spack.repo.path.get_pkg_class(owner).package_dir
+            pkg_dir = spack.repo.PATH.get_pkg_class(owner).package_dir
             path = os.path.join(pkg_dir, rec["relative_path"])
             print("    path:       %s" % path)
         else:
@@ -60,7 +60,7 @@ def _show_patch(sha256):
 
 def resource_list(args):
     """list all resources known to spack (currently just patches)"""
-    patches = spack.repo.path.patch_index.index
+    patches = spack.repo.PATH.patch_index.index
     for sha256 in patches:
         if args.only_hashes:
             print(sha256)

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -68,7 +68,7 @@ def tags(parser, args):
         return
 
     # unique list of available tags
-    available_tags = sorted(spack.repo.path.tag_index.keys())
+    available_tags = sorted(spack.repo.PATH.tag_index.keys())
     if not available_tags:
         tty.msg("No tagged packages")
         return

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -228,7 +228,7 @@ def create_reporter(args, specs_to_test, test_suite):
 
 def test_list(args):
     """list installed packages with available tests"""
-    tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag else set()
+    tagged = set(spack.repo.PATH.packages_with_tags(*args.tag)) if args.tag else set()
 
     def has_test_and_tags(pkg_class):
         tests = spack.install_test.test_functions(pkg_class)
@@ -237,7 +237,7 @@ def test_list(args):
     if args.list_all:
         report_packages = [
             pkg_class.name
-            for pkg_class in spack.repo.path.all_package_classes()
+            for pkg_class in spack.repo.PATH.all_package_classes()
             if has_test_and_tags(pkg_class)
         ]
 

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -155,7 +155,7 @@ def url_list(args):
     urls = set()
 
     # Gather set of URLs from all packages
-    for pkg_cls in spack.repo.path.all_package_classes():
+    for pkg_cls in spack.repo.PATH.all_package_classes():
         url = getattr(pkg_cls, "url", None)
         urls = url_list_parsing(args, urls, url, pkg_cls)
 
@@ -192,7 +192,7 @@ def url_summary(args):
     tty.msg("Generating a summary of URL parsing in Spack...")
 
     # Loop through all packages
-    for pkg_cls in spack.repo.path.all_package_classes():
+    for pkg_cls in spack.repo.PATH.all_package_classes():
         urls = set()
         pkg = pkg_cls(spack.spec.Spec(pkg_cls.name))
 
@@ -336,7 +336,7 @@ def url_stats(args):
     version_stats = UrlStats()
     resource_stats = UrlStats()
 
-    for pkg_cls in spack.repo.path.all_package_classes():
+    for pkg_cls in spack.repo.PATH.all_package_classes():
         npkgs += 1
 
         for v in pkg_cls.versions:

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -45,7 +45,7 @@ def setup_parser(subparser):
 
 def versions(parser, args):
     spec = spack.spec.Spec(args.package)
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     pkg = pkg_cls(spec)
 
     safe_versions = pkg.versions

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -113,7 +113,7 @@ class Concretizer:
         pref_key = lambda spec: 0  # no-op pref key
 
         if spec.virtual:
-            candidates = spack.repo.path.providers_for(spec)
+            candidates = spack.repo.PATH.providers_for(spec)
             if not candidates:
                 raise spack.error.UnsatisfiableProviderSpecError(candidates[0], spec)
 

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -90,7 +90,7 @@ def spec_from_entry(entry):
         name=entry["name"], version=entry["version"], compiler=compiler_str, arch=arch_str
     )
 
-    pkg_cls = spack.repo.path.get_pkg_class(entry["name"])
+    pkg_cls = spack.repo.PATH.get_pkg_class(entry["name"])
 
     if "parameters" in entry:
         variant_strs = list()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -203,7 +203,7 @@ def activate(env, use_env_repo=False):
         env.store_token = spack.store.reinitialize()
 
     if use_env_repo:
-        spack.repo.path.put_first(env.repo)
+        spack.repo.PATH.put_first(env.repo)
 
     tty.debug("Using environment '%s'" % env.name)
 
@@ -227,7 +227,7 @@ def deactivate():
 
     # use _repo so we only remove if a repo was actually constructed
     if _active_environment._repo:
-        spack.repo.path.remove(_active_environment._repo)
+        spack.repo.PATH.remove(_active_environment._repo)
 
     tty.debug("Deactivated environment '%s'" % _active_environment.name)
 
@@ -1084,8 +1084,8 @@ class Environment:
         if list_name == user_speclist_name:
             if spec.anonymous:
                 raise SpackEnvironmentError("cannot add anonymous specs to an environment")
-            elif not spack.repo.path.exists(spec.name) and not spec.abstract_hash:
-                virtuals = spack.repo.path.provider_index.providers.keys()
+            elif not spack.repo.PATH.exists(spec.name) and not spec.abstract_hash:
+                virtuals = spack.repo.PATH.provider_index.providers.keys()
                 if spec.name not in virtuals:
                     msg = "no such package: %s" % spec.name
                     raise SpackEnvironmentError(msg)
@@ -1262,7 +1262,7 @@ class Environment:
             # better if we can create the `source_path` directly into its final
             # destination.
             abspath = spack.util.path.canonicalize_path(path, default_wd=self.path)
-            pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
             # We construct a package class ourselves, rather than asking for
             # Spec.package, since Spec only allows this when it is concrete
             package = pkg_cls(spec)
@@ -1490,7 +1490,7 @@ class Environment:
         # for a write lock. We do this indirectly by retrieving the
         # provider index, which should in turn trigger the update of
         # all the indexes if there's any need for that.
-        _ = spack.repo.path.provider_index
+        _ = spack.repo.PATH.provider_index
 
         # Ensure we have compilers in compilers.yaml to avoid that
         # processes try to write the config file in parallel
@@ -2280,7 +2280,7 @@ class Environment:
         repository = spack.repo.create_or_construct(repository_dir, spec_node.namespace)
         pkg_dir = repository.dirname_for_package_name(spec_node.name)
         fs.mkdirp(pkg_dir)
-        spack.repo.path.dump_provenance(spec_node, pkg_dir)
+        spack.repo.PATH.dump_provenance(spec_node, pkg_dir)
 
     def manifest_uptodate_or_warn(self):
         """Emits a warning if the manifest file is not up-to-date."""

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -535,7 +535,7 @@ class DAGWithDependencyTypes(DotGraphBuilder):
 
 def _static_edges(specs, deptype):
     for spec in specs:
-        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
         possible = pkg_cls.possible_dependencies(expand_virtuals=True, deptype=deptype)
 
         for parent_name, dependencies in possible.items():

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -49,7 +49,7 @@ process_hash = SpecHashDescriptor(
 
 
 def _content_hash_override(spec):
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     pkg = pkg_cls(spec)
     return pkg.content_hash()
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -1147,12 +1147,12 @@ class TestSuite:
     def write_reproducibility_data(self):
         for spec in self.specs:
             repo_cache_path = self.stage.repo.join(spec.name)
-            spack.repo.path.dump_provenance(spec, repo_cache_path)
+            spack.repo.PATH.dump_provenance(spec, repo_cache_path)
             for vspec in spec.package.virtuals_provided:
                 repo_cache_path = self.stage.repo.join(vspec.name)
                 if not os.path.exists(repo_cache_path):
                     try:
-                        spack.repo.path.dump_provenance(vspec, repo_cache_path)
+                        spack.repo.PATH.dump_provenance(vspec, repo_cache_path)
                     except spack.repo.UnknownPackageError:
                         pass  # not all virtuals have package files
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -590,7 +590,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)
         if node is spec:
-            spack.repo.path.dump_provenance(node, dest_pkg_dir)
+            spack.repo.PATH.dump_provenance(node, dest_pkg_dir)
         elif source_pkg_dir:
             fs.install_tree(source_pkg_dir, dest_pkg_dir)
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -605,7 +605,7 @@ def setup_main_options(args):
         spack.config.config.scopes["command_line"].sections["repos"] = syaml.syaml_dict(
             [(key, [spack.paths.mock_packages_path])]
         )
-        spack.repo.path = spack.repo.create(spack.config.config)
+        spack.repo.PATH = spack.repo.create(spack.config.config)
 
     # If the user asked for it, don't check ssl certs.
     if args.insecure:

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -442,7 +442,7 @@ def mirror_archive_paths(fetcher, per_package_ref, spec=None):
     storage path of the resource associated with the specified ``fetcher``."""
     ext = None
     if spec:
-        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
         versions = pkg_cls.versions.get(spec.version, {})
         ext = versions.get("extension", None)
     # If the spec does not explicitly specify an extension (the default case),
@@ -474,7 +474,7 @@ def get_all_versions(specs):
     """
     version_specs = []
     for spec in specs:
-        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
         # Skip any package that has no known versions.
         if not pkg_cls.versions:
             tty.msg("No safe (checksummed) versions for package %s" % pkg_cls.name)

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -143,7 +143,7 @@ class LmodConfiguration(BaseConfiguration):
 
         # Check if all the tokens in the hierarchy are virtual specs.
         # If not warn the user and raise an error.
-        not_virtual = [t for t in tokens if t != "compiler" and not spack.repo.path.is_virtual(t)]
+        not_virtual = [t for t in tokens if t != "compiler" and not spack.repo.PATH.is_virtual(t)]
         if not_virtual:
             msg = "Non-virtual specs in 'hierarchy' list for lmod: {0}\n"
             msg += "Please check the 'modules.yaml' configuration files"

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -665,7 +665,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         self.win_rpath = fsys.WindowsSimulatedRPath(self)
 
         if self.is_extension:
-            pkg_cls = spack.repo.path.get_pkg_class(self.extendee_spec.name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(self.extendee_spec.name)
             pkg_cls(self.extendee_spec)._check_extendable()
 
         super().__init__()
@@ -728,11 +728,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 continue
 
             # expand virtuals if enabled, otherwise just stop at virtuals
-            if spack.repo.path.is_virtual(name):
+            if spack.repo.PATH.is_virtual(name):
                 if virtuals is not None:
                     virtuals.add(name)
                 if expand_virtuals:
-                    providers = spack.repo.path.providers_for(name)
+                    providers = spack.repo.PATH.providers_for(name)
                     dep_names = [spec.name for spec in providers]
                 else:
                     visited.setdefault(cls.name, set()).add(name)
@@ -756,7 +756,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     continue
 
                 try:
-                    dep_cls = spack.repo.path.get_pkg_class(dep_name)
+                    dep_cls = spack.repo.PATH.get_pkg_class(dep_name)
                 except spack.repo.UnknownPackageError:
                     # log unknown packages
                     missing.setdefault(cls.name, set()).add(dep_name)
@@ -2459,8 +2459,8 @@ def possible_dependencies(*pkg_or_spec, **kwargs):
         if not isinstance(pos, spack.spec.Spec):
             pos = spack.spec.Spec(pos)
 
-        if spack.repo.path.is_virtual(pos.name):
-            packages.extend(p.package_class for p in spack.repo.path.providers_for(pos.name))
+        if spack.repo.PATH.is_virtual(pos.name):
+            packages.extend(p.package_class for p in spack.repo.PATH.providers_for(pos.name))
             continue
         else:
             packages.append(pos.package_class)

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -147,7 +147,7 @@ class PackagePrefs:
             variants = " ".join(variants)
 
         # Only return variants that are actually supported by the package
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         spec = spack.spec.Spec("%s %s" % (pkg_name, variants))
         return dict(
             (name, variant) for name, variant in spec.variants.items() if name in pkg_cls.variants
@@ -162,7 +162,7 @@ def spec_externals(spec):
     from spack.util.module_cmd import path_from_modules  # noqa: F401
 
     def _package(maybe_abstract_spec):
-        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
         return pkg_cls(maybe_abstract_spec)
 
     allpkgs = spack.config.get("packages")
@@ -199,7 +199,7 @@ def is_spec_buildable(spec):
     so_far = all_buildable  # the default "so far"
 
     def _package(s):
-        pkg_cls = spack.repo.path.get_pkg_class(s.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(s.name)
         return pkg_cls(s)
 
     # check whether any providers for this package override the default

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -238,7 +238,7 @@ class UrlPatch(Patch):
 
 def from_dict(dictionary, repository=None):
     """Create a patch from json dictionary."""
-    repository = repository or spack.repo.path
+    repository = repository or spack.repo.PATH
     owner = dictionary.get("owner")
     if "owner" not in dictionary:
         raise ValueError("Invalid patch dictionary: %s" % dictionary)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -112,7 +112,7 @@ class ReposFinder:
 
         # If it's a module in some repo, or if it is the repo's
         # namespace, let the repo handle it.
-        for repo in path.repos:
+        for repo in PATH.repos:
             # We are using the namespace of the repo and the repo contains the package
             if namespace == repo.full_namespace:
                 # With 2 nested conditionals we can call "repo.real_name" only once
@@ -128,7 +128,7 @@ class ReposFinder:
 
         # No repo provides the namespace, but it is a valid prefix of
         # something in the RepoPath.
-        if path.by_namespace.is_prefix(fullname):
+        if PATH.by_namespace.is_prefix(fullname):
             return SpackNamespaceLoader()
 
         return None
@@ -149,9 +149,9 @@ NOT_PROVIDED = object()
 def packages_path():
     """Get the test repo if it is active, otherwise the builtin repo."""
     try:
-        return spack.repo.path.get_repo("builtin.mock").packages_path
+        return spack.repo.PATH.get_repo("builtin.mock").packages_path
     except spack.repo.UnknownNamespaceError:
-        return spack.repo.path.get_repo("builtin").packages_path
+        return spack.repo.PATH.get_repo("builtin").packages_path
 
 
 class GitExe:
@@ -247,7 +247,7 @@ def add_package_to_git_stage(packages):
     git = GitExe()
 
     for pkg_name in packages:
-        filename = spack.repo.path.filename_for_package_name(pkg_name)
+        filename = spack.repo.PATH.filename_for_package_name(pkg_name)
         if not os.path.isfile(filename):
             tty.die("No such package: %s.  Path does not exist:" % pkg_name, filename)
 
@@ -1344,7 +1344,7 @@ def create(configuration):
 
 
 #: Singleton repo path instance
-path: Union[RepoPath, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(_path)
+PATH: Union[RepoPath, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(_path)
 
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()
@@ -1353,7 +1353,7 @@ sys.meta_path.append(REPOS_FINDER)
 
 def all_package_names(include_virtuals=False):
     """Convenience wrapper around ``spack.repo.all_package_names()``."""
-    return path.all_package_names(include_virtuals)
+    return PATH.all_package_names(include_virtuals)
 
 
 @contextlib.contextmanager
@@ -1368,7 +1368,7 @@ def use_repositories(*paths_and_repos, **kwargs):
     Returns:
         Corresponding RepoPath object
     """
-    global path
+    global PATH
     # TODO (Python 2.7): remove this kwargs on deprecation of Python 2.7 support
     override = kwargs.get("override", True)
     paths = [getattr(x, "root", x) for x in paths_and_repos]
@@ -1377,12 +1377,12 @@ def use_repositories(*paths_and_repos, **kwargs):
     spack.config.config.push_scope(
         spack.config.InternalConfigScope(name=scope_name, data={repos_key: paths})
     )
-    path, saved = create(configuration=spack.config.config), path
+    PATH, saved = create(configuration=spack.config.config), PATH
     try:
-        yield path
+        yield PATH
     finally:
         spack.config.config.remove_scope(scope_name=scope_name)
-        path = saved
+        PATH = saved
 
 
 class MockRepositoryBuilder:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -237,7 +237,7 @@ def listify(args):
 
 def packagize(pkg):
     if isinstance(pkg, str):
-        return spack.repo.path.get_pkg_class(pkg)
+        return spack.repo.PATH.get_pkg_class(pkg)
     else:
         return pkg
 
@@ -342,7 +342,7 @@ def extend_flag_list(flag_list, new_flags):
 
 def check_packages_exist(specs):
     """Ensure all packages mentioned in specs exist."""
-    repo = spack.repo.path
+    repo = spack.repo.PATH
     for spec in specs:
         for s in spec.traverse():
             try:
@@ -529,7 +529,7 @@ class Result:
 def _normalize_packages_yaml(packages_yaml):
     normalized_yaml = copy.copy(packages_yaml)
     for pkg_name in packages_yaml:
-        is_virtual = spack.repo.path.is_virtual(pkg_name)
+        is_virtual = spack.repo.PATH.is_virtual(pkg_name)
         if pkg_name == "all" or not is_virtual:
             continue
 
@@ -537,7 +537,7 @@ def _normalize_packages_yaml(packages_yaml):
         data = normalized_yaml.pop(pkg_name)
         is_buildable = data.get("buildable", True)
         if not is_buildable:
-            for provider in spack.repo.path.providers_for(pkg_name):
+            for provider in spack.repo.PATH.providers_for(pkg_name):
                 entry = normalized_yaml.setdefault(provider.name, {})
                 entry["buildable"] = False
 
@@ -1416,7 +1416,7 @@ class SpackSolverSetup:
                 continue
 
             # This package does not appear in any repository
-            if pkg_name not in spack.repo.path:
+            if pkg_name not in spack.repo.PATH:
                 continue
 
             self.gen.h2("External package: {0}".format(pkg_name))
@@ -1598,7 +1598,7 @@ class SpackSolverSetup:
                 if not spec.concrete:
                     reserved_names = spack.directives.reserved_names
                     if not spec.virtual and vname not in reserved_names:
-                        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+                        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
                         try:
                             variant_def, _ = pkg_cls.variants[vname]
                         except KeyError:
@@ -1606,7 +1606,7 @@ class SpackSolverSetup:
                             raise RuntimeError(msg.format(vname, spec.name))
                         else:
                             variant_def.validate_or_raise(
-                                variant, spack.repo.path.get_pkg_class(spec.name)
+                                variant, spack.repo.PATH.get_pkg_class(spec.name)
                             )
 
                 clauses.append(f.variant_value(spec.name, vname, value))
@@ -1678,7 +1678,7 @@ class SpackSolverSetup:
                                 except spack.repo.UnknownNamespaceError:
                                     # Try to look up the package of the same name and use its
                                     # providers. This is as good as we can do without edge info.
-                                    pkg_class = spack.repo.path.get_pkg_class(dep.name)
+                                    pkg_class = spack.repo.PATH.get_pkg_class(dep.name)
                                     spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
                                     pkg = pkg_class(spec)
 
@@ -1724,7 +1724,7 @@ class SpackSolverSetup:
         packages_yaml = spack.config.get("packages")
         packages_yaml = _normalize_packages_yaml(packages_yaml)
         for pkg_name in possible_pkgs:
-            pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
             # All the versions from the corresponding package.py file. Since concepts
             # like being a "develop" version or being preferred exist only at a
@@ -1755,7 +1755,7 @@ class SpackSolverSetup:
             # specs will be computed later
             version_preferences = packages_yaml.get(pkg_name, {}).get("version", [])
             version_defs = []
-            pkg_class = spack.repo.path.get_pkg_class(pkg_name)
+            pkg_class = spack.repo.PATH.get_pkg_class(pkg_name)
             for vstr in version_preferences:
                 v = vn.ver(vstr)
                 if isinstance(v, vn.GitVersion):
@@ -2053,7 +2053,7 @@ class SpackSolverSetup:
         # aggregate constraints into per-virtual sets
         constraint_map = collections.defaultdict(lambda: set())
         for pkg_name, versions in self.version_constraints:
-            if not spack.repo.path.is_virtual(pkg_name):
+            if not spack.repo.PATH.is_virtual(pkg_name):
                 continue
             constraint_map[pkg_name].add(versions)
 
@@ -2141,7 +2141,7 @@ class SpackSolverSetup:
             self.reusable_and_possible[h] = spec
             try:
                 # Only consider installed packages for repo we know
-                spack.repo.path.get(spec)
+                spack.repo.PATH.get(spec)
             except (spack.repo.UnknownNamespaceError, spack.repo.UnknownPackageError):
                 return
 
@@ -2366,7 +2366,7 @@ class SpackSolverSetup:
             # Prefer spec's name if it exists, in case the spec is
             # requiring a specific implementation inside of a virtual section
             # e.g. packages:mpi:require:openmpi@4.0.1
-            pkg_class = spack.repo.path.get_pkg_class(spec.name or pkg_name)
+            pkg_class = spack.repo.PATH.get_pkg_class(spec.name or pkg_name)
             satisfying_versions = self._check_for_defined_matching_versions(
                 pkg_class, spec.versions
             )
@@ -2621,7 +2621,7 @@ class SpecBuilder:
             # predicates on virtual packages.
             if name != "error":
                 pkg = args[0]
-                if spack.repo.path.is_virtual(pkg):
+                if spack.repo.PATH.is_virtual(pkg):
                     continue
 
                 # if we've already gotten a concrete spec for this pkg,
@@ -2639,7 +2639,7 @@ class SpecBuilder:
         for spec in self._specs.values():
             if spec.namespace:
                 continue
-            repo = spack.repo.path.repo_for_pkg(spec)
+            repo = spack.repo.PATH.repo_for_pkg(spec)
             spec.namespace = repo.namespace
 
         # fix flags after all specs are constructed

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1299,7 +1299,7 @@ class SpecBuildInterface(lang.ObjectWrapper):
         original_spec = getattr(spec, "wrapped_obj", spec)
         self.wrapped_obj = original_spec
         self.token = original_spec, name, query_parameters
-        is_virtual = spack.repo.path.is_virtual(name)
+        is_virtual = spack.repo.PATH.is_virtual(name)
         self.last_query = QueryState(
             name=name, extra_parameters=query_parameters, isvirtual=is_virtual
         )
@@ -1733,7 +1733,7 @@ class Spec:
             self.name
         )
         if not self._package:
-            self._package = spack.repo.path.get(self)
+            self._package = spack.repo.PATH.get(self)
         return self._package
 
     @property
@@ -1741,11 +1741,11 @@ class Spec:
         """Internal package call gets only the class object for a package.
         Use this to just get package metadata.
         """
-        return spack.repo.path.get_pkg_class(self.fullname)
+        return spack.repo.PATH.get_pkg_class(self.fullname)
 
     @property
     def virtual(self):
-        return spack.repo.path.is_virtual(self.name)
+        return spack.repo.PATH.is_virtual(self.name)
 
     @property
     def concrete(self):
@@ -2272,7 +2272,7 @@ class Spec:
         # TODO: this doesn't account for the case where the changed spec
         # (and the user spec) have dependencies
         new_spec = init_spec.copy()
-        package_cls = spack.repo.path.get_pkg_class(new_spec.name)
+        package_cls = spack.repo.PATH.get_pkg_class(new_spec.name)
         if change_spec.versions and not change_spec.versions == vn.any_version:
             new_spec.versions = change_spec.versions
         for variant, value in change_spec.variants.items():
@@ -2546,7 +2546,7 @@ class Spec:
         assert isinstance(self.extra_attributes, collections.abc.Mapping), msg
 
         # Validate the spec calling a package specific method
-        pkg_cls = spack.repo.path.get_pkg_class(self.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
         validate_fn = getattr(pkg_cls, "validate_detected_spec", lambda x, y: None)
         validate_fn(self, self.extra_attributes)
 
@@ -2645,7 +2645,7 @@ class Spec:
         """
         # Make an index of stuff this spec already provides
         self_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.path, specs=self.traverse(), restrict=True
+            repository=spack.repo.PATH, specs=self.traverse(), restrict=True
         )
         changed = False
         done = False
@@ -2785,7 +2785,7 @@ class Spec:
         visited_user_specs = set()
         for dep in self.traverse():
             visited_user_specs.add(dep.name)
-            pkg_cls = spack.repo.path.get_pkg_class(dep.name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(dep.name)
             visited_user_specs.update(x.name for x in pkg_cls(dep).provided)
 
         extra = set(user_spec_deps.keys()).difference(visited_user_specs)
@@ -2868,7 +2868,7 @@ class Spec:
             # we can do it as late as possible to allow as much
             # compatibility across repositories as possible.
             if s.namespace is None:
-                s.namespace = spack.repo.path.repo_for_pkg(s.name).namespace
+                s.namespace = spack.repo.PATH.repo_for_pkg(s.name).namespace
 
             if s.concrete:
                 continue
@@ -2926,7 +2926,7 @@ class Spec:
 
             # Get the path from the module the package can override the default
             # (this is mostly needed for Cray)
-            pkg_cls = spack.repo.path.get_pkg_class(external_spec.name)
+            pkg_cls = spack.repo.PATH.get_pkg_class(external_spec.name)
             package = pkg_cls(external_spec)
             external_spec.external_path = getattr(
                 package, "external_prefix", md.path_from_modules(external_spec.external_modules)
@@ -3200,7 +3200,7 @@ class Spec:
         Raise an exception if there is a conflicting virtual
         dependency already in this spec.
         """
-        assert spack.repo.path.is_virtual_safe(vdep.name), vdep
+        assert spack.repo.PATH.is_virtual_safe(vdep.name), vdep
 
         # note that this defensively copies.
         providers = provider_index.providers_for(vdep)
@@ -3266,7 +3266,7 @@ class Spec:
         # If it's a virtual dependency, try to find an existing
         # provider in the spec, and merge that.
         virtuals = ()
-        if spack.repo.path.is_virtual_safe(dep.name):
+        if spack.repo.PATH.is_virtual_safe(dep.name):
             virtuals = (dep.name,)
             visited.add(dep.name)
             provider = self._find_provider(dep, provider_index)
@@ -3274,11 +3274,11 @@ class Spec:
                 dep = provider
         else:
             index = spack.provider_index.ProviderIndex(
-                repository=spack.repo.path, specs=[dep], restrict=True
+                repository=spack.repo.PATH, specs=[dep], restrict=True
             )
             items = list(spec_deps.items())
             for name, vspec in items:
-                if not spack.repo.path.is_virtual_safe(vspec.name):
+                if not spack.repo.PATH.is_virtual_safe(vspec.name):
                     continue
 
                 if index.providers_for(vspec):
@@ -3428,7 +3428,7 @@ class Spec:
         # Initialize index of virtual dependency providers if
         # concretize didn't pass us one already
         provider_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.path, specs=[s for s in all_spec_deps.values()], restrict=True
+            repository=spack.repo.PATH, specs=[s for s in all_spec_deps.values()], restrict=True
         )
 
         # traverse the package DAG and fill out dependencies according
@@ -3459,7 +3459,7 @@ class Spec:
         for spec in self.traverse():
             # raise an UnknownPackageError if the spec's package isn't real.
             if (not spec.virtual) and spec.name:
-                spack.repo.path.get_pkg_class(spec.fullname)
+                spack.repo.PATH.get_pkg_class(spec.fullname)
 
             # validate compiler in addition to the package name.
             if spec.compiler:
@@ -3527,7 +3527,7 @@ class Spec:
                 variant = pkg_variant.make_variant(value)
                 self.variants[variant_name] = variant
 
-        pkg_cls = spack.repo.path.get_pkg_class(self.name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
         pkg_variant.validate_or_raise(self.variants[variant_name], pkg_cls)
 
     def constrain(self, other, deps=True):
@@ -3732,8 +3732,8 @@ class Spec:
         if self.name != other.name and self.name and other.name:
             if self.virtual and other.virtual:
                 # Two virtual specs intersect only if there are providers for both
-                lhs = spack.repo.path.providers_for(str(self))
-                rhs = spack.repo.path.providers_for(str(other))
+                lhs = spack.repo.PATH.providers_for(str(self))
+                rhs = spack.repo.PATH.providers_for(str(other))
                 intersection = [s for s in lhs if any(s.intersects(z) for z in rhs)]
                 return bool(intersection)
 
@@ -3742,7 +3742,7 @@ class Spec:
                 virtual_spec, non_virtual_spec = (self, other) if self.virtual else (other, self)
                 try:
                     # Here we might get an abstract spec
-                    pkg_cls = spack.repo.path.get_pkg_class(non_virtual_spec.fullname)
+                    pkg_cls = spack.repo.PATH.get_pkg_class(non_virtual_spec.fullname)
                     pkg = pkg_cls(non_virtual_spec)
                 except spack.repo.UnknownEntityError:
                     # If we can't get package info on this spec, don't treat
@@ -3813,10 +3813,10 @@ class Spec:
 
         # For virtual dependencies, we need to dig a little deeper.
         self_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.path, specs=self.traverse(), restrict=True
+            repository=spack.repo.PATH, specs=self.traverse(), restrict=True
         )
         other_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.path, specs=other.traverse(), restrict=True
+            repository=spack.repo.PATH, specs=other.traverse(), restrict=True
         )
 
         # This handles cases where there are already providers for both vpkgs
@@ -3857,7 +3857,7 @@ class Spec:
             if not self.virtual and other.virtual:
                 try:
                     # Here we might get an abstract spec
-                    pkg_cls = spack.repo.path.get_pkg_class(self.fullname)
+                    pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
                     pkg = pkg_cls(self)
                 except spack.repo.UnknownEntityError:
                     # If we can't get package info on this spec, don't treat
@@ -3939,8 +3939,8 @@ class Spec:
             # translate patch sha256sums to patch objects by consulting the index
             if self._patches_assigned():
                 for sha256 in self.variants["patches"]._patches_in_order_of_appearance:
-                    index = spack.repo.path.patch_index
-                    pkg_cls = spack.repo.path.get_pkg_class(self.name)
+                    index = spack.repo.PATH.patch_index
+                    pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
                     patch = index.patch_for_package(sha256, pkg_cls)
                     self._patches.append(patch)
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -102,7 +102,7 @@ class TestState:
     def restore(self):
         if _SERIALIZE:
             spack.config.config = self.config
-            spack.repo.path = spack.repo.create(self.config)
+            spack.repo.PATH = spack.repo.create(self.config)
             spack.platforms.host = self.platform
             spack.store.STORE = self.store
             self.test_patches.restore()

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -32,10 +32,10 @@ def packages_with_tags(tags, installed, skip_empty):
     """
     tag_pkgs = collections.defaultdict(lambda: list)
     spec_names = _get_installed_package_names() if installed else []
-    keys = spack.repo.path.tag_index if tags is None else tags
+    keys = spack.repo.PATH.tag_index if tags is None else tags
     for tag in keys:
         packages = [
-            name for name in spack.repo.path.tag_index[tag] if not installed or name in spec_names
+            name for name in spack.repo.PATH.tag_index[tag] if not installed or name in spec_names
         ]
         if packages or not skip_empty:
             tag_pkgs[tag] = packages

--- a/lib/spack/spack/test/buildrequest.py
+++ b/lib/spack/spack/test/buildrequest.py
@@ -15,7 +15,7 @@ def test_build_request_errors(install_mockery):
         inst.BuildRequest("abc", {})
 
     spec = spack.spec.Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     with pytest.raises(ValueError, match="must have a concrete spec"):
         inst.BuildRequest(pkg_cls(spec), {})
 

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -15,7 +15,7 @@ def test_build_task_errors(install_mockery):
         inst.BuildTask("abc", None, False, 0, 0, 0, [])
 
     spec = spack.spec.Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     with pytest.raises(ValueError, match="must have a concrete spec"):
         inst.BuildTask(pkg_cls(spec), None, False, 0, 0, 0, [])
 

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -72,7 +72,7 @@ def test_checksum_interactive(mock_packages, mock_fetch, mock_stage, monkeypatch
 
 
 def test_checksum_versions(mock_packages, mock_clone_repo, mock_fetch, mock_stage):
-    pkg_cls = spack.repo.path.get_pkg_class("zlib")
+    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
     versions = [str(v) for v in pkg_cls.versions]
     output = spack_checksum("zlib", *versions)
     assert "Found 3 versions" in output
@@ -101,14 +101,14 @@ def test_checksum_deprecated_version(mock_packages, mock_clone_repo, mock_fetch,
 
 
 def test_checksum_at(mock_packages):
-    pkg_cls = spack.repo.path.get_pkg_class("zlib")
+    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
     versions = [str(v) for v in pkg_cls.versions]
     output = spack_checksum(f"zlib@{versions[0]}")
     assert "Found 1 version" in output
 
 
 def test_checksum_url(mock_packages):
-    pkg_cls = spack.repo.path.get_pkg_class("zlib")
+    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
     output = spack_checksum(f"{pkg_cls.url}", fail_on_error=False)
     assert "accepts package names" in output
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -266,7 +266,7 @@ def test_dev_build_multiple(
     # root and dependency if they wanted a dev build for both.
     leaf_dir = tmpdir.mkdir("leaf")
     leaf_spec = spack.spec.Spec("dev-build-test-install@=1.0.0")  # non-existing version
-    leaf_pkg_cls = spack.repo.path.get_pkg_class(leaf_spec.name)
+    leaf_pkg_cls = spack.repo.PATH.get_pkg_class(leaf_spec.name)
     with leaf_dir.as_cwd():
         with open(leaf_pkg_cls.filename, "w") as f:
             f.write(leaf_pkg_cls.original_string)
@@ -275,7 +275,7 @@ def test_dev_build_multiple(
     # don't concretize outside environment -- dev info will be wrong
     root_dir = tmpdir.mkdir("root")
     root_spec = spack.spec.Spec("dev-build-test-dependent@0.0.0")
-    root_pkg_cls = spack.repo.path.get_pkg_class(root_spec.name)
+    root_pkg_cls = spack.repo.PATH.get_pkg_class(root_spec.name)
     with root_dir.as_cwd():
         with open(root_pkg_cls.filename, "w") as f:
             f.write(root_pkg_cls.original_string)
@@ -329,7 +329,7 @@ def test_dev_build_env_dependency(
     dep_spec = spack.spec.Spec("dev-build-test-install")
 
     with build_dir.as_cwd():
-        dep_pkg_cls = spack.repo.path.get_pkg_class(dep_spec.name)
+        dep_pkg_cls = spack.repo.PATH.get_pkg_class(dep_spec.name)
         with open(dep_pkg_cls.filename, "w") as f:
             f.write(dep_pkg_cls.original_string)
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -277,7 +277,7 @@ def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkey
     def setup_error(pkg, env):
         raise RuntimeError("cmake-client had issues!")
 
-    pkg = spack.repo.path.get_pkg_class("cmake-client")
+    pkg = spack.repo.PATH.get_pkg_class("cmake-client")
     monkeypatch.setattr(pkg, "setup_run_environment", setup_error)
 
     spack.environment.shell.activate(e)

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -43,7 +43,7 @@ def define_plat_exe(exe):
 
 
 def test_find_external_single_package(mock_executable, executables_found, _platform_executables):
-    pkgs_to_check = [spack.repo.path.get_pkg_class("cmake")]
+    pkgs_to_check = [spack.repo.PATH.get_pkg_class("cmake")]
     cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
     executables_found({str(cmake_path): define_plat_exe("cmake")})
 
@@ -58,7 +58,7 @@ def test_find_external_single_package(mock_executable, executables_found, _platf
 def test_find_external_two_instances_same_package(
     mock_executable, executables_found, _platform_executables
 ):
-    pkgs_to_check = [spack.repo.path.get_pkg_class("cmake")]
+    pkgs_to_check = [spack.repo.PATH.get_pkg_class("cmake")]
 
     # Each of these cmake instances is created in a different prefix
     # In Windows, quoted strings are echo'd with quotes includes
@@ -347,7 +347,7 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch, _platfo
     def _determine_variants(cls, exes, version_str):
         return "languages=c", {"prefix": "/opt/gcc/bin", "compilers": {"c": exes[0]}}
 
-    gcc_cls = spack.repo.path.get_pkg_class("gcc")
+    gcc_cls = spack.repo.PATH.get_pkg_class("gcc")
     monkeypatch.setattr(gcc_cls, "determine_variants", _determine_variants)
 
     # Find the external spec

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -82,7 +82,7 @@ def mock_pkg_git_repo(git, tmpdir_factory):
 
 @pytest.fixture(scope="module")
 def mock_pkg_names():
-    repo = spack.repo.path.get_repo("builtin.mock")
+    repo = spack.repo.PATH.get_repo("builtin.mock")
 
     # Be sure to include virtual packages since packages with stand-alone
     # tests may inherit additional tests from the virtuals they provide,
@@ -105,11 +105,11 @@ pkg = spack.main.SpackCommand("pkg")
 
 
 def test_packages_path():
-    assert spack.repo.packages_path() == spack.repo.path.get_repo("builtin").packages_path
+    assert spack.repo.packages_path() == spack.repo.PATH.get_repo("builtin").packages_path
 
 
 def test_mock_packages_path(mock_packages):
-    assert spack.repo.packages_path() == spack.repo.path.get_repo("builtin.mock").packages_path
+    assert spack.repo.packages_path() == spack.repo.PATH.get_repo("builtin.mock").packages_path
 
 
 def test_pkg_add(git, mock_pkg_git_repo):
@@ -126,8 +126,8 @@ def test_pkg_add(git, mock_pkg_git_repo):
         finally:
             shutil.rmtree("pkg-e")
             # Removing a package mid-run disrupts Spack's caching
-            if spack.repo.path.repos[0]._fast_package_checker:
-                spack.repo.path.repos[0]._fast_package_checker.invalidate()
+            if spack.repo.PATH.repos[0]._fast_package_checker:
+                spack.repo.PATH.repos[0]._fast_package_checker.invalidate()
 
     with pytest.raises(spack.main.SpackCommandError):
         pkg("add", "does-not-exist")
@@ -248,7 +248,7 @@ def test_pkg_source_requires_one_arg(mock_packages):
 def test_pkg_source(mock_packages):
     fake_source = pkg("source", "fake")
 
-    fake_file = spack.repo.path.filename_for_package_name("fake")
+    fake_file = spack.repo.PATH.filename_for_package_name("fake")
     with open(fake_file) as f:
         contents = f.read()
         assert fake_source == contents
@@ -303,7 +303,7 @@ def test_pkg_grep(mock_packages, capfd):
     pkg("grep", "-l", "splice", output=str)
     output, _ = capfd.readouterr()
     assert output.strip() == "\n".join(
-        spack.repo.path.get_pkg_class(name).module.__file__
+        spack.repo.PATH.get_pkg_class(name).module.__file__
         for name in ["splice-a", "splice-h", "splice-t", "splice-vh", "splice-z"]
     )
 

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -120,7 +120,7 @@ def test_changed_files_all_files():
     assert len(files) > 6000
 
     # a builtin package
-    zlib = spack.repo.path.get_pkg_class("zlib")
+    zlib = spack.repo.PATH.get_pkg_class("zlib")
     zlib_file = zlib.module.__file__
     if zlib_file.endswith("pyc"):
         zlib_file = zlib_file[:-1]

--- a/lib/spack/spack/test/cmd/tags.py
+++ b/lib/spack/spack/test/cmd/tags.py
@@ -41,7 +41,7 @@ def test_tags_no_tags(monkeypatch):
     class tag_path:
         tag_index = dict()
 
-    monkeypatch.setattr(spack.repo, "path", tag_path)
+    monkeypatch.setattr(spack.repo, "PATH", tag_path)
     out = tags()
     assert "No tagged" in out
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -43,7 +43,7 @@ def check_spec(abstract, concrete):
             cflag = concrete.compiler_flags[flag]
             assert set(aflag) <= set(cflag)
 
-    for name in spack.repo.path.get_pkg_class(abstract.name).variants:
+    for name in spack.repo.PATH.get_pkg_class(abstract.name).variants:
         assert name in concrete.variants
 
     for flag in concrete.compiler_flags.valid_compiler_flags():
@@ -296,7 +296,7 @@ class TestConcretize:
         """Make sure insufficient versions of MPI are not in providers list when
         we ask for some advanced version.
         """
-        repo = spack.repo.path
+        repo = spack.repo.PATH
         assert not any(s.intersects("mpich2@:1.0") for s in repo.providers_for("mpi@2.1"))
         assert not any(s.intersects("mpich2@:1.1") for s in repo.providers_for("mpi@2.2"))
         assert not any(s.intersects("mpich@:1") for s in repo.providers_for("mpi@2"))
@@ -305,7 +305,7 @@ class TestConcretize:
 
     def test_provides_handles_multiple_providers_of_same_version(self):
         """ """
-        providers = spack.repo.path.providers_for("mpi@3.0")
+        providers = spack.repo.PATH.providers_for("mpi@3.0")
 
         # Note that providers are repo-specific, so we don't misinterpret
         # providers, but vdeps are not namespace-specific, so we can
@@ -1450,7 +1450,7 @@ class TestConcretize:
         assert s["lapack"].name == "low-priority-provider"
 
         for virtual_pkg in ("mpi", "lapack"):
-            for pkg in spack.repo.path.providers_for(virtual_pkg):
+            for pkg in spack.repo.PATH.providers_for(virtual_pkg):
                 if pkg.name == "low-priority-provider":
                     continue
                 assert pkg not in s
@@ -1923,7 +1923,7 @@ class TestConcretize:
             pytest.xfail("Use case not supported by the original concretizer")
 
         # Add a conflict to "mpich" that match an already installed "mpich~debug"
-        pkg_cls = spack.repo.path.get_pkg_class("mpich")
+        pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
         monkeypatch.setitem(pkg_cls.conflicts, "~debug", [(Spec(), None)])
 
         # If we concretize with --fresh the conflict is taken into account

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1158,13 +1158,13 @@ def test_license_dir_config(mutable_config, mock_packages):
     expected_dir = spack.paths.default_license_dir
     assert spack.config.get("config:license_dir") == expected_dir
     assert spack.package_base.PackageBase.global_license_dir == expected_dir
-    assert spack.repo.path.get_pkg_class("a").global_license_dir == expected_dir
+    assert spack.repo.PATH.get_pkg_class("a").global_license_dir == expected_dir
 
     rel_path = os.path.join(os.path.sep, "foo", "bar", "baz")
     spack.config.set("config:license_dir", rel_path)
     assert spack.config.get("config:license_dir") == rel_path
     assert spack.package_base.PackageBase.global_license_dir == rel_path
-    assert spack.repo.path.get_pkg_class("a").global_license_dir == rel_path
+    assert spack.repo.PATH.get_pkg_class("a").global_license_dir == rel_path
 
 
 @pytest.mark.regression("22547")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -773,7 +773,7 @@ def concretize_scope(mutable_config, tmpdir):
     yield str(tmpdir.join("concretize"))
 
     mutable_config.pop_scope()
-    spack.repo.path._provider_index = None
+    spack.repo.PATH._provider_index = None
 
 
 @pytest.fixture
@@ -1937,5 +1937,5 @@ def nullify_globals(request, monkeypatch):
     ensure_configuration_fixture_run_before(request)
     monkeypatch.setattr(spack.config, "config", None)
     monkeypatch.setattr(spack.caches, "misc_cache", None)
-    monkeypatch.setattr(spack.repo, "path", None)
+    monkeypatch.setattr(spack.repo, "PATH", None)
     monkeypatch.setattr(spack.store, "STORE", None)

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -16,7 +16,7 @@ def test_false_directives_do_not_exist(mock_packages):
     """Ensure directives that evaluate to False at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.path.get_pkg_class("when-directives-false")
+    cls = spack.repo.PATH.get_pkg_class("when-directives-false")
     assert not cls.dependencies
     assert not cls.resources
     assert not cls.patches
@@ -26,7 +26,7 @@ def test_true_directives_exist(mock_packages):
     """Ensure directives that evaluate to True at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.path.get_pkg_class("when-directives-true")
+    cls = spack.repo.PATH.get_pkg_class("when-directives-true")
 
     assert cls.dependencies
     assert spack.spec.Spec() in cls.dependencies["extendee"]
@@ -40,7 +40,7 @@ def test_true_directives_exist(mock_packages):
 
 
 def test_constraints_from_context(mock_packages):
-    pkg_cls = spack.repo.path.get_pkg_class("with-constraint-met")
+    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert spack.spec.Spec("@1.0") in pkg_cls.dependencies["b"]
@@ -51,7 +51,7 @@ def test_constraints_from_context(mock_packages):
 
 @pytest.mark.regression("26656")
 def test_constraints_from_context_are_merged(mock_packages):
-    pkg_cls = spack.repo.path.get_pkg_class("with-constraint-met")
+    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert spack.spec.Spec("@0.14:15 ^b@3.8:4.0") in pkg_cls.dependencies["c"]
@@ -68,7 +68,7 @@ def test_extends_spec(config, mock_packages):
 
 @pytest.mark.regression("34368")
 def test_error_on_anonymous_dependency(config, mock_packages):
-    pkg = spack.repo.path.get_pkg_class("a")
+    pkg = spack.repo.PATH.get_pkg_class("a")
     with pytest.raises(spack.directives.DependencyError):
         spack.directives._depends_on(pkg, "@4.5")
 
@@ -85,7 +85,7 @@ def test_error_on_anonymous_dependency(config, mock_packages):
     ],
 )
 def test_maintainer_directive(config, mock_packages, package_name, expected_maintainers):
-    pkg_cls = spack.repo.path.get_pkg_class(package_name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
     assert pkg_cls.maintainers == expected_maintainers
 
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -79,7 +79,7 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
     layout.
     """
     layout = temporary_store.layout
-    pkg_names = list(spack.repo.path.all_package_names())[:max_packages]
+    pkg_names = list(spack.repo.PATH.all_package_names())[:max_packages]
 
     for name in pkg_names:
         if name.startswith("external"):
@@ -191,7 +191,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages):
 def test_find(temporary_store, config, mock_packages):
     """Test that finding specs within an install layout works."""
     layout = temporary_store.layout
-    package_names = list(spack.repo.path.all_package_names())[:max_packages]
+    package_names = list(spack.repo.PATH.all_package_names())[:max_packages]
 
     # Create install prefixes for all packages in the list
     installed_specs = {}

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -100,7 +100,7 @@ def test_fetch(
     t = mock_git_repository.checks[type_of_test]
     h = mock_git_repository.hash
 
-    pkg_class = spack.repo.path.get_pkg_class("git-test")
+    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
     # This would fail using the default-no-per-version-git check but that
     # isn't included in this test
     monkeypatch.delattr(pkg_class, "git")
@@ -147,7 +147,7 @@ def test_fetch_pkg_attr_submodule_init(
     """
 
     t = mock_git_repository.checks["default-no-per-version-git"]
-    pkg_class = spack.repo.path.get_pkg_class("git-test")
+    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
     # For this test, the version args don't specify 'git' (which is
     # the majority of version specifications)
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
@@ -179,7 +179,7 @@ def test_adhoc_version_submodules(
 ):
     t = mock_git_repository.checks["tag"]
     # Construct the package under test
-    pkg_class = spack.repo.path.get_pkg_class("git-test")
+    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
     monkeypatch.setitem(pkg_class.versions, Version("git"), t.args)
     monkeypatch.setattr(pkg_class, "git", "file://%s" % mock_git_repository.path, raising=False)
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -24,7 +24,7 @@ def test_static_graph_mpileaks(config, mock_packages):
     assert '  "libelf" [label="libelf"]\n' in dot
     assert '  "libdwarf" [label="libdwarf"]\n' in dot
 
-    mpi_providers = spack.repo.path.providers_for("mpi")
+    mpi_providers = spack.repo.PATH.providers_for("mpi")
     for spec in mpi_providers:
         assert ('"mpileaks" -> "%s"' % spec.name) in dot
         assert ('"callpath" -> "%s"' % spec.name) in dot

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -52,7 +52,7 @@ def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch
 
     # Mock deletion of the package
     spec._package = None
-    monkeypatch.setattr(spack.repo.path, "get", find_nothing)
+    monkeypatch.setattr(spack.repo.PATH, "get", find_nothing)
     with pytest.raises(spack.repo.UnknownPackageError):
         spec.package
 
@@ -616,7 +616,7 @@ def test_log_install_with_build_files(install_mockery, monkeypatch):
 def test_unconcretized_install(install_mockery, mock_fetch, mock_packages):
     """Test attempts to perform install phases with unconcretized spec."""
     spec = Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
 
     with pytest.raises(ValueError, match="must have a concrete spec"):
         pkg_cls(spec).do_install()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -458,7 +458,7 @@ def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir, capsys):
 
 def test_package_id_err(install_mockery):
     s = spack.spec.Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.path.get_pkg_class(s.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(s.name)
     with pytest.raises(ValueError, match="spec is not concretized"):
         inst.package_id(pkg_cls(s))
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -181,7 +181,7 @@ def test_load_installed_package_not_in_repo(install_mockery, mock_fetch, monkeyp
 
     # Mock deletion of the package
     spec._package = None
-    monkeypatch.setattr(spack.repo.path, "get", find_nothing)
+    monkeypatch.setattr(spack.repo.PATH, "get", find_nothing)
     with pytest.raises(spack.repo.UnknownPackageError):
         spec.package
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -48,7 +48,7 @@ def mpileaks_possible_deps(mock_packages, mpi_names):
 
 
 def test_possible_dependencies(mock_packages, mpileaks_possible_deps):
-    pkg_cls = spack.repo.path.get_pkg_class("mpileaks")
+    pkg_cls = spack.repo.PATH.get_pkg_class("mpileaks")
     expanded_possible_deps = pkg_cls.possible_dependencies(expand_virtuals=True)
     assert mpileaks_possible_deps == expanded_possible_deps
     assert {
@@ -62,14 +62,14 @@ def test_possible_dependencies(mock_packages, mpileaks_possible_deps):
 
 
 def test_possible_direct_dependencies(mock_packages, mpileaks_possible_deps):
-    pkg_cls = spack.repo.path.get_pkg_class("mpileaks")
+    pkg_cls = spack.repo.PATH.get_pkg_class("mpileaks")
     deps = pkg_cls.possible_dependencies(transitive=False, expand_virtuals=False)
     assert {"callpath": set(), "mpi": set(), "mpileaks": {"callpath", "mpi"}} == deps
 
 
 def test_possible_dependencies_virtual(mock_packages, mpi_names):
     expected = dict(
-        (name, set(spack.repo.path.get_pkg_class(name).dependencies)) for name in mpi_names
+        (name, set(spack.repo.PATH.get_pkg_class(name).dependencies)) for name in mpi_names
     )
 
     # only one mock MPI has a dependency
@@ -79,14 +79,14 @@ def test_possible_dependencies_virtual(mock_packages, mpi_names):
 
 
 def test_possible_dependencies_missing(mock_packages):
-    pkg_cls = spack.repo.path.get_pkg_class("missing-dependency")
+    pkg_cls = spack.repo.PATH.get_pkg_class("missing-dependency")
     missing = {}
     pkg_cls.possible_dependencies(transitive=True, missing=missing)
     assert {"this-is-a-missing-dependency"} == missing["missing-dependency"]
 
 
 def test_possible_dependencies_with_deptypes(mock_packages):
-    dtbuild1 = spack.repo.path.get_pkg_class("dtbuild1")
+    dtbuild1 = spack.repo.PATH.get_pkg_class("dtbuild1")
 
     assert {
         "dtbuild1": {"dtrun2", "dtlink2"},

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -20,17 +20,17 @@ from spack.version import VersionChecksumError
 
 def pkg_factory(name):
     """Return a package object tied to an abstract spec"""
-    pkg_cls = spack.repo.path.get_pkg_class(name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(name)
     return pkg_cls(Spec(name))
 
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestPackage:
     def test_load_package(self):
-        spack.repo.path.get_pkg_class("mpich")
+        spack.repo.PATH.get_pkg_class("mpich")
 
     def test_package_name(self):
-        pkg_cls = spack.repo.path.get_pkg_class("mpich")
+        pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
         assert pkg_cls.name == "mpich"
 
     def test_package_filename(self):
@@ -64,7 +64,7 @@ class TestPackage:
         from spack.pkg.builtin import mock  # noqa: F401
 
     def test_inheritance_of_diretives(self):
-        pkg_cls = spack.repo.path.get_pkg_class("simple-inheritance")
+        pkg_cls = spack.repo.PATH.get_pkg_class("simple-inheritance")
 
         # Check dictionaries that should have been filled by directives
         assert len(pkg_cls.dependencies) == 3
@@ -127,7 +127,7 @@ def test_urls_for_versions(mock_packages, config):
 
 def test_url_for_version_with_no_urls(mock_packages, config):
     spec = Spec("git-test")
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     with pytest.raises(spack.package_base.NoURLError):
         pkg_cls(spec).url_for_version("1.0")
 
@@ -316,7 +316,7 @@ def test_fetch_options(version_str, digest_end, extra_options):
 
 def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
-    pkg_cls = spack.repo.path.get_pkg_class(spec.name)
+    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
 
     assert spack.package_base.deprecated_version(pkg_cls, "1.1.0")
     assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -191,7 +191,7 @@ def test_nested_directives(mock_packages):
     """Ensure pkg data structures are set up properly by nested directives."""
     # this ensures that the patch() directive results were removed
     # properly from the DirectiveMeta._directives_to_be_executed list
-    patcher = spack.repo.path.get_pkg_class("patch-several-dependencies")
+    patcher = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
     assert len(patcher.patches) == 0
 
     # this ensures that results of dependency patches were properly added

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -26,19 +26,19 @@ from spack.spec import Spec
 
 
 def test_provider_index_round_trip(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
 
     ostream = io.StringIO()
     p.to_json(ostream)
 
     istream = io.StringIO(ostream.getvalue())
-    q = ProviderIndex.from_json(istream, repository=spack.repo.path)
+    q = ProviderIndex.from_json(istream, repository=spack.repo.PATH)
 
     assert p == q
 
 
 def test_providers_for_simple(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
 
     blas_providers = p.providers_for("blas")
     assert Spec("netlib-blas") in blas_providers
@@ -51,7 +51,7 @@ def test_providers_for_simple(mock_packages):
 
 
 def test_mpi_providers(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
 
     mpi_2_providers = p.providers_for("mpi@2")
     assert Spec("mpich2") in mpi_2_providers
@@ -64,12 +64,12 @@ def test_mpi_providers(mock_packages):
 
 
 def test_equal(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
-    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
     assert p == q
 
 
 def test_copy(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.path)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
     q = p.copy()
     assert p == q

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -59,9 +59,9 @@ def test_repo_unknown_pkg(mutable_mock_repo):
 @pytest.mark.maybeslow
 def test_repo_last_mtime():
     latest_mtime = max(
-        os.path.getmtime(p.module.__file__) for p in spack.repo.path.all_package_classes()
+        os.path.getmtime(p.module.__file__) for p in spack.repo.PATH.all_package_classes()
     )
-    assert spack.repo.path.last_mtime() == latest_mtime
+    assert spack.repo.PATH.last_mtime() == latest_mtime
 
 
 def test_repo_invisibles(mutable_mock_repo, extra_repo):
@@ -90,10 +90,10 @@ def test_use_repositories_doesnt_change_class():
     """Test that we don't create the same package module and class multiple times
     when swapping repositories.
     """
-    zlib_cls_outer = spack.repo.path.get_pkg_class("zlib")
-    current_paths = [r.root for r in spack.repo.path.repos]
+    zlib_cls_outer = spack.repo.PATH.get_pkg_class("zlib")
+    current_paths = [r.root for r in spack.repo.PATH.repos]
     with spack.repo.use_repositories(*current_paths):
-        zlib_cls_inner = spack.repo.path.get_pkg_class("zlib")
+        zlib_cls_inner = spack.repo.PATH.get_pkg_class("zlib")
     assert id(zlib_cls_inner) == id(zlib_cls_outer)
 
 
@@ -126,7 +126,7 @@ def test_all_virtual_packages_have_default_providers():
     configuration = spack.config.create()
     defaults = configuration.get("packages", scope="defaults")
     default_providers = defaults["all"]["providers"]
-    providers = spack.repo.path.provider_index.providers
+    providers = spack.repo.PATH.provider_index.providers
     default_providers_filename = configuration.scopes["defaults"].get_section_filename("packages")
     for provider in providers:
         assert provider in default_providers, (

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -44,7 +44,7 @@ def set_dependency(saved_deps, monkeypatch):
         """
         spec = Spec(spec)
         # Save original dependencies before making any changes.
-        pkg_cls = spack.repo.path.get_pkg_class(pkg_name)
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         if pkg_name not in saved_deps:
             saved_deps[pkg_name] = (pkg_cls, pkg_cls.dependencies.copy())
 

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -97,7 +97,7 @@ def test_tag_get_installed_packages(mock_packages, mock_archive, mock_fetch, ins
 
 def test_tag_index_round_trip(mock_packages):
     # Assumes at least two packages -- mpich and mpich2 -- have tags
-    mock_index = spack.repo.path.tag_index
+    mock_index = spack.repo.PATH.tag_index
     assert mock_index.tags
 
     ostream = io.StringIO()
@@ -153,7 +153,7 @@ def test_tag_no_tags(mock_packages):
 
 
 def test_tag_update_package(mock_packages):
-    mock_index = spack.repo.path.tag_index
+    mock_index = spack.repo.PATH.tag_index
     index = spack.tag.TagIndex(repository=mock_packages)
     for name in spack.repo.all_package_names():
         index.update_package(name)

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -20,9 +20,9 @@ datadir = os.path.join(spack.paths.test_path, "data", "unparse")
 
 def compare_sans_name(eq, spec1, spec2):
     content1 = ph.canonical_source(spec1)
-    content1 = content1.replace(spack.repo.path.get_pkg_class(spec1.name).__name__, "TestPackage")
+    content1 = content1.replace(spack.repo.PATH.get_pkg_class(spec1.name).__name__, "TestPackage")
     content2 = ph.canonical_source(spec2)
-    content2 = content2.replace(spack.repo.path.get_pkg_class(spec2.name).__name__, "TestPackage")
+    content2 = content2.replace(spack.repo.PATH.get_pkg_class(spec2.name).__name__, "TestPackage")
     if eq:
         assert content1 == content2
     else:
@@ -31,12 +31,12 @@ def compare_sans_name(eq, spec1, spec2):
 
 def compare_hash_sans_name(eq, spec1, spec2):
     content1 = ph.canonical_source(spec1)
-    pkg_cls1 = spack.repo.path.get_pkg_class(spec1.name)
+    pkg_cls1 = spack.repo.PATH.get_pkg_class(spec1.name)
     content1 = content1.replace(pkg_cls1.__name__, "TestPackage")
     hash1 = pkg_cls1(spec1).content_hash(content=content1)
 
     content2 = ph.canonical_source(spec2)
-    pkg_cls2 = spack.repo.path.get_pkg_class(spec2.name)
+    pkg_cls2 = spack.repo.PATH.get_pkg_class(spec2.name)
     content2 = content2.replace(pkg_cls2.__name__, "TestPackage")
     hash2 = pkg_cls2(spec2).content_hash(content=content2)
 

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -337,7 +337,7 @@ def package_ast(spec, filter_multimethods=True, source=None):
     spec = spack.spec.Spec(spec)
 
     if source is None:
-        filename = spack.repo.path.filename_for_package_name(spec.name)
+        filename = spack.repo.PATH.filename_for_package_name(spec.name)
         with open(filename) as f:
             source = f.read()
 

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -74,7 +74,7 @@ class GitRefLookup(AbstractRefLookup):
     def pkg(self):
         if not self._pkg:
             try:
-                pkg = spack.repo.path.get_pkg_class(self.pkg_name)
+                pkg = spack.repo.PATH.get_pkg_class(self.pkg_name)
                 pkg.git
             except (spack.repo.RepoError, AttributeError) as e:
                 raise VersionLookupError(f"Couldn't get the git repo for {self.pkg_name}") from e


### PR DESCRIPTION
This makes the name of the global variable representing the repository currently in use uppercase. Doing so is advised by pylint rules, and helps to identify where the global is used.