### PR TITLE
libyogrt: patch to include slurm.h during config

### DIFF
--- a/var/spack/repos/builtin/packages/libyogrt/config_slurm.patch
+++ b/var/spack/repos/builtin/packages/libyogrt/config_slurm.patch
@@ -1,0 +1,13 @@
+diff --git a/config/x_ac_slurm.m4 b/config/x_ac_slurm.m4
+index c204ffa..5f43177 100644
+--- a/config/x_ac_slurm.m4
++++ b/config/x_ac_slurm.m4
+@@ -50,7 +50,7 @@ AC_DEFUN([X_AC_SLURM], [
+             _x_ac_slurm_libs_save="$LIBS"
+             LIBS="-L$d/$bit -lslurm -lpthread -lcrypto $LIBS"
+             AC_LINK_IFELSE(
+-              [AC_LANG_PROGRAM([],[slurm_get_rem_time(0);])],
++              [AC_LANG_PROGRAM([#include <slurm/slurm.h>],[slurm_get_rem_time(0);])],
+               [AS_VAR_SET([x_ac_cv_slurm_dir], [$d])
+                AS_VAR_SET([x_ac_cv_slurm_libdir], [$d/$bit])]
+             )

--- a/var/spack/repos/builtin/packages/libyogrt/package.py
+++ b/var/spack/repos/builtin/packages/libyogrt/package.py
@@ -53,6 +53,9 @@ class Libyogrt(AutotoolsPackage):
 
     variant("static", default=False, description="build static library")
 
+    # include slurm.h during config test to avoid implicit function declaration
+    patch("config_slurm.patch")
+
     def url_for_version(self, version):
         if version < Version("1.21"):
             return "https://github.com/LLNL/libyogrt/archive/%s.tar.gz" % version


### PR DESCRIPTION
The config test in libyogrt fails to compile a test program looking for ``slurm_get_rem_time()`` when using a compiler that throws an error on implicit function declarations.  A patch is being worked upstream in libyogrt to resolve this issue in a future release.  Until then, this patches libyogrt installs by way of its Spack package.