### PR TITLE
embree: fix linux build on aarch64 for 3.13.5

### DIFF
--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -37,6 +37,17 @@ class Embree(CMakePackage):
 
     depends_on("tbb")
 
+    # official aarch64 support on macOS starting with 3.13.0, on Linux since 4.0.0
+    # upstream patch for Linux/aarch64 applies cleanly to 3.13.5, and 3.13.3 works by chance
+    conflicts("@:3.12", when="target=aarch64:")
+    conflicts("@:3.13.2", when="target=aarch64: platform=linux")
+    conflicts("@3.13.4", when="target=aarch64: platform=linux")
+    patch(
+        "https://github.com/embree/embree/commit/82ca6b5ccb7abe0403a658a0e079926478f04cb1.patch?full_index=1",
+        sha256="3af5a65e8875549b4c930d4b0f2840660beba4a7f295d8c89068250a1df376f2",
+        when="@3.13.5",
+    )
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
- upstream patch does not apply cleanly to older versions, not required for newer ones
- also add conflict for older versions, except for 3.13.3 which works by chance

While not fixing the build of 3.13.1 on Linux/aarch64, it should still help with #39534.