### PR TITLE
Add algorithmic differentiation packages for SU2

### DIFF
--- a/var/spack/repos/builtin/packages/codipack/package.py
+++ b/var/spack/repos/builtin/packages/codipack/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Codipack(CMakePackage, Package):
+    """CoDiPack is a C++-library that enables the computation of gradients in computer programs
+    using Algorithmic Differentiation. It is based on the Operator Overloading approach and uses
+    static polymorphism and expression templates, resulting in an extremely fast evaluation of
+    adjoints or forward derivatives. It is specifically designed with HPC applications in mind."""
+
+    homepage = "https://www.scicomp.uni-kl.de/software/codi/"
+    url = "https://github.com/SciCompKL/CoDiPack/archive/refs/tags/v2.1.0.tar.gz"
+    git = "https://github.com/SciCompKL/CoDiPack.git"
+
+    version("2.1.0", sha256="c8d07eb01eaa056175902d5b153b8606b05d208ff0a541d15284f4d9ff6e87c2")
+    version("2.0.2", sha256="c6eecfdbf5818daf80871461f23f8a29b5b72e314d2034047d0b0fcd44744339")
+    version("1.9.3", sha256="27dd92d0b5132de37b431989c0c3d5bd829821a6a2e31e0529137e427421f06e")
+    version("openmp", branch="experimentalOpenMPSupport")
+
+    depends_on("cmake@3.12:", type="build", when="@2.1.0:")
+
+    build_system(
+        conditional("cmake", when="@2.1.0:"),
+        conditional("generic", when="@:2.0.2"),
+        default="cmake",
+    )
+
+
+class GenericBuilder(spack.build_systems.generic.GenericBuilder):
+    def install(self, pkg, spec, prefix):
+        mkdirp(join_path(prefix, "include"))
+        install_tree(join_path(self.stage.source_path, "include"), join_path(prefix, "include"))

--- a/var/spack/repos/builtin/packages/medipack/package.py
+++ b/var/spack/repos/builtin/packages/medipack/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Medipack(CMakePackage):
+    """MeDiPack (Message Differentiation Package) is a tool that handles the MPI communication
+    of Algorithmic Differentiation (AD) tools like CoDiPack."""
+
+    homepage = "https://github.com/SciCompKL/MeDiPack"
+    url = "https://github.com/SciCompKL/MeDiPack/archive/refs/tags/v1.2.2.tar.gz"
+
+    version("1.2.2", sha256="8937fa1025c6fb12f516cacf38a7f776221e7e818b30f17ce334c63f78513aa7")
+    version("1.2.1", sha256="c746196b98cfe24a212584cdb88bd12ebb14f4a54728070d605e0c6d0e75db8a")
+
+    depends_on("cmake@3.12:", type="build", when="@1.2.2:")
+
+    build_system(
+        conditional("cmake", when="@1.2.2:"),
+        conditional("generic", when="@:1.2.1"),
+        default="cmake",
+    )
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix, "include"))
+        install_tree(join_path(self.stage.source_path, "include"), join_path(prefix, "include"))
+        mkdirp(join_path(prefix, "src"))
+        install_tree(join_path(self.stage.source_path, "src"), join_path(prefix, "src"))

--- a/var/spack/repos/builtin/packages/opdilib/package.py
+++ b/var/spack/repos/builtin/packages/opdilib/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Opdilib(Package):
+    """OpDiLib (Open Multiprocessing Differentiation Library) is a universal add-on for
+    reverse mode operator overloading AD tools that enables the differentiation of
+    OpenMP parallel code."""
+
+    homepage = "https://github.com/SciCompKL/OpDiLib"
+    url = "https://github.com/SciCompKL/OpDiLib/archive/refs/tags/v1.5.tar.gz"
+
+    version("1.5", sha256="47b345954df5e7ee8147e7b29db2ec160ba02ccc93b3b88af0b34bb880170248")
+    version("1.4", sha256="f1dd2575a8c3b2328df89b732dbeaa23657731d77e4bf7ee201c6571f20d13d5")
+    version("1.3.2", sha256="5da4a99ab1332e5c3746cb6d55ee4cd96ce578b06987e2b10e33ae6413b7cf7a")
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix, "include"))
+        install_tree(join_path(self.stage.source_path, "include"), join_path(prefix, "include"))
+        mkdirp(join_path(prefix, "syntax"))
+        install_tree(join_path(self.stage.source_path, "syntax"), join_path(prefix, "syntax"))

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -90,7 +90,6 @@ class Su2(MesonPackage):
             )
             filter_file("externals/medi/src", self.spec["medipack"].prefix.src, "meson.build")
 
-
         if (
             self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
         ) and self.spec.satisfies("+openmp"):

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -75,32 +75,28 @@ class Su2(MesonPackage):
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 
     def patch(self):
-        if "+autodiff" in self.spec or "+directdiff" in self.spec:
+        if self.spec.satisfiles("+autodiff") or self.spec.satisfiles("+directdiff"):
             filter_file(
                 "externals/codi/include",
                 join_path(self.spec["codipack"].prefix, "include"),
                 "meson.build",
             )
 
-        if ("+autodiff" in self.spec or "+directdiff" in self.spec) and "+mpi" in self.spec:
+        if (
+            self.spec.satisfiles("+autodiff") or self.spec.satisfiles("+directdiff")
+        ) and self.spec.satisfiles("+mpi"):
             filter_file(
-                "externals/medi/include",
-                join_path(self.spec["medipack"].prefix, "include"),
-                "meson.build",
+                "externals/medi/include", self.spec["medipack"].prefix.include, "meson.build"
             )
-            filter_file(
-                "externals/medi/src", join_path(self.spec["medipack"].prefix, "src"), "meson.build"
-            )
+            filter_file("externals/medi/src", self.spec["medipack"].prefix.src, "meson.build")
 
         if ("+autodiff" in self.spec or "+directdiff" in self.spec) and "+openmp" in self.spec:
             filter_file(
-                "externals/opdi/include",
-                join_path(self.spec["opdilib"].prefix, "include"),
-                "meson.build",
+                "externals/opdi/include", self.spec["opdilib"].prefix.include, "meson.build"
             )
             filter_file(
                 "externals/opdi/syntax/check.py",
-                join_path(self.spec["opdilib"].prefix, "syntax", "check.py"),
+                join_path(self.spec["opdilib"].prefix.syntax, "check.py"),
                 "meson.build",
             )
 

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -75,7 +75,7 @@ class Su2(MesonPackage):
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 
     def patch(self):
-        if self.spec.satisfiles("+autodiff") or self.spec.satisfiles("+directdiff"):
+        if self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff"):
             filter_file(
                 "externals/codi/include",
                 join_path(self.spec["codipack"].prefix, "include"),
@@ -83,14 +83,17 @@ class Su2(MesonPackage):
             )
 
         if (
-            self.spec.satisfiles("+autodiff") or self.spec.satisfiles("+directdiff")
+            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
         ) and self.spec.satisfiles("+mpi"):
             filter_file(
                 "externals/medi/include", self.spec["medipack"].prefix.include, "meson.build"
             )
             filter_file("externals/medi/src", self.spec["medipack"].prefix.src, "meson.build")
 
-        if ("+autodiff" in self.spec or "+directdiff" in self.spec) and "+openmp" in self.spec:
+
+        if (
+            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
+        ) and self.spec.satisfies("+openmp"):
             filter_file(
                 "externals/opdi/include", self.spec["opdilib"].prefix.include, "meson.build"
             )

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -75,16 +75,14 @@ class Su2(MesonPackage):
     patch("meson_version.patch", when="@7.4.0:7.5.1")
 
     def patch(self):
-        if self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff"):
+        if "+autodiff" in self.spec or "+directdiff" in self.spec:
             filter_file(
                 "externals/codi/include",
                 join_path(self.spec["codipack"].prefix, "include"),
                 "meson.build",
             )
 
-        if (
-            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
-        ) and self.spec.satisfies("+mpi"):
+        if ("+autodiff" in self.spec or "+directdiff" in self.spec) and "+mpi" in self.spec:
             filter_file(
                 "externals/medi/include",
                 join_path(self.spec["medipack"].prefix, "include"),
@@ -94,9 +92,7 @@ class Su2(MesonPackage):
                 "externals/medi/src", join_path(self.spec["medipack"].prefix, "src"), "meson.build"
             )
 
-        if (
-            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
-        ) and self.spec.satisfies("+openmp"):
+        if ("+autodiff" in self.spec or "+directdiff" in self.spec) and "+openmp" in self.spec:
             filter_file(
                 "externals/opdi/include",
                 join_path(self.spec["opdilib"].prefix, "include"),

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -34,20 +34,20 @@ class Su2(MesonPackage):
     version("7.0.0", sha256="6207dcca15eaebc11ce12b2866c937b4ad9b93274edf6f23d0487948ac3963b8")
     version("6.2.0", sha256="ffc953326e8432a1a6534556a5f6cf086046d3149cfcec6b4e7390eebe30ce2e")
 
-    variant("mpi", default=False, description="enable MPI support")
-    variant("openmp", default=False, description="enable OpenMP support")
-    variant("tecio", default=True, description="enable TECIO support")
-    variant("cgns", default=True, description="enable CGNS support")
-    variant("autodiff", default=False, description="enable AD(reverse) support")
-    variant("directdiff", default=False, description="enable AD(forward) support")
-    variant("pywrapper", default=False, description="enable Python wrapper support")
-    variant("mkl", default=False, description="enable Intel MKL support")
-    variant("openblas", default=False, description="enable OpenBLAS support")
-    variant("mpp", default=False, description="enable Mutation++ support")
+    variant("mpi", default=False, description="Enable MPI support")
+    variant("openmp", default=False, description="Enable OpenMP support")
+    variant("tecio", default=True, description="Enable TECIO support")
+    variant("cgns", default=True, description="Enable CGNS support")
+    variant("autodiff", default=False, description="Enable AD(reverse) support")
+    variant("directdiff", default=False, description="Enable AD(forward) support")
+    variant("pywrapper", default=False, description="Enable Python wrapper support")
+    variant("mkl", default=False, description="Enable Intel MKL support")
+    variant("openblas", default=False, description="Enable OpenBLAS support")
+    variant("mpp", default=False, description="Enable Mutation++ support")
     variant(
         "mixedprec",
         default=False,
-        description="use single precision floating point arithmetic for sparse algebra",
+        description="Enable the use of single precision on linear solvers and preconditioners",
     )
 
     depends_on("meson@0.61.1:", type=("build"))
@@ -61,9 +61,52 @@ class Su2(MesonPackage):
     depends_on("openblas", when="+openblas ~mkl")
     depends_on("cmake", type="build", when="+mpp")
 
+    depends_on("codipack@:1.9.3", when="+autodiff")
+    depends_on("codipack@:1.9.3", when="+directdiff")
+    depends_on("medipack", when="+autodiff +mpi")
+    depends_on("medipack", when="+directdiff +mpi")
+    depends_on("opdilib", when="+autodiff +openmp")
+    depends_on("opdilib", when="+directdiff +openmp")
+    depends_on("codipack@openmp", when="+autodiff +openmp")
+    depends_on("codipack@openmp", when="+directdiff +openmp")
+
     # Remove the part that fixes the meson version to 0.61.1.
     # This fix is considered meaningless and will be removed in the next version(@7.6:) of SU2.
     patch("meson_version.patch", when="@7.4.0:7.5.1")
+
+    def patch(self):
+        if self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff"):
+            filter_file(
+                "externals/codi/include",
+                join_path(self.spec["codipack"].prefix, "include"),
+                "meson.build",
+            )
+
+        if (
+            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
+        ) and self.spec.satisfies("+mpi"):
+            filter_file(
+                "externals/medi/include",
+                join_path(self.spec["medipack"].prefix, "include"),
+                "meson.build",
+            )
+            filter_file(
+                "externals/medi/src", join_path(self.spec["medipack"].prefix, "src"), "meson.build"
+            )
+
+        if (
+            self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff")
+        ) and self.spec.satisfies("+openmp"):
+            filter_file(
+                "externals/opdi/include",
+                join_path(self.spec["opdilib"].prefix, "include"),
+                "meson.build",
+            )
+            filter_file(
+                "externals/opdi/syntax/check.py",
+                join_path(self.spec["opdilib"].prefix, "syntax", "check.py"),
+                "meson.build",
+            )
 
     def meson_args(self):
         args = [
@@ -71,7 +114,7 @@ class Su2(MesonPackage):
             "-Denable-tecio={}".format("+tecio" in self.spec),
             "-Denable-cgns={}".format("+cgns" in self.spec),
             "-Denable-autodiff={}".format("+autodiff" in self.spec),
-            "-Denable-directdiff={}".format("+direcdiff" in self.spec),
+            "-Denable-directdiff={}".format("+directdiff" in self.spec),
             "-Denable-pywrapper={}".format("+pywrapper" in self.spec),
             "-Denable-mkl={}".format("+mkl" in self.spec),
             "-Denable-openblas={}".format("+openblas" in self.spec),


### PR DESCRIPTION
I have added CodiPack, MediPack, and Opdlib to the installation of SU2 and included them as dependencies. All three packages are related to AD (Algorithmic Differentiation). Previously, SU2 imported them using Git submodules.