### PR TITLE
singularityce: fix package name in comment

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -190,7 +190,7 @@ class Singularityce(SingularityBase):
     See package definition or `spack-build-out.txt` build log for details,
     e.g.
 
-    tail -15 $(spack location -i singularity)/.spack/spack-build-out.txt
+    tail -15 $(spack location -i singularityce)/.spack/spack-build-out.txt
     """
 
     homepage = "https://sylabs.io/singularity/"


### PR DESCRIPTION
The suggested command to run in the comment uses an incorrect package name. Updating this to the correct package name allows a user to copy and paste the command and run it without issue.