### PR TITLE
BF: Attempt to fix issues patching read only files on lustre

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1462,6 +1462,14 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             tty.msg("No patches needed for {0}".format(self.name))
             return
 
+        # Make sure staged files are writable to avoid issues with file permissions
+        # on Lustre
+        for dir_path, _, sub_files in os.walk(self.stage.source_path):
+            for sub_file in sub_files:
+                sub_path = os.path.join(dir_path, sub_file)
+                perm = os.stat(sub_path).st_mode
+                os.chmod(sub_path, perm | 0o200)
+
         # Construct paths to special files in the archive dir used to
         # keep track of whether patches were successfully applied.
         archive_dir = self.stage.source_path


### PR DESCRIPTION
This is a more general fix to issue with running patch command against read-only files on Lustre (fixed for a specific case here: #8764).

I was running into the same issue installing Perl but with a different file:

```
==> Installing perl-5.38.0-jogxvat3xdgsrvoo6tdkt67vde457rej [21/29]
==> No binary for perl-5.38.0-jogxvat3xdgsrvoo6tdkt67vde457rej found: installing from source
File cpan/Compress-Raw-Zlib/Makefile.PL is read-only; trying to patch anyway
/usr/bin/patch: setting attribute lustre.lov for lustre.lov: Permission denied
```

I'm open to any suggestions for improving this, especially lowering the performance impact (e.g. detect lustre and only walk the staging dir in that case).