### PR TITLE
singularityce: fix after no spaces in Executable allowed

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -79,14 +79,14 @@ class SingularityBase(MakefilePackage):
     # Hijack the edit stage to run mconfig.
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
-            confstring = "./mconfig --prefix=%s" % prefix
-            confstring += " " + " ".join(self.config_options)
+            _config_options = ["--prefix=%s" % prefix]
+            _config_options += self.config_options
             if "~suid" in spec:
-                confstring += " --without-suid"
+                _config_options += " --without-suid"
             if "~network" in spec:
-                confstring += " --without-network"
-            configure = Executable(confstring)
-            configure()
+                _config_options += " --without-network"
+            configure = Executable("./mconfig")
+            configure(*_config_options)
 
     # Set these for use by MakefilePackage's default build/install methods.
     build_targets = ["-C", "builddir", "parallel=False"]


### PR DESCRIPTION
After https://github.com/spack/spack/commit/c202a045e69ea2968ddff41008518cc427d8ddac the `singularityce` treatment of `./mconfig` fails, leading to failing installs for `apptainer`, `singularity`, `singularityce`.

This changes the config string to a list of options that is passed to the executable after it has been created.

Tested that this now builds `apptainer` without problems.