### PR TITLE
[intel-oneapi-mkl] hpcx-mpi support

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -220,9 +220,14 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         resolved_libs = find_libraries(libs, lib_path, shared=shared)
         # Add MPI libraries for cluster support. If MPI is not in the
         # spec, then MKL is externally installed and application must
-        # link with MPI libaries
-        if self.spec.satisfies("+cluster ^mpi"):
-            resolved_libs = resolved_libs + self.spec["mpi"].libs
+        # link with MPI libaries. If MPI is in spect, but there are no
+        # libraries, then the package (e.g. hpcx-mpi) relies on the
+        # compiler wrapper to add the libraries.
+        try:
+            if self.spec.satisfies("+cluster ^mpi"):
+                resolved_libs = resolved_libs + self.spec["mpi"].libs
+        except spack.error.NoLibrariesError:
+            pass
         return resolved_libs
 
     def _xlp64_lib(self, lib):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -220,7 +220,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         resolved_libs = find_libraries(libs, lib_path, shared=shared)
         # Add MPI libraries for cluster support. If MPI is not in the
         # spec, then MKL is externally installed and application must
-        # link with MPI libaries. If MPI is in spect, but there are no
+        # link with MPI libaries. If MPI is in spec, but there are no
         # libraries, then the package (e.g. hpcx-mpi) relies on the
         # compiler wrapper to add the libraries.
         try:


### PR DESCRIPTION
Handle the case when an mpi package does not provide libs

Resolves: #39629 

@lorisercole: Can you see if this fixes the problem? It gets past the initial error but I don't have hpcx-mpi installed so cannot fully test it.