### PR TITLE
geant4: new variant data to depend on geant4-data

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -55,6 +55,7 @@ class Geant4(CMakePackage):
     conflicts("cxxstd=14", when="@11:", msg="geant4@11: only supports cxxstd=17")
 
     variant("threads", default=True, description="Build with multithreading")
+    variant("data", default=True, description="Depend on all required datasets")
     variant("vecgeom", default=False, description="Enable vecgeom support")
     variant("opengl", default=False, description="Optional OpenGL support")
     variant("x11", default=False, description="Optional X11 support")
@@ -85,7 +86,7 @@ class Geant4(CMakePackage):
         "11.0.0:11.0",
         "11.1:",
     ]:
-        depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
+        depends_on("geant4-data@" + _vers, type="run", when="@" + _vers + " +data")
 
     depends_on("expat")
     depends_on("zlib-api")


### PR DESCRIPTION
This is an alternative solution to #39396, by adding a new variant `data`, which defaults to true, to control depending on the `geant4-data` package. In some use cases, the user may want to choose not to install all data files (because they can be certain that they won't be used). In those cases, the user can install `geant4 -data` to avoid automatically installing the data. In this case, the users accepts the responsibility to provide the data by installing the invidvidual data packages in spack, or by providing it outside of spack.