### PR TITLE
gitlab ci: Use image with awscli for rebuild-index job

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -279,7 +279,7 @@ protected-publish:
 
 e4s-generate:
   extends: [ ".e4s", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
+  image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 e4s-build:
   extends: [ ".e4s", ".build" ]
@@ -302,7 +302,7 @@ e4s-build:
 
 gpu-tests-generate:
   extends: [ ".gpu-tests", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
+  image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 gpu-tests-build:
   extends: [ ".gpu-tests", ".build" ]
@@ -472,7 +472,7 @@ radiuss-aws-aarch64-build:
 
 data-vis-sdk-generate:
   extends: [ ".data-vis-sdk", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
+  image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
 data-vis-sdk-build:
   extends: [ ".data-vis-sdk", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -70,6 +70,7 @@ ci:
 
   - reindex-job:
       tags: ["service"]
+      image: "ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01"
       variables:
         CI_JOB_SIZE: "medium"
         KUBERNETES_CPU_REQUEST: "4000m"

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -67,7 +67,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01, entrypoint: ['']}
+        image: {name: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01, entrypoint: [''] }
 
   cdash:
     'build-group:': Data and Vis SDK

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -97,7 +97,7 @@ spack:
   - lammps
   - legion
   - libnrm
-  - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed 
+  - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed
     +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +mgard
   - libquo
   - libunwind
@@ -176,8 +176,8 @@ spack:
   - hypre +cuda
   - kokkos +wrapper +cuda
   - kokkos-kernels +cuda ^kokkos +wrapper +cuda +cuda_lambda
-  - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua 
-    +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz 
+  - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua
+    +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz
     +mgard +cuda ^cusz +cuda
   - magma +cuda
   - mfem +cuda
@@ -242,7 +242,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01"
+        image: "ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01"
 
   cdash:
     build-group: E4S

--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -56,7 +56,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01
+        image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
     - match_behavior: first
       submapping:
       - match:


### PR DESCRIPTION
Stack-specific pipelines run `spack buildcache update-index` at the end, which runs much faster if `aws` cli is installed.  Currently these pipelines are picking an image without `aws` installed, see [here](https://gitlab.spack.io/spack/spack/-/jobs/8058095).

- [x] Instead of pointing to the image on DockerHub, which rate limits us and causes pipeline failures during busy times, use the version at ghcr
- [x] And we might as well use the ghcr version everywhere else too.