### PR TITLE
bam-readcount: add 1.0.1, correct build flags

### DIFF
--- a/var/spack/repos/builtin/packages/bam-readcount/package.py
+++ b/var/spack/repos/builtin/packages/bam-readcount/package.py
@@ -12,4 +12,8 @@ class BamReadcount(CMakePackage):
     homepage = "https://github.com/genome/bam-readcount"
     url = "https://github.com/genome/bam-readcount/archive/v0.8.0.tar.gz"
 
+    version("1.0.1", sha256="8ebf84d9efee0f2d3b43f0452dbf16b27337c960e25128f6a7173119e62588b8")
     version("0.8.0", sha256="4f4dd558e3c6bfb24d6a57ec441568f7524be6639b24f13ea6f2bb350c7ea65f")
+
+    def setup_build_environment(self, env):
+        env.append_flags("CFLAGS", self.compiler.cc_pic_flag)


### PR DESCRIPTION
Updating to `@1.0.1`. Build was previously failing for me with `recompile with -fPIC` messages, so added the `setup_build_environment` func to set the flag.