### PR TITLE
Revert "Add `concretise` and `containerise` aliases for our UK users"

### DIFF
--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -812,9 +812,6 @@ def bash(args: Namespace, out: IO) -> None:
     parser = spack.main.make_argument_parser()
     spack.main.add_all_commands(parser)
 
-    aliases = ";".join(f"{key}:{val}" for key, val in spack.main.aliases.items())
-    out.write(f'SPACK_ALIASES="{aliases}"\n\n')
-
     writer = BashCompletionWriter(parser.prog, out, args.aliases)
     writer.write(parser)
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -51,7 +51,7 @@ from spack.error import SpackError
 stat_names = pstats.Stats.sort_arg_dict_default
 
 #: top-level aliases for Spack commands
-aliases = {"concretise": "concretize", "containerise": "containerize", "rm": "remove"}
+aliases = {"rm": "remove"}
 
 #: help levels in order of detail (i.e., number of commands shown)
 levels = ["short", "long"]

--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -52,20 +52,6 @@ if test -n "${ZSH_VERSION:-}" ; then
   fi
 fi
 
-# compgen -W doesn't work in some versions of zsh, so use this instead.
-# see https://www.zsh.org/mla/workers/2011/msg00582.html
-_compgen_w() {
-    if test -n "${ZSH_VERSION:-}" ; then
-        typeset -a words
-        words=( ${~=1} )
-        local find="$2"
-        results=(${(M)words[@]:#$find*})
-        echo "${results[@]}"
-    else
-        compgen -W "$1" -- "$2"
-    fi
-}
-
 # Bash programmable completion for Spack
 _bash_completion_spack() {
     # In all following examples, let the cursor be denoted by brackets, i.e. []
@@ -151,7 +137,7 @@ _bash_completion_spack() {
     if [[ "$(LC_ALL=C type $subfunction 2>&1)" =~ $rgx ]]
     then
         $subfunction
-        COMPREPLY=($(_compgen_w "$SPACK_COMPREPLY" "$cur"))
+        COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))
     fi
 
     # if every completion is an alias for the same thing, just return that thing.
@@ -373,7 +359,7 @@ _spack_compress_aliases() {
     fi
 
     # get the alias of the first thing in the list of completions
-    _spack_get_alias "${COMPREPLY[@]:0:1}"
+    _spack_get_alias "${COMPREPLY[0]}"
     local first_alias="$SPACK_ALIAS"
 
     # if anything in the list would alias to something different, stop

--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -139,9 +139,6 @@ _bash_completion_spack() {
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))
     fi
-
-    # if every completion is an alias for the same thing, just return that thing.
-    _spack_compress_aliases
 }
 
 # Helper functions for subcommands
@@ -329,49 +326,6 @@ complete -o bashdefault -o default -F _bash_completion_spack spacktivate
 
 _spacktivate() {
   _spack_env_activate
-}
-
-# Simple function to get the spack alias for a command
-_spack_get_alias() {
-    local possible_alias="${1-}"
-    local IFS=";"
-
-    # spack aliases are a ;-separated list of :-separated pairs
-    for item in $SPACK_ALIASES; do
-        # maps a possible alias to its command
-        eval "local real_command=\"\${item#*${possible_alias}:}\""
-        if [ "$real_command" != "$item" ]; then
-            SPACK_ALIAS="$real_command"
-            return
-        fi
-    done
-
-    # no alias found -- just return $1
-    SPACK_ALIAS="$possible_alias"
-}
-
-# If all commands in COMPREPLY alias to the same thing, set COMPREPLY to
-# just the real command, not the aliases.
-_spack_compress_aliases() {
-    # if there's only one thing, don't bother compressing aliases; complete the alias
-    if [ "${#COMPREPLY[@]}" == "1" ]; then
-        return
-    fi
-
-    # get the alias of the first thing in the list of completions
-    _spack_get_alias "${COMPREPLY[0]}"
-    local first_alias="$SPACK_ALIAS"
-
-    # if anything in the list would alias to something different, stop
-    for comp in "${COMPREPLY[@]:1}"; do
-        _spack_get_alias "$comp"
-        if [ "$SPACK_ALIAS" != "$first_alias" ]; then
-            return
-        fi
-    done
-
-    # all commands alias to first alias; just return that
-    COMPREPLY=("$first_alias")
 }
 
 # Spack commands

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -61,12 +61,6 @@ contains 'python' _spack_completions spack extensions ''
 contains 'hdf5' _spack_completions spack -d install --jobs 8 ''
 contains 'hdf5' _spack_completions spack install -v ''
 
-title 'Testing alias handling'
-contains 'concretize' _spack_completions spack c
-contains 'concretise' _spack_completions spack c
-contains 'concretize' _spack_completions spack conc
-does_not_contain 'concretise' _spack_completions spack conc
-
 # XFAIL: Fails for Python 2.6 because pkg_resources not found?
 #contains 'compilers.py' _spack_completions spack unit-test ''
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -52,20 +52,6 @@ if test -n "${ZSH_VERSION:-}" ; then
   fi
 fi
 
-# compgen -W doesn't work in some versions of zsh, so use this instead.
-# see https://www.zsh.org/mla/workers/2011/msg00582.html
-_compgen_w() {
-    if test -n "${ZSH_VERSION:-}" ; then
-        typeset -a words
-        words=( ${~=1} )
-        local find="$2"
-        results=(${(M)words[@]:#$find*})
-        echo "${results[@]}"
-    else
-        compgen -W "$1" -- "$2"
-    fi
-}
-
 # Bash programmable completion for Spack
 _bash_completion_spack() {
     # In all following examples, let the cursor be denoted by brackets, i.e. []
@@ -151,7 +137,7 @@ _bash_completion_spack() {
     if [[ "$(LC_ALL=C type $subfunction 2>&1)" =~ $rgx ]]
     then
         $subfunction
-        COMPREPLY=($(_compgen_w "$SPACK_COMPREPLY" "$cur"))
+        COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))
     fi
 
     # if every completion is an alias for the same thing, just return that thing.
@@ -373,7 +359,7 @@ _spack_compress_aliases() {
     fi
 
     # get the alias of the first thing in the list of completions
-    _spack_get_alias "${COMPREPLY[@]:0:1}"
+    _spack_get_alias "${COMPREPLY[0]}"
     local first_alias="$SPACK_ALIAS"
 
     # if anything in the list would alias to something different, stop

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -139,9 +139,6 @@ _bash_completion_spack() {
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))
     fi
-
-    # if every completion is an alias for the same thing, just return that thing.
-    _spack_compress_aliases
 }
 
 # Helper functions for subcommands
@@ -331,54 +328,9 @@ _spacktivate() {
   _spack_env_activate
 }
 
-# Simple function to get the spack alias for a command
-_spack_get_alias() {
-    local possible_alias="${1-}"
-    local IFS=";"
-
-    # spack aliases are a ;-separated list of :-separated pairs
-    for item in $SPACK_ALIASES; do
-        # maps a possible alias to its command
-        eval "local real_command=\"\${item#*${possible_alias}:}\""
-        if [ "$real_command" != "$item" ]; then
-            SPACK_ALIAS="$real_command"
-            return
-        fi
-    done
-
-    # no alias found -- just return $1
-    SPACK_ALIAS="$possible_alias"
-}
-
-# If all commands in COMPREPLY alias to the same thing, set COMPREPLY to
-# just the real command, not the aliases.
-_spack_compress_aliases() {
-    # if there's only one thing, don't bother compressing aliases; complete the alias
-    if [ "${#COMPREPLY[@]}" == "1" ]; then
-        return
-    fi
-
-    # get the alias of the first thing in the list of completions
-    _spack_get_alias "${COMPREPLY[0]}"
-    local first_alias="$SPACK_ALIAS"
-
-    # if anything in the list would alias to something different, stop
-    for comp in "${COMPREPLY[@]:1}"; do
-        _spack_get_alias "$comp"
-        if [ "$SPACK_ALIAS" != "$first_alias" ]; then
-            return
-        fi
-    done
-
-    # all commands alias to first alias; just return that
-    COMPREPLY=("$first_alias")
-}
-
 # Spack commands
 #
 # Everything below here is auto-generated.
-SPACK_ALIASES="concretise:concretize;containerise:containerize;rm:remove"
-
 
 _spack() {
     if $list_options

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -337,7 +337,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize config containerize create debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -737,10 +737,6 @@ _spack_concretize() {
     SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps -j --jobs"
 }
 
-_spack_concretise() {
-    SPACK_COMPREPLY="-h --help -f --force --test -q --quiet -U --fresh --reuse --reuse-deps -j --jobs"
-}
-
 _spack_config() {
     if $list_options
     then
@@ -831,10 +827,6 @@ _spack_config_revert() {
 }
 
 _spack_containerize() {
-    SPACK_COMPREPLY="-h --help --list-os --last-stage"
-}
-
-_spack_containerise() {
     SPACK_COMPREPLY="-h --help --list-os --last-stage"
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -365,10 +365,8 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a commands -d 'list
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a compiler -d 'manage compilers'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a compilers -d 'list available compilers'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a concretize -d 'concretize an environment and write a lockfile'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a concretise -d 'concretize an environment and write a lockfile'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a config -d 'get and set configuration options'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a containerize -d 'creates recipes to build images for different container runtimes'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a containerise -d 'creates recipes to build images for different container runtimes'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a create -d 'create a new package file'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a debug -d 'debugging commands for troubleshooting Spack'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dependencies -d 'show dependencies of a package'
@@ -1102,25 +1100,6 @@ complete -c spack -n '__fish_spack_using_command concretize' -l reuse-deps -d 'r
 complete -c spack -n '__fish_spack_using_command concretize' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command concretize' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
-# spack concretise
-set -g __fish_spack_optspecs_spack_concretise h/help f/force test= q/quiet U/fresh reuse reuse-deps j/jobs=
-complete -c spack -n '__fish_spack_using_command concretise' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command concretise' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command concretise' -s f -l force -f -a force
-complete -c spack -n '__fish_spack_using_command concretise' -s f -l force -d 're-concretize even if already concretized'
-complete -c spack -n '__fish_spack_using_command concretise' -l test -r -f -a 'root all'
-complete -c spack -n '__fish_spack_using_command concretise' -l test -r -d 'concretize with test dependencies of only root packages or all packages'
-complete -c spack -n '__fish_spack_using_command concretise' -s q -l quiet -f -a quiet
-complete -c spack -n '__fish_spack_using_command concretise' -s q -l quiet -d 'don\'t print concretized specs'
-complete -c spack -n '__fish_spack_using_command concretise' -s U -l fresh -f -a concretizer_reuse
-complete -c spack -n '__fish_spack_using_command concretise' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
-complete -c spack -n '__fish_spack_using_command concretise' -l reuse -f -a concretizer_reuse
-complete -c spack -n '__fish_spack_using_command concretise' -l reuse -d 'reuse installed packages/buildcaches when possible'
-complete -c spack -n '__fish_spack_using_command concretise' -l reuse-deps -f -a concretizer_reuse
-complete -c spack -n '__fish_spack_using_command concretise' -l reuse-deps -d 'reuse installed dependencies only'
-complete -c spack -n '__fish_spack_using_command concretise' -s j -l jobs -r -f -a jobs
-complete -c spack -n '__fish_spack_using_command concretise' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
-
 # spack config
 set -g __fish_spack_optspecs_spack_config h/help scope=
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a get -d 'print configuration values'
@@ -1214,15 +1193,6 @@ complete -c spack -n '__fish_spack_using_command containerize' -l list-os -f -a 
 complete -c spack -n '__fish_spack_using_command containerize' -l list-os -d 'list all the OS that can be used in the bootstrap phase and exit'
 complete -c spack -n '__fish_spack_using_command containerize' -l last-stage -r -f -a 'bootstrap build final'
 complete -c spack -n '__fish_spack_using_command containerize' -l last-stage -r -d 'last stage in the container recipe'
-
-# spack containerise
-set -g __fish_spack_optspecs_spack_containerise h/help list-os last-stage=
-complete -c spack -n '__fish_spack_using_command containerise' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command containerise' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command containerise' -l list-os -f -a list_os
-complete -c spack -n '__fish_spack_using_command containerise' -l list-os -d 'list all the OS that can be used in the bootstrap phase and exit'
-complete -c spack -n '__fish_spack_using_command containerise' -l last-stage -r -f -a 'bootstrap build final'
-complete -c spack -n '__fish_spack_using_command containerise' -l last-stage -r -d 'last stage in the container recipe'
 
 # spack create
 set -g __fish_spack_optspecs_spack_create h/help keep-stage n/name= t/template= r/repo= N/namespace= f/force skip-editor b/batch


### PR DESCRIPTION
Reverts spack/spack#39499

This has bugs; a typo `spack isn<tab>` completes to `spack concretize` instead of complaining, which is rather annoying