### PR TITLE
intel-oneapi-mkl: add hpcx-mpi to the list of supported MPI libs

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -201,14 +201,16 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 ]
             ):
                 libs.append(self._xlp64_lib("libmkl_blacs_intelmpi"))
-            elif any(self.spec.satisfies(m) for m in ["^openmpi", "mpi_family=openmpi"]):
+            elif any(
+                self.spec.satisfies(m) for m in ["^openmpi", "^hpcx-mpi", "mpi_family=openmpi"]
+            ):
                 libs.append(self._xlp64_lib("libmkl_blacs_openmpi"))
             else:
                 raise RuntimeError(
                     (
-                        "intel-oneapi-mpi +cluster requires one of ^intel-oneapi-mpi, "
+                        "intel-oneapi-mkl +cluster requires one of ^intel-oneapi-mpi, "
                         "^intel-mpi, ^mpich, ^cray-mpich, mpi_family=mpich, ^openmpi, "
-                        "or mpi_family=openmpi"
+                        "^hpcx-mpi, or mpi_family=openmpi"
                     )
                 )
 


### PR DESCRIPTION
This PR completes #39343 in case one uses `hpcx-mpi` as  external library, to avoid a RuntimeError.
`hpcx-mpi` is based on `openmpi`, so the fix is quite simple.