### PR TITLE
llvm: fix OpenMP linking

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -914,7 +914,12 @@ class Llvm(CMakePackage, CudaPackage):
 
         # Semicolon seperated list of runtimes to enable
         if runtimes:
-            cmake_args.append(define("LLVM_ENABLE_RUNTIMES", runtimes))
+            cmake_args.extend([
+                define("LLVM_ENABLE_RUNTIMES", runtimes),
+                define("RUNTIMES_CMAKE_ARGS", [
+                    define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True),
+                ]),
+            ])
 
         return cmake_args
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -738,6 +738,7 @@ class Llvm(CMakePackage, CudaPackage):
             env.prepend_path("PATH", self.stage.path)
 
     def setup_run_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["hwloc"].prefix.lib)
         if "+clang" in self.spec:
             env.set("CC", join_path(self.spec.prefix.bin, "clang"))
             env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -914,12 +914,14 @@ class Llvm(CMakePackage, CudaPackage):
 
         # Semicolon seperated list of runtimes to enable
         if runtimes:
-            cmake_args.extend([
-                define("LLVM_ENABLE_RUNTIMES", runtimes),
-                define("RUNTIMES_CMAKE_ARGS", [
-                    define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True),
-                ]),
-            ])
+            cmake_args.extend(
+                [
+                    define("LLVM_ENABLE_RUNTIMES", runtimes),
+                    define(
+                        "RUNTIMES_CMAKE_ARGS", [define("CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)]
+                    ),
+                ]
+            )
 
         return cmake_args
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -738,7 +738,6 @@ class Llvm(CMakePackage, CudaPackage):
             env.prepend_path("PATH", self.stage.path)
 
     def setup_run_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["hwloc"].prefix.lib)
         if "+clang" in self.spec:
             env.set("CC", join_path(self.spec.prefix.bin, "clang"))
             env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))


### PR DESCRIPTION
Clang can compile OpenMP hello world. However, when we try to link OpenMP hello world program we pickup the wrong hwloc library. This leads to an undefined reference at link time unless you add the Spack-installed hwloc library to LD_LIBRARY_PATH.

I am not sure that this is the rightway to fix things but it works for me. 