### PR TITLE
lua: unzip also required during build

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -53,7 +53,7 @@ class LuaImplPackage(MakefilePackage):
         return os.path.join("share", self.lua_dir_name, self.__verdir())
 
     # luarocks needs unzip for some packages (e.g. lua-luaposix)
-    depends_on("unzip", type="run")
+    depends_on("unzip", type=("build", "run"))
 
     # luarocks needs a fetcher (curl/wget), unfortunately I have not found
     # how to force a choice for curl or wget, but curl seems the default.


### PR DESCRIPTION
otherwise luarocks fails during installation of lua@5.3.6 on ubuntu 22.04 w/o system unzip:

Configuring LuaRocks version 3.8.0...

Lua version detected: 5.3
Lua interpreter found: /opt/spack/linux-ubuntu22.04-aarch64/gcc-11.3.0/lua-5.3.6-6kslud53jtwujk3iipicygk52t7smng4/bin/lua lua.h found: /opt/spack/linux-ubuntu22.04-aarch64/gcc-11.3.0/lua-5.3.6-6kslud53jtwujk3iipicygk52t7smng4/include/lua.h Could not find 'unzip'.
Make sure it is installed and available in your PATH.

configure failed.