### PR TITLE
ASP-based solver: optimize key to intermediate dicts

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -62,9 +62,6 @@ To output an @, use '@@'.  To output a } inside braces, use '}}'.
 import re
 import sys
 from contextlib import contextmanager
-from typing import Optional
-
-from ..lang import memoized
 
 
 class ColorParseError(Exception):
@@ -250,24 +247,23 @@ class match_to_ansi:
         return self.escape(string) + colored_text
 
 
-def colorize(string: str, color: Optional[bool] = None, enclose: Optional[bool] = None) -> str:
+def colorize(string, **kwargs):
     """Replace all color expressions in a string with ANSI control codes.
 
     Args:
-        string: The string to replace
-        color: If False, output will be plain text without control
+        string (str): The string to replace
+
+    Returns:
+        str: The filtered string
+
+    Keyword Arguments:
+        color (bool): If False, output will be plain text without control
             codes, for output to non-console devices.
-        enclose: If True, enclose ansi color sequences with
+        enclose (bool): If True, enclose ansi color sequences with
             square brackets to prevent misestimation of terminal width.
     """
-    color_arg = color if color is not None else get_color_when()
-    return _colorize(string, color=color_arg, enclose=enclose)
-
-
-@memoized
-def _colorize(string: str, color: Optional[bool] = None, enclose: Optional[bool] = None) -> str:
-    color = _color_when_value(color)
-    string = re.sub(color_re, match_to_ansi(color, enclose), string)
+    color = _color_when_value(kwargs.get("color", get_color_when()))
+    string = re.sub(color_re, match_to_ansi(color, kwargs.get("enclose")), string)
     string = string.replace("}}", "}")
     return string
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -267,12 +267,14 @@ def _id(thing):
 
 @llnl.util.lang.key_ordering
 class AspFunction(AspObject):
+    __slots__ = ["name", "args"]
+
     def __init__(self, name, args=None):
         self.name = name
         self.args = () if args is None else tuple(args)
 
     def _cmp_key(self):
-        return (self.name, self.args)
+        return self.name, self.args
 
     def __call__(self, *args):
         """Return a new instance of this function with added arguments.
@@ -731,7 +733,9 @@ class PyclingoDriver:
         """
         symbol = head.symbol() if hasattr(head, "symbol") else head
 
-        self.out.write("%s.\n" % str(symbol))
+        # This is commented out to avoid evaluating str(symbol) when we have no stream
+        if not isinstance(self.out, llnl.util.lang.Devnull):
+            self.out.write(f"{str(symbol)}.\n")
 
         atom = self.backend.add_atom(symbol)
 
@@ -1363,26 +1367,29 @@ class SpackSolverSetup:
         self.gen.fact(fn.condition_reason(condition_id, msg))
 
         cache = self._trigger_cache[named_cond.name]
-        if named_cond not in cache:
+
+        named_cond_key = str(named_cond)
+        if named_cond_key not in cache:
             trigger_id = next(self._trigger_id_counter)
             requirements = self.spec_clauses(named_cond, body=True, required_from=name)
-            cache[named_cond] = (trigger_id, requirements)
-        trigger_id, requirements = cache[named_cond]
+            cache[named_cond_key] = (trigger_id, requirements)
+        trigger_id, requirements = cache[named_cond_key]
         self.gen.fact(fn.pkg_fact(named_cond.name, fn.condition_trigger(condition_id, trigger_id)))
 
         if not imposed_spec:
             return condition_id
 
         cache = self._effect_cache[named_cond.name]
-        if imposed_spec not in cache:
+        imposed_spec_key = str(imposed_spec)
+        if imposed_spec_key not in cache:
             effect_id = next(self._effect_id_counter)
             requirements = self.spec_clauses(imposed_spec, body=False, required_from=name)
             if not node:
                 requirements = list(
                     filter(lambda x: x.args[0] not in ("node", "virtual_node"), requirements)
                 )
-            cache[imposed_spec] = (effect_id, requirements)
-        effect_id, requirements = cache[imposed_spec]
+            cache[imposed_spec_key] = (effect_id, requirements)
+        effect_id, requirements = cache[imposed_spec_key]
         self.gen.fact(fn.pkg_fact(named_cond.name, fn.condition_effect(condition_id, effect_id)))
         return condition_id
 


### PR DESCRIPTION
Computing `str(spec)` is much faster than computing `hash(spec)`, and since all the abstract specs we deal with come from user configuration they cannot cover DAG structures that are not captured by `str()` but are captured by `hash()`.