### PR TITLE
podman: add fuse variant

### DIFF
--- a/var/spack/repos/builtin/packages/podman/package.py
+++ b/var/spack/repos/builtin/packages/podman/package.py
@@ -23,7 +23,7 @@ class Podman(Package):
     # issue was fixed as of 4.4.0
     patch("markdown-utf8.diff", when="@4:4.3.1")
 
-    variant("fuse", default=True, description="Use recommended fuse-overlayfs storage driver")
+    variant("fuse", default=False, description="Use recommended fuse-overlayfs storage driver")
 
     depends_on("go", type="build")
     depends_on("go-md2man", type="build")

--- a/var/spack/repos/builtin/packages/podman/package.py
+++ b/var/spack/repos/builtin/packages/podman/package.py
@@ -23,6 +23,8 @@ class Podman(Package):
     # issue was fixed as of 4.4.0
     patch("markdown-utf8.diff", when="@4:4.3.1")
 
+    variant("fuse", default=True, description="Use recommended fuse-overlayfs storage driver")
+
     depends_on("go", type="build")
     depends_on("go-md2man", type="build")
     depends_on("pkgconfig", type="build")
@@ -34,6 +36,7 @@ class Podman(Package):
     depends_on("libassuan")
     depends_on("libgpg-error")
     depends_on("libseccomp")
+    depends_on("fuse-overlayfs", type="run", when="+fuse")
 
     def patch(self):
         defs = FileFilter("vendor/github.com/containers/common/pkg/config/default.go")


### PR DESCRIPTION
Podman has two storage drivers that it looks for, fuse-overlayfs and vfs. According to the docs:

> --storage-driver=value Storage driver. The default storage driver for UID 0 is configured in containers-storage.conf(5) in rootless mode), **and is vfs for non-root users when fuse-overlayfs is not available**. The STORAGE_DRIVER environment variable overrides the default. The --storage-driver specified driver overrides all.

This PR adds fuse-overlayfs as a runtime dependency. The executable `fuse-overlayfs` has to specified in the `storage.conf` file as the `mount_program` to take advantage. I wasn't sure to make the fuse variant default to `True` because of the way the docs are worded. I kept as `False` to not disturb other installations.