### PR TITLE
ffmpeg: apply upstream fix for build with binutils 2.41

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -111,6 +111,13 @@ class Ffmpeg(AutotoolsPackage):
         when="@5.1.2",
     )
 
+    # Patch fixing a build failure with binutils 2.41.0
+    patch(
+        "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/effadce6c756247ea8bae32dc13bb3e6f464f0eb",
+        sha256="d1ea47c29968507fee772234bc734d29958b62ab92400801ef28559b538a9168",
+        when="@6.0",
+    )
+
     @property
     def libs(self):
         return find_libraries("*", self.prefix, recursive=True)


### PR DESCRIPTION
While spack does not yet provide binutils 2.41, they might still be installed. However, building ffmpeg on x86_64 fails with multiple errors like this:
./libavcodec/x86/mathops.h:125: Error: operand type mismatch for `shr'

also reported here: https://trac.ffmpeg.org/ticket/10405