### PR TITLE
ASP-based solver: unique objects for reused specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2949,12 +2949,10 @@ class SpecBuilder:
         # fix flags after all specs are constructed
         self.reorder_flags()
 
-        # cycle detection
-        roots = [spec.root for spec in self._specs.values() if not spec.root.installed]
-
         # inject patches -- note that we' can't use set() to unique the
         # roots here, because the specs aren't complete, and the hash
         # function will loop forever.
+        roots = [spec.root for spec in self._specs.values() if not spec.root.installed]
         roots = dict((id(r), r) for r in roots)
         for root in roots.values():
             spack.spec.Spec.inject_patches_variant(root)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1005,14 +1005,15 @@ class ReusableSpecsByHash(collections.abc.Mapping):
         if dag_hash in self.data:
             return False
 
-        # Unify objects in the container
-        for edge in reversed(spack.traverse.traverse_edges_topo([spec], direction="children")):
-            current_node = edge.spec
+        # Unify objects in the container. The current implementation needs children
+        # nodes to be visited before parents (so DFS post-order is fine).
+        for current_node in traverse.traverse_nodes([spec], order="post", direction="children"):
             current_hash = current_node.dag_hash()
 
             if current_hash in self.data:
                 continue
 
+            # Add the node and reconstruct dependencies
             self.data[current_hash] = current_node.copy(deps=False)
             container_node = self.data[current_hash]
             for edge_under_reconstruction in current_node.edges_to_dependencies():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2620,7 +2620,6 @@ class SpecBuilder:
         self._specs = {}
         self._result = None
         self._command_line_specs = specs
-        self._hash_specs = []
         self._flag_sources = collections.defaultdict(lambda: set())
         self._flag_compiler_defaults = set()
 
@@ -2631,7 +2630,6 @@ class SpecBuilder:
     def hash(self, node, h):
         if node not in self._specs:
             self._specs[node] = self._hash_lookup[h]
-        self._hash_specs.append(node)
 
     def node(self, node):
         if node not in self._specs:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1170,7 +1170,7 @@ class TestConcretize:
     )
     @pytest.mark.parametrize("mock_db", [True, False])
     def test_reuse_does_not_overwrite_dev_specs(
-        self, dev_first, spec, mock_db, tmpdir, monkeypatch
+        self, dev_first, spec, mock_db, tmpdir, temporary_store, monkeypatch
     ):
         """Test that reuse does not mix dev specs with non-dev specs.
 
@@ -1182,8 +1182,7 @@ class TestConcretize:
         # dev and non-dev specs that are otherwise identical
         spec = Spec(spec)
         dev_spec = spec.copy()
-        dev_constraint = "dev_path=%s" % tmpdir.strpath
-        dev_spec["dev-build-test-install"].constrain(dev_constraint)
+        dev_spec["dev-build-test-install"].constrain(f"dev_path={tmpdir.strpath}")
 
         # run the test in both orders
         first_spec = dev_spec if dev_first else spec
@@ -1196,7 +1195,7 @@ class TestConcretize:
             return [first_spec]
 
         if mock_db:
-            monkeypatch.setattr(spack.store.STORE.db, "query", mock_fn)
+            temporary_store.db.add(first_spec, None)
         else:
             monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", mock_fn)
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2263,3 +2263,26 @@ class TestConcretizeSeparately:
 def test_drop_moving_targets(v_str, v_opts, checksummed):
     v = Version(v_str)
     assert spack.solver.asp._is_checksummed_version((v, v_opts)) == checksummed
+
+
+class TestConcreteSpecsByHash:
+    """Tests the container of concrete specs"""
+
+    @pytest.mark.parametrize("input_specs", [["a"], ["a foobar=bar", "b"], ["a foobar=baz", "b"]])
+    def test_adding_specs(self, input_specs, default_mock_concretization):
+        """Tests that concrete specs in the container are equivalent, but stored as different
+        objects in memory.
+        """
+        container = spack.solver.asp.ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        for root in input_specs:
+            assert root.dag_hash() in container
+            assert root is not container[root.dag_hash()]
+            assert root == container[root.dag_hash()]
+
+            for node in root.traverse():
+                assert node.dag_hash() in container
+                assert node is not container[node.dag_hash()]

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2279,10 +2279,7 @@ class TestConcreteSpecsByHash:
             container.add(s)
 
         for root in input_specs:
-            assert root.dag_hash() in container
-            assert root is not container[root.dag_hash()]
-            assert root == container[root.dag_hash()]
-
-            for node in root.traverse():
+            for node in root.traverse(root=True):
+                assert node == container[node.dag_hash()]
                 assert node.dag_hash() in container
                 assert node is not container[node.dag_hash()]


### PR DESCRIPTION
fixes #39570

Reused specs used to be referenced directly into the built spec.

This might cause issues like in https://github.com/spack/spack/issues/39570 where two objects in memory represent the same node, because two reused specs were loaded from different sources but referred to the same spec by DAG hash.

Here the issue is solved by registering the concrete specs to be reused in a container that ensures their consistency.
