### PR TITLE
environment: match spec to be removed to their actual representation

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2664,7 +2664,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         self.yaml_content = with_defaults_added
         self.changed = False
 
-    def _first_match(self, user_spec: str) -> str:
+    def _all_matches(self, user_spec: str) -> List[str]:
         """Maps the input string to the first equivalent user spec in the manifest,
         and returns it.
 
@@ -2674,11 +2674,15 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         Raises:
             ValueError: if no equivalent match is found
         """
+        result = []
         for yaml_spec_str in self.pristine_configuration["specs"]:
             if Spec(yaml_spec_str) == Spec(user_spec):
-                return yaml_spec_str
-        else:
+                result.append(yaml_spec_str)
+
+        if not result:
             raise ValueError(f"cannot find a spec equivalent to {user_spec}")
+
+        return result
 
     def add_user_spec(self, user_spec: str) -> None:
         """Appends the user spec passed as input to the list of root specs.
@@ -2700,9 +2704,9 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             SpackEnvironmentError: when the user spec is not in the list
         """
         try:
-            user_spec = self._first_match(user_spec)
-            self.pristine_configuration["specs"].remove(user_spec)
-            self.configuration["specs"].remove(user_spec)
+            for key in self._all_matches(user_spec):
+                self.pristine_configuration["specs"].remove(key)
+                self.configuration["specs"].remove(key)
         except ValueError as e:
             msg = f"cannot remove {user_spec} from {self}, no such spec exists"
             raise SpackEnvironmentError(msg) from e

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2664,6 +2664,22 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         self.yaml_content = with_defaults_added
         self.changed = False
 
+    def _first_match(self, user_spec: str) -> str:
+        """Maps the input string to the first equivalent user spec in the manifest,
+        and returns it.
+
+        Args:
+            user_spec: user spec to be found
+
+        Raises:
+            ValueError: if no equivalent match is found
+        """
+        for yaml_spec_str in self.pristine_configuration["specs"]:
+            if Spec(yaml_spec_str) == Spec(user_spec):
+                return yaml_spec_str
+        else:
+            raise ValueError(f"cannot find a spec equivalent to {user_spec}")
+
     def add_user_spec(self, user_spec: str) -> None:
         """Appends the user spec passed as input to the list of root specs.
 
@@ -2684,6 +2700,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             SpackEnvironmentError: when the user spec is not in the list
         """
         try:
+            user_spec = self._first_match(user_spec)
             self.pristine_configuration["specs"].remove(user_spec)
             self.configuration["specs"].remove(user_spec)
         except ValueError as e:

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -97,8 +97,10 @@ class SpecList:
             msg += "Either %s is not in %s or %s is " % (spec, self.name, spec)
             msg += "expanded from a matrix and cannot be removed directly."
             raise SpecListError(msg)
-        assert len(remove) == 1
-        self.yaml_list.remove(remove[0])
+
+        # Remove may contain more than one string representation of the same spec
+        for item in remove:
+            self.yaml_list.remove(item)
 
         # invalidate cache variables when we change the list
         self._expanded_list = None


### PR DESCRIPTION
fixes #39387

Before the input spec was normalized, and string match would fail if the user spec was manually edited and written in non-normal form.