### PR TITLE
itk: misc fixes

### DIFF
--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -58,7 +58,7 @@ class Itk(CMakePackage):
     depends_on("expat")
     depends_on("fftw-api")
     depends_on("googletest")
-    depends_on("hdf5+cxx+hl~mpi")
+    depends_on("hdf5+cxx+hl")
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("libtiff")

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -65,6 +65,12 @@ class Itk(CMakePackage):
     depends_on("mpi")
     depends_on("zlib-api")
 
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/InsightSoftwareConsortium/ITK/pull/4041.diff",
+        sha256="6be7a28d41b8d56b782116b03b5fea70df35c3368e5c1bd83d166b46575f6172",
+        when="@5.2.0:5.3.0",
+    )
+
     def cmake_args(self):
         use_mkl = "^mkl" in self.spec
         args = [

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -62,7 +62,6 @@ class Itk(CMakePackage):
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("libtiff")
-    depends_on("mpi")
     depends_on("zlib-api")
 
     patch(

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -65,8 +65,8 @@ class Itk(CMakePackage):
     depends_on("zlib-api")
 
     patch(
-        "https://patch-diff.githubusercontent.com/raw/InsightSoftwareConsortium/ITK/pull/4041.diff?full_index=1",
-        sha256="6be7a28d41b8d56b782116b03b5fea70df35c3368e5c1bd83d166b46575f6172",
+        "https://github.com/InsightSoftwareConsortium/ITK/commit/9a719a0d2f5f489eeb9351b0ef913c3693147a4f.patch?full_index=1",
+        sha256="ec1f7fa71f2b7f05d9632c6b0321e7d436fff86fca92c60c12839b13ea79bd70",
         when="@5.2.0:5.3.0",
     )
 

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -58,7 +58,7 @@ class Itk(CMakePackage):
     depends_on("expat")
     depends_on("fftw-api")
     depends_on("googletest")
-    depends_on("hdf5+cxx")
+    depends_on("hdf5+cxx+hl~mpi")
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("libtiff")

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -65,7 +65,7 @@ class Itk(CMakePackage):
     depends_on("zlib-api")
 
     patch(
-        "https://patch-diff.githubusercontent.com/raw/InsightSoftwareConsortium/ITK/pull/4041.diff",
+        "https://patch-diff.githubusercontent.com/raw/InsightSoftwareConsortium/ITK/pull/4041.diff?full_index=1",
         sha256="6be7a28d41b8d56b782116b03b5fea70df35c3368e5c1bd83d166b46575f6172",
         when="@5.2.0:5.3.0",
     )


### PR DESCRIPTION
- Add patch https://github.com/InsightSoftwareConsortium/ITK/pull/4041 so that it builds on newer compilers
- Add `+hl` to the hdf5 dependency
- Remove MPI dependency