### PR TITLE
veccore: new variant vc

### DIFF
--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -32,15 +32,10 @@ class Veccore(CMakePackage):
     version("0.4.0", sha256="0a38b958c92647c30b5709d17edaf39d241b92b988f1040c0fbe24932b42927e")
     version("0.3.2", sha256="d72b03df00f5e94b2d07f78ab3af6d9d956c19e9a1fae07267b48f6fc8d7713f")
 
-    variant("umesimd", default=False, description="Enable UME::SIMD backend")
     variant("vc", default=False, description="Enable Vc backend")
 
-    depends_on("umesimd@0.8.1:", when="@0.3.2: +umesimd")
     depends_on("vc@1.2.0:", when="@0.2.0: +vc")
     depends_on("vc@1.3.3:", when="@0.6.0: +vc")
 
     def cmake_args(self):
-        return [
-            self.define_from_variant("UMESIMD", "umesimd"),
-            self.define_from_variant("VC", "vc"),
-        ]
+        return [self.define_from_variant("VC", "vc")]

--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -31,3 +31,16 @@ class Veccore(CMakePackage):
     version("0.4.1", sha256="59ffe668c061acde89afb33749f4eb8bab35dd5f6e51f632758794c1a745aabf")
     version("0.4.0", sha256="0a38b958c92647c30b5709d17edaf39d241b92b988f1040c0fbe24932b42927e")
     version("0.3.2", sha256="d72b03df00f5e94b2d07f78ab3af6d9d956c19e9a1fae07267b48f6fc8d7713f")
+
+    variant("umesimd", default=False, description="Enable UME::SIMD backend")
+    variant("vc", default=False, description="Enable Vc backend")
+
+    depends_on("umesimd@0.8.1:", when="@0.3.2: +umesimd")
+    depends_on("vc@1.2.0:", when="@0.2.0: +vc")
+    depends_on("vc@1.3.3:", when="@0.6.0: +vc")
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant("UMESIMD", "umesimd"),
+            self.define_from_variant("VC", "vc"),
+        ]


### PR DESCRIPTION
This adds a new variant to the `veccore` package, to support the optional `vc` backend (on e.g. gcc-9). The dependency versions are from the CMakeLists.txt history. Defaults are false.

There is also `cuda` support in `veccore`, but that's not added here at this point because it affects the type of package.