### PR TITLE
py-uhi: new versions 0.3.2, 0.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-uhi/package.py
+++ b/var/spack/repos/builtin/packages/py-uhi/package.py
@@ -13,11 +13,15 @@ class PyUhi(PythonPackage):
     homepage = "https://github.com/Scikit-HEP/uhi"
     pypi = "uhi/uhi-0.3.0.tar.gz"
 
+    version("0.3.3", sha256="800caf3a5f1273b08bcc3bb4b49228fe003942e23423812b0110546aad9a24be")
+    version("0.3.2", sha256="fd6ed2ae8ce68ba6be37b872de86e7775b45d54f858768c8fdaba162b6452ab2")
     version("0.3.1", sha256="6f1ebcadd1d0628337a30b012184325618047abc01c3539538b1655c69101d91")
     version("0.3.0", sha256="3f441bfa89fae11aa762ae1ef1b1b454362d228e9084477773ffb82d6e9f5d2c")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-numpy@1.13.3:", type=("build", "run"))
     depends_on("py-typing-extensions@3.7:", type=("build", "run"), when="^python@:3.7")
+    depends_on("py-hatchling", when="@0.3.2:", type="build")
+    depends_on("py-hatch-vcs", when="@0.3.3:", type="build")
+    depends_on("py-flit-core@3.2:", when="@0.3.1", type="build")
     depends_on("py-poetry-core@1:", when="@:0.3.0", type="build")
-    depends_on("py-flit-core@3.2:", when="@0.3.1:", type="build")


### PR DESCRIPTION
`py-uhi` switched to flit then hatchling for the new versions.

Last three versions all install fine:
```console
$ spack find -lvx
==> In environment py-uhi
==> Root specs
------- py-uhi@0.3.1   ------- py-uhi@0.3.2   ------- py-uhi@0.3.3 

==> Installed packages
-- linux-ubuntu23.04-skylake / gcc@13.1.0 -----------------------
b2awmfd py-uhi@0.3.1 build_system=python_pip  h2ixlan py-uhi@0.3.2 build_system=python_pip  rizcwpw py-uhi@0.3.3 build_system=python_pip
==> 3 installed packages
```