### PR TITLE
geant4, vecgeom: support variant cxxstd=20

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.variant import Value, _ConditionalVariantValues
+from spack.variant import _ConditionalVariantValues
 
 
 class Geant4(CMakePackage):

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.variant import _ConditionalVariantValues, Value
 
 
 class Geant4(CMakePackage):
@@ -43,16 +44,18 @@ class Geant4(CMakePackage):
     version("10.4.0", sha256="e919b9b0a88476e00c0b18ab65d40e6a714b55ee4778f66bac32a5396c22aa74")
     version("10.3.3", sha256="bcd36a453da44de9368d1d61b0144031a58e4b43a6d2d875e19085f2700a89d8")
 
-    _cxxstd_values = ("11", "14", "17")
+    _cxxstd_values = (
+        conditional("11", "14", when="@:10"),
+        conditional("17", when="@10.4.1:"),
+        conditional("20", when="@10.7.0:"),
+    )
     variant(
         "cxxstd",
-        default=_cxxstd_values[0],
+        default="11",
         values=_cxxstd_values,
         multi=False,
         description="Use the specified C++ standard when building.",
     )
-    conflicts("cxxstd=11", when="@11:", msg="geant4@11: only supports cxxstd=17")
-    conflicts("cxxstd=14", when="@11:", msg="geant4@11: only supports cxxstd=17")
 
     variant("threads", default=True, description="Build with multithreading")
     variant("vecgeom", default=False, description="Enable vecgeom support")
@@ -97,30 +100,34 @@ class Geant4(CMakePackage):
     depends_on("python@3:", when="+python")
     extends("python", when="+python")
 
-    for std in _cxxstd_values:
-        # CLHEP version requirements to be reviewed
-        depends_on("clhep@2.4.6.0: cxxstd=" + std, when="@11.1: cxxstd=" + std)
+    # CLHEP version requirements to be reviewed
+    depends_on("clhep@2.4.6.0:", when="@11.1:")
+    depends_on("clhep@2.4.5.1:", when="@11.0.0:")
+    depends_on("clhep@2.4.4.0:", when="@10.7.0:")
+    depends_on("clhep@2.3.3.0:", when="@10.3.3:10.6")
 
-        depends_on("clhep@2.4.5.1: cxxstd=" + std, when="@11.0.0: cxxstd=" + std)
+    # Vecgeom specific versions for each Geant4 version
+    with when("+vecgeom"):
+        depends_on("vecgeom@1.2.0:", when="@11.1:")
+        depends_on("vecgeom@1.1.18:1.1", when="@11.0.0:11.0")
+        depends_on("vecgeom@1.1.8:1.1", when="@10.7.0:10.7")
+        depends_on("vecgeom@1.1.5", when="@10.6.0:10.6")
+        depends_on("vecgeom@1.1.0", when="@10.5.0:10.5")
+        depends_on("vecgeom@0.5.2", when="@10.4.0:10.4")
+        depends_on("vecgeom@0.3rc", when="@10.3.0:10.3")
 
-        depends_on("clhep@2.4.4.0: cxxstd=" + std, when="@10.7.0: cxxstd=" + std)
+    for _cxxstd in _cxxstd_values:
+        for _v in _cxxstd if isinstance(_cxxstd, _ConditionalVariantValues) else [Value(_cxxstd, when="")]:
+            (std, when) = (_v.value, _v.when)
 
-        depends_on("clhep@2.3.3.0: cxxstd=" + std, when="@10.3.3:10.6 cxxstd=" + std)
+            depends_on(f"clhep cxxstd={std}", when=f"{when} cxxstd={std}")
+            depends_on(f"vecgeom cxxstd={std}", when=f"{when} +vecgeom cxxstd={std}")
 
-        # Spack only supports Xerces-c 3 and above, so no version req
-        depends_on("xerces-c netaccessor=curl cxxstd=" + std, when="cxxstd=" + std)
+            # Spack only supports Xerces-c 3 and above, so no version req
+            depends_on(f"xerces-c netaccessor=curl cxxstd={std}", when=f"{when} cxxstd={std}")
 
-        # Vecgeom specific versions for each Geant4 version
-        depends_on("vecgeom@1.2.0: cxxstd=" + std, when="@11.1: +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@1.1.18:1.1 cxxstd=" + std, when="@11.0.0:11.0 +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@1.1.8:1.1 cxxstd=" + std, when="@10.7.0:10.7 +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@1.1.5 cxxstd=" + std, when="@10.6.0:10.6 +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@1.1.0 cxxstd=" + std, when="@10.5.0:10.5 +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@0.5.2 cxxstd=" + std, when="@10.4.0:10.4 +vecgeom cxxstd=" + std)
-        depends_on("vecgeom@0.3rc cxxstd=" + std, when="@10.3.0:10.3 +vecgeom cxxstd=" + std)
-
-        # Boost.python, conflict handled earlier
-        depends_on("boost@1.70: +python cxxstd=" + std, when="+python cxxstd=" + std)
+            # Boost.python, conflict handled earlier
+            depends_on(f"boost@1.70: +python cxxstd={std}", when=f"{when} +python cxxstd={std}")
 
     # Visualization driver dependencies
     depends_on("gl", when="+opengl")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -116,7 +116,6 @@ class Geant4(CMakePackage):
         depends_on("vecgeom@0.5.2", when="@10.4.0:10.4")
         depends_on("vecgeom@0.3rc", when="@10.3.0:10.3")
 
-    @staticmethod
     def std_when(values):
         for v in values:
             if isinstance(v, _ConditionalVariantValues):

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -116,22 +116,24 @@ class Geant4(CMakePackage):
         depends_on("vecgeom@0.5.2", when="@10.4.0:10.4")
         depends_on("vecgeom@0.3rc", when="@10.3.0:10.3")
 
-    for _cxxstd in _cxxstd_values:
-        for _v in (
-            _cxxstd
-            if isinstance(_cxxstd, _ConditionalVariantValues)
-            else [Value(_cxxstd, when="")]
-        ):
-            (std, when) = (_v.value, _v.when)
+    @staticmethod
+    def std_when(values):
+        for v in values:
+            if isinstance(v, _ConditionalVariantValues):
+                for c in v:
+                    yield (c.value, c.when)
+           else:
+                yield (v, "")
 
-            depends_on(f"clhep cxxstd={std}", when=f"{when} cxxstd={std}")
-            depends_on(f"vecgeom cxxstd={std}", when=f"{when} +vecgeom cxxstd={std}")
+    for _std, _when in std_when(_cxxstd_values):
+        depends_on(f"clhep cxxstd={_std}", when=f"{_when} cxxstd={_std}")
+        depends_on(f"vecgeom cxxstd={_std}", when=f"{_when} +vecgeom cxxstd={_std}")
 
-            # Spack only supports Xerces-c 3 and above, so no version req
-            depends_on(f"xerces-c netaccessor=curl cxxstd={std}", when=f"{when} cxxstd={std}")
+        # Spack only supports Xerces-c 3 and above, so no version req
+        depends_on(f"xerces-c netaccessor=curl cxxstd={_std}", when=f"{_when} cxxstd={_std}")
 
-            # Boost.python, conflict handled earlier
-            depends_on(f"boost@1.70: +python cxxstd={std}", when=f"{when} +python cxxstd={std}")
+        # Boost.python, conflict handled earlier
+        depends_on(f"boost@1.70: +python cxxstd={_std}", when=f"{_when} +python cxxstd={_std}")
 
     # Visualization driver dependencies
     depends_on("gl", when="+opengl")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.variant import _ConditionalVariantValues, Value
+from spack.variant import Value, _ConditionalVariantValues
 
 
 class Geant4(CMakePackage):
@@ -117,7 +117,11 @@ class Geant4(CMakePackage):
         depends_on("vecgeom@0.3rc", when="@10.3.0:10.3")
 
     for _cxxstd in _cxxstd_values:
-        for _v in _cxxstd if isinstance(_cxxstd, _ConditionalVariantValues) else [Value(_cxxstd, when="")]:
+        for _v in (
+            _cxxstd
+            if isinstance(_cxxstd, _ConditionalVariantValues)
+            else [Value(_cxxstd, when="")]
+        ):
             (std, when) = (_v.value, _v.when)
 
             depends_on(f"clhep cxxstd={std}", when=f"{when} cxxstd={std}")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -122,7 +122,7 @@ class Geant4(CMakePackage):
             if isinstance(v, _ConditionalVariantValues):
                 for c in v:
                     yield (c.value, c.when)
-           else:
+            else:
                 yield (v, "")
 
     for _std, _when in std_when(_cxxstd_values):

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -5,7 +5,7 @@
 
 
 from spack.package import *
-from spack.variant import _ConditionalVariantValues, Value
+from spack.variant import Value, _ConditionalVariantValues
 
 
 class Vecgeom(CMakePackage, CudaPackage):
@@ -139,11 +139,7 @@ class Vecgeom(CMakePackage, CudaPackage):
         deprecated=True,
     )
 
-    _cxxstd_values = (
-        conditional("11", "14", when="@:1.1"),
-        "17",
-        conditional("20", when="@1.2:")
-    )
+    _cxxstd_values = (conditional("11", "14", when="@:1.1"), "17", conditional("20", when="@1.2:"))
     variant(
         "cxxstd",
         default="17",
@@ -178,7 +174,11 @@ class Vecgeom(CMakePackage, CudaPackage):
     )
 
     for _cxxstd in _cxxstd_values:
-        for _v in _cxxstd if isinstance(_cxxstd, _ConditionalVariantValues) else [Value(_cxxstd, when="")]:
+        for _v in (
+            _cxxstd
+            if isinstance(_cxxstd, _ConditionalVariantValues)
+            else [Value(_cxxstd, when="")]
+        ):
             (std, when) = (_v.value, _v.when)
             depends_on(f"geant4 cxxstd={std}", when=f"{when} +geant4 cxxstd={std}")
             depends_on(f"root cxxstd={std}", when=f"{when} +root cxxstd={std}")


### PR DESCRIPTION
This adds support for cxxstd=20 to both geant4 and vecgeom. Due to a circular dependency, this needs to be done in a single PR or the audit will fail.

C++ 10 and 14 are not supported anymore in `geant4@11:`, so those are now conditional. The default must be an actual value, so that's now an explicit `"11"`.

TODO:
- [x] #39768 
- [x] #39769 
- [x] #39784 