### PR TITLE
New: py-alpaca-farm, py-alpaca-eval, py-tiktoken; Updated: py-accelerate, py-transformers

### DIFF
--- a/var/spack/repos/builtin/packages/py-accelerate/package.py
+++ b/var/spack/repos/builtin/packages/py-accelerate/package.py
@@ -12,11 +12,16 @@ class PyAccelerate(PythonPackage):
     homepage = "https://github.com/huggingface/accelerate"
     pypi = "accelerate/accelerate-0.16.0.tar.gz"
 
+    maintainers("meyersbs")
+
+    version("0.21.0", sha256="e2959a0bf74d97c0b3c0e036ed96065142a060242281d27970d4c4e34f11ca59")
     version("0.16.0", sha256="d13e30f3e6debfb46cada7b931af85560619b6a6a839d0cafeeab6ed7c6a498d")
 
+    depends_on("python@3.8.0:", when="@0.21.0:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.17:", type=("build", "run"))
     depends_on("py-packaging@20:", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-torch@1.10.0:", when="@0.21.0:", type=("build", "run"))
     depends_on("py-torch@1.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-alpaca-eval/package.py
+++ b/var/spack/repos/builtin/packages/py-alpaca-eval/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyAlpacaEval(PythonPackage):
+    """An automatic evaluator for instruction-following language models.
+    Human-validated, high-quality, cheap, and fast."""
+
+    homepage = "https://github.com/tatsu-lab/alpaca_eval"
+    pypi = "alpaca_eval/alpaca_eval-0.2.8.tar.gz"
+
+    maintainers("meyersbs")
+
+    version("0.2.8", sha256="5b21b74d7362ee229481b6a6d826dd620b2ef6b82e4f5470645e0a4b696a31e6")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-python-dotenv", type=("build", "run"))
+    depends_on("py-datasets", type=("build", "run"))
+    depends_on("py-openai", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-tiktoken@0.3.2:", type=("build", "run"))
+    depends_on("py-fire", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-alpaca-farm/package.py
+++ b/var/spack/repos/builtin/packages/py-alpaca-farm/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAlpacaFarm(PythonPackage):
+    """AlpacaFarm is a simulator that enables research and development on learning
+    from feedback at a fraction of the usual cost, promoting accessible research on
+    instruction following and alignment."""
+
+    homepage = "https://github.com/tatsu-lab/alpaca_farm"
+    pypi = "alpaca_farm/alpaca_farm-0.1.9.tar.gz"
+
+    maintainers("meyersbs")
+
+    version("0.1.9", sha256="1039d33c814d0bbbcab6a0e77ed8e897992ad7107d5c4999d56bdad7e0b0a59f")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-datasets", type=("build", "run"))
+    depends_on("py-einops", type=("build", "run"))
+    depends_on("py-nltk", type=("build", "run"))
+    depends_on("py-accelerate@0.18.0:", type=("build", "run"))
+    depends_on("py-tabulate", type=("build", "run"))
+    depends_on("py-transformers@4.26.0:", type=("build", "run"))
+    depends_on("py-statsmodels", type=("build", "run"))
+    depends_on("py-tiktoken@0.3.2:", type=("build", "run"))
+    depends_on("py-markdown", type=("build", "run"))
+    depends_on("py-scikit-learn", type=("build", "run"))
+    depends_on("py-sentencepiece", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-wandb", type=("build", "run"))
+    depends_on("py-torch@1.13.1:", type=("build", "run"))
+    depends_on("py-fire", type=("build", "run"))
+    depends_on("py-openai", type=("build", "run"))
+    depends_on("py-alpaca-eval@0.2.8:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tiktoken/package.py
+++ b/var/spack/repos/builtin/packages/py-tiktoken/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyTiktoken(PythonPackage):
+    """tiktoken is a fast BPE tokeniser for use with OpenAI's models."""
+
+    homepage = "https://github.com/openai/tiktoken"
+    pypi = "tiktoken/tiktoken-0.4.0.tar.gz"
+
+    maintainers("meyersbs")
+
+    version("0.4.0", sha256="59b20a819969735b48161ced9b92f05dc4519c17be4015cfb73b65270a243620")
+
+    # From pyproject.toml
+    depends_on("py-setuptools@62.4:", type="build")
+    depends_on("py-setuptools-rust@1.5.2:", type="build")
+    depends_on("py-wheel", type="build")
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-regex@2022.1.18:", type=("build", "run"))
+    depends_on("py-requests@2.26.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-transformers/package.py
+++ b/var/spack/repos/builtin/packages/py-transformers/package.py
@@ -16,15 +16,18 @@ class PyTransformers(PythonPackage):
 
     maintainers("adamjstewart")
 
+    version("4.31.0", sha256="4302fba920a1c24d3a429a29efff6a63eac03f3f3cf55b55927fc795d01cb273")
     version("4.24.0", sha256="486f353a8e594002e48be0e2aba723d96eda839e63bfe274702a4b5eda85559b")
     version("4.6.1", sha256="83dbff763b7e7dc57cbef1a6b849655d4fcab6bffdd955c5e8bea12a4f76dc10")
     version("2.8.0", sha256="b9f29cdfd39c28f29e0806c321270dea337d6174a7aa60daf9625bf83dbb12ee")
 
+    depends_on("python@3.8:", when="@4.31:", type=("build", "run"))
     depends_on("python@3.7:", when="@4.24:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-importlib-metadata", when="@4.6: ^python@:3.7", type=("build", "run"))
     depends_on("py-filelock", type=("build", "run"))
+    depends_on("py-huggingface-hub@0.14.1:0", when="@4.26:", type=("build", "run"))
     depends_on("py-huggingface-hub@0.10:0", when="@4.24:", type=("build", "run"))
     depends_on("py-huggingface-hub@0.0.8", when="@4.6.1", type=("build", "run"))
     depends_on("py-numpy@1.17:", when="@4.6:", type=("build", "run"))
@@ -34,6 +37,7 @@ class PyTransformers(PythonPackage):
     depends_on("py-pyyaml@5.1:", when="@4.24:", type=("build", "run"))
     depends_on("py-regex@:2019.12.16,2019.12.18:", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"))
+    depends_on("py-safetensors@0.3.1:", when="@4.31:", type=("build", "run"))
     depends_on("py-tokenizers@0.11.1:0.11.2,0.11.4:0.13", when="@4.24:", type=("build", "run"))
     depends_on("py-tokenizers@0.10.1:0.10", when="@4.6.1", type=("build", "run"))
     depends_on("py-tokenizers@0.5.2", when="@2.8.0", type=("build", "run"))


### PR DESCRIPTION
New:
- py-alpaca-farm
- py-alpaca-eval
- py-tiktoken

Updated:
- py-accelerate
- py-transformers

``` mermaid
graph TD;
  'py-alpaca-farm'-->'py-accelerate';
  'py-alpaca-farm'-->'py-tiktoken';
  'py-alpaca-farm'-->'py-alpaca-eval';
  'py-alpaca-farm'-->'py-transformers';
  'py-alpaca-eval'-->'py-tiktoken';
```

```
$ spack load py-alpaca-farm
$ python3
Python 3.10.12 (main, Aug 14 2023, 10:51:41) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from alpaca_farm.auto_annotations import PairwiseAutoAnnotator
>>> import transformers
>>> import alpaca_eval
>>> import accelerate
>>> 
```