### PR TITLE
spack checksum pkg@1.2, use as version filter

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -870,6 +870,7 @@ def interactive_version_filter(
     url_dict: Dict[StandardVersion, str],
     known_versions: Iterable[StandardVersion] = (),
     *,
+    initial_verion_filter: Optional[VersionList] = None,
     url_changes: Set[StandardVersion] = set(),
     input: Callable[..., str] = input,
 ) -> Optional[Dict[StandardVersion, str]]:
@@ -883,8 +884,9 @@ def interactive_version_filter(
         Filtered dictionary of versions to URLs or None if the user wants to quit
     """
     # Find length of longest string in the list for padding
-    sorted_and_filtered = sorted(url_dict.keys(), reverse=True)
-    version_filter = VersionList([":"])
+    version_filter = initial_verion_filter or VersionList([":"])
+    sorted_and_filtered = [v for v in url_dict if v.satisfies(version_filter)]
+    sorted_and_filtered.sort(reverse=True)
     max_len = max(len(str(v)) for v in sorted_and_filtered)
     orig_url_dict = url_dict  # only copy when using editor to modify
     print_header = True

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -11,6 +11,7 @@ import spack.cmd.checksum
 import spack.repo
 import spack.spec
 from spack.main import SpackCommand
+import spack.parser
 from spack.stage import interactive_version_filter
 from spack.version import Version
 
@@ -254,17 +255,10 @@ def test_checksum_deprecated_version(mock_packages, mock_clone_repo, mock_fetch,
     assert "Added 0 new versions to" not in output
 
 
-def test_checksum_at(mock_packages):
-    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
-    versions = [str(v) for v in pkg_cls.versions]
-    output = spack_checksum(f"zlib@{versions[0]}")
-    assert "Found 1 version" in output
-
-
 def test_checksum_url(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
-    output = spack_checksum(f"{pkg_cls.url}", fail_on_error=False)
-    assert "accepts package names" in output
+    with pytest.raises(spack.parser.SpecSyntaxError):
+        spack_checksum(f"{pkg_cls.url}")
 
 
 def test_checksum_verification_fails(install_mockery, capsys):

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -8,10 +8,10 @@ import argparse
 import pytest
 
 import spack.cmd.checksum
+import spack.parser
 import spack.repo
 import spack.spec
 from spack.main import SpackCommand
-import spack.parser
 from spack.stage import interactive_version_filter
 from spack.version import Version
 


### PR DESCRIPTION
Currently `spack checksum pkg@1.2` splits on `@` and looks for `1.2` as a concrete version.

With this PR, `@1.2` is interpreted as an initial version filter.

This allows you to checksum version ranges faster:

![Screenshot from 2023-10-26 14-20-49](https://github.com/spack/spack/assets/194764/5b480e19-6cb5-4578-90b3-905f95b8eae0)
