### PR TITLE
mapl: Fix pflogger dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -204,9 +204,9 @@ class Mapl(CMakePackage):
 
     # pFlogger depends on yaFyaml in the same way. MAPL 2.22 and below uses old
     # yaFyaml so we need to use old pFlogger, but MAPL 2.23+ uses new yaFyaml
-    depends_on("pflogger@:1.6", when="@:2.22+pflogger")
-    depends_on("pflogger@1.9.1:", when="@2.23:2.39+pflogger")
-    depends_on("pflogger@1.9.5:", when="@2.40:+pflogger")
+    depends_on("pflogger@:1.6 +mpi", when="@:2.22+pflogger")
+    depends_on("pflogger@1.9.1: +mpi", when="@2.23:2.39+pflogger")
+    depends_on("pflogger@1.9.5: +mpi", when="@2.40:+pflogger")
 
     # fArgParse v1.4.1 is the first usable version with MAPL
     # we now require 1.5.0 with MAPL 2.40+


### PR DESCRIPTION
Testing shows that mapl requires the `+mpi` variant of `pflogger` when building with `+pflogger` (see https://github.com/JCSDA/spack-stack/issues/754). This was missed because on my local machine, I always had:
```yaml
packages:
  pflogger:
     variants: +mpi
```
in my local `packages.yaml` file so the dependency was always met.