### PR TITLE
fix the failure with rccl package for rocm-5.5.0 release. 

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -57,6 +57,7 @@ class Mesa(MesonPackage):
     depends_on("unwind")
     depends_on("expat")
     depends_on("zlib-api")
+    depends_on("libxml2")
 
     # Internal options
     variant("llvm", default=True, description="Enable LLVM.")

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -190,6 +190,7 @@ class Rccl(CMakePackage):
         "5.3.3",
         "5.4.0",
         "5.4.3",
+        "5.5.0",
         "5.5.1",
     ]:
         depends_on("rocm-smi-lib@" + ver, when="@" + ver)


### PR DESCRIPTION
Added libxml2 for mesa when i saw the failure of -lxml2 not found on a bare rhel9 docker container.