### PR TITLE
Inject configuration into solver classes, instead of using globals

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -75,7 +75,8 @@ def compare_specs(a, b, to_string=False, color=None):
         color = get_color_when()
 
     # Prepare a solver setup to parse differences
-    setup = asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+    driver = asp.PyclingoDriver(configuration=spack.config.CONFIG)
+    setup = asp.SpackSolverSetup(driver=driver)
 
     # get facts for specs, making sure to include build dependencies of concrete
     # specs and to descend into dependency hashes so we include all facts.

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -11,6 +11,7 @@ from llnl.util.tty.color import cprint, get_color_when
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.config
 import spack.environment as ev
 import spack.solver.asp as asp
 import spack.util.environment
@@ -74,7 +75,7 @@ def compare_specs(a, b, to_string=False, color=None):
         color = get_color_when()
 
     # Prepare a solver setup to parse differences
-    setup = asp.SpackSolverSetup()
+    setup = asp.SpackSolverSetup(configuration=spack.config.CONFIG)
 
     # get facts for specs, making sure to include build dependencies of concrete
     # specs and to descend into dependency hashes so we include all facts.

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -172,7 +172,7 @@ def solve(parser, args):
 
     specs = list(env.user_specs) if env else spack.cmd.parse_specs(args.specs)
 
-    solver = asp.Solver()
+    solver = asp.Solver(configuration=spack.config.CONFIG)
     output = sys.stdout if "asp" in show else None
     setup_only = set(show) == {"asp"}
     unify = spack.config.get("concretizer:unify")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -744,7 +744,7 @@ def concretize_specs_together(*abstract_specs, **kwargs):
 def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
 
-    solver = spack.solver.asp.Solver()
+    solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
     result = solver.solve(abstract_specs, tests=kwargs.get("tests", False))
     result.raise_if_unsat()
     return [s.copy() for s in result.specs]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -826,8 +826,11 @@ def create():
     return cfg
 
 
+#: Used for type hints that might be called with the singleton
+ConfigurationType = Union[Configuration, llnl.util.lang.Singleton]
+
 #: This is the singleton configuration instance for Spack.
-CONFIG: Union[Configuration, llnl.util.lang.Singleton] = llnl.util.lang.Singleton(create)
+CONFIG: ConfigurationType = llnl.util.lang.Singleton(create)
 
 
 def add_from_file(filename, scope=None):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1394,7 +1394,7 @@ class Environment:
         self.specs_by_hash = {}
 
         result_by_user_spec = {}
-        solver = spack.solver.asp.Solver()
+        solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
         for result in solver.solve_in_rounds(specs_to_concretize, tests=tests):
             result_by_user_spec.update(result.specs_by_input)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2960,7 +2960,7 @@ class Spec:
         if self._concrete:
             return
 
-        solver = spack.solver.asp.Solver()
+        solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
         result = solver.solve([self], tests=tests)
         result.raise_if_unsat()
 

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -11,13 +11,6 @@ from llnl.util.filesystem import touch
 import spack.paths
 
 
-@pytest.fixture()
-def builder_test_repository():
-    builder_test_path = os.path.join(spack.paths.repos_path, "builder.test")
-    with spack.repo.use_repositories(builder_test_path) as mock_repo:
-        yield mock_repo
-
-
 @pytest.mark.parametrize(
     "spec_str,expected_values",
     [

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1670,7 +1670,7 @@ class TestConcretize:
 
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
-            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(driver=solver.driver)
             result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
 
         for spec in result.specs:
@@ -1689,7 +1689,7 @@ class TestConcretize:
 
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
-            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(driver=solver.driver)
             with pytest.raises(
                 spack.solver.asp.UnsatisfiableSpecError, match="'dep-with-variants@999'"
             ):
@@ -1706,7 +1706,7 @@ class TestConcretize:
 
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
-            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(driver=solver.driver)
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
             # The result here should have a single spec to build ('a')
             # and it should be using b@1.0 with a version badness of 2
@@ -1742,7 +1742,7 @@ class TestConcretize:
         reusable_specs = [wrong_compiler, wrong_os]
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
-            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(driver=solver.driver)
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
         concrete_spec = result.specs[0]
         assert concrete_spec.satisfies("%{}".format(s.compiler))
@@ -1998,7 +1998,7 @@ class TestConcretize:
         """
         specs = [Spec(s) for s in specs]
         solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
-        setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
+        setup = spack.solver.asp.SpackSolverSetup(driver=solver.driver)
         result, _, _ = solver.driver.solve(setup, specs, reuse=[])
 
         assert result.specs

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -470,7 +470,7 @@ class TestConcretize:
 
         assert spec.satisfies("^openblas+shared")
 
-    def test_no_matching_compiler_specs(self, mock_low_high_config):
+    def test_no_matching_compiler_specs(self):
         # only relevant when not building compilers as needed
         with spack.concretize.enable_compiler_existence_check():
             s = Spec("a %gcc@=0.0.0")
@@ -1601,7 +1601,7 @@ class TestConcretize:
         import spack.solver.asp
 
         specs = [Spec(s) for s in specs]
-        solver = spack.solver.asp.Solver()
+        solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
         solver.reuse = False
         concrete_specs = set()
         for result in solver.solve_in_rounds(specs):
@@ -1646,7 +1646,7 @@ class TestConcretize:
         import spack.solver.asp
 
         specs = [Spec(s) for s in specs]
-        solver = spack.solver.asp.Solver()
+        solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
         solver.reuse = False
         concrete_specs = {}
         for result in solver.solve_in_rounds(specs):
@@ -1669,8 +1669,8 @@ class TestConcretize:
         root_specs = [Spec("mpileaks"), Spec("zmpi")]
 
         with spack.config.override("concretizer:reuse", True):
-            solver = spack.solver.asp.Solver()
-            setup = spack.solver.asp.SpackSolverSetup()
+            solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
             result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
 
         for spec in result.specs:
@@ -1688,8 +1688,8 @@ class TestConcretize:
         root_spec = Spec("non-existing-conditional-dep@2.0")
 
         with spack.config.override("concretizer:reuse", True):
-            solver = spack.solver.asp.Solver()
-            setup = spack.solver.asp.SpackSolverSetup()
+            solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
             with pytest.raises(
                 spack.solver.asp.UnsatisfiableSpecError, match="'dep-with-variants@999'"
             ):
@@ -1705,8 +1705,8 @@ class TestConcretize:
         root_spec = Spec("a foobar=bar")
 
         with spack.config.override("concretizer:reuse", True):
-            solver = spack.solver.asp.Solver()
-            setup = spack.solver.asp.SpackSolverSetup()
+            solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
             # The result here should have a single spec to build ('a')
             # and it should be using b@1.0 with a version badness of 2
@@ -1741,8 +1741,8 @@ class TestConcretize:
         wrong_os.architecture = spack.spec.ArchSpec("test-ubuntu2204-x86_64")
         reusable_specs = [wrong_compiler, wrong_os]
         with spack.config.override("concretizer:reuse", True):
-            solver = spack.solver.asp.Solver()
-            setup = spack.solver.asp.SpackSolverSetup()
+            solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
+            setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
         concrete_spec = result.specs[0]
         assert concrete_spec.satisfies("%{}".format(s.compiler))
@@ -1997,8 +1997,8 @@ class TestConcretize:
         know a concretization exists.
         """
         specs = [Spec(s) for s in specs]
-        solver = spack.solver.asp.Solver()
-        setup = spack.solver.asp.SpackSolverSetup()
+        solver = spack.solver.asp.Solver(configuration=spack.config.CONFIG)
+        setup = spack.solver.asp.SpackSolverSetup(configuration=spack.config.CONFIG)
         result, _, _ = solver.driver.solve(setup, specs, reuse=[])
 
         assert result.specs

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -583,6 +583,14 @@ def mock_packages(mock_repo_path, mock_pkg_install, request):
 
 
 @pytest.fixture(scope="function")
+def builder_test_repository(request):
+    ensure_configuration_fixture_run_before(request)
+    builder_test_path = os.path.join(spack.paths.repos_path, "builder.test")
+    with spack.repo.use_repositories(builder_test_path) as mock_repo:
+        yield mock_repo
+
+
+@pytest.fixture(scope="function")
 def mutable_mock_repo(mock_repo_path, request):
     """Function-scoped mock packages, for tests that need to modify them."""
     ensure_configuration_fixture_run_before(request)


### PR DESCRIPTION
This PR injects `spack.config.Configuration` objects into the solver at construction time. In this way the solver will access its own instance of the configuration, instead of accessing a global instance. The repository and the store instances are created by the solver based on the configuration.

At the moment, this takes care of direct access, so the solver might be accessing global variables indirectly via other calls.