### PR TITLE
perl-http-message: add dependency on perl-clone

### DIFF
--- a/var/spack/repos/builtin/packages/perl-http-message/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-message/package.py
@@ -21,3 +21,4 @@ class PerlHttpMessage(PerlPackage):
     depends_on("perl-try-tiny", type=("build", "run"))
     depends_on("perl-uri", type=("build", "run"))
     depends_on("perl-http-date", type=("build", "run"))
+    depends_on("perl-clone", type=("build", "run"))


### PR DESCRIPTION
Clone is a hard dependency as of HTTP-Message v6.44. This causes problems in packages like Roary which depend on perl-http-message:

    $ spack load roary
    $ roary
    Use of uninitialized value in require at /var/scratch/spack/opt/spack/linux-centos8-x86_64_v3/gcc-8.5.0/perl-http-message-6.44-lzp5th4jddd3gojkjfli4hljgem2nl26/lib/perl5/HTTP/Headers.pm line 8.
    Can't locate Clone.pm in @INC (you may need to install the Clone module) (@INC contains:  /home/aorth/lib ...

See: https://github.com/libwww-perl/HTTP-Message/blob/master/Changes