### PR TITLE
Python iconv

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -233,7 +233,7 @@ class Python(Package):
     if sys.platform != "win32":
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2")
+        depends_on("iconv", when="~libxml2")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -234,6 +234,7 @@ class Python(Package):
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("iconv", when="~libxml2")
+        depends_on("gettext ~libxml2", when="~libxml2 ^gettext")
 
         # Optional dependencies
         # See detect_modules() in setup.py for details


### PR DESCRIPTION
Allow building python with libc+iconv or libiconv instead of gettext.

With this change you can:
spack spec python                                   # gives python +libxml2 ^gettext +libxml2 ^libxml2
spack spec python ~libxml2 ^gettext       # gives python ~lixml2 ^gettext ~libxml2
spack spec python ~libxml2 ^libc+iconv  # gives python ~libxml2 ^libc+iconv

and specifying your preferred iconv in packages.yaml  works for python ~libxml2