### PR TITLE
nlcglib: pass cuda_arch setting to kokkos dependency

### DIFF
--- a/var/spack/repos/builtin/packages/nlcglib/package.py
+++ b/var/spack/repos/builtin/packages/nlcglib/package.py
@@ -49,9 +49,12 @@ class Nlcglib(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("rocblas")
         depends_on("rocsolver")
 
-    with when("+cuda"):
-        depends_on("kokkos+cuda+cuda_lambda+wrapper", when="%gcc")
-        depends_on("kokkos+cuda")
+    for arch in CudaPackage.cuda_arch_values:
+        depends_on(
+            f"kokkos+cuda+cuda_lambda+wrapper cuda_arch={arch}",
+            when=f"%gcc +cuda cuda_arch={arch}",
+        )
+        depends_on(f"kokkos+cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
 
     def cmake_args(self):
         options = [


### PR DESCRIPTION
Fixes #39724 

When building with `+cuda`, the specified `cuda_arch` was not passed to kokkos, leading to a wrong concretization.