### PR TITLE
xyce: Disable CMake test for OneAPI

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/454-oneapi-xyce.patch
+++ b/var/spack/repos/builtin/packages/xyce/454-oneapi-xyce.patch
@@ -1,0 +1,34 @@
+diff --git a/src/LinearAlgebraServicesPKG/ksparse/alloc.c b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
+index 320878d7817273269e8805acaa9f6f7a252443f1..af40b7e800e5e8b573a69608aae49c324f2a0253 100644
+--- a/src/LinearAlgebraServicesPKG/ksparse/alloc.c
++++ b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
+@@ -53,6 +53,7 @@ Copyright 1990 Regents of the University of California.  All rights reserved.
+  */
+ 
+ void bye_bye(i)
++    int i;
+ {
+     printf ("inv = %d\n",1/i);
+ }
+
+diff --git a/cmake/tps.cmake b/cmake/tps.cmake
+index 3732758f6..b3f00bb7a 100644
+--- a/cmake/tps.cmake
++++ b/cmake/tps.cmake
+@@ -211,16 +211,6 @@ endif()
+ if (MSVC)
+      set(CMAKE_REQUIRED_DEFINITIONS "${Trilinos_CXX_COMPILER_FLAGS}")
+ endif()
+-get_target_property(CMAKE_REQUIRED_LIBRARIES Teuchos::all_libs INTERFACE_LINK_LIBRARIES)
+-
+-# Perform an initial check to see if we can compile against Trilinos at all.
+-# This could reveal compiler setup problems and/or Trilinos setup problems.
+-check_include_file_cxx(Teuchos_SerialDenseMatrix.hpp Trilinos_COMPILE_SUCCESS ${OpenMP_CXX_FLAGS})
+-if (NOT Trilinos_COMPILE_SUCCESS)
+-     message(FATAL_ERROR "Unable to compile against Trilinos. It is possible\
+-     Trilinos was not properly configured, or the environment has changed since\
+-     Trilinos was installed. See the CMake log files for more information.")
+-endif()
+ 
+ # After the release of Trilinos 12.12.1, the abstract solver interface in NOX
+ # was changed to include a new method that returns solver statistics.  This

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -142,6 +142,14 @@ class Xyce(CMakePackage):
         when="@7.4:7.6 +pymi",
     )
 
+    # fix oneapi issue 7.6 and prior
+    # can switch to github PR once in master
+    patch(
+        "454-oneapi-xyce.patch",
+        sha256="76a3ff987e43d1657f24d55cfd864b487876a72a9a7c8a37c3151a9b586a21c1",
+        when="@:7.6",
+    )
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
- Removes a call to `check_include_file_cxx` with the OneAPI compiler
- Adds a typename to a line that previously did not compile with OneAPI

@eugeneswalker  