### PR TITLE
Harden compiler detection against errors

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -44,7 +44,7 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         "error": str,
         "ignore_errors": ignore_errors,
         "timeout": 120,
-        "fail_on_timeout": True,
+        "fail_on_error": False,
     }
     if version_arg:
         output = compiler(version_arg, **compiler_invocation_args)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -237,7 +237,7 @@ class Compiler:
     _all_compiler_rpath_libraries = ["libc", "libc++", "libstdc++"]
 
     # string matcher for string representation of platforms supported by a compiler
-    supported_platforms = any
+    is_supported_on_platform = any
 
     # Default flags used by a compiler to set an rpath
     @property

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -236,7 +236,7 @@ class Compiler:
     # by any compiler
     _all_compiler_rpath_libraries = ["libc", "libc++", "libstdc++"]
 
-    # string matcher for string representation of platforms supported by a compiler
+    #: Platform matcher for Platform objects supported by compiler
     is_supported_on_platform = lambda x: True
 
     # Default flags used by a compiler to set an rpath

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 import shutil
+import sys
 import tempfile
 from typing import List, Optional, Sequence
 
@@ -602,7 +603,14 @@ class Compiler:
         # defined for the compiler
         compiler_names = getattr(cls, "{0}_names".format(language))
         prefixes = [""] + cls.prefixes
-        suffixes = [""] + cls.suffixes
+        suffixes = [""]
+        if sys.platform == "win32":
+            ext = r"\.(?:exe|bat)"
+            cls_suf = [suf + ext for suf in cls.suffixes]
+            ext_suf = [ext]
+            suffixes = suffixes + cls.suffixes + cls_suf + ext_suf
+        else:
+            suffixes = suffixes + cls.suffixes
         regexp_fmt = r"^({0}){1}({2})$"
         return [
             re.compile(regexp_fmt.format(prefix, re.escape(name), suffix))

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -43,7 +43,7 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         "output": str,
         "error": str,
         "ignore_errors": ignore_errors,
-        "timeout": 2.5,
+        "timeout": 120,
         "fail_on_timeout": True,
     }
     if version_arg:

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -39,10 +39,16 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         version_arg (str): the argument used to extract version information
     """
     compiler = spack.util.executable.Executable(compiler_path)
+    compiler_invocation_args = {"output": str,
+                                "error": str,
+                                "ignore_errors": ignore_errors,
+                                "timeout": 2.5,
+                                "fail_on_timeout": True
+                               }
     if version_arg:
-        output = compiler(version_arg, output=str, error=str, ignore_errors=ignore_errors)
+        output = compiler(version_arg, **compiler_invocation_args)
     else:
-        output = compiler(output=str, error=str, ignore_errors=ignore_errors)
+        output = compiler(**compiler_invocation_args)
     return output
 
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -44,7 +44,7 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         "error": str,
         "ignore_errors": ignore_errors,
         "timeout": 120,
-        "fail_on_error": False,
+        "fail_on_error": True,
     }
     if version_arg:
         output = compiler(version_arg, **compiler_invocation_args)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -593,16 +593,7 @@ class Compiler:
         # defined for the compiler
         compiler_names = getattr(cls, "{0}_names".format(language))
         prefixes = [""] + cls.prefixes
-        suffixes = [""]
-        # Windows compilers generally have an extension of some sort
-        # as do most files on Windows, handle that case here
-        if sys.platform == "win32":
-            ext = r"\.(?:exe|bat)"
-            cls_suf = [suf + ext for suf in cls.suffixes]
-            ext_suf = [ext]
-            suffixes = suffixes + cls.suffixes + cls_suf + ext_suf
-        else:
-            suffixes = suffixes + cls.suffixes
+        suffixes = [""] + cls.suffixes
         regexp_fmt = r"^({0}){1}({2})$"
         return [
             re.compile(regexp_fmt.format(prefix, re.escape(name), suffix))

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -235,6 +235,8 @@ class Compiler:
     # by any compiler
     _all_compiler_rpath_libraries = ["libc", "libc++", "libstdc++"]
 
+    # string matcher for string representation of platforms supported by a compiler
+    supported_platforms = any
     # Default flags used by a compiler to set an rpath
     @property
     def cc_rpath_arg(self):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -237,7 +237,7 @@ class Compiler:
     _all_compiler_rpath_libraries = ["libc", "libc++", "libstdc++"]
 
     # string matcher for string representation of platforms supported by a compiler
-    is_supported_on_platform = any
+    is_supported_on_platform = lambda x: True
 
     # Default flags used by a compiler to set an rpath
     @property

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -9,7 +9,6 @@ import os
 import platform
 import re
 import shutil
-import sys
 import tempfile
 from typing import List, Optional, Sequence
 
@@ -39,12 +38,13 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         version_arg (str): the argument used to extract version information
     """
     compiler = spack.util.executable.Executable(compiler_path)
-    compiler_invocation_args = {"output": str,
-                                "error": str,
-                                "ignore_errors": ignore_errors,
-                                "timeout": 2.5,
-                                "fail_on_timeout": True
-                               }
+    compiler_invocation_args = {
+        "output": str,
+        "error": str,
+        "ignore_errors": ignore_errors,
+        "timeout": 2.5,
+        "fail_on_timeout": True,
+    }
     if version_arg:
         output = compiler(version_arg, **compiler_invocation_args)
     else:
@@ -237,6 +237,7 @@ class Compiler:
 
     # string matcher for string representation of platforms supported by a compiler
     supported_platforms = any
+
     # Default flags used by a compiler to set an rpath
     @property
     def cc_rpath_arg(self):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -298,7 +298,7 @@ def select_new_compilers(compilers, scope=None):
     return compilers_not_in_config
 
 
-def supported_compilers()  -> List[str]:
+def supported_compilers() -> List[str]:
     """Return a set of names of compilers supported by Spack.
 
     See available_compilers() to get a list of all the available
@@ -306,12 +306,10 @@ def supported_compilers()  -> List[str]:
     """
     # Hack to be able to call the compiler `apple-clang` while still
     # using a valid python name for the module
-    return sorted(
-        all_compiler_names()
-    )
+    return sorted(all_compiler_names())
 
 
-def supported_compilers_for_host_platform()  -> List[str]:
+def supported_compilers_for_host_platform() -> List[str]:
     """Return a set of compiler class objects supported by Spack
     that are also supported by the current host platform
     """

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -333,7 +333,7 @@ def supported_compilers_for_platform(platform: str):
         return name if name != "apple_clang" else "apple-clang"
 
     return sorted(
-        name
+        replace_apple_clang(name)
         for name in llnl.util.lang.list_modules(spack.paths.compilers_path)
         if class_for_compiler_name(replace_apple_clang(name)).supported_platforms(platform)
     )
@@ -655,7 +655,7 @@ def arguments_to_detect_version_fn(operating_system, paths):
     def _default(search_paths):
         command_arguments = []
         files_to_be_tested = fs.files_in(*search_paths)
-        for compiler_name in spack.compilers.supported_compilers():
+        for compiler_name in spack.compilers.supported_compilers_for_host_platform():
             compiler_cls = class_for_compiler_name(compiler_name)
 
             for language in ("cc", "cxx", "f77", "fc"):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -328,7 +328,7 @@ def supported_compilers_for_platform(platform: str) -> List[str]:
     return [
         name
         for name in supported_compilers()
-        if class_for_compiler_name(name).supported_platforms(platform)
+        if class_for_compiler_name(name).is_supported_on_platform(platform)
     ]
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -312,6 +312,31 @@ def supported_compilers():
     )
 
 
+def supported_compilers_for_host_platform():
+    """Return a set of compiler class objects supported by Spack
+    that are also supported by the current host platform
+    """
+    host_plat = str(spack.platforms.real_host())
+    return supported_compilers_for_platform(host_plat)
+
+
+def supported_compilers_for_platform(platform: str):
+    """Return a set of compiler class objects supported by Spack
+    that are also supported by the provided platform
+
+    Args:
+        platform (str): string representation of platform
+            for which compiler compatability should be determined
+    """
+    def replace_apple_clang(name):
+        return name if name != "apple_clang" else "apple-clang"
+    return sorted(
+        name
+        for name in llnl.util.lang.list_modules(spack.paths.compilers_path)
+        if class_for_compiler_name(replace_apple_clang(name)).supported_platforms(platform)
+    )
+
+
 @_auto_compiler_spec
 def supported(compiler_spec):
     """Test if a particular compiler is supported."""

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -313,11 +313,11 @@ def supported_compilers_for_host_platform() -> List[str]:
     """Return a set of compiler class objects supported by Spack
     that are also supported by the current host platform
     """
-    host_plat = str(spack.platforms.real_host())
+    host_plat = spack.platforms.real_host()
     return supported_compilers_for_platform(host_plat)
 
 
-def supported_compilers_for_platform(platform: str) -> List[str]:
+def supported_compilers_for_platform(platform: spack.platforms.Platform) -> List[str]:
     """Return a set of compiler class objects supported by Spack
     that are also supported by the provided platform
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -328,8 +328,10 @@ def supported_compilers_for_platform(platform: str):
         platform (str): string representation of platform
             for which compiler compatability should be determined
     """
+
     def replace_apple_clang(name):
         return name if name != "apple_clang" else "apple-clang"
+
     return sorted(
         name
         for name in llnl.util.lang.list_modules(spack.paths.compilers_path)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -718,9 +718,11 @@ def detect_version(detect_version_args):
                 value = fn_args._replace(id=compiler_id._replace(version=version))
                 return value, None
 
-            error = "Couldn't get version for compiler {0}".format(path)
+            error = f"Couldn't get version for compiler {path}".format(path)
         except spack.util.executable.ProcessError as e:
-            error = "Couldn't get version for compiler {0}\n".format(path) + str(e)
+            error = f"Couldn't get version for compiler {path}\n" + str(e)
+        except spack.util.executable.ProcessTimeoutError as e:
+            error = f"Couldn't get version for compiler {path}\n" + str(e)
         except Exception as e:
             # Catching "Exception" here is fine because it just
             # means something went wrong running a candidate executable.

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -155,10 +155,8 @@ class Msvc(Compiler):
     #: Regex used to extract version from compiler's output
     version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
     suffixes = [""]
-    # Initialize, deferring to base class but then adding the vcvarsallfile
-    # file based on compiler executable path.
 
-    is_supported_on_platform = lambda x: x == "windows"
+    is_supported_on_platform = lambda x: isinstance(x, spack.platforms.Windows)
 
     def __init__(self, *args, **kwargs):
         # This positional argument "paths" is later parsed and process by the base class
@@ -169,6 +167,8 @@ class Msvc(Compiler):
         cspec = args[0]
         new_pth = [pth if pth else get_valid_fortran_pth(cspec.version) for pth in paths]
         paths[:] = new_pth
+        # Initialize, deferring to base class but then adding the vcvarsallfile
+        # file based on compiler executable path.
         super().__init__(*args, **kwargs)
         # To use the MSVC compilers, VCVARS must be invoked
         # VCVARS is located at a fixed location, referencable

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -158,7 +158,7 @@ class Msvc(Compiler):
     # Initialize, deferring to base class but then adding the vcvarsallfile
     # file based on compiler executable path.
 
-    supported_platforms = lambda x: x == "windows"
+    is_supported_on_platform = lambda x: x == "windows"
 
     def __init__(self, *args, **kwargs):
         # This positional argument "paths" is later parsed and process by the base class

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -158,6 +158,8 @@ class Msvc(Compiler):
     # Initialize, deferring to base class but then adding the vcvarsallfile
     # file based on compiler executable path.
 
+    supported_platforms = lambda x: x == "windows"
+
     def __init__(self, *args, **kwargs):
         # This positional argument "paths" is later parsed and process by the base class
         # via the call to `super` later in this method

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -154,7 +154,7 @@ class Msvc(Compiler):
 
     #: Regex used to extract version from compiler's output
     version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
-    suffixes = [".exe", ".bat"]
+    suffixes = [""]
     # Initialize, deferring to base class but then adding the vcvarsallfile
     # file based on compiler executable path.
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -154,7 +154,10 @@ class Msvc(Compiler):
 
     #: Regex used to extract version from compiler's output
     version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
-    suffixes = [""]
+    # The MSVC compiler class overrides this to prevent instances
+    # of erroneous matching on executable names that cannot be msvc
+    # compilers
+    suffixes = []
 
     is_supported_on_platform = lambda x: isinstance(x, spack.platforms.Windows)
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -154,7 +154,7 @@ class Msvc(Compiler):
 
     #: Regex used to extract version from compiler's output
     version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
-
+    suffixes = [".exe", ".bat"]
     # Initialize, deferring to base class but then adding the vcvarsallfile
     # file based on compiler executable path.
 

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -125,7 +125,7 @@ class Executable:
 
         """
 
-        def process_cmd_output():
+        def process_cmd_output(out, err):
             result = None
             if output in (str, str.split) or error in (str, str.split):
                 result = ""
@@ -227,7 +227,7 @@ class Executable:
             )
             out, err = proc.communicate(timeout=timeout)
 
-            result = process_cmd_output()
+            result = process_cmd_output(out, err)
             rc = self.returncode = proc.returncode
             if fail_on_error and rc != 0 and (rc not in ignore_errors):
                 long_msg = cmd_line_string
@@ -263,10 +263,10 @@ class Executable:
                 f"Command {cmd_line_string} experienced a timeout after\
 {timeout}s running process {proc.pid}"
             )
-            result = process_cmd_output()
+            result = process_cmd_output(out, err)
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_timeout:
-                raise ProcessError(str(te), f"\nProcess timed out after {timeout}s" f"{long_msg}")
+                raise ProcessError(f"\nProcess timed out after {timeout}s" f"{long_msg}") from te
 
         finally:
             if close_ostream:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -102,8 +102,6 @@ class Executable:
                 as Spack does not use a shell. Defaults to False.
             timeout (int or float): The number of seconds to wait before killing
                 the child process
-            fail_on_timeout (bool): Raise an exception if the subprocess times out
-                Note: this is a no-op if `timeout` is not specified as an argument
             input: Where to read stdin from
             output: Where to send stdout
             error: Where to send stderr
@@ -261,7 +259,7 @@ class Executable:
             out, err = proc.communicate()
             result = process_cmd_output(out, err)
             long_msg = cmd_line_string + f"\n{result}"
-            if fail_on_timeout:
+            if fail_on_error:
                 raise ProcessError(
                     f"\nProcess timed out after {timeout}s"
                     f"We expected the following command to run quickly but\

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -124,9 +124,10 @@ class Executable:
         By default, the subprocess inherits the parent's file descriptors.
 
         """
+
         def process_cmd_output():
             result = None
-            if  output in (str, str.split) or error in (str, str.split):
+            if output in (str, str.split) or error in (str, str.split):
                 result = ""
                 if output in (str, str.split):
                     if sys.platform == "win32":
@@ -258,15 +259,14 @@ class Executable:
         except subprocess.TimeoutExpired as te:
             proc.kill()
             out, err = proc.communicate()
-            tty.warn(f"Command {cmd_line_string} experienced a timeout after {timeout}s running process {proc.pid}")
+            tty.warn(
+                f"Command {cmd_line_string} experienced a timeout after\
+{timeout}s running process {proc.pid}"
+            )
             result = process_cmd_output()
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_timeout:
-                raise ProcessError(
-                    str(te),
-                    f"\nProcess timed out after {timeout}s"
-                    f"{long_msg}"
-                )
+                raise ProcessError(str(te), f"\nProcess timed out after {timeout}s" f"{long_msg}")
 
         finally:
             if close_ostream:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -263,7 +263,7 @@ class Executable:
                     f"\nProcess timed out after {timeout}s"
                     f"We expected the following command to run quickly but\
 it did not, please report this as an issue: {long_msg}",
-                long_message=long_msg
+                    long_message=long_msg,
                 ) from te
 
         finally:
@@ -366,7 +366,6 @@ class ProcessError(spack.error.SpackError):
 class ProcessTimeoutError(ProcessError):
     """ProcessTimeoutErrors are raised when Executable calls with a
     specified timeout exceed that time"""
-
 
 
 class CommandNotFoundError(spack.error.SpackError):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -100,6 +100,10 @@ class Executable:
                 an exception even if ``fail_on_error`` is set to ``True``
             ignore_quotes (bool): If False, warn users that quotes are not needed
                 as Spack does not use a shell. Defaults to False.
+            timeout (int or float): The number of seconds to wait before killing
+                the child process
+            fail_on_timeout (bool): Raise an exception if the subprocess times out
+                Note: this is a no-op if `timeout` is not specified as an argument
             input: Where to read stdin from
             output: Where to send stdout
             error: Where to send stderr
@@ -120,6 +124,28 @@ class Executable:
         By default, the subprocess inherits the parent's file descriptors.
 
         """
+        def process_cmd_output():
+            result = None
+            if  output in (str, str.split) or error in (str, str.split):
+                result = ""
+                if output in (str, str.split):
+                    if sys.platform == "win32":
+                        outstr = str(out.decode("ISO-8859-1"))
+                    else:
+                        outstr = str(out.decode("utf-8"))
+                    result += outstr
+                    if output is str.split:
+                        sys.stdout.write(outstr)
+                if error in (str, str.split):
+                    if sys.platform == "win32":
+                        errstr = str(err.decode("ISO-8859-1"))
+                    else:
+                        errstr = str(err.decode("utf-8"))
+                    result += errstr
+                    if error is str.split:
+                        sys.stderr.write(errstr)
+            return result
+
         # Environment
         env_arg = kwargs.get("env", None)
 
@@ -150,6 +176,8 @@ class Executable:
         fail_on_error = kwargs.pop("fail_on_error", True)
         ignore_errors = kwargs.pop("ignore_errors", ())
         ignore_quotes = kwargs.pop("ignore_quotes", False)
+        timeout = kwargs.pop("timeout", None)
+        fail_on_timeout = kwargs.pop("fail_on_timeout", False)
 
         # If they just want to ignore one error code, make it a tuple.
         if isinstance(ignore_errors, int):
@@ -196,28 +224,9 @@ class Executable:
             proc = subprocess.Popen(
                 cmd, stdin=istream, stderr=estream, stdout=ostream, env=env, close_fds=False
             )
-            out, err = proc.communicate()
+            out, err = proc.communicate(timeout=timeout)
 
-            result = None
-            if output in (str, str.split) or error in (str, str.split):
-                result = ""
-                if output in (str, str.split):
-                    if sys.platform == "win32":
-                        outstr = str(out.decode("ISO-8859-1"))
-                    else:
-                        outstr = str(out.decode("utf-8"))
-                    result += outstr
-                    if output is str.split:
-                        sys.stdout.write(outstr)
-                if error in (str, str.split):
-                    if sys.platform == "win32":
-                        errstr = str(err.decode("ISO-8859-1"))
-                    else:
-                        errstr = str(err.decode("utf-8"))
-                    result += errstr
-                    if error is str.split:
-                        sys.stderr.write(errstr)
-
+            result = process_cmd_output()
             rc = self.returncode = proc.returncode
             if fail_on_error and rc != 0 and (rc not in ignore_errors):
                 long_msg = cmd_line_string
@@ -245,6 +254,18 @@ class Executable:
                     str(e),
                     "\nExit status %d when invoking command: %s"
                     % (proc.returncode, cmd_line_string),
+                )
+        except subprocess.TimeoutExpired as te:
+            proc.kill()
+            out, err = proc.communicate()
+            tty.warn(f"Command {cmd_line_string} experienced a timeout after {timeout}s running process {proc.pid}")
+            result = process_cmd_output()
+            long_msg = cmd_line_string + f"\n{result}"
+            if fail_on_timeout:
+                raise ProcessError(
+                    str(te),
+                    f"\nProcess timed out after {timeout}s"
+                    f"{long_msg}"
                 )
 
         finally:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -176,7 +176,6 @@ class Executable:
         ignore_errors = kwargs.pop("ignore_errors", ())
         ignore_quotes = kwargs.pop("ignore_quotes", False)
         timeout = kwargs.pop("timeout", None)
-        fail_on_timeout = kwargs.pop("fail_on_timeout", False)
 
         # If they just want to ignore one error code, make it a tuple.
         if isinstance(ignore_errors, int):
@@ -260,10 +259,11 @@ class Executable:
             result = process_cmd_output(out, err)
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_error:
-                raise ProcessError(
+                raise ProcessTimeoutError(
                     f"\nProcess timed out after {timeout}s"
                     f"We expected the following command to run quickly but\
-it did not, please report this as an issue: {long_msg}"
+it did not, please report this as an issue: {long_msg}",
+                long_message=long_msg
                 ) from te
 
         finally:
@@ -361,6 +361,12 @@ def which(*args, **kwargs):
 
 class ProcessError(spack.error.SpackError):
     """ProcessErrors are raised when Executables exit with an error code."""
+
+
+class ProcessTimeoutError(ProcessError):
+    """ProcessTimeoutErrors are raised when Executable calls with a
+    specified timeout exceed that time"""
+
 
 
 class CommandNotFoundError(spack.error.SpackError):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -259,14 +259,14 @@ class Executable:
         except subprocess.TimeoutExpired as te:
             proc.kill()
             out, err = proc.communicate()
-            tty.warn(
-                f"Command {cmd_line_string} experienced a timeout after\
-{timeout}s running process {proc.pid}"
-            )
             result = process_cmd_output(out, err)
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_timeout:
-                raise ProcessError(f"\nProcess timed out after {timeout}s" f"{long_msg}") from te
+                raise ProcessError(
+                    f"\nProcess timed out after {timeout}s"
+                    f"We expected the following command to run quickly but\
+it did not, please report this as an issue: {long_msg}"
+                ) from te
 
         finally:
             if close_ostream:


### PR DESCRIPTION
This PR does three things:

1. Prevents things like `cl-.*` from being detected as potential MSVC installs. `cl` is always just `cl` in all cases that Spack supports. Change the MSVC class to indicated this.
2. Compiler detection should timeout after a certain period of time. Because compiler detection executes a number of arbitrary executables on the system, we could encounter a program that just hangs, or even a compiler that hangs on a license key or similar. A timeout would prevent this from rendering Spack non functional. This PR introduces a `timeout` and `fail_on_timeout` arguments to `Executable`'s `__call__` method, and adds handling for those arguments. There is no default timeout, if one is not specified, there will be no timeout.
3. Prevent compilers unsupported on certain platforms from being detected there. #39622 raised the issue "why are we wasting time trying to detect MSVC on non Windows platforms?". The answer is that we really should not be. This PR introduces two methods to the compiler module designed to pick up compilers supported on given platforms.

Resolves https://github.com/spack/spack/issues/39622
