### PR TITLE
linux-headers: drop rsync dep, add new version

### DIFF
--- a/var/spack/repos/builtin/packages/linux-headers/package.py
+++ b/var/spack/repos/builtin/packages/linux-headers/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -14,6 +16,7 @@ class LinuxHeaders(Package):
     list_url = "https://www.kernel.org/pub/linux/kernel"
     list_depth = 2
 
+    version("6.5.2", sha256="2027e14057d568ad3ddc100dadf4c8853a49b031270478a61d88f6011572650f")
     version("6.2.8", sha256="fed0ad87d42f83a70ce019ff2800bc30a855e672e72bf6d54a014d98d344f665")
     version("4.9.10", sha256="bd6e05476fd8d9ea4945e11598d87bc97806bbc8d03556abbaaf809707661525")
 
@@ -24,4 +27,12 @@ class LinuxHeaders(Package):
         env.unset("ARCH")
 
     def install(self, spec, prefix):
-        make("headers_install", "INSTALL_HDR_PATH={0}".format(prefix))
+        make("headers")
+
+        src, dst = join_path("usr", "include"), join_path(prefix, "include")
+
+        # This copy_tree + ignore is really poor API design, but the it avoids
+        # running make install_headers which depends on rsync.
+        copy_tree(
+            src, dst, ignore=lambda f: os.path.isfile(join_path(src, f)) and not f.endswith(".h")
+        )


### PR DESCRIPTION
`make headers_install` needs rsync, so use `copy_tree` instead.
