### PR TITLE
less: update version, dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/less/package.py
+++ b/var/spack/repos/builtin/packages/less/package.py
@@ -15,6 +15,9 @@ class Less(AutotoolsPackage):
     url = "https://www.greenwoodsoftware.com/less/less-551.zip"
     list_url = "https://www.greenwoodsoftware.com/less/download.html"
 
+    depends_on("ncurses")
+
+    version("643", sha256="3bb417c4b909dfcb0adafc371ab87f0b22e8b15f463ec299d156c495fc9aa196")
     version("590", sha256="69056021c365b16504cf5bd3864436a5e50cb2f98b76cd68b99b457064139375")
     version("551", sha256="2630db16ef188e88b513b3cc24daa9a798c45643cc7da06e549c9c00cfd84244")
     version("530", sha256="8c1652ba88a726314aa2616d1c896ca8fe9a30253a5a67bc21d444e79a6c6bc3")


### PR DESCRIPTION
`less` didn't properly express a dependency on `ncurses`.

- [x] add `ncurses` dependency
- [x] add latest version 643
- [x] test builds of `less` 643, 590, 551, 530