### PR TITLE
mpi4py: do not re-generate cython sources that already exist in mpi4py release tarball

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -30,15 +30,7 @@ class PyMpi4py(PythonPackage):
 
     depends_on("py-setuptools@40.9:", type="build")
     depends_on("mpi")
-    depends_on("py-cython@0.27.0:", type="build")
-
-    # https://github.com/mpi4py/mpi4py/pull/311
-    conflicts("^py-cython@3:")
+    depends_on("py-cython@3.0.0:", when="@master", type="build")
 
     def setup_build_environment(self, env):
         env.set("MPICC", f"{self.spec['mpi'].mpicc} -shared")
-
-    @run_before("install")
-    def cythonize(self):
-        with working_dir(self.build_directory):
-            python(join_path("conf", "cythonize.py"))


### PR DESCRIPTION
(that depend on cython < 0.29.36)

This avoids conflict with petsc4py versions that have a dependency on cython@3.0.0

- revert https://github.com/spack/spack/pull/36460, https://github.com/spack/spack/pull/38996
- update cython dependency for mpi4py@master

ref: https://github.com/mpi4py/mpi4py/issues/386#issuecomment-1695761887