### PR TITLE
Expand Windows EXE detection regex

### DIFF
--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -39,7 +39,7 @@ if sys.platform == "win32":
     DETECTION_TIMEOUT = 120
 
 
-def common_windows_package_paths(pkg_cls) -> List[str]:
+def common_windows_package_paths(pkg_cls=None) -> List[str]:
     """Get the paths for common package installation location on Windows
     that are outside the PATH
     Returns [] on unix
@@ -51,8 +51,9 @@ def common_windows_package_paths(pkg_cls) -> List[str]:
     paths.extend(WindowsKitExternalPaths.find_windows_kit_bin_paths())
     paths.extend(WindowsKitExternalPaths.find_windows_kit_reg_installed_roots_paths())
     paths.extend(WindowsKitExternalPaths.find_windows_kit_reg_sdk_paths())
-    paths.extend(compute_windows_user_path_for_package(pkg_cls))
-    paths.extend(compute_windows_program_path_for_package(pkg_cls))
+    if pkg_cls:
+        paths.extend(compute_windows_user_path_for_package(pkg_cls))
+        paths.extend(compute_windows_program_path_for_package(pkg_cls))
     return paths
 
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -249,11 +249,9 @@ class Finder:
             return []
         if initial_guess is None:
             initial_guess = self.default_path_hints()
-            # initial_guess.extend(common_windows_package_paths(pkg_cls))
+            initial_guess.extend(common_windows_package_paths(pkg_cls))
         candidates = self.candidate_files(patterns=patterns, paths=initial_guess)
         result = self.detect_specs(pkg=pkg_cls, paths=candidates)
-        print(result)
-        raise RuntimeError
         return result
 
 
@@ -359,6 +357,10 @@ def by_path(
                 except Exception:
                     llnl.util.tty.debug(
                         f"[EXTERNAL DETECTION] Skipping {pkg_name}: timeout reached"
+                    )
+                except Exception as e:
+                    llnl.util.tty.debug(
+                        f"[EXTERNAL DETECTION] Skipping {pkg_name}: exception occured {e}"
                     )
 
     return result

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -107,9 +107,7 @@ def libraries_in_ld_and_system_library_path(
     return path_to_dict(search_paths)
 
 
-def libraries_in_windows_paths(
-    path_hints: Optional[List[str]] = None,
-) -> Dict[str, str]:
+def libraries_in_windows_paths(path_hints: Optional[List[str]] = None) -> Dict[str, str]:
     """Get the paths of all libraries available from the system PATH paths.
 
     For more details, see `libraries_in_ld_and_system_library_path` regarding

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -256,7 +256,7 @@ class Finder:
 
 
 class ExecutablesFinder(Finder):
-    def default_path_hints() -> List[str]:
+    def default_path_hints(self) -> List[str]:
         return spack.util.environment.get_path("PATH")
 
     def search_patterns(self, *, pkg: "spack.package_base.PackageBase") -> List[str]:

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -107,7 +107,9 @@ def libraries_in_ld_and_system_library_path(
     return path_to_dict(search_paths)
 
 
-def libraries_in_windows_paths(path_hints: List[str]) -> Dict[str, str]:
+def libraries_in_windows_paths(
+    path_hints: Optional[List[str]] = None,
+) -> Dict[str, str]:
     """Get the paths of all libraries available from the system PATH paths.
 
     For more details, see `libraries_in_ld_and_system_library_path` regarding

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -249,9 +249,11 @@ class Finder:
             return []
         if initial_guess is None:
             initial_guess = self.default_path_hints()
-            initial_guess.extend(common_windows_package_paths(pkg_cls))
+            # initial_guess.extend(common_windows_package_paths(pkg_cls))
         candidates = self.candidate_files(patterns=patterns, paths=initial_guess)
         result = self.detect_specs(pkg=pkg_cls, paths=candidates)
+        print(result)
+        raise RuntimeError
         return result
 
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -131,6 +131,9 @@ def _group_by_prefix(paths: Set[str]) -> Dict[str, Set[str]]:
 class Finder:
     """Inspects the file-system looking for packages. Guesses places where to look using PATH."""
 
+    def default_path_hints(self) -> List[str]:
+        return []
+
     def search_patterns(self, *, pkg: "spack.package_base.PackageBase") -> List[str]:
         """Returns the list of patterns used to match candidate files.
 
@@ -245,7 +248,7 @@ class Finder:
         if not patterns:
             return []
         if initial_guess is None:
-            initial_guess = spack.util.environment.get_path("PATH")
+            initial_guess = self.default_path_hints()
             initial_guess.extend(common_windows_package_paths(pkg_cls))
         candidates = self.candidate_files(patterns=patterns, paths=initial_guess)
         result = self.detect_specs(pkg=pkg_cls, paths=candidates)
@@ -253,6 +256,9 @@ class Finder:
 
 
 class ExecutablesFinder(Finder):
+    def default_path_hints() -> List[str]:
+        return spack.util.environment.get_path("PATH")
+
     def search_patterns(self, *, pkg: "spack.package_base.PackageBase") -> List[str]:
         result = []
         if hasattr(pkg, "executables") and hasattr(pkg, "platform_executables"):

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -315,7 +315,7 @@ class LibrariesFinder(Finder):
         libraries_by_path = (
             libraries_in_ld_and_system_library_path(path_hints=paths)
             if sys.platform != "win32"
-            else libraries_in_windows_paths()
+            else libraries_in_windows_paths(path_hints=paths)
         )
         patterns = [re.compile(x) for x in patterns]
         result = []

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -28,16 +28,6 @@ def executables_found(monkeypatch):
     return _factory
 
 
-@pytest.fixture(autouse=True)
-def limit_search_to_path(monkeypatch):
-    """Pytest fixture that prevents the use of default search paths on Windows during testing"""
-
-    def _mock_windows_search_paths(pkg=None):
-        return []
-
-    monkeypatch.setattr(spack.detection.path.Finder, "path_hints", _mock_windows_search_paths)
-
-
 def define_plat_exe(exe):
     if sys.platform == "win32":
         exe += ".bat"

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -28,21 +28,13 @@ def executables_found(monkeypatch):
     return _factory
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(autouse=True)
 def limit_search_to_path(monkeypatch):
     """Pytest fixture that prevents the use of default search paths on Windows during testing"""
 
-    def _mock_windows_search_paths(pkg):
+    def _mock_windows_search_paths(pkg=None):
         return []
 
-    monkeypatch.setattr(
-        spack.detection.common, "compute_windows_user_path_for_package", _mock_windows_search_paths
-    )
-    monkeypatch.setattr(
-        spack.detection.common,
-        "compute_windows_program_path_for_package",
-        _mock_windows_search_paths,
-    )
     monkeypatch.setattr(
         spack.detection.path, "common_windows_package_paths", _mock_windows_search_paths
     )

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -28,21 +28,13 @@ def executables_found(monkeypatch):
     return _factory
 
 
-@pytest.fixture
-def _platform_executables(monkeypatch):
-    def _win_exe_ext():
-        return ".bat"
-
-    monkeypatch.setattr(spack.util.path, "win_exe_ext", _win_exe_ext)
-
-
 def define_plat_exe(exe):
     if sys.platform == "win32":
         exe += ".bat"
     return exe
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="https://github.com/spack/spack/pull/39850")
+
 def test_find_external_single_package(mock_executable):
     cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
     search_dir = cmake_path.parent.parent
@@ -236,7 +228,7 @@ def test_list_detectable_packages(mutable_config, mutable_mock_repo):
     assert external.returncode == 0
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="https://github.com/spack/spack/pull/39850")
+
 def test_packages_yaml_format(mock_executable, mutable_config, monkeypatch, _platform_executables):
     # Prepare an environment to detect a fake gcc
     gcc_exe = mock_executable("gcc", output="echo 4.2.1")
@@ -282,7 +274,7 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch, _platfo
     assert gcc.external_path == os.path.sep + os.path.join("opt", "gcc", "bin")
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="https://github.com/spack/spack/pull/39850")
+
 def test_new_entries_are_reported_correctly(
     mock_executable, mutable_config, monkeypatch, _platform_executables
 ):

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -35,9 +35,7 @@ def limit_search_to_path(monkeypatch):
     def _mock_windows_search_paths(pkg=None):
         return []
 
-    monkeypatch.setattr(
-        spack.detection.path, "common_windows_package_paths", _mock_windows_search_paths
-    )
+    monkeypatch.setattr(spack.detection.path.Finder, "path_hints", _mock_windows_search_paths)
 
 
 def define_plat_exe(exe):

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -237,30 +237,6 @@ def test_list_detectable_packages(mutable_config, mutable_mock_repo):
     assert external.returncode == 0
 
 
-def test_packages_yaml_format(mock_executable, mutable_config, monkeypatch):
-    # Prepare an environment to detect a fake gcc
-    gcc_exe = mock_executable("gcc", output="echo 4.2.1")
-    prefix = os.path.dirname(gcc_exe)
-    monkeypatch.setenv("PATH", prefix)
-
-    # Find the external spec
-    external("find", "gcc")
-
-    # Check entries in 'packages.yaml'
-    packages_yaml = spack.config.get("packages")
-    assert "gcc" in packages_yaml
-    assert "externals" in packages_yaml["gcc"]
-    externals = packages_yaml["gcc"]["externals"]
-    assert len(externals) == 1
-    external_gcc = externals[0]
-    assert external_gcc["spec"] == "gcc@4.2.1 languages=c"
-    assert external_gcc["prefix"] == os.path.dirname(prefix)
-    assert "extra_attributes" in external_gcc
-    extra_attributes = external_gcc["extra_attributes"]
-    assert "prefix" not in extra_attributes
-    assert extra_attributes["compilers"]["c"] == str(gcc_exe)
-
-
 def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
     gcc_exe = mock_executable("gcc", output="echo 4.2.1")
     search_dir = gcc_exe.parent

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import collections
+
+import spack.detection
+import spack.spec
+
+
+def test_detection_update_config(mutable_config):
+    # mock detected package
+    detected_packages = collections.defaultdict(list)
+    detected_packages["cmake"] = [
+        spack.detection.common.DetectedPackage(
+            spec=spack.spec.Spec("cmake@3.27.5"), prefix="/usr/bin"
+        )
+    ]
+
+    # update config for new package
+    spack.detection.common.update_configuration(detected_packages)
+    # Check entries in 'packages.yaml'
+    packages_yaml = spack.config.get("packages")
+    assert "cmake" in packages_yaml
+    assert "externals" in packages_yaml["cmake"]
+    externals = packages_yaml["cmake"]["externals"]
+    assert len(externals) == 1
+    external_gcc = externals[0]
+    assert external_gcc["spec"] == "cmake@3.27.5"
+    assert external_gcc["prefix"] == "/usr/bin"

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -98,7 +98,7 @@ SPACK_PATH_PADDING_CHARS = "__spack_path_placeholder__"
 
 
 def win_exe_ext():
-    return ".exe"
+    return r"(?:\.bat|\.exe)"
 
 
 def sanitize_filename(filename: str) -> str:


### PR DESCRIPTION
.bat or .exe files can be considered executable on Windows. This PR expands the regex for detectable packages to allow for the detection of packages that vendor .bat wrappers (intel mpi for example)
This approach has the added benefit of inherently supporting the mocked testing suite executables (which are .bat files)