### PR TITLE
ASP-based solver: don't declare deprecated versions unless required

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -176,17 +176,29 @@ def solve(parser, args):
     output = sys.stdout if "asp" in show else None
     setup_only = set(show) == {"asp"}
     unify = spack.config.get("concretizer:unify")
+    allow_deprecated = spack.config.get("config:deprecated", False)
     if unify != "when_possible":
         # set up solver parameters
         # Note: reuse and other concretizer prefs are passed as configuration
         result = solver.solve(
-            specs, out=output, timers=args.timers, stats=args.stats, setup_only=setup_only
+            specs,
+            out=output,
+            timers=args.timers,
+            stats=args.stats,
+            setup_only=setup_only,
+            deprecated=allow_deprecated,
         )
         if not setup_only:
             _process_result(result, show, required_format, kwargs)
     else:
         for idx, result in enumerate(
-            solver.solve_in_rounds(specs, out=output, timers=args.timers, stats=args.stats)
+            solver.solve_in_rounds(
+                specs,
+                out=output,
+                timers=args.timers,
+                stats=args.stats,
+                deprecated=allow_deprecated,
+            )
         ):
             if "solutions" in show:
                 tty.msg("ROUND {0}".format(idx))

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -186,7 +186,7 @@ def solve(parser, args):
             timers=args.timers,
             stats=args.stats,
             setup_only=setup_only,
-            deprecated=allow_deprecated,
+            allow_deprecated=allow_deprecated,
         )
         if not setup_only:
             _process_result(result, show, required_format, kwargs)
@@ -197,7 +197,7 @@ def solve(parser, args):
                 out=output,
                 timers=args.timers,
                 stats=args.stats,
-                deprecated=allow_deprecated,
+                allow_deprecated=allow_deprecated,
             )
         ):
             if "solutions" in show:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -744,8 +744,11 @@ def concretize_specs_together(*abstract_specs, **kwargs):
 def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
 
+    allow_deprecated = spack.config.get("config:deprecated", False)
     solver = spack.solver.asp.Solver()
-    result = solver.solve(abstract_specs, tests=kwargs.get("tests", False))
+    result = solver.solve(
+        abstract_specs, tests=kwargs.get("tests", False), deprecated=allow_deprecated
+    )
     result.raise_if_unsat()
     return [s.copy() for s in result.specs]
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -747,7 +747,7 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     allow_deprecated = spack.config.get("config:deprecated", False)
     solver = spack.solver.asp.Solver()
     result = solver.solve(
-        abstract_specs, tests=kwargs.get("tests", False), deprecated=allow_deprecated
+        abstract_specs, tests=kwargs.get("tests", False), allow_deprecated=allow_deprecated
     )
     result.raise_if_unsat()
     return [s.copy() for s in result.specs]

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1398,7 +1398,7 @@ class Environment:
         solver = spack.solver.asp.Solver()
         allow_deprecated = spack.config.get("config:deprecated", False)
         for result in solver.solve_in_rounds(
-            specs_to_concretize, tests=tests, deprecated=allow_deprecated
+            specs_to_concretize, tests=tests, allow_deprecated=allow_deprecated
         ):
             result_by_user_spec.update(result.specs_by_input)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1396,7 +1396,10 @@ class Environment:
 
         result_by_user_spec = {}
         solver = spack.solver.asp.Solver()
-        for result in solver.solve_in_rounds(specs_to_concretize, tests=tests):
+        allow_deprecated = spack.config.get("config:deprecated", False)
+        for result in solver.solve_in_rounds(
+            specs_to_concretize, tests=tests, deprecated=allow_deprecated
+        ):
             result_by_user_spec.update(result.specs_by_input)
 
         result = []

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -793,7 +793,7 @@ class PyclingoDriver:
         if choice:
             self.assumptions.append(atom)
 
-    def solve(self, setup, specs, reuse=None, output=None, control=None, deprecated=False):
+    def solve(self, setup, specs, reuse=None, output=None, control=None, allow_deprecated=False):
         """Set up the input and solve for dependencies of ``specs``.
 
         Arguments:
@@ -804,7 +804,7 @@ class PyclingoDriver:
                 the output of this solve.
             control (clingo.Control): configuration for the solver. If None,
                 default values will be used
-            deprecated: if True, allow deprecated versions in the solve
+            allow_deprecated: if True, allow deprecated versions in the solve
 
         Return:
             A tuple of the solve result, the timer for the different phases of the
@@ -824,7 +824,7 @@ class PyclingoDriver:
         timer.start("setup")
         with self.control.backend() as backend:
             self.backend = backend
-            setup.setup(self, specs, reuse=reuse, deprecated=deprecated)
+            setup.setup(self, specs, reuse=reuse, allow_deprecated=allow_deprecated)
         timer.stop("setup")
 
         timer.start("load")
@@ -1907,7 +1907,7 @@ class SpackSolverSetup:
         return clauses
 
     def define_package_versions_and_validate_preferences(
-        self, possible_pkgs, *, require_checksum: bool, deprecated: bool
+        self, possible_pkgs, *, require_checksum: bool, allow_deprecated: bool
     ):
         """Declare any versions in specs not declared in packages."""
         packages_yaml = spack.config.get("packages")
@@ -1929,7 +1929,7 @@ class SpackSolverSetup:
             for idx, (v, version_info) in enumerate(package_py_versions):
                 if version_info.get("deprecated", False):
                     self.deprecated_versions[pkg_name].add(v)
-                    if not deprecated:
+                    if not allow_deprecated:
                         continue
 
                 self.possible_versions[pkg_name].add(v)
@@ -1964,7 +1964,9 @@ class SpackSolverSetup:
                 )
                 self.possible_versions[pkg_name].add(vdef)
 
-    def define_ad_hoc_versions_from_specs(self, specs, origin, *, require_checksum: bool):
+    def define_ad_hoc_versions_from_specs(
+        self, specs, origin, *, allow_deprecated: bool, require_checksum: bool
+    ):
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
         for s in traverse.traverse_nodes(specs):
             # If there is a concrete version on the CLI *that we know nothing
@@ -1979,6 +1981,9 @@ class SpackSolverSetup:
                 raise UnsatisfiableSpecError(
                     s.format("No matching version for constraint {name}{@versions}")
                 )
+
+            if not allow_deprecated and version in self.deprecated_versions[s.name]:
+                continue
 
             declared = DeclaredVersion(version=version, idx=0, origin=origin)
             self.declared_versions[s.name].append(declared)
@@ -2350,7 +2355,7 @@ class SpackSolverSetup:
         specs: Sequence[spack.spec.Spec],
         *,
         reuse: Optional[List[spack.spec.Spec]] = None,
-        deprecated: bool = False,
+        allow_deprecated: bool = False,
     ):
         """Generate an ASP program with relevant constraints for specs.
 
@@ -2362,7 +2367,7 @@ class SpackSolverSetup:
             driver: driver instance of this solve
             specs: list of Specs to solve
             reuse: list of concrete specs that can be reused
-            deprecated: if True adds deprecated versions into the solve
+            allow_deprecated: if True adds deprecated versions into the solve
         """
         self._condition_id_counter = itertools.count()
 
@@ -2387,6 +2392,9 @@ class SpackSolverSetup:
         # driver is used by all the functions below to add facts and
         # rules to generate an ASP program.
         self.gen = driver
+
+        if not allow_deprecated:
+            self.gen.fact(fn.deprecated_versions_not_allowed())
 
         # Calculate develop specs
         # they will be used in addition to command line specs
@@ -2439,15 +2447,20 @@ class SpackSolverSetup:
         # TODO: make a config option for this undocumented feature
         checksummed = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
         self.define_package_versions_and_validate_preferences(
-            self.pkgs, deprecated=deprecated, require_checksum=checksummed
+            self.pkgs, allow_deprecated=allow_deprecated, require_checksum=checksummed
         )
         self.define_ad_hoc_versions_from_specs(
-            specs, Provenance.SPEC, require_checksum=checksummed
+            specs, Provenance.SPEC, allow_deprecated=allow_deprecated, require_checksum=checksummed
         )
         self.define_ad_hoc_versions_from_specs(
-            dev_specs, Provenance.DEV_SPEC, require_checksum=checksummed
+            dev_specs,
+            Provenance.DEV_SPEC,
+            allow_deprecated=allow_deprecated,
+            require_checksum=checksummed,
         )
-        self.validate_and_define_versions_from_requirements(require_checksum=checksummed)
+        self.validate_and_define_versions_from_requirements(
+            allow_deprecated=allow_deprecated, require_checksum=checksummed
+        )
 
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
@@ -2496,7 +2509,9 @@ class SpackSolverSetup:
             if self.concretize_everything:
                 self.gen.fact(fn.solve_literal(idx))
 
-    def validate_and_define_versions_from_requirements(self, *, require_checksum: bool):
+    def validate_and_define_versions_from_requirements(
+        self, *, allow_deprecated: bool, require_checksum: bool
+    ):
         """If package requirements mention concrete versions that are not mentioned
         elsewhere, then we need to collect those to mark them as possible
         versions. If they are abstract and statically have no match, then we
@@ -2527,6 +2542,9 @@ class SpackSolverSetup:
                     continue
 
                 if v in self.possible_versions[name]:
+                    continue
+
+                if not allow_deprecated and v in self.deprecated_versions[name]:
                     continue
 
                 # If concrete an not yet defined, conditionally define it, like we do for specs
@@ -2970,7 +2988,7 @@ class Solver:
         stats=False,
         tests=False,
         setup_only=False,
-        deprecated=False,
+        allow_deprecated=False,
     ):
         """
         Arguments:
@@ -2982,7 +3000,7 @@ class Solver:
             If a tuple of package names, concretize test dependencies for named
             packages (defaults to False: do not concretize test dependencies).
           setup_only (bool): if True, stop after setup and don't solve (default False).
-          deprecated (bool): allow deprecated version in the solve
+          allow_deprecated (bool): allow deprecated version in the solve
         """
         # Check upfront that the variants are admissible
         specs = [s.lookup_hash() for s in specs]
@@ -2991,12 +3009,12 @@ class Solver:
         setup = SpackSolverSetup(tests=tests)
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
         result, _, _ = self.driver.solve(
-            setup, specs, reuse=reusable_specs, output=output, deprecated=deprecated
+            setup, specs, reuse=reusable_specs, output=output, allow_deprecated=allow_deprecated
         )
         return result
 
     def solve_in_rounds(
-        self, specs, out=None, timers=False, stats=False, tests=False, deprecated=False
+        self, specs, out=None, timers=False, stats=False, tests=False, allow_deprecated=False
     ):
         """Solve for a stable model of specs in multiple rounds.
 
@@ -3012,7 +3030,7 @@ class Solver:
             timers (bool): print timing if set to True
             stats (bool): print internal statistics if set to True
             tests (bool): add test dependencies to the solve
-            deprecated (bool): allow deprecated version in the solve
+            allow_deprecated (bool): allow deprecated version in the solve
         """
         specs = [s.lookup_hash() for s in specs]
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
@@ -3026,7 +3044,11 @@ class Solver:
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
         while True:
             result, _, _ = self.driver.solve(
-                setup, input_specs, reuse=reusable_specs, output=output, deprecated=deprecated
+                setup,
+                input_specs,
+                reuse=reusable_specs,
+                output=output,
+                allow_deprecated=allow_deprecated,
             )
             yield result
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -13,7 +13,7 @@ import pprint
 import re
 import types
 import warnings
-from typing import List, NamedTuple, Tuple, Union
+from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import archspec.cpu
 
@@ -138,7 +138,15 @@ class RequirementKind(enum.Enum):
     PACKAGE = enum.auto()
 
 
-DeclaredVersion = collections.namedtuple("DeclaredVersion", ["version", "idx", "origin"])
+class DeclaredVersion(NamedTuple):
+    """Data class to contain information on declared versions used in the solve"""
+
+    #: String representation of the version
+    version: str
+    #: Unique index assigned to this version
+    idx: int
+    #: Provenance of the version
+    origin: Provenance
 
 
 # Below numbers are used to map names of criteria to the order
@@ -785,7 +793,7 @@ class PyclingoDriver:
         if choice:
             self.assumptions.append(atom)
 
-    def solve(self, setup, specs, reuse=None, output=None, control=None):
+    def solve(self, setup, specs, reuse=None, output=None, control=None, deprecated=False):
         """Set up the input and solve for dependencies of ``specs``.
 
         Arguments:
@@ -796,6 +804,7 @@ class PyclingoDriver:
                 the output of this solve.
             control (clingo.Control): configuration for the solver. If None,
                 default values will be used
+            deprecated: if True, allow deprecated versions in the solve
 
         Return:
             A tuple of the solve result, the timer for the different phases of the
@@ -815,7 +824,7 @@ class PyclingoDriver:
         timer.start("setup")
         with self.control.backend() as backend:
             self.backend = backend
-            setup.setup(self, specs, reuse=reuse)
+            setup.setup(self, specs, reuse=reuse, deprecated=deprecated)
         timer.stop("setup")
 
         timer.start("load")
@@ -1898,7 +1907,7 @@ class SpackSolverSetup:
         return clauses
 
     def define_package_versions_and_validate_preferences(
-        self, possible_pkgs, require_checksum: bool
+        self, possible_pkgs, *, require_checksum: bool, deprecated: bool
     ):
         """Declare any versions in specs not declared in packages."""
         packages_yaml = spack.config.get("packages")
@@ -1918,13 +1927,15 @@ class SpackSolverSetup:
                 ]
 
             for idx, (v, version_info) in enumerate(package_py_versions):
+                if version_info.get("deprecated", False):
+                    self.deprecated_versions[pkg_name].add(v)
+                    if not deprecated:
+                        continue
+
                 self.possible_versions[pkg_name].add(v)
                 self.declared_versions[pkg_name].append(
                     DeclaredVersion(version=v, idx=idx, origin=Provenance.PACKAGE_PY)
                 )
-                deprecated = version_info.get("deprecated", False)
-                if deprecated:
-                    self.deprecated_versions[pkg_name].add(v)
 
             if pkg_name not in packages_yaml or "version" not in packages_yaml[pkg_name]:
                 continue
@@ -1953,7 +1964,7 @@ class SpackSolverSetup:
                 )
                 self.possible_versions[pkg_name].add(vdef)
 
-    def define_ad_hoc_versions_from_specs(self, specs, origin, require_checksum: bool):
+    def define_ad_hoc_versions_from_specs(self, specs, origin, *, require_checksum: bool):
         """Add concrete versions to possible versions from lists of CLI/dev specs."""
         for s in traverse.traverse_nodes(specs):
             # If there is a concrete version on the CLI *that we know nothing
@@ -2333,7 +2344,14 @@ class SpackSolverSetup:
                 if spec.concrete:
                     self._facts_from_concrete_spec(spec, possible)
 
-    def setup(self, driver, specs, reuse=None):
+    def setup(
+        self,
+        driver: PyclingoDriver,
+        specs: Sequence[spack.spec.Spec],
+        *,
+        reuse: Optional[List[spack.spec.Spec]] = None,
+        deprecated: bool = False,
+    ):
         """Generate an ASP program with relevant constraints for specs.
 
         This calls methods on the solve driver to set up the problem with
@@ -2341,9 +2359,10 @@ class SpackSolverSetup:
         specs, as well as constraints from the specs themselves.
 
         Arguments:
-            driver (PyclingoDriver): driver instance of this solve
-            specs (list): list of Specs to solve
-            reuse (None or list): list of concrete specs that can be reused
+            driver: driver instance of this solve
+            specs: list of Specs to solve
+            reuse: list of concrete specs that can be reused
+            deprecated: if True adds deprecated versions into the solve
         """
         self._condition_id_counter = itertools.count()
 
@@ -2372,7 +2391,7 @@ class SpackSolverSetup:
         # Calculate develop specs
         # they will be used in addition to command line specs
         # in determining known versions/targets/os
-        dev_specs = ()
+        dev_specs: Tuple[spack.spec.Spec, ...] = ()
         env = ev.active_environment()
         if env:
             dev_specs = tuple(
@@ -2418,11 +2437,17 @@ class SpackSolverSetup:
         self.external_packages()
 
         # TODO: make a config option for this undocumented feature
-        require_checksum = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
-        self.define_package_versions_and_validate_preferences(self.pkgs, require_checksum)
-        self.define_ad_hoc_versions_from_specs(specs, Provenance.SPEC, require_checksum)
-        self.define_ad_hoc_versions_from_specs(dev_specs, Provenance.DEV_SPEC, require_checksum)
-        self.validate_and_define_versions_from_requirements(require_checksum)
+        checksummed = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
+        self.define_package_versions_and_validate_preferences(
+            self.pkgs, deprecated=deprecated, require_checksum=checksummed
+        )
+        self.define_ad_hoc_versions_from_specs(
+            specs, Provenance.SPEC, require_checksum=checksummed
+        )
+        self.define_ad_hoc_versions_from_specs(
+            dev_specs, Provenance.DEV_SPEC, require_checksum=checksummed
+        )
+        self.validate_and_define_versions_from_requirements(require_checksum=checksummed)
 
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
@@ -2471,7 +2496,7 @@ class SpackSolverSetup:
             if self.concretize_everything:
                 self.gen.fact(fn.solve_literal(idx))
 
-    def validate_and_define_versions_from_requirements(self, require_checksum: bool):
+    def validate_and_define_versions_from_requirements(self, *, require_checksum: bool):
         """If package requirements mention concrete versions that are not mentioned
         elsewhere, then we need to collect those to mark them as possible
         versions. If they are abstract and statically have no match, then we
@@ -2937,7 +2962,16 @@ class Solver:
 
         return reusable_specs
 
-    def solve(self, specs, out=None, timers=False, stats=False, tests=False, setup_only=False):
+    def solve(
+        self,
+        specs,
+        out=None,
+        timers=False,
+        stats=False,
+        tests=False,
+        setup_only=False,
+        deprecated=False,
+    ):
         """
         Arguments:
           specs (list): List of ``Spec`` objects to solve for.
@@ -2948,6 +2982,7 @@ class Solver:
             If a tuple of package names, concretize test dependencies for named
             packages (defaults to False: do not concretize test dependencies).
           setup_only (bool): if True, stop after setup and don't solve (default False).
+          deprecated (bool): allow deprecated version in the solve
         """
         # Check upfront that the variants are admissible
         specs = [s.lookup_hash() for s in specs]
@@ -2955,10 +2990,14 @@ class Solver:
         reusable_specs.extend(self._reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
-        result, _, _ = self.driver.solve(setup, specs, reuse=reusable_specs, output=output)
+        result, _, _ = self.driver.solve(
+            setup, specs, reuse=reusable_specs, output=output, deprecated=deprecated
+        )
         return result
 
-    def solve_in_rounds(self, specs, out=None, timers=False, stats=False, tests=False):
+    def solve_in_rounds(
+        self, specs, out=None, timers=False, stats=False, tests=False, deprecated=False
+    ):
         """Solve for a stable model of specs in multiple rounds.
 
         This relaxes the assumption of solve that everything must be consistent and
@@ -2973,6 +3012,7 @@ class Solver:
             timers (bool): print timing if set to True
             stats (bool): print internal statistics if set to True
             tests (bool): add test dependencies to the solve
+            deprecated (bool): allow deprecated version in the solve
         """
         specs = [s.lookup_hash() for s in specs]
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
@@ -2986,7 +3026,7 @@ class Solver:
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
         while True:
             result, _, _ = self.driver.solve(
-                setup, input_specs, reuse=reusable_specs, output=output
+                setup, input_specs, reuse=reusable_specs, output=output, deprecated=deprecated
             )
             yield result
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -196,6 +196,13 @@ attr("deprecated", node(ID, Package), Version) :-
      attr("version", node(ID, Package), Version),
      pkg_fact(Package, deprecated_version(Version)).
 
+error(100, "Package '{0}' needs the deprecated version '{1}', and this is not allowed", Package, Version)
+  :- deprecated_versions_not_allowed(),
+     attr("version", node(ID, Package), Version),
+     not external(node(ID, Package)),
+     not concrete(node(ID, Package)),
+     pkg_fact(Package, deprecated_version(Version)).
+
 possible_version_weight(node(ID, Package), Weight)
  :- attr("version", node(ID, Package), Version),
     pkg_fact(Package, version_declared(Version, Weight)).
@@ -252,6 +259,7 @@ attr("node_version_satisfies", node(ID, Package), Constraint)
      pkg_fact(Package, version_satisfies(Constraint, Version)).
 
 #defined version_satisfies/3.
+#defined deprecated_versions_not_allowed/0.
 #defined deprecated_version/2.
 
 %-----------------------------------------------------------------------------

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1361,16 +1361,6 @@ opt_criterion(75, "requirement weight").
       build_priority(PackageNode, Priority)
 }.
 
-% Minimize the number of deprecated versions being used
-opt_criterion(73, "deprecated versions used").
-#minimize{ 0@273: #true }.
-#minimize{ 0@73: #true }.
-#minimize{
-    1@73+Priority,PackageNode
-    : attr("deprecated", PackageNode, _),
-      build_priority(PackageNode, Priority)
-}.
-
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1369,6 +1369,16 @@ opt_criterion(75, "requirement weight").
       build_priority(PackageNode, Priority)
 }.
 
+% Minimize the number of deprecated versions being used
+opt_criterion(73, "deprecated versions used").
+#minimize{ 0@273: #true }.
+#minimize{ 0@73: #true }.
+#minimize{
+    1@73+Priority,PackageNode
+    : attr("deprecated", PackageNode, _),
+      build_priority(PackageNode, Priority)
+}.
+
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2924,8 +2924,9 @@ class Spec:
         if self._concrete:
             return
 
+        allow_deprecated = spack.config.get("config:deprecated", False)
         solver = spack.solver.asp.Solver()
-        result = solver.solve([self], tests=tests)
+        result = solver.solve([self], tests=tests, deprecated=allow_deprecated)
         result.raise_if_unsat()
 
         # take the best answer

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2926,7 +2926,7 @@ class Spec:
 
         allow_deprecated = spack.config.get("config:deprecated", False)
         solver = spack.solver.asp.Solver()
-        result = solver.solve([self], tests=tests, deprecated=allow_deprecated)
+        result = solver.solve([self], tests=tests, allow_deprecated=allow_deprecated)
         result.raise_if_unsat()
 
         # take the best answer

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1362,9 +1362,10 @@ class TestConcretize:
     )
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_deprecated_versions_not_selected(self, spec_str, expected):
-        s = Spec(spec_str).concretized()
-        for abstract_spec in expected:
-            assert abstract_spec in s
+        with spack.config.override("config:deprecated", True):
+            s = Spec(spec_str).concretized()
+            for abstract_spec in expected:
+                assert abstract_spec in s
 
     @pytest.mark.regression("24196")
     def test_version_badness_more_important_than_default_mv_variants(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1357,7 +1357,7 @@ class TestConcretize:
             # Version 1.1.0 is deprecated and should not be selected, unless we
             # explicitly asked for that
             ("deprecated-versions", ["deprecated-versions@1.0.0"]),
-            ("deprecated-versions@1.1.0", ["deprecated-versions@1.1.0"]),
+            ("deprecated-versions@=1.1.0", ["deprecated-versions@1.1.0"]),
         ],
     )
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1356,16 +1356,15 @@ class TestConcretize:
         [
             # Version 1.1.0 is deprecated and should not be selected, unless we
             # explicitly asked for that
-            ("deprecated-versions", ["deprecated-versions@1.0.0"]),
-            ("deprecated-versions@=1.1.0", ["deprecated-versions@1.1.0"]),
+            ("deprecated-versions", "deprecated-versions@1.0.0"),
+            ("deprecated-versions@=1.1.0", "deprecated-versions@1.1.0"),
         ],
     )
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_deprecated_versions_not_selected(self, spec_str, expected):
         with spack.config.override("config:deprecated", True):
             s = Spec(spec_str).concretized()
-            for abstract_spec in expected:
-                assert abstract_spec in s
+            s.satisfies(expected)
 
     @pytest.mark.regression("24196")
     def test_version_badness_more_important_than_default_mv_variants(self):

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -545,13 +545,13 @@ packages:
 
 def test_requirements_are_higher_priority_than_deprecation(concretize_scope, test_repo):
     """Test that users can override a deprecated version with a requirement."""
-    # @2.3 is a deprecated versions. Ensure that any_of picks both constraints,
+    # 2.3 is a deprecated versions. Ensure that any_of picks both constraints,
     # since they are possible
     conf_str = """\
 packages:
   y:
     require:
-    - any_of: ["@2.3", "%gcc"]
+    - any_of: ["@=2.3", "%gcc"]
 """
     update_packages_config(conf_str)
 

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -543,8 +543,20 @@ packages:
             assert not s2.satisfies("@2.5 %gcc")
 
 
-def test_requirements_are_higher_priority_than_deprecation(concretize_scope, test_repo):
-    """Test that users can override a deprecated version with a requirement."""
+@pytest.mark.parametrize(
+    "allow_deprecated,expected,not_expected",
+    [(True, ["@=2.3", "%gcc"], []), (False, ["%gcc"], ["@=2.3"])],
+)
+def test_requirements_and_deprecated_versions(
+    allow_deprecated, expected, not_expected, concretize_scope, test_repo
+):
+    """Tests the expected behavior of requirements and deprecated versions.
+
+    If deprecated versions are not allowed, concretization should just pick
+    the other requirement.
+
+    If deprecated versions are allowed, both requirements are honored.
+    """
     # 2.3 is a deprecated versions. Ensure that any_of picks both constraints,
     # since they are possible
     conf_str = """\
@@ -555,9 +567,13 @@ packages:
 """
     update_packages_config(conf_str)
 
-    s1 = Spec("y").concretized()
-    assert s1.satisfies("@2.3")
-    assert s1.satisfies("%gcc")
+    with spack.config.override("config:deprecated", allow_deprecated):
+        s1 = Spec("y").concretized()
+        for constrain in expected:
+            assert s1.satisfies(constrain)
+
+        for constrain in not_expected:
+            assert not s1.satisfies(constrain)
 
 
 @pytest.mark.parametrize("spec_str,requirement_str", [("x", "%gcc"), ("x", "%clang")])


### PR DESCRIPTION
This reverts commit d7b5a27d1d9466fbc4c56306cecd067c76b93b5d.

Full description from #38181 :

---
Currently, the concretizer emits facts for all versions known to Spack, including deprecated versions, and has a specific optimization objective to minimize their use.

This PR simplifies how deprecated versions are handled by considering them possible versions for a spec only if they appear in a spec literal or if the --deprecated option is passed to commands. The optimization objective has also been removed, in favor of just ordering versions and having deprecated ones last.

This results in a slight speed-up and a simplification of the logic program.