### PR TITLE
data-vis-sdk: make llvm~libomptarget the default

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -25,7 +25,7 @@ spack:
     llvm:
       require: '@14:'
       # Minimize LLVM
-      variants: ~lldb~lld~polly~gold libunwind=none compiler-rt=none
+      variants: ~lldb~lld~libomptarget~polly~gold libunwind=none compiler-rt=none
     all:
       require: target=x86_64_v3
 


### PR DESCRIPTION
Currently the configuration of the pipeline is such that there are multiple "optimal" solutions. This is due to the pipeline making `~lld` the default for LLVM, but leaving `+libomptarget` from `package.py`.

Since LLVM recipe has a:
```python
conflicts("~lld", "+libomptarget")
```
clingo is forced to change one of the two defaults, and the penalty for doing so is the same for each. Hence, it is random whether we'll get `+libomptarget+lld` or `~libomptarget~lld`.

This fixes it by changing also the default for libomptarget.