### PR TITLE
acts: impose cxxstd variant on geant4 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -320,8 +320,10 @@ class Acts(CMakePackage, CudaPackage):
     for _cxxstd in _cxxstd_values:
         if isinstance(_cxxstd, _ConditionalVariantValues):
             for _v in _cxxstd:
+                depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^geant4")
                 depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^root")
         else:
+            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^geant4")
             depends_on(f"root cxxstd={_cxxstd}", when=f"cxxstd={_cxxstd} ^root")
 
     # ACTS has been using C++17 for a while, which precludes use of old GCC

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -320,7 +320,9 @@ class Acts(CMakePackage, CudaPackage):
     for _cxxstd in _cxxstd_values:
         if isinstance(_cxxstd, _ConditionalVariantValues):
             for _v in _cxxstd:
-                depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^geant4")
+                depends_on(
+                    f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^geant4"
+                )
                 depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^root")
         else:
             depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} ^geant4")


### PR DESCRIPTION
When ACTS builds the Geant4 example, it injects both the `-std=gnu++20` from ACTS and the `-std=c++17` from Geant4, which leads to build failures.

TODO:
- [x] #39785

<details><summary>build failure details</summary>
<pre>
#45 840.7      920     [ 70%] Building CXX object Examples/Algorithms/Geant4/CMakeFiles/A
#45 840.7              ctsExamplesGeant4.dir/src/SensitiveSurfaceMapper.cpp.o
#45 840.7      921     cd /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdo
#45 840.7              vpgvmeykwgi5jxl/spack-build-tgwsfgp/Examples/Algorithms/Geant4 && 
#45 840.7              /opt/spack/lib/spack/env/gcc/g++ -DACTS_CONCEPTS_SUPPORTED -DACTS_
#45 840.7              ENABLE_LOG_FAILURE_THRESHOLD -DACTS_LOG_FAILURE_THRESHOLD=MAX -DAc
#45 840.7              tsExamplesGeant4_EXPORTS -DBOOST_SPIRIT_USE_PHOENIX_V3 -DDD4HEP_US
#45 840.7              E_XERCESC -DG4LIB_BUILD_DLL -DG4UI_USE_QT -DG4UI_USE_TCSH -DG4VIS_
#45 840.7              USE_OPENGL -DG4VIS_USE_OPENGLQT -DG4VIS_USE_OPENGLX -DG4VIS_USE_QT
#45 840.7              3D -DG4VIS_USE_RAYTRACERX -DG4VIS_USE_TOOLSSG_QT_GLES -DG4VIS_USE_
#45 840.7              TOOLSSG_X11_GLES -DPTL_BUILD_DLL -DQT_3DCORE_LIB -DQT_3DEXTRAS_LIB
#45 840.7               -DQT_3DINPUT_LIB -DQT_3DLOGIC_LIB -DQT_3DRENDER_LIB -DQT_CORE_LIB
#45 840.7               -DQT_GAMEPAD_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT
#45 840.7              _OPENGL_LIB -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -I/tmp/root/spa
#45 840.7              ck-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/
#45 840.7              spack-src/Examples/Algorithms/Geant4/include -I/tmp/root/spack-sta
#45 840.7              ge/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-
#45 840.7              src/Core/include -I/tmp/root/spack-stage/spack-stage-acts-28.0.0-t
#45 840.7              gwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-build-tgwsfgp/Core -I/tmp/ro
#45 840.7              ot/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeykwg
#45 840.7              i5jxl/spack-src/Examples/Framework/include -I/tmp/root/spack-stage
#45 840.7              /spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-sr
#45 840.7              c/Fatras/include -I/tmp/root/spack-stage/spack-stage-acts-28.0.0-t
#45 840.7              gwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Plugins/FpeMonitoring/in
#45 840.7              clude -I/tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgi
#45 840.7              rqwdovpgvmeykwgi5jxl/spack-src/Examples/Detectors/TelescopeDetecto
#45 840.7              r/include -I/tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpu
#45 840.7              jxgirqwdovpgvmeykwgi5jxl/spack-src/Examples/Detectors/DD4hepDetect
#45 840.7              or/include -I/tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgp
#45 840.7              ujxgirqwdovpgvmeykwgi5jxl/spack-src/Plugins/DD4hep/include -I/tmp/
#45 840.7              root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeyk
#45 840.7              wgi5jxl/spack-src/Plugins/TGeo/include -I/tmp/root/spack-stage/spa
#45 840.7              ck-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Pl
#45 840.7              ugins/Identification/include -isystem /opt/software/linux-debian12
#45 840.7              -x86_64_v2/gcc-12.2.0/geant4-11.1.2.east-ibfn3k7msz7ubtjd2aserdlyl
#45 840.7              7kpmbsp/include/Geant4 -isystem /opt/software/linux-debian12-x86_6
#45 840.7              4_v2/gcc-12.2.0/boost-1.82.0-52hnlpxsrir4ac7lhd6znsxnscwfcvvg/incl
#45 840.7              ude -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/eig
#45 840.7              en-3.4.0-kgxjkle2vrkqlsinu3wfvmesakl2xdrt/include/eigen3 -isystem 
#45 840.7              /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/root-6.28.04-nz5
#45 840.7              jnp5voyds75o2r7chipss4ohl45k3/include/root -isystem /opt/software/
#45 840.7              linux-debian12-x86_64_v2/gcc-12.2.0/intel-tbb-2020.3-h2uvzxumkgbg4
#45 840.7              lrr6zyjrd4ls4gij7th/include -isystem /opt/software/linux-debian12-
#45 840.7              x86_64_v2/gcc-12.2.0/clhep-2.4.6.4-7pma6e3oe6dlg7tmad43jduw3q6hhdo
#45 840.7              u/include -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2
#45 840.7              .0/expat-2.5.0-47cmm7nehipjtvcs3s6lnoowdq4t762a/include -isystem /
#45 840.7              opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/libice-1.0.9-qpb6
#45 840.7              z5ugi2zohrtfjmlodqvahfufmaee/include -isystem /opt/software/linux-
#45 840.7              debian12-x86_64_v2/gcc-12.2.0/libsm-1.2.3-tl36bdjawdzqdxvhbdvj4wqq
#45 840.7              esi6ob5d/include -isystem /opt/software/linux-debian12-x86_64_v2/g
#45 840.7              cc-12.2.0/xproto-7.0.31-z4sp2ngysh6onjxoljpoaqfzp3za7xu6/include -
#45 840.7              isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/libxext-
#45 840.7              1.3.3-3ogdhs3x4krwvukcbcrepxmncw2qzbpu/include -isystem /opt/softw
#45 840.7              are/linux-debian12-x86_64_v2/gcc-12.2.0/libxmu-1.1.4-rkphukygsbr4h
#45 840.7              ets7cq7hg43adsfuzkd/include -isystem /opt/software/linux-debian12-
#45 840.7              x86_64_v2/gcc-12.2.0/libxt-1.1.5-efk4c52y2q4z6sps2x7roqzgx2xnjpax/
#45 840.7              include -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0
#45 840.7              /qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/include -isystem /opt/
#45 840.7              software/linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhu
#45 840.7              y7wvf3tunm6pqezy3ju2u/include/QtCore -isystem /opt/software/linux-
#45 840.7              debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqez
#45 840.7              y3ju2u/./mkspecs/linux-g++ -isystem /opt/software/linux-debian12-x
#45 840.7              86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/inc
#45 840.7              lude/QtGui -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.
#45 840.7              2.0/mesa-22.1.6-wvkgm3s4wgoclk323lmohtw2xfjoofcm/include -isystem 
#45 840.7              /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpq
#45 840.7              garhuy7wvf3tunm6pqezy3ju2u/include/QtWidgets -isystem /opt/softwar
#45 840.7              e/linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3t
#45 840.7              unm6pqezy3ju2u/include/QtOpenGL -isystem /opt/software/linux-debia
#45 840.7              n12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2
#45 840.7              u/include/QtPrintSupport -isystem /opt/software/linux-debian12-x86
#45 840.7              _64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/inclu
#45 840.7              de/Qt3DCore -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12
#45 840.7              .2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/include/QtNetwork 
#45 840.7              -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15
#45 840.7              .9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/include/Qt3DExtras -isystem /o
#45 840.7              pt/software/linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqga
#45 840.7              rhuy7wvf3tunm6pqezy3ju2u/include/Qt3DRender -isystem /opt/software
#45 840.7              /linux-debian12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tu
#45 840.7              nm6pqezy3ju2u/include/Qt3DInput -isystem /opt/software/linux-debia
#45 840.7              n12-x86_64_v2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2
#45 840.7              u/include/QtGamepad -isystem /opt/software/linux-debian12-x86_64_v
#45 840.7              2/gcc-12.2.0/qt-5.15.9-yyzwpqgarhuy7wvf3tunm6pqezy3ju2u/include/Qt
#45 840.7              3DLogic -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0
#45 840.7              /xerces-c-3.2.4-g233npbtqnly6pxggbwrsuplsamqbyqb/include -isystem 
#45 840.7              /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/zlib-1.2.13-4qrm
#45 840.7              ahtit7zrirqtj3u43g6fetkuhhev/include -isystem /opt/software/linux-
#45 840.7              debian12-x86_64_v2/gcc-12.2.0/dd4hep-1.26-ju4caauohutkgsl2uz43jkmy
#45 840.7              wozqfwvl/include -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-loc
#45 840.7              al-typedefs -O3 -DNDEBUG  -std=gnu++20 -fPIC -DBOOST_STACKTRACE_US
#45 840.7              E_BACKTRACE -fPIC -W -Wall -pedantic -Wno-non-virtual-dtor -Wno-lo
#45 840.7              ng-long -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-
#45 840.7              variadic-macros -Wshadow -pipe -pthread -ftls-model=global-dynamic
#45 840.7               -std=c++17 -MD -MT Examples/Algorithms/Geant4/CMakeFiles/ActsExam
#45 840.7              plesGeant4.dir/src/SensitiveSurfaceMapper.cpp.o -MF CMakeFiles/Act
#45 840.7              sExamplesGeant4.dir/src/SensitiveSurfaceMapper.cpp.o.d -o CMakeFil
#45 840.7              es/ActsExamplesGeant4.dir/src/SensitiveSurfaceMapper.cpp.o -c /tmp
#45 840.7              /root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpgvmey
#45 840.7              kwgi5jxl/spack-src/Examples/Algorithms/Geant4/src/SensitiveSurface
#45 840.7              Mapper.cpp
#45 840.7      922     In file included from /tmp/root/spack-stage/spack-stage-acts-28.0.
#45 840.7              0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Core/include/Acts/Geo
#45 840.7              metry/TrackingGeometry.hpp:14,
#45 840.7      923                      from /tmp/root/spack-stage/spack-stage-acts-28.0.
#45 840.7              0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Examples/Algorithms/G
#45 840.7              eant4/src/SensitiveSurfaceMapper.cpp:15:
#45 840.7   >> 924     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/SurfaceVisitorCo
#45 840.7              ncept.hpp:19:1: error: 'concept' does not name a type; did you mea
#45 840.7              n 'const'?
#45 840.7      925        19 | concept SurfaceVisitor = requires(T v) {
#45 840.7      926           | ^~~~~~~
#45 840.7      927           | const
#45 840.7      928     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/SurfaceVisitorCo
#45 840.7              ncept.hpp:19:1: note: 'concept' only available with '-std=c++20' o
#45 840.7              r '-fconcepts'
#45 840.7      929     In file included from /tmp/root/spack-stage/spack-stage-acts-28.0.
#45 840.7              0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Core/include/Acts/Geo
#45 840.7              metry/TrackingVolume.hpp:26,
#45 840.7      930                      from /tmp/root/spack-stage/spack-stage-acts-28.0.
#45 840.7              0-tgwsfgpujxgirqwdovpgvmeykwgi5jxl/spack-src/Core/include/Acts/Geo
#45 840.7              metry/TrackingGeometry.hpp:15:
#45 840.7   >> 931     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:264:26: error: 'SurfaceVisitor' has not been declared
#45 840.7      932       264 |   template <ACTS_CONCEPT(SurfaceVisitor) visitor_t>
#45 840.7      933           |                          ^~~~~~~~~~~~~~
#45 840.7      934     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Utilities/Concepts.hpp:14
#45 840.7              :25: note: in definition of macro 'ACTS_CONCEPT'
#45 840.7      935        14 | #define ACTS_CONCEPT(x) x
#45 840.7      936           |                         ^
#45 840.7   >> 937     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:265:22: error: 'visitor_t' has not been declared
#45 840.7      938       265 |   void visitSurfaces(visitor_t&& visitor) const {
#45 840.7      939           |                      ^~~~~~~~~
#45 840.7      940     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp: In member function 'void Acts::TrackingVolume::visitSurfaces(i
#45 840.7              nt&&) const':
#45 840.7   >> 941     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:275:20: error: expression cannot be used as a function
#45 840.7      942       275 |             visitor(srf);
#45 840.7      943           |             ~~~~~~~^~~~~
#45 840.7   >> 944     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:282:30: error: no matching function for call to 'Acts::Tracking
#45 840.7              Volume::visitSurfaces(int&) const'
#45 840.7      945       282 |         volume->visitSurfaces(visitor);
#45 840.7      946           |         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
#45 840.7      947     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:265:8: note: candidate: 'template<<declaration error> > void Ac
#45 840.7              ts::TrackingVolume::visitSurfaces(int&&) const'
#45 840.7      948       265 |   void visitSurfaces(visitor_t&& visitor) const {
#45 840.7      949           |        ^~~~~~~~~~~~~
#45 840.7      950     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingVolume.h
#45 840.7              pp:265:8: note:   template argument deduction/substitution failed:
#45 840.7      951     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp: At global scope:
#45 840.7   >> 952     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp:109:26: error: 'SurfaceVisitor' has not been declared
#45 840.7      953       109 |   template <ACTS_CONCEPT(SurfaceVisitor) visitor_t>
#45 840.7      954           |                          ^~~~~~~~~~~~~~
#45 840.7      955     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Utilities/Concepts.hpp:14
#45 840.7              :25: note: in definition of macro 'ACTS_CONCEPT'
#45 840.7      956        14 | #define ACTS_CONCEPT(x) x
#45 840.7      957           |                         ^
#45 840.7   >> 958     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp:110:22: error: 'visitor_t' has not been declared
#45 840.7      959       110 |   void visitSurfaces(visitor_t&& visitor) const {
#45 840.7      960           |                      ^~~~~~~~~
#45 840.7      961     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp: In member function 'void Acts::TrackingGeometry::visitSurfac
#45 840.7              es(int&&) const':
#45 840.7   >> 962     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp:111:53: error: 'visitor_t' was not declared in this scope; di
#45 840.7              d you mean 'visitor'?
#45 840.7      963       111 |     highestTrackingVolume()->template visitSurfaces<visito
#45 840.7              r_t>(
#45 840.7      964           |                                                     ^~~~~~
#45 840.7              ~~~
#45 840.7      965           |                                                     visito
#45 840.7              r
#45 840.7   >> 966     /tmp/root/spack-stage/spack-stage-acts-28.0.0-tgwsfgpujxgirqwdovpg
#45 840.7              vmeykwgi5jxl/spack-src/Core/include/Acts/Geometry/TrackingGeometry
#45 840.7              .hpp:112:32: error: no matching function for call to 'forward<visi
#45 840.7              tor_t>(int&)'
#45 840.7      967       112 |         std::forward<visitor_t>(visitor));
#45 840.7      968           |         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
#45 840.7      969     In file included from /usr/include/c++/12/bits/stl_pair.h:61,
#45 840.7      970                      from /usr/include/c++/12/bits/stl_algobase.h:64,
#45 840.7      971                      from /usr/include/c++/12/bits/specfun.h:45,
#45 840.7      972                      from /usr/include/c++/12/cmath:1935,
#45 840.7 
#45 840.7      ...
#45 840.7 
#45 840.7      980           |     ^~~~~~~
#45 840.7      981     /usr/include/c++/12/bits/move.h:77:5: note:   template argument de
#45 840.7              duction/substitution failed:
#45 840.7      982     /usr/include/c++/12/bits/move.h:89:5: note: candidate: 'template<c
#45 840.7              lass _Tp> constexpr _Tp&& std::forward(typename remove_reference<_
#45 840.7              Tp>::type&&)'
#45 840.7      983        89 |     forward(typename std::remove_reference<_Tp>::type&& __
#45 840.7              t) noexcept
#45 840.7      984           |     ^~~~~~~
#45 840.7      985     /usr/include/c++/12/bits/move.h:89:5: note:   template argument de
#45 840.7              duction/substitution failed:
#45 840.7   >> 986     make[3]: *** [Examples/Algorithms/Geant4/CMakeFiles/ActsExamplesGe
#45 840.7              ant4.dir/build.make:177: Examples/Algorithms/Geant4/CMakeFiles/Act
#45 840.7              sExamplesGeant4.dir/src/SensitiveSurfaceMapper.cpp.o] Error 1
</pre>
</details>