### PR TITLE
bugfix: only complete aliases for potential aliases

### DIFF
--- a/share/spack/bash/spack-completion.bash
+++ b/share/spack/bash/spack-completion.bash
@@ -367,8 +367,10 @@ _spack_get_alias() {
 # If all commands in COMPREPLY alias to the same thing, set COMPREPLY to
 # just the real command, not the aliases.
 _spack_compress_aliases() {
-    # if there's only one thing, don't bother compressing aliases; complete the alias
-    if [ "${#COMPREPLY[@]}" == "1" ]; then
+    # If there are zero or one completions, don't do anything
+    # If this isn't the first argument, bail because aliases currently only apply
+    # to top-level commands.
+    if [ "${#COMPREPLY[@]}" -le "1" ] || [ "$COMP_CWORD" != "1" ]; then
         return
     fi
 

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -67,6 +67,9 @@ contains 'concretise' _spack_completions spack c
 contains 'concretize' _spack_completions spack conc
 does_not_contain 'concretise' _spack_completions spack conc
 
+does_not_contain 'concretize' _spack_completions spack isnotacommand
+does_not_contain 'concretize' _spack_completions spack env isnotacommand
+
 # XFAIL: Fails for Python 2.6 because pkg_resources not found?
 #contains 'compilers.py' _spack_completions spack unit-test ''
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -367,8 +367,10 @@ _spack_get_alias() {
 # If all commands in COMPREPLY alias to the same thing, set COMPREPLY to
 # just the real command, not the aliases.
 _spack_compress_aliases() {
-    # if there's only one thing, don't bother compressing aliases; complete the alias
-    if [ "${#COMPREPLY[@]}" == "1" ]; then
+    # If there are zero or one completions, don't do anything
+    # If this isn't the first argument, bail because aliases currently only apply
+    # to top-level commands.
+    if [ "${#COMPREPLY[@]}" -le "1" ] || [ "$COMP_CWORD" != "1" ]; then
         return
     fi
 


### PR DESCRIPTION
Closes #39840.
Fixes #39886.

Smart alias completion introduced in #39499 wasn't as smart as it needed to be, and would complete any invalid command prefix and some env names with alias names.

- [x] don't complete aliases if there are no potential completions e.g., don't convert `spack isnotacommand` -> `spack concretize`
- [x] don't complete with an aliases if we're not looking at a top-level subcommand.
- [x] add tests