### PR TITLE
Ginkgo: add PAPI SDE support

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -69,7 +69,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # setup for rocthrust, this needs to also be added here.
     depends_on("rocprim", when="+rocm")
     depends_on("hwloc@2.1:", when="+hwloc")
-    # TODO: replace with the next PAPI version when available
+    # TODO: replace with the next PAPI version when available (>7.0.1.0)
     depends_on("papi@master+sde", when="+sde")
 
     depends_on("googletest", type="test")
@@ -84,7 +84,6 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+mpi", when="@:1.4.0")
 
     conflicts("+sde", when="@:1.6.0")
-    conflicts("+sde", when="@master")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
     conflicts("^hip@4.1.0:", when="@:1.3.0")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -47,8 +47,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     variant("sycl", default=False, description="Enable SYCL backend")
     variant("develtools", default=False, description="Compile with develtools enabled")
     variant("hwloc", default=False, description="Enable HWLOC support")
-    variant("sde", default=False, description="Enable PAPI SDE support")
-    variant("mpi", default=False, description="Enable MPI support")
+    variant("sde", default=False, description="Enable PAPI SDE support", when="@1.7.0:")
+    variant("mpi", default=False, description="Enable MPI support", when="@1.4.0:")
 
     depends_on("cmake@3.9:", type="build", when="@:1.3.0")
     depends_on("cmake@3.13:", type="build", when="@1.4.0:1.6.0")
@@ -81,9 +81,6 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("%gcc@:5.2.9")
     conflicts("+rocm", when="@:1.1.1")
-    conflicts("+mpi", when="@:1.4.0")
-
-    conflicts("+sde", when="@:1.6.0")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
     conflicts("^hip@4.1.0:", when="@:1.3.0")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -48,7 +48,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     variant("develtools", default=False, description="Compile with develtools enabled")
     variant("hwloc", default=False, description="Enable HWLOC support")
     variant("sde", default=False, description="Enable PAPI SDE support", when="@1.7.0:")
-    variant("mpi", default=False, description="Enable MPI support", when="@1.4.0:")
+    variant("mpi", default=False, description="Enable MPI support", when="@1.5.0:")
 
     depends_on("cmake@3.9:", type="build", when="@:1.3.0")
     depends_on("cmake@3.13:", type="build", when="@1.4.0:1.6.0")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -47,6 +47,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     variant("sycl", default=False, description="Enable SYCL backend")
     variant("develtools", default=False, description="Compile with develtools enabled")
     variant("hwloc", default=False, description="Enable HWLOC support")
+    variant("sde", default=False, description="Enable PAPI SDE support")
     variant("mpi", default=False, description="Enable MPI support")
 
     depends_on("cmake@3.9:", type="build", when="@:1.3.0")
@@ -68,6 +69,8 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # setup for rocthrust, this needs to also be added here.
     depends_on("rocprim", when="+rocm")
     depends_on("hwloc@2.1:", when="+hwloc")
+    # TODO: replace with the next PAPI version when available
+    depends_on("papi@master+sde", when="+sde")
 
     depends_on("googletest", type="test")
     depends_on("numactl", type="test", when="+hwloc")
@@ -79,6 +82,9 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%gcc@:5.2.9")
     conflicts("+rocm", when="@:1.1.1")
     conflicts("+mpi", when="@:1.4.0")
+
+    conflicts("+sde", when="@:1.6.0")
+    conflicts("+sde", when="@master")
 
     # ROCm 4.1.0 breaks platform settings which breaks Ginkgo's HIP support.
     conflicts("^hip@4.1.0:", when="@:1.3.0")
@@ -151,6 +157,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("BUILD_SHARED_LIBS", "shared"),
             from_variant("GINKGO_JACOBI_FULL_OPTIMIZATIONS", "full_optimizations"),
             from_variant("GINKGO_BUILD_HWLOC", "hwloc"),
+            from_variant("GINKGO_WITH_PAPI_SDE", "sde"),
             from_variant("GINKGO_DEVEL_TOOLS", "develtools"),
             # As we are not exposing benchmarks, examples, tests nor doc
             # as part of the installation, disable building them altogether.


### PR DESCRIPTION
Adds a new option `+sde` which enables PAPI Software Define Events (SDE).

This allows other libraries to access software-defined Ginkgo counters through the standard PAPI interfaces.
Currently, only the most recent Ginkgo version (develop) and the most recent PAPI (master) is supported.