### PR TITLE
xmlrpc-c: Add build of xmlrpc tools directory

### DIFF
--- a/var/spack/repos/builtin/packages/xmlrpc-c/package.py
+++ b/var/spack/repos/builtin/packages/xmlrpc-c/package.py
@@ -24,3 +24,13 @@ class XmlrpcC(AutotoolsPackage):
             args.append("--build=arm-linux")
 
         return args
+
+    def build(self, spec, prefix):
+        make()
+        with working_dir("tools"):
+            make()
+
+    def install(self, spec, prefix):
+        make("install")
+        with working_dir("tools"):
+            make("install")


### PR DESCRIPTION
The xmlrpc tools directory is not included in the standard `make` or `make install` invocations, but includes useful tools such as the `xmlrpc` command-line client.