### PR TITLE
Arg handling fix for singularityce

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -82,9 +82,9 @@ class SingularityBase(MakefilePackage):
             _config_options = ["--prefix=%s" % prefix]
             _config_options += self.config_options
             if "~suid" in spec:
-                _config_options += " --without-suid"
+                _config_options += ["--without-suid"]
             if "~network" in spec:
-                _config_options += " --without-network"
+                _config_options += ["--without-network"]
             configure = Executable("./mconfig")
             configure(*_config_options)
 


### PR DESCRIPTION
After PR #39553, builds of singularityce and apptainer fail if `~suid` is used. The `--without-suid` argument is added to the list using a concatenate, but the string form is added instead of a list element, so the string is broken up into it's constituent characters and mconfig fails:

```
==> apptainer: Executing phase: 'edit'
==> [2023-08-28-00:38:26.948809] './mconfig' '--prefix=/glade/derecho/scratch/vanderwb/spack-tests/derecho/23.09/envs/build/opt/[padded-to-128-chars]/apptainer/1.1.9/gcc/7.5.0/pjkr' ' ' '-' '-' 'w' 'i' 't' 'h' 'o' 'u' 't' '-' 's' 'u' 'i' 'd'
```

This PR ensures that the option (and `--without-network`) are added as list elements, which seems the intent of the code and is in keeping with the other optional mconfig flags.