### PR TITLE
Damaris package updated to use Damaris v.1.9.0 

### DIFF
--- a/var/spack/repos/builtin/packages/damaris/package.py
+++ b/var/spack/repos/builtin/packages/damaris/package.py
@@ -16,11 +16,17 @@ class Damaris(CMakePackage):
     maintainers("jcbowden")
 
     version("master", branch="master")
-    version("1.6.0", tag="v1.6.0", commit="1fe4c61cce03babd24315b8e6156f226baac97a2")
-    version("1.5.0", tag="v1.5.0", commit="68206a696ad430aa8426ca370501aa71914fbc87")
-    version("1.3.3", tag="v1.3.3", commit="f1c473507c080738f7092f6a7d72deb938ade786")
-    version("1.3.2", tag="v1.3.2", commit="38b50664523e56900809a19f0cf52fc0ab5dca53")
-    version("1.3.1", tag="v1.3.1", commit="6cee3690fa7d387acc8f5f650a7b019e13b90284")
+    version("1.9.0", tag="v1.9.0")
+    version("1.8.2", tag="v1.8.2")
+    version("1.8.1", tag="v1.8.1")
+    version("1.8.0", tag="v1.8.0")
+    version("1.7.1", tag="v1.7.1")
+    version("1.7.0", tag="v1.7.0")
+    version("1.6.0", tag="v1.6.0", deprecated=True)
+    version("1.5.0", tag="v1.5.0", deprecated=True)
+    version("1.3.3", tag="v1.3.3", deprecated=True)
+    version("1.3.2", tag="v1.3.2", deprecated=True)
+    version("1.3.1", tag="v1.3.1", deprecated=True)
 
     variant("fortran", default=True, description="Enables Fortran support")
     variant("hdf5", default=False, description="Enables the HDF5 storage plugin")
@@ -36,24 +42,19 @@ class Damaris(CMakePackage):
     variant(
         "python",
         default=False,
-        description="Enables building of Python enabled Damaris library - "
-        "boost::python boost::numpy needed",
+        description="Enables building of Python enabled Damaris library using Boost::python",
     )
 
-    depends_on("mpi")
-    depends_on("cmake@3.18.0:", type=("build"))
-    depends_on(
-        "boost"
-        "+exception+locale+system+serialization+chrono+atomic"
-        "+container+regex+thread+log+filesystem+date_time"
-        "@1.67:"
-    )
     depends_on("xsd")
     depends_on("xerces-c")
+    depends_on("mpi")
+    depends_on("cmake@3.18.0:", type=("build"))
+    depends_on("boost+thread+log+filesystem+date_time" "@1.67:")
+    depends_on("boost+thread+log+filesystem+date_time+python+numpy" "@1.67:", when="+python")
+    depends_on("py-mpi4py", when="+python", type=("build", "run"))
     depends_on("hdf5@1.8.20:", when="+hdf5")
-    depends_on("paraview+python", when="+catalyst")
+    depends_on("paraview+python+mpi+development_files", when="+catalyst")
     depends_on("visit+mpi", when="+visit")
-    depends_on("boost+thread+log+filesystem+date_time+python+numpy @1.67:", when="+python")
 
     def cmake_args(self):
         args = []
@@ -77,6 +78,7 @@ class Damaris(CMakePackage):
         if self.spec.variants["catalyst"].value:
             args.extend(["-DENABLE_CATALYST:BOOL=ON"])
             args.extend(["-DParaView_ROOT:PATH=%s" % self.spec["catalyst"].prefix])
+
         if self.spec.variants["examples"].value:
             args.extend(["-DENABLE_EXAMPLES:BOOL=ON"])
 


### PR DESCRIPTION
Package added py-mpi4py dependency when +python specified.

This is a second attempt of getting changes added to the spack/Develop branch. First effort seemed to go stale  (PR #39122) 