### PR TITLE
Update sp recipe, incl. adding develop version

### DIFF
--- a/var/spack/repos/builtin/packages/sp/package.py
+++ b/var/spack/repos/builtin/packages/sp/package.py
@@ -13,19 +13,32 @@ class Sp(CMakePackage):
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-sp"
     url = "https://github.com/NOAA-EMC/NCEPLIBS-sp/archive/refs/tags/v2.3.3.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-sp"
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("develop", branch="develop")
     version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
     version("2.3.3", sha256="c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f")
 
     variant("shared", default=False, description="Build shared library", when="@2.4:")
+    variant("openmp", default=False, description="Use OpenMP threading")
     variant("pic", default=False, description="Enable position-independent code (PIC)")
+    variant(
+        "precision",
+        default=["4", "d"],
+        values=["4", "d", "8"],
+        multi=True,
+        description="Library versions: 4=4-byte reals, d=8-byte reals, 8=8-byte ints and reals",
+        when="@2.4:",
+    )
 
     def setup_run_environment(self, env):
-        suffixes = ["4", "d"]
-        if self.spec.satisfies("@:2.3"):
-            suffixes += ["8"]
+        if self.spec.satisfies("@2.4:"):
+            suffixes = self.spec.variants["precision"].value
+        else:
+            suffixes = ["4", "d", "8"]
+
         for suffix in suffixes:
             lib = find_libraries(
                 "libsp_" + suffix,
@@ -40,4 +53,9 @@ class Sp(CMakePackage):
         args = []
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
+        args.append(self.define_from_variant("OPENMP", "openmp"))
+        args.append(self.define("BUILD_4", self.spec.satisfies("precision=4")))
+        args.append(self.define("BUILD_D", self.spec.satisfies("precision=d")))
+        args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
+        args.append(self.define("BUILD_DEPRECATED", False))
         return args


### PR DESCRIPTION
This PR updates the sp package recipe, including adding a develop version, a 'precision' variant for the 4/d/8 library versions, and automatically disabling deprecated functions (set BUILD_DEPRECATED=OFF).