### PR TITLE
boxlib: Add BL_USE_PARTICLES cmake var

### DIFF
--- a/var/spack/repos/builtin/packages/boxlib/package.py
+++ b/var/spack/repos/builtin/packages/boxlib/package.py
@@ -32,6 +32,7 @@ class Boxlib(CMakePackage):
         options.extend(
             [
                 "-DBL_SPACEDIM=%d" % int(spec.variants["dims"].value),
+                "-DBL_USE_PARTICLES=1",
                 "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON",
                 "-DENABLE_FBASELIB=ON",
                 "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,


### PR DESCRIPTION
Set BL_USE_PARTICLES to 1, which should case boxlib build to include Particles classes according to CMakeLists.txt.

This seems to fix #18172
The aforementioned error seems to occur in cmake phase while processing CMakeLists.txt in Src/C_ParticleLib, and appears to be due to the variable containing the list of src files for the add_library() call being empty unless BL_USE_PARTICLES is set to 1.