### PR TITLE
extendee_spec: fix traversal key

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -49,6 +49,7 @@ import spack.paths
 import spack.repo
 import spack.spec
 import spack.store
+import spack.traverse
 import spack.url
 import spack.util.environment
 import spack.util.path
@@ -1231,7 +1232,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         deps = []
 
         # If the extendee is in the spec's deps already, return that.
-        for dep in self.spec.traverse(deptype=("link", "run")):
+        for dep in self.spec.traverse(deptype=("link", "run"), key=spack.traverse.by_dag_hash):
             if dep.name in self.extendees:
                 deps.append(dep)
 


### PR DESCRIPTION
Due to #39570 we may end up in a situation where the same spec appears multiple
times in the link-run sub-dag, with same dag hash, but different `id`.

Therefore, key by dag hash when iterating.


