### PR TITLE
Fixed HeFFTe package spec to not do the smoke test prior to 2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -138,7 +138,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
         """build and run make(test)"""
 
         if self.spec.satisfies("@:2.2.0"):
-            return
+            raise SkipTest("Test is not supported for versions @:2.2.0")
 
         # using the tests copied from <prefix>/share/heffte/testing
         cmake_dir = self.test_suite.current_test_cache_dir.testing

--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -128,12 +128,18 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     def setup_smoke_test(self):
+        if self.spec.satisfies("@:2.2.0"):
+            return
         install_tree(
             self.prefix.share.heffte.testing, join_path(self.install_test_root, "testing")
         )
 
     def test_make_test(self):
         """build and run make(test)"""
+
+        if self.spec.satisfies("@:2.2.0"):
+            return
+
         # using the tests copied from <prefix>/share/heffte/testing
         cmake_dir = self.test_suite.current_test_cache_dir.testing
 


### PR DESCRIPTION
HeFFTe smoke test setup code breaks spack installs with HeFFTe prior to 2.2.0 (specifically, for example, building Cabana which currently requires 2.1.0). This pull request disables the smoke test code prior to version 2.2.0.