### PR TITLE
Update version constraint for HIP patch

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -339,7 +339,7 @@ class Hip(CMakePackage):
     patch(
         "https://github.com/ROCm-Developer-Tools/HIP/commit/50ee82f6bc4aad10908ce09198c9f7ebfb2a3561.patch?full_index=1",
         sha256="c2ee21cdc55262c7c6ba65546b5ca5f65ea89730",
-        when="@5.2:5.4",
+        when="@5.2:",
     )
 
     @property


### PR DESCRIPTION
The given patch still hasn't made it upstream and applies to at least 5.5. I've removed the upper bound because I've seen no indication that this would get merged upstream but can keep the upper bound at 5.5 as well if you'd prefer that.