### PR TITLE
glibc: add package

### DIFF
--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -432,6 +432,47 @@ def get_rpaths(path):
     return rpath.split(":")
 
 
+def delete_rpath(path):
+    """Modifies a binary to remove the rpath. It zeros out the rpath string
+    and also drops the DT_R(UN)PATH entry from the dynamic section, so it doesn't
+    show up in 'readelf -d file', nor in 'strings file'."""
+    with open(path, "rb+") as f:
+        elf = parse_elf(f, interpreter=False, dynamic_section=True)
+
+        if not elf.has_rpath:
+            return
+
+        # Zero out the rpath *string* in the binary
+        new_rpath_string = b"\x00" * len(elf.dt_rpath_str)
+        rpath_offset = elf.pt_dynamic_strtab_offset + elf.rpath_strtab_offset
+        f.seek(rpath_offset)
+        f.write(new_rpath_string)
+
+        # Next update the dynamic array
+        f.seek(elf.pt_dynamic_p_offset)
+        dynamic_array_fmt = elf.byte_order + ("qQ" if elf.is_64_bit else "lL")
+        dynamic_array_size = calcsize(dynamic_array_fmt)
+        new_offset = elf.pt_dynamic_p_offset  # points to the new dynamic array
+        old_offset = elf.pt_dynamic_p_offset  # points to the current dynamic array
+        for _ in range(elf.pt_dynamic_p_filesz // dynamic_array_size):
+            data = read_exactly(f, dynamic_array_size, "Malformed dynamic array entry")
+            tag, _ = unpack(dynamic_array_fmt, data)
+
+            # Overwrite any entry that is not DT_RPATH or DT_RUNPATH, including DT_NULL
+            if tag != ELF_CONSTANTS.DT_RPATH and tag != ELF_CONSTANTS.DT_RUNPATH:
+                if new_offset != old_offset:
+                    f.seek(new_offset)
+                    f.write(data)
+                    f.seek(old_offset + dynamic_array_size)
+                new_offset += dynamic_array_size
+
+            # End of the dynamic array
+            if tag == ELF_CONSTANTS.DT_NULL:
+                break
+
+            old_offset += dynamic_array_size
+
+
 def replace_rpath_in_place_or_raise(path, substitutions):
     regex = re.compile(b"|".join(re.escape(p) for p in substitutions.keys()))
 

--- a/var/spack/repos/builtin/packages/glibc/32cf406.patch
+++ b/var/spack/repos/builtin/packages/glibc/32cf406.patch
@@ -1,0 +1,21 @@
+From 32cf40699346d37fabfa887bbd95e95004799ae1 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@redhat.com>
+Date: Mon, 6 Sep 2010 14:55:59 +0200
+Subject: [PATCH] Don't mix pattern rules with normal rules
+
+diff --git a/manual/Makefile b/manual/Makefile
+index c5866eb9def..b1f5fa73e5e 100644
+--- a/manual/Makefile
++++ b/manual/Makefile
+@@ -232,7 +232,10 @@ ifdef objpfx
+ .PHONY: stubs
+ stubs: $(objpfx)stubs
+ endif
+-$(objpfx)stubs ../po/manual.pot $(objpfx)stamp%:
++$(objpfx)stubs ../po/manual.pot:
++	$(make-target-directory)
++	touch $@
++$(objpfx)stamp%:
+ 	$(make-target-directory)
+ 	touch $@
+ 

--- a/var/spack/repos/builtin/packages/glibc/39b1f61.patch
+++ b/var/spack/repos/builtin/packages/glibc/39b1f61.patch
@@ -1,0 +1,13 @@
+diff --git a/malloc/obstack.c b/malloc/obstack.c
+index 25a90514f78..c3c7db4a96b 100644
+--- a/malloc/obstack.c
++++ b/malloc/obstack.c
+@@ -115,7 +115,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ /* A looong time ago (before 1994, anyway; we're not sure) this global variable
+    was used by non-GNU-C macros to avoid multiple evaluation.  The GNU C
+    library still exports it because somebody might use it.  */
+-struct obstack *_obstack_compat;
++struct obstack *_obstack_compat = 0;
+ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
+ #  endif
+ # endif

--- a/var/spack/repos/builtin/packages/glibc/4a531bb.patch
+++ b/var/spack/repos/builtin/packages/glibc/4a531bb.patch
@@ -1,0 +1,123 @@
+commit 4a531bb0b3b582cb693de9f76d2d97d970f9a5d5
+Author: H.J. Lu <hongjiu.lu@intel.com>
+Date:   Fri Dec 24 20:14:37 2010 -0500
+
+    Remove `.ctors' and `.dtors' output sections
+
+diff --git a/config.h.in b/config.h.in
+index 18bf01a38c..9e797eb5b7 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -201,6 +201,9 @@
+ /* Define if multi-arch DSOs should be generated.  */
+ #undef USE_MULTIARCH
+ 
++/* Define if `.ctors' and `.dtors' sections shouldn't be used.  */
++#define NO_CTORS_DTORS_SECTIONS
++
+ /*
+ ^L */
+ 
+diff --git a/elf/sofini.c b/elf/sofini.c
+index 5e06f0ca92..13e74b7903 100644
+--- a/elf/sofini.c
++++ b/elf/sofini.c
+@@ -1,12 +1,14 @@
+ /* Finalizer module for ELF shared C library.  This provides terminating
+    null pointer words in the `.ctors' and `.dtors' sections.  */
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+ static void (*const __CTOR_END__[1]) (void)
+      __attribute__ ((used, section (".ctors")))
+      = { 0 };
+ static void (*const __DTOR_END__[1]) (void)
+      __attribute__ ((used, section (".dtors")))
+      = { 0 };
++#endif
+ 
+ /* Terminate the frame unwind info section with a 4byte 0 as a sentinel;
+    this would be the 'length' field in a real FDE.  */
+diff --git a/elf/soinit.c b/elf/soinit.c
+index 6fecbb5674..1db676af01 100644
+--- a/elf/soinit.c
++++ b/elf/soinit.c
+@@ -3,6 +3,7 @@
+    the `.ctors' and `.dtors' sections so the lists are terminated, and
+    calling those lists of functions.  */
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+ #include <libc-internal.h>
+ #include <stdlib.h>
+ 
+@@ -40,3 +41,4 @@ __libc_fini (void)
+ 
+ void (*_fini_ptr) (void) __attribute__ ((section (".fini_array")))
+      = &__libc_fini;
++#endif
+diff --git a/sysdeps/i386/init-first.c b/sysdeps/i386/init-first.c
+index c6355a8b7b..2af042fe4b 100644
+--- a/sysdeps/i386/init-first.c
++++ b/sysdeps/i386/init-first.c
+@@ -59,7 +59,9 @@ _init (int argc, ...)
+ {
+   init (&argc);
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
++#endif
+ }
+ #endif
+ 
+diff --git a/sysdeps/mach/hurd/i386/init-first.c b/sysdeps/mach/hurd/i386/init-first.c
+index f9a7a58deb..60823bd789 100644
+--- a/sysdeps/mach/hurd/i386/init-first.c
++++ b/sysdeps/mach/hurd/i386/init-first.c
+@@ -92,7 +92,7 @@ posixland_init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (envp);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }
+diff --git a/sysdeps/mach/hurd/powerpc/init-first.c b/sysdeps/mach/hurd/powerpc/init-first.c
+index 20fa1d4f12..21b5054b0a 100644
+--- a/sysdeps/mach/hurd/powerpc/init-first.c
++++ b/sysdeps/mach/hurd/powerpc/init-first.c
+@@ -82,7 +82,7 @@ posixland_init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (__environ);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }
+diff --git a/sysdeps/sh/init-first.c b/sysdeps/sh/init-first.c
+index d816625ef4..1f3a821fea 100644
+--- a/sysdeps/sh/init-first.c
++++ b/sysdeps/sh/init-first.c
+@@ -59,7 +59,9 @@ _init (int argc, ...)
+ {
+   init (&argc);
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
++#endif
+ }
+ #endif
+ 
+diff --git a/sysdeps/unix/sysv/linux/init-first.c b/sysdeps/unix/sysv/linux/init-first.c
+index 7b2333d4bf..a60212f4ed 100644
+--- a/sysdeps/unix/sysv/linux/init-first.c
++++ b/sysdeps/unix/sysv/linux/init-first.c
+@@ -93,7 +93,7 @@ _init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (envp);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }

--- a/var/spack/repos/builtin/packages/glibc/7c8a673.patch
+++ b/var/spack/repos/builtin/packages/glibc/7c8a673.patch
@@ -1,0 +1,21 @@
+commit 7c8a67320e26b8c11108bf0a3410d3aef9cf3486
+Author: Ulrich Drepper <drepper@redhat.com>
+Date:   Sat Jan 31 00:21:15 2009 +0000
+
+    * elf/Makefile (ld.so): Adjust the sed script to insert _begin in to
+    
+            newer linker scripts.
+
+diff --git a/elf/Makefile b/elf/Makefile
+index 8079fe9f96..e44ff1d382 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -304,7 +304,7 @@ $(objpfx)ld.so: $(objpfx)librtld.os $(ld-map)
+ 		  $(LDFLAGS-rtld) -Wl,-z,defs -Wl,--verbose 2>&1 |	\
+ 		  LC_ALL=C \
+ 		  sed -e '/^=========/,/^=========/!d;/^=========/d'	\
+-		      -e 's/\. = 0 + SIZEOF_HEADERS;/& _begin = . - SIZEOF_HEADERS;/' \
++		      -e 's/\. = .* + SIZEOF_HEADERS;/& _begin = . - SIZEOF_HEADERS;/' \
+ 		  > $@.lds
+ 	$(LINK.o) -nostdlib -nostartfiles -shared -o $@			\
+ 		  $(LDFLAGS-rtld) -Wl,-z,defs $(z-now-$(bind-now))	\

--- a/var/spack/repos/builtin/packages/glibc/fb21f89.patch
+++ b/var/spack/repos/builtin/packages/glibc/fb21f89.patch
@@ -1,0 +1,13 @@
+diff --git a/sunrpc/rpc_clntout.c b/sunrpc/rpc_clntout.c
+index ec040c775e2..ce4d2a4c953 100644
+--- a/sunrpc/rpc_clntout.c
++++ b/sunrpc/rpc_clntout.c
+@@ -31,7 +31,7 @@
+  */
+ #include <stdio.h>
+ #include <string.h>
+-#include <rpc/types.h>
++#include "rpc/types.h"
+ #include "rpc_parse.h"
+ #include "rpc_util.h"
+ #include "proto.h"

--- a/var/spack/repos/builtin/packages/glibc/locs-2.22.patch
+++ b/var/spack/repos/builtin/packages/glibc/locs-2.22.patch
@@ -1,0 +1,19 @@
+diff --git a/misc/regexp.c b/misc/regexp.c
+index ee7d572..e0b4b47 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -23,11 +23,11 @@
+ #include <regex.h>
+ 
+ /* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++char *loc1  __attribute__ ((nocommon));
++char *loc2  __attribute__ ((nocommon));
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs  __attribute__ ((nocommon));
+ 
+ 
+ /* Find the next match in STRING.  The compiled regular expression is

--- a/var/spack/repos/builtin/packages/glibc/locs.patch
+++ b/var/spack/repos/builtin/packages/glibc/locs.patch
@@ -1,0 +1,20 @@
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+ 
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+ 
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -121,6 +121,12 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
 
+    def configure_args(self):
+        # todo: deal better with kernel headers.
+        # this is added mostly s.t. new gcc/binutils doesn't hit broken assembly.
+        # with gcc 13 it works until but not including glibc 2.9.
+        return ["--enable-kernel=4.4.1"]
+
     def build(self, spec, prefix):
         # 1. build just ld.so
         # 2. drop the rpath from ld.so -- otherwise it cannot be executed

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Glibc(AutotoolsPackage, GNUMirrorPackage):
+    """The GNU C Library provides many of the low-level components used
+    directly by programs written in the C or C++ languages."""
+
+    homepage = "https://www.gnu.org/software/libc/"
+    gnu_mirror_path = "libc/glibc-2.33.tar.gz"
+    git = "https://sourceware.org/git/glibc.git"
+
+    maintainers("haampie")
+
+    build_directory = "build"
+
+    version("master", branch="master")
+    version("2.38", sha256="16e51e0455e288f03380b436e41d5927c60945abd86d0c9852b84be57dd6ed5e")
+    version("2.37", sha256="e3a790c2f84eed5c5d569ed6172c253c607dd3962135437da413aa39aa4fd352")
+    version("2.36", sha256="02efa6ffbbaf3e10e88f16818a862608d04b0ef838c66f6025ae120530792c9c")
+    version("2.35", sha256="3e8e0c6195da8dfbd31d77c56fb8d99576fb855fafd47a9e0a895e51fd5942d4")
+    version("2.34", sha256="255b7632746b5fdd478cb7b36bebd1ec1f92c2b552ee364c940f48eb38d07f62")
+    version("2.33", sha256="ad7dbed6b0cde9ddc90e84856da7e2c1f976a5e791cdee947d8dbb0392fc76cf")
+    version("2.32", sha256="f52e5bdc6607cb692c0f7134b75b3ba34b5121628a1750c03e3c9aa0b9d9e65a")
+    version("2.31", sha256="cb2d64fb808affff30d8a99a85de9d2aa67dc2cbac4ae99af4500d6cfea2bda7")
+    version("2.30", sha256="decb0a29f1410735bed0e8e7247361da2bbf0dcfef7ac15bf26e7f910cb964c0")
+    version("2.29", sha256="2fc8c555fd0e5dab5b91e7dd0422865c1885be89ff080b2c1357041afbbc717f")
+    version("2.28", sha256="f318d6e3f1f4ed0b74d2832ac4f491d0fb928e451c9eda594cbf1c3bee7af47c")
+    version("2.27", sha256="881ca905e6b5eec724de7948f14d66a07d97bdee8013e1b2a7d021ff5d540522")
+    version("2.26", sha256="dcc2482b00fdb1c316f385f8180e182bbd37c065dc7d8281a4339d2834ef1be7")
+    version("2.25", sha256="ad984bac07844ecc222039d43bd5f1f1e1571590ea28045232ae3fa404cefc32")
+    version("2.24", sha256="7e01959a42d37739e40d8ce58f9c14750cc68bc8a8669889ed586f9f03b91fbe")
+    version("2.23", sha256="2bd08abb24811cda62e17e61e9972f091f02a697df550e2e44ddcfb2255269d2")
+    version("2.22", sha256="a62610c4084a0fd8cec58eee12ef9e61fdf809c31e7cecbbc28feb8719f08be5")
+    version("2.21", sha256="8d8f78058f2e9c7237700f76fe4e0ae500db31470290cd0b8a9739c0c8ce9738")
+    version("2.20", sha256="37e1de410d572a19b707b99786db9822bb4775e9d70517d88937ab12e6d6debc")
+    version("2.19", sha256="18ad6db70724699d264add80b1f813630d0141cf3a3558b4e1a7c15f6beac796")
+    version("2.18", sha256="c8e727b5feef883184241a4767725ec280c0288794bc5cd4432497370db47734")
+    version("2.17", sha256="a3b2086d5414e602b4b3d5a8792213feb3be664ffc1efe783a829818d3fca37a")
+
+    depends_on("bison", type="build")
+    depends_on("texinfo", type="build")
+    depends_on("gettext", type="build")
+
+    # The GCC 10 issue here is not necessarily a build issue, but a broken configure
+    # script that cannot deal with multi-digit major versions.
+    conflicts("%gcc@10:", when="@:2.20")
+    conflicts("%gcc@5:", when="@:2.15")
+    conflicts("%gcc@3:", when="@:2.2")
+
+    # Old versions require gmake 3.x, which we don't have in Spack currently
+    # depends_on("gmake@:3", when="@:2.18", type="build")
+
+    with when("@master"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -59,6 +59,9 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # _obstack_compat symbol is not initialized
     patch("39b1f61.patch", when="@:2.17")
 
+    # rpc/types.h include issue
+    patch("fb21f89.patch", when="@:2.16")
+
     def patch(self):
         # Deal with Make version detection not taking into account >= 4.x
         filter_file(

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -117,16 +117,18 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     depends_on("gettext", type="build")
     depends_on("perl", type="build")
 
+    depends_on("linux-headers")
+
     with when("@master"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
 
     def configure_args(self):
-        # todo: deal better with kernel headers.
-        # this is added mostly s.t. new gcc/binutils doesn't hit broken assembly.
-        # with gcc 13 it works until but not including glibc 2.9.
-        return ["--enable-kernel=4.4.1"]
+        return [
+            "--enable-kernel=4.4.1",
+            "--with-headers={}".format(self.spec["linux-headers"].prefix.include),
+        ]
 
     def build(self, spec, prefix):
         # 1. build just ld.so

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -56,6 +56,9 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     patch("locs.patch", when="@2.23:2.25")
     patch("locs-2.22.patch", when="@:2.22")
 
+    # _obstack_compat symbol is not initialized
+    patch("39b1f61.patch", when="@:2.17")
+
     def patch(self):
         # Deal with Make version detection not taking into account >= 4.x
         filter_file(

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -80,7 +80,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     patch("7c8a673.patch", when="@:2.9")
 
     def patch(self):
-        # Deal with Make version detection not taking into account >= 4.x
+        # Support gmake >= 4
         filter_file(
             "    3.79* | 3.[89]*)",
             "    3.79* | 3.[89]* |  [4-9].* | [1-9][0-9]*)",
@@ -88,7 +88,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
             string=True,
         )
 
-        # Similarly: gcc >= 5 was not anticipated.
+        # Suport gcc >= 5
         filter_file(
             "3.4* | 4.[0-9]* )",
             "3.4* | 4.[0-9]* | [5-9].* | [1-9][0-9]*)",
@@ -96,7 +96,15 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
             string=True,
         )
 
-        # Similarly ld version detection.
+        # Support gcc >= 10
+        filter_file(
+            "4.[4-9].* | 4.[1-9][0-9].* | [5-9].* )",
+            "4.[4-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9]*)",
+            "configure",
+            string=True,
+        )
+
+        # Support binutils
         filter_file(
             "2.1[3-9]*)",
             "2.1[3-9]*|2.1[0-9][0-9]*|2.[2-9][0-9]*|[3-9].*|[1-9][0-9]*)",
@@ -107,10 +115,6 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     depends_on("bison", type="build")
     depends_on("texinfo", type="build")
     depends_on("gettext", type="build")
-
-    # The GCC 10 issue here is not necessarily a build issue, but a broken configure
-    # script that cannot deal with multi-digit major versions.
-    conflicts("%gcc@10:", when="@:2.20")
 
     with when("@master"):
         depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -59,6 +59,9 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # _obstack_compat symbol is not initialized
     patch("39b1f61.patch", when="@:2.17")
 
+    # Install fails with "unknown command hsep / vsep"
+    patch("texi.patch", when="@2.16.0")
+
     # rpc/types.h include issue
     patch("fb21f89.patch", when="@:2.16")
 
@@ -86,8 +89,6 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # The GCC 10 issue here is not necessarily a build issue, but a broken configure
     # script that cannot deal with multi-digit major versions.
     conflicts("%gcc@10:", when="@:2.20")
-    conflicts("%gcc@5:", when="@:2.15")
-    conflicts("%gcc@3:", when="@:2.2")
 
     with when("@master"):
         depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -127,5 +127,5 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
         # 3. do the rest of the build that may directly run ld.so
         with working_dir(self.build_directory):
             make("-C", "..", f"objdir={os.getcwd()}", "lib")
-            delete_rpath("elf/ld.so")
+            delete_rpath(join_path("elf", "ld.so"))
             make()

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -94,7 +94,9 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
 
-    @run_after("install")
+    @run_after("build")
     def remove_rpath_from_dynamic_linker(self):
-        # find the ld-*.so file in lib/
-        delete_rpath(find_first(self.prefix.lib, "ld-*.so.*"))
+        # Our compiler/linker wrapper adds an rpath to the dynamic linker itself, which
+        # is not allowed by glibc, it'll error immediately. During install the dynamic
+        # linker is already executed sometimes, so we drop the rpath right after the build.
+        delete_rpath(find_first(self.build_directory, "ld-*.so.*"))

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -115,6 +115,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     depends_on("bison", type="build")
     depends_on("texinfo", type="build")
     depends_on("gettext", type="build")
+    depends_on("perl", type="build")
 
     with when("@master"):
         depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/glibc/texi.patch
+++ b/var/spack/repos/builtin/packages/glibc/texi.patch
@@ -1,0 +1,15 @@
+diff --git a/manual/stdio.texi b/manual/stdio.texi
+index be769a5..7b436f0 100644
+--- a/manual/stdio.texi
++++ b/manual/stdio.texi
+@@ -3137,7 +3137,7 @@ The postfix tag corresponds to bytes, kilobytes, megabytes, gigabytes,
+ etc.  The full table is:
+ 
+ @ifinfo
+-@multitable @hsep @vsep {' '} {2^10 (1024)} {zetta} {Upper} {10^24 (1000)}
++@multitable {' '} {2^10 (1024)} {zetta} {Upper} {10^24 (1000)}
+ @item low @tab Multiplier  @tab From  @tab Upper @tab Multiplier
+ @item ' ' @tab 1           @tab       @tab ' '   @tab 1
+ @item k   @tab 2^10 (1024) @tab kilo  @tab K     @tab 10^3 (1000)
+-- 
+1.8.0.1


### PR DESCRIPTION
How to use this:

```
$ spack install glibc@...
$ export GLIBC=$(spack location -i glibc)
$ gcc -B $GLIBC/lib -isystem $GLIBC/include -L $GLIBC/lib -Wl,-rpath,$GLIBC/lib  -Wl,--dynamic-linker,$GLIBC/lib/ld-linux-x86-64.so.2 hello.c

$ ./a.out
Hello world

$ file hello.c
< should say interpreter points to spack install glibc >
```

The `-B` flag is necessary s.t. GCC picks up crt*.o from the glibc lib dir instead of system.