### PR TITLE
Sirius: fix for the cmake variable

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -289,12 +289,12 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant(cm_label + "CREATE_PYTHON_MODULE", "python"),
             self.define_from_variant(cm_label + "USE_CUDA", "cuda"),
             self.define_from_variant(cm_label + "USE_ROCM", "rocm"),
-            self.define_from_variant(cm_label + "BUILD_TESTING", "tests"),
             self.define_from_variant(cm_label + "BUILD_APPS", "apps"),
             self.define_from_variant(cm_label + "BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant(cm_label + "USE_FP32", "single_precision"),
             self.define_from_variant(cm_label + "USE_PROFILER", "profiler"),
             self.define_from_variant(cm_label + "USE_WANNIER90", "wannier90"),
+            self.define_from_variant("BUILD_TESTING", "tests"),
         ]
 
         lapack = spec["lapack"]


### PR DESCRIPTION
BUILD_TESTING is a CMake variable and should not be scoped