### PR TITLE
[SIRIUS] Update package

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -23,16 +23,56 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     version("7.4.3", sha256="015679a60a39fa750c5d1bd8fb1ce73945524bef561270d8a171ea2fd4687fec")
     version("7.4.0", sha256="f9360a695a1e786d8cb9d6702c82dd95144a530c4fa7e8115791c7d1e92b020b")
-    version("7.3.2", sha256="a256508de6b344345c295ad8642dbb260c4753cd87cc3dd192605c33542955d7")
-    version("7.3.1", sha256="8bf9848b8ebf0b43797fd359adf8c84f00822de4eb677e3049f22baa72735e98")
-    version("7.3.0", sha256="69b5cf356adbe181be6c919032859c4e0160901ff42a885d7e7ea0f38cc772e2")
-    version("7.2.7", sha256="929bf7f131a4847624858b9c4295532c24b0c06f6dcef5453c0dfc33fb78eb03")
-    version("7.2.6", sha256="e751fd46cdc7c481ab23b0839d3f27fb00b75dc61dc22a650c92fe8e35336e3a")
-    version("7.2.5", sha256="794e03d4da91025f77542d3d593d87a8c74e980394f658a0210a4fd91c011f22")
-    version("7.2.4", sha256="aeed0e83b80c3a79a9469e7f3fe10d80ad331795e38dbc3c49cb0308e2bd084d")
-    version("7.2.3", sha256="6c10f0e87e50fcc7cdb4d1b2d35e91dba6144de8f111e36c7d08912e5942a906")
-    version("7.2.1", sha256="01bf6c9893ff471473e13351ca7fdc2ed6c1f4b1bb7afa151909ea7cd6fa0de7")
-    version("7.2.0", sha256="537800459db8a7553d7aa251c19f3a31f911930194b068bc5bca2dfb2c9b71db")
+    version(
+            "7.3.2",
+            sha256="a256508de6b344345c295ad8642dbb260c4753cd87cc3dd192605c33542955d7",
+            deprecated=True
+    )
+    version(
+            "7.3.1",
+            sha256="8bf9848b8ebf0b43797fd359adf8c84f00822de4eb677e3049f22baa72735e98",
+            deprecated=True
+    )
+    version(
+            "7.3.0",
+            sha256="69b5cf356adbe181be6c919032859c4e0160901ff42a885d7e7ea0f38cc772e2",
+            deprecated=True
+    )
+    version(
+            "7.2.7",
+            sha256="929bf7f131a4847624858b9c4295532c24b0c06f6dcef5453c0dfc33fb78eb03",
+            deprecated=True
+    )
+    version(
+            "7.2.6",
+            sha256="e751fd46cdc7c481ab23b0839d3f27fb00b75dc61dc22a650c92fe8e35336e3a",
+            deprecated=True
+    )
+    version(
+            "7.2.5",
+            sha256="794e03d4da91025f77542d3d593d87a8c74e980394f658a0210a4fd91c011f22",
+            deprecated=True
+    )
+    version(
+            "7.2.4",
+            sha256="aeed0e83b80c3a79a9469e7f3fe10d80ad331795e38dbc3c49cb0308e2bd084d",
+            deprecated=True
+    )
+    version(
+            "7.2.3",
+            sha256="6c10f0e87e50fcc7cdb4d1b2d35e91dba6144de8f111e36c7d08912e5942a906",
+            deprecated=True
+    )
+    version(
+            "7.2.1",
+            sha256="01bf6c9893ff471473e13351ca7fdc2ed6c1f4b1bb7afa151909ea7cd6fa0de7",
+            deprecated=True
+    )
+    version(
+            "7.2.0",
+            sha256="537800459db8a7553d7aa251c19f3a31f911930194b068bc5bca2dfb2c9b71db",
+            deprecated=True
+    )
     version(
         "7.0.2",
         sha256="ee613607ce3be0b2c3f69b560b2415ce1b0e015179002aa90739430dbfaa0389",
@@ -46,91 +86,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     version(
         "7.0.0",
         sha256="da783df11e7b65668e29ba8d55c8a6827e2216ad6d88040f84f42ac20fd1bb99",
-        deprecated=True,
-    )
-    version(
-        "6.5.7",
-        sha256="d886c3066163c43666ebac2ea50351df03907b5686671e514a75f131ba51b43c",
-        deprecated=True,
-    )
-    version(
-        "6.5.6",
-        sha256="c8120100bde4477545eae489ea7f9140d264a3f88696ec92728616d78f214cae",
-        deprecated=True,
-    )
-    version(
-        "6.5.5",
-        sha256="0b23d3a8512682eea67aec57271031c65f465b61853a165015b38f7477651dd1",
-        deprecated=True,
-    )
-    version(
-        "6.5.4",
-        sha256="5f731926b882a567d117afa5e0ed33291f1db887fce52f371ba51f014209b85d",
-        deprecated=True,
-    )
-    version(
-        "6.5.3",
-        sha256="eae0c303f332425a8c792d4455dca62557931b28a5df8b4c242652d5ffddd580",
-        deprecated=True,
-    )
-    version(
-        "6.5.2",
-        sha256="c18adc45b069ebae03f94eeeeed031ee99b3d8171fa6ee73c7c6fb1e42397fe7",
-        deprecated=True,
-    )
-    version(
-        "6.5.1",
-        sha256="599dd0fa25a4e83db2a359257a125e855d4259188cf5b0065b8e7e66378eacf3",
-        deprecated=True,
-    )
-    version(
-        "6.5.0",
-        sha256="5544f3abbb71dcd6aa08d18aceaf53c38373de4cbd0c3af44fbb39c20cfeb7cc",
-        deprecated=True,
-    )
-    version(
-        "6.4.4",
-        sha256="1c5de9565781847658c3cc11edcb404e6e6d1c5a9dfc81e977de7a9a7a162c8a",
-        deprecated=True,
-    )
-    version(
-        "6.4.3",
-        sha256="4d1effeadb84b3e1efd7d9ac88018ef567aa2e0aa72e1112f0abf2e493e2a189",
-        deprecated=True,
-    )
-    version(
-        "6.4.2",
-        sha256="40b9b66deebb6538fc0f4cd802554d0d763ea6426b9b2f0e8db8dc617e494479",
-        deprecated=True,
-    )
-    version(
-        "6.4.1",
-        sha256="86f25c71517952a63e92e0a9bcf66d27e4afb2b0d67cf84af480f116b8e7f53c",
-        deprecated=True,
-    )
-    version(
-        "6.4.0",
-        sha256="bc61758b71dd2996e2ff515b8c3560b2c69c00931cb2811a163a31bcfea4436e",
-        deprecated=True,
-    )
-    version(
-        "6.3.4",
-        sha256="8839e988b4bb6ef99b6180f7fba03a5537e31fce51bb3e4c2298b513d6a07e0a",
-        deprecated=True,
-    )
-    version(
-        "6.3.3",
-        sha256="7ba30a4e5c9a545433251211454ec0d59b74ba8941346057bc7de11e7f6886f7",
-        deprecated=True,
-    )
-    version(
-        "6.3.2",
-        sha256="1723e5ad338dad9a816369a6957101b2cae7214425406b12e8712c82447a7ee5",
-        deprecated=True,
-    )
-    version(
-        "6.1.5",
-        sha256="379f0a2e5208fd6d91c2bd4939c3a5c40002975fb97652946fa1bfe4a3ef97cb",
         deprecated=True,
     )
 
@@ -164,7 +119,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "profiler", default=True, description="Use internal profiler to measure execution time"
     )
-
+    depends_on("cmake@3.23:", type="build")
     depends_on("mpi")
     depends_on("gsl")
     depends_on("lapack")
@@ -191,7 +146,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("magma", when="+magma")
     depends_on("boost cxxstd=14 +filesystem", when="+boost_filesystem")
 
-    depends_on("spfft@0.9.6: +mpi", when="@6.4.0:")
     depends_on("spfft@0.9.13:", when="@7.0.1:")
     depends_on("spfft+single_precision", when="+single_precision ^spfft")
     depends_on("spfft+cuda", when="+cuda ^spfft")
@@ -217,7 +171,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     # FindHIP cmake script only works for < 4.1
     depends_on("hip@:4.0", when="@:7.2.0 +rocm")
 
-    conflicts("+shared", when="@6.3.0:6.4")
     conflicts("+boost_filesystem", when="~apps")
     conflicts("^libxc@5.0.0")  # known to produce incorrect results
     conflicts("+single_precision", when="@:7.2.4")
@@ -244,31 +197,17 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("umpire+cuda~device_alloc", when="+cuda")
         depends_on("umpire+rocm~device_alloc", when="+rocm")
 
-    patch("strip-spglib-include-subfolder.patch", when="@6.1.5")
-    patch("link-libraries-fortran.patch", when="@6.1.5")
-    patch("cmake-fix-shared-library-installation.patch", when="@6.1.5")
     patch("mpi_datatypes.patch", when="@:7.2.6")
 
     @property
     def libs(self):
         libraries = []
 
-        if "@6.3.0:" in self.spec:
-            libraries += ["libsirius"]
+        libraries += ["libsirius"]
 
-            return find_libraries(
-                libraries, root=self.prefix, shared="+shared" in self.spec, recursive=True
-            )
-        else:
-            if "+fortran" in self.spec:
-                libraries += ["libsirius_f"]
-
-            if "+cuda" in self.spec:
-                libraries += ["libsirius_cu"]
-
-            return find_libraries(
-                libraries, root=self.prefix, shared="+shared" in self.spec, recursive=True
-            )
+        return find_libraries(
+            libraries, root=self.prefix, shared="+shared" in self.spec, recursive=True
+        )
 
     def cmake_args(self):
         spec = self.spec
@@ -333,17 +272,9 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define(cm_label + "ELPA_INCLUDE_DIR", elpa_incdir))
 
         if "+cuda" in spec:
-            cuda_arch = spec.variants["cuda_arch"].value
+            cuda_arch = self.spec.variants["cuda_arch"].value
             if cuda_arch[0] != "none":
-                # Specify a single arch directly
-                if "@:6" in spec:
-                    args.append(
-                        self.define("CMAKE_CUDA_FLAGS", "-arch=sm_{0}".format(cuda_arch[0]))
-                    )
-
-                # Make SIRIUS handle it
-                else:
-                    args.append(self.define("CUDA_ARCH", ";".join(cuda_arch)))
+                args += [self.define("CMAKE_CUDA_ARCHITECTURES", cuda_arch)]
 
         if "+rocm" in spec:
             archs = ",".join(self.spec.variants["amdgpu_target"].value)

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -24,54 +24,54 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     version("7.4.3", sha256="015679a60a39fa750c5d1bd8fb1ce73945524bef561270d8a171ea2fd4687fec")
     version("7.4.0", sha256="f9360a695a1e786d8cb9d6702c82dd95144a530c4fa7e8115791c7d1e92b020b")
     version(
-            "7.3.2",
-            sha256="a256508de6b344345c295ad8642dbb260c4753cd87cc3dd192605c33542955d7",
-            deprecated=True
+        "7.3.2",
+        sha256="a256508de6b344345c295ad8642dbb260c4753cd87cc3dd192605c33542955d7",
+        deprecated=True,
     )
     version(
-            "7.3.1",
-            sha256="8bf9848b8ebf0b43797fd359adf8c84f00822de4eb677e3049f22baa72735e98",
-            deprecated=True
+        "7.3.1",
+        sha256="8bf9848b8ebf0b43797fd359adf8c84f00822de4eb677e3049f22baa72735e98",
+        deprecated=True,
     )
     version(
-            "7.3.0",
-            sha256="69b5cf356adbe181be6c919032859c4e0160901ff42a885d7e7ea0f38cc772e2",
-            deprecated=True
+        "7.3.0",
+        sha256="69b5cf356adbe181be6c919032859c4e0160901ff42a885d7e7ea0f38cc772e2",
+        deprecated=True,
     )
     version(
-            "7.2.7",
-            sha256="929bf7f131a4847624858b9c4295532c24b0c06f6dcef5453c0dfc33fb78eb03",
-            deprecated=True
+        "7.2.7",
+        sha256="929bf7f131a4847624858b9c4295532c24b0c06f6dcef5453c0dfc33fb78eb03",
+        deprecated=True,
     )
     version(
-            "7.2.6",
-            sha256="e751fd46cdc7c481ab23b0839d3f27fb00b75dc61dc22a650c92fe8e35336e3a",
-            deprecated=True
+        "7.2.6",
+        sha256="e751fd46cdc7c481ab23b0839d3f27fb00b75dc61dc22a650c92fe8e35336e3a",
+        deprecated=True,
     )
     version(
-            "7.2.5",
-            sha256="794e03d4da91025f77542d3d593d87a8c74e980394f658a0210a4fd91c011f22",
-            deprecated=True
+        "7.2.5",
+        sha256="794e03d4da91025f77542d3d593d87a8c74e980394f658a0210a4fd91c011f22",
+        deprecated=True,
     )
     version(
-            "7.2.4",
-            sha256="aeed0e83b80c3a79a9469e7f3fe10d80ad331795e38dbc3c49cb0308e2bd084d",
-            deprecated=True
+        "7.2.4",
+        sha256="aeed0e83b80c3a79a9469e7f3fe10d80ad331795e38dbc3c49cb0308e2bd084d",
+        deprecated=True,
     )
     version(
-            "7.2.3",
-            sha256="6c10f0e87e50fcc7cdb4d1b2d35e91dba6144de8f111e36c7d08912e5942a906",
-            deprecated=True
+        "7.2.3",
+        sha256="6c10f0e87e50fcc7cdb4d1b2d35e91dba6144de8f111e36c7d08912e5942a906",
+        deprecated=True,
     )
     version(
-            "7.2.1",
-            sha256="01bf6c9893ff471473e13351ca7fdc2ed6c1f4b1bb7afa151909ea7cd6fa0de7",
-            deprecated=True
+        "7.2.1",
+        sha256="01bf6c9893ff471473e13351ca7fdc2ed6c1f4b1bb7afa151909ea7cd6fa0de7",
+        deprecated=True,
     )
     version(
-            "7.2.0",
-            sha256="537800459db8a7553d7aa251c19f3a31f911930194b068bc5bca2dfb2c9b71db",
-            deprecated=True
+        "7.2.0",
+        sha256="537800459db8a7553d7aa251c19f3a31f911930194b068bc5bca2dfb2c9b71db",
+        deprecated=True,
     )
     version(
         "7.0.2",


### PR DESCRIPTION
As a maintainer and developer of SIRIUS I would like to update and simplify the spack package for it. The following is changed
* versions below 6.0 are removed from the recipe. If needed they can be found in tagged release of spack
* versions below 7.3 are flagged as deprecated
* dependency on cmake>=3.23 is expicitely introduced
* propery set CMAKE_CUDA_ARCHITECTURES for cmake of SIRIUS

The build of SIRIUS is tested with this updates and is working (https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4931289112286619/3535154434359889/-/jobs/4949593897)