### PR TITLE
py-cryptography: does not run-depend on py-setuptools-rust

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -32,7 +32,7 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@40.6:", when="@2.7:36", type="build")
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
-    depends_on("py-setuptools-rust@0.11.4:", when="@3.4:", type=("build", "run"))
+    depends_on("py-setuptools-rust@0.11.4:", when="@3.4:", type="build")
     depends_on("rust@1.48:", when="@38:", type="build")
     depends_on("rust@1.41:", when="@3.4.5:", type="build")
     depends_on("rust@1.45:", when="@3.4.3:3.4.4", type="build")

--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -32,7 +32,7 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@40.6:", when="@2.7:36", type="build")
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
-    depends_on("py-setuptools-rust@0.11.4:", when="@3.4:", type="build")
+    depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
     depends_on("rust@1.48:", when="@38:", type="build")
     depends_on("rust@1.41:", when="@3.4.5:", type="build")
     depends_on("rust@1.45:", when="@3.4.3:3.4.4", type="build")

--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -33,6 +33,7 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
     depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
+    depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
     depends_on("rust@1.48:", when="@38:", type="build")
     depends_on("rust@1.41:", when="@3.4.5:", type="build")
     depends_on("rust@1.45:", when="@3.4.3:3.4.4", type="build")


### PR DESCRIPTION
As of 3.4.2, https://github.com/pyca/cryptography/pull/5779 and backport https://github.com/pyca/cryptography/pull/5781, py-cryptography does not have a runtime dependency on py-setuptools-rust anymore, only a build dependency. Version 3.4.1 is the last version with `install_requires=setup_requirements`. Since the older versions after 3.4 but before 3.4.2 are not in spack, no specific exception is added to require the runtime dependency for 3.4:3.4.1.

(Yay, rust is garbage collected away again.)