### PR TITLE
libtool: prepend ACLOCAL_PATH instead of appending

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -81,7 +81,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
             filter_file("-fno-builtin", "-Mnobuiltin", "libltdl/configure")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.append_path("ACLOCAL_PATH", self.prefix.share.aclocal)
+        env.prepend_path("ACLOCAL_PATH", self.prefix.share.aclocal)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Automake is very likely to be a build dependency, so we add


### PR DESCRIPTION
We do not sanitize `ACLOCAL_PATH` in the build environment (which we probably should do) and we might have a situation when the first entry of `ACLOCAL_PATH` with `libtool.m4` targets the wrong installation of `libtool`, i.e. not the one that Spack considers the dependency. This PR fixes the problem by prepending `ACLOCAL_PATH` in the build environment of a dependent package instead of appending it.