### PR TITLE
adios2: correct c-blosc dependency

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -131,7 +131,8 @@ class Adios2(CMakePackage, CudaPackage):
     depends_on("hdf5+mpi", when="+hdf5+mpi")
 
     depends_on("libpressio", when="+libpressio")
-    depends_on("c-blosc", when="+blosc")
+    depends_on("c-blosc", when="@:2.8 +blosc")
+    depends_on("c-blosc2", when="@2.9: +blosc")
     depends_on("bzip2", when="+bzip2")
     depends_on("libpng@1.6:", when="+png")
     depends_on("zfp@0.5.1:0.5", when="+zfp")

--- a/var/spack/repos/builtin/packages/c-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc2/package.py
@@ -43,6 +43,8 @@ class CBlosc2(CMakePackage):
     depends_on("zlib-api", when="+zlib")
     depends_on("zstd", when="+zstd")
 
+    conflicts("%oneapi")
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
ADIOS2 2.9.0 changed dependency from c-blocs -> c-blosc2.