### PR TITLE
Add support of new version of MALT (1.2.2)

### DIFF
--- a/var/spack/repos/builtin/packages/malt/package.py
+++ b/var/spack/repos/builtin/packages/malt/package.py
@@ -15,10 +15,11 @@ class Malt(CMakePackage):
 
     # Project infos
     homepage = "https://memtt.github.io/malt"
-    url = "https://github.com/memtt/malt/archive/v1.2.1.tar.gz"
+    url = "https://github.com/memtt/malt/archive/v1.2.2.tar.gz"
     maintainers("svalat")
 
     # Versions
+    version("1.2.2", sha256="e19f49ad97bf2deedf0557eb00267f4dcf1c932c494dd07ada07fcdf5421935f")
     version("1.2.1", sha256="0e4c0743561f9fcc04dc83457386167a9851fc9289765f8b4f9390384ae3618a")
 
     # Variants


### PR DESCRIPTION
Add version 1.2.2 for package MALT.

This version of MALT has been released in June with mostly minor fixes.