### PR TITLE
libyogrt %oneapi: add cflag=-Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/libyogrt/package.py
+++ b/var/spack/repos/builtin/packages/libyogrt/package.py
@@ -61,6 +61,12 @@ class Libyogrt(AutotoolsPackage):
                 version
             )
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi"):
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)
+
     def configure_args(self):
         args = []
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/39462

```
==> Installing libyogrt-1.33-57t7gblnvwkgqk5pd25op3sokmsg4z5e [48/48]
==> No binary for libyogrt-1.33-57t7gblnvwkgqk5pd25op3sokmsg4z5e found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/79/797d20c49cdc4f6beae8660b4f41ba7ac13f7e93a0344b47f0bdc64f780d1398.tar.gz
==> No patches needed for libyogrt
==> libyogrt: Executing phase: 'autoreconf'
==> libyogrt: Executing phase: 'configure'
==> libyogrt: Executing phase: 'build'
==> libyogrt: Executing phase: 'install'
==> libyogrt: Successfully installed libyogrt-1.33-57t7gblnvwkgqk5pd25op3sokmsg4z5e
  Stage: 0.27s.  Autoreconf: 0.00s.  Configure: 3.90s.  Build: 1.00s.  Install: 0.28s.  Post-install: 0.04s.  Total: 5.67s
[+] /spack/opt/spack/linux-ubuntu20.04-x86_64/oneapi-2023.2.1/libyogrt-1.33-57t7gblnvwkgqk5pd25op3sokmsg4z5e
```

@adammoody 