### PR TITLE
NMake Builder: refactor makefile api

### DIFF
--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -95,7 +95,7 @@ class NMakeBuilder(BaseBuilder):
         return self.stage.source_path
 
     @property
-    def nmakefile_name(self):
+    def makefile_name(self):
         """Name of the current makefile. This is currently an empty value.
         If a project defines this value, it will be used with the /f argument
         to provide nmake an explicit makefile. This is usefule in scenarios where
@@ -126,8 +126,8 @@ class NMakeBuilder(BaseBuilder):
         """Run "nmake" on the build targets specified by the builder."""
         opts = self.std_nmake_args
         opts += self.nmake_args()
-        if self.nmakefile_name:
-            opts.append("/f {}".format(self.nmakefile_name))
+        if self.makefile_name:
+            opts.append("/F{}".format(self.makefile_name))
         with fs.working_dir(self.build_directory):
             inspect.getmodule(self.pkg).nmake(
                 *opts, *self.build_targets, ignore_quotes=self.ignore_quotes
@@ -139,8 +139,8 @@ class NMakeBuilder(BaseBuilder):
         opts = self.std_nmake_args
         opts += self.nmake_args()
         opts += self.nmake_install_args()
-        if self.nmakefile_name:
-            opts.append("/f {}".format(self.nmakefile_name))
+        if self.makefile_name:
+            opts.append("/F{}".format(self.makefile_name))
         opts.append(self.define("PREFIX", prefix))
         with fs.working_dir(self.build_directory):
             inspect.getmodule(self.pkg).nmake(


### PR DESCRIPTION
NMake makefiles are still called makefiles. For some reason I named the corresponding builder variable nmakefile, which is a bit unintuitive and lead to a few easy to make, hard to notice mistakes creating packages. Common sense rename of builder property to be "makefile"

For example of one of these mistakes, the `libxml2` package incorrectly defines the `makefile_name` property instead of the `nmakefile_name` property in develop at the moment. This happens to work by sheer luck, but is a good example of how easy that mistake is to miss.