### PR TITLE
sirius: fix cuda_arch flags

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -342,8 +342,10 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
                     )
 
                 # Make SIRIUS handle it
+                elif "@6:7.4.3" in spec:
+                    args.append(self.define("CMAKE_CUDA_ARCH", ";".join(cuda_arch)))
                 else:
-                    args.append(self.define("CUDA_ARCH", ";".join(cuda_arch)))
+                    args.append(self.define("CMAKE_CUDA_ARCHITECTURES", ";".join(cuda_arch)))
 
         if "+rocm" in spec:
             archs = ",".join(self.spec.variants["amdgpu_target"].value)


### PR DESCRIPTION
Current develop branch doesn't take into account cuda_arch via spack. This is fixed  #39624 too, but that PR is waiting for some changes in cp2k. 