### PR TITLE
glibc: restore older versions

### DIFF
--- a/var/spack/repos/builtin/packages/glibc/32cf406.patch
+++ b/var/spack/repos/builtin/packages/glibc/32cf406.patch
@@ -1,0 +1,21 @@
+From 32cf40699346d37fabfa887bbd95e95004799ae1 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@redhat.com>
+Date: Mon, 6 Sep 2010 14:55:59 +0200
+Subject: [PATCH] Don't mix pattern rules with normal rules
+
+diff --git a/manual/Makefile b/manual/Makefile
+index c5866eb9def..b1f5fa73e5e 100644
+--- a/manual/Makefile
++++ b/manual/Makefile
+@@ -232,7 +232,10 @@ ifdef objpfx
+ .PHONY: stubs
+ stubs: $(objpfx)stubs
+ endif
+-$(objpfx)stubs ../po/manual.pot $(objpfx)stamp%:
++$(objpfx)stubs ../po/manual.pot:
++	$(make-target-directory)
++	touch $@
++$(objpfx)stamp%:
+ 	$(make-target-directory)
+ 	touch $@
+ 

--- a/var/spack/repos/builtin/packages/glibc/4a531bb.patch
+++ b/var/spack/repos/builtin/packages/glibc/4a531bb.patch
@@ -1,0 +1,123 @@
+commit 4a531bb0b3b582cb693de9f76d2d97d970f9a5d5
+Author: H.J. Lu <hongjiu.lu@intel.com>
+Date:   Fri Dec 24 20:14:37 2010 -0500
+
+    Remove `.ctors' and `.dtors' output sections
+
+diff --git a/config.h.in b/config.h.in
+index 18bf01a38c..9e797eb5b7 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -201,6 +201,9 @@
+ /* Define if multi-arch DSOs should be generated.  */
+ #undef USE_MULTIARCH
+ 
++/* Define if `.ctors' and `.dtors' sections shouldn't be used.  */
++#define NO_CTORS_DTORS_SECTIONS
++
+ /*
+ ^L */
+ 
+diff --git a/elf/sofini.c b/elf/sofini.c
+index 5e06f0ca92..13e74b7903 100644
+--- a/elf/sofini.c
++++ b/elf/sofini.c
+@@ -1,12 +1,14 @@
+ /* Finalizer module for ELF shared C library.  This provides terminating
+    null pointer words in the `.ctors' and `.dtors' sections.  */
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+ static void (*const __CTOR_END__[1]) (void)
+      __attribute__ ((used, section (".ctors")))
+      = { 0 };
+ static void (*const __DTOR_END__[1]) (void)
+      __attribute__ ((used, section (".dtors")))
+      = { 0 };
++#endif
+ 
+ /* Terminate the frame unwind info section with a 4byte 0 as a sentinel;
+    this would be the 'length' field in a real FDE.  */
+diff --git a/elf/soinit.c b/elf/soinit.c
+index 6fecbb5674..1db676af01 100644
+--- a/elf/soinit.c
++++ b/elf/soinit.c
+@@ -3,6 +3,7 @@
+    the `.ctors' and `.dtors' sections so the lists are terminated, and
+    calling those lists of functions.  */
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+ #include <libc-internal.h>
+ #include <stdlib.h>
+ 
+@@ -40,3 +41,4 @@ __libc_fini (void)
+ 
+ void (*_fini_ptr) (void) __attribute__ ((section (".fini_array")))
+      = &__libc_fini;
++#endif
+diff --git a/sysdeps/i386/init-first.c b/sysdeps/i386/init-first.c
+index c6355a8b7b..2af042fe4b 100644
+--- a/sysdeps/i386/init-first.c
++++ b/sysdeps/i386/init-first.c
+@@ -59,7 +59,9 @@ _init (int argc, ...)
+ {
+   init (&argc);
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
++#endif
+ }
+ #endif
+ 
+diff --git a/sysdeps/mach/hurd/i386/init-first.c b/sysdeps/mach/hurd/i386/init-first.c
+index f9a7a58deb..60823bd789 100644
+--- a/sysdeps/mach/hurd/i386/init-first.c
++++ b/sysdeps/mach/hurd/i386/init-first.c
+@@ -92,7 +92,7 @@ posixland_init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (envp);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }
+diff --git a/sysdeps/mach/hurd/powerpc/init-first.c b/sysdeps/mach/hurd/powerpc/init-first.c
+index 20fa1d4f12..21b5054b0a 100644
+--- a/sysdeps/mach/hurd/powerpc/init-first.c
++++ b/sysdeps/mach/hurd/powerpc/init-first.c
+@@ -82,7 +82,7 @@ posixland_init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (__environ);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }
+diff --git a/sysdeps/sh/init-first.c b/sysdeps/sh/init-first.c
+index d816625ef4..1f3a821fea 100644
+--- a/sysdeps/sh/init-first.c
++++ b/sysdeps/sh/init-first.c
+@@ -59,7 +59,9 @@ _init (int argc, ...)
+ {
+   init (&argc);
+ 
++#ifndef NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
++#endif
+ }
+ #endif
+ 
+diff --git a/sysdeps/unix/sysv/linux/init-first.c b/sysdeps/unix/sysv/linux/init-first.c
+index 7b2333d4bf..a60212f4ed 100644
+--- a/sysdeps/unix/sysv/linux/init-first.c
++++ b/sysdeps/unix/sysv/linux/init-first.c
+@@ -93,7 +93,7 @@ _init (int argc, char **argv, char **envp)
+   __getopt_clean_environment (envp);
+ #endif
+ 
+-#ifdef SHARED
++#if defined SHARED && !defined NO_CTORS_DTORS_SECTIONS
+   __libc_global_ctors ();
+ #endif
+ }

--- a/var/spack/repos/builtin/packages/glibc/67fbfa5.patch
+++ b/var/spack/repos/builtin/packages/glibc/67fbfa5.patch
@@ -1,0 +1,53 @@
+From 67fbfa5ca15f75774dcb3794aceb06aa42544c94 Mon Sep 17 00:00:00 2001
+From: Roland McGrath <roland@gnu.org>
+Date: Fri, 1 Feb 2008 00:20:11 +0000
+Subject: [PATCH] [BZ #5442]
+
+	* configure.in: Use -print-file-name if it yields a directory,
+	for each of include and include-fixed.
+	* configure: Regenerated.
+---
+ ChangeLog      | 5 +++++
+ configure      | 8 ++++++--
+ configure.in   | 8 ++++++--
+ nptl/ChangeLog | 4 ++++
+ 4 files changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index 1f2cd4fc533..4b969787e3d 100755
+--- a/configure
++++ b/configure
+@@ -5065,8 +5065,12 @@ echo "$as_me: WARNING:
+ # header directory and add that to the list.  NOTE: Only does the right
+ # thing on a system that doesn't need fixincludes.  (Not presently a problem.)
+ if test -n "$sysheaders"; then
+-  ccheaders=`$CC -print-file-name=include`
+-  SYSINCLUDES="-nostdinc -isystem $ccheaders \
++  SYSINCLUDES=-nostdinc
++  for d in include include-fixed; do
++    i=`$CC -print-file-name="$d"` && test "x$i" != "x$d" &&
++    SYSINCLUDES="$SYSINCLUDES -isystem $i"
++  done
++  SYSINCLUDES="$SYSINCLUDES \
+ -isystem `echo $sysheaders | sed 's/:/ -isystem /g'`"
+   if test -n "$CXX"; then
+     cxxversion=`$CXX -dumpversion 2>&5` &&
+diff --git a/configure.in b/configure.in
+index 6ea1b26ff34..3098ebfd3d7 100644
+--- a/configure.in
++++ b/configure.in
+@@ -914,8 +914,12 @@ test -n "$aux_missing" && AC_MSG_WARN([
+ # header directory and add that to the list.  NOTE: Only does the right
+ # thing on a system that doesn't need fixincludes.  (Not presently a problem.)
+ if test -n "$sysheaders"; then
+-  ccheaders=`$CC -print-file-name=include`
+-  SYSINCLUDES="-nostdinc -isystem $ccheaders \
++  SYSINCLUDES=-nostdinc
++  for d in include include-fixed; do
++    i=`$CC -print-file-name="$d"` && test "x$i" != x && test "x$i" != "x$d" &&
++    SYSINCLUDES="$SYSINCLUDES -isystem $i"
++  done
++  SYSINCLUDES="$SYSINCLUDES \
+ -isystem `echo $sysheaders | sed 's/:/ -isystem /g'`"
+   if test -n "$CXX"; then
+     cxxversion=`$CXX -dumpversion 2>&AS_MESSAGE_LOG_FD` &&

--- a/var/spack/repos/builtin/packages/glibc/7c8a673.patch
+++ b/var/spack/repos/builtin/packages/glibc/7c8a673.patch
@@ -1,0 +1,21 @@
+commit 7c8a67320e26b8c11108bf0a3410d3aef9cf3486
+Author: Ulrich Drepper <drepper@redhat.com>
+Date:   Sat Jan 31 00:21:15 2009 +0000
+
+    * elf/Makefile (ld.so): Adjust the sed script to insert _begin in to
+    
+            newer linker scripts.
+
+diff --git a/elf/Makefile b/elf/Makefile
+index 8079fe9f96..e44ff1d382 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -304,7 +304,7 @@ $(objpfx)ld.so: $(objpfx)librtld.os $(ld-map)
+ 		  $(LDFLAGS-rtld) -Wl,-z,defs -Wl,--verbose 2>&1 |	\
+ 		  LC_ALL=C \
+ 		  sed -e '/^=========/,/^=========/!d;/^=========/d'	\
+-		      -e 's/\. = 0 + SIZEOF_HEADERS;/& _begin = . - SIZEOF_HEADERS;/' \
++		      -e 's/\. = .* + SIZEOF_HEADERS;/& _begin = . - SIZEOF_HEADERS;/' \
+ 		  > $@.lds
+ 	$(LINK.o) -nostdlib -nostartfiles -shared -o $@			\
+ 		  $(LDFLAGS-rtld) -Wl,-z,defs $(z-now-$(bind-now))	\

--- a/var/spack/repos/builtin/packages/glibc/fb21f89.patch
+++ b/var/spack/repos/builtin/packages/glibc/fb21f89.patch
@@ -1,0 +1,13 @@
+diff --git a/sunrpc/rpc_clntout.c b/sunrpc/rpc_clntout.c
+index ec040c775e2..ce4d2a4c953 100644
+--- a/sunrpc/rpc_clntout.c
++++ b/sunrpc/rpc_clntout.c
+@@ -31,7 +31,7 @@
+  */
+ #include <stdio.h>
+ #include <string.h>
+-#include <rpc/types.h>
++#include "rpc/types.h"
+ #include "rpc_parse.h"
+ #include "rpc_util.h"
+ #include "proto.h"

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -44,6 +44,18 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     version("2.19", sha256="18ad6db70724699d264add80b1f813630d0141cf3a3558b4e1a7c15f6beac796")
     version("2.18", sha256="c8e727b5feef883184241a4767725ec280c0288794bc5cd4432497370db47734")
     version("2.17", sha256="a3b2086d5414e602b4b3d5a8792213feb3be664ffc1efe783a829818d3fca37a")
+    version("2.16.0", sha256="a75be51658cc1cfb6324ec6dbdbed416526c44c14814823129f0fcc74c279f6e")
+    version("2.15", sha256="da6b95d14b722539c2ec02e7ae1221318dba3d27f19c098a882ffa71bb429c20")
+    version("2.14.1", sha256="f80c40897df49c463a6d5a45f734acbfe1bf42ef209a92a5c217aeb383631bdb")
+    version("2.13", sha256="bd90d6119bcc2898befd6e1bbb2cb1ed3bb1c2997d5eaa6fdbca4ee16191a906")
+    version("2.12.2", sha256="6b7392a7b339a3f2db6e4bc8d5418cf29116d9e7e36b313e845cb65e449c5346")
+    version("2.11.3", sha256="ddc3210f4029991f5142fda7f269f9bfb197917e5d9445ba2d90d31f74cc2765")
+    version("2.10.1", sha256="cd9743db33389e7b4eb2942a4f365d12fc015f115113b230152280c43ccc7e3f")
+    version("2.9", sha256="e0210dec2a4ca0a03d8ee26e2a4ebccc915d99f4cdb1489ff0f9f4ce7bda3e30")
+    version("2.8", sha256="a5b91339355a7bbafc5f44b524556f7f25de83dd56f2c00ef9240dabd6865663")
+    version("2.7", sha256="f5ef515cb70f8d4cfcee0b3aac05b73def60d897bdb7a71f4356782febfe415a")
+    version("2.6.1", sha256="6be7639ccad715d25eef560ce9d1637ef206fb9a162714f6ab8167fc0d971cae")
+    version("2.5", sha256="16d3ac4e86eed75d85d80f1f214a6bd58d27f13590966b5ad0cc181df85a3493")
 
     # Spack commit 29aa7117f42f758bc537e03e4bedf66ced0accfa has older versions
     # of glibc, but they are removed, because glibc < 2.17 links against
@@ -57,15 +69,48 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # _obstack_compat symbol is not initialized
     patch("39b1f61.patch", when="@:2.17")
 
+    # docs: install fails with "unknown command hsep / vsep"
+    patch("texi.patch", when="@2.16.0")
+
+    # rpc/types.h include issue, should be from local version, not system.
+    patch("fb21f89.patch", when="@:2.16")
+
+    # Use init_array (modified commit 4a531bb to unconditionally define
+    # NO_CTORS_DTORS_SECTIONS)
+    patch("4a531bb.patch", when="@:2.12")
+
+    # make: mixed implicit and static pattern rules (trivial issue in docs)
+    patch("32cf406.patch", when="@:2.10")
+
+    # linker flag output regex
+    patch("7c8a673.patch", when="@:2.9")
+
+    # include_next <limits.h> not working
+    patch("67fbfa5.patch", when="@:2.7")
+
     def setup_build_environment(self, env):
         if self.spec.satisfies("@:2.21"):
             env.append_flags("LDFLAGS", "-no-pie")
+        if self.spec.satisfies("@:2.16"):
+            # for some reason CPPFLAGS -U_FORTIFY_SOURCE is not enough, it has to be CFLAGS
+            env.append_flags("CPPFLAGS", "-U_FORTIFY_SOURCE")
+            env.append_flags("CFLAGS", "-O2 -g -fno-stack-protector -U_FORTIFY_SOURCE")
+        if self.spec.satisfies("@2.5"):
+            env.append_flags("CFLAGS", "-fgnu89-inline")
 
     def patch(self):
         # Support gmake >= 4
         filter_file(
             "    3.79* | 3.[89]*)",
             "    3.79* | 3.[89]* |  [4-9].* | [1-9][0-9]*)",
+            "configure",
+            string=True,
+        )
+
+        # Suport gcc >= 5
+        filter_file(
+            "3.4* | 4.[0-9]* )",
+            "3.4* | 4.[0-9]* | [5-9].* | [1-9][0-9]*)",
             "configure",
             string=True,
         )
@@ -80,6 +125,14 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
         filter_file(
             "4.[4-9].* | 4.[1-9][0-9].* | [5-9].* )",
             "4.[4-9].* | 4.[1-9][0-9].* | [5-9].* | [1-9][0-9]*)",
+            "configure",
+            string=True,
+        )
+
+        # Support binutils
+        filter_file(
+            "2.1[3-9]*)",
+            "2.1[3-9]*|2.1[0-9][0-9]*|2.[2-9][0-9]*|[3-9].*|[1-9][0-9]*)",
             "configure",
             string=True,
         )

--- a/var/spack/repos/builtin/packages/glibc/texi.patch
+++ b/var/spack/repos/builtin/packages/glibc/texi.patch
@@ -1,0 +1,15 @@
+diff --git a/manual/stdio.texi b/manual/stdio.texi
+index be769a5..7b436f0 100644
+--- a/manual/stdio.texi
++++ b/manual/stdio.texi
+@@ -3137,7 +3137,7 @@ The postfix tag corresponds to bytes, kilobytes, megabytes, gigabytes,
+ etc.  The full table is:
+ 
+ @ifinfo
+-@multitable @hsep @vsep {' '} {2^10 (1024)} {zetta} {Upper} {10^24 (1000)}
++@multitable {' '} {2^10 (1024)} {zetta} {Upper} {10^24 (1000)}
+ @item low @tab Multiplier  @tab From  @tab Upper @tab Multiplier
+ @item ' ' @tab 1           @tab       @tab ' '   @tab 1
+ @item k   @tab 2^10 (1024) @tab kilo  @tab K     @tab 10^3 (1000)
+-- 
+1.8.0.1


### PR DESCRIPTION
Tested with gcc 7.5.0 itself based on glibc 2.31.

This allows building glibc all the way to 2.5, which is ... centos 5
