### PR TITLE
modules: Prevent bleed between matching configs

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -178,7 +178,7 @@ def merge_config_rules(configuration, spec):
         if spec.satisfies(constraint):
             if hasattr(constraint, "override") and constraint.override:
                 spec_configuration = {}
-            update_dictionary_extending_lists(spec_configuration, action)
+            update_dictionary_extending_lists(spec_configuration, copy.deepcopy(action))
 
     # Transform keywords for dependencies or prerequisites into a list of spec
 


### PR DESCRIPTION
When the configurations are merged from all matching specs, the Python objects (`list`s) are reused across multiple calls which causes values to "bleed" between the specs. `copy.deepcopy` the configuration fragments before merging to prevent this "bleed."

Fixes https://github.com/spack/spack/issues/39420