### PR TITLE
dfbplus: fix compilation

### DIFF
--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -28,7 +28,7 @@ class Dftbplus(MakefilePackage, CMakePackage):
 
     build_system(
         conditional("cmake", when="@20.1:"),
-        conditional("make", when="@:19.1"),
+        conditional("makefile", when="@:19.1"),
         default="cmake",
     )
 

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -76,6 +76,12 @@ class Dftbplus(MakefilePackage, CMakePackage):
         default=False,
         description="Use DftD3 dispersion library " "(if you need this dispersion model)",
     )
+    variant(
+        "api",
+        default=False,
+        description="Build the API library " "(if you need to link to DFTB+ from other codes)",
+        when="build_system=cmake",
+    )
 
     depends_on("lapack")
     depends_on("blas")
@@ -195,5 +201,6 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define("BLAS_FOUND", True),
             self.define("BLAS_INCLUDE_DIRS", spec["blas"].prefix.include),
             self.define("BLAS_LIBRARIES", blas_libs),
+            self.define_from_variant("WITH_API","api")
         ]
         return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class Dftbplus(MakefilePackage):
+class Dftbplus(MakefilePackage, CMakePackage):
     """DFTB+ is an implementation of the
     Density Functional based Tight Binding (DFTB) method,
     containing many extensions to the original method."""
@@ -25,6 +25,12 @@ class Dftbplus(MakefilePackage):
     version("20.1", tag="20.1", submodules=True)  # This and higher version uses Cmake
     version('19.1', tag='19.1', submodules=True)
     # version("19.1", sha256="4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8")
+
+    build_system(
+        conditional("cmake", when="@20.1:"),
+        conditional("make", when="@:19.1"),
+        default="cmake",
+    )
 
     resource(
         name="slakos",
@@ -79,12 +85,16 @@ class Dftbplus(MakefilePackage):
     depends_on("magma", when="+gpu")
     depends_on("arpack-ng", when="+arpack")
     depends_on("dftd3-lib@0.9.2", when="+dftd3")
-    depends_on("m4", type="build")
+    depends_on("m4", type="build", when="@:19.1")
     depends_on("python@3.2:", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))  # for tests
+    depends_on("cmake", type="build", when="@20.1:")
 
 
 
+
+
+class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def edit(self, spec, prefix):
         """
         First, change the ROOT variable, because, for some reason,
@@ -173,3 +183,8 @@ class Dftbplus(MakefilePackage):
             )
 
             mconfig.filter("WITH_DFTD3 := .*", "WITH_DFTD3 := 1")
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        args = [ ]
+        return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -193,8 +193,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         lapack_libs = spec["lapack"].libs.joined(";")
         blas_libs = spec["blas"].libs.joined(";")
         args = [
-            self.define_from_variant("MPI", "mpi"),
-            # self.define_from_variant("ICB", "icb"),
+            self.define_from_variant("WITH_MPI", "mpi"),
             self.define("LAPACK_FOUND", True),
             self.define("LAPACK_INCLUDE_DIRS", spec["lapack"].prefix.include),
             self.define("LAPACK_LIBRARIES", lapack_libs),

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -78,7 +78,7 @@ class Dftbplus(MakefilePackage, CMakePackage):
     )
     variant(
         "api",
-        default=False,
+        default=True,
         description="Build the API library " "(if you need to link to DFTB+ from other codes)",
         when="build_system=cmake",
     )

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -87,6 +87,11 @@ class Dftbplus(MakefilePackage, CMakePackage):
         default=True,
         description="Build with OpenMP support " "(if you need to use OpenMP parallelization)",
     )
+    variant(
+        "sharedlibs",
+        default=False,
+        description="Build as shared library",
+    )
 
     depends_on("lapack")
     depends_on("blas")
@@ -198,6 +203,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         lapack_libs = spec["lapack"].libs.joined(";")
         blas_libs = spec["blas"].libs.joined(";")
         args = [
+            self.define_from_variant("WITH_OPENMP", "openmp"),
             self.define_from_variant("WITH_MPI", "mpi"),
             self.define("LAPACK_FOUND", True),
             self.define("LAPACK_INCLUDE_DIRS", spec["lapack"].prefix.include),
@@ -205,6 +211,13 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define("BLAS_FOUND", True),
             self.define("BLAS_INCLUDE_DIRS", spec["blas"].prefix.include),
             self.define("BLAS_LIBRARIES", blas_libs),
-            self.define_from_variant("WITH_API","api")
+            self.define_from_variant("WITH_ELSI", "elsi"),
+            self.define_from_variant("WITH_GPU", "gpu"),
+            self.define_from_variant("WITH_TRANSPORT", "transport"),
+            self.define_from_variant("WITH_SOCKETS", "sockets"),
+            self.define_from_variant("WITH_ARPACK", "arpack"),
+            self.define_from_variant("WITH_DFTD3", "dftd3"),
+            self.define_from_variant("WITH_API", "api"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "sharedlibs"),
         ]
         return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -82,6 +82,11 @@ class Dftbplus(MakefilePackage, CMakePackage):
         description="Build the API library " "(if you need to link to DFTB+ from other codes)",
         when="build_system=cmake",
     )
+    variant(
+        "openmp",
+        default=True,
+        description="Build with OpenMP support " "(if you need to use OpenMP parallelization)",
+    )
 
     depends_on("lapack")
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -231,7 +231,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if "+mpi" in spec:
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("MPI_Fortran_COMPILER", spec["mpi"].mpifc))
-            args.append(self.define("SCALAPACK_LIBRARY",  spec["scalapack"].libs.join(";")))
-            args.append(self.define("SCALAPACK_LIBRARIES", spec["scalapack"].libs.join(";")))
+            args.append(self.define("SCALAPACK_LIBRARY",  spec["scalapack"].libs.joined(";")))
+            args.append(self.define("SCALAPACK_LIBRARIES", spec["scalapack"].libs.joined(";")))
             args.append(self.define("SCALAPACK_INCLUDE_DIR", spec["scalapack"].prefix.include))
         return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -89,7 +89,7 @@ class Dftbplus(MakefilePackage, CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("elsi", when="+elsi")
     depends_on("magma", when="+gpu")
-    depends_on("arpack-ng", when="+arpack")
+    depends_on("arpack-ng", when="+arpack~mpi")
     depends_on("dftd3-lib@0.9.2", when="+dftd3")
     depends_on("m4", type="build", when="@:19.1")
     depends_on("python@3.2:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -91,9 +91,6 @@ class Dftbplus(MakefilePackage, CMakePackage):
     depends_on("cmake", type="build", when="@20.1:")
 
 
-
-
-
 class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def edit(self, spec, prefix):
         """
@@ -186,5 +183,17 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
-        args = [ ]
+        spec = self.spec
+        lapack_libs = spec["lapack"].libs.joined(";")
+        blas_libs = spec["blas"].libs.joined(";")
+        args = [
+            self.define_from_variant("MPI", "mpi"),
+            self.define_from_variant("ICB", "icb"),
+            self.define("LAPACK_FOUND", True),
+            self.define("LAPACK_INCLUDE_DIRS", spec["lapack"].prefix.include),
+            self.define("LAPACK_LIBRARIES", lapack_libs),
+            self.define("BLAS_FOUND", True),
+            self.define("BLAS_INCLUDE_DIRS", spec["blas"].prefix.include),
+            self.define("BLAS_LIBRARIES", blas_libs),
+        ]
         return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -188,7 +188,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         blas_libs = spec["blas"].libs.joined(";")
         args = [
             self.define_from_variant("MPI", "mpi"),
-            self.define_from_variant("ICB", "icb"),
+            # self.define_from_variant("ICB", "icb"),
             self.define("LAPACK_FOUND", True),
             self.define("LAPACK_INCLUDE_DIRS", spec["lapack"].prefix.include),
             self.define("LAPACK_LIBRARIES", lapack_libs),

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -23,7 +23,7 @@ class Dftbplus(MakefilePackage, CMakePackage):
     version("21.1", tag="21.1", submodules=True)
     version("20.2", tag="20.2", submodules=True)
     version("20.1", tag="20.1", submodules=True)  # This and higher version uses Cmake
-    version('19.1', tag='19.1', submodules=True)
+    version("19.1", tag="19.1", submodules=True)
     # version("19.1", sha256="4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8")
 
     build_system(
@@ -87,11 +87,7 @@ class Dftbplus(MakefilePackage, CMakePackage):
         default=True,
         description="Build with OpenMP support " "(if you need to use OpenMP parallelization)",
     )
-    variant(
-        "sharedlibs",
-        default=False,
-        description="Build as shared library",
-    )
+    variant("sharedlibs", default=False, description="Build as shared library")
 
     depends_on("lapack")
     depends_on("blas")
@@ -197,6 +193,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
             mconfig.filter("WITH_DFTD3 := .*", "WITH_DFTD3 := 1")
 
+
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         # Note: dftbplus@20.1 uses plural form of the option names
@@ -231,7 +228,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if "+mpi" in spec:
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("MPI_Fortran_COMPILER", spec["mpi"].mpifc))
-            args.append(self.define("SCALAPACK_LIBRARY",  spec["scalapack"].libs.joined(";")))
+            args.append(self.define("SCALAPACK_LIBRARY", spec["scalapack"].libs.joined(";")))
             args.append(self.define("SCALAPACK_LIBRARIES", spec["scalapack"].libs.joined(";")))
             args.append(self.define("SCALAPACK_INCLUDE_DIR", spec["scalapack"].prefix.include))
         return args

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -71,6 +71,11 @@ class Dftbplus(MakefilePackage):
     depends_on("magma", when="+gpu")
     depends_on("arpack-ng", when="+arpack")
     depends_on("dftd3-lib@0.9.2", when="+dftd3")
+    depends_on("m4", type="build")
+    depends_on("python@3.2:", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))  # for tests
+
+
 
     def edit(self, spec, prefix):
         """

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -14,9 +14,17 @@ class Dftbplus(MakefilePackage):
     containing many extensions to the original method."""
 
     homepage = "https://www.dftbplus.org"
-    url = "https://github.com/dftbplus/dftbplus/archive/19.1.tar.gz"
-
-    version("19.1", sha256="4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8")
+    # url = "https://github.com/dftbplus/dftbplus/archive/19.1.tar.gz"
+    git = "https://github.com/dftbplus/dftbplus.git"
+    version("23.1", tag="23.1", submodules=True)
+    version("22.2", tag="22.2", submodules=True)
+    version("22.1", tag="22.1", submodules=True)
+    version("21.2", tag="21.2", submodules=True)
+    version("21.1", tag="21.1", submodules=True)
+    version("20.2", tag="20.2", submodules=True)
+    version("20.1", tag="20.1", submodules=True)  # This and higher version uses Cmake
+    version('19.1', tag='19.1', submodules=True)
+    # version("19.1", sha256="4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8")
 
     resource(
         name="slakos",


### PR DESCRIPTION
dftbplus has moved to cmake from version >=20.1
This MR:
- Test compilation with git instead of release tarballs
As suggested at https://github.com/spack/spack/issues/23086
- add a cmake class
- define the variants `api`, `sharedlibs`, `openmp`
- add new versions
- arpack variant available only in serial variant

Tested the spec:
```shell
$ spack install  dftbplus@22.2%gcc@10.3.0~arpack+dftd3~elsi~gpu+mpi+sockets+transport+api+sharedlibs+openmp
...
Installed spec dftbplus-22.2-dsywquizcda4ymfl6u3kauuriugelguc

$ ldd $(spack location -i /dsywq)/bin/dftb+

        libscalapackfx.so => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/dftbplus-22.2-dsywquizcda4ymfl6u3kauuriugelguc/lib/libscalapackfx.so (0x00007f14fea26000)
        libgomp.so.1 => /$SPACK_DIR/opt/spack/linux-debian11-x86_64_v2/gcc-10.2.1/gcc-10.3.0-2jv5rmury5evj3g7of6gfjuwgxt6fv3c/lib64/libgomp.so.1 (0x00007f14fe9e4000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f14fe9b1000)
        libopenblas.so.0 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/openblas-0.3.15-e4jepfgfld6mblcims5ns6fmwhtvhmdq/lib/libopenblas.so.0 (0x00007f14fdcae000)
        libgfortran.so.5 => /$SPACK_DIR/opt/spack/linux-debian11-x86_64_v2/gcc-10.2.1/gcc-10.3.0-2jv5rmury5evj3g7of6gfjuwgxt6fv3c/lib64/libgfortran.so.5 (0x00007f14fd9f2000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f14fd8ae000)
        libgcc_s.so.1 => /$SPACK_DIR/opt/spack/linux-debian11-x86_64_v2/gcc-10.2.1/gcc-10.3.0-2jv5rmury5evj3g7of6gfjuwgxt6fv3c/lib64/libgcc_s.so.1 (0x00007f14fd893000)
        libquadmath.so.0 => /$SPACK_DIR/opt/spack/linux-debian11-x86_64_v2/gcc-10.2.1/gcc-10.3.0-2jv5rmury5evj3g7of6gfjuwgxt6fv3c/lib64/libquadmath.so.0 (0x00007f14fd84a000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f14fd676000)
        libopen-rte.so.40 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/openmpi-4.1.4-p4prjesim3nopnzqgxdrle7xpj3m6jo3/lib/libopen-rte.so.40 (0x00007f14fd552000)
        libopen-pal.so.40 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/openmpi-4.1.4-p4prjesim3nopnzqgxdrle7xpj3m6jo3/lib/libopen-pal.so.40 (0x00007f14fd450000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f14fd448000)
        libpmix.so.2 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/pmix-4.1.2-mnhsyp3ylodczimkdiqgx6dkccv5nh6n/lib/libpmix.so.2 (0x00007f14fd25e000)
        libnl-3.so.200 => /lib/x86_64-linux-gnu/libnl-3.so.200 (0x00007f14fd23b000)
        libnl-route-3.so.200 => /lib/x86_64-linux-gnu/libnl-route-3.so.200 (0x00007f14fd1c0000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f14fd1b6000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f14fd1b1000)
        libz.so.1 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/zlib-1.2.13-pmej54iva3uv3kksar24etztmzonupvn/lib/libz.so.1 (0x00007f14fd195000)
        libhwloc.so.15 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/hwloc-2.8.0-23pr7nufpzanqemkkygm3rnfsoutnfvo/lib/libhwloc.so.15 (0x00007f14fd136000)
        libevent_core-2.1.so.7 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/libevent-2.1.12-gjnv2pspapfrhslmycrskmtq45kenln3/lib/libevent_core-2.1.so.7 (0x00007f14fd0fe000)
        libevent_pthreads-2.1.so.7 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/libevent-2.1.12-gjnv2pspapfrhslmycrskmtq45kenln3/lib/libevent_pthreads-2.1.so.7 (0x00007f14fd0f9000)
        libscalapack.so => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/netlib-scalapack-2.2.0-j3ftwycapnwwsmhiss2uje4uw6prck75/lib/libscalapack.so (0x00007f14fcb57000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f14ffca1000)
        libpciaccess.so.0 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/libpciaccess-0.16-bbfewe32lwqpi4jovvrf2ff54bkk6boi/lib/libpciaccess.so.0 (0x00007f14fcb49000)
        libxml2.so.2 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/libxml2-2.10.1-jyhbf7zlc57t4ormzrnpo4nfss7n2fsn/lib/libxml2.so.2 (0x00007f14fc9e3000)
        liblzma.so.5 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/xz-5.2.7-mqoliwjm3ksvkbfclfs5436rilol2hb2/lib/liblzma.so.5 (0x00007f14fc9b8000)
        libiconv.so.2 => /$SPACK_DIR/opt/spack/linux-debian11-sandybridge/gcc-10.3.0/libiconv-1.16-lsxxshub4ji2nfja7fojeh2pejgovuwr/lib/libiconv.so.2 (0x00007f14fc8b9000)

```

I am not a user of dftbplus, hence these tests were only to conclude that the code compiles, and has the right libraries linked.