### PR TITLE
asp.py: fix deprecation warning

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2730,7 +2730,7 @@ class SpecBuilder:
 
                 spec.compiler_flags.update({flag_type: ordered_compiler_flags})
 
-    def deprecated(self, node, version):
+    def deprecated(self, node: NodeArgument, version: str) -> None:
         tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
     @staticmethod

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2730,9 +2730,8 @@ class SpecBuilder:
 
                 spec.compiler_flags.update({flag_type: ordered_compiler_flags})
 
-    def deprecated(self, pkg, version):
-        msg = 'using "{0}@{1}" which is a deprecated version'
-        tty.warn(msg.format(pkg, version))
+    def deprecated(self, node, version):
+        tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
     @staticmethod
     def sort_fn(function_tuple):


### PR DESCRIPTION
Before this printed

```
==> Warning: using "NodeArgument(id='0', pkg='openssl')@1.1.1v" which is a deprecated version
```