### PR TITLE
zlib: new version 1.3

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -23,6 +23,7 @@ class Zlib(MakefilePackage, Package):
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://zlib.net/fossils/zlib-1.2.11.tar.gz"
 
+    version("1.3", sha256="ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e")
     version("1.2.13", sha256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30")
     version(
         "1.2.12",


### PR DESCRIPTION
This adds the newest version of zlib, release notes at https://zlib.net/ and https://zlib.net/ChangeLog.txt.

The only non-fix change listed is: "Building using K&R (pre-ANSI) function definitions is no longer supported" (https://github.com/madler/zlib/commit/e9d5486e6635141f589e110fd789648aa08e9544). That should improve future compatibility for C2x standard compilers.