### PR TITLE
seacas: Set TPL_ENABLE_Pthread=ON when +thread_safe

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -195,7 +195,7 @@ class Seacas(CMakePackage):
                 from_variant("BUILD_SHARED_LIBS", "shared"),
                 from_variant("SEACASExodus_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("SEACASIoss_ENABLE_THREADSAFE", "thread_safe"),
-                #SEACASExodus_ENABLE_THREADSAFE=ON requires TPL_ENABLE_Pthread=ON
+                # SEACASExodus_ENABLE_THREADSAFE=ON requires TPL_ENABLE_Pthread=ON
                 from_variant("TPL_ENABLE_Pthread", "thread_safe"),
                 from_variant("TPL_ENABLE_X11", "x11"),
                 from_variant(project_name_base + "_ENABLE_Fortran", "fortran"),

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -195,6 +195,8 @@ class Seacas(CMakePackage):
                 from_variant("BUILD_SHARED_LIBS", "shared"),
                 from_variant("SEACASExodus_ENABLE_THREADSAFE", "thread_safe"),
                 from_variant("SEACASIoss_ENABLE_THREADSAFE", "thread_safe"),
+                #SEACASExodus_ENABLE_THREADSAFE=ON requires TPL_ENABLE_Pthread=ON
+                from_variant("TPL_ENABLE_Pthread", "thread_safe"),
                 from_variant("TPL_ENABLE_X11", "x11"),
                 from_variant(project_name_base + "_ENABLE_Fortran", "fortran"),
             ]


### PR DESCRIPTION
This should fix #39702

Basically, following suggestion of error message and setting TPL_ENABLE_Pthread to the value of the boolean spack variant thread_safe