### PR TITLE
openscenegraph: support more file formats

### DIFF
--- a/var/spack/repos/builtin/packages/openscenegraph/openscenegraph-3.6.5-openexr3.patch
+++ b/var/spack/repos/builtin/packages/openscenegraph/openscenegraph-3.6.5-openexr3.patch
@@ -1,0 +1,68 @@
+https://bugs.gentoo.org/833491
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -752,7 +752,6 @@ ELSE()
+-    FIND_PACKAGE(ilmbase)
+     FIND_PACKAGE(Inventor)
+     FIND_PACKAGE(Jasper)
+-    FIND_PACKAGE(OpenEXR)
++    FIND_PACKAGE(OpenEXR CONFIG)
+     FIND_PACKAGE(OpenCascade)
+     FIND_PACKAGE(COLLADA)
+     FIND_PACKAGE(FBX)
+--- a/src/osgPlugins/CMakeLists.txt
++++ b/src/osgPlugins/CMakeLists.txt
+@@ -105,7 +105,7 @@ ENDIF()
+ IF(JASPER_FOUND)
+     ADD_PLUGIN_DIRECTORY(jp2)
+ ENDIF()
+-IF(OPENEXR_FOUND AND ZLIB_FOUND AND OSG_CPP_EXCEPTIONS_AVAILABLE)
++IF(OpenEXR_FOUND AND ZLIB_FOUND AND OSG_CPP_EXCEPTIONS_AVAILABLE)
+     ADD_PLUGIN_DIRECTORY(exr)
+ ENDIF()
+ IF(GIFLIB_FOUND)
+--- a/src/osgPlugins/exr/CMakeLists.txt
++++ b/src/osgPlugins/exr/CMakeLists.txt
+@@ -1,9 +1,7 @@
+-INCLUDE_DIRECTORIES( ${ILMBASE_INCLUDE_DIR}/OpenEXR )
+-INCLUDE_DIRECTORIES( ${OPENEXR_INCLUDE_DIR}/OpenEXR )
+-
+ SET(TARGET_SRC ReaderWriterEXR.cpp )
+ 
+-SET(TARGET_LIBRARIES_VARS ${OPENEXR_LIBRARIES_VARS} ${ILMBASE_LIBRARIES_VARS} ZLIB_LIBRARIES)
++SET(OPENEXR_LIBRARIES_VARS OpenEXR::OpenEXR)
++SET(TARGET_LIBRARIES_VARS OPENEXR_LIBRARIES_VARS ZLIB_LIBRARIES)
+ 
+ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+     REMOVE_CXX_FLAG(-Wshadow)
+--- a/src/osgPlugins/exr/ReaderWriterEXR.cpp
++++ b/src/osgPlugins/exr/ReaderWriterEXR.cpp
+@@ -41,11 +41,11 @@ public:
+       {
+         return _inStream->read(c,n).good();
+       };
+-      virtual Int64    tellg ()
++      virtual uint64_t    tellg ()
+       {
+           return _inStream->tellg();
+       };
+-      virtual void    seekg (Int64 pos)
++      virtual void    seekg (uint64_t pos)
+       {
+         _inStream->seekg(pos);
+       };
+@@ -69,11 +69,11 @@ public:
+       {
+         _outStream->write(c,n);
+       };
+-      virtual Int64    tellp ()
++      virtual uint64_t    tellp ()
+       {
+         return _outStream->tellp();
+       };
+-      virtual void seekp (Int64 pos)
++      virtual void seekp (uint64_t pos)
+       {
+         _outStream->seekp(pos);
+       };

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -89,20 +89,17 @@ class Openscenegraph(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        shared_status = "ON" if "+shared" in spec else "OFF"
-        opengl_profile = "GL{0}".format(spec["gl"].version.up_to(1))
-
         args = [
             # Variant Options #
-            "-DDYNAMIC_OPENSCENEGRAPH={0}".format(shared_status),
-            "-DDYNAMIC_OPENTHREADS={0}".format(shared_status),
-            "-DOPENGL_PROFILE={0}".format(opengl_profile),
+            self.define_from_variant("DYNAMIC_OPENSCENEGRAPH", "shared"),
+            self.define_from_variant("DYNAMIC_OPENTHREADS", "shared"),
             self.define_from_variant("BUILD_OSG_APPLICATIONS", "apps"),
             # General Options #
-            "-DOSG_NOTIFY_DISABLED=ON",
-            "-DLIB_POSTFIX=",
-            "-DCMAKE_RELWITHDEBINFO_POSTFIX=",
-            "-DCMAKE_MINSIZEREL_POSTFIX=",
+            self.define("OPENGL_PROFILE", f"GL{spec['gl'].version.up_to(1)}"),
+            self.define("OSG_NOTIFY_DISABLED", True),
+            self.define("LIB_POSTFIX", ""),
+            self.define("CMAKE_RELWITHDEBINFO_POSTFIX", ""),
+            self.define("CMAKE_MINSIZEREL_POSTFIX", ""),
         ]
 
         # explicitly disable or enable plugins depending on variants

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -107,25 +107,16 @@ class Openscenegraph(CMakePackage):
 
         # explicitly disable or enable plugins depending on variants
         # CMake will still search for the packages, but won't build the plugins requiring them
-        def build_plugin(plugin, variant=False):
-            if not variant:
-                variant = plugin
-            if spec.satisfies("+{}".format(variant)):
-                value = 1
-            else:
-                value = 0
-            return self.define("BUILD_OSG_PLUGIN_{}".format(plugin.upper()), value)
-
-        args.append(build_plugin("dicom", "dcmtk"))
-        args.append(build_plugin("exr", "openexr"))
-        args.append(build_plugin("ffmpeg"))
-        args.append(build_plugin("gdal"))
-        args.append(build_plugin("ogr", "gdal"))
-        args.append(build_plugin("gta"))
-        args.append(build_plugin("inventor"))
-        args.append(build_plugin("opencascade"))
-        args.append(build_plugin("pdf"))
-        args.append(build_plugin("svg"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_DICOM", "dcmtk"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_EXR", "openexr"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_FFMPEG", "ffmpeg"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_GDAL", "gdal"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_OGR", "gdal"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_GTA", "gta"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_INVENTOR", "inventor"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_OPENCASCADE", "opencascade"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_PDF", "pdf"))
+        args.append(self.define_from_variant("BUILD_OSG_PLUGIN_SVG", "svg"))
 
         # NOTE: This is necessary in order to allow OpenSceneGraph to compile
         # despite containing a number of implicit bool to int conversions.

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -67,7 +67,7 @@ class Openscenegraph(CMakePackage):
     depends_on("libgta", when="+gta")
     depends_on("coin3d", when="+inventor")
     depends_on("opencascade@:7.5", when="+opencascade")
-    depends_on("openexr@2", when="+openexr")
+    depends_on("openexr", when="+openexr")
     depends_on("ilmbase", when="+openexr")
     depends_on("poppler+glib", when="+pdf")
     depends_on("librsvg", when="+svg")
@@ -78,6 +78,8 @@ class Openscenegraph(CMakePackage):
     depends_on("ffmpeg@:2", when="@:3.4.0+ffmpeg")
 
     patch("glibc-jasper.patch", when="@3.4%gcc")
+    # from gentoo: https://raw.githubusercontent.com/gentoo/gentoo/9523b20c27d12dd72d1fd5ced3ba4995099925a2/dev-games/openscenegraph/files/openscenegraph-3.6.5-openexr3.patch
+    patch("openscenegraph-3.6.5-openexr3.patch", when="@3.6:")
 
     def patch(self):
         # pkgconfig does not work for GTA on macos

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -111,9 +111,9 @@ class Openscenegraph(CMakePackage):
             if not variant:
                 variant = plugin
             if spec.satisfies("+{}".format(variant)):
-                value=1
+                value = 1
             else:
-                value=0
+                value = 0
             return self.define("BUILD_OSG_PLUGIN_{}".format(plugin.upper()), value)
 
         args.append(build_plugin("dicom", "dcmtk"))

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -127,15 +127,6 @@ class Openscenegraph(CMakePackage):
         args.append(build_plugin("pdf"))
         args.append(build_plugin("svg"))
 
-        if spec.satisfies("~ffmpeg"):
-            for ffmpeg_lib in ["libavcodec", "libavformat", "libavutil"]:
-                args.extend(
-                    [
-                        "-DFFMPEG_{0}_INCLUDE_DIRS=".format(ffmpeg_lib.upper()),
-                        "-DFFMPEG_{0}_LIBRARIES=".format(ffmpeg_lib.upper()),
-                    ]
-                )
-
         # NOTE: This is necessary in order to allow OpenSceneGraph to compile
         # despite containing a number of implicit bool to int conversions.
         if spec.satisfies("%gcc"):

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -16,6 +16,8 @@ class Openscenegraph(CMakePackage):
     git = "https://github.com/openscenegraph/OpenSceneGraph.git"
     url = "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.4.tar.gz"
 
+    maintainers("aumuell")
+
     version("master", branch="master")
     version("stable", branch="OpenSceneGraph-3.6")
     version("3.6.5", sha256="aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12")

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -14,6 +14,8 @@ class Openscenegraph(CMakePackage):
     git = "https://github.com/openscenegraph/OpenSceneGraph.git"
     url = "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.4.tar.gz"
 
+    version("master", branch="master")
+    version("stable", branch="OpenSceneGraph-3.6")
     version("3.6.5", sha256="aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12")
     version("3.6.4", sha256="81394d1b484c631028b85d21c5535280c21bbd911cb058e8746c87e93e7b9d33")
     version("3.4.1", sha256="930eb46f05781a76883ec16c5f49cfb29a059421db131005d75bec4d78401fd5")

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -68,7 +68,7 @@ class Openscenegraph(CMakePackage):
     depends_on("coin3d", when="+inventor")
     depends_on("opencascade@:7.5", when="+opencascade")
     depends_on("openexr", when="+openexr")
-    depends_on("ilmbase", when="+openexr")
+    depends_on("ilmbase", when="+openexr ^openexr@:2")
     depends_on("poppler+glib", when="+pdf")
     depends_on("librsvg", when="+svg")
 

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -105,6 +105,28 @@ class Openscenegraph(CMakePackage):
             "-DCMAKE_MINSIZEREL_POSTFIX=",
         ]
 
+        # explicitly disable or enable plugins depending on variants
+        # CMake will still search for the packages, but won't build the plugins requiring them
+        def build_plugin(plugin, variant=False):
+            if not variant:
+                variant = plugin
+            if spec.satisfies("+{}".format(variant)):
+                value=1
+            else:
+                value=0
+            return self.define("BUILD_OSG_PLUGIN_{}".format(plugin.upper()), value)
+
+        args.append(build_plugin("dicom", "dcmtk"))
+        args.append(build_plugin("exr", "openexr"))
+        args.append(build_plugin("ffmpeg"))
+        args.append(build_plugin("gdal"))
+        args.append(build_plugin("ogr", "gdal"))
+        args.append(build_plugin("gta"))
+        args.append(build_plugin("inventor"))
+        args.append(build_plugin("opencascade"))
+        args.append(build_plugin("pdf"))
+        args.append(build_plugin("svg"))
+
         if spec.satisfies("~ffmpeg"):
             for ffmpeg_lib in ["libavcodec", "libavformat", "libavutil"]:
                 args.extend(

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -34,9 +34,7 @@ class Openscenegraph(CMakePackage):
         "ffmpeg", default=False, description="Builds ffmpeg plugin for audio encoding/decoding"
     )
     variant("gdal", default=False, description="Build support for geospatial files using GDAL")
-    variant(
-        "gta", default=False, description="Build support for Generic Tagged Array (GTA) files"
-    )
+    variant("gta", default=False, description="Build support for Generic Tagged Array (GTA) files")
     variant(
         "inventor", default=False, description="Build support for Open Inventor files using Coin3D"
     )

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -43,7 +43,7 @@ class Openscenegraph(CMakePackage):
     )
     variant("openexr", default=False, description="Build support for OpenEXR files")
     variant("pdf", default=False, description="Build support for PDF files using Poppler")
-    variant("svg", default=False, description="Build support for SVD files using librsvg")
+    variant("svg", default=False, description="Build support for SVG files using librsvg")
 
     depends_on("cmake@2.8.7:", type="build")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
add support for all formats for which the required libraries are provided by spack,
each additional dependency is optional