### PR TITLE
Fix q-e-sirius+openmp FFTW3 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -38,6 +38,7 @@ class QESirius(CMakePackage):
     depends_on("sirius ~apps", when="~sirius_apps")
     depends_on("sirius +openmp", when="+openmp")
     depends_on("sirius@develop", when="@develop")
+    depends_on("fftw@3 +openmp", when="+openmp")
 
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")


### PR DESCRIPTION
Fixes #39726 

We must make sure that `sirius` uses `fftw@3+openmp`, otherwise the compilation will fail (although `sirius` will build fine).
This does not seem like a general requirement for building `sirius+openmp`, but a `q-e-sirius` requirement.
Let me know if you have any comments.

@simonpintarelli 
