### PR TITLE
Dakota 6.18 Upgrade

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -7,6 +7,16 @@ from spack.package import *
 from spack.pkg.builtin.boost import Boost
 
 
+def submodules(package):
+    submodules = []
+    submodules.append("dakota-examples")
+    submodules.append("packages/external")
+    submodules.append("packages/pecos")
+    submodules.append("packages/surfpack")
+
+    return submodules
+
+
 class Dakota(CMakePackage):
     """The Dakota toolkit provides a flexible, extensible interface between
     analysis codes and iterative systems analysis methods. Dakota
@@ -27,8 +37,10 @@ class Dakota(CMakePackage):
     """
 
     homepage = "https://dakota.sandia.gov/"
+    git = "https://github.com/snl-dakota/dakota.git"
     url = "https://dakota.sandia.gov/sites/default/files/distributions/public/dakota-6.12-release-public.src.tar.gz"
 
+    version("6.18", tag="v6.18.0", submodules=submodules)
     version("6.12", sha256="4d69f9cbb0c7319384ab9df27643ff6767eb410823930b8fbd56cc9de0885bc9")
     version("6.9", sha256="989b689278964b96496e3058b8ef5c2724d74bcd232f898fe450c51eba7fe0c2")
     version("6.3", sha256="0fbc310105860d77bb5c96de0e8813d75441fca1a5e6dfaf732aa095c4488d52")
@@ -46,12 +58,14 @@ class Dakota(CMakePackage):
     depends_on("python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
     depends_on("boost@:1.68.0", when="@:6.12")
+    depends_on("boost@1.69.0:", when="@6.18:")
 
     # TODO: replace this with an explicit list of components of Boost,
     # for instance depends_on('boost +filesystem')
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants, when="@:6.12")
     depends_on("cmake@2.8.9:", type="build")
+    depends_on("cmake@3.17:", type="build", when="@6.18:")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
- Removed old versions <6.18 due to change from Sandia's internal gitlab to external GitHub
- Does not support 6.16 and 6.17 due to bug in dakota .gitmodules file (fixed in 6.18)
- Created submodules function to load publicly available modules

@adamjstewart 
@g-mathias
@tldahlgren 