### PR TITLE
bootstrap: detect git

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -480,11 +480,18 @@ def _add_externals_if_missing() -> None:
         spack.repo.PATH.get_pkg_class("bison"),
         # GnuPG
         spack.repo.PATH.get_pkg_class("gawk"),
+        # develop deps
+        spack.repo.PATH.get_pkg_class("git"),
     ]
     if IS_WINDOWS:
         search_list.append(spack.repo.PATH.get_pkg_class("winbison"))
-    detected_packages = spack.detection.by_executable(search_list)
-    spack.detection.update_configuration(detected_packages, scope="bootstrap")
+    externals = spack.detection.by_executable(search_list)
+    # System git is typically deprecated, so mark as non-buildable to force it as external
+    non_buildable_externals = {k: externals.pop(k) for k in ("git",) if k in externals}
+    spack.detection.update_configuration(externals, scope="bootstrap", buildable=True)
+    spack.detection.update_configuration(
+        non_buildable_externals, scope="bootstrap", buildable=False
+    )
 
 
 def clingo_root_spec() -> str:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -23,6 +23,7 @@ from spack.environment import depfile
 
 from ._common import _root_spec
 from .config import root_path, spec_for_current_python, store_path
+from .core import _add_externals_if_missing
 
 
 class BootstrapEnvironment(spack.environment.Environment):
@@ -185,6 +186,7 @@ def pytest_root_spec() -> str:
 
 def ensure_environment_dependencies() -> None:
     """Ensure Spack dependencies from the bootstrap environment are installed and ready to use"""
+    _add_externals_if_missing()
     with BootstrapEnvironment() as env:
         env.update_installations()
         env.update_syspath_and_environ()


### PR DESCRIPTION
Currently git is not detected as external, leading to a lot of compilation time in `spack bootstrap now --dev`.

Makes sense to detect it, given that it's required in "Core Functionalities" in `spack status`