### PR TITLE
gettext: Fix KeyError: "shared" and add 0.22.3

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -19,6 +19,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     executables = [r"^gettext$"]
 
+    version("0.22.3", sha256="b838228b3f8823a6c1eddf07297197c4db13f7e1b173b9ef93f3f945a63080b6")
     version("0.21.1", sha256="50dbc8f39797950aa2c98e939947c527e5ac9ebd2c1b99dd7b06ba33a6767ae6")
     version("0.21", sha256="d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192")
     version("0.20.2", sha256="b22b818e644c37f6e3d1643a1943c32c3a9bff726d601e53047d2682019ceaba")
@@ -127,10 +128,12 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def libs(self):
+        # Do not fail if the installed gettext did not yet have the shared variant:
+        shared_variant = self.spec.variants.get("shared")
         libs = find_libraries(
             ["libasprintf", "libgettextlib", "libgettextpo", "libgettextsrc", "libintl"],
             root=self.prefix,
             recursive=True,
-            shared=self.spec.variants["shared"].value,
+            shared=True if not shared_variant else shared_variant.value,
         )
         return libs

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -17,6 +17,7 @@ class Procps(AutotoolsPackage):
     url = "https://gitlab.com/procps-ng/procps/-/archive/v4.0.3/procps-v4.0.3.tar.gz"
 
     version("master", branch="master")
+    version("4.0.4", sha256="3214fab0f817d169f2c117842ba635bafb1cd6090273e311a8b5c6fc393ddb9d")
     version("4.0.3", sha256="14cc21219c45d196772274ea3f194f6d668b6cc667fbde9ee6d8039121b73fa6")
     version("4.0.2", sha256="b03e4b55eaa5661e726acb714e689356d80bc056b09965c2284d039ba8dc21e8")
     version("4.0.1", sha256="1eaff353306aba12816d14881f2b88c7c9d06023825f7224700f0c01f66c65cd")
@@ -35,8 +36,11 @@ class Procps(AutotoolsPackage):
     depends_on("pkgconfig@0.9.0:", type="build")
     depends_on("dejagnu", type="test")
     depends_on("iconv")
-    depends_on("gettext", type="build")
-    depends_on("gettext", when="+nls")
+    depends_on("gettext", type="build")  # required by autogen.sh
+    with when("+nls"):
+        depends_on("gettext")
+        # msgfmt 0.22 gives parsing errors
+        depends_on("gettext@:0.21", when="@:4.0.3")
     depends_on("ncurses")
 
     conflicts("platform=darwin", msg="procps is linux-only")


### PR DESCRIPTION
@tldahlgren This fixes the keyerror for "shared" that you also got: https://github.com/spack/spack/pull/40454#issuecomment-1758219620

After the merge of https://github.com/spack/spack/pull/37957 (Add static and pic variants) this happens:

When a gettext install from a build before that merge is present, building any package using gettext fails with `keyerror: "shared"` because the use of `self.spec.variants["shared"]` does not check for the presence of the new variant in the old installation but expects that the new key variants["shared"] exists always.

Fix it with a fallback to the default of True and update gettext to v22.3