### PR TITLE
Add awscli@1.29.41 and its dependency py-botocore@1.31.41

### DIFF
--- a/var/spack/repos/builtin/packages/awscli/package.py
+++ b/var/spack/repos/builtin/packages/awscli/package.py
@@ -42,5 +42,5 @@ class Awscli(PythonPackage):
     depends_on("py-rsa@3.1.2:4.7", when="@1.27:", type=("build", "run"))
     depends_on("py-rsa@3.1.2:3.5.0", when="@1.16", type=("build", "run"))
 
-    depends_on("py-s3transfer@0.6.0:0.6", when="@1.27:", type=("build", "run"))
-    depends_on("py-s3transfer@0.2.0:0.2", when="@1.16", type=("build", "run"))
+    depends_on("py-s3transfer@0.6", when="@1.27:", type=("build", "run"))
+    depends_on("py-s3transfer@0.2", when="@1.16", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/awscli/package.py
+++ b/var/spack/repos/builtin/packages/awscli/package.py
@@ -13,6 +13,7 @@ class Awscli(PythonPackage):
 
     pypi = "awscli/awscli-1.16.308.tar.gz"
 
+    version("1.29.41", sha256="c029edd2c0bd72fb49cefe1a8f83ce2b46ba31ab45769677f7ba0771461078cb")
     version("1.27.84", sha256="a27a7d1f3efa9dd2acf9d8bd72b939337d53da4ac71721cde6d5dff94aa446f7")
     version("1.27.56", sha256="58fd7122547db71646c053c914bd4f9b673356dd8c9520ae6d35560a8aec208b")
     version("1.16.308", sha256="3632fb1db2538128509a7b5e89f2a2c4ea3426bec139944247bddc4d79bf7603")
@@ -22,22 +23,24 @@ class Awscli(PythonPackage):
     depends_on("python@3.7:", when="@1.25:", type=("build", "run"))
 
     # py-botocore is pinned to the patch version number
+    depends_on("py-botocore@1.31.41", when="@1.29.41", type=("build", "run"))
     depends_on("py-botocore@1.29.84", when="@1.27.84", type=("build", "run"))
     depends_on("py-botocore@1.29.56", when="@1.27.56", type=("build", "run"))
     depends_on("py-botocore@1.13.44", when="@1.16.308", type=("build", "run"))
     depends_on("py-botocore@1.12.169", when="@1.16.179", type=("build", "run"))
 
-    depends_on("py-colorama@0.2.5:0.4.4", when="@1.27", type=("build", "run"))
+    depends_on("py-colorama@0.2.5:0.4.4", when="@1.27:", type=("build", "run"))
     depends_on("py-colorama@0.2.5:0.3.9", when="@1.16", type=("build", "run"))
 
-    depends_on("py-docutils@0.10:0.16", when="@1.27", type=("build", "run"))
+    depends_on("py-docutils@0.10:0.16", when="@1.27:", type=("build", "run"))
     depends_on("py-docutils@0.10:0.15", when="@1.16", type=("build", "run"))
 
+    depends_on("py-pyyaml@3.10:6.0", when="@1.29", type=("build", "run"))
     depends_on("py-pyyaml@3.10:5.4", when="@1.27", type=("build", "run"))
     depends_on("py-pyyaml@3.10:5.2", when="@1.16", type=("build", "run"))
 
-    depends_on("py-rsa@3.1.2:4.7", when="@1.27", type=("build", "run"))
+    depends_on("py-rsa@3.1.2:4.7", when="@1.27:", type=("build", "run"))
     depends_on("py-rsa@3.1.2:3.5.0", when="@1.16", type=("build", "run"))
 
-    depends_on("py-s3transfer@0.6.0:0.6", when="@1.27", type=("build", "run"))
+    depends_on("py-s3transfer@0.6.0:0.6", when="@1.27:", type=("build", "run"))
     depends_on("py-s3transfer@0.2.0:0.2", when="@1.16", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -12,6 +12,7 @@ class PyBotocore(PythonPackage):
     homepage = "https://github.com/boto/botocore"
     pypi = "botocore/botocore-1.13.44.tar.gz"
 
+    version("1.31.41", sha256="4dad7c5a5e70940de54ebf8de3955450c1f092f43cacff8103819d1e7d5374fa")
     version("1.29.84", sha256="a36f7f6f8eae5dbd4a1cc8cb6fc747f6315500541181eff2093ee0529fc8e4bc")
     version("1.29.76", sha256="c2f67b6b3f8acf2968eafca06526f07b9fb0d27bac4c68a635d51abb675134a7")
     version("1.29.56", sha256="ca4d6403d745218270a20d9ca3ca9a33e3ad2fabb59a96ed8d6e1a824b274c86")


### PR DESCRIPTION
This PR adds the latest version of `awscli@1.29.41` and its dependency `py-botoc3@1.31.41` (there is always a one-to-one match between those packages). The other, existing dependencies were adjusted as per the package `setup.py`.

I tested building this on macOS arm64 w/ clang+gfortran, macOS x86_64 w/ clang+gfortran, Ubuntu x86_64 w/ icc+ifort.