### PR TITLE
package_qscintilla_build_with_qt6

### DIFF
--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -73,10 +73,10 @@ class Qscintilla(QMakePackage):
         makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
         if '^qt-base' in self.spec:
             makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix,
-                    "$(INSTALL_ROOT)", string=True)
+                            "$(INSTALL_ROOT)", string=True)
         else:
             makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix,
-                    "$(INSTALL_ROOT)", string=True)
+                            "$(INSTALL_ROOT)", string=True)
 
     @run_after("install", when='+designer')
     def make_designer(self):
@@ -104,7 +104,7 @@ class Qscintilla(QMakePackage):
             cp = which('cp')
             cp(ftoml, 'pyproject.toml')
             sip_inc_dir = join_path(self.spec[py_pyqtx].prefix,
-                    self.spec['python'].package.platlib, pyqtx, 'bindings' )
+                                    self.spec['python'].package.platlib, pyqtx, 'bindings')
 
             with open('pyproject.toml', 'a') as tomlfile:
                 tomlfile.write(
@@ -115,10 +115,10 @@ class Qscintilla(QMakePackage):
                 # QT += widgets and QT += printsupport need to be added to Qsci.pro file
                 # to be generated via project.py
                 qsciproj = FileFilter(join_path("project.py"))
+                ptrn="super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG",
                 qsciproj.filter(
-                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG)",
-                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG,qmake_QT"
-                    +"=['widgets','printsupport'])", string=True)
+                    ptrn+")",
+                    ptrn+",qmake_QT=['widgets','printsupport'])", string=True)
             sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
             sip_build(
                 "--target-dir=" + python_platlib,
@@ -128,7 +128,7 @@ class Qscintilla(QMakePackage):
                 "--verbose",
             )
 
-            makefile = FileFilter(join_path("build","Qsci", "Makefile"))
+            makefile = FileFilter(join_path("build", "Qsci", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
             make("install", "-C", join_path("build", "Qsci"), parallel=False)
 

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -168,7 +168,7 @@ class Qscintilla(QMakePackage):
                     # its prefix of qscintilla itself as opposed to prefix for py-pyqt6
                     # qscintilla+python builds fine when sip_inc_dir is hardcoded!
                     str(self.spec)
-                    sip_inc_dir = join_path(self.spec['py-pyqt6'].prefix, python_platlib, 'PyQt6', 'bindings' )
+                    sip_inc_dir = join_path(self.spec['py-pyqt6'].prefix, self.spec['python'].package.platlib, 'PyQt6', 'bindings' )
                     with open('pyproject.toml', 'a') as tomlfile:
                         tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["/home/sbulut/Downloads/spack/opt/spack/linux-linuxmint21-skylake/gcc-11.4.0/py-pyqt6-6.5.1-6vq3475u5e3s74qbpv3gnwashddf6pni/lib/python3.10/site-packages/PyQt6/bindings"]\n')
                         #tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -16,7 +16,6 @@ class Qscintilla(QMakePackage):
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/intro"
     url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
 
-    # Directory structure is changed as of ver. 2.12.0
     version("2.14.1", sha256="dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d")
     version("2.14.0", sha256="449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c")
     version("2.13.4", sha256="890c261f31e116f426b0ea03a136d44fc89551ebfd126d7b0bdf8a7197879986")

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -72,9 +72,11 @@ class Qscintilla(QMakePackage):
     def fix_install_path(self):
         makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
         if '^qt-base' in self.spec:
-            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix, "$(INSTALL_ROOT)", string=True)
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix,
+                    "$(INSTALL_ROOT)", string=True)
         else:
-            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)", string=True)
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix,
+                    "$(INSTALL_ROOT)", string=True)
 
     @run_after("install", when='+designer')
     def make_designer(self):
@@ -101,10 +103,12 @@ class Qscintilla(QMakePackage):
         with working_dir(join_path(self.stage.source_path, "Python")):
             cp = which('cp')
             cp(ftoml, 'pyproject.toml')
-            sip_inc_dir = join_path(self.spec[py_pyqtx].prefix, self.spec['python'].package.platlib, pyqtx, 'bindings' )
+            sip_inc_dir = join_path(self.spec[py_pyqtx].prefix,
+                    self.spec['python'].package.platlib, pyqtx, 'bindings' )
 
             with open('pyproject.toml', 'a') as tomlfile:
-                tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
+                tomlfile.write(
+                        '\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
             mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
 
             if '^py-pyqt5' in self.spec:
@@ -113,7 +117,8 @@ class Qscintilla(QMakePackage):
                 qsciproj = FileFilter(join_path("project.py"))
                 qsciproj.filter(
                     "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG)",
-                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG,qmake_QT=['widgets','printsupport'])", string=True)
+                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG,qmake_QT"
+                    +"=['widgets','printsupport'])", string=True)
             sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
             sip_build(
                 "--target-dir=" + python_platlib,
@@ -125,8 +130,8 @@ class Qscintilla(QMakePackage):
 
             makefile = FileFilter(join_path("build","Qsci", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
-            make("install","-C",join_path("build","Qsci"), parallel=False)
+            make("install","-C",join_path("build", "Qsci"), parallel=False)
 
-            makefile = FileFilter(join_path("build","Makefile"))
+            makefile = FileFilter(join_path("build", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
             make("install","-C","build/", parallel=False)

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -27,9 +27,8 @@ class Qscintilla(QMakePackage):
     variant("designer", default=False, description="Enable pluging for Qt-Designer")
     variant("python", default=False, description="Build python bindings")
 
-    depends_on("qt+opengl", when="+python ^qt@5")
-    depends_on("qt-base+opengl", when="+python ^qt-base")
     depends_on("qmake")
+    depends_on("qmake+opengl", when="+python")
     depends_on("py-pyqt6", type=("build", "run"), when="+python ^qt-base")
     depends_on("py-pyqt-builder", type="build", when="+python")
     depends_on("py-pyqt5", type=("build", "run"), when="+python ^qt@5")
@@ -120,8 +119,8 @@ class Qscintilla(QMakePackage):
 
             makefile = FileFilter(join_path("build", "Qsci", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
-            make("install", "-C", join_path("build", "Qsci"), parallel=False)
+            make("install", "-C", join_path("build", "Qsci"))
 
             makefile = FileFilter(join_path("build", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
-            make("install", "-C", "build/", parallel=False)
+            make("install", "-C", "build/")

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os,sys
+import os
 
 from spack.package import *
 
@@ -20,25 +20,8 @@ class Qscintilla(QMakePackage):
     version("2.13.3", sha256="711d28e37c8fccaa8229e8e39a5b3b2d97f3fffc63da10b71c71b84fa3649398")
     version(
         "2.12.0",
-        sha256="a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed",
+        sha256="2116181cce3076aa4897e36182532d0e6768081fb0cf6dcdd5be720519ab1434",
         url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz",
-    )
-
-    # Last standard release dates back to 2021/11/23
-    version(
-        "2.11.6",
-        sha256="e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7",
-        url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla-2.11.6.tar.gz",
-    )
-    version(
-        "2.11.2",
-        sha256="029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1",
-        url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz",
-    )
-    version(
-        "2.10.2",
-        sha256="14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0",
-        url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.10.2/QScintilla-2.10.2.tar.gz",
     )
 
     variant("designer", default=False, description="Enable pluging for Qt-Designer")
@@ -50,12 +33,15 @@ class Qscintilla(QMakePackage):
     depends_on("py-pyqt6", type=("build", "run"), when="+python ^qt-base")
     depends_on("py-pyqt-builder", type="build", when="+python")
     depends_on("py-pyqt5", type=("build", "run"), when="+python ^qt@5")
-    depends_on("py-pyqt4 +qsci_api", type=("build", "run"), when="+python ^qt@4")
     depends_on("python", type=("build", "run"), when="+python")
     # adter install inquires py-sip variant : so we need to have it
     depends_on("py-sip", type="build", when="~python")
 
     extends("python", when="+python")
+
+    # https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/ChangeLog
+    conflicts('^qt@4', when='@2.12:')
+
     @property
     def build_directory(self):
         if self.version >= Version("2.12"):
@@ -67,6 +53,10 @@ class Qscintilla(QMakePackage):
         # below, DEFINES ... gets rid of ...regex...errors during build
         # although, there shouldn't be such errors since we use '-std=c++11'
         args = ["CONFIG+=-std=c++11", "DEFINES+=NO_CXX11_REGEX=1"]
+        # by default, the package tries to build with accessibility support, and fails
+        # possibly there's a bug somewhere that needs to be fixed
+        if "^qt-base" in self.spec:
+            args.append("DEFINES+=QT_NO_ACCESSIBILITY")
         return args
 
     # When INSTALL_ROOT is unset, qscintilla is installed under qt_prefix
@@ -78,139 +68,65 @@ class Qscintilla(QMakePackage):
         env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
 
     # Fix install prefix
-    @run_before("qmake")
-    def fix_qaccesswidget(self):
-        with working_dir(join_path(self.stage.source_path, "src")):
-            qscipro = FileFilter("qscintilla.pro")
-
-            qscipro.filter(
-                "TEMPLATE = lib",
-                "TEMPLATE = lib\nDEFINES += QT_NO_ACCESSIBILITY\nINCLUDEPATH += "+str(self.spec['qt-base'].prefix)+'/include'+"\nQT += widgets" + "\nQT += printsupport\n",
-            )
-
-
-    # Fix install prefix
     @run_after("qmake")
     def fix_install_path(self):
-        makefile = FileFilter(join_path(self.build_directory, "Makefile"))
-        makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix, "$(INSTALL_ROOT)", string=True, backup=True)
+        makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
+        if '^qt-base' in self.spec:
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix, "$(INSTALL_ROOT)", string=True)
+        else:
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)", string=True)
 
-
-    @run_after("install")
-    def postinstall(self):
+    @run_after("install", when='+designer')
+    def make_designer(self):
         # Make designer plugin
-        if "+designer" in self.spec:
-            with working_dir(os.path.join(self.stage.source_path, "designer-Qt4Qt5")):
-                qscipro = FileFilter("designer.pro")
-                qscipro.filter("TEMPLATE = lib", "TEMPLATE = lib\nINCLUDEPATH += ../Qt4Qt5\n")
+        with working_dir(os.path.join(self.stage.source_path, "designer")):
+            # TODO: qmake fails with qt6
+            qmake('designer.pro', 'INCLUDEPATH+=../src')
+            make()
+            makefile = FileFilter("Makefile")
+            makefile.filter(r"\$\(INSTALL_ROOT\)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)")
+            make("install")
 
-                qmake()
-                make()
-                makefile = FileFilter("Makefile")
-                makefile.filter(r"\$\(INSTALL_ROOT\)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)")
-                make("install")
+    @run_after("install", when='+python')
+    def make_qsci_python(self):
+        if "^py-pyqt5" in self.spec:
+            py_pyqtx = "py-pyqt5"
+            pyqtx = "PyQt5"
+            ftoml = 'pyproject-qt5.toml'
+        elif "^py-pyqt6" in self.spec:
+            py_pyqtx = "py-pyqt6"
+            pyqtx = "PyQt6"
+            ftoml = 'pyproject-qt6.toml'
 
-    @run_after("install")
-    def make_qsci(self):
-        if "+python" in self.spec:
-            if "^py-pyqt4" in self.spec:
-                py_pyqtx = "py-pyqt4"
-                pyqtx = "PyQt4"
-            elif "^py-pyqt5" in self.spec:
-                py_pyqtx = "py-pyqt5"
-                pyqtx = "PyQt5"
-            elif "^py-pyqt6" in self.spec:
-                py_pyqtx = "py-pyqt6"
-                pyqtx = "PyQt6"
+        with working_dir(join_path(self.stage.source_path, "Python")):
+            cp = which('cp')
+            cp(ftoml, 'pyproject.toml')
+            sip_inc_dir = join_path(self.spec[py_pyqtx].prefix, self.spec['python'].package.platlib, pyqtx, 'bindings' )
 
-            with working_dir(join_path(self.stage.source_path, "src")):
-                # Fix build errors
-                # "QAbstractScrollArea: No such file or directory"
-                # "qprinter.h: No such file or directory"
-                # ".../Qsci.so: undefined symbol: _ZTI10Qsci...."
-                qscipro = FileFilter("qscintilla.pro")
-                if "^qt@4" in self.spec:
-                    qtx = "qt4"
-                elif "^qt@5" in self.spec:
-                    qtx = "qt5"
-                elif "^qt-base@6" in self.spec:
-                    qtx = "qt6"
+            with open('pyproject.toml', 'a') as tomlfile:
+                tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
+            mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
 
+            if '^py-pyqt5' in self.spec:
+                # QT += widgets and QT += printsupport need to be added to Qsci.pro file
+                # to be generated via project.py
+                qsciproj = FileFilter(join_path("project.py"))
+                qsciproj.filter(
+                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG)",
+                    "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG,qmake_QT=['widgets','printsupport'])", string=True)
+            sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
+            sip_build(
+                "--target-dir=" + python_platlib,
+                "--qsci-include-dir=" + self.spec.prefix.include,
+                "--qsci-library-dir=" + self.spec.prefix.lib,
+                "--api-dir=" + self.prefix.share.qsci,
+                "--verbose",
+            )
 
-                link_qscilibs = "LIBS += -L" + self.prefix.lib + " -lqscintilla2_" + qtx
-                qscipro.filter(
-                    "TEMPLATE = lib",
-                    "TEMPLATE = lib\nINCLUDEPATH += {includepath}\nQT += widgets" + "\nQT += printsupport\n" + link_qscilibs,
-                )
+            makefile = FileFilter(join_path("build","Qsci", "Makefile"))
+            makefile.filter("$(INSTALL_ROOT)", "", string=True)
+            make("install","-C",join_path("build","Qsci"), parallel=False)
 
-                make()
-
-                # Fix installation prefixes
-                makefile = FileFilter("Makefile")
-                makefile.filter("$(INSTALL_ROOT)", "", string=True)
-
-                if "@2.11:" in self.spec:
-                    make("install", parallel=False)
-                else:
-                    make("install", parallel=False)
-
-            if 'py-pyqt6' in self.spec:
-                with working_dir(join_path(self.stage.source_path, "Python")):
-                    cp = which('cp')
-                    cp('pyproject-qt6.toml', 'pyproject.toml')
-                    sip_inc_dir = join_path(self.spec['py-pyqt6'].prefix, self.spec['python'].package.platlib, 'PyQt6', 'bindings' )
-                    with open('pyproject.toml', 'a') as tomlfile:
-                        tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
-                    mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
-
-                    sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
-                    sip_build(
-                        "--target-dir=" + python_platlib,
-                        "--qsci-include-dir=" + self.spec.prefix.include,
-                        "--qsci-library-dir=" + self.spec.prefix.lib,
-                        "--api-dir=" + self.prefix.share.qsci,
-                        "--verbose",
-                    )
-                    makefile = FileFilter(join_path("build","Qsci", "Makefile"))
-                    makefile.filter("$(INSTALL_ROOT)", "", string=True)
-                    make("install","-C",join_path("build","Qsci"), parallel=False)
-
-                    makefile = FileFilter(join_path("build","Makefile"))
-                    makefile.filter("$(INSTALL_ROOT)", "", string=True)
-                    make("install","-C","build/", parallel=False)
-
-            else: #pyqt4 or 5
-                with working_dir(join_path(self.stage.source_path, "Python")):
-                    pydir = join_path(python_platlib, pyqtx)
-                    mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
-                    python = self.spec["python"].command
-                    python(
-                        "configure.py",
-                        "--pyqt=" + pyqtx,
-                        "--sip=" + self.spec["py-sip"].prefix.bin.sip,
-                        "--qsci-incdir=" + self.spec.prefix.include,
-                        "--qsci-libdir=" + self.spec.prefix.lib,
-                        "--qsci-sipdir=" + os.path.join(self.prefix.share.sip, pyqtx),
-                        "--apidir=" + self.prefix.share.qsci,
-                        "--destdir=" + pydir,
-                        "--pyqt-sipdir=" + os.path.join(self.spec[py_pyqtx].prefix.share.sip, pyqtx),
-                        "--sip-incdir="
-                        + join_path(
-                            self.spec["py-sip"].prefix.include,
-                            "python" + str(self.spec["python"].version.up_to(2)),
-                        ),
-                        "--stubsdir=" + pydir,
-                    )
-
-
-    @run_after("install")
-    def extend_path_setup(self):
-        if self.spec["py-sip"].satisfies("@:4"):
-            # See github issue #14121 and PR #15297
-            module = self.spec["py-sip"].variants["module"].value
-            if module != "sip":
-                module = module.split(".")[0]
-                with working_dir(python_platlib):
-                    with open(os.path.join(module, "__init__.py"), "w") as f:
-                        f.write("from pkgutil import extend_path\n")
-                        f.write("__path__ = extend_path(__path__, __name__)\n")
+            makefile = FileFilter(join_path("build","Makefile"))
+            makefile.filter("$(INSTALL_ROOT)", "", string=True)
+            make("install","-C","build/", parallel=False)

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -76,7 +76,8 @@ class Qscintilla(QMakePackage):
             qmake('designer.pro', 'INCLUDEPATH+=../src')
             make()
             makefile = FileFilter("Makefile")
-            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)", string=True)
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)",
+                            string=True)
             make("install")
 
     @run_after("install", when='+python')
@@ -106,8 +107,8 @@ class Qscintilla(QMakePackage):
                 qsciproj = FileFilter(join_path("project.py"))
                 ptrn="super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG",
                 qsciproj.filter(
-                    ptrn+")",
-                    ptrn+",qmake_QT=['widgets','printsupport'])", string=True)
+                    ptrn + ")",
+                    ptrn + ",qmake_QT=['widgets','printsupport'])", string=True)
             sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
             sip_build(
                 "--target-dir=" + python_platlib,

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -96,8 +96,7 @@ class Qscintilla(QMakePackage):
             ftoml = 'pyproject-qt6.toml'
 
         with working_dir(join_path(self.stage.source_path, "Python")):
-            cp = which('cp')
-            cp(ftoml, 'pyproject.toml')
+            copy(ftoml, 'pyproject.toml')
             sip_inc_dir = join_path(self.spec[py_pyqtx].prefix,
                                     self.spec['python'].package.platlib, pyqtx, 'bindings')
 

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
+import os,sys
 
 from spack.package import *
 
@@ -17,6 +17,7 @@ class Qscintilla(QMakePackage):
     url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
 
     # Directory structure is changed in latest release, logic is lost
+    version("2.13.3", sha256="711d28e37c8fccaa8229e8e39a5b3b2d97f3fffc63da10b71c71b84fa3649398")
     version(
         "2.12.0",
         sha256="a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed",
@@ -27,7 +28,6 @@ class Qscintilla(QMakePackage):
     version(
         "2.11.6",
         sha256="e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7",
-        preferred=True,
         url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla-2.11.6.tar.gz",
     )
     version(
@@ -44,8 +44,11 @@ class Qscintilla(QMakePackage):
     variant("designer", default=False, description="Enable pluging for Qt-Designer")
     variant("python", default=False, description="Build python bindings")
 
-    depends_on("qt+opengl", when="+python")
-    depends_on("qt")
+    depends_on("qt+opengl", when="+python ^qt@5")
+    depends_on("qt-base+opengl", when="+python ^qt-base")
+    depends_on("qmake")
+    depends_on("py-pyqt6", type=("build", "run"), when="+python ^qt-base")
+    depends_on("py-pyqt-builder", type="build", when="+python")
     depends_on("py-pyqt5", type=("build", "run"), when="+python ^qt@5")
     depends_on("py-pyqt4 +qsci_api", type=("build", "run"), when="+python ^qt@4")
     depends_on("python", type=("build", "run"), when="+python")
@@ -53,7 +56,12 @@ class Qscintilla(QMakePackage):
     depends_on("py-sip", type="build", when="~python")
 
     extends("python", when="+python")
-    build_directory = "Qt4Qt5"
+    @property
+    def build_directory(self):
+        if self.version >= Version("2.12"):
+            return "src"
+        else:
+            return "Qt4Qt5"
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build
@@ -70,10 +78,27 @@ class Qscintilla(QMakePackage):
         env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
 
     # Fix install prefix
+    @run_before("qmake")
+    def fix_qaccesswidget(self):
+        with working_dir(join_path(self.stage.source_path, "src")):
+            qscipro = FileFilter("qscintilla.pro")
+
+            qscipro.filter(
+                "TEMPLATE = lib",
+                "TEMPLATE = lib\nDEFINES += QT_NO_ACCESSIBILITY\nINCLUDEPATH += "+str(self.spec['qt-base'].prefix)+'/include'+"\nQT += widgets" + "\nQT += printsupport\n",
+            )
+
+
+    # Fix install prefix
     @run_after("qmake")
     def fix_install_path(self):
-        makefile = FileFilter(join_path("Qt4Qt5", "Makefile"))
-        makefile.filter(r"\$\(INSTALL_ROOT\)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)")
+        # qt <= 5
+        #makefile = FileFilter(join_path("Qt4Qt5", "Makefile"))
+        #makefile.filter(r"\$\(INSTALL_ROOT\)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)")
+        # qt-base@6
+        makefile = FileFilter(join_path(self.build_directory, "Makefile"))
+        makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix, "$(INSTALL_ROOT)", string=True, backup=True)
+
 
     @run_after("install")
     def postinstall(self):
@@ -98,57 +123,90 @@ class Qscintilla(QMakePackage):
             elif "^py-pyqt5" in self.spec:
                 py_pyqtx = "py-pyqt5"
                 pyqtx = "PyQt5"
+            elif "^py-pyqt6" in self.spec:
+                py_pyqtx = "py-pyqt6"
+                pyqtx = "PyQt6"
 
-            with working_dir(join_path(self.stage.source_path, "Python")):
-                pydir = join_path(python_platlib, pyqtx)
-                mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
-                python = self.spec["python"].command
-                python(
-                    "configure.py",
-                    "--pyqt=" + pyqtx,
-                    "--sip=" + self.spec["py-sip"].prefix.bin.sip,
-                    "--qsci-incdir=" + self.spec.prefix.include,
-                    "--qsci-libdir=" + self.spec.prefix.lib,
-                    "--qsci-sipdir=" + os.path.join(self.prefix.share.sip, pyqtx),
-                    "--apidir=" + self.prefix.share.qsci,
-                    "--destdir=" + pydir,
-                    "--pyqt-sipdir=" + os.path.join(self.spec[py_pyqtx].prefix.share.sip, pyqtx),
-                    "--sip-incdir="
-                    + join_path(
-                        self.spec["py-sip"].prefix.include,
-                        "python" + str(self.spec["python"].version.up_to(2)),
-                    ),
-                    "--stubsdir=" + pydir,
-                )
-
+            with working_dir(join_path(self.stage.source_path, "src")):
                 # Fix build errors
                 # "QAbstractScrollArea: No such file or directory"
                 # "qprinter.h: No such file or directory"
                 # ".../Qsci.so: undefined symbol: _ZTI10Qsci...."
-                qscipro = FileFilter("Qsci/Qsci.pro")
+                qscipro = FileFilter("qscintilla.pro")
                 if "^qt@4" in self.spec:
                     qtx = "qt4"
                 elif "^qt@5" in self.spec:
                     qtx = "qt5"
+                elif "^qt-base@6" in self.spec:
+                    qtx = "qt6"
+
 
                 link_qscilibs = "LIBS += -L" + self.prefix.lib + " -lqscintilla2_" + qtx
                 qscipro.filter(
                     "TEMPLATE = lib",
-                    "TEMPLATE = lib\nQT += widgets" + "\nQT += printsupport\n" + link_qscilibs,
+                    "TEMPLATE = lib\nINCLUDEPATH += {includepath}\nQT += widgets" + "\nQT += printsupport\n" + link_qscilibs,
                 )
 
                 make()
 
                 # Fix installation prefixes
                 makefile = FileFilter("Makefile")
-                makefile.filter(r"\$\(INSTALL_ROOT\)", "")
-                makefile = FileFilter("Qsci/Makefile")
-                makefile.filter(r"\$\(INSTALL_ROOT\)", "")
+                makefile.filter("$(INSTALL_ROOT)", "", string=True)
+                #makefile = FileFilter("Qsci/Makefile")
+                #makefile.filter("$(INSTALL_ROOT)", "", string=True)
 
                 if "@2.11:" in self.spec:
                     make("install", parallel=False)
                 else:
-                    make("install")
+                    make("install", parallel=False)
+
+            if 'py-pyqt6' in self.spec:
+                with working_dir(join_path(self.stage.source_path, "Python")):
+                    cp = which('cp')
+                    cp('pyproject-qt6.toml', 'pyproject.toml')
+                    # TODO below sip_inc_dir is incorrect:
+                    # its prefix of qscintilla itself as opposed to prefix for py-pyqt6
+                    # qscintilla+python builds fine when sip_inc_dir is hardcoded!
+                    str(self.spec)
+                    sip_inc_dir = join_path(self.spec['py-pyqt6'].prefix, python_platlib, 'PyQt6', 'bindings' )
+                    with open('pyproject.toml', 'a') as tomlfile:
+                        tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["/home/sbulut/Downloads/spack/opt/spack/linux-linuxmint21-skylake/gcc-11.4.0/py-pyqt6-6.5.1-6vq3475u5e3s74qbpv3gnwashddf6pni/lib/python3.10/site-packages/PyQt6/bindings"]\n')
+                        #tomlfile.write('\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
+                    mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
+
+                    sip_build = Executable(self.spec["py-sip"].prefix.bin.join("sip-build"))
+                    sip_build(
+                        "--target-dir=" + self.spec.prefix,
+                        "--qsci-include-dir=" + self.spec.prefix.include,
+                        "--qsci-library-dir=" + self.spec.prefix.lib,
+                        "--api-dir=" + self.prefix.share.qsci,
+                        "--verbose",
+                    )
+                    make("install","-C","build/")
+
+            else: #pyqt4 or 5
+                with working_dir(join_path(self.stage.source_path, "Python")):
+                    pydir = join_path(python_platlib, pyqtx)
+                    mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
+                    python = self.spec["python"].command
+                    python(
+                        "configure.py",
+                        "--pyqt=" + pyqtx,
+                        "--sip=" + self.spec["py-sip"].prefix.bin.sip,
+                        "--qsci-incdir=" + self.spec.prefix.include,
+                        "--qsci-libdir=" + self.spec.prefix.lib,
+                        "--qsci-sipdir=" + os.path.join(self.prefix.share.sip, pyqtx),
+                        "--apidir=" + self.prefix.share.qsci,
+                        "--destdir=" + pydir,
+                        "--pyqt-sipdir=" + os.path.join(self.spec[py_pyqtx].prefix.share.sip, pyqtx),
+                        "--sip-incdir="
+                        + join_path(
+                            self.spec["py-sip"].prefix.include,
+                            "python" + str(self.spec["python"].version.up_to(2)),
+                        ),
+                        "--stubsdir=" + pydir,
+                    )
+
 
     @run_after("install")
     def extend_path_setup(self):

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -108,7 +108,7 @@ class Qscintilla(QMakePackage):
 
             with open('pyproject.toml', 'a') as tomlfile:
                 tomlfile.write(
-                        '\n[tool.sip.project]\nsip-include-dirs = ["'+str(sip_inc_dir)+'"]\n')
+                        f'\n[tool.sip.project]\nsip-include-dirs = ["{sip_inc_dir}"]\n')
             mkdirp(os.path.join(self.prefix.share.sip, pyqtx))
 
             if '^py-pyqt5' in self.spec:

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -130,8 +130,8 @@ class Qscintilla(QMakePackage):
 
             makefile = FileFilter(join_path("build","Qsci", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
-            make("install","-C",join_path("build", "Qsci"), parallel=False)
+            make("install", "-C", join_path("build", "Qsci"), parallel=False)
 
             makefile = FileFilter(join_path("build", "Makefile"))
             makefile.filter("$(INSTALL_ROOT)", "", string=True)
-            make("install","-C","build/", parallel=False)
+            make("install", "-C", "build/", parallel=False)

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -18,6 +18,7 @@ class Qscintilla(QMakePackage):
 
     # Directory structure is changed in latest release, logic is lost
 
+    version("2.14.1", sha256="dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d")
     version("2.14.0", sha256="449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c")
     version("2.13.4", sha256="890c261f31e116f426b0ea03a136d44fc89551ebfd126d7b0bdf8a7197879986")
     version("2.13.3", sha256="711d28e37c8fccaa8229e8e39a5b3b2d97f3fffc63da10b71c71b84fa3649398")

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -42,12 +42,7 @@ class Qscintilla(QMakePackage):
     # https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/ChangeLog
     conflicts('^qt@4', when='@2.12:')
 
-    @property
-    def build_directory(self):
-        if self.version >= Version("2.12"):
-            return "src"
-        else:
-            return "Qt4Qt5"
+    build_directory = "src"
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -16,8 +16,7 @@ class Qscintilla(QMakePackage):
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/intro"
     url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
 
-    # Directory structure is changed in latest release, logic is lost
-
+    # Directory structure is changed as of ver. 2.12.0
     version("2.14.1", sha256="dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d")
     version("2.14.0", sha256="449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c")
     version("2.13.4", sha256="890c261f31e116f426b0ea03a136d44fc89551ebfd126d7b0bdf8a7197879986")
@@ -41,7 +40,7 @@ class Qscintilla(QMakePackage):
     # https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/ChangeLog
     conflicts("^qt@4", when="@2.12:")
 
-    build_directory = "src"
+    build_directory = "src" # was Qt4Qt5 before 2.12.0
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -17,12 +17,11 @@ class Qscintilla(QMakePackage):
     url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
 
     # Directory structure is changed in latest release, logic is lost
+
+    version("2.14.0", sha256="449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c")
+    version("2.13.4", sha256="890c261f31e116f426b0ea03a136d44fc89551ebfd126d7b0bdf8a7197879986")
     version("2.13.3", sha256="711d28e37c8fccaa8229e8e39a5b3b2d97f3fffc63da10b71c71b84fa3649398")
-    version(
-        "2.12.0",
-        sha256="2116181cce3076aa4897e36182532d0e6768081fb0cf6dcdd5be720519ab1434",
-        url="https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz",
-    )
+    version("2.12.0", sha256="2116181cce3076aa4897e36182532d0e6768081fb0cf6dcdd5be720519ab1434")
 
     variant("designer", default=False, description="Enable pluging for Qt-Designer")
     variant("python", default=False, description="Build python bindings")
@@ -105,7 +104,7 @@ class Qscintilla(QMakePackage):
                 # QT += widgets and QT += printsupport need to be added to Qsci.pro file
                 # to be generated via project.py
                 qsciproj = FileFilter(join_path("project.py"))
-                ptrn="super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG",
+                ptrn = "super().__init__(project, 'Qsci', qmake_CONFIG=qmake_CONFIG",
                 qsciproj.filter(
                     ptrn + ")",
                     ptrn + ",qmake_QT=['widgets','printsupport'])", string=True)

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -66,12 +66,8 @@ class Qscintilla(QMakePackage):
     @run_after("qmake")
     def fix_install_path(self):
         makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
-        if '^qt-base' in self.spec:
-            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt-base"].prefix,
-                            "$(INSTALL_ROOT)", string=True)
-        else:
-            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix,
-                            "$(INSTALL_ROOT)", string=True)
+        makefile.filter("$(INSTALL_ROOT)" + self.spec["qmake"].prefix,
+                        "$(INSTALL_ROOT)", string=True)
 
     @run_after("install", when='+designer')
     def make_designer(self):

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -148,8 +148,6 @@ class Qscintilla(QMakePackage):
                 # Fix installation prefixes
                 makefile = FileFilter("Makefile")
                 makefile.filter("$(INSTALL_ROOT)", "", string=True)
-                #makefile = FileFilter("Qsci/Makefile")
-                #makefile.filter("$(INSTALL_ROOT)", "", string=True)
 
                 if "@2.11:" in self.spec:
                     make("install", parallel=False)
@@ -173,9 +171,13 @@ class Qscintilla(QMakePackage):
                         "--api-dir=" + self.prefix.share.qsci,
                         "--verbose",
                     )
+                    makefile = FileFilter(join_path("build","Qsci", "Makefile"))
+                    makefile.filter("$(INSTALL_ROOT)", "", string=True)
+                    make("install","-C",join_path("build","Qsci"), parallel=False)
+
                     makefile = FileFilter(join_path("build","Makefile"))
                     makefile.filter("$(INSTALL_ROOT)", "", string=True)
-                    make("install","-C","build/")
+                    make("install","-C","build/", parallel=False)
 
             else: #pyqt4 or 5
                 with working_dir(join_path(self.stage.source_path, "Python")):

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -77,7 +77,7 @@ class Qscintilla(QMakePackage):
             make()
             makefile = FileFilter("Makefile")
             makefile.filter(
-                "$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)", string=True
+                "$(INSTALL_ROOT)" + self.spec["qmake"].prefix, "$(INSTALL_ROOT)", string=True
             )
             make("install")
 

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -81,7 +81,7 @@ class Qscintilla(QMakePackage):
             qmake('designer.pro', 'INCLUDEPATH+=../src')
             make()
             makefile = FileFilter("Makefile")
-            makefile.filter(r"\$\(INSTALL_ROOT\)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)")
+            makefile.filter("$(INSTALL_ROOT)" + self.spec["qt"].prefix, "$(INSTALL_ROOT)", string=True)
             make("install")
 
     @run_after("install", when='+python')

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -40,7 +40,7 @@ class Qscintilla(QMakePackage):
     # https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/ChangeLog
     conflicts("^qt@4", when="@2.12:")
 
-    build_directory = "src" # was Qt4Qt5 before 2.12.0
+    build_directory = "src"  # was Qt4Qt5 before 2.12.0
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build


### PR DESCRIPTION
`qscintilla+python` builds fine except `self.spec['py-pyqt6'].prefix` return's qscintilla's prefix as opposed to `py-pyqt6`'s. I hardcoded this prefix so make sure rest of the build works.