### PR TITLE
Add patch to build silo on nixos

### DIFF
--- a/var/spack/repos/builtin/packages/silo/mkinc-usr-bin-env-perl.patch
+++ b/var/spack/repos/builtin/packages/silo/mkinc-usr-bin-env-perl.patch
@@ -1,0 +1,23 @@
+diff --git a/config/mkinc b/config/mkinc
+index e52bb64..6d96176 100755
+--- a/config/mkinc
++++ b/config/mkinc
+@@ -17,7 +17,7 @@ exec perl /tmp/visitperl$$ $0 ${1+"$@"}
+ unlink $0;
+ $0 = shift @ARGV;
+
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #########################################################################
+ # Copyright (C) 1994-2016 Lawrence Livermore National Security, LLC.
+ # LLNL-CODE-425250.
+diff --git a/config/mklite b/config/mklite
+index f9394a9..274c867 100755
+--- a/config/mklite
++++ b/config/mklite
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+
+ #
+ # Tool to generate lite_pdb.h file from pdb.h and score.h headers.

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -46,6 +46,7 @@ class Silo(AutotoolsPackage):
     variant("hzip", default=True, description="Enable hzip support")
     variant("fpzip", default=True, description="Enable fpzip support")
 
+    depends_on("perl", type="build")
     depends_on("m4", type="build", when="+shared")
     depends_on("autoconf", type="build", when="+shared")
     depends_on("autoconf-archive", type="build", when="+shared")
@@ -88,6 +89,9 @@ class Silo(AutotoolsPackage):
 
     # zfp include missing
     patch("zfp_error.patch", when="@4.11 +hdf5")
+
+    # use /usr/bin/env perl for portability
+    patch("mkinc-usr-bin-env-perl.patch")
 
     def flag_handler(self, name, flags):
         spec = self.spec


### PR DESCRIPTION
Change the shebang in `mkinc` from `/usr/bin/perl` to `/usr/bin/env perl` for portability to systems that don't necessarily have `perl` in `/usr/bin`. Also adds `perl` as a build-time dependency.

Ping @G-071.