### PR TITLE
gffcompare: new package @0.12.6

### DIFF
--- a/var/spack/repos/builtin/packages/gffcompare/package.py
+++ b/var/spack/repos/builtin/packages/gffcompare/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gffcompare(MakefilePackage):
+    """gffcompare: classify, merge, tracking and annotation of GFF files by comparing to a
+    reference annotation GFF"""
+
+    homepage = "https://ccb.jhu.edu/software/stringtie/gffcompare.shtml"
+    url = (
+        "https://github.com/gpertea/gffcompare/releases/download/v0.12.6/gffcompare-0.12.6.tar.gz"
+    )
+
+    version("0.12.6", sha256="0e713bc9177d874c935802d11669776da5e9377a8c4d031153b48a783d3391d0")
+
+    def build(self, spec, prefix):
+        make("release")
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install("gffcompare", prefix.bin)
+        install("trmap", prefix.bin)


### PR DESCRIPTION
Adding `gffcompare@0.12.6`. Manual install as there's no `install` target in the makefile. Otherwise behaves fine for me with `gcc@13`.