### PR TITLE
libjpeg-turbo: Fix Darwin lib install name

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -92,5 +92,5 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     @run_after("install")
     def darwin_fix(self):
         # The shared library is not installed correctly on Darwin; fix this
-        if self.spec.satisfies("platform=darwin"):
+        if self.spec.satisfies("platform=darwin") and ("+shared" in self.spec):
             fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -88,3 +88,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         ]
 
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
## Description

The libjpeg-turbo library has a bad install name on macOS:
```
> otool -L envs/unified-env/install/apple-clang/13.1.6/libjpeg-turbo-2.1.0-3wyhtqp/lib/libjpeg.62.3.0.dylib 
envs/unified-env/install/apple-clang/13.1.6/libjpeg-turbo-2.1.0-3wyhtqp/lib/libjpeg.62.3.0.dylib:
	@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```
This PR fixes it:
```
> otool -L envs/unified-env/install/apple-clang/13.1.6/libjpeg-turbo-2.1.0-3wyhtqp/lib/libjpeg.62.3.0.dylib 
envs/unified-env/install/apple-clang/13.1.6/libjpeg-turbo-2.1.0-3wyhtqp/lib/libjpeg.62.3.0.dylib:
	/Users/heinzell/work/spack-stack/spack-stack-met_graphics/envs/unified-env/install/apple-clang/13.1.6/libjpeg-turbo-2.1.0-3wyhtqp/lib/libjpeg.62.3.0.dylib (compatibility version 62.0.0, current version 62.3.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```