### PR TITLE
bugfix: irrelevant package name warning

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -387,7 +387,7 @@ class FastPackageChecker(collections.abc.Mapping):
 
             # Warn about invalid names that look like packages.
             if not nm.valid_module_name(pkg_name):
-                if not pkg_name.startswith("."):
+                if not pkg_name.startswith(".") and pkg_name != "repo.yaml":
                     tty.warn(
                         'Skipping package at {0}. "{1}" is not '
                         "a valid Spack module name.".format(pkg_dir, pkg_name)


### PR DESCRIPTION
If a repo has `subdirectory: ""` set in the repo.yaml config, every invocation of Spack warns that `repo.yaml` is not a valid package name.

This PR removes the warning for files named `repo.yaml`.