### PR TITLE
fms: add v2023.02 and v2023.01.01

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -19,7 +19,9 @@ class Fms(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776")
 
     version("2023.02", sha256="dc029ffadfd82c334f104268bedd8635c77976485f202f0966ae4cf06d2374be")
-    version("2023.01.01", sha256="f83e2814a1e3ba439ab847ec8bb251f3889d5ca14fb20849507590adbbe8e899")
+    version(
+        "2023.01.01", sha256="f83e2814a1e3ba439ab847ec8bb251f3889d5ca14fb20849507590adbbe8e899"
+    )
     version("2023.01", sha256="6079ea885e9365513b453c77aadfc7c305bf413b840656bb333db1eabba0f18e")
     version("2022.04", sha256="f741479128afc2b93ca8291a4c5bcdb024a8cbeda1a26bf77a236c0f629e1b03")
     version("2022.03", sha256="42d2ac53d3c889a8177a6d7a132583364c0f6e5d5cbde0d980443b6797ad4838")
@@ -79,7 +81,7 @@ class Fms(CMakePackage):
         "deprecated_io",
         default=False,
         description="Compiles with support for deprecated io modules fms_io and mpp_io",
-        when="@2023.02:"
+        when="@2023.02:",
     )
 
     depends_on("netcdf-c")
@@ -97,7 +99,7 @@ class Fms(CMakePackage):
             self.define("32BIT", "precision=32" in self.spec),
             self.define("64BIT", "precision=64" in self.spec),
             self.define_from_variant("FPIC", "pic"),
-            self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io")
+            self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -79,7 +79,7 @@ class Fms(CMakePackage):
         "deprecated_io",
         default=False,
         description="Compiles with support for deprecated io modules fms_io and mpp_io",
-        when="@2023.02:",
+        when="@2023.02:"
     )
 
     depends_on("netcdf-c")
@@ -97,7 +97,7 @@ class Fms(CMakePackage):
             self.define("32BIT", "precision=32" in self.spec),
             self.define("64BIT", "precision=64" in self.spec),
             self.define_from_variant("FPIC", "pic"),
-            self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
+            self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io")
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -18,6 +18,8 @@ class Fms(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776")
 
+    version("2023.02", sha256="dc029ffadfd82c334f104268bedd8635c77976485f202f0966ae4cf06d2374be")
+    version("2023.01.01", sha256="f83e2814a1e3ba439ab847ec8bb251f3889d5ca14fb20849507590adbbe8e899")
     version("2023.01", sha256="6079ea885e9365513b453c77aadfc7c305bf413b840656bb333db1eabba0f18e")
     version("2022.04", sha256="f741479128afc2b93ca8291a4c5bcdb024a8cbeda1a26bf77a236c0f629e1b03")
     version("2022.03", sha256="42d2ac53d3c889a8177a6d7a132583364c0f6e5d5cbde0d980443b6797ad4838")
@@ -73,6 +75,12 @@ class Fms(CMakePackage):
     variant(
         "pic", default=False, description="Build with position independent code", when="@2022.02:"
     )
+    variant(
+        "deprecated_io",
+        default=False,
+        description="Compiles with support for deprecated io modules fms_io and mpp_io",
+        when="@2023.02:",
+    )
 
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
@@ -89,6 +97,7 @@ class Fms(CMakePackage):
             self.define("32BIT", "precision=32" in self.spec),
             self.define("64BIT", "precision=64" in self.spec),
             self.define_from_variant("FPIC", "pic"),
+            self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))


### PR DESCRIPTION
Adds the most recent version and patch for FMS.

Also adds a compile time option for the deprecation of the older io routines.