### PR TITLE
Bugfix: chrgrp avoidance check

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -601,7 +601,16 @@ def group_ids(uid=None):
 
 
 @system_path_filter(arg_slice=slice(1))
-def chgrp(path, group, follow_symlinks=True, _stat=None, _lstat=None, _chown=None, _lchown=None, _getgrnam=None):
+def chgrp(
+    path,
+    group,
+    follow_symlinks=True,
+    _stat=None,
+    _lstat=None,
+    _chown=None,
+    _lchown=None,
+    _getgrnam=None,
+):
     """Implement the bash chgrp function on a single path"""
     if sys.platform == "win32":
         raise OSError("Function 'chgrp' is not supported on Windows")

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -617,8 +617,8 @@ def chgrp(
 
     stat = _stat or os.stat
     lstat = _lstat or os.lstat
-    chown = _chown or os._chown
-    lchown = _lchown or os._lchown
+    chown = _chown or os.chown
+    lchown = _lchown or os.lchown
     getgrnam = _getgrnam or grp.getgrnam
 
     if isinstance(group, str):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -601,23 +601,29 @@ def group_ids(uid=None):
 
 
 @system_path_filter(arg_slice=slice(1))
-def chgrp(path, group, follow_symlinks=True):
+def chgrp(path, group, follow_symlinks=True, _stat=None, _lstat=None, _chown=None, _lchown=None, _getgrnam=None):
     """Implement the bash chgrp function on a single path"""
     if sys.platform == "win32":
         raise OSError("Function 'chgrp' is not supported on Windows")
 
+    stat = _stat or os.stat
+    lstat = _lstat or os.lstat
+    chown = _chown or os._chown
+    lchown = _lchown or os._lchown
+    getgrnam = _getgrnam or grp.getgrnam
+
     if isinstance(group, str):
-        gid = grp.getgrnam(group).gr_gid
+        gid = getgrnam(group).gr_gid
     else:
         gid = group
-    if follow_symlinks and os.stat(path).st_gid == gid:
+    if follow_symlinks and stat(path).st_gid == gid:
         return
-    elif (not follow_symlinks) and os.lstat(path).st_gid == gid:
+    elif (not follow_symlinks) and lstat(path).st_gid == gid:
         return
     if follow_symlinks:
-        os.chown(path, -1, gid)
+        chown(path, -1, gid)
     else:
-        os.lchown(path, -1, gid)
+        lchown(path, -1, gid)
 
 
 @system_path_filter(arg_slice=slice(1))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -610,7 +610,9 @@ def chgrp(path, group, follow_symlinks=True):
         gid = grp.getgrnam(group).gr_gid
     else:
         gid = group
-    if os.stat(path).st_gid == gid:
+    if follow_symlinks and os.stat(path).st_gid == gid:
+        return
+    elif (not follow_symlinks) and os.lstat(path).st_gid == gid:
         return
     if follow_symlinks:
         os.chown(path, -1, gid)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -504,7 +504,6 @@ def test_filter_files_with_different_encodings(regex, replacement, filename, tmp
 
 @pytest.mark.not_on_windows("chgrp isn't used on Windows")
 def test_chgrp_dont_set_group_if_already_set():
-
     class Fail:
         def __init__(self, name):
             self.name = name
@@ -519,14 +518,10 @@ def test_chgrp_dont_set_group_if_already_set():
 
         def __call__(self, *args, **kwargs):
             self.called_with.append(args[0])
-            tty.debug(f"{self.name} noop")
 
     class FakeStat:
         def __init__(self, gid):
             self.st_gid = gid
-
-    original_stat = os.stat
-    original_lstat = os.lstat
 
     class Stat:
         def __init__(self, gid):


### PR DESCRIPTION
Fixes an improperly-handled case in https://github.com/spack/spack/pull/38036

When `follow_symlinks==False`, this needs to use `lstat`, otherwise `stat` will resolve the symlink.

This refactors the associated test to eliminate monkeypatching of `os.` (and also to add checks for when `lstat` should be called).

See: https://github.com/spack/spack/pull/38036/files#r1298369358