### PR TITLE
aws-sdk-cpp: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
+++ b/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
@@ -34,3 +34,6 @@ class AwsSdkCpp(CMakePackage):
         sha256="ba86e0556322604fb4b70e2dd4f4fb874701868b07353fc1d5c329d90777bf45",
         when="@1.9.247",
     )
+
+    def cmake_args(self):
+        return [self.define("BUILD_ONLY", ("s3", "transfer"))]

--- a/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
+++ b/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
@@ -18,7 +18,10 @@ class AwsSdkCpp(CMakePackage):
     homepage = "https://github.com/aws/aws-sdk-cpp"
     git = "https://github.com/aws/aws-sdk-cpp.git"
 
+    version("1.11.144", tag="1.11.144", submodules=True)
+    version("1.10.57", tag="1.10.57", submodules=True)
     version("1.10.32", tag="1.10.32", submodules=True)
+    version("1.9.379", tag="1.9.379", submodules=True)
     version("1.9.247", tag="1.9.247", submodules=True)
 
     depends_on("cmake@3.1:", type="build")


### PR DESCRIPTION
Only build `s3` and `transfer`, since those are the only thing required by its dependents (adios2 & py-torchdata) if I understand correctly.

That reduces the install size from ... 1.2GB to 30MB :roll_eyes: 