### PR TITLE
clhep: support variant cxxstd=20

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -53,12 +53,10 @@ class Clhep(CMakePackage):
     variant(
         "cxxstd",
         default="11",
-        values=("11", "14", "17"),
+        values=("11", "14", conditional("17", when="@2.3.4.3:"), conditional("20", when="@2.4.6.4:")),
         multi=False,
         description="Use the specified C++ standard when building.",
     )
-
-    conflicts("cxxstd=17", when="@:2.3.4.2")
 
     depends_on("cmake@2.8.12.2:", when="@2.2.0.4:2.3.0.0", type="build")
     depends_on("cmake@3.2:", when="@2.3.0.1:", type="build")

--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -53,7 +53,12 @@ class Clhep(CMakePackage):
     variant(
         "cxxstd",
         default="11",
-        values=("11", "14", conditional("17", when="@2.3.4.3:"), conditional("20", when="@2.4.6.4:")),
+        values=(
+            "11",
+            "14",
+            conditional("17", when="@2.3.4.3:"),
+            conditional("20", when="@2.4.6.4:"),
+        ),
         multi=False,
         description="Use the specified C++ standard when building.",
     )


### PR DESCRIPTION
CLHEP has support for C++20 as of 2.4.6.4, https://gitlab.cern.ch/CLHEP/CLHEP/-/merge_requests/23. This PR adds the variant value to the list of cxxstd values, and replaces the C++17 conflict with a conditional (which didn't exist back then, https://github.com/spack/spack/pull/10518).