### PR TITLE
Update g2c recipe: add develop version and misc. variants

### DIFF
--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -13,22 +13,65 @@ class G2c(CMakePackage):
 
     homepage = "https://github.com/NOAA-EMC/NCEPLIBS-g2c"
     url = "https://github.com/NOAA-EMC/NCEPLIBS-g2c/archive/refs/tags/v1.6.4.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-g2c"
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
-    variant("png", default=True, description="Use PNG library")
-    variant("jasper", default=True, description="Use Jasper library")
-    variant("openjpeg", default=False, description="Use OpenJPEG library")
-
+    version("develop", branch="develop")
     version("1.7.0", sha256="73afba9da382fed73ed8692d77fa037bb313280879cd4012a5e5697dccf55175")
     version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
     version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
+
+    variant("png", default=True)
+    variant("jasper", default=True)
+    variant("openjpeg", default=False)
+    variant("pic", default=True, description="Build with position-independent-code")
+    variant(
+        "libs",
+        default=("shared", "static"),
+        values=("shared", "static"),
+        multi=True,
+        description="Build shared libs, static libs or both",
+        when="@1.7:",
+    )
+    variant(
+        "pthreads",
+        default=False,
+        description="Turn on thread-safty with pthreads",
+        when="@develop",
+    )
+    variant(
+        "utils",
+        default=True,
+        description="Build and install some utility programs",
+        when="@develop",
+    )
 
     depends_on("libpng", when="+png")
     depends_on("jasper", when="+jasper")
     depends_on("openjpeg", when="+openjpeg")
 
+    conflicts("+jasper +openjpeg", msg="Either Jasper or OpenJPEG should be used, not both")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            self.define("BUILD_SHARED_LIBS", self.spec.satisfies("libs=shared")),
+            self.define("BUILD_STATIC_LIBS", self.spec.satisfies("libs=static")),
+            self.define_from_variant("USE_PNG", "png"),
+            self.define_from_variant("USE_Jasper", "jasper"),
+            self.define_from_variant("USE_OpenJPEG", "openjpeg"),
+            self.define_from_variant("PTHREADS", "pthreads"),
+            self.define_from_variant("UTILS", "utils"),
+        ]
+
+        return args
+
     def setup_run_environment(self, env):
-        lib = find_libraries("libg2c", root=self.prefix, shared=False, recursive=True)
+        if self.spec.satisfies("@:1.6"):
+            shared = False
+        else:
+            shared = self.spec.satisfies("libs=shared")
+        lib = find_libraries("libg2c", root=self.prefix, shared=shared, recursive=True)
         env.set("G2C_LIB", lib[0])
         env.set("G2C_INC", join_path(self.prefix, "include"))

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -63,6 +63,7 @@ class G2c(CMakePackage):
             self.define_from_variant("USE_OpenJPEG", "openjpeg"),
             self.define_from_variant("PTHREADS", "pthreads"),
             self.define_from_variant("UTILS", "utils"),
+            self.define("BUILD_TESTING", self.run_tests),
         ]
 
         return args
@@ -75,3 +76,7 @@ class G2c(CMakePackage):
         lib = find_libraries("libg2c", root=self.prefix, shared=shared, recursive=True)
         env.set("G2C_LIB", lib[0])
         env.set("G2C_INC", join_path(self.prefix, "include"))
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -22,9 +22,9 @@ class G2c(CMakePackage):
     version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
     version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
 
-    variant("png", default=True)
-    variant("jasper", default=True)
-    variant("openjpeg", default=False)
+    variant("png", default=True, description="Use PNG library")
+    variant("jasper", default=True, description="Use Jasper library")
+    variant("openjpeg", default=False, description="Use OpenJPEG library")
     variant("pic", default=True, description="Build with position-independent-code")
     variant(
         "libs",
@@ -37,7 +37,7 @@ class G2c(CMakePackage):
     variant(
         "pthreads",
         default=False,
-        description="Turn on thread-safty with pthreads",
+        description="Turn on thread-safety with pthreads",
         when="@develop",
     )
     variant(


### PR DESCRIPTION
This PR adds a develop version for g2c, adds miscellaneous variants, and adds logic for running ctest through `spack install --test`.