### PR TITLE
squashfs: Add static variant

### DIFF
--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -62,11 +62,7 @@ class Squashfs(MakefilePackage):
         multi=False,
         description="Default compression algorithm",
     )
-    variant(
-        "static",
-        default=False,
-        description="Build fully static mksquashfs executable",
-    )
+    variant("static", default=False, description="Build fully static mksquashfs executable")
 
     conflicts(
         "squashfs~gzip default_compression=gzip",

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -91,13 +91,13 @@ class Squashfs(MakefilePackage):
 
     depends_on("zlib-api", when="+gzip")
     depends_on("lz4", when="+lz4")
-    depends_on("lz4 libs=shared,static", when="+lz4 +static")
+    depends_on("lz4 libs=static", when="+lz4 +static")
     depends_on("lzo", when="+lzo")
-    depends_on("lzo libs=shared,static", when="+lzo +static")
+    depends_on("lzo libs=static", when="+lzo +static")
     depends_on("xz", when="+xz")
-    depends_on("xz libs=shared,static", when="+xz +static")
+    depends_on("xz libs=static", when="+xz +static")
     depends_on("zstd", when="+zstd")
-    depends_on("zstd libs=shared,static", when="+zstd +static")
+    depends_on("zstd libs=static", when="+zstd +static")
 
     # patch from
     # https://github.com/plougher/squashfs-tools/commit/fe2f5da4b0f8994169c53e84b7cb8a0feefc97b5.patch

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -65,7 +65,7 @@ class Squashfs(MakefilePackage):
     variant(
         "static",
         default=False,
-        description="Build static squashfs tools, requires glibc-static on OS",
+        description="Build fully static mksquashfs executable",
     )
 
     conflicts(

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -61,6 +61,11 @@ class Squashfs(MakefilePackage):
         multi=False,
         description="Default compression algorithm",
     )
+    variant(
+        "static",
+        default=False,
+        description="Build static squashfs tools, requires glibc-static on OS",
+    )
 
     conflicts(
         "squashfs~gzip default_compression=gzip",
@@ -85,9 +90,13 @@ class Squashfs(MakefilePackage):
 
     depends_on("zlib-api", when="+gzip")
     depends_on("lz4", when="+lz4")
+    depends_on("lz4 libs=shared,static", when="+lz4 +static")
     depends_on("lzo", when="+lzo")
+    depends_on("lzo libs=shared,static", when="+lzo +static")
     depends_on("xz", when="+xz")
+    depends_on("xz libs=shared,static", when="+xz +static")
     depends_on("zstd", when="+zstd")
+    depends_on("zstd libs=shared,static", when="+zstd +static")
 
     # patch from
     # https://github.com/plougher/squashfs-tools/commit/fe2f5da4b0f8994169c53e84b7cb8a0feefc97b5.patch
@@ -103,6 +112,7 @@ class Squashfs(MakefilePackage):
             "XZ_SUPPORT={0}".format(1 if "+xz" in spec else 0),
             "ZSTD_SUPPORT={0}".format(1 if "+zstd" in spec else 0),
             "COMP_DEFAULT={0}".format(default),
+            "EXTRA_LDFLAGS={0}".format("-static" if "+static" in spec else ""),
         ]
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -13,6 +13,7 @@ class Squashfs(MakefilePackage):
     url = "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
 
     # version      sha1
+    version("4.6.1", sha256="94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c")
     version(
         "4.5.1",
         sha256="277b6e7f75a4a57f72191295ae62766a10d627a4f5e5f19eadfbc861378deea7",


### PR DESCRIPTION
In order to support a new package that I will be adding, Podman-HPC, the executables, need to be built statically. See https://github.com/NERSC/podman-hpc. They have a Dockerfile approach to build it for folks now, and the proposed changes in this PR will allow Spack to do this too. See https://github.com/NERSC/podman-hpc/tree/main/extra/squash. In addition, this PR adds version 4.6.1 of squashfs-tools to get new command line options added post 4.5.