### PR TITLE
Added rc shell support.

### DIFF
--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -35,6 +35,9 @@ def shell_init_instructions(cmd, equivalent):
         color.colorize("@*c{For fish:}"),
         "  source %s/setup-env.fish" % spack.paths.share_path,
         "",
+        color.colorize("@*c{For rc:}"),
+        "  source %s/setup-env.rc" % spack.paths.share_path,
+        "",
         color.colorize("@*c{For Windows batch:}"),
         "  %s\\spack_cmd.bat" % spack.paths.bin_path,
         "",
@@ -52,6 +55,7 @@ def shell_init_instructions(cmd, equivalent):
             equivalent.format(sh_arg="--sh  ") + "  # bash/zsh/sh",
             equivalent.format(sh_arg="--csh ") + "  # csh/tcsh",
             equivalent.format(sh_arg="--fish") + "  # fish",
+            equivalent.format(sh_arg="--rc") + "  # rc",
             equivalent.format(sh_arg="--bat ") + "  # batch",
             equivalent.format(sh_arg="--pwsh") + "  # powershell",
         ]

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -80,6 +80,13 @@ def env_activate_setup_parser(subparser):
         help="print fish commands to activate the environment",
     )
     shells.add_argument(
+        "--rc",
+        action="store_const",
+        dest="shell",
+        const="rc",
+        help="print rc commands to activate the environment",
+    )
+    shells.add_argument(
         "--bat",
         action="store_const",
         dest="shell",
@@ -231,6 +238,13 @@ def env_deactivate_setup_parser(subparser):
         dest="shell",
         const="fish",
         help="print fish commands to activate the environment",
+    )
+    shells.add_argument(
+        "--rc",
+        action="store_const",
+        dest="shell",
+        const="rc",
+        help="print rc commands to activate the environment",
     )
     shells.add_argument(
         "--bat",

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -46,6 +46,13 @@ def setup_parser(subparser):
         help="print fish commands to load the package",
     )
     shells.add_argument(
+        "--rc",
+        action="store_const",
+        dest="shell",
+        const="rc",
+        help="print rc commands to load the package",
+    )
+    shells.add_argument(
         "--bat",
         action="store_const",
         dest="shell",

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -46,6 +46,7 @@ _SHELL_SET_STRINGS = {
     "sh": "export {0}={1};\n",
     "csh": "setenv {0} {1};\n",
     "fish": "set -gx {0} {1};\n",
+    "rc": "{0}={1};\n",
     "bat": 'set "{0}={1}"\n',
     "pwsh": "$Env:{0}='{1}'\n",
 }
@@ -55,6 +56,7 @@ _SHELL_UNSET_STRINGS = {
     "sh": "unset {0};\n",
     "csh": "unsetenv {0};\n",
     "fish": "set -e {0};\n",
+    "rc": "{0}=();\n",
     "bat": 'set "{0}="\n',
     "pwsh": "Set-Item -Path Env:{0}\n",
 }
@@ -69,13 +71,15 @@ ModificationList = List[Union["NameModifier", "NameValueModifier"]]
 _find_unsafe = re.compile(r"[^\w@%+=:,./-]", re.ASCII).search
 
 
-def double_quote_escape(s):
+def double_quote_escape(s, shell="sh"):
     """Return a shell-escaped version of the string *s*.
 
     This is similar to how shlex.quote works, but it escapes with double quotes
     instead of single quotes, to allow environment variable expansion within
     quoted strings.
     """
+    if shell == "rc":
+        return "'" + s.replace("'", "''") + "'"
     if not s:
         return '""'
     if _find_unsafe(s) is None:
@@ -724,7 +728,7 @@ class EnvironmentModifications:
                     cmds += _SHELL_UNSET_STRINGS[shell].format(name)
                 else:
                     if sys.platform != "win32":
-                        new_env_name = double_quote_escape(new_env[name])
+                        new_env_name = double_quote_escape(new_env[name], shell)
                     else:
                         new_env_name = new_env[name]
                     cmd = _SHELL_SET_STRINGS[shell].format(name, new_env_name)

--- a/share/spack/setup-env.rc
+++ b/share/spack/setup-env.rc
@@ -1,0 +1,331 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+########################################################################
+#
+# This file is part of Spack and sets up the spack environment for rc,
+# This includes environment modules and lmod support,
+# and it also puts spack in your path. The script also checks that at least
+# module support exists, and provides suggestions if it doesn't. Source
+# it like this:
+#
+#    . /path/to/spack/share/spack/setup-env.rc
+#
+########################################################################
+# This is a wrapper around the spack command that forwards calls to
+# 'spack load' and 'spack unload' to shell functions.  This in turn
+# allows them to be used to invoke environment modules functions.
+#
+# 'spack load' is smarter than just 'load' because it converts its
+# arguments into a unique Spack spec that is then passed to module
+# commands.  This allows the user to use packages without knowing all
+# their installation details.
+#
+# e.g., rather than requiring a full spec for libelf, the user can type:
+#
+#     spack load libelf
+#
+# This will first find the available libelf module file and use a
+# matching one.  If there are two versions of libelf, the user would
+# need to be more specific, e.g.:
+#
+#     spack load libelf@0.8.13
+#
+# This is very similar to how regular spack commands work and it
+# avoids the need to come up with a user-friendly naming scheme for
+# spack module files.
+########################################################################
+
+# prevent infinite recursion when spack shells out (e.g., on cray for modules)
+if(~ $_sp_initializing true) {
+    echo 'Error: recursive call to spack/share/setup-env.rc' >[1=2]
+    exit 1
+}
+_sp_initializing=true
+_sp_shell_args = (--rc --sh --csh --fish)
+
+fn _spack_shell_wrapper {
+    # Store LD_LIBRARY_PATH variables from spack shell function
+    # This is necessary because MacOS System Integrity Protection clears
+    # variables that affect dyld on process start.
+    for(var in LD_LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH) {
+        ! ~ $#$var 0 && SPACK_$var = $$var
+    }
+
+    # accumulate flags meant for the main spack command
+    #     while $1 is set (while there are arguments)
+    #       and $1 starts with '-' (and the arguments are flags)
+    # (Note the loop condition is unreadable in bash)
+    _sp_flags=()
+    while(~ $*(1) -*) {
+        _sp_flags = ($_sp_flags $*(1))
+        shift
+	}
+
+    # h and V flags don't require further output parsing.
+    #if(~ h $_sp_flags || ~ V $_sp_flags) {
+    #    command spack $_sp_flags $*
+    #} if not # there's an imposter rc with no 'if not'
+
+	# set the subcommand if there is one (if $1 is set)
+	_sp_subcommand=$*(1)
+	~ $#_sp_subcommand 1 && shift
+
+	# Filter out use and unuse.  For any other commands, just run the
+    # command.
+    switch($_sp_subcommand) {
+        case cd
+            _sp_arg=()
+            if(! ~ $#* 0) {
+                _sp_arg=$*(1)
+                shift
+            }
+            if(~ $_sp_arg -h --help) {
+                command spack cd -h
+            }
+            if(!~ $_sp_arg -h --help) {
+                LOC=`{spack location $_sp_arg $*}
+                if([ -d $LOC]) {
+                    cd $LOC
+                }
+                if(! [ -d $LOC]) {
+                    return 1
+                }
+            }
+        case env
+            _sp_arg=()
+            if(! ~ $#* 0) {
+                _sp_arg=$*(1)
+                shift
+            }
+
+            if(~ $_sp_arg -h --help) {
+                command spack env -h
+            } # if not # there's an imposter rc with no 'if not'
+            if(! ~ $_sp_arg -h --help) {
+				_sp_do_eval = true
+				# args contain --sh, --csh, or -h/--help: don't eval
+				~ $* ($_sp_shell_args -h --help) && _sp_do_eval = false
+
+                switch($_sp_arg) {
+                    case activate
+                        # Get --sh, --csh, or -h/--help arguments.
+                        # No extra rewriting needed because rc
+                        # understands lists and does not re-expand variables.
+                        if(~ $_sp_do_eval false) {
+                            command spack env activate $*
+                        }
+						# if not
+						if(! ~ $_sp_do_eval false) {
+                            stdout=`{command spack $_sp_flags env activate --rc $*} && eval $stdout
+                        }
+                    case deactivate
+                        if(~ $_sp_do_eval false) {
+                            command spack env deactivate $*
+						}
+						# if not
+                        if(! ~ $_sp_do_eval false) {
+							if(! ~ $#* 0) {
+								# Any other arguments are an error
+								command spack env deactivate -h
+							}
+							# if not
+							if(~ $#* 0) {
+								# No args: source the output of the command.
+								stdout=`{command spack $_sp_flags env deactivate --rc} && eval $stdout
+							}
+                        }
+                    case *
+                        command spack env $_sp_arg $*
+                }
+            }
+        case load unload
+            _sp_do_eval = true
+            for(arg in $_sp_shell_args -h --help --list) {
+                # Args contain --sh, --csh, or -h/--help: just execute.
+				~ $arg $* && _sp_do_eval = false
+			}
+			if(~ $_sp_do_eval true) {
+                stdout=`{command spack $_sp_flags $_sp_subcommand --rc $*} \
+					&& eval $stdout
+			}
+			# if not
+			if(! ~ $_sp_do_eval true) {
+                command spack $_sp_flags $_sp_subcommand $*
+            }
+        case *
+            command spack $_sp_flags $_sp_subcommand $*
+	}
+}
+
+########################################################################
+# Prepends directories to path, if they exist.
+#      pathadd /path/to/dir            # add to PATH
+# or   pathadd OTHERPATH /path/to/dir  # add to OTHERPATH
+########################################################################
+fn _spack_pathadd {
+    # If no variable name is supplied, just append to PATH
+    # otherwise append to that variable.
+    _pa_varname=PATH
+    _pa_new_path=$*(1)
+    if([ -n $*(2) ]) {
+        _pa_varname=$*(1)
+        _pa_new_path=$*(2)
+    }
+
+    # Do the actual prepending here.
+    _pa_oldvalue=$$_pa_varname
+
+    _pa_canonical=:$_pa_oldvalue:
+    if([ -d $_pa_new_path ] && \
+       ! ~ $_pa_canonical *:$_pa_new_path:*) {
+        if(~ $#_pa_oldvalue 0)
+            $_pa_varname=$_pa_new_path
+        if(! ~ $#_pa_oldvalue 0)
+            $_pa_varname=$_pa_new_path:$_pa_oldvalue
+    }
+}
+
+
+# Determine which shell is being used
+fn _spack_determine_shell {
+    if([ -f /proc/$pid/exe ]) {
+        # If procfs is present this seems a more reliable
+        # way to detect the current shell
+        _sp_exe=`{readlink /proc/$pid/exe}
+        # Shell may contain number, like zsh5 instead of zsh
+        basename $_sp_exe | tr -d '0123456789'
+    }
+    if(! [ -f /proc/$pid/exe ]) {
+		echo rc
+	}
+    #PS_FORMAT= ps -p $pid | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
+}
+_sp_shell=`{_spack_determine_shell}
+
+fn spacktivate { spack env activate }
+
+#
+# Figure out where this file is.
+#
+# Try to read the /proc filesystem (works on linux without lsof)
+# In dash, the sourced file is the last one opened (and it's kept open)
+_sp_source_file_fd=`{ls /proc/$pid/fd >[2]/dev/null | sort -n | tail -1}
+if(! _sp_source_file=`{readlink /proc/$pid/fd/$_sp_source_file_fd}) {
+	# Last resort: try lsof. This works in dash on macos -- same reason.
+	# macos has lsof installed by default; some linux containers don't.
+	_sp_lsof_output=`{lsof -p $pid -Fn0 | tail -1}
+	_sp_source_file=`{echo $_sp_lsof_output | sed -e 's/^*n//'}
+}
+
+#
+# Find root directory and add bin to path.
+#
+# We send cd output to /dev/null to avoid because a lot of users set up
+# their shell so that cd prints things out to the tty.
+_sp_share_dir=`{cd `{dirname $_sp_source_file} > /dev/null && pwd}
+_sp_prefix=`{cd `{dirname `{dirname $_sp_share_dir}} > /dev/null && pwd}
+
+if([ -x $_sp_prefix/bin/spack ]) {
+    SPACK_ROOT=`{_sp_prefix}
+}
+# if not
+if(! [ -x $_sp_prefix/bin/spack ]) {
+    # If the shell couldn't find the sourced script, fall back to
+    # whatever the user set SPACK_ROOT to.
+    if([ -n $SPACK_ROOT ]) {
+        _sp_prefix=$SPACK_ROOT
+        _sp_share_dir=$_sp_prefix/share/spack
+    }
+
+    # If SPACK_ROOT didn't work, fail.
+    if(! [ -x $_sp_prefix/bin/spack ]) {
+        echo '==> Error: SPACK_ROOT must point to spack''s prefix when using' $_sp_shell
+        echo 'Run this with the correct prefix before sourcing setup-env.rc:'
+        echo '    SPACK_ROOT=</path/to/spack>'
+        return 1
+    }
+}
+_spack_pathadd PATH $_sp_prefix/bin
+
+#
+# Check whether a function of the given name is defined.
+# Note: does not bother escaping quotes in $*(1)
+# (which requires a call to sed).
+#
+fn _spack_fn_exists {
+    ~ `{rc -c 'whatis ''' ^ $*(1) ^ '''' >[2]/dev/null} 'fn '*
+}
+
+# Define the spack shell function with some informative no-ops, so when users
+# run `which spack`, they see the path to spack and where the function is from.
+eval 'fn spack {
+    echo this is a shell function from: '$_sp_share_dir/setup-env.rc' >/dev/null
+    echo the real spack script is here: '$_sp_prefix/bin/spack' >/dev/null
+    _spack_shell_wrapper $*
+}'
+
+# functions are already exported
+
+# Identify and lock the python interpreter
+if(! command -v $SPACK_PYTHON >/dev/null) {
+    # unset if not found
+    SPACK_PYTHON=()
+}
+for(cmd in python3 python python2) {
+    if(~ $#SPACK_PYTHON 0 && command -v $cmd >/dev/null) {
+        SPACK_PYTHON=`{command -v $cmd}
+    }
+}
+
+if(~ $#SPACK_SKIP_MODULES 0) {
+    need_module = no
+    _spack_fn_exists use || _spack_fn_exists module || need_module = yes
+
+    #
+    # make available environment-modules
+    #
+    if(~ $need_module yes) {
+        eval `{spack --print-shell-vars rc,modules}
+
+        # _sp_module_prefix is set by spack --print-sh-vars
+        if( ! ~ $_sp_module_prefix not_installed) {
+            # activate it!
+            # environment-modules@4: has a bin directory inside its prefix
+            _sp_module_bin=$_sp_module_prefix/bin
+            if(! [ -d $_sp_module_bin ]) {
+                # environment-modules@3 has a nested bin directory
+                _sp_module_bin=$_sp_module_prefix/Modules/bin
+            }
+
+            # _sp_module_bin and _sp_shell are evaluated here; the quoted
+            # eval statement and $* are deferred.
+			# The extra ''-s put '-s around $_sp_module_bin, in case
+		    # it contained spaces.
+            eval 'fn module { eval `{'''$_sp_module_bin'''/modulecmd '''$_sp_shell''' $*} }'
+            _spack_pathadd PATH $_sp_module_bin
+        }
+    }
+	# if not
+	if(! ~ $need_module yes) {
+        eval `{command spack --print-shell-vars rc} || return
+    }
+
+    #
+    # set module system roots
+    #
+    fn _sp_multi_pathadd {
+        for(pth in `{echo $*(2) | sed -e 's/:/ /g'}) {
+            for(systype in `{echo $_sp_compatible_sys_types | sed -e 's/:/ /g'}) {
+                _spack_pathadd $*(1) $pth/$systype
+            }
+        }
+    }
+    _sp_multi_pathadd MODULEPATH $_sp_tcl_roots
+}
+
+# done: unset sentinel variable as we're no longer initializing
+_sp_initializing=false

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1007,14 +1007,14 @@ _spack_env() {
 _spack_env_activate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh -v --with-view -V --without-view -p --prompt --temp -d --dir"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --rc --bat --pwsh -v --with-view -V --without-view -p --prompt --temp -d --dir"
     else
         _environments
     fi
 }
 
 _spack_env_deactivate() {
-    SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh"
+    SPACK_COMPREPLY="-h --help --sh --csh --fish --rc --bat --pwsh"
 }
 
 _spack_env_create() {
@@ -1306,7 +1306,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --rc --bat --pwsh --first --only --list"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1416,7 +1416,7 @@ complete -c spack -n '__fish_spack_using_command env' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -d 'show this help message and exit'
 
 # spack env activate
-set -g __fish_spack_optspecs_spack_env_activate h/help sh csh fish bat pwsh v/with-view V/without-view p/prompt temp d/dir=
+set -g __fish_spack_optspecs_spack_env_activate h/help sh csh fish rc bat pwsh v/with-view V/without-view p/prompt temp d/dir=
 complete -c spack -n '__fish_spack_using_command_pos 0 env activate' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command env activate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env activate' -s h -l help -d 'show this help message and exit'
@@ -1426,6 +1426,8 @@ complete -c spack -n '__fish_spack_using_command env activate' -l csh -f -a shel
 complete -c spack -n '__fish_spack_using_command env activate' -l csh -d 'print csh commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env activate' -l fish -f -a shell
 complete -c spack -n '__fish_spack_using_command env activate' -l fish -d 'print fish commands to activate the environment'
+complete -c spack -n '__fish_spack_using_command env activate' -l rc -f -a shell
+complete -c spack -n '__fish_spack_using_command env activate' -l rc -d 'print rc commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env activate' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command env activate' -l bat -d 'print bat commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env activate' -l pwsh -f -a shell
@@ -1442,7 +1444,7 @@ complete -c spack -n '__fish_spack_using_command env activate' -s d -l dir -r -f
 complete -c spack -n '__fish_spack_using_command env activate' -s d -l dir -r -d 'activate the environment in this directory'
 
 # spack env deactivate
-set -g __fish_spack_optspecs_spack_env_deactivate h/help sh csh fish bat pwsh
+set -g __fish_spack_optspecs_spack_env_deactivate h/help sh csh fish rc bat pwsh
 complete -c spack -n '__fish_spack_using_command env deactivate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env deactivate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l sh -f -a shell
@@ -1451,6 +1453,8 @@ complete -c spack -n '__fish_spack_using_command env deactivate' -l csh -f -a sh
 complete -c spack -n '__fish_spack_using_command env deactivate' -l csh -d 'print csh commands to deactivate the environment'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l fish -f -a shell
 complete -c spack -n '__fish_spack_using_command env deactivate' -l fish -d 'print fish commands to activate the environment'
+complete -c spack -n '__fish_spack_using_command env deactivate' -l rc -f -a shell
+complete -c spack -n '__fish_spack_using_command env deactivate' -l rc -d 'print rc commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command env deactivate' -l bat -d 'print bat commands to activate the environment'
 complete -c spack -n '__fish_spack_using_command env deactivate' -l pwsh -f -a shell
@@ -1976,7 +1980,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish rc bat pwsh first only= list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -1986,6 +1990,8 @@ complete -c spack -n '__fish_spack_using_command load' -l csh -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l csh -d 'print csh commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l fish -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l fish -d 'print fish commands to load the package'
+complete -c spack -n '__fish_spack_using_command load' -l rc -f -a shell
+complete -c spack -n '__fish_spack_using_command load' -l rc -d 'print rc commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l bat -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l bat -d 'print bat commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell


### PR DESCRIPTION
Most of the effort is in share/spack/setup-env.rc -- which is actually simpler and easier to read than share/spack/setup-env.sh.
rc only interprets commands (quotes, $-s, lists/spaces) once, during parsing, and so does not need quotes everywhere.
However, calls to double_quote_escape from lib/spack/spack/util/environment.py don't make sense for rc, which doesn't treat double-quotes differently than any other character.  So, for rc, double_quote_escape uses single quotes.