### PR TITLE
update q-e-sirius package

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -17,7 +17,7 @@ class QESirius(CMakePackage):
 
     maintainers("simonpintarelli")
 
-    version("develop-ristretto", branch="ristretto", submodules=True)
+    version("develop-ristretto", branch="ristretto", preferred=True, submodules=True)
     version(
         "6.7-rc1-sirius",
         tag="v6.7-rc1-sirius",
@@ -27,29 +27,52 @@ class QESirius(CMakePackage):
 
     variant("mpi", default=True, description="Builds with MPI support")
     variant("openmp", default=True, description="Enables OpenMP support")
-    variant("scalapack", default=False, description="Enables SCALAPACK support")
-    variant("elpa", default=False, description="Uses ELPA as an eigenvalue solver")
     variant("libxc", default=False, description="Support functionals through libxc")
-    variant("hdf5", default=False, description="Enables HDF5 support")
     variant("sirius_apps", default=False, description="Build SIRIUS standalone binaries")
+    # Support for HDF5 has been added starting in QE 6.1.0 and is
+    # still experimental
+    variant(
+        "hdf5",
+        default="none",
+        description="Orbital and density data I/O with HDF5",
+        values=("parallel", "serial", "none"),
+        multi=False,
+    )
 
     depends_on("sirius +fortran")
     depends_on("sirius +apps", when="+sirius_apps")
     depends_on("sirius ~apps", when="~sirius_apps")
     depends_on("sirius +openmp", when="+openmp")
-    depends_on("sirius@develop", when="@develop")
+    depends_on("sirius@develop", when="@develop-ristretto")
 
     depends_on("mpi", when="+mpi")
-    depends_on("scalapack", when="+scalapack")
     depends_on("elpa", when="+elpa")
     depends_on("libxc", when="+libxc")
-    depends_on("hdf5", when="+hdf5")
-
+    depends_on("fftw-api@3")
+    depends_on("blas")
+    depends_on("lapack")
     depends_on("git", type="build")
     depends_on("pkgconfig", type="build")
 
     conflicts("~mpi", when="+scalapack", msg="SCALAPACK requires MPI support")
     conflicts("~scalapack", when="+elpa", msg="ELPA requires SCALAPACK support")
+
+    with when("+mpi"):
+        depends_on("mpi")
+        variant("scalapack", default=True, description="Enables scalapack support")
+
+    with when("+scalapack"):
+        depends_on("scalapack")
+        variant("elpa", default=False, description="Uses elpa as an eigenvalue solver")
+
+    # Versions of HDF5 prior to 1.8.16 lead to QE runtime errors
+    depends_on("hdf5@1.8.16:+fortran+hl+mpi", when="hdf5=parallel")
+    depends_on("hdf5@1.8.16:+fortran+hl~mpi", when="hdf5=serial")
+
+    with when("+openmp"):
+        depends_on("fftw+openmp", when="^fftw")
+        depends_on("openblas threads=openmp", when="^openblas")
+        depends_on("intel-mkl threads=openmp", when="^intel-mkl")
 
     def cmake_args(self):
         args = [
@@ -61,14 +84,19 @@ class QESirius(CMakePackage):
             self.define_from_variant("QE_ENABLE_OPENMP", "openmp"),
             self.define_from_variant("QE_ENABLE_ELPA", "elpa"),
             self.define_from_variant("QE_ENABLE_LIBXC", "libxc"),
-            self.define_from_variant("QE_ENABLE_HDF5", "hdf5"),
             self.define_from_variant("QE_ENABLE_SCALAPACK", "scalapack"),
         ]
+
+        if not self.spec.satisfies("hdf5=none"):
+            args.append(self.define("QE_ENABLE_HDF5", True))
 
         # Work around spack issue #19970 where spack sets
         # rpaths for MKL just during make, but cmake removes
         # them during make install.
         if "^mkl" in self.spec:
             args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
+        spec = self.spec
+        args.append(self.define("BLAS_LIBRARIES", spec["blas"].libs.joined(";")))
+        args.append(self.define("LAPACK_LIBRARIES", spec["lapack"].libs.joined(";")))
 
         return args


### PR DESCRIPTION
- set develop as preferred version
- add `hdf5=none|parallel|serial` from quantum-espresso 
- add missing dependency on `fftw-api`
- depend on `openblas threads=openmp`, `fftw+openmp`, etc when openmp is enabled
- enable scalapack variant only for +mpi
- manually set LAPACK_LIBRARIES, BLAS_LIBRARIES 
