### PR TITLE
libarchive: use openssl by default

### DIFF
--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -85,7 +85,7 @@ class Libarchive(AutotoolsPackage):
     )
     variant(
         "crypto",
-        default="mbedtls",
+        default="openssl",
         values=("mbedtls", "nettle", "openssl"),
         description="What crypto library to use for mtree and xar hashes",
     )


### PR DESCRIPTION
mbedtls is probably fine too, but openssl is the more battle tested option, so
probably the best default.

