### PR TITLE
assimp: minizip is a dependency

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -44,6 +44,7 @@ class Assimp(CMakePackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("zlib-api")
+    depends_on("minizip")
 
     def patch(self):
         filter_file("-Werror", "", "code/CMakeLists.txt")


### PR DESCRIPTION
assimp needs minizip, but cmake gets passed -DASSIMP_BUILD_MINIZIP=OFF. In this case it will still build an internal minizip, unless it finds an installed minizip. But linking to minizip from homebrew fails on macos.

This is fixed by making the dependency on minizip explicit. Otherwise it would not make sense to request -DASSIMP_BUILD_MINIZIP=OFF.