### PR TITLE
spack.caches: make fetch_cache_location lowercase

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -443,7 +443,7 @@ def mirror_create(args):
         )
 
     # When no directory is provided, the source dir is used
-    path = args.directory or spack.caches.FETCH_CACHE_location()
+    path = args.directory or spack.caches.fetch_cache_location()
 
     if args.all and not ev.active_environment():
         create_mirror_for_all_specs(


### PR DESCRIPTION
`fetch_cache_location` was erroneously renamed to `FETCH_CACHE_location` as part of #39428, resulting in the following error when doing `spack module create`:

```
==> Error: module 'spack.caches' has no attribute 'FETCH_CACHE_location'
```