### PR TITLE
boost: support variant cxxstd=20

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -178,6 +178,7 @@ class Boost(Package):
             conditional("17", when="@1.63.0:"),
             # C++20/2a is not support by Boost < 1.73.0
             conditional("2a", when="@1.73.0:"),
+            conditional("20", when="@1.77.0:"),
         ),
         multi=False,
         description="Use the specified C++ standard when building.",


### PR DESCRIPTION
As of [1.77.0](https://www.boost.org/users/history/version_1_77_0.html), boost supports the cxxstd=20 value, as listed in the tested configurations at the bottom of those release notes (until [1.76.0](https://www.boost.org/users/history/version_1_76_0.html), the highest listed cxxstd  was 2a). As of [1.83.0](https://www.boost.org/users/history/version_1_83_0.html), cxxstd=20 is still the highest value listed, even though the [build system supports](https://github.com/boostorg/build/commit/62809bc0e5e931bcb0b290ffd85bc67e20b49a9d) 2b, 23, and even 2c, 26. I'm not adding these here.

Rationale: downstream code that links against boost often uses cxxstd=20, and a common pattern in spack is to iterate over the cxxstd values and add a depends_on for the respective standard. Not having cxxstd=20 for boost breaks this pattern.