### PR TITLE
Add `--exclusive` flag for batch operations

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -545,13 +545,20 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose"]
+    spack_cmd = [
+        SPACK_COMMAND,
+        "--exclusive",
+        "--color=always",
+        "--backtrace",
+        "--verbose",
+        "install",
+    ]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:
         spack_cmd.append("-k")
 
-    install_args = []
+    install_args = ["--use-buildcache=package:never,dependencies:only"]
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
@@ -561,55 +568,17 @@ def ci_rebuild(args):
     slash_hash = "/{}".format(job_spec.dag_hash())
 
     # Arguments when installing dependencies from cache
-    deps_install_args = install_args
+    deps_install_args = install_args + ["--only=dependencies"]
 
     # Arguments when installing the root from sources
-    root_install_args = install_args + [
-        "--keep-stage",
-        "--only=package",
-        "--use-buildcache=package:never,dependencies:only",
-    ]
+    root_install_args = install_args + ["--keep-stage", "--only=package"]
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
-    root_install_args.append(slash_hash)
-
-    # ["x", "y"] -> "'x' 'y'"
-    args_to_string = lambda args: " ".join("'{}'".format(arg) for arg in args)
 
     commands = [
-        # apparently there's a race when spack bootstraps? do it up front once
-        [SPACK_COMMAND, "-e", env.path, "bootstrap", "now"],
-        [
-            SPACK_COMMAND,
-            "-e",
-            env.path,
-            "env",
-            "depfile",
-            "-o",
-            "Makefile",
-            "--use-buildcache=package:never,dependencies:only",
-            slash_hash,  # limit to spec we're building
-        ],
-        [
-            # --output-sync requires GNU make 4.x.
-            # Old make errors when you pass it a flag it doesn't recognize,
-            # but it doesn't error or warn when you set unrecognized flags in
-            # this variable.
-            "export",
-            "GNUMAKEFLAGS=--output-sync=recurse",
-        ],
-        [
-            MAKE_COMMAND,
-            "SPACK={}".format(args_to_string(spack_cmd)),
-            "SPACK_COLOR=always",
-            "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
-            "-j$(nproc)",
-            "install-deps/{}".format(
-                ev.depfile.MakefileSpec(job_spec).safe_format("{name}-{version}-{hash}")
-            ),
-        ],
-        spack_cmd + ["install"] + root_install_args,
+        spack_cmd + deps_install_args + [slash_hash],
+        spack_cmd + root_install_args + [slash_hash],
     ]
 
     tty.debug("Installing {0} from source".format(job_spec.name))

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1090,6 +1090,8 @@ class Database:
                 os.remove(temp_file)
             raise
 
+        self.modified = False
+
     def _read(self):
         """Re-read Database from the data in the set location. This does no locking."""
         if os.path.isfile(self._index_path):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1106,9 +1106,11 @@ class Database:
                 self.last_seen_verifier = current_verifier
                 # Read from file if a database exists
                 self._read_from_file(self._index_path)
+                self.modified = False
             elif self._state_is_inconsistent:
                 self._read_from_file(self._index_path)
                 self._state_is_inconsistent = False
+                self.modified = False
             return
         elif self.is_upstream:
             tty.warn("upstream not found: {0}".format(self._index_path))

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -550,6 +550,11 @@ def make_argument_parser(**kwargs):
         help="always show backtraces for exceptions",
     )
     parser.add_argument(
+        "--exclusive",
+        action="store_true",
+        help="do not allow other spack instances to write to the database",
+    )
+    parser.add_argument(
         "-V", "--version", action="store_true", help="show version number and exit"
     )
     parser.add_argument(
@@ -638,12 +643,18 @@ def allows_unknown_args(command):
 
 def _invoke_command(command, parser, args, unknown_args):
     """Run a spack command *without* setting spack global options."""
-    if allows_unknown_args(command):
-        return_val = command(parser, args, unknown_args)
+    if args.exclusive:
+        maybe_exclusive = spack.store.STORE.db.write_transaction
     else:
-        if unknown_args:
-            tty.die("unrecognized arguments: %s" % " ".join(unknown_args))
-        return_val = command(parser, args)
+        maybe_exclusive = llnl.util.lang.nullcontext
+
+    with maybe_exclusive():
+        if allows_unknown_args(command):
+            return_val = command(parser, args, unknown_args)
+        else:
+            if unknown_args:
+                tty.die("unrecognized arguments: %s" % " ".join(unknown_args))
+            return_val = command(parser, args)
 
     # Allow commands to return and error code if they want
     return 0 if return_val is None else return_val

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -399,7 +399,7 @@ SPACK_ALIASES="concretise:concretize;containerise:containerize;rm:remove"
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace --exclusive -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -347,7 +347,7 @@ complete -c spack --erase
 # Everything below here is auto-generated.
 
 # spack
-set -g __fish_spack_optspecs_spack h/help H/all-help color= c/config= C/config-scope= d/debug timestamp pdb e/env= D/env-dir= E/no-env use-env-repo k/insecure l/enable-locks L/disable-locks m/mock b/bootstrap p/profile sorted-profile= lines= v/verbose stacktrace backtrace V/version print-shell-vars=
+set -g __fish_spack_optspecs_spack h/help H/all-help color= c/config= C/config-scope= d/debug timestamp pdb e/env= D/env-dir= E/no-env use-env-repo k/insecure l/enable-locks L/disable-locks m/mock b/bootstrap p/profile sorted-profile= lines= v/verbose stacktrace backtrace exclusive V/version print-shell-vars=
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a add -d 'add a spec to an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a arch -d 'print architecture information about this machine'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a audit -d 'audit configuration files, packages, etc.'
@@ -473,6 +473,8 @@ complete -c spack -n '__fish_spack_using_command ' -l stacktrace -f -a stacktrac
 complete -c spack -n '__fish_spack_using_command ' -l stacktrace -d 'add stacktraces to all printed statements'
 complete -c spack -n '__fish_spack_using_command ' -l backtrace -f -a backtrace
 complete -c spack -n '__fish_spack_using_command ' -l backtrace -d 'always show backtraces for exceptions'
+complete -c spack -n '__fish_spack_using_command ' -l exclusive -f -a exclusive
+complete -c spack -n '__fish_spack_using_command ' -l exclusive -d 'do not allow other spack instances to write to the database'
 complete -c spack -n '__fish_spack_using_command ' -s V -l version -f -a version
 complete -c spack -n '__fish_spack_using_command ' -s V -l version -d 'show version number and exit'
 complete -c spack -n '__fish_spack_using_command ' -l print-shell-vars -r -f -a print_shell_vars

--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -30,7 +30,6 @@ class PyTorchgeo(PythonPackage):
     variant("docs", default=False, description="Install documentation dependencies")
     variant("style", default=False, description="Install style checking tools")
     variant("tests", default=False, description="Install testing tools")
-    variant("rebuild-me", default=False, description="CI test")
 
     # NOTE: historically, dependencies had upper bounds based on semantic version compatibility.
     # However, these were removed to improve maintainability and flexibility of the recipe.

--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -30,6 +30,7 @@ class PyTorchgeo(PythonPackage):
     variant("docs", default=False, description="Install documentation dependencies")
     variant("style", default=False, description="Install style checking tools")
     variant("tests", default=False, description="Install testing tools")
+    variant("rebuild-me", default=False, description="CI test")
 
     # NOTE: historically, dependencies had upper bounds based on semantic version compatibility.
     # However, these were removed to improve maintainability and flexibility of the recipe.


### PR DESCRIPTION
This introduces a new flag `--exclusive` which is useful to speed up workflows that involve:

1. Installation of many packages from a buildcache
2. Installation of many pure python packages
3. Uninstall of many packages

When running `spack --exclusive (un)install ...` Spack takes a write lock on the database
during the whole process, so that reading and writing the database happens at most once,
instead of after each (un)install.

The advantage should be improved performance, the downside is that database write failures
are encountered late.

This PR also removes use of `spack env depfile` from `spack ci`, since the bottleneck when
installing from cache with multiple processes is usually re-reading and writing the DB. So,
here we go from O(n^2) reads / writes to O(n).