### PR TITLE
rhash: simplify, new versions

### DIFF
--- a/var/spack/repos/builtin/packages/rhash/package.py
+++ b/var/spack/repos/builtin/packages/rhash/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class Rhash(MakefilePackage):
+class Rhash(MakefilePackage, AutotoolsPackage):
     """RHash is a console utility for computing and verifying hash sums of
     files. It supports CRC32, MD4, MD5, SHA1, SHA256, SHA512, SHA3, Tiger,
     TTH, Torrent BTIH, AICH, ED2K, GOST R 34.11-94, RIPEMD-160, HAS-160,
@@ -17,26 +17,24 @@ class Rhash(MakefilePackage):
     homepage = "https://sourceforge.net/projects/rhash/"
     url = "https://github.com/rhash/RHash/archive/v1.3.5.tar.gz"
 
+    version("1.4.4", sha256="8e7d1a8ccac0143c8fe9b68ebac67d485df119ea17a613f4038cda52f84ef52a")
+    version("1.4.3", sha256="1e40fa66966306920f043866cbe8612f4b939b033ba5e2708c3f41be257c8a3e")
     version("1.4.2", sha256="600d00f5f91ef04194d50903d3c79412099328c42f28ff43a0bdb777b00bec62")
     version("1.3.5", sha256="98e0688acae29e68c298ffbcdbb0f838864105f9b2bd8857980664435b1f1f2e")
 
-    # configure: fix clang detection on macOS
-    # Patch accepted and merged upstream, remove on next release
-    patch(
-        "https://github.com/rhash/RHash/commit/4dc506066cf1727b021e6352535a8bb315c3f8dc.patch?full_index=1",
-        when="@1.4.2",
-        sha256="3fbfe4603d2ec5228fd198fc87ff3ee281e1f68d252c1afceaa15cba76e9b6b4",
+    build_system(
+        conditional("autotools", when="@1.4:"),
+        conditional("makefile", when="@:1.3"),
+        default="autotools",
     )
 
     # Intel 20xx.yy.z works just fine.  Un-block it from the configure script
     # https://github.com/rhash/RHash/pull/197
-    patch("rhash-intel20.patch", when="@1.3.6:")
+    patch("rhash-intel20.patch", when="@1.3.6:1.4.2")
 
-    # For macOS build instructions, see:
-    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/rhash.rb
 
-    @when("@:1.3.5")
-    def build(self, spec, prefix):
+class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
+    def build(self, pkg, spec, prefix):
         # Doesn't build shared libraries by default
         make("PREFIX={0}".format(prefix))
 
@@ -45,34 +43,7 @@ class Rhash(MakefilePackage):
         else:
             make("PREFIX={0}".format(prefix), "lib-shared")
 
-    @when("@1.3.6:")
-    def build(self, spec, prefix):
-        configure("--prefix=")
-        make()
-
-    def check(self):
-        # Makefile has both `test` and `check` targets:
-        #
-        # * `test`  - used to test that the build is working properly
-        # * `check` - used to check that the tarball is ready for upload
-        #
-        # Default implmentation is to run both `make test` and `make check`.
-        # `test` passes, but `check` fails, so only run `test`.
-        make("test")
-        if self.spec.satisfies("@:1.3.5"):
-            make("test-static-lib")
-        else:
-            make("test-lib-static")
-
-        if not self.spec.satisfies("@:1.3.5 platform=darwin"):
-            make("test-shared")
-            if self.spec.satisfies("@:1.3.5"):
-                make("test-shared-lib")
-            else:
-                make("test-lib-shared")
-
-    @when("@:1.3.5")
-    def install(self, spec, prefix):
+    def install(self, pkg, spec, prefix):
         # Some things are installed to $(DESTDIR)$(PREFIX) while other things
         # are installed to $DESTDIR/etc.
         make("install", "DESTDIR={0}".format(prefix), "PREFIX=")
@@ -86,22 +57,6 @@ class Rhash(MakefilePackage):
                 join_path(prefix.lib, "librhash.so.0"), join_path(prefix.lib, "librhash.so")
             )
 
-    @when("@1.3.6:")
-    def install(self, spec, prefix):
-        # Intermittent issues during installation, prefix.bin directory already exists
-        make("install", "DESTDIR={0}".format(prefix), parallel=False)
-        make("install-pkg-config", "DESTDIR={0}".format(prefix))
-        make("install-lib-so-link", "DESTDIR={0}".format(prefix))
-        make("install-lib-headers", "DESTDIR={0}".format(prefix))
 
-    @run_after("install")
-    def darwin_fix(self):
-        # The shared library is not installed correctly on Darwin; fix this
-        if self.spec.satisfies("@1.3.6: platform=darwin"):
-            # Fix RPATH for <prefix>/bin/rhash
-            old = "/lib/librhash.0.dylib"
-            new = self.prefix.lib.join("librhash.dylib")
-            install_name_tool = Executable("install_name_tool")
-            install_name_tool("-change", old, new, self.prefix.bin.rhash)
-            # Fix RPATH for <prefix>/lib/librhash.dylib
-            fix_darwin_install_name(self.prefix.lib)
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+    pass


### PR DESCRIPTION
draft because the actual build system is not really autotools, but a handwritten configure script (with bugs).