### PR TITLE
cepgen: new version 1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/cepgen/package.py
+++ b/var/spack/repos/builtin/packages/cepgen/package.py
@@ -14,11 +14,15 @@ class Cepgen(CMakePackage):
 
     tags = ["hep"]
 
+    version("1.1.0", sha256="2a4eaed161f007269516cbfb6e90421e657ab1922d4509de0165f08dde91bf3d")
     version(
         "1.0.2patch1", sha256="333bba0cb1965a98dec127e00c150eab1a515cd348a90f7b1d66d5cd8d206d21"
     )
 
     generator("ninja")
+
+    depends_on("cmake@3.5:", type="build", when="@1.0:")
+    depends_on("cmake@3.20:", type="build", when="@1.1:")
 
     depends_on("gsl")
     depends_on("openblas")


### PR DESCRIPTION
No build system changes beyond the increase in CMake minimum version, https://github.com/cepgen/cepgen/releases/tag/1.1.0.