### PR TITLE
Fix metaclass base class

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -175,7 +175,7 @@ class WindowsRPath:
 detectable_packages = collections.defaultdict(list)
 
 
-class DetectablePackageMeta:
+class DetectablePackageMeta(type):
     """Check if a package is detectable and add default implementations
     for the detection function.
     """


### PR DESCRIPTION
The base class of a metaclass should be `type`, not `object`.