### PR TITLE
hpx-kokkos: add 0.4.0 and other minor changes

### DIFF
--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -11,6 +11,7 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/STEllAR-GROUP/hpx-kokkos"
     url = "https://github.com/STEllAR-GROUP/hpx-kokkos/archive/0.0.0.tar.gz"
+    git = "https://github.com/STEllAR-GROUP/hpx-kokkos.git"
     maintainers("G-071", "msimberg")
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -13,7 +13,8 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
     url = "https://github.com/STEllAR-GROUP/hpx-kokkos/archive/0.0.0.tar.gz"
     maintainers("G-071", "msimberg")
 
-    version("master", git="https://github.com/STEllAR-GROUP/hpx-kokkos.git", branch="master")
+    version("master", branch="master")
+    version("0.4.0", sha256="dafef55521cf4bf7ab28ebad546ea1d3fb83fac3a9932e292db4ab3666cd833f")
     version("0.3.0", sha256="83c1d11dab95552ad0abdae767c71f757811d7b51d82bd231653dc942e89a45d")
     version("0.2.0", sha256="289b711cea26afe80be002fc521234c9194cd0e8f69863f3b08b654674dbe5d5")
     version("0.1.0", sha256="24edb817d0969f4aea1b68eab4984c2ea9a58f4760a9b8395e20f85b178f0850")

--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -28,6 +28,14 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
         description="Use the specified C++ standard when building.",
     )
 
+    future_types_map = {"polling": "event", "callback": "callback"}
+    variant(
+        "future_type",
+        default="polling",
+        values=future_types_map.keys(),
+        description="Integration type for GPU futures",
+    )
+
     depends_on("cmake@3.19:", type="build")
 
     depends_on("hpx")
@@ -54,3 +62,15 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hpx +rocm", when="+rocm")
     depends_on("kokkos +rocm", when="+rocm")
+
+    def cmake_args(self):
+        spec, args = self.spec, []
+
+        args += [
+            self.define(
+                "HPX_KOKKOS_CUDA_FUTURE_TYPE",
+                self.future_types_map[spec.variants["future_type"].value],
+            ),
+        ]
+
+        return args


### PR DESCRIPTION
- adds 0.4.0
- adds a variant to choose the type of futures used internally
- adds support for running tests

cc @G-071.