### PR TITLE
Replace lzma with xz dependency

### DIFF
--- a/var/spack/repos/builtin/packages/angsd/package.py
+++ b/var/spack/repos/builtin/packages/angsd/package.py
@@ -31,7 +31,7 @@ class Angsd(MakefilePackage):
     conflicts("^htslib@1.6:", when="@0.919")
 
     depends_on("zlib-api")
-    depends_on("lzma")
+    depends_on("xz")
     depends_on("curl")
 
     depends_on("r", type="run", when="+r")

--- a/var/spack/repos/builtin/packages/eagle/package.py
+++ b/var/spack/repos/builtin/packages/eagle/package.py
@@ -22,7 +22,7 @@ class Eagle(MakefilePackage):
 
     depends_on("curl")
     depends_on("zlib-api")
-    depends_on("lzma")
+    depends_on("xz")
     depends_on("htslib")
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/kmod/package.py
+++ b/var/spack/repos/builtin/packages/kmod/package.py
@@ -28,7 +28,7 @@ class Kmod(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("lzma")
+    depends_on("xz")
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")

--- a/var/spack/repos/builtin/packages/rpm/package.py
+++ b/var/spack/repos/builtin/packages/rpm/package.py
@@ -94,7 +94,6 @@ class Rpm(AutotoolsPackage):
     depends_on("bzip2")
     depends_on("gzip")
     depends_on("xz")
-    depends_on("lzma")
     with when("+zstd"):
         depends_on("zstd")
         depends_on("zstd@1.3.8:", when="@4.17:")

--- a/var/spack/repos/builtin/packages/srcml-identifier-getter-tool/package.py
+++ b/var/spack/repos/builtin/packages/srcml-identifier-getter-tool/package.py
@@ -20,7 +20,7 @@ class SrcmlIdentifierGetterTool(CMakePackage):
 
     depends_on("libxml2")
     depends_on("zlib-api")
-    depends_on("lzma")
+    depends_on("xz")
 
     def install(self, spec, prefix):
         super().install(spec, prefix)


### PR DESCRIPTION
`lzma` (https://tukaani.org/lzma/) has been out of maintenance since 2008, and the developer indicates that "Users of LZMA Utils should move to XZ Utils" (https://tukaani.org/xz/). Because both `lzma` and `xz` are presenting themselves as `liblzma` there is a potential for confusion, and `lzma` can reasonably be indicated as deprecated.

The current dependents of `lzma` are:
```
$ spack dependents lzma 
angsd eagle kmod py-pyliblzma rpm srcml-identifier-getter-tool
```

- The package `py-pyliblzma` is proposed for removal in #39399.
- This PR updates `angsd`, `eagle`, `kmod`, `rpm`, and `srcml-identifier-getter-tool`.
  - `angsd`, `eagle`, `kmod`, and `srcml-identifier-getter-tool` build fine with `xz` for both oldest and newest version in spack
    - ~~`angsd` fails to link in an unrelated part of the code for other reasons since fixed (https://github.com/ANGSD/angsd/pull/372), it would need a newer version of `htslib` and `angsd` but that's out of scope here.~~
  - `rpm` has supported `xz` 5.2.0 since 4.14, older than what is in spack (https://github.com/rpm-software-management/rpm/commit/bec7592a36a2243aa4656afecf3247598baac5ff), ~~but its `lua` dependency fails to download a required patch to provide a pkg-config file required by `rpm` because of a dead link, see https://github.com/spack/spack/pull/39403.~~
