### PR TITLE
filtlong: update to 0.2.1, patch for %gcc@13:

### DIFF
--- a/var/spack/repos/builtin/packages/filtlong/gcc13.patch
+++ b/var/spack/repos/builtin/packages/filtlong/gcc13.patch
@@ -1,0 +1,10 @@
+--- src/kmers.h	2018-01-04 03:52:20.000000000 +0000
++++ src/kmers.h.patched	2023-09-04 13:19:09.206573971 +0100
+@@ -17,6 +17,7 @@
+ #define KMERS_H
+ 
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ #include <unordered_set>

--- a/var/spack/repos/builtin/packages/filtlong/package.py
+++ b/var/spack/repos/builtin/packages/filtlong/package.py
@@ -19,6 +19,7 @@ class Filtlong(MakefilePackage):
 
     depends_on("zlib-api")
 
+    # %gcc@13: requires std libraries be manually added - add an include for `cstdint`
     patch("gcc13.patch", level=0, when="%gcc@13:")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/filtlong/package.py
+++ b/var/spack/repos/builtin/packages/filtlong/package.py
@@ -13,10 +13,13 @@ class Filtlong(MakefilePackage):
     homepage = "https://github.com/rrwick/Filtlong"
     url = "https://github.com/rrwick/Filtlong/archive/v0.2.0.tar.gz"
 
+    version("0.2.1", sha256="e6f47675e87f98cf2481a60bef5cad38396f1e4db653a5c1673139f37770273a")
     version("0.2.0", sha256="a4afb925d7ced8d083be12ca58911bb16d5348754e7c2f6431127138338ee02a")
     version("0.1.1", sha256="ddae7a5850efeb64424965a443540b1ced34286fbefad9230ab71f4af314081b")
 
     depends_on("zlib-api")
+
+    patch("gcc13.patch", level=0, when="%gcc@13:")
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)


### PR DESCRIPTION
Correcting build issue for `gcc13` and updating to the latest minor release at the same time. Same fix applied as suggested separately: https://github.com/rrwick/Filtlong/pull/39