### PR TITLE
preCICE: prepare for version 3

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -46,6 +46,18 @@ class Precice(CMakePackage):
     variant("petsc", default=True, description="Enable PETSc support")
     variant("python", default=False, description="Enable Python support", when="@2:")
     variant("shared", default=True, description="Build shared libraries")
+    variant(
+        "release_with_debug_log",
+        default=False,
+        description="Release build with debug log",
+        when="@2.4:",
+    )
+    variant(
+        "release_with_assertions",
+        default=False,
+        description="Release build with assertions",
+        when="@2.4:",
+    )
 
     depends_on("cmake@3.5:", type="build")
     depends_on("cmake@3.10.2:", type="build", when="@1.4:")
@@ -89,7 +101,7 @@ class Precice(CMakePackage):
             "-DTPL_ENABLE_EIGEN3:BOOL=ON",
             "-DTPL_ENABLE_LIBXML2:BOOL=ON",
             self.define_from_variant("TPL_ENABLE_PETSC", "petsc"),
-            self.define_from_variant("TPL_ENABLE_PYTHON", "python")
+            self.define_from_variant("TPL_ENABLE_PYTHON", "python"),
         ]
 
     def cmake_args(self):
@@ -118,6 +130,25 @@ class Precice(CMakePackage):
         # The TPL arguments were removed in 3.0.0.
         if spec.satisfies("@1.6:3"):
             cmake_args.extend(self.xsdk_tpl_args())
+
+        # Release options
+        if spec.satisfies("@2.4:"):
+            cmake_args.extend(
+                [
+                    self.define_from_variant(
+                        "PRECICE_RELEASE_WITH_DEBUG_LOG", "release_with_debug_log"
+                    ),
+                    self.define_from_variant(
+                        "PRECICE_RELEASE_WITH_ASSERTIONS", "release_with_assertions"
+                    ),
+                ]
+            )
+
+        # Disable CPack
+        if spec.satisfies("@3:"):
+            cmake_args.append("-DPRECICE_CONFIGURE_PACKAGE_GENERATION:BOOL=OFF")
+
+        ### Dependencies
 
         # Boost
         cmake_args.append("-DBOOST_ROOT=%s" % spec["boost"].prefix)

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -46,37 +46,20 @@ class Precice(CMakePackage):
     variant("petsc", default=True, description="Enable PETSc support")
     variant("python", default=False, description="Enable Python support", when="@2:")
     variant("shared", default=True, description="Build shared libraries")
-    variant(
-        "debug_log",
-        default=False,
-        description="Enable debug log in non-debug builds",
-        when="@2.4:",
-    )
-    variant(
-        "debug_log",
-        default=True,
-        description="Enable debug log in non-debug builds",
-        when="@2.4: build_type=Debug",
-    )
-    conflicts(
-        "~debug_log",
-        when="@2.4: build_type=Debug",
-        msg="Disabling debug log isn't possible in debug builds.",
-    ),
-    variant(
-        "checked", default=False, description="Enable assertions in non-debug builds", when="@2.4:"
-    )
-    variant(
-        "checked",
-        default=True,
-        description="Enable assertions in non-debug builds",
-        when="@2.4: build_type=Debug",
-    )
-    conflicts(
-        "~checked",
-        when="@2.4: build_type=Debug",
-        msg="Disabling assertions isn't possible in debug builds.",
-    ),
+
+    for build_type in ("Release", "RelWithDebInfo", "MinSizeRel"):
+        variant(
+            "debug_log",
+            default=False,
+            description="Enable debug log in non-debug builds",
+            when=f"@2.4: build_type={build_type}",
+        )
+        variant(
+            "checked",
+            default=False,
+            description="Enable assertions in non-debug builds",
+            when=f"@2.4: build_type={build_type}",
+        )
 
     depends_on("cmake@3.5:", type="build")
     depends_on("cmake@3.10.2:", type="build", when="@1.4:")

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -47,17 +47,36 @@ class Precice(CMakePackage):
     variant("python", default=False, description="Enable Python support", when="@2:")
     variant("shared", default=True, description="Build shared libraries")
     variant(
-        "release_with_debug_log",
+        "debug_log",
         default=False,
-        description="Release build with debug log",
+        description="Enable debug log in non-debug builds",
         when="@2.4:",
     )
     variant(
-        "release_with_assertions",
-        default=False,
-        description="Release build with assertions",
-        when="@2.4:",
+        "debug_log",
+        default=True,
+        description="Enable debug log in non-debug builds",
+        when="@2.4: build_type=Debug",
     )
+    conflicts(
+        "~debug_log",
+        when="@2.4: build_type=Debug",
+        msg="Disabling debug log isn't possible in debug builds.",
+    ),
+    variant(
+        "checked", default=False, description="Enable assertions in non-debug builds", when="@2.4:"
+    )
+    variant(
+        "checked",
+        default=True,
+        description="Enable assertions in non-debug builds",
+        when="@2.4: build_type=Debug",
+    )
+    conflicts(
+        "~checked",
+        when="@2.4: build_type=Debug",
+        msg="Disabling assertions isn't possible in debug builds.",
+    ),
 
     depends_on("cmake@3.5:", type="build")
     depends_on("cmake@3.10.2:", type="build", when="@1.4:")
@@ -137,12 +156,8 @@ class Precice(CMakePackage):
         if spec.satisfies("@2.4:"):
             cmake_args.extend(
                 [
-                    self.define_from_variant(
-                        "PRECICE_RELEASE_WITH_DEBUG_LOG", "release_with_debug_log"
-                    ),
-                    self.define_from_variant(
-                        "PRECICE_RELEASE_WITH_ASSERTIONS", "release_with_assertions"
-                    ),
+                    self.define_from_variant("PRECICE_RELEASE_WITH_DEBUG_LOG", "debug_log"),
+                    self.define_from_variant("PRECICE_RELEASE_WITH_ASSERTIONS", "checked"),
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -110,14 +110,16 @@ class Precice(CMakePackage):
 
         # Select the correct CMake variables by version
         mpi_option = "MPI"
-        if spec.satisfies("@2:"):
-            mpi_option = "PRECICE_MPICommunication"
         petsc_option = "PETSC"
-        if spec.satisfies("@2:"):
-            petsc_option = "PRECICE_PETScMapping"
         python_option = "PYTHON"
         if spec.satisfies("@2:"):
+            mpi_option = "PRECICE_MPICommunication"
+            petsc_option = "PRECICE_PETScMapping"
             python_option = "PRECICE_PythonActions"
+        if spec.satisfies("@3:"):
+            mpi_option = "PRECICE_FEATURE_MPI_COMMUNICATION"
+            petsc_option = "PRECICE_FEATURE_PETSC_MAPPING"
+            python_option = "PRECICE_FEATURE_PYTHON_ACTIONS"
 
         cmake_args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
@@ -148,7 +150,7 @@ class Precice(CMakePackage):
         if spec.satisfies("@3:"):
             cmake_args.append("-DPRECICE_CONFIGURE_PACKAGE_GENERATION:BOOL=OFF")
 
-        ### Dependencies
+        # Dependencies
 
         # Boost
         cmake_args.append("-DBOOST_ROOT=%s" % spec["boost"].prefix)


### PR DESCRIPTION
This PR prepares the spack package of preCICE for the upcoming version 3.
The spec `precice@develop` now builds correctly again, which is necessary for the tests of `xsdk@1.0.0`.
Related to https://github.com/xsdk-project/xsdk-issues/issues/217