### PR TITLE
Fix working_env fixture

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -418,12 +418,11 @@ def remove_whatever_it_is(path):
 @pytest.fixture
 def working_env():
     saved_env = os.environ.copy()
-    yield
-    # os.environ = saved_env doesn't work
-    # it causes module_parsing::test_module_function to fail
-    # when it's run after any test using this fixutre
-    os.environ.clear()
-    os.environ.update(saved_env)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
My suspicion is that pytest may raise exceptions it catches itself on layer outside of the fixtures, so that os.environ is not always reset.