### PR TITLE
libfuse: fix werror

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -16,6 +16,8 @@ class Libfuse(MesonPackage):
     homepage = "https://github.com/libfuse/libfuse"
     url = "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz"
 
+    keep_werror = "all"
+
     version("3.11.0", sha256="25a00226d2d449c15b2f08467d6d5ebbb2a428260c4ab773721c32adbc6da072")
     version("3.10.5", sha256="e73f75e58da59a0e333d337c105093c496c0fd7356ef3a5a540f560697c9c4e6")
     version("3.10.4", sha256="bfcb2520fd83db29e9fefd57d3abd5285f38ad484739aeee8e03fbec9b2d984a")


### PR DESCRIPTION
Libfuse does not currently build with compilers that do not support the symver attribute because it requires the use of `-Werror` when configuring. See https://github.com/libfuse/libfuse/blob/master/meson.build lines 127-149. Because Spack's default behavior is to replace `-Werror` with `-Wno-error`, the test always passes and thus meson always believes that the symver attribute is acceptable. The `keep_werror` attribute was added to the libfuse package to fix the issue.

This may fix the issue identified in #36572.