### PR TITLE
ci: Tag reindex job to match the image architecture

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -69,7 +69,7 @@ ci:
         KUBERNETES_MEMORY_REQUEST: "16G"
 
   - reindex-job:
-      tags: ["service"]
+      tags: ["service", "x86_64"]
       image: "ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01"
       variables:
         CI_JOB_SIZE: "medium"


### PR DESCRIPTION
Fix some rebuild-index jobs that fail when they land on graviton runners.

For example, [this](https://gitlab.spack.io/spack/spack/-/jobs/8170522) one.