### PR TITLE
py-boost-histogram: new version 1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-boost-histogram/package.py
+++ b/var/spack/repos/builtin/packages/py-boost-histogram/package.py
@@ -12,6 +12,7 @@ class PyBoostHistogram(PythonPackage):
     homepage = "https://github.com/scikit-hep/boost-histogram"
     pypi = "boost_histogram/boost_histogram-1.2.1.tar.gz"
 
+    version("1.3.2", sha256="e175efbc1054a27bc53fbbe95472cac9ea93999c91d0611840d776b99588d51a")
     version("1.3.1", sha256="31cd396656f3a37834e07d304cdb84d9906bc2172626a3d92fe577d08bcf410f")
     version("1.2.1", sha256="a27842b2f1cfecc509382da2b25b03056354696482b38ec3c0220af0fc9b7579")
 


### PR DESCRIPTION
New versions, no changes to package requirements.

```console
==> Installing py-boost-histogram-1.3.2-b2nrginfubtnfudkvtzucyxjhvywe6dl [42/42]
==> No binary for py-boost-histogram-1.3.2-b2nrginfubtnfudkvtzucyxjhvywe6dl found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/b/boost_histogram/boost_histogram-1.3.2.tar.gz
==> No patches needed for py-boost-histogram
==> py-boost-histogram: Executing phase: 'install'
==> py-boost-histogram: Successfully installed py-boost-histogram-1.3.2-b2nrginfubtnfudkvtzucyxjhvywe6dl
  Stage: 1.85s.  Install: 1m 48.70s.  Post-install: 0.07s.  Total: 1m 50.76s
[+] /opt/software/linux-ubuntu23.04-skylake/gcc-13.1.0/py-boost-histogram-1.3.2-b2nrginfubtnfudkvtzucyxjhvywe6dl
```