### PR TITLE
Added Spack requirements

### DIFF
--- a/lib/spack/docs/tables/system_prerequisites.csv
+++ b/lib/spack/docs/tables/system_prerequisites.csv
@@ -17,3 +17,6 @@ git, , , Manage Software Repositories
 svn, , Optional, Manage Software Repositories
 hg, , Optional, Manage Software Repositories
 Python header files, , Optional (e.g. ``python3-dev`` on Debian), Bootstrapping from sources
+sed, , , Used by configure scripts
+grep, , , Used by configure scripts
+awk, , , Used by configure scripts


### PR DESCRIPTION
On first bootstrap, berkeley-db's ./configure wants grep and sed and gdbm's ./config.status wants awk