### PR TITLE
aws-sdk-cpp: disable tests

### DIFF
--- a/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
+++ b/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
@@ -36,4 +36,8 @@ class AwsSdkCpp(CMakePackage):
     )
 
     def cmake_args(self):
-        return [self.define("BUILD_ONLY", ("s3", "transfer"))]
+        return [
+            self.define("BUILD_ONLY", ("s3", "transfer")),
+            self.define("ENABLE_TESTING", False),
+            self.define("AUTORUN_UNIT_TESTS", False),
+        ]


### PR DESCRIPTION
The tests are run by default and are very flaky, at least on darwin. Looks like
some race condition.

