### PR TITLE
pruners-ninja %oneapi cflags: -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/pruners-ninja/package.py
+++ b/var/spack/repos/builtin/packages/pruners-ninja/package.py
@@ -24,3 +24,9 @@ class PrunersNinja(AutotoolsPackage):
     depends_on("libtool", type="build")
 
     patch("pruners-mutli-def-a-pr3-fix.patch")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi"):
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)


### PR DESCRIPTION
Needed for building with `%oneapi`