### PR TITLE
geant4-data: expose dependencies as variants

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -138,7 +138,7 @@ class Geant4Data(BundlePackage):
         _vers = "@" + _vers
         for _dv in _dsets:
             _d, _v = _dv.split("@")
-            variant(_d, default=True, when=_vers)
+            variant(_d, default=True, when=_vers, description="Install dataset " + _d)
             depends_on(_dv, type=("build", "run"), when=_vers)
 
     @property

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -139,7 +139,7 @@ class Geant4Data(BundlePackage):
         for _dv in _dsets:
             _d, _v = _dv.split("@")
             variant(_d, default=True, when=_vers)
-            depends_on(_d, type=("build", "run"), when=_vers)
+            depends_on(_dv, type=("build", "run"), when=_vers)
 
     @property
     def datadir(self):

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -139,7 +139,7 @@ class Geant4Data(BundlePackage):
         for _dv in _dsets:
             _d, _v = _dv.split("@")
             variant(_d, default=True, when=_vers, description="Install dataset " + _d)
-            depends_on(_dv, type=("build", "run"), when=_vers)
+            depends_on(_dv, type=("build", "run"), when=_vers + " +" + _d)
 
     @property
     def datadir(self):

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -136,7 +136,9 @@ class Geant4Data(BundlePackage):
 
     for _vers, _dsets in _datasets.items():
         _vers = "@" + _vers
-        for _d in _dsets:
+        for _dv in _dsets:
+            _d, _v = _dv.split("@")
+            variant(_d, default=True, when=_vers)
             depends_on(_d, type=("build", "run"), when=_vers)
 
     @property


### PR DESCRIPTION
This is an alternative solution to #39395, by exposing the individual datasets as variants in the `geant4-data` package. In some use cases, the user may want to choose not to install all data files (because they can be certain that they won't be used). In those cases, the user can install `geant4-data -g4ndl` to avoid automatically installing the `g4ndl` data. In this case, the users accepts the responsibility to provide the data by installing the invidvidual data packages in spack, or by providing it outside of spack.