### PR TITLE
py-matplotlib %oneapi: add cxxflags=-Wno-error=register

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -261,6 +261,12 @@ class PyMatplotlib(PythonPackage):
     def archive_files(self):
         return [os.path.join(self.build_directory, self.config_file)]
 
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi"):
+                flags.append("-Wno-error=register")
+        return (flags, None, None)
+
     def setup_build_environment(self, env):
         include = []
         library = []


### PR DESCRIPTION
Needed to build with `%oneapi`