### PR TITLE
seacas: correctly limit fmt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -140,7 +140,7 @@ class Seacas(CMakePackage):
     depends_on("netcdf-c@4.8.0:~mpi", when="~mpi")
     depends_on("hdf5+hl~mpi", when="~mpi")
 
-    depends_on("fmt@8.1.0:", when="@2022-03-04:2022-05-16")
+    depends_on("fmt@8.1.0:9", when="@2022-03-04:2022-05-16")
     depends_on("fmt@9.1.0", when="@2022-10-14")
     depends_on("fmt@9.1.0:", when="@2023-05-30")
     depends_on("matio", when="+matio")


### PR DESCRIPTION
fixes #40150

versions older than 2022-10-14 do not build with fmt@10, either: fmt/core.h:1579:3: error: static_assert failed due to requirement 'formattable'