### PR TITLE
compilers/gcc.py: support cxx{20,23}_flag

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -105,7 +105,7 @@ class Gcc(spack.compiler.Compiler):
             raise spack.compiler.UnsupportedCompilerFlag(
                 self, "the C++20 standard", "cxx20_flag", "< 8.0"
             )
-        elif self.real_version < Version("10.0"):
+        elif self.real_version < Version("11.0"):
             return "-std=c++2a"
         else:
             return "-std=c++20"

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -100,6 +100,28 @@ class Gcc(spack.compiler.Compiler):
             return "-std=c++17"
 
     @property
+    def cxx20_flag(self):
+        if self.real_version < Version("8.0"):
+            raise spack.compiler.UnsupportedCompilerFlag(
+                self, "the C++20 standard", "cxx20_flag", "< 8.0"
+            )
+        elif self.real_version < Version("10.0"):
+            return "-std=c++2a"
+        else:
+            return "-std=c++20"
+
+    @property
+    def cxx23_flag(self):
+        if self.real_version < Version("11.0"):
+            raise spack.compiler.UnsupportedCompilerFlag(
+                self, "the C++23 standard", "cxx23_flag", "< 11.0"
+            )
+        elif self.real_version < Version("14.0"):
+            return "-std=c++2b"
+        else:
+            return "-std=c++23"
+
+    @property
     def c99_flag(self):
         if self.real_version < Version("4.5"):
             raise spack.compiler.UnsupportedCompilerFlag(


### PR DESCRIPTION
This adds the cxx20_flag and cxx23_flag to gcc.
- c++2a support was introduced in gcc-8, and deprecated in favor of c++20 in gcc-11
- c++2b support was introduced in gcc-11, and (I assume) will be deprecated in favor of c++23 in gcc-14 (isn't deprecated yet in gcc-13)