### PR TITLE
fuse-overlayfs: needs pkconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
+++ b/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
@@ -29,4 +29,5 @@ class FuseOverlayfs(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("fuse")


### PR DESCRIPTION
When building on a fresh RHEL8 VM, fuse-overlayfs was not able to build unless the pkgconfig dependency was added. I assume folks may have had a system installation of this and didn't notice it.