### PR TITLE
gitlab ci: Put Cray binaries in public mirrors

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -773,30 +773,8 @@ deprecated-ci-build:
 #       job: aws-pcluster-generate-neoverse_v1
 
 # Cray definitions
-.base-cray-job:
-  variables:
-    SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-cray/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
-    AWS_ACCESS_KEY_ID: ${CRAY_MIRRORS_AWS_ACCESS_KEY_ID}
-    AWS_SECRET_ACCESS_KEY: ${CRAY_MIRRORS_AWS_SECRET_ACCESS_KEY}
-  rules:
-    - if: $CI_COMMIT_REF_NAME == "develop"
-      # Pipelines on develop only rebuild what is missing from the mirror
-      when: always
-      variables:
-        SPACK_PIPELINE_TYPE: "spack_protected_branch"
-        SPACK_REQUIRE_SIGNING: "True"
-    - if: $CI_COMMIT_REF_NAME =~ /^pr[\d]+_.*$/
-      # Pipelines on PR branches rebuild only what's missing, and do extra pruning
-      when: always
-      variables:
-        SPACK_PIPELINE_TYPE: "spack_pull_request"
-        SPACK_BUILDCACHE_DESTINATION: "s3://spack-binaries-cray/prs/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
-        SPACK_PRUNE_UNTOUCHED: "True"
-        SPACK_PRUNE_UNTOUCHED_DEPENDENT_DEPTH: "1"
-
 .generate-cray:
-  extends: [ ".generate-common", ".base-cray-job" ]
-  stage: generate
+  extends: [ ".generate-common", ".base-job" ]
   before_script:
     - echo $PATH
     - module avail
@@ -811,11 +789,6 @@ deprecated-ci-build:
   extends: [ ".generate-cray" ]
 
 
-.build-cray:
-  extends: [ ".base-cray-job" ]
-  stage: build
-
-
 #######################################
 # E4S - Cray RHEL
 #######################################
@@ -828,7 +801,7 @@ e4s-cray-rhel-generate:
   extends: [ ".generate-cray-rhel", ".e4s-cray-rhel" ]
 
 e4s-cray-rhel-build:
-  extends: [ ".build-cray", ".e4s-cray-rhel" ]
+  extends: [ ".build", ".e4s-cray-rhel" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
@@ -850,7 +823,7 @@ e4s-cray-sles-generate:
   extends: [ ".generate-cray-sles", ".e4s-cray-sles" ]
 
 e4s-cray-sles-build:
-  extends: [ ".build-cray", ".e4s-cray-sles" ]
+  extends: [ ".build", ".e4s-cray-sles" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -63,7 +63,7 @@ spack:
 
   # - amrex # disabled temporarily pending resolution of unreproducible CI failure
 
-  mirrors: { "mirror": "s3://spack-binaries-cray/develop/e4s-cray-rhel" }
+  mirrors: { "mirror": "s3://spack-binaries/develop/e4s-cray-rhel" }
 
   cdash:
     build-group: E4S Cray

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -41,13 +41,13 @@ spack:
 
   specs:
   - adios2
-  - amrex  
+  - amrex
   - butterflypack
   - conduit
   - h5bench
   - hdf5-vol-async
   - hdf5-vol-cache
-  - hdf5-vol-log  
+  - hdf5-vol-log
   - hypre
   - kokkos
   - kokkos-kernels
@@ -57,7 +57,7 @@ spack:
   - superlu-dist
   # - flux-core # python cray sles issue
 
-  mirrors: { "mirror": "s3://spack-binaries-cray/develop/e4s-cray-sles" }
+  mirrors: { "mirror": "s3://spack-binaries/develop/e4s-cray-sles" }
 
   cdash:
     build-group: E4S Cray SLES


### PR DESCRIPTION
I think this should be sufficient to stop putting the Cray binaries in their own private mirror.  I'll follow up to clean up the extra infrastructure we set up which is no longer required.