### PR TITLE
scorep: Change in configuration option for nvhpc compiler 

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -140,6 +140,12 @@ class Scorep(AutotoolsPackage):
     # https://github.com/spack/spack/issues/1609
     conflicts("platform=darwin")
 
+    def find_libpath(self, libname, root):
+        libs = find_libraries(libname, root, shared=True, recursive=True)
+        if len(libs.directories) == 0:
+            return None
+        return libs.directories[0]
+
     def configure_args(self):
         spec = self.spec
 
@@ -169,10 +175,9 @@ class Scorep(AutotoolsPackage):
         if "+unwind" in spec:
             config_args.append("--with-libunwind=%s" % spec["libunwind"].prefix)
         if "+cuda" in spec:
-            if format(cname) == "nvhpc":
-                config_args.append("--with-libcudart=%s" % spec["cuda"].prefix)
-            else:
-                config_args.append("--with-libcuda=%s" % spec["cuda"].prefix)
+            config_args.append("--with-libcudart=%s" % spec["cuda"].prefix)
+            cuda_driver_path = self.find_libpath("libcuda", spec["cuda"].prefix)
+            config_args.append("--with-libcuda-lib=%s" % cuda_driver_path)
         if "+hip" in spec:
             config_args.append("--with-rocm=%s" % spec["hip"].prefix)
 

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -15,7 +15,8 @@ class Scorep(AutotoolsPackage):
     homepage = "https://www.vi-hps.org/projects/score-p"
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.1/scorep-7.1.tar.gz"
     maintainers("wrwilliams")
-
+   
+    version("8.1", sha256="3a40b481fce610871ddf6bdfb88a6d06b9e5eb38c6080faac6d5e44990060a37")
     version("8.0", sha256="4c0f34f20999f92ebe6ca1ff706d0846b8ce6cd537ffbedb49dfaef0faa66311")
     version("7.1", sha256="98dea497982001fb82da3429ca55669b2917a0858c71abe2cfe7cd113381f1f7")
     version("7.0", sha256="68f24a68eb6f94eaecf500e17448f566031946deab74f2cba072ee8368af0996")

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -15,7 +15,7 @@ class Scorep(AutotoolsPackage):
     homepage = "https://www.vi-hps.org/projects/score-p"
     url = "https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.1/scorep-7.1.tar.gz"
     maintainers("wrwilliams")
-   
+
     version("8.1", sha256="3a40b481fce610871ddf6bdfb88a6d06b9e5eb38c6080faac6d5e44990060a37")
     version("8.0", sha256="4c0f34f20999f92ebe6ca1ff706d0846b8ce6cd537ffbedb49dfaef0faa66311")
     version("7.1", sha256="98dea497982001fb82da3429ca55669b2917a0858c71abe2cfe7cd113381f1f7")
@@ -170,9 +170,9 @@ class Scorep(AutotoolsPackage):
             config_args.append("--with-libunwind=%s" % spec["libunwind"].prefix)
         if "+cuda" in spec:
             if format(cname) == "nvhpc":
-              config_args.append("--with-libcudart=%s" % spec["cuda"].prefix)
+                config_args.append("--with-libcudart=%s" % spec["cuda"].prefix)
             else:
-              config_args.append("--with-libcuda=%s" % spec["cuda"].prefix)
+                config_args.append("--with-libcuda=%s" % spec["cuda"].prefix)
         if "+hip" in spec:
             config_args.append("--with-rocm=%s" % spec["hip"].prefix)
 

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -169,7 +169,10 @@ class Scorep(AutotoolsPackage):
         if "+unwind" in spec:
             config_args.append("--with-libunwind=%s" % spec["libunwind"].prefix)
         if "+cuda" in spec:
-            config_args.append("--with-libcuda=%s" % spec["cuda"].prefix)
+            if format(cname) == "nvhpc":
+              config_args.append("--with-libcudart=%s" % spec["cuda"].prefix)
+            else:
+              config_args.append("--with-libcuda=%s" % spec["cuda"].prefix)
         if "+hip" in spec:
             config_args.append("--with-rocm=%s" % spec["hip"].prefix)
 


### PR DESCRIPTION
I suggest two modifications:

1. sha for scorep-p version 8.1

2. for nvhpc compiler, the configuration option `--with-libcuda `did not find all the needed libraries on Leonardo booster partition. It has been replaced by `--with-libcudart`. This modification maps the manual installation as suggested when using PGI compiler (https://scorepci.pages.jsc.fz-juelich.de/scorep-pipelines/doc.r14395/installationfile.html) and worked on Leonardo cluster.

The suggested modifications have been tested by installing spack on Leonardo cluster with nvhpc/23.1, openmpi/4.1.4 and cuda/11.8 to instrument MPI+OpenACC+CUDA applications. 

 