### PR TITLE
dd4hep: Fix automatic finding of the lib or lib64 directory

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -246,7 +246,8 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["dd4hep"].libs.directories[0])
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["dd4hep"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["dd4hep"].prefix.lib64)
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero


### PR DESCRIPTION
Which isn't found by `directories[0]` since it doesn't have a standard, all lowercase, `libpkg.so` library