### PR TITLE
uninstall: batch db update in write transaction

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -281,7 +281,8 @@ def uninstall_specs(args, specs):
         confirm_removal(uninstall_list)
 
     # Uninstall everything on the list
-    do_uninstall(uninstall_list, args.force)
+    with spack.store.STORE.db.write_transaction():
+        do_uninstall(uninstall_list, args.force)
 
     if env:
         with env.write_transaction():


### PR DESCRIPTION
Delay writing the `index.json` until all specs are removed, since persisting the db to disk takes longer than removing a package in many cases