### PR TITLE
json: minify by default

### DIFF
--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -11,7 +11,7 @@ import spack.error
 
 __all__ = ["load", "dump", "SpackJSONError"]
 
-_json_dump_args = {"indent": 2, "separators": (",", ": ")}
+_json_dump_args = {"indent": None, "separators": (",", ":")}
 
 
 def load(stream: Any) -> Dict:


### PR DESCRIPTION
Minify index.json, spack.lock, spec.json, etc

The only exception to this is `spec.json.sig`, which directly uses
`json.dump()` already, since clear signed text has line length restrictions.

The idea in the past was likely to have something human readable, but humans
rarely read `.spack-db/index.json` and friends, and *if* they do, they can just
do `jq < .spack-db/index.json` and get pretty indenting and colors, and run
queries. If they don't have `jq` they can `spack install jq`.

Machines on the other hand parse minified data much faster, and we should
optimize for that common use case.

My local index.json is parsed 1.3x faster and requires 2.2x fewer bytes.
