### PR TITLE
remove mxnet from darwin aarch64 since theres no supported release

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -29,9 +29,6 @@ spack:
   - py-keras-preprocessing
   - py-keras2onnx
 
-  # MXNet
-  - mxnet
-
   # PyTorch
   - py-botorch
   - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -29,6 +29,9 @@ spack:
   - py-keras-preprocessing
   - py-keras2onnx
 
+  # MXNet not supported on darwin aarch64 yet
+  # - mxnet
+
   # PyTorch
   - py-botorch
   - py-efficientnet-pytorch


### PR DESCRIPTION
There's a conflict on @:1, meaning that we build some arbitrary git branch in
Gitlab CI. Better wait for a release that actually adds support.

