### PR TITLE
py-setuptools: document Python 3.12 support

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -199,7 +199,7 @@ class PySetuptools(Package, PythonExtension):
     depends_on("python@2.7:2.8,3.4:", when="@:43", type=("build", "run"))
 
     # https://github.com/pypa/setuptools/issues/3661
-    conflicts("python@3.12:", when="@:67", type=("build", "run"))
+    conflicts("python@3.12:", when="@:67")
 
     depends_on("py-pip", type="build")
 

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -199,7 +199,7 @@ class PySetuptools(Package, PythonExtension):
     depends_on("python@2.7:2.8,3.4:", when="@:43", type=("build", "run"))
 
     # https://github.com/pypa/setuptools/issues/3661
-    depends_on("python@:3.11", when="@:67", type=("build", "run"))
+    conflicts("python@3.12:", when="@:67", type=("build", "run"))
 
     depends_on("py-pip", type="build")
 

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -191,11 +191,16 @@ class PySetuptools(Package, PythonExtension):
     )
 
     extends("python")
+
     depends_on("python@3.7:", when="@59.7:", type=("build", "run"))
     depends_on("python@3.6:", when="@51:", type=("build", "run"))
     depends_on("python@3.5:", when="@45:50", type=("build", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@44", type=("build", "run"))
     depends_on("python@2.7:2.8,3.4:", when="@:43", type=("build", "run"))
+
+    # https://github.com/pypa/setuptools/issues/3661
+    depends_on("python@:3.11", when="@:67", type=("build", "run"))
+
     depends_on("py-pip", type="build")
 
     def url_for_version(self, version):


### PR DESCRIPTION
Python 3.12 wasn't supported until the 68.0.0 release of setuptools due to the removal of distutils in the standard library.