### PR TITLE
lorene: add headers to the install

### DIFF
--- a/var/spack/repos/builtin/packages/lorene/package.py
+++ b/var/spack/repos/builtin/packages/lorene/package.py
@@ -113,6 +113,7 @@ class Lorene(MakefilePackage):
         mkdirp(prefix.lib)
         install_tree("Lib", prefix.lib)
         install_tree("Export/C++/Include", prefix.include)
+        install_tree("C++/Include", prefix.include)
         mkdirp(prefix.bin)
         if "+bin_star" in spec:
             for exe in [

--- a/var/spack/repos/builtin/packages/lorene/package.py
+++ b/var/spack/repos/builtin/packages/lorene/package.py
@@ -110,7 +110,6 @@ class Lorene(MakefilePackage):
                 )
 
     def install(self, spec, prefix):
-        mkdirp(prefix.lib)
         install_tree("Lib", prefix.lib)
         install_tree("Export/C++/Include", prefix.include)
         install_tree("C++/Include", prefix.include)

--- a/var/spack/repos/builtin/packages/lorene/package.py
+++ b/var/spack/repos/builtin/packages/lorene/package.py
@@ -112,6 +112,7 @@ class Lorene(MakefilePackage):
     def install(self, spec, prefix):
         mkdirp(prefix.lib)
         install_tree("Lib", prefix.lib)
+        install_tree("Export/C++/Include", prefix.include)
         mkdirp(prefix.bin)
         if "+bin_star" in spec:
             for exe in [


### PR DESCRIPTION
The Lorene install script leaves out the header files. This PR modifies the install phase to include them.