### PR TITLE
py-pandas@0.24.2 %oneapi: add cflag=-Wno-error=implicit-function-dec...

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -136,3 +136,9 @@ class PyPandas(PythonPackage):
     depends_on("py-setuptools@24.2:", when="@:1.2", type="build")
 
     skip_modules = ["pandas.tests", "pandas.plotting._matplotlib", "pandas.core._numba.kernels"]
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("@0.24.2 %oneapi"):
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)


### PR DESCRIPTION
Needed to build with `%oneapi`