### PR TITLE
WarpX 23.08

### DIFF
--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -11,11 +11,12 @@ class PyPicmistandard(PythonPackage):
 
     homepage = "https://picmi-standard.github.io"
     git = "https://github.com/picmi-standard/picmi.git"
-    pypi = "picmistandard/picmistandard-0.25.0.tar.gz"
+    pypi = "picmistandard/picmistandard-0.26.0.tar.gz"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
 
-    version("develop", branch="master")
+    version("master", branch="master")
+    version("0.26.0", sha256="b22689f576d064bf0cd8f435621e912359fc2ee9347350eab845d2d36ebb62eb")
     version("0.25.0", sha256="3fe6a524822d382e52bfc9d3378249546075d28620969954c5ffb43e7968fb02")
     version("0.24.0", sha256="55a82adcc14b41eb612caf0d9e47b0e2a56ffc196a58b41fa0cc395c6924be9a")
     version("0.23.2", sha256="2853fcfaf2f226a88bb6063ae564832b7e69965294fd652cd2ac04756fa4599a")

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -51,7 +51,7 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
-        "23.08"
+        "23.08",
         "23.07",
         "23.06",
         "23.05",

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.07.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.08.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
@@ -27,6 +27,7 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version("develop", branch="development")
+    version("23.08", sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc")
     version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
     version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
     version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
@@ -50,6 +51,7 @@ class PyWarpx(PythonPackage):
     variant("mpi", default=True, description="Enable MPI support")
 
     for v in [
+        "23.08"
         "23.07",
         "23.06",
         "23.05",
@@ -73,24 +75,23 @@ class PyWarpx(PythonPackage):
     ]:
         depends_on("warpx@{0}".format(v), when="@{0}".format(v), type=["build", "link"])
 
-    depends_on("python@3.6:3.9", type=("build", "run"), when="@:21.12")
-    depends_on("python@3.6:", type=("build", "run"), when="@22.01:")
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@23.09:")
     depends_on("py-numpy@1.15.0:1", type=("build", "run"))
     depends_on("py-mpi4py@2.1.0:", type=("build", "run"), when="+mpi")
     depends_on("py-periodictable@1.5:1", type=("build", "run"))
-    depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
-    depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
-    depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")
-    depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:23.03")
-    depends_on("py-picmistandard@0.23.2", type=("build", "run"), when="@23.04:23.05")
-    depends_on("py-picmistandard@0.24.0", type=("build", "run"), when="@23.06")
     depends_on("py-picmistandard@0.25.0", type=("build", "run"), when="@23.07:")
+    depends_on("py-picmistandard@0.24.0", type=("build", "run"), when="@23.06")
+    depends_on("py-picmistandard@0.23.2", type=("build", "run"), when="@23.04:23.05")
+    depends_on("py-picmistandard@0.0.22", type=("build", "run"), when="@22.12:23.03")
+    depends_on("py-picmistandard@0.0.20", type=("build", "run"), when="@22.10:22.11")
+    depends_on("py-picmistandard@0.0.19", type=("build", "run"), when="@22.02:22.09")
+    depends_on("py-picmistandard@0.0.18", type=("build", "run"), when="@22.01")
     depends_on("py-setuptools@42:", type="build")
     # Since we use PYWARPX_LIB_DIR to pull binaries out of the
     # 'warpx' spack package, we don't need py-cmake as declared
     # depends_on('py-cmake@3.15:3', type='build')
     # depends_on('py-cmake@3.18:3', type='build', when='@22.01:')
-    depends_on("py-wheel", type="build")
     depends_on("warpx +lib ~mpi +shared", type=("build", "link"), when="~mpi")
     depends_on("warpx +lib +mpi +shared", type=("build", "link"), when="+mpi")
 

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.07.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.08.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers("ax3l", "dpgrote", "MaxThevenet", "RemiLehe")
@@ -25,6 +25,7 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
+    version("23.08", sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc")
     version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
     version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
     version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")


### PR DESCRIPTION
Update WarpX and related Python packages to the lastest releases.