### PR TITLE
parallelio: add v2.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -39,7 +39,7 @@ class Parallelio(CMakePackage):
 
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
 
-    # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.  
+    # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.
     # netcdf4 filters are only available with the parallel build of netcdf.
     patch("pio_260.patch", when="@2.6.0")
 

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -40,6 +40,7 @@ class Parallelio(CMakePackage):
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
 
     # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.  
+    # netcdf4 filters are only available with the parallel build of netcdf.
     patch("pio_260.patch", when="@2.6.0")
 
     depends_on("cmake@3.7:", type="build")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -37,11 +37,14 @@ class Parallelio(CMakePackage):
     )
     variant("mpi", default=True, description="Use mpi to build, otherwise use mpi-serial")
 
-    patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
-
+    # This patch addresses building pio2.6.1 with serial netcdf, again the issue is netcdf filters
+    patch("serial261.patch", when="@2.6.1")
+    
     # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.
     # netcdf4 filters are only available with the parallel build of netcdf.
     patch("pio_260.patch", when="@2.6.0")
+    patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
+
 
     depends_on("cmake@3.7:", type="build")
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -38,6 +38,8 @@ class Parallelio(CMakePackage):
     variant("mpi", default=True, description="Use mpi to build, otherwise use mpi-serial")
 
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
+
+    # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.  
     patch("pio_260.patch", when="@2.6.0")
 
     depends_on("cmake@3.7:", type="build")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -39,12 +39,11 @@ class Parallelio(CMakePackage):
 
     # This patch addresses building pio2.6.1 with serial netcdf, again the issue is netcdf filters
     patch("serial261.patch", when="@2.6.1")
-    
+
     # This patch addresses an issue when compiling pio2.6.0 with a serial netcdf library.
     # netcdf4 filters are only available with the parallel build of netcdf.
     patch("pio_260.patch", when="@2.6.0")
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
-
 
     depends_on("cmake@3.7:", type="build")
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -17,6 +17,7 @@ class Parallelio(CMakePackage):
 
     maintainers("jedwards4b")
 
+    version("2.6.1", sha256="83d3108d2b9db8219aa6b6ee333cfc12b2a588bcfc781587df5f8b24a716a6eb")
     version("2.6.0", sha256="e56a980c71c7f57f396a88beae08f1670d4adf59be6411cd573fe85868ef98c0")
     version("2.5.10", sha256="fac694827c81434a7766976711ba7179940e361e8ed0c189c7b397fd44d401de")
     version("2.5.9", sha256="e5dbc153d8637111de3a51a9655660bf15367d55842de78240dcfc024380553d")
@@ -37,6 +38,7 @@ class Parallelio(CMakePackage):
     variant("mpi", default=True, description="Use mpi to build, otherwise use mpi-serial")
 
     patch("remove_redefinition_of_mpi_offset.patch", when="@:2.5.6")
+    patch("pio_260.patch", when="@2.6.0")
 
     depends_on("cmake@3.7:", type="build")
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/parallelio/pio_260.patch
+++ b/var/spack/repos/builtin/packages/parallelio/pio_260.patch
@@ -1,0 +1,20 @@
+diff --git a/src/clib/pio_internal.h b/src/clib/pio_internal.h
+index c360ae4e..79cc48eb 100644
+--- a/src/clib/pio_internal.h
++++ b/src/clib/pio_internal.h
+@@ -17,11 +17,13 @@
+ #include <limits.h>
+ #include <math.h>
+ #include <netcdf.h>
+-#ifdef _NETCDF4
+-#include <netcdf_par.h>
++#ifdef PIO_HAS_PAR_FILTERS
+ #include <netcdf_filter.h>
+ #include <netcdf_meta.h>
+ #endif
++#ifdef _NETCDF4
++#include <netcdf_par.h>
++#endif
+ #ifdef _PNETCDF
+ #include <pnetcdf.h>
+ #endif

--- a/var/spack/repos/builtin/packages/parallelio/serial261.patch
+++ b/var/spack/repos/builtin/packages/parallelio/serial261.patch
@@ -1,0 +1,36 @@
+diff --git a/src/clib/pio.h b/src/clib/pio.h
+index 0aea5a5f..767de18f 100644
+--- a/src/clib/pio.h
++++ b/src/clib/pio.h
+@@ -1267,9 +1267,8 @@ extern "C" {
+                                const long long *op);
+     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
+                                 const unsigned long long *op);
+-/* use this variable in the NETCDF library (introduced in v4.9.0) to determine if the following
+-   functions are available */
+-#ifdef NC_HAS_MULTIFILTERS
++
++#ifdef PIO_HAS_PAR_FILTERS
+   int PIOc_def_var_filter(int ncid, int varid,unsigned int id, size_t nparams, unsigned int *params);
+   int PIOc_inq_var_filter_ids(int ncid, int varid, size_t *nfiltersp, unsigned int *ids);
+   int PIOc_inq_var_filter_info(int ncid, int varid, unsigned int id, size_t *nparamsp, unsigned int *params );
+diff --git a/src/ncint/ncintdispatch.c b/src/ncint/ncintdispatch.c
+index a77396bd..3dce9d2c 100644
+--- a/src/ncint/ncintdispatch.c
++++ b/src/ncint/ncintdispatch.c
+@@ -127,6 +127,7 @@ NC_Dispatch NCINT_dispatcher = {
+     NC_NOTNC4_def_var_filter,
+     NC_NOTNC4_set_var_chunk_cache,
+     NC_NOTNC4_get_var_chunk_cache,
++#ifdef PIO_HAS_PAR_FILTERS
+ #if NC_DISPATCH_VERSION == 2
+     PIO_NCINT_filter_actions,
+ #endif
+@@ -141,6 +142,7 @@ NC_Dispatch NCINT_dispatcher = {
+ #if NC_DISPATCH_VERSION >= 5
+     PIOc_inq_filter_avail,
+ #endif
++#endif
+ };
+ 
+ /**


### PR DESCRIPTION
Adds a patch for version 2.6.0 and an sha for the new release.