### PR TITLE
unifyfs: support openssl 3

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -97,9 +97,6 @@ class Unifyfs(AutotoolsPackage):
     patch("unifyfs-sysio.c.patch", when="@0.9.1")
     patch("include-sys-sysmacros.h.patch", when="@0.9.1:0.9.2")
 
-    # Parallel disabled to prevent tests from being run out-of-order when
-    # installed with the --test={root, all} option.
-    parallel = False
     debug_build = False
     build_directory = "spack-build"
 
@@ -154,3 +151,6 @@ class Unifyfs(AutotoolsPackage):
     def patch(self):
         filter_file("-Werror", "", "client/src/Makefile.in")
         filter_file("-Werror", "", "client/src/Makefile.am")
+    def check(self):
+        with working_dir(self.build_directory):
+            make("check", parallel=False)

--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -124,6 +124,15 @@ class Unifyfs(AutotoolsPackage):
         if self.spec.satisfies("%oneapi"):
             env.append_flags("CFLAGS", "-Wno-unused-function")
 
+    @when("%cce@11.0.3:")
+    def patch(self):
+        filter_file("-Werror", "", "client/src/Makefile.in")
+        filter_file("-Werror", "", "client/src/Makefile.am")
+
+    @when("@develop")
+    def autoreconf(self, spec, prefix):
+        Executable("./autogen.sh")()
+
     def configure_args(self):
         spec = self.spec
         args = ["--with-gotcha=%s" % spec["gotcha"].prefix]
@@ -142,15 +151,6 @@ class Unifyfs(AutotoolsPackage):
 
         return args
 
-    @when("@develop")
-    def autoreconf(self, spec, prefix):
-        sh = which("sh")
-        sh("./autogen.sh")
-
-    @when("%cce@11.0.3:")
-    def patch(self):
-        filter_file("-Werror", "", "client/src/Makefile.in")
-        filter_file("-Werror", "", "client/src/Makefile.am")
     def check(self):
         with working_dir(self.build_directory):
             make("check", parallel=False)

--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -73,7 +73,10 @@ class Unifyfs(AutotoolsPackage):
     # after v0.13.1.
     depends_on("mochi-margo@0.10:", when="@1.1:")
     depends_on("mpi")
-    depends_on("openssl@:1")
+
+    # unifyfs@:1.1 uses MD5 functions that are deprecated in OpenSSL 3, and
+    # likely to be removed in the next major release.
+    depends_on("openssl@:3")
 
     # Mochi-Margo dependencies
     depends_on("mercury@1.0.1+bmi", when="@:0.9.1")


### PR DESCRIPTION
- unifyfs: drop upperbound on deprecated openssl
   The package uses deprecated MD5 functions from OpenSSL, which causes
   warnings, but (a) Spack by default disables -Werror, and (b) those
   functions are guaranteed to continue to exist in OpenSSL 3.

- unifyfs: enable parallel build, only make check sequential
- unifyfs: order class methods by install phases
