### PR TITLE
py-multiqc: add 1.15, correct py-matplotlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-multiqc/package.py
+++ b/var/spack/repos/builtin/packages/py-multiqc/package.py
@@ -14,6 +14,7 @@ class PyMultiqc(PythonPackage):
     homepage = "https://multiqc.info"
     pypi = "multiqc/multiqc-1.0.tar.gz"
 
+    version("1.15", sha256="ce5359a12226cf4ce372c6fdad142cfe2ae7501ffa97ac7aab544ced4db5ea3c")
     version("1.14", sha256="dcbba405f0c9521ed2bbd7e8f7a9200643047311c9619878b81d167300149362")
     version("1.13", sha256="0564fb0f894e6ca0822a0f860941b3ed2c33dce407395ac0c2103775d45cbfa0")
     version("1.7", sha256="02e6a7fac7cd9ed036dcc6c92b8f8bcacbd28983ba6be53afb35e08868bd2d68")
@@ -24,7 +25,7 @@ class PyMultiqc(PythonPackage):
     depends_on("python@2.7:", when="@:1.7", type=("build", "run"))
     depends_on("python@3:", when="@1.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-matplotlib@2.1.1:", type=("build", "run"), when="@:1.13")
+    depends_on("py-matplotlib@2.1.1:", type=("build", "run"), when="@1.13:")
     depends_on("py-matplotlib@2.1.1:2", type=("build", "run"), when="@1.7")
     depends_on("py-matplotlib@:2.1.0", type=("build", "run"), when="@1.5")
     depends_on("py-matplotlib", type=("build", "run"), when="@:1.3")


### PR DESCRIPTION
Adding the latest version of `py-multiqc`. Correcting the `py-matplotlib` dependency that shouldn't have been fixed to `@:1.13`.