### PR TITLE
legion: depend on cray-pmi when using gasnet and cray-mpich

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -50,7 +50,7 @@ class Legion(CMakePackage, ROCmPackage):
     depends_on("ucx", when="network=ucx")
     depends_on("ucx", when="conduit=ucx")
     depends_on("mpi", when="conduit=mpi")
-    depends_on("cray-pmi", when="conduit=ofi-slingshot11 ^cray-mpich")
+    depends_on("cray-pmi", when="network=gasnet ^cray-mpich")
     depends_on("cuda@10.0:11.9", when="+cuda_unsupported_compiler @:23.03.0")
     depends_on("cuda@10.0:11.9", when="+cuda @:23.03.0")
     depends_on("cuda@10.0:12.2", when="+cuda_unsupported_compiler @23.06.0:")


### PR DESCRIPTION
Previously I added the extra dependency because an external `cray-mpich` wouldn't pull in `cray-pmi` when building for `conduit=ofi-slingshot11` and the internal GASNet build would then complain about it. However, this also affects other conduits such as `mpi`. This PR makes the dependency apply for building with `network=gasnet`, which covers all conduits.