### PR TITLE
enzyme: drop llvm 10 and 11

### DIFF
--- a/var/spack/repos/builtin/packages/enzyme/package.py
+++ b/var/spack/repos/builtin/packages/enzyme/package.py
@@ -24,6 +24,7 @@ class Enzyme(CMakePackage):
     root_cmakelists_dir = "enzyme"
 
     version("main", branch="main")
+    version("0.0.81", sha256="4c17d0c28f0572a3ab97a60f1e56bbc045ed5dd64c2daac53ae34371ca5e8b34")
     version("0.0.69", sha256="144d964187551700fdf0a4807961ceab1480d4e4cd0bb0fc7bbfab48fe053aa2")
     version("0.0.48", sha256="f5af62448dd2a8a316e59342ff445003581bc154f06b9b4d7a5a2c7259cf5769")
     version("0.0.32", sha256="9d42e42f7d0faf9beed61b2b1d27c82d1b369aeb9629539d5b7eafbe95379292")
@@ -34,7 +35,8 @@ class Enzyme(CMakePackage):
     depends_on("llvm@7:12", when="@0.0.13:0.0.15")
     depends_on("llvm@7:14", when="@0.0.32:0.0.47")
     depends_on("llvm@7:14", when="@0.0.48:0.0.68")
-    depends_on("llvm@9:16", when="@0.0.69:")
+    depends_on("llvm@9:16", when="@0.0.69:0.0.79")
+    depends_on("llvm@11:16", when="@0.0.80:")
     depends_on("cmake@3.13:", type="build")
 
     def cmake_args(self):


### PR DESCRIPTION
drop now unsupported llvm versions