### PR TITLE
Add cuda as a variant to opa-psm2

### DIFF
--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class OpaPsm2(MakefilePackage):
+class OpaPsm2(MakefilePackage, CudaPackage):
     """Omni-Path Performance Scaled Messaging 2 (PSM2) library"""
 
     homepage = "https://github.com/cornelisnetworks/opa-psm2"
@@ -45,6 +45,8 @@ class OpaPsm2(MakefilePackage):
             # this variable must be set when we use the Intel compilers to
             # ensure that the proper flags are set
             env.set("CCARCH", "icc")
+        if "+cuda" in self.spec:
+            env.set("PSM_CUDA", "1")
 
     def edit(self, spec, prefix):
         # Change the makefile so libraries and includes are not

--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -31,6 +31,7 @@ class OpaPsm2(MakefilePackage, CudaPackage):
     variant("avx2", default=True, description="Enable AVX2 instructions")
 
     depends_on("numactl")
+    depends_on("cuda@8:", when="+cuda")
 
     # patch to get the Makefile to use the spack compiler wrappers
     patch(


### PR DESCRIPTION
Enable cuda support on opa-psm2 by setting PSM_CUDA to 1 if the "+cuda" variant is requested.