### PR TITLE
py-rseqc: add 5.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-rseqc/package.py
+++ b/var/spack/repos/builtin/packages/py-rseqc/package.py
@@ -18,12 +18,12 @@ class PyRseqc(PythonPackage):
     version("4.0.1", sha256="6a16a3c56b73917082d3ac060a113c7d32cccf39f86efa87a6f1e6b52642210d")
     version("3.0.1", sha256="d5f4cb2c24a7348929f5c4947d84c5869e8cd2cba5ba5248d991ebb37c4c6b3d")
 
-    depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-nose@0.10.4:", type="build")
     depends_on("py-cython@0.17:", type=("build", "run"))
+    depends_on("py-pysam", type=("build", "run"))
     depends_on("py-bx-python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-pysam", type=("build", "run"))
     depends_on("py-pybigwig", type=("build", "run"))
+    
     depends_on("r", type="run")

--- a/var/spack/repos/builtin/packages/py-rseqc/package.py
+++ b/var/spack/repos/builtin/packages/py-rseqc/package.py
@@ -14,6 +14,8 @@ class PyRseqc(PythonPackage):
     homepage = "http://rseqc.sourceforge.net"
     pypi = "RSeQC/RSeQC-2.6.4.tar.gz"
 
+    version("5.0.1", sha256="3c7d458784861af352d8da3f4f1cc8941934b37643164e9b74f929a32bd9ca80")
+    version("4.0.1", sha256="6a16a3c56b73917082d3ac060a113c7d32cccf39f86efa87a6f1e6b52642210d")
     version("3.0.1", sha256="d5f4cb2c24a7348929f5c4947d84c5869e8cd2cba5ba5248d991ebb37c4c6b3d")
 
     depends_on("python@3.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-rseqc/package.py
+++ b/var/spack/repos/builtin/packages/py-rseqc/package.py
@@ -25,5 +25,5 @@ class PyRseqc(PythonPackage):
     depends_on("py-bx-python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pybigwig", type=("build", "run"))
-    
+
     depends_on("r", type="run")


### PR DESCRIPTION
Updating to `@5.0.1`. No changes required to get this installed for me.