### PR TITLE
Fix style issues with latest versions of tools

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -780,7 +780,7 @@ class winlog:
             raise RuntimeError("file argument must be set by __init__ ")
 
         # Open both write and reading on logfile
-        if type(self.logfile) == io.StringIO:
+        if isinstance(self.logfile, io.StringIO):
             self._ioflag = True
             # cannot have two streams on tempfile, so we must make our own
             sys.stdout = self.logfile

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -430,7 +430,7 @@ class Configuration:
         return [
             s
             for s in self.scopes.values()
-            if (type(s) == ConfigScope or type(s) == SingleFileScope)
+            if (type(s) is ConfigScope or type(s) is SingleFileScope)
         ]
 
     def highest_precedence_scope(self) -> ConfigScope:

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -236,7 +236,7 @@ class when:
 
         # Create a multimethod with this name if there is not one already
         original_method = MultiMethodMeta._locals.get(method.__name__)
-        if not type(original_method) == SpecMultiMethod:
+        if not isinstance(original_method, SpecMultiMethod):
             original_method = SpecMultiMethod(original_method)
 
         if self.spec is not None:

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -54,7 +54,7 @@ def test_pickle(tmpdir):
     with tmpdir.as_cwd():
         build_env("--pickle", _out_file, "zlib")
         environment = pickle.load(open(_out_file, "rb"))
-        assert type(environment) == dict
+        assert isinstance(environment, dict)
         assert "PATH" in environment
 
 

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -134,7 +134,7 @@ class TestLibraryList:
         assert a == "/dir1/liblapack.%s" % plat_static_ext
 
         b = library_list[:]
-        assert type(b) == type(library_list)
+        assert type(b) is type(library_list)
         assert library_list == b
         assert library_list is not b
 
@@ -152,8 +152,8 @@ class TestLibraryList:
         assert both == both + both
 
         # Always produce an instance of LibraryList
-        assert type(library_list + pylist) == type(library_list)
-        assert type(pylist + library_list) == type(library_list)
+        assert type(library_list + pylist) is type(library_list)
+        assert type(pylist + library_list) is type(library_list)
 
 
 class TestHeaderList:
@@ -219,7 +219,7 @@ class TestHeaderList:
         assert a == "/dir1/Python.h"
 
         b = header_list[:]
-        assert type(b) == type(header_list)
+        assert type(b) is type(header_list)
         assert header_list == b
         assert header_list is not b
 
@@ -237,8 +237,8 @@ class TestHeaderList:
         assert h == h + h
 
         # Always produce an instance of HeaderList
-        assert type(header_list + pylist) == type(header_list)
-        assert type(pylist + header_list) == type(header_list)
+        assert type(header_list + pylist) is type(header_list)
+        assert type(pylist + header_list) is type(header_list)
 
 
 #: Directory where the data for the test below is stored

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -53,7 +53,6 @@ php_in_text = ("line\n") * 100 + "php\n" + ("line\n" * 100)
 php_line_patched = "<?php #!/this/" + ("x" * too_long) + "/is/php\n"
 php_line_patched2 = "?>\n"
 
-sbang_line = "#!/bin/sh %s/bin/sbang\n" % spack.store.STORE.unpadded_root
 last_line = "last!\n"
 
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -515,10 +515,10 @@ class TestSpecSemantics:
         s.normalize()
 
         assert s["callpath"] == s
-        assert type(s["dyninst"]) == Spec
-        assert type(s["libdwarf"]) == Spec
-        assert type(s["libelf"]) == Spec
-        assert type(s["mpi"]) == Spec
+        assert isinstance(s["dyninst"], Spec)
+        assert isinstance(s["libdwarf"], Spec)
+        assert isinstance(s["libelf"], Spec)
+        assert isinstance(s["mpi"], Spec)
 
         assert s["dyninst"].name == "dyninst"
         assert s["libdwarf"].name == "libdwarf"

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -525,13 +525,13 @@ class TestBoolValuedVariant:
 
 def test_from_node_dict():
     a = MultiValuedVariant.from_node_dict("foo", ["bar"])
-    assert type(a) == MultiValuedVariant
+    assert type(a) is MultiValuedVariant
 
     a = MultiValuedVariant.from_node_dict("foo", "bar")
-    assert type(a) == SingleValuedVariant
+    assert type(a) is SingleValuedVariant
 
     a = MultiValuedVariant.from_node_dict("foo", "true")
-    assert type(a) == BoolValuedVariant
+    assert type(a) is BoolValuedVariant
 
 
 class TestVariant:

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -68,7 +68,7 @@ def syaml_type(obj):
     """
     for syaml_t, t in syaml_types.items():
         if type(obj) is not bool and isinstance(obj, t):
-            return syaml_t(obj) if type(obj) != syaml_t else obj
+            return syaml_t(obj) if type(obj) is not syaml_t else obj
     return obj
 
 

--- a/lib/spack/spack/util/string.py
+++ b/lib/spack/spack/util/string.py
@@ -5,7 +5,7 @@
 
 
 def comma_list(sequence, article=""):
-    if type(sequence) != list:
+    if type(sequence) is not list:
         sequence = list(sequence)
 
     if not sequence:

--- a/var/spack/repos/builtin/packages/py-jax/package.py
+++ b/var/spack/repos/builtin/packages/py-jax/package.py
@@ -34,11 +34,7 @@ class PyJax(PythonPackage):
     depends_on("py-scipy@1.2.1:", type=("build", "run"))
 
     # See _minimum_jaxlib_version in jax/version.py
-    jax_to_jaxlib = {
-        "0.4.3": "0.4.2",
-        "0.3.23": "0.3.15",
-        "0.2.25": "0.1.69",
-    }
+    jax_to_jaxlib = {"0.4.3": "0.4.2", "0.3.23": "0.3.15", "0.2.25": "0.1.69"}
 
     for jax, jaxlib in jax_to_jaxlib.items():
         depends_on(f"py-jaxlib@{jaxlib}:", when=f"@{jax}", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-nltk/resourcegen.py
+++ b/var/spack/repos/builtin/packages/py-nltk/resourcegen.py
@@ -8,7 +8,7 @@ import urllib.request
 import xml.etree.ElementTree
 from typing import Optional
 
-url = None  # type: Optional[str]
+url: Optional[str] = None
 url = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/index.xml"
 if url is not None:
     document = urllib.request.urlopen(url).read()

--- a/var/spack/repos/builtin/packages/turbine/package.py
+++ b/var/spack/repos/builtin/packages/turbine/package.py
@@ -13,7 +13,6 @@ class Turbine(AutotoolsPackage):
     homepage = "http://swift-lang.org/Swift-T"
     url = "https://swift-lang.github.io/swift-t-downloads/spack/turbine-1.3.0.tar.gz"
     git = "https://github.com/swift-lang/swift-t.git"
-    configure_directory = "turbine/code"
 
     version("master", branch="master")
     version("1.3.0", sha256="9709e5dada91a7dce958a7967d6ff2bd39ccc9e7da62d05a875324b5089da393")


### PR DESCRIPTION
closes #39176

This fixes a few style issues reported by latest versions of tools. 

The changes are backward compatible with the previous versions of the tools used by Spack, but we ought to decide if it is worth pinning style deps to a smaller version range to ensure more uniformity across environments.