### PR TITLE
hdf5-vol-cache %oneapi: cflags: add -Wno-error=incompatible-function...

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
@@ -20,6 +20,12 @@ class Hdf5VolCache(CMakePackage):
     depends_on("hdf5@1.14: +mpi +threadsafe")
     depends_on("hdf5-vol-async")
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi"):
+                flags.append("-Wno-error=incompatible-function-pointer-types")
+        return (flags, None, None)
+
     def setup_run_environment(self, env):
         env.prepend_path("HDF5_PLUGIN_PATH", self.spec.prefix.lib)
 


### PR DESCRIPTION
Add `-Wno-error=incompatible-function-pointer-types` needed to build with OneAPI