### PR TITLE
libpng: add libs property

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -38,6 +38,13 @@ class Libpng(CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
+    @property
+    def libs(self):
+        # v1.2 does not have a version-less symlink
+        libraries = f"libpng{self.version.up_to(2).joined}"
+        shared = "libs=shared" in self.spec
+        return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):


### PR DESCRIPTION
Fixes an issue with `spec["libpng"].libs` for libpng 1.2 reported in #39262.