### PR TITLE
qt: change version for opengl dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -691,7 +691,7 @@ class Qt(Package):
                 config_args.extend(["-skip", "connectivity"])
         elif "+gui" in spec:
             # Linux-only QT5 dependencies
-            config_args.append("-system-xcb")
+            config_args.append("-xcb")
             if "+opengl" in spec:
                 config_args.append("-I{0}/include".format(spec["libx11"].prefix))
                 config_args.append("-I{0}/include".format(spec["xproto"].prefix))

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -691,7 +691,10 @@ class Qt(Package):
                 config_args.extend(["-skip", "connectivity"])
         elif "+gui" in spec:
             # Linux-only QT5 dependencies
-            config_args.append("-xcb")
+            if version < Version("5.9.9"):
+                config_args.append("-system-xcb")
+            else:
+                config_args.append("-xcb")
             if "+opengl" in spec:
                 config_args.append("-I{0}/include".format(spec["libx11"].prefix))
                 config_args.append("-I{0}/include".format(spec["xproto"].prefix))

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -689,7 +689,7 @@ class Qt(Package):
                 # Errors on bluetooth even when bluetooth is disabled...
                 # at least on apple-clang%12
                 config_args.extend(["-skip", "connectivity"])
-        elif version < Version("6") and "+gui" in spec:
+        elif "+gui" in spec:
             # Linux-only QT5 dependencies
             config_args.append("-system-xcb")
             if "+opengl" in spec:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -689,7 +689,7 @@ class Qt(Package):
                 # Errors on bluetooth even when bluetooth is disabled...
                 # at least on apple-clang%12
                 config_args.extend(["-skip", "connectivity"])
-        elif version < Version("5.15") and "+gui" in spec:
+        elif version < Version("6") and "+gui" in spec:
             # Linux-only QT5 dependencies
             config_args.append("-system-xcb")
             if "+opengl" in spec:


### PR DESCRIPTION
For the versions 5.15.X I'm having problems where libx11 is not found:

```
Trying source 0 (type makeSpec) of library xlib ...
X11/Xlib.h not found in [] and global paths.
  => source produced no result.
test config.qtbase_gui.libraries.xlib FAILED
```

The commit that last changed this is from 2021 so I guess versions 5.15 didn't exist back then or no one tested it: https://github.com/spack/spack/commit/579d97117d3e486c33d72d2f9db6f6f13792f416
Unless I'm missing something I think it should be fine for v5 and maybe even for v6 so that it would make sense to completely remove the version check (or someone will have this problem when v6 is added).