### PR TITLE
openfoam-org: zoltan renumbering and decompsition

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -88,6 +88,7 @@ class OpenfoamOrg(Package):
     )
     variant("metis", default=False, description="With metis decomposition")
     variant("scotch", default=True, description="With scotch/ptscotch decomposition")
+    variant("zoltan", default=False, description="Enable Zoltan renumbering and decomposition")
     variant(
         "precision",
         default="dp",
@@ -104,6 +105,7 @@ class OpenfoamOrg(Package):
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
     depends_on("scotch~metis+mpi~int64", when="+scotch~int64")
     depends_on("scotch~metis+mpi+int64", when="+scotch+int64")
+    depends_on("zoltan+shared", when="+zoltan")
 
     depends_on("metis@5:", when="+metis")
     depends_on("metis+int64", when="+metis+int64")
@@ -260,6 +262,13 @@ class OpenfoamOrg(Package):
         rewrite_environ_files(  # Adjust etc/bashrc and etc/cshrc
             edits, posix=join_path("etc", "bashrc"), cshell=join_path("etc", "cshrc")
         )
+        if self.spec.satisfies("@10:") and "+zoltan" in self.spec:
+            filter_file("libzoltan.a", "libzoltan.so", join_path("src", "renumber", "Allwmake"))
+            filter_file(
+                "libzoltan.a",
+                "libzoltan.so",
+                join_path("src", "parallel", "decompose", "Allwmake"),
+            )
 
     def configure(self, spec, prefix):
         """Make adjustments to the OpenFOAM configuration files in their various
@@ -289,6 +298,7 @@ class OpenfoamOrg(Package):
         self.etc_config = {
             "CGAL": {},
             "scotch": {},
+            "zoltan": {},
             "metis": {},
             "paraview": [],
             "gperftools": [],  # Currently unused
@@ -300,6 +310,16 @@ class OpenfoamOrg(Package):
                 # For src/parallel/decompose/Allwmake
                 "SCOTCH_VERSION": "scotch-{0}".format(spec["scotch"].version),
             }
+
+        if "+zoltan" in spec:
+            if spec.satisfies("@:9"):
+                self.etc_prefs["ZOLTAN_ARCH_PATH"] = spec["zoltan"].prefix
+                self.etc_prefs["ZOLTAN_VERSION"] = "Zoltan-{0}".format(spec["zoltan"].version)
+            else:
+                self.etc_config["zoltan"] = {
+                    "ZOLTAN_ARCH_PATH": spec["zoltan"].prefix,
+                    "ZOLTAN_VERSION": "Zoltan-{0}".format(spec["zoltan"].version),
+                }
 
         if "+metis" in spec:
             self.etc_config["metis"] = {"METIS_ARCH_PATH": spec["metis"].prefix}


### PR DESCRIPTION
The _Zoltan_ package in _OpenFOAM-org_ serves two primary functions. One is for "renumber", and the other is for "decomposition". The "renumber" functionality has been available since the initial version (starting from version 2.3.1), although it wasn't included in Spack. The decomposition functionality was introduced in version 10 and onwards.
In _Openfoam-org_, a shared version of the _Zoltan_ library is required. However, even in the Zoltan library, when using the shared version, a file with the extension ".a" (libzoltan.a) is generated. Therefore, in Spack, this is converted into a shared library package (.so). 
```python
    @run_after("install")
    def solib_install(self):
        if "+shared" in self.spec:
            for lib_path in find(self.spec.prefix.lib, "lib*.a"):
                lib_shared_name = re.sub(r"\.a$", ".{0}".format(dso_suffix), lib_path)
                move(lib_path, lib_shared_name)
```
However, there is a portion in the _Openfoam-org_ files that checks the path for the libzoltan.a file. Consequently, I have modified it to check the path for the .so file instead.
