### PR TITLE
WinReg detection: refactor SDK detection 

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -300,7 +300,7 @@ class WindowsCompilerExternalPaths:
 
 class WindowsKitExternalPaths:
     @staticmethod
-    def find_windows_kit_roots() -> Optional[str]:
+    def find_windows_kit_roots() -> List[str]:
         """Return Windows kit root, typically %programfiles%\\Windows Kits\\10|11\\"""
         if sys.platform != "win32":
             return []
@@ -312,17 +312,23 @@ class WindowsKitExternalPaths:
     def find_windows_kit_bin_paths(kit_base: Optional[str] = None) -> List[str]:
         """Returns Windows kit bin directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
-        assert kit_base is not None, "unexpected value for kit_base"
-        kit_bin = os.path.join(kit_base, "bin")
-        return glob.glob(os.path.join(kit_bin, "[0-9]*", "*\\"))
+        assert kit_base, "unexpected value for kit_base"
+        kit_paths = []
+        for kit in kit_base:
+            kit_bin = os.path.join(kit, "bin")
+            kit_paths.extend(glob.glob(os.path.join(kit_bin, "[0-9]*", "*\\")))
+        return kit_paths
 
     @staticmethod
     def find_windows_kit_lib_paths(kit_base: Optional[str] = None) -> List[str]:
         """Returns Windows kit lib directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
-        assert kit_base is not None, "unexpected value for kit_base"
-        kit_lib = os.path.join(kit_base, "Lib")
-        return glob.glob(os.path.join(kit_lib, "[0-9]*", "*", "*\\"))
+        assert kit_base, "unexpected value for kit_base"
+        kit_paths = []
+        for kit in kit_base:
+            kit_lib = os.path.join(kit, "Lib")
+            kit_paths.extend(glob.glob(os.path.join(kit_lib, "[0-9]*", "*", "*\\")))
+        return kit_paths
 
     @staticmethod
     def find_windows_driver_development_kit_paths() -> List[str]:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -305,9 +305,7 @@ class WindowsKitExternalPaths:
         if sys.platform != "win32":
             return []
         program_files = os.environ["PROGRAMFILES(x86)"]
-        kit_base = os.path.join(
-            program_files, "Windows Kits", "**"
-        )
+        kit_base = os.path.join(program_files, "Windows Kits", "**")
         return glob.glob(kit_base)
 
     @staticmethod
@@ -346,9 +344,9 @@ class WindowsKitExternalPaths:
         kit_root_reg = re.compile(r"KitsRoot[0-9]+")
         root_paths = []
         for kit_root in filter(kit_root_reg.match, reg.get_values().keys()):
-            root_paths.extend(WindowsKitExternalPaths.find_windows_kit_lib_paths(
-                reg.get_value(kit_root).value
-            ))
+            root_paths.extend(
+                WindowsKitExternalPaths.find_windows_kit_lib_paths(reg.get_value(kit_root).value)
+            )
         return root_paths
 
     @staticmethod
@@ -361,9 +359,10 @@ class WindowsKitExternalPaths:
         )
         for key in filter(sdk_regex.match, [x.name for x in windows_reg.get_subkeys()]):
             reg = windows_reg.get_subkey(key)
-            sdk_paths.extend(WindowsKitExternalPaths.find_windows_kit_lib_paths(
-                                reg.get_value("InstallationFolder").value
-                            )
+            sdk_paths.extend(
+                WindowsKitExternalPaths.find_windows_kit_lib_paths(
+                    reg.get_value("InstallationFolder").value
+                )
             )
         return sdk_paths
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -299,20 +299,16 @@ class WindowsCompilerExternalPaths:
 
 
 class WindowsKitExternalPaths:
-    plat_major_ver = None
-    if sys.platform == "win32":
-        plat_major_ver = str(winOs.windows_version()[0])
-
     @staticmethod
     def find_windows_kit_roots() -> Optional[str]:
         """Return Windows kit root, typically %programfiles%\\Windows Kits\\10|11\\"""
         if sys.platform != "win32":
-            return None
+            return []
         program_files = os.environ["PROGRAMFILES(x86)"]
         kit_base = os.path.join(
-            program_files, "Windows Kits", WindowsKitExternalPaths.plat_major_ver
+            program_files, "Windows Kits", "**"
         )
-        return kit_base
+        return glob.glob(kit_base)
 
     @staticmethod
     def find_windows_kit_bin_paths(kit_base: Optional[str] = None) -> List[str]:
@@ -347,23 +343,29 @@ class WindowsKitExternalPaths:
         if not reg:
             # couldn't find key, return empty list
             return []
-        return WindowsKitExternalPaths.find_windows_kit_lib_paths(
-            reg.get_value("KitsRoot%s" % WindowsKitExternalPaths.plat_major_ver).value
-        )
+        kit_root_reg = re.compile(r"KitsRoot[0-9]+")
+        root_paths = []
+        for kit_root in filter(kit_root_reg.match, reg.get_values().keys()):
+            root_paths.extend(WindowsKitExternalPaths.find_windows_kit_lib_paths(
+                reg.get_value(kit_root).value
+            ))
+        return root_paths
 
     @staticmethod
     def find_windows_kit_reg_sdk_paths() -> List[str]:
-        reg = spack.util.windows_registry.WindowsRegistryView(
-            "SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v%s.0"
-            % WindowsKitExternalPaths.plat_major_ver,
+        sdk_paths = []
+        sdk_regex = re.compile(r"v[0-9]+.[0-9]+")
+        windows_reg = spack.util.windows_registry.WindowsRegistryView(
+            "SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows",
             root_key=spack.util.windows_registry.HKEY.HKEY_LOCAL_MACHINE,
         )
-        if not reg:
-            # couldn't find key, return empty list
-            return []
-        return WindowsKitExternalPaths.find_windows_kit_lib_paths(
-            reg.get_value("InstallationFolder").value
-        )
+        for key in filter(sdk_regex.match, [x.name for x in windows_reg.get_subkeys()]):
+            reg = windows_reg.get_subkey(key)
+            sdk_paths.extend(WindowsKitExternalPaths.find_windows_kit_lib_paths(
+                                reg.get_value("InstallationFolder").value
+                            )
+            )
+        return sdk_paths
 
 
 def find_win32_additional_install_paths() -> List[str]:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -312,7 +312,7 @@ class WindowsKitExternalPaths:
     def find_windows_kit_bin_paths(kit_base: Optional[str] = None) -> List[str]:
         """Returns Windows kit bin directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
-        assert kit_base, "unexpected value for kit_base"
+        assert kit_base, "Unexpectedly empty value for Windows kit base path"
         kit_paths = []
         for kit in kit_base:
             kit_bin = os.path.join(kit, "bin")
@@ -323,7 +323,7 @@ class WindowsKitExternalPaths:
     def find_windows_kit_lib_paths(kit_base: Optional[str] = None) -> List[str]:
         """Returns Windows kit lib directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
-        assert kit_base, "unexpected value for kit_base"
+        assert kit_base, "Unexpectedly empty value for Windows kit base path"
         kit_paths = []
         for kit in kit_base:
             kit_lib = os.path.join(kit, "Lib")


### PR DESCRIPTION
Currently, Windows SDK detection will only pick up SDK versions related to the current version of Windows Spack is running on. However, in some circumstances, we want to detect other version of the SDK, for example, for compiling on Windows 11 for Windows 10 to ensure an API is compatible with Win10. 

This MR allows us to pick up all SDK versions for external detection. 