### PR TITLE
`llvm@12:15`: fix `elf` dep conditions

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/add-include-for-libelf-llvm-12-14.patch
+++ b/var/spack/repos/builtin/packages/llvm/add-include-for-libelf-llvm-12-14.patch
@@ -1,0 +1,26 @@
+From e5f0939fde75f769c53c6c99c9ed6886e7d58c43 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Wed, 23 Aug 2023 11:35:23 +0200
+Subject: [PATCH] Add corresponding -I for libelf.h
+
+Funnily enough, it's added to `include_directories` in multiple places,
+except where it's necessary.
+---
+ openmp/libomptarget/plugins/amdgpu/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt b/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
+index 92523c23f68b..52e1923f97b7 100644
+--- a/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
++++ b/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
+@@ -51,6 +51,7 @@ endif()
+ include_directories(
+   ${CMAKE_CURRENT_SOURCE_DIR}/impl
+   ${LIBOMPTARGET_LLVM_INCLUDE_DIRS}
++  ${LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR}
+ )
+ 
+ set(LIBOMPTARGET_DLOPEN_LIBHSA OFF)
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/llvm/add-include-for-libelf-llvm-15.patch
+++ b/var/spack/repos/builtin/packages/llvm/add-include-for-libelf-llvm-15.patch
@@ -1,0 +1,26 @@
+From 5e149c3ec8118ad8f3d20a30ce5d3fbac4072515 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Wed, 23 Aug 2023 11:35:23 +0200
+Subject: [PATCH] Add corresponding -I for libelf.h
+
+Funnily enough, it's added to `include_directories` in multiple places,
+except where it's necessary.
+---
+ openmp/libomptarget/plugins/amdgpu/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt b/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
+index 66bf680d15c7..6be12ab6d7f8 100644
+--- a/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
++++ b/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
+@@ -99,6 +99,7 @@ target_include_directories(
+   PRIVATE
+   ${LIBOMPTARGET_INCLUDE_DIR}
+   ${CMAKE_CURRENT_SOURCE_DIR}/impl
++  ${LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR}
+ )
+ 
+ 
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -277,8 +277,9 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("perl-data-dumper", type=("build"))
     depends_on("hwloc")
     depends_on("hwloc@2.0.1:", when="@13")
-    depends_on("elf", when="+cuda")
-    depends_on("elf", when="+libomptarget")
+    with when("@:15"):
+        depends_on("elf", when="+cuda")
+        depends_on("elf", when="+libomptarget")
     depends_on("libffi", when="+libomptarget")
 
     # llvm-config --system-libs libraries.
@@ -778,13 +779,7 @@ class Llvm(CMakePackage, CudaPackage):
                 ]
             )
             if "openmp=runtime" in spec:
-                cmake_args.extend(
-                    [
-                        define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
-                        # work around bad libelf detection in libomptarget
-                        define("LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR", spec["elf"].prefix.include),
-                    ]
-                )
+                cmake_args.append(define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True))
         else:
             # still build libomptarget but disable cuda
             cmake_args.extend(
@@ -925,7 +920,6 @@ class Llvm(CMakePackage, CudaPackage):
                 cmake_args.extend(
                     [
                         define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
-                        define("LIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR", spec["elf"].prefix.include),
                         self.stage.source_path + "/openmp",
                     ]
                 )

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -277,8 +277,9 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("perl-data-dumper", type=("build"))
     depends_on("hwloc")
     depends_on("hwloc@2.0.1:", when="@13")
-    depends_on("elf", when="+cuda")  # libomptarget
-    depends_on("libffi", when="+libomptarget")  # libomptarget
+    depends_on("elf", when="+cuda")
+    depends_on("elf", when="+libomptarget")
+    depends_on("libffi", when="+libomptarget")
 
     # llvm-config --system-libs libraries.
     depends_on("zlib-api")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -542,6 +542,9 @@ class Llvm(CMakePackage, CudaPackage):
         when="@13:14 compiler-rt=runtime",
     )
 
+    patch("add-include-for-libelf-llvm-12-14.patch", when="@12:14")
+    patch("add-include-for-libelf-llvm-15.patch", when="@15")
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #


### PR DESCRIPTION
Should fix Gitlab CI on develop, LLVM forgets to add an `-I` flag, which is problematic for runtimes, since then we don't wrap the compiler.

Fortunately LLVM 16 no longer requires external libelf, and uses LLVM ELF utilities instead.