### PR TITLE
py-scipy: re-apply scipy/scipy#14935 workaround

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -193,7 +193,7 @@ class PyScipy(PythonPackage):
 
         # https://github.com/scipy/scipy/issues/14935
         if self.spec.satisfies("%intel ^py-pythran") or self.spec.satisfies("%oneapi ^py-pythran"):
-            if self.spec["py-pythran"].version < Version("0.12"):
+            if self.spec["py-pythran"].version < Version("0.13"):
                 env.set("SCIPY_USE_PYTHRAN", "0")
 
         # Pick up BLAS/LAPACK from numpy

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -192,9 +192,8 @@ class PyScipy(PythonPackage):
                 env.set("NPY_DISTUTILS_APPEND_FLAGS", "1")
 
         # https://github.com/scipy/scipy/issues/14935
-        if self.spec.satisfies("%intel ^py-pythran") or self.spec.satisfies("%oneapi ^py-pythran"):
-            if self.spec["py-pythran"].version < Version("0.13"):
-                env.set("SCIPY_USE_PYTHRAN", "0")
+        if self.spec.satisfies("%intel ^py-pythran"):
+            env.set("SCIPY_USE_PYTHRAN", "0")
 
         # Pick up BLAS/LAPACK from numpy
         if self.spec.satisfies("@:1.8"):


### PR DESCRIPTION
It appears the promised fixes in scipy/scipy#14935 did not make it into upstream `py-pythran@0.12.x`.  I still get build failures with `intel-classic@2021.2.0` when using `py-pythran@0.12.0` AND the latest `py-pythran@0.12.2` so this MR simply bumps the conditional to wait for `py-pythran@0.13.x`.