### PR TITLE
xerces-c: support variant cxxstd=20

### DIFF
--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -31,7 +31,7 @@ class XercesC(AutotoolsPackage):
     variant(
         "cxxstd",
         default="default",
-        values=("default", "98", "11", "14", "17"),
+        values=("default", "98", "11", "14", "17", "20"),
         multi=False,
         description="Use the specified C++ standard when building",
     )


### PR DESCRIPTION
Xerces-C++ is a dependency of some packages that would benefit from C++20 features (e.g. Geant4), and would like to link against Xerces-C++ that is compiled with C++20 support (rather than mixing and matching standards in compiled code and, potentially, headers). The easiest approach is to extend the list of C++ standards that can be used to compile Xerces-C++. Compiling the oldest version in spack, `xerces-c@3.1.3 cxxstd=20`, works just fine ([spack-build-out.txt](https://github.com/spack/spack/files/12515026/spack-build-out.txt)), as does compiling with the newest version, `xerces-c@3.2.4 cxxstd=20` ([spack-build-out.txt](https://github.com/spack/spack/files/12515130/spack-build-out.txt)).

TODO:
- [x] #39777