### PR TITLE
glibc: dont link libgcc_eh.a pre 2.17, and backport at_random auxval patch

### DIFF
--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.11.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.11.patch
@@ -1,0 +1,258 @@
+From 3827ce5d1c15c19e10fe7cfe8484084538469508 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Thu, 14 Sep 2023 12:24:27 +0200
+Subject: [PATCH] 95f5a9a-revisited
+
+---
+ Makeconfig         | 32 ++++++++++++++++++++++++--------
+ Rules              | 39 +++++++++++++++++++++++++++++++--------
+ elf/Makefile       |  6 +++++-
+ elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 106 insertions(+), 17 deletions(-)
+ create mode 100644 elf/static-stubs.c
+
+diff --git a/Makeconfig b/Makeconfig
+index 47638b13c6..6384e22a72 100644
+--- a/Makeconfig
++++ b/Makeconfig
+@@ -423,7 +423,7 @@ endif
+ 
+ # Command for linking programs with the C library.
+ ifndef +link
+-+link = $(CC) -nostdlib -nostartfiles -o $@ \
+++link-before-libc = $(CC) -nostdlib -nostartfiles -o $@ \
+ 	      $(sysdep-LDFLAGS) $(config-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F)) \
+ 	      $(combreloc-LDFLAGS) $(relro-LDFLAGS) $(hashstyle-LDFLAGS) \
+ 	      $(addprefix $(csu-objpfx),$(start-installed-name)) \
+@@ -432,7 +432,10 @@ ifndef +link
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs) $(link-libc) $(+postctor) $(+postinit)
++	      $(link-extra-libs)
+++link-after-libc = $(+postctor) $(+postinit)
+++link = $(+link-before-libc) $(link-libc) $(+link-after-libc)
+++link-tests = $(+link-before-libc) $(link-libc-tests) $(+link-after-libc)
+ endif
+ # Command for linking PIE programs with the C library.
+ ifndef +link-pie
+@@ -449,7 +452,7 @@ ifndef +link-pie
+ endif
+ # Command for statically linking programs with the C library.
+ ifndef +link-static
+-+link-static = $(CC) -nostdlib -nostartfiles -static -o $@ \
+++link-static-before-libc = $(CC) -nostdlib -nostartfiles -static -o $@ \
+ 	      $(sysdep-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F))  \
+ 	      $(addprefix $(csu-objpfx),$(static-start-installed-name)) \
+ 	      $(+preinit) $(+prector) \
+@@ -457,7 +460,12 @@ ifndef +link-static
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs-static) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs-static) $(link-libc-static) $(+postctor) $(+postinit)
++	      $(link-extra-libs-static) $(link-libc-static)
+++link-static-after-libc = $(+postctor) $(+postinit)
+++link-static = $(+link-static-before-libc) $(link-libc-static) \
++	      $(+link-static-after-libc)
+++link-static-tests = $(+link-static-before-libc) $(link-libc-static-tests) \
++	      $(+link-static-after-libc)
+ endif
+ # Command for statically linking bounded-pointer programs with the C library.
+ ifndef +link-bounded
+@@ -482,9 +490,11 @@ ifeq ($(elf),yes)
+ # We need the versioned name of libc.so in the deps of $(others) et al
+ # so that the symlink to libc.so is created before anything tries to
+ # run the linked programs.
+-link-libc = -Wl,-rpath-link=$(rpath-link) \
++link-libc-before-gnulib = -Wl,-rpath-link=$(rpath-link) \
+ 	    $(common-objpfx)libc.so$(libc.so-version) \
+-	    $(common-objpfx)$(patsubst %,$(libtype.oS),c) $(gnulib)
++	    $(common-objpfx)$(patsubst %,$(libtype.oS),c)
++link-libc = $(link-libc-before-gnulib) $(gnulib)
++link-libc-tests = $(link-libc-before-gnulib) $(gnulib-tests)
+ # This is how to find at build-time things that will be installed there.
+ rpath-dirs = math elf dlfcn nss nis rt resolv crypt
+ endif
+@@ -495,6 +505,7 @@ else
+ nssobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)nss)
+ resolvobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)resolv)
+ link-libc = $(common-objpfx)libc.a $(otherlibs) $(gnulib) $(common-objpfx)libc.a $(gnulib)
++link-libc-tests = $(common-objpfx)libc.a $(otherlibs) $(gnulib-tests) $(common-objpfx)libc.a $(gnulib-tests)
+ endif
+ endif
+ 
+@@ -523,6 +534,7 @@ endif
+ # The static libraries.
+ ifeq (yes,$(build-static))
+ link-libc-static = $(common-objpfx)libc.a $(static-gnulib) $(common-objpfx)libc.a
++link-libc-static-tests = $(common-objpfx)libc.a $(static-gnulib-tests) $(common-objpfx)libc.a
+ else
+ ifeq (yes,$(build-shared))
+ # We can try to link the programs with lib*_pic.a...
+@@ -542,8 +554,12 @@ ifneq ($(have-as-needed),yes)
+ else
+  libgcc_eh := -Wl,--as-needed -lgcc_s$(libgcc_s_suffix) $(libunwind) -Wl,--no-as-needed
+ endif
+-gnulib := -lgcc $(libgcc_eh)
+-static-gnulib := -lgcc -lgcc_eh $(libunwind)
++gnulib-arch =
++gnulib = -lgcc $(gnulib-arch)
++gnulib-tests := -lgcc $(libgcc_eh)
++static-gnulib-arch =
++static-gnulib = -lgcc $(static-gnulib-arch)
++static-gnulib-tests := -lgcc -lgcc_eh $(libunwind)
+ libc.so-gnulib := -lgcc
+ endif
+ ifeq ($(elf),yes)
+diff --git a/Rules b/Rules
+index 5ace24cee0..45eb7541dc 100644
+--- a/Rules
++++ b/Rules
+@@ -104,29 +104,52 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
+ endif
+ 
+ ifeq ($(build-programs),yes)
+-binaries-all = $(others) $(sysdep-others) $(tests) $(xtests) $(test-srcs)
+-binaries-static = $(others-static) $(tests-static) $(xtests-static)
++binaries-all-notests = $(others) $(sysdep-others)
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-notests) $(binaries-all-tests)
++binaries-static-notests = $(others-static)
++binaries-static-tests = $(tests-static) $(xtests-static)
++binaries-static = $(binaries-static-notests) $(binaries-static-tests)
+ else
+-binaries-all = $(tests) $(xtests) $(test-srcs)
++binaries-all-notests =
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-tests)
++binaries-static-notests =
++binaries-static-tests =
+ binaries-static =
+ endif
+ 
+-binaries-shared = $(filter-out $(binaries-static), $(binaries-all))
++binaries-shared-tests = $(filter-out $(binaries-static), $(binaries-all-tests))
++binaries-shared-notests = $(filter-out $(binaries-static), $(binaries-all-notests))
+ 
+-ifneq "$(strip $(binaries-shared))" ""
+-$(addprefix $(objpfx),$(binaries-shared)): %: %.o \
++ifneq "$(strip $(binaries-shared-notests))" ""
++$(addprefix $(objpfx),$(binaries-shared-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link)
+ endif
+ 
+-ifneq "$(strip $(binaries-static))" ""
+-$(addprefix $(objpfx),$(binaries-static)): %: %.o \
++ifneq "$(strip $(binaries-shared-tests))" ""
++$(addprefix $(objpfx),$(binaries-shared-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-tests)
++endif
++
++ifneq "$(strip $(binaries-static-notests))" ""
++$(addprefix $(objpfx),$(binaries-static-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc-static))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link-static)
+ endif
+ 
++ifneq "$(strip $(binaries-static-tests))" ""
++$(addprefix $(objpfx),$(binaries-static-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc-static-tests))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-static-tests)
++endif
++
+ ifeq ($(build-bounded),yes)
+ binaries-bounded = $(addsuffix -bp,$(tests) $(xtests) $(test-srcs))
+ $(addprefix $(objpfx),$(binaries-bounded)): %-bp: %.ob \
+diff --git a/elf/Makefile b/elf/Makefile
+index 34609a0f85..84709920e8 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -150,6 +150,8 @@ others		= sprof sln
+ install-bin	= sprof
+ others-static   = sln
+ install-rootsbin = sln
++sln-modules	:= static-stubs
++extra-objs	+= $(sln-modules:=.o)
+ 
+ ifeq (yes,$(use-ldconfig))
+ ifeq (yes,$(build-shared))
+@@ -157,7 +159,7 @@ others-static	+= ldconfig
+ others		+= ldconfig
+ install-rootsbin += ldconfig
+ 
+-ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon
++ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon static-stubs
+ extra-objs	+= $(ldconfig-modules:=.o)
+ 
+ # To find xmalloc.c and xstrdup.c
+@@ -448,6 +450,8 @@ $(objpfx)ldd: ldd.bash.in $(common-objpfx)soversions.mk \
+ 
+ $(objpfx)sprof: $(libdl)
+ 
++$(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
++
+ $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
+ SYSCONF-FLAGS := -D'SYSCONFDIR="$(sysconfdir)"'
+ CFLAGS-ldconfig.c = $(SYSCONF-FLAGS) -D'LIBDIR="$(libdir)"' \
+diff --git a/elf/static-stubs.c b/elf/static-stubs.c
+new file mode 100644
+index 0000000000..a6cc26db1a
+--- /dev/null
++++ b/elf/static-stubs.c
+@@ -0,0 +1,46 @@
++/* Stub implementations of functions to link into statically linked
++   programs without needing libgcc_eh.
++   Copyright (C) 2012 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
++   sysdeps/unix/sysv/linux/libc_fatal.c.  */
++#include <sysdeps/posix/libc_fatal.c>
++
++#include <stdlib.h>
++#include <unwind.h>
++
++/* These programs do not use thread cancellation, so _Unwind_Resume
++   and the personality routine are never actually called.  */
++
++void
++_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
++{
++  abort ();
++}
++
++_Unwind_Reason_Code
++__gcc_personality_v0 (int version __attribute__ ((unused)),
++		      _Unwind_Action actions __attribute__ ((unused)),
++		      _Unwind_Exception_Class exception_class
++		      __attribute__ ((unused)),
++		      struct _Unwind_Exception *ue_header
++		      __attribute__ ((unused)),
++		      struct _Unwind_Context *context __attribute__ ((unused)))
++{
++  abort ();
++}
+\ No newline at end of file
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.11.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.11.patch
@@ -1,15 +1,7 @@
-From 3827ce5d1c15c19e10fe7cfe8484084538469508 Mon Sep 17 00:00:00 2001
-From: Harmen Stoppels <me@harmenstoppels.nl>
-Date: Thu, 14 Sep 2023 12:24:27 +0200
-Subject: [PATCH] 95f5a9a-revisited
-
----
- Makeconfig         | 32 ++++++++++++++++++++++++--------
- Rules              | 39 +++++++++++++++++++++++++++++++--------
- elf/Makefile       |  6 +++++-
- elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 106 insertions(+), 17 deletions(-)
- create mode 100644 elf/static-stubs.c
+From 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 3 Jul 2012 19:14:59 +0000
+Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
 
 diff --git a/Makeconfig b/Makeconfig
 index 47638b13c6..6384e22a72 100644
@@ -200,59 +192,3 @@ index 34609a0f85..84709920e8 100644
  $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
  SYSCONF-FLAGS := -D'SYSCONFDIR="$(sysconfdir)"'
  CFLAGS-ldconfig.c = $(SYSCONF-FLAGS) -D'LIBDIR="$(libdir)"' \
-diff --git a/elf/static-stubs.c b/elf/static-stubs.c
-new file mode 100644
-index 0000000000..a6cc26db1a
---- /dev/null
-+++ b/elf/static-stubs.c
-@@ -0,0 +1,46 @@
-+/* Stub implementations of functions to link into statically linked
-+   programs without needing libgcc_eh.
-+   Copyright (C) 2012 Free Software Foundation, Inc.
-+   This file is part of the GNU C Library.
-+
-+   The GNU C Library is free software; you can redistribute it and/or
-+   modify it under the terms of the GNU Lesser General Public
-+   License as published by the Free Software Foundation; either
-+   version 2.1 of the License, or (at your option) any later version.
-+
-+   The GNU C Library is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-+   Lesser General Public License for more details.
-+
-+   You should have received a copy of the GNU Lesser General Public
-+   License along with the GNU C Library; if not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
-+   sysdeps/unix/sysv/linux/libc_fatal.c.  */
-+#include <sysdeps/posix/libc_fatal.c>
-+
-+#include <stdlib.h>
-+#include <unwind.h>
-+
-+/* These programs do not use thread cancellation, so _Unwind_Resume
-+   and the personality routine are never actually called.  */
-+
-+void
-+_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-+
-+_Unwind_Reason_Code
-+__gcc_personality_v0 (int version __attribute__ ((unused)),
-+		      _Unwind_Action actions __attribute__ ((unused)),
-+		      _Unwind_Exception_Class exception_class
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Exception *ue_header
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Context *context __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-\ No newline at end of file
--- 
-2.39.2
-

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.13.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.13.patch
@@ -1,0 +1,259 @@
+From a76dba068d1b01fa447f2cc38c2595cb4a9e5578 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Thu, 14 Sep 2023 12:18:55 +0200
+Subject: [PATCH] 95f5a9a-revisited
+
+---
+ Makeconfig         | 32 ++++++++++++++++++++++++--------
+ Rules              | 39 +++++++++++++++++++++++++++++++--------
+ elf/Makefile       |  6 +++++-
+ elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 106 insertions(+), 17 deletions(-)
+ create mode 100644 elf/static-stubs.c
+
+diff --git a/Makeconfig b/Makeconfig
+index e5cbf646fa..870a4bec4f 100644
+--- a/Makeconfig
++++ b/Makeconfig
+@@ -431,7 +431,7 @@ endif
+ 
+ # Command for linking programs with the C library.
+ ifndef +link
+-+link = $(CC) -nostdlib -nostartfiles -o $@ \
+++link-before-libc = $(CC) -nostdlib -nostartfiles -o $@ \
+ 	      $(sysdep-LDFLAGS) $(config-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F)) \
+ 	      $(combreloc-LDFLAGS) $(relro-LDFLAGS) $(hashstyle-LDFLAGS) \
+ 	      $(addprefix $(csu-objpfx),$(start-installed-name)) \
+@@ -440,7 +440,10 @@ ifndef +link
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs) $(link-libc) $(+postctor) $(+postinit)
++	      $(link-extra-libs)
+++link-after-libc = $(+postctor) $(+postinit)
+++link = $(+link-before-libc) $(link-libc) $(+link-after-libc)
+++link-tests = $(+link-before-libc) $(link-libc-tests) $(+link-after-libc)
+ endif
+ # Command for linking PIE programs with the C library.
+ ifndef +link-pie
+@@ -457,7 +460,7 @@ ifndef +link-pie
+ endif
+ # Command for statically linking programs with the C library.
+ ifndef +link-static
+-+link-static = $(CC) -nostdlib -nostartfiles -static -o $@ \
+++link-static-before-libc = $(CC) -nostdlib -nostartfiles -static -o $@ \
+ 	      $(sysdep-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F))  \
+ 	      $(addprefix $(csu-objpfx),$(static-start-installed-name)) \
+ 	      $(+preinit) $(+prector) \
+@@ -465,7 +468,12 @@ ifndef +link-static
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs-static) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs-static) $(link-libc-static) $(+postctor) $(+postinit)
++	      $(link-extra-libs-static) $(link-libc-static)
+++link-static-after-libc = $(+postctor) $(+postinit)
+++link-static = $(+link-static-before-libc) $(link-libc-static) \
++	      $(+link-static-after-libc)
+++link-static-tests = $(+link-static-before-libc) $(link-libc-static-tests) \
++	      $(+link-static-after-libc)
+ endif
+ # Command for statically linking bounded-pointer programs with the C library.
+ ifndef +link-bounded
+@@ -490,10 +498,12 @@ ifeq ($(elf),yes)
+ # We need the versioned name of libc.so in the deps of $(others) et al
+ # so that the symlink to libc.so is created before anything tries to
+ # run the linked programs.
+-link-libc = -Wl,-rpath-link=$(rpath-link) \
++link-libc-before-gnulib = -Wl,-rpath-link=$(rpath-link) \
+ 	    $(common-objpfx)libc.so$(libc.so-version) \
+ 	    $(common-objpfx)$(patsubst %,$(libtype.oS),c) \
+-	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed) $(gnulib)
++	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed)
++link-libc = $(link-libc-before-gnulib) $(gnulib)
++link-libc-tests = $(link-libc-before-gnulib) $(gnulib-tests)
+ # This is how to find at build-time things that will be installed there.
+ rpath-dirs = math elf dlfcn nss nis rt resolv crypt
+ endif
+@@ -504,6 +514,7 @@ else
+ nssobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)nss)
+ resolvobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)resolv)
+ link-libc = $(common-objpfx)libc.a $(otherlibs) $(gnulib) $(common-objpfx)libc.a $(gnulib)
++link-libc-tests = $(common-objpfx)libc.a $(otherlibs) $(gnulib-tests) $(common-objpfx)libc.a $(gnulib-tests)
+ endif
+ endif
+ 
+@@ -532,6 +543,7 @@ endif
+ # The static libraries.
+ ifeq (yes,$(build-static))
+ link-libc-static = $(common-objpfx)libc.a $(static-gnulib) $(common-objpfx)libc.a
++link-libc-static-tests = $(common-objpfx)libc.a $(static-gnulib-tests) $(common-objpfx)libc.a
+ else
+ ifeq (yes,$(build-shared))
+ # We can try to link the programs with lib*_pic.a...
+@@ -551,8 +563,12 @@ ifneq ($(have-as-needed),yes)
+ else
+  libgcc_eh := -Wl,--as-needed -lgcc_s$(libgcc_s_suffix) $(libunwind) -Wl,--no-as-needed
+ endif
+-gnulib := -lgcc $(libgcc_eh)
+-static-gnulib := -lgcc -lgcc_eh $(libunwind)
++gnulib-arch =
++gnulib = -lgcc $(gnulib-arch)
++gnulib-tests := -lgcc $(libgcc_eh)
++static-gnulib-arch =
++static-gnulib = -lgcc $(static-gnulib-arch)
++static-gnulib-tests := -lgcc -lgcc_eh $(libunwind)
+ libc.so-gnulib := -lgcc
+ endif
+ ifeq ($(elf),yes)
+diff --git a/Rules b/Rules
+index 5ace24cee0..45eb7541dc 100644
+--- a/Rules
++++ b/Rules
+@@ -104,29 +104,52 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
+ endif
+ 
+ ifeq ($(build-programs),yes)
+-binaries-all = $(others) $(sysdep-others) $(tests) $(xtests) $(test-srcs)
+-binaries-static = $(others-static) $(tests-static) $(xtests-static)
++binaries-all-notests = $(others) $(sysdep-others)
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-notests) $(binaries-all-tests)
++binaries-static-notests = $(others-static)
++binaries-static-tests = $(tests-static) $(xtests-static)
++binaries-static = $(binaries-static-notests) $(binaries-static-tests)
+ else
+-binaries-all = $(tests) $(xtests) $(test-srcs)
++binaries-all-notests =
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-tests)
++binaries-static-notests =
++binaries-static-tests =
+ binaries-static =
+ endif
+ 
+-binaries-shared = $(filter-out $(binaries-static), $(binaries-all))
++binaries-shared-tests = $(filter-out $(binaries-static), $(binaries-all-tests))
++binaries-shared-notests = $(filter-out $(binaries-static), $(binaries-all-notests))
+ 
+-ifneq "$(strip $(binaries-shared))" ""
+-$(addprefix $(objpfx),$(binaries-shared)): %: %.o \
++ifneq "$(strip $(binaries-shared-notests))" ""
++$(addprefix $(objpfx),$(binaries-shared-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link)
+ endif
+ 
+-ifneq "$(strip $(binaries-static))" ""
+-$(addprefix $(objpfx),$(binaries-static)): %: %.o \
++ifneq "$(strip $(binaries-shared-tests))" ""
++$(addprefix $(objpfx),$(binaries-shared-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-tests)
++endif
++
++ifneq "$(strip $(binaries-static-notests))" ""
++$(addprefix $(objpfx),$(binaries-static-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc-static))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link-static)
+ endif
+ 
++ifneq "$(strip $(binaries-static-tests))" ""
++$(addprefix $(objpfx),$(binaries-static-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc-static-tests))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-static-tests)
++endif
++
+ ifeq ($(build-bounded),yes)
+ binaries-bounded = $(addsuffix -bp,$(tests) $(xtests) $(test-srcs))
+ $(addprefix $(objpfx),$(binaries-bounded)): %-bp: %.ob \
+diff --git a/elf/Makefile b/elf/Makefile
+index 2d2d568013..fe1924ebd4 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -150,6 +150,8 @@ others		= sprof sln
+ install-bin	= sprof
+ others-static   = sln
+ install-rootsbin = sln
++sln-modules	:= static-stubs
++extra-objs	+= $(sln-modules:=.o)
+ 
+ ifeq (yes,$(use-ldconfig))
+ ifeq (yes,$(build-shared))
+@@ -157,7 +159,7 @@ others-static	+= ldconfig
+ others		+= ldconfig
+ install-rootsbin += ldconfig
+ 
+-ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon
++ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon static-stubs
+ extra-objs	+= $(ldconfig-modules:=.o)
+ 
+ # To find xmalloc.c and xstrdup.c
+@@ -458,6 +460,8 @@ $(objpfx)ldd: ldd.bash.in $(common-objpfx)soversions.mk \
+ 
+ $(objpfx)sprof: $(libdl)
+ 
++$(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
++
+ $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
+ SYSCONF-FLAGS := -D'SYSCONFDIR="$(sysconfdir)"'
+ CFLAGS-ldconfig.c = $(SYSCONF-FLAGS) -D'LIBDIR="$(libdir)"' \
+diff --git a/elf/static-stubs.c b/elf/static-stubs.c
+new file mode 100644
+index 0000000000..a6cc26db1a
+--- /dev/null
++++ b/elf/static-stubs.c
+@@ -0,0 +1,46 @@
++/* Stub implementations of functions to link into statically linked
++   programs without needing libgcc_eh.
++   Copyright (C) 2012 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
++   sysdeps/unix/sysv/linux/libc_fatal.c.  */
++#include <sysdeps/posix/libc_fatal.c>
++
++#include <stdlib.h>
++#include <unwind.h>
++
++/* These programs do not use thread cancellation, so _Unwind_Resume
++   and the personality routine are never actually called.  */
++
++void
++_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
++{
++  abort ();
++}
++
++_Unwind_Reason_Code
++__gcc_personality_v0 (int version __attribute__ ((unused)),
++		      _Unwind_Action actions __attribute__ ((unused)),
++		      _Unwind_Exception_Class exception_class
++		      __attribute__ ((unused)),
++		      struct _Unwind_Exception *ue_header
++		      __attribute__ ((unused)),
++		      struct _Unwind_Context *context __attribute__ ((unused)))
++{
++  abort ();
++}
+\ No newline at end of file
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.13.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.13.patch
@@ -1,15 +1,7 @@
-From a76dba068d1b01fa447f2cc38c2595cb4a9e5578 Mon Sep 17 00:00:00 2001
-From: Harmen Stoppels <me@harmenstoppels.nl>
-Date: Thu, 14 Sep 2023 12:18:55 +0200
-Subject: [PATCH] 95f5a9a-revisited
-
----
- Makeconfig         | 32 ++++++++++++++++++++++++--------
- Rules              | 39 +++++++++++++++++++++++++++++++--------
- elf/Makefile       |  6 +++++-
- elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 106 insertions(+), 17 deletions(-)
- create mode 100644 elf/static-stubs.c
+From 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 3 Jul 2012 19:14:59 +0000
+Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
 
 diff --git a/Makeconfig b/Makeconfig
 index e5cbf646fa..870a4bec4f 100644
@@ -201,59 +193,3 @@ index 2d2d568013..fe1924ebd4 100644
  $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
  SYSCONF-FLAGS := -D'SYSCONFDIR="$(sysconfdir)"'
  CFLAGS-ldconfig.c = $(SYSCONF-FLAGS) -D'LIBDIR="$(libdir)"' \
-diff --git a/elf/static-stubs.c b/elf/static-stubs.c
-new file mode 100644
-index 0000000000..a6cc26db1a
---- /dev/null
-+++ b/elf/static-stubs.c
-@@ -0,0 +1,46 @@
-+/* Stub implementations of functions to link into statically linked
-+   programs without needing libgcc_eh.
-+   Copyright (C) 2012 Free Software Foundation, Inc.
-+   This file is part of the GNU C Library.
-+
-+   The GNU C Library is free software; you can redistribute it and/or
-+   modify it under the terms of the GNU Lesser General Public
-+   License as published by the Free Software Foundation; either
-+   version 2.1 of the License, or (at your option) any later version.
-+
-+   The GNU C Library is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-+   Lesser General Public License for more details.
-+
-+   You should have received a copy of the GNU Lesser General Public
-+   License along with the GNU C Library; if not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
-+   sysdeps/unix/sysv/linux/libc_fatal.c.  */
-+#include <sysdeps/posix/libc_fatal.c>
-+
-+#include <stdlib.h>
-+#include <unwind.h>
-+
-+/* These programs do not use thread cancellation, so _Unwind_Resume
-+   and the personality routine are never actually called.  */
-+
-+void
-+_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-+
-+_Unwind_Reason_Code
-+__gcc_personality_v0 (int version __attribute__ ((unused)),
-+		      _Unwind_Action actions __attribute__ ((unused)),
-+		      _Unwind_Exception_Class exception_class
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Exception *ue_header
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Context *context __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-\ No newline at end of file
--- 
-2.39.2
-

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.15.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.15.patch
@@ -1,15 +1,7 @@
-From 6cc2f80f137f3e4424038c421d55740762627fb1 Mon Sep 17 00:00:00 2001
-From: Harmen Stoppels <me@harmenstoppels.nl>
-Date: Thu, 14 Sep 2023 11:57:44 +0200
-Subject: [PATCH] 95f5a9a-revisited
-
----
- Makeconfig         | 32 ++++++++++++++++++++++++--------
- Rules              | 42 +++++++++++++++++++++++++++++++++---------
- elf/Makefile       |  6 +++++-
- elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 108 insertions(+), 18 deletions(-)
- create mode 100644 elf/static-stubs.c
+From 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 3 Jul 2012 19:14:59 +0000
+Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
 
 diff --git a/Makeconfig b/Makeconfig
 index 8195245052..b23cee8723 100644
@@ -217,58 +209,3 @@ index f20f52dee1..64555b9243 100644
  $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
  
  $(objpfx)pldd: $(pldd-modules:%=$(objpfx)%.o)
-diff --git a/elf/static-stubs.c b/elf/static-stubs.c
-new file mode 100644
-index 0000000000..6c5eebc3fb
---- /dev/null
-+++ b/elf/static-stubs.c
-@@ -0,0 +1,46 @@
-+/* Stub implementations of functions to link into statically linked
-+   programs without needing libgcc_eh.
-+   Copyright (C) 2012 Free Software Foundation, Inc.
-+   This file is part of the GNU C Library.
-+
-+   The GNU C Library is free software; you can redistribute it and/or
-+   modify it under the terms of the GNU Lesser General Public
-+   License as published by the Free Software Foundation; either
-+   version 2.1 of the License, or (at your option) any later version.
-+
-+   The GNU C Library is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-+   Lesser General Public License for more details.
-+
-+   You should have received a copy of the GNU Lesser General Public
-+   License along with the GNU C Library; if not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
-+   sysdeps/unix/sysv/linux/libc_fatal.c.  */
-+#include <sysdeps/posix/libc_fatal.c>
-+
-+#include <stdlib.h>
-+#include <unwind.h>
-+
-+/* These programs do not use thread cancellation, so _Unwind_Resume
-+   and the personality routine are never actually called.  */
-+
-+void
-+_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-+
-+_Unwind_Reason_Code
-+__gcc_personality_v0 (int version __attribute__ ((unused)),
-+		      _Unwind_Action actions __attribute__ ((unused)),
-+		      _Unwind_Exception_Class exception_class
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Exception *ue_header
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Context *context __attribute__ ((unused)))
-+{
-+  abort ();
-+}
--- 
-2.39.2
-

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.15.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.15.patch
@@ -1,0 +1,274 @@
+From 6cc2f80f137f3e4424038c421d55740762627fb1 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Thu, 14 Sep 2023 11:57:44 +0200
+Subject: [PATCH] 95f5a9a-revisited
+
+---
+ Makeconfig         | 32 ++++++++++++++++++++++++--------
+ Rules              | 42 +++++++++++++++++++++++++++++++++---------
+ elf/Makefile       |  6 +++++-
+ elf/static-stubs.c | 46 ++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 108 insertions(+), 18 deletions(-)
+ create mode 100644 elf/static-stubs.c
+
+diff --git a/Makeconfig b/Makeconfig
+index 8195245052..b23cee8723 100644
+--- a/Makeconfig
++++ b/Makeconfig
+@@ -447,7 +447,7 @@ endif
+ 
+ # Command for linking programs with the C library.
+ ifndef +link
+-+link = $(CC) -nostdlib -nostartfiles -o $@ \
+++link-before-libc = $(CC) -nostdlib -nostartfiles -o $@ \
+ 	      $(sysdep-LDFLAGS) $(config-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F)) \
+ 	      $(combreloc-LDFLAGS) $(relro-LDFLAGS) $(hashstyle-LDFLAGS) \
+ 	      $(addprefix $(csu-objpfx),$(start-installed-name)) \
+@@ -456,7 +456,10 @@ ifndef +link
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs) $(link-libc) $(+postctor) $(+postinit)
++	      $(link-extra-libs)
+++link-after-libc = $(+postctor) $(+postinit)
+++link = $(+link-before-libc) $(link-libc) $(+link-after-libc)
+++link-tests = $(+link-before-libc) $(link-libc-tests) $(+link-after-libc)
+ endif
+ # Command for linking PIE programs with the C library.
+ ifndef +link-pie
+@@ -473,7 +476,7 @@ ifndef +link-pie
+ endif
+ # Command for statically linking programs with the C library.
+ ifndef +link-static
+-+link-static = $(CC) -nostdlib -nostartfiles -static -o $@ \
+++link-static-before-libc = $(CC) -nostdlib -nostartfiles -static -o $@ \
+ 	      $(sysdep-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F))  \
+ 	      $(addprefix $(csu-objpfx),$(static-start-installed-name)) \
+ 	      $(+preinit) $(+prector) \
+@@ -481,7 +484,12 @@ ifndef +link-static
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs-static) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs-static) $(link-libc-static) $(+postctor) $(+postinit)
++	      $(link-extra-libs-static) $(link-libc-static)
+++link-static-after-libc = $(+postctor) $(+postinit)
+++link-static = $(+link-static-before-libc) $(link-libc-static) \
++	      $(+link-static-after-libc)
+++link-static-tests = $(+link-static-before-libc) $(link-libc-static-tests) \
++	      $(+link-static-after-libc)
+ endif
+ # Command for statically linking bounded-pointer programs with the C library.
+ ifndef +link-bounded
+@@ -506,10 +514,12 @@ ifeq ($(elf),yes)
+ # We need the versioned name of libc.so in the deps of $(others) et al
+ # so that the symlink to libc.so is created before anything tries to
+ # run the linked programs.
+-link-libc = -Wl,-rpath-link=$(rpath-link) \
++link-libc-before-gnulib = -Wl,-rpath-link=$(rpath-link) \
+ 	    $(common-objpfx)libc.so$(libc.so-version) \
+ 	    $(common-objpfx)$(patsubst %,$(libtype.oS),c) \
+-	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed) $(gnulib)
++	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed)
++link-libc = $(link-libc-before-gnulib) $(gnulib)
++link-libc-tests = $(link-libc-before-gnulib) $(gnulib-tests)
+ # This is how to find at build-time things that will be installed there.
+ rpath-dirs = math elf dlfcn nss nis rt resolv crypt
+ endif
+@@ -520,6 +530,7 @@ else
+ nssobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)nss)
+ resolvobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)resolv)
+ link-libc = $(common-objpfx)libc.a $(otherlibs) $(gnulib) $(common-objpfx)libc.a $(gnulib)
++link-libc-tests = $(common-objpfx)libc.a $(otherlibs) $(gnulib-tests) $(common-objpfx)libc.a $(gnulib-tests)
+ endif
+ endif
+ 
+@@ -548,6 +559,7 @@ endif
+ # The static libraries.
+ ifeq (yes,$(build-static))
+ link-libc-static = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib) -Wl,--end-group
++link-libc-static-tests = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib-tests) -Wl,--end-group
+ else
+ ifeq (yes,$(build-shared))
+ # We can try to link the programs with lib*_pic.a...
+@@ -567,8 +579,12 @@ ifneq ($(have-as-needed),yes)
+ else
+  libgcc_eh := -Wl,--as-needed -lgcc_s$(libgcc_s_suffix) $(libunwind) -Wl,--no-as-needed
+ endif
+-gnulib := -lgcc $(libgcc_eh)
+-static-gnulib := -lgcc -lgcc_eh $(libunwind)
++gnulib-arch =
++gnulib = -lgcc $(gnulib-arch)
++gnulib-tests := -lgcc $(libgcc_eh)
++static-gnulib-arch =
++static-gnulib = -lgcc $(static-gnulib-arch)
++static-gnulib-tests := -lgcc -lgcc_eh $(libunwind)
+ libc.so-gnulib := -lgcc
+ endif
+ ifeq ($(elf),yes)
+diff --git a/Rules b/Rules
+index 00f03df6da..4a31d2905c 100644
+--- a/Rules
++++ b/Rules
+@@ -104,29 +104,46 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
+ endif
+ 
+ ifeq ($(build-programs),yes)
+-binaries-all = $(others) $(sysdep-others) $(tests) $(xtests) $(test-srcs)
+-binaries-static = $(others-static) $(tests-static) $(xtests-static)
++binaries-all-notests = $(others) $(sysdep-others)
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-notests) $(binaries-all-tests)
++binaries-static-notests = $(others-static)
++binaries-static-tests = $(tests-static) $(xtests-static)
++binaries-static = $(binaries-static-notests) $(binaries-static-tests)
+ ifeq (yesyes,$(have-fpie)$(build-shared))
+ binaries-pie = $(others-pie) $(tests-pie) $(xtests-pie)
+ else
+ binaries-pie =
+ endif
+ else
+-binaries-all = $(tests) $(xtests) $(test-srcs)
++binaries-all-notests =
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-tests)
++binaries-static-notests =
++binaries-static-tests =
+ binaries-static =
+ binaries-pie =
+ endif
+ 
+-binaries-shared = $(filter-out $(binaries-pie) $(binaries-static), \
+-			       $(binaries-all))
++binaries-shared-tests = $(filter-out $(binaries-pie) $(binaries-static), \
++				     $(binaries-all-tests))
++binaries-shared-notests = $(filter-out $(binaries-pie) $(binaries-static), \
++				       $(binaries-all-notests))
+ 
+-ifneq "$(strip $(binaries-shared))" ""
+-$(addprefix $(objpfx),$(binaries-shared)): %: %.o \
++ifneq "$(strip $(binaries-shared-notests))" ""
++$(addprefix $(objpfx),$(binaries-shared-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link)
+ endif
+ 
++ifneq "$(strip $(binaries-shared-tests))" ""
++$(addprefix $(objpfx),$(binaries-shared-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-tests)
++endif
++
+ ifneq "$(strip $(binaries-pie))" ""
+ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+@@ -134,13 +151,20 @@ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
+ 	$(+link-pie)
+ endif
+ 
+-ifneq "$(strip $(binaries-static))" ""
+-$(addprefix $(objpfx),$(binaries-static)): %: %.o \
++ifneq "$(strip $(binaries-static-notests))" ""
++$(addprefix $(objpfx),$(binaries-static-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc-static))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link-static)
+ endif
+ 
++ifneq "$(strip $(binaries-static-tests))" ""
++$(addprefix $(objpfx),$(binaries-static-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc-static-tests))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-static-tests)
++endif
++
+ ifeq ($(build-bounded),yes)
+ binaries-bounded = $(addsuffix -bp,$(tests) $(xtests) $(test-srcs))
+ $(addprefix $(objpfx),$(binaries-bounded)): %-bp: %.ob \
+diff --git a/elf/Makefile b/elf/Makefile
+index f20f52dee1..64555b9243 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -156,6 +156,8 @@ others		= sprof sln pldd
+ install-bin	= sprof pldd
+ others-static   = sln
+ install-rootsbin = sln
++sln-modules	:= static-stubs
++extra-objs	+= $(sln-modules:=.o)
+ 
+ ifeq (yes,$(use-ldconfig))
+ ifeq (yes,$(build-shared))
+@@ -163,7 +165,7 @@ others-static	+= ldconfig
+ others		+= ldconfig
+ install-rootsbin += ldconfig
+ 
+-ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon
++ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon static-stubs
+ extra-objs	+= $(ldconfig-modules:=.o)
+ 
+ pldd-modules := xmalloc
+@@ -495,6 +497,8 @@ $(objpfx)ldd: ldd.bash.in $(common-objpfx)soversions.mk \
+ 
+ $(objpfx)sprof: $(libdl)
+ 
++$(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
++
+ $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
+ 
+ $(objpfx)pldd: $(pldd-modules:%=$(objpfx)%.o)
+diff --git a/elf/static-stubs.c b/elf/static-stubs.c
+new file mode 100644
+index 0000000000..6c5eebc3fb
+--- /dev/null
++++ b/elf/static-stubs.c
+@@ -0,0 +1,46 @@
++/* Stub implementations of functions to link into statically linked
++   programs without needing libgcc_eh.
++   Copyright (C) 2012 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
++   sysdeps/unix/sysv/linux/libc_fatal.c.  */
++#include <sysdeps/posix/libc_fatal.c>
++
++#include <stdlib.h>
++#include <unwind.h>
++
++/* These programs do not use thread cancellation, so _Unwind_Resume
++   and the personality routine are never actually called.  */
++
++void
++_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
++{
++  abort ();
++}
++
++_Unwind_Reason_Code
++__gcc_personality_v0 (int version __attribute__ ((unused)),
++		      _Unwind_Action actions __attribute__ ((unused)),
++		      _Unwind_Exception_Class exception_class
++		      __attribute__ ((unused)),
++		      struct _Unwind_Exception *ue_header
++		      __attribute__ ((unused)),
++		      struct _Unwind_Context *context __attribute__ ((unused)))
++{
++  abort ();
++}
+-- 
+2.39.2
+

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.16.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.16.patch
@@ -4,7 +4,7 @@ Date: Tue, 3 Jul 2012 19:14:59 +0000
 Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
 
 diff --git a/Makeconfig b/Makeconfig
-index 417fa508a6..859b588e00 100644
+index 417fa508a6..c860e68cdd 100644
 --- a/Makeconfig
 +++ b/Makeconfig
 @@ -415,9 +415,9 @@ LDFLAGS.so += $(hashstyle-LDFLAGS)
@@ -77,51 +77,15 @@ index 417fa508a6..859b588e00 100644
  endif
  endif
  
-@@ -513,8 +524,43 @@ endif
+@@ -513,6 +524,7 @@ endif
  
  # The static libraries.
  link-libc-static = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib) -Wl,--end-group
 +link-libc-static-tests = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib-tests) -Wl,--end-group
  link-libc-bounded = $(common-objpfx)libc_b.a $(gnulib) $(common-objpfx)libc_b.a
  
-+# How to link against libgcc.  Some libgcc functions, such as those
-+# for "long long" arithmetic or software floating point, can always be
-+# built without use of C library headers and do not have any global
-+# state so can safely be linked statically into any executable or
-+# shared library requiring them; these functions are in libgcc.a.
-+# Other functions, relating to exception handling, may require C
-+# library headers to build and it may not be safe to have more than
-+# one copy of them in a process; these functions are only in
-+# libgcc_s.so and libgcc_eh.a.
-+#
-+# To avoid circular dependencies when bootstrapping, it is desirable
-+# to avoid use of libgcc_s and libgcc_eh in building glibc.  Where any
-+# glibc functionality (in particular, thread cancellation) requires
-+# exception handling, this is implemented through dlopen of libgcc_s
-+# to avoid unnecessary dependencies on libgcc_s by programs not using
-+# that functionality; executables built with glibc do not use
-+# exception handling other than through thread cancellation.
-+#
-+# Undefined references to functions from libgcc_eh or libgcc_s may
-+# arise for code built with -fexceptions.  In the case of statically
-+# linked programs installed by glibc, unwinding will never actually
-+# occur at runtime and the use of elf/static-stubs.c to resolve these
-+# references is safe.  In the case of statically linked test programs
-+# and test programs built with -fexceptions, unwinding may occur in
-+# some cases and it is preferable to link with libgcc_eh or libgcc_s
-+# so that the testing is as similar as possible to how programs will
-+# be built with the installed glibc.
-+#
-+# Some architectures have architecture-specific systems for exception
-+# handling that may involve undefined references to
-+# architecture-specific functions.  On those architectures,
-+# gnulib-arch and static-gnulib-arch may be defined in sysdeps
-+# makefiles to use additional libraries for linking executables and
-+# shared libraries built by glibc.
  ifndef gnulib
- ifneq ($(have-cc-with-libunwind),yes)
-   libunwind =
-@@ -522,8 +568,12 @@ else
+@@ -522,8 +534,12 @@ else
    libunwind = -lunwind
  endif
  libgcc_eh := -Wl,--as-needed -lgcc_s $(libunwind) -Wl,--no-as-needed
@@ -137,10 +101,10 @@ index 417fa508a6..859b588e00 100644
  endif
  +preinit = $(addprefix $(csu-objpfx),crti.o)
 diff --git a/Rules b/Rules
-index 3c61a2933b..17d938e39c 100644
+index 3c61a2933b..be3a738574 100644
 --- a/Rules
 +++ b/Rules
-@@ -103,29 +102,46 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
+@@ -103,29 +103,46 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
  endif
  
  ifeq ($(build-programs),yes)
@@ -194,7 +158,7 @@ index 3c61a2933b..17d938e39c 100644
  ifneq "$(strip $(binaries-pie))" ""
  $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
    $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
-@@ -133,13 +149,20 @@ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
+@@ -133,13 +150,20 @@ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
  	$(+link-pie)
  endif
  

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-2.16.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-2.16.patch
@@ -3,17 +3,6 @@ From: Joseph Myers <joseph@codesourcery.com>
 Date: Tue, 3 Jul 2012 19:14:59 +0000
 Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
 
----
- ChangeLog                  | 47 ++++++++++++++++++++++++++
- Makeconfig                 | 68 +++++++++++++++++++++++++++++++++-----
- Rules                      | 45 +++++++++++++++++++------
- elf/Makefile               |  6 +++-
- elf/static-stubs.c         | 46 ++++++++++++++++++++++++++
- ports/ChangeLog.arm        |  7 ++++
- ports/sysdeps/arm/Makefile |  8 +++++
- 7 files changed, 206 insertions(+), 21 deletions(-)
- create mode 100644 elf/static-stubs.c
-
 diff --git a/Makeconfig b/Makeconfig
 index 417fa508a6..859b588e00 100644
 --- a/Makeconfig
@@ -259,56 +248,3 @@ index 0c26ce545a..90541991d2 100644
  $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
  
  $(objpfx)pldd: $(pldd-modules:%=$(objpfx)%.o)
-diff --git a/elf/static-stubs.c b/elf/static-stubs.c
-new file mode 100644
-index 0000000000..6c5eebc3fb
---- /dev/null
-+++ b/elf/static-stubs.c
-@@ -0,0 +1,46 @@
-+/* Stub implementations of functions to link into statically linked
-+   programs without needing libgcc_eh.
-+   Copyright (C) 2012 Free Software Foundation, Inc.
-+   This file is part of the GNU C Library.
-+
-+   The GNU C Library is free software; you can redistribute it and/or
-+   modify it under the terms of the GNU Lesser General Public
-+   License as published by the Free Software Foundation; either
-+   version 2.1 of the License, or (at your option) any later version.
-+
-+   The GNU C Library is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-+   Lesser General Public License for more details.
-+
-+   You should have received a copy of the GNU Lesser General Public
-+   License along with the GNU C Library; if not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
-+   sysdeps/unix/sysv/linux/libc_fatal.c.  */
-+#include <sysdeps/posix/libc_fatal.c>
-+
-+#include <stdlib.h>
-+#include <unwind.h>
-+
-+/* These programs do not use thread cancellation, so _Unwind_Resume
-+   and the personality routine are never actually called.  */
-+
-+void
-+_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-+
-+_Unwind_Reason_Code
-+__gcc_personality_v0 (int version __attribute__ ((unused)),
-+		      _Unwind_Action actions __attribute__ ((unused)),
-+		      _Unwind_Exception_Class exception_class
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Exception *ue_header
-+		      __attribute__ ((unused)),
-+		      struct _Unwind_Context *context __attribute__ ((unused)))
-+{
-+  abort ();
-+}
-

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a-stub.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a-stub.patch
@@ -1,0 +1,57 @@
+From 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 3 Jul 2012 19:14:59 +0000
+Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
+
+diff --git a/elf/static-stubs.c b/elf/static-stubs.c
+new file mode 100644
+index 0000000000..6c5eebc3fb
+--- /dev/null
++++ b/elf/static-stubs.c
+@@ -0,0 +1,46 @@
++/* Stub implementations of functions to link into statically linked
++   programs without needing libgcc_eh.
++   Copyright (C) 2012 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
++   sysdeps/unix/sysv/linux/libc_fatal.c.  */
++#include <sysdeps/posix/libc_fatal.c>
++
++#include <stdlib.h>
++#include <unwind.h>
++
++/* These programs do not use thread cancellation, so _Unwind_Resume
++   and the personality routine are never actually called.  */
++
++void
++_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
++{
++  abort ();
++}
++
++_Unwind_Reason_Code
++__gcc_personality_v0 (int version __attribute__ ((unused)),
++		      _Unwind_Action actions __attribute__ ((unused)),
++		      _Unwind_Exception_Class exception_class
++		      __attribute__ ((unused)),
++		      struct _Unwind_Exception *ue_header
++		      __attribute__ ((unused)),
++		      struct _Unwind_Context *context __attribute__ ((unused)))
++{
++  abort ();
++}

--- a/var/spack/repos/builtin/packages/glibc/95f5a9a.patch
+++ b/var/spack/repos/builtin/packages/glibc/95f5a9a.patch
@@ -1,0 +1,314 @@
+From 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7 Mon Sep 17 00:00:00 2001
+From: Joseph Myers <joseph@codesourcery.com>
+Date: Tue, 3 Jul 2012 19:14:59 +0000
+Subject: [PATCH] Avoid use of libgcc_s and libgcc_eh when building glibc.
+
+---
+ ChangeLog                  | 47 ++++++++++++++++++++++++++
+ Makeconfig                 | 68 +++++++++++++++++++++++++++++++++-----
+ Rules                      | 45 +++++++++++++++++++------
+ elf/Makefile               |  6 +++-
+ elf/static-stubs.c         | 46 ++++++++++++++++++++++++++
+ ports/ChangeLog.arm        |  7 ++++
+ ports/sysdeps/arm/Makefile |  8 +++++
+ 7 files changed, 206 insertions(+), 21 deletions(-)
+ create mode 100644 elf/static-stubs.c
+
+diff --git a/Makeconfig b/Makeconfig
+index 417fa508a6..859b588e00 100644
+--- a/Makeconfig
++++ b/Makeconfig
+@@ -415,9 +415,9 @@ LDFLAGS.so += $(hashstyle-LDFLAGS)
+ LDFLAGS-rtld += $(hashstyle-LDFLAGS)
+ endif
+ 
+-# Command for linking programs with the C library.
++# Commands for linking programs with the C library.
+ ifndef +link
+-+link = $(CC) -nostdlib -nostartfiles -o $@ \
+++link-before-libc = $(CC) -nostdlib -nostartfiles -o $@ \
+ 	      $(sysdep-LDFLAGS) $(config-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F)) \
+ 	      $(combreloc-LDFLAGS) $(relro-LDFLAGS) $(hashstyle-LDFLAGS) \
+ 	      $(addprefix $(csu-objpfx),$(start-installed-name)) \
+@@ -426,7 +426,10 @@ ifndef +link
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs) $(link-libc) $(+postctor) $(+postinit)
++	      $(link-extra-libs)
+++link-after-libc = $(+postctor) $(+postinit)
+++link = $(+link-before-libc) $(link-libc) $(+link-after-libc)
+++link-tests = $(+link-before-libc) $(link-libc-tests) $(+link-after-libc)
+ endif
+ # Command for linking PIE programs with the C library.
+ ifndef +link-pie
+@@ -443,7 +446,7 @@ ifndef +link-pie
+ endif
+ # Command for statically linking programs with the C library.
+ ifndef +link-static
+-+link-static = $(CC) -nostdlib -nostartfiles -static -o $@ \
+++link-static-before-libc = $(CC) -nostdlib -nostartfiles -static -o $@ \
+ 	      $(sysdep-LDFLAGS) $(LDFLAGS) $(LDFLAGS-$(@F))  \
+ 	      $(addprefix $(csu-objpfx),$(static-start-installed-name)) \
+ 	      $(+preinit) $(+prector) \
+@@ -451,7 +454,12 @@ ifndef +link-static
+ 						     $(start-installed-name))\
+ 			   $(+preinit) $(link-extra-libs-static) \
+ 			   $(common-objpfx)libc% $(+postinit),$^) \
+-	      $(link-extra-libs-static) $(link-libc-static) $(+postctor) $(+postinit)
++	      $(link-extra-libs-static) $(link-libc-static)
+++link-static-after-libc = $(+postctor) $(+postinit)
+++link-static = $(+link-static-before-libc) $(link-libc-static) \
++	       $(+link-static-after-libc)
+++link-static-tests = $(+link-static-before-libc) $(link-libc-static-tests) \
++		     $(+link-static-after-libc)
+ endif
+ # Command for statically linking bounded-pointer programs with the C library.
+ ifndef +link-bounded
+@@ -475,10 +483,12 @@ ifeq (yes,$(build-shared))
+ # We need the versioned name of libc.so in the deps of $(others) et al
+ # so that the symlink to libc.so is created before anything tries to
+ # run the linked programs.
+-link-libc = -Wl,-rpath-link=$(rpath-link) \
++link-libc-before-gnulib = -Wl,-rpath-link=$(rpath-link) \
+ 	    $(common-objpfx)libc.so$(libc.so-version) \
+ 	    $(common-objpfx)$(patsubst %,$(libtype.oS),c) \
+-	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed) $(gnulib)
++	    $(as-needed) $(common-objpfx)elf/ld.so $(no-as-needed)
++link-libc = $(link-libc-before-gnulib) $(gnulib)
++link-libc-tests = $(link-libc-before-gnulib) $(gnulib-tests)
+ # This is how to find at build-time things that will be installed there.
+ rpath-dirs = math elf dlfcn nss nis rt resolv crypt
+ rpath-link = \
+@@ -488,6 +498,7 @@ else
+ nssobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)nss)
+ resolvobjdir := $(patsubst ../$(subdir),.,$(common-objpfx)resolv)
+ link-libc = $(common-objpfx)libc.a $(otherlibs) $(gnulib) $(common-objpfx)libc.a $(gnulib)
++link-libc-tests = $(common-objpfx)libc.a $(otherlibs) $(gnulib-tests) $(common-objpfx)libc.a $(gnulib-tests)
+ endif
+ endif
+ 
+@@ -513,8 +524,43 @@ endif
+ 
+ # The static libraries.
+ link-libc-static = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib) -Wl,--end-group
++link-libc-static-tests = -Wl,--start-group $(common-objpfx)libc.a $(static-gnulib-tests) -Wl,--end-group
+ link-libc-bounded = $(common-objpfx)libc_b.a $(gnulib) $(common-objpfx)libc_b.a
+ 
++# How to link against libgcc.  Some libgcc functions, such as those
++# for "long long" arithmetic or software floating point, can always be
++# built without use of C library headers and do not have any global
++# state so can safely be linked statically into any executable or
++# shared library requiring them; these functions are in libgcc.a.
++# Other functions, relating to exception handling, may require C
++# library headers to build and it may not be safe to have more than
++# one copy of them in a process; these functions are only in
++# libgcc_s.so and libgcc_eh.a.
++#
++# To avoid circular dependencies when bootstrapping, it is desirable
++# to avoid use of libgcc_s and libgcc_eh in building glibc.  Where any
++# glibc functionality (in particular, thread cancellation) requires
++# exception handling, this is implemented through dlopen of libgcc_s
++# to avoid unnecessary dependencies on libgcc_s by programs not using
++# that functionality; executables built with glibc do not use
++# exception handling other than through thread cancellation.
++#
++# Undefined references to functions from libgcc_eh or libgcc_s may
++# arise for code built with -fexceptions.  In the case of statically
++# linked programs installed by glibc, unwinding will never actually
++# occur at runtime and the use of elf/static-stubs.c to resolve these
++# references is safe.  In the case of statically linked test programs
++# and test programs built with -fexceptions, unwinding may occur in
++# some cases and it is preferable to link with libgcc_eh or libgcc_s
++# so that the testing is as similar as possible to how programs will
++# be built with the installed glibc.
++#
++# Some architectures have architecture-specific systems for exception
++# handling that may involve undefined references to
++# architecture-specific functions.  On those architectures,
++# gnulib-arch and static-gnulib-arch may be defined in sysdeps
++# makefiles to use additional libraries for linking executables and
++# shared libraries built by glibc.
+ ifndef gnulib
+ ifneq ($(have-cc-with-libunwind),yes)
+   libunwind =
+@@ -522,8 +568,12 @@ else
+   libunwind = -lunwind
+ endif
+ libgcc_eh := -Wl,--as-needed -lgcc_s $(libunwind) -Wl,--no-as-needed
+-gnulib := -lgcc $(libgcc_eh)
+-static-gnulib := -lgcc -lgcc_eh $(libunwind)
++gnulib-arch =
++gnulib = -lgcc $(gnulib-arch)
++gnulib-tests := -lgcc $(libgcc_eh)
++static-gnulib-arch =
++static-gnulib = -lgcc $(static-gnulib-arch)
++static-gnulib-tests := -lgcc -lgcc_eh $(libunwind)
+ libc.so-gnulib := -lgcc
+ endif
+ +preinit = $(addprefix $(csu-objpfx),crti.o)
+diff --git a/Rules b/Rules
+index 3c61a2933b..17d938e39c 100644
+--- a/Rules
++++ b/Rules
+@@ -103,29 +102,46 @@ xtests: tests $(xtests:%=$(objpfx)%.out) $(xtests-bp.out)
+ endif
+ 
+ ifeq ($(build-programs),yes)
+-binaries-all = $(others) $(sysdep-others) $(tests) $(xtests) $(test-srcs)
+-binaries-static = $(others-static) $(tests-static) $(xtests-static)
++binaries-all-notests = $(others) $(sysdep-others)
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-notests) $(binaries-all-tests)
++binaries-static-notests = $(others-static)
++binaries-static-tests = $(tests-static) $(xtests-static)
++binaries-static = $(binaries-static-notests) $(binaries-static-tests)
+ ifeq (yesyes,$(have-fpie)$(build-shared))
+ binaries-pie = $(others-pie) $(tests-pie) $(xtests-pie)
+ else
+ binaries-pie =
+ endif
+ else
+-binaries-all = $(tests) $(xtests) $(test-srcs)
++binaries-all-notests =
++binaries-all-tests = $(tests) $(xtests) $(test-srcs)
++binaries-all = $(binaries-all-tests)
++binaries-static-notests =
++binaries-static-tests =
+ binaries-static =
+ binaries-pie =
+ endif
+ 
+-binaries-shared = $(filter-out $(binaries-pie) $(binaries-static), \
+-			       $(binaries-all))
++binaries-shared-tests = $(filter-out $(binaries-pie) $(binaries-static), \
++				     $(binaries-all-tests))
++binaries-shared-notests = $(filter-out $(binaries-pie) $(binaries-static), \
++				       $(binaries-all-notests))
+ 
+-ifneq "$(strip $(binaries-shared))" ""
+-$(addprefix $(objpfx),$(binaries-shared)): %: %.o \
++ifneq "$(strip $(binaries-shared-notests))" ""
++$(addprefix $(objpfx),$(binaries-shared-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link)
+ endif
+ 
++ifneq "$(strip $(binaries-shared-tests))" ""
++$(addprefix $(objpfx),$(binaries-shared-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-tests)
++endif
++
+ ifneq "$(strip $(binaries-pie))" ""
+ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc))) \
+@@ -133,13 +149,20 @@ $(addprefix $(objpfx),$(binaries-pie)): %: %.o \
+ 	$(+link-pie)
+ endif
+ 
+-ifneq "$(strip $(binaries-static))" ""
+-$(addprefix $(objpfx),$(binaries-static)): %: %.o \
++ifneq "$(strip $(binaries-static-notests))" ""
++$(addprefix $(objpfx),$(binaries-static-notests)): %: %.o \
+   $(sort $(filter $(common-objpfx)lib%,$(link-libc-static))) \
+   $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
+ 	$(+link-static)
+ endif
+ 
++ifneq "$(strip $(binaries-static-tests))" ""
++$(addprefix $(objpfx),$(binaries-static-tests)): %: %.o \
++  $(sort $(filter $(common-objpfx)lib%,$(link-libc-static-tests))) \
++  $(addprefix $(csu-objpfx),start.o) $(+preinit) $(+postinit)
++	$(+link-static-tests)
++endif
++
+ ifeq ($(build-bounded),yes)
+ binaries-bounded = $(addsuffix -bp,$(tests) $(xtests) $(test-srcs))
+ $(addprefix $(objpfx),$(binaries-bounded)): %-bp: %.ob \
+diff --git a/elf/Makefile b/elf/Makefile
+index 0c26ce545a..90541991d2 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -71,6 +71,8 @@ others		= sprof sln pldd
+ install-bin	= sprof pldd
+ others-static   = sln
+ install-rootsbin = sln
++sln-modules	:= static-stubs
++extra-objs	+= $(sln-modules:=.o)
+ 
+ ifeq (yes,$(use-ldconfig))
+ ifeq (yes,$(build-shared))
+@@ -78,7 +80,7 @@ others-static	+= ldconfig
+ others		+= ldconfig
+ install-rootsbin += ldconfig
+ 
+-ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon
++ldconfig-modules := cache readlib xmalloc xstrdup chroot_canon static-stubs
+ extra-objs	+= $(ldconfig-modules:=.o)
+ endif
+ endif
+@@ -411,6 +413,8 @@ $(objpfx)ldd: ldd.bash.in $(common-objpfx)soversions.mk \
+ 
+ $(objpfx)sprof: $(libdl)
+ 
++$(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
++
+ $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
+ 
+ $(objpfx)pldd: $(pldd-modules:%=$(objpfx)%.o)
+diff --git a/elf/static-stubs.c b/elf/static-stubs.c
+new file mode 100644
+index 0000000000..6c5eebc3fb
+--- /dev/null
++++ b/elf/static-stubs.c
+@@ -0,0 +1,46 @@
++/* Stub implementations of functions to link into statically linked
++   programs without needing libgcc_eh.
++   Copyright (C) 2012 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Avoid backtrace (and so _Unwind_Backtrace) dependencies from
++   sysdeps/unix/sysv/linux/libc_fatal.c.  */
++#include <sysdeps/posix/libc_fatal.c>
++
++#include <stdlib.h>
++#include <unwind.h>
++
++/* These programs do not use thread cancellation, so _Unwind_Resume
++   and the personality routine are never actually called.  */
++
++void
++_Unwind_Resume (struct _Unwind_Exception *exc __attribute__ ((unused)))
++{
++  abort ();
++}
++
++_Unwind_Reason_Code
++__gcc_personality_v0 (int version __attribute__ ((unused)),
++		      _Unwind_Action actions __attribute__ ((unused)),
++		      _Unwind_Exception_Class exception_class
++		      __attribute__ ((unused)),
++		      struct _Unwind_Exception *ue_header
++		      __attribute__ ((unused)),
++		      struct _Unwind_Context *context __attribute__ ((unused)))
++{
++  abort ();
++}
+

--- a/var/spack/repos/builtin/packages/glibc/965cb60-2.5.patch
+++ b/var/spack/repos/builtin/packages/glibc/965cb60-2.5.patch
@@ -1,0 +1,176 @@
+diff --git a/csu/libc-start.c b/csu/libc-start.c
+index 194db6b1ec..f85ec9604e 100644
+--- a/csu/libc-start.c
++++ b/csu/libc-start.c
+@@ -151,8 +151,8 @@ LIBC_START_MAIN (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
+ 
+ # ifndef SHARED
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
+-#  ifdef THREAD_SET_STACK_GUARD
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
++# ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #  else
+   __stack_chk_guard = stack_chk_guard;
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 4b7be6bc27..f62867abf1 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -84,6 +84,9 @@ struct r_scope_elem _dl_initial_searchlist;
+ int _dl_starting_up = 1;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++void *_dl_random;
++
+ /* Get architecture specific initializer.  */
+ #include <dl-procinfo.c>
+ 
+@@ -218,6 +221,9 @@ _dl_aux_init (ElfW(auxv_t) *av)
+ 	__libc_enable_secure = av->a_un.a_val;
+ 	__libc_enable_secure_decided = 1;
+ 	break;
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+       }
+   if (seen == 0xf)
+     {
+diff --git a/elf/dl-sysdep.c b/elf/dl-sysdep.c
+index 68e08f480a..133ba0d29f 100644
+--- a/elf/dl-sysdep.c
++++ b/elf/dl-sysdep.c
+@@ -62,6 +62,7 @@ int __libc_multiple_libcs = 0;	/* Defining this here avoids the inclusion
+ void *__libc_stack_end attribute_relro = NULL;
+ rtld_hidden_data_def(__libc_stack_end)
+ static ElfW(auxv_t) *_dl_auxv attribute_relro;
++void *_dl_random attribute_relro = NULL;
+ 
+ #ifndef DL_FIND_ARG_COMPONENTS
+ # define DL_FIND_ARG_COMPONENTS(cookie, argc, argv, envp, auxp)	\
+@@ -173,6 +174,9 @@ _dl_sysdep_start (void **start_argptr,
+ 	GLRO(dl_sysinfo_dso) = (void *) av->a_un.a_val;
+ 	break;
+ #endif
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ #ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ #endif
+@@ -293,6 +297,7 @@ _dl_show_auxv (void)
+ 	  [AT_SECURE - 2] =		{ "AT_SECURE:       ", dec },
+ 	  [AT_SYSINFO - 2] =		{ "AT_SYSINFO:      0x", hex },
+ 	  [AT_SYSINFO_EHDR - 2] =	{ "AT_SYSINFO_EHDR: 0x", hex },
++	  [AT_RANDOM - 2] =		{ "AT_RANDOM:       0x", hex },
+ 	};
+       unsigned int idx = (unsigned int) (av->a_type - 2);
+ 
+diff --git a/elf/rtld.c b/elf/rtld.c
+index a357a46987..a02a319677 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -1837,7 +1837,7 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
+ #endif
+ 
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ #ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #else
+diff --git a/sysdeps/generic/dl-osinfo.h b/sysdeps/generic/dl-osinfo.h
+index 60b84a900d..02ec28d424 100644
+--- a/sysdeps/generic/dl-osinfo.h
++++ b/sysdeps/generic/dl-osinfo.h
+@@ -1,12 +1,29 @@
+ #include <stdint.h>
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+-  uintptr_t ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
+-  p[0] = 0;
++  uintptr_t ret;
++  if (dl_random == NULL)
++    {
++      ret = 0;
++      unsigned char *p = (unsigned char *) &ret;
++      p[sizeof (ret) - 1] = 255;
++      p[sizeof (ret) - 2] = '\n';
++      p[0] = 0;
++    }
++  else
++    memcmp (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++  if (dl_random == NULL)
++    ret = stack_chk_guard;
++  else
++    memcmp (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index eee6141c6a..54789c0639 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -740,6 +740,9 @@ weak_extern (_dl_starting_up)
+ extern int _dl_starting_up_internal attribute_hidden;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++extern void *_dl_random attribute_hidden;
++
+ /* OS-dependent function to open the zero-fill device.  */
+ extern int _dl_sysdep_open_zero_fill (void); /* dl-sysdep.c */
+ 
+diff --git a/sysdeps/unix/sysv/linux/dl-osinfo.h b/sysdeps/unix/sysv/linux/dl-osinfo.h
+index 0738501a56..d796651ff4 100644
+--- a/sysdeps/unix/sysv/linux/dl-osinfo.h
++++ b/sysdeps/unix/sysv/linux/dl-osinfo.h
+@@ -159,22 +159,20 @@ _dl_discover_osversion (void)
+   } while (0)
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+   uintptr_t ret;
+-#ifdef ENABLE_STACKGUARD_RANDOMIZE
+-  int fd = __open ("/dev/urandom", O_RDONLY);
+-  if (fd >= 0)
+-    {
+-      ssize_t reslen = __read (fd, &ret, sizeof (ret));
+-      __close (fd);
+-      if (reslen == (ssize_t) sizeof (ret))
+-	return ret;
+-    }
+-#endif
+-  ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
++    /* We need in the moment only 8 bytes on 32-bit platforms and 16
++       bytes on 64-bit platforms.  Therefore we can use the data
++       directly and not use the kernel-provided data to seed a PRNG.  */
++    memcpy (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++    memcpy (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }

--- a/var/spack/repos/builtin/packages/glibc/965cb60-2.6.patch
+++ b/var/spack/repos/builtin/packages/glibc/965cb60-2.6.patch
@@ -1,0 +1,176 @@
+diff --git a/csu/libc-start.c b/csu/libc-start.c
+index 0ed993651e..a8b1be8c7d 100644
+--- a/csu/libc-start.c
++++ b/csu/libc-start.c
+@@ -142,8 +142,8 @@ LIBC_START_MAIN (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
+ 
+ # ifndef SHARED
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
+-#  ifdef THREAD_SET_STACK_GUARD
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
++# ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #  else
+   __stack_chk_guard = stack_chk_guard;
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 2c11ac6881..321ed07a18 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -84,6 +84,9 @@ struct r_scope_elem _dl_initial_searchlist;
+ int _dl_starting_up = 1;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++void *_dl_random;
++
+ /* Get architecture specific initializer.  */
+ #include <dl-procinfo.c>
+ 
+@@ -216,6 +219,9 @@ _dl_aux_init (ElfW(auxv_t) *av)
+ 	__libc_enable_secure = av->a_un.a_val;
+ 	__libc_enable_secure_decided = 1;
+ 	break;
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ # ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ # endif
+diff --git a/elf/dl-sysdep.c b/elf/dl-sysdep.c
+index 85e331a90f..6ce20b5150 100644
+--- a/elf/dl-sysdep.c
++++ b/elf/dl-sysdep.c
+@@ -62,6 +62,7 @@ int __libc_multiple_libcs = 0;	/* Defining this here avoids the inclusion
+ void *__libc_stack_end attribute_relro = NULL;
+ rtld_hidden_data_def(__libc_stack_end)
+ static ElfW(auxv_t) *_dl_auxv attribute_relro;
++void *_dl_random attribute_relro = NULL;
+ 
+ #ifndef DL_FIND_ARG_COMPONENTS
+ # define DL_FIND_ARG_COMPONENTS(cookie, argc, argv, envp, auxp)	\
+@@ -173,6 +174,9 @@ _dl_sysdep_start (void **start_argptr,
+ 	GLRO(dl_sysinfo_dso) = (void *) av->a_un.a_val;
+ 	break;
+ #endif
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ #ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ #endif
+@@ -293,6 +297,7 @@ _dl_show_auxv (void)
+ 	  [AT_SECURE - 2] =		{ "AT_SECURE:       ", dec },
+ 	  [AT_SYSINFO - 2] =		{ "AT_SYSINFO:      0x", hex },
+ 	  [AT_SYSINFO_EHDR - 2] =	{ "AT_SYSINFO_EHDR: 0x", hex },
++	  [AT_RANDOM - 2] =		{ "AT_RANDOM:       0x", hex },
+ 	};
+       unsigned int idx = (unsigned int) (av->a_type - 2);
+ 
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 7612a69324..e77ac43713 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -1816,7 +1816,7 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
+     tcbp = init_tls ();
+ 
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ #ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #else
+diff --git a/sysdeps/generic/dl-osinfo.h b/sysdeps/generic/dl-osinfo.h
+index 60b84a900d..02ec28d424 100644
+--- a/sysdeps/generic/dl-osinfo.h
++++ b/sysdeps/generic/dl-osinfo.h
+@@ -1,12 +1,29 @@
+ #include <stdint.h>
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+-  uintptr_t ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
+-  p[0] = 0;
++  uintptr_t ret;
++  if (dl_random == NULL)
++    {
++      ret = 0;
++      unsigned char *p = (unsigned char *) &ret;
++      p[sizeof (ret) - 1] = 255;
++      p[sizeof (ret) - 2] = '\n';
++      p[0] = 0;
++    }
++  else
++    memcmp (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++  if (dl_random == NULL)
++    ret = stack_chk_guard;
++  else
++    memcmp (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index aefd105f0a..929b91b56c 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -726,6 +726,9 @@ weak_extern (_dl_starting_up)
+ extern int _dl_starting_up_internal attribute_hidden;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++extern void *_dl_random attribute_hidden;
++
+ /* OS-dependent function to open the zero-fill device.  */
+ extern int _dl_sysdep_open_zero_fill (void); /* dl-sysdep.c */
+ 
+diff --git a/sysdeps/unix/sysv/linux/dl-osinfo.h b/sysdeps/unix/sysv/linux/dl-osinfo.h
+index 0738501a56..d796651ff4 100644
+--- a/sysdeps/unix/sysv/linux/dl-osinfo.h
++++ b/sysdeps/unix/sysv/linux/dl-osinfo.h
+@@ -159,22 +159,20 @@ _dl_discover_osversion (void)
+   } while (0)
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+   uintptr_t ret;
+-#ifdef ENABLE_STACKGUARD_RANDOMIZE
+-  int fd = __open ("/dev/urandom", O_RDONLY);
+-  if (fd >= 0)
+-    {
+-      ssize_t reslen = __read (fd, &ret, sizeof (ret));
+-      __close (fd);
+-      if (reslen == (ssize_t) sizeof (ret))
+-	return ret;
+-    }
+-#endif
+-  ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
++    /* We need in the moment only 8 bytes on 32-bit platforms and 16
++       bytes on 64-bit platforms.  Therefore we can use the data
++       directly and not use the kernel-provided data to seed a PRNG.  */
++    memcpy (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++    memcpy (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }

--- a/var/spack/repos/builtin/packages/glibc/965cb60-2.7.patch
+++ b/var/spack/repos/builtin/packages/glibc/965cb60-2.7.patch
@@ -1,0 +1,174 @@
+diff --git a/csu/libc-start.c b/csu/libc-start.c
+index a14ed71616..8b3f436f46 100644
+--- a/csu/libc-start.c
++++ b/csu/libc-start.c
+@@ -140,7 +140,7 @@ LIBC_START_MAIN (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
+   __pthread_initialize_minimal ();
+ 
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ # ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ # else
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 2c11ac6881..321ed07a18 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -84,6 +84,9 @@ struct r_scope_elem _dl_initial_searchlist;
+ int _dl_starting_up = 1;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++void *_dl_random;
++
+ /* Get architecture specific initializer.  */
+ #include <dl-procinfo.c>
+ 
+@@ -216,6 +219,9 @@ _dl_aux_init (ElfW(auxv_t) *av)
+ 	__libc_enable_secure = av->a_un.a_val;
+ 	__libc_enable_secure_decided = 1;
+ 	break;
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ # ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ # endif
+diff --git a/elf/dl-sysdep.c b/elf/dl-sysdep.c
+index 85e331a90f..6ce20b5150 100644
+--- a/elf/dl-sysdep.c
++++ b/elf/dl-sysdep.c
+@@ -62,6 +62,7 @@ int __libc_multiple_libcs = 0;	/* Defining this here avoids the inclusion
+ void *__libc_stack_end attribute_relro = NULL;
+ rtld_hidden_data_def(__libc_stack_end)
+ static ElfW(auxv_t) *_dl_auxv attribute_relro;
++void *_dl_random attribute_relro = NULL;
+ 
+ #ifndef DL_FIND_ARG_COMPONENTS
+ # define DL_FIND_ARG_COMPONENTS(cookie, argc, argv, envp, auxp)	\
+@@ -173,6 +174,9 @@ _dl_sysdep_start (void **start_argptr,
+ 	GLRO(dl_sysinfo_dso) = (void *) av->a_un.a_val;
+ 	break;
+ #endif
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ #ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ #endif
+@@ -293,6 +297,7 @@ _dl_show_auxv (void)
+ 	  [AT_SECURE - 2] =		{ "AT_SECURE:       ", dec },
+ 	  [AT_SYSINFO - 2] =		{ "AT_SYSINFO:      0x", hex },
+ 	  [AT_SYSINFO_EHDR - 2] =	{ "AT_SYSINFO_EHDR: 0x", hex },
++	  [AT_RANDOM - 2] =		{ "AT_RANDOM:       0x", hex },
+ 	};
+       unsigned int idx = (unsigned int) (av->a_type - 2);
+ 
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 7612a69324..e77ac43713 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -1816,7 +1816,7 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
+     tcbp = init_tls ();
+ 
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ #ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #else
+diff --git a/sysdeps/generic/dl-osinfo.h b/sysdeps/generic/dl-osinfo.h
+index 60b84a900d..02ec28d424 100644
+--- a/sysdeps/generic/dl-osinfo.h
++++ b/sysdeps/generic/dl-osinfo.h
+@@ -1,12 +1,29 @@
+ #include <stdint.h>
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+-  uintptr_t ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
+-  p[0] = 0;
++  uintptr_t ret;
++  if (dl_random == NULL)
++    {
++      ret = 0;
++      unsigned char *p = (unsigned char *) &ret;
++      p[sizeof (ret) - 1] = 255;
++      p[sizeof (ret) - 2] = '\n';
++      p[0] = 0;
++    }
++  else
++    memcmp (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++  if (dl_random == NULL)
++    ret = stack_chk_guard;
++  else
++    memcmp (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index 958a099b82..c4d2874085 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -726,6 +726,9 @@ weak_extern (_dl_starting_up)
+ extern int _dl_starting_up_internal attribute_hidden;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++extern void *_dl_random attribute_hidden;
++
+ /* OS-dependent function to open the zero-fill device.  */
+ extern int _dl_sysdep_open_zero_fill (void); /* dl-sysdep.c */
+ 
+diff --git a/sysdeps/unix/sysv/linux/dl-osinfo.h b/sysdeps/unix/sysv/linux/dl-osinfo.h
+index 082790f63b..d90f228942 100644
+--- a/sysdeps/unix/sysv/linux/dl-osinfo.h
++++ b/sysdeps/unix/sysv/linux/dl-osinfo.h
+@@ -154,22 +154,20 @@ _dl_discover_osversion (void)
+   } while (0)
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+   uintptr_t ret;
+-#ifdef ENABLE_STACKGUARD_RANDOMIZE
+-  int fd = __open ("/dev/urandom", O_RDONLY);
+-  if (fd >= 0)
+-    {
+-      ssize_t reslen = __read (fd, &ret, sizeof (ret));
+-      __close (fd);
+-      if (reslen == (ssize_t) sizeof (ret))
+-	return ret;
+-    }
+-#endif
+-  ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
++    /* We need in the moment only 8 bytes on 32-bit platforms and 16
++       bytes on 64-bit platforms.  Therefore we can use the data
++       directly and not use the kernel-provided data to seed a PRNG.  */
++    memcpy (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++    memcpy (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }

--- a/var/spack/repos/builtin/packages/glibc/965cb60.patch
+++ b/var/spack/repos/builtin/packages/glibc/965cb60.patch
@@ -1,0 +1,205 @@
+From 965cb60a21674edb8e20b1a2a41297bcd4622361 Mon Sep 17 00:00:00 2001
+From: Ulrich Drepper <drepper@redhat.com>
+Date: Sun, 11 Jan 2009 04:44:06 +0000
+Subject: [PATCH] * sysdeps/generic/dl-osinfo.h (_dl_setup_stack_chk_guard)
+
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 6bd573ec57..7b3ccf3d4d 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -84,6 +84,9 @@ struct r_scope_elem _dl_initial_searchlist;
+ int _dl_starting_up = 1;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++void *_dl_random;
++
+ /* Get architecture specific initializer.  */
+ #include <dl-procinfo.c>
+ 
+@@ -216,6 +219,9 @@ _dl_aux_init (ElfW(auxv_t) *av)
+ 	__libc_enable_secure = av->a_un.a_val;
+ 	__libc_enable_secure_decided = 1;
+ 	break;
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ # ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ # endif
+diff --git a/elf/dl-sysdep.c b/elf/dl-sysdep.c
+index e6f4272a63..29ae895473 100644
+--- a/elf/dl-sysdep.c
++++ b/elf/dl-sysdep.c
+@@ -62,6 +62,7 @@ int __libc_multiple_libcs = 0;	/* Defining this here avoids the inclusion
+ void *__libc_stack_end attribute_relro = NULL;
+ rtld_hidden_data_def(__libc_stack_end)
+ static ElfW(auxv_t) *_dl_auxv attribute_relro;
++void *_dl_random attribute_relro = NULL;
+ 
+ #ifndef DL_FIND_ARG_COMPONENTS
+ # define DL_FIND_ARG_COMPONENTS(cookie, argc, argv, envp, auxp)	\
+@@ -173,6 +174,9 @@ _dl_sysdep_start (void **start_argptr,
+ 	GLRO(dl_sysinfo_dso) = (void *) av->a_un.a_val;
+ 	break;
+ #endif
++      case AT_RANDOM:
++	_dl_random = (void *) av->a_un.a_val;
++	break;
+ #ifdef DL_PLATFORM_AUXV
+       DL_PLATFORM_AUXV
+ #endif
+@@ -294,6 +298,7 @@ _dl_show_auxv (void)
+ 	  [AT_SECURE - 2] =		{ "AT_SECURE:       ", dec },
+ 	  [AT_SYSINFO - 2] =		{ "AT_SYSINFO:      0x", hex },
+ 	  [AT_SYSINFO_EHDR - 2] =	{ "AT_SYSINFO_EHDR: 0x", hex },
++	  [AT_RANDOM - 2] =		{ "AT_RANDOM:       0x", hex },
+ 	};
+       unsigned int idx = (unsigned int) (av->a_type - 2);
+ 
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 46bece7fa3..60d414d637 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -841,7 +841,7 @@ static void
+ security_init (void)
+ {
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ #ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ #else
+@@ -851,18 +851,18 @@ security_init (void)
+   /* Set up the pointer guard as well, if necessary.  */
+   if (GLRO(dl_pointer_guard))
+     {
+-      // XXX If it is cheap, we should use a separate value.
+-      uintptr_t pointer_chk_guard = stack_chk_guard;
+-#ifndef HP_TIMING_NONAVAIL
+-      hp_timing_t now;
+-      HP_TIMING_NOW (now);
+-      pointer_chk_guard ^= now;
+-#endif
++      uintptr_t pointer_chk_guard = _dl_setup_pointer_guard (_dl_random,
++							     stack_chk_guard);
+ #ifdef THREAD_SET_POINTER_GUARD
+       THREAD_SET_POINTER_GUARD (pointer_chk_guard);
+ #endif
+       __pointer_chk_guard_local = pointer_chk_guard;
+     }
++
++  /* We do not need the _dl_random value anymore.  The less
++     information we leave behind, the better, so clear the
++     variable.  */
++  _dl_random = NULL;
+ }
+ 
+ 
+diff --git a/sysdeps/generic/dl-osinfo.h b/sysdeps/generic/dl-osinfo.h
+index 60b84a900d..02ec28d424 100644
+--- a/sysdeps/generic/dl-osinfo.h
++++ b/sysdeps/generic/dl-osinfo.h
+@@ -1,12 +1,29 @@
+ #include <stdint.h>
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+-  uintptr_t ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
+-  p[0] = 0;
++  uintptr_t ret;
++  if (dl_random == NULL)
++    {
++      ret = 0;
++      unsigned char *p = (unsigned char *) &ret;
++      p[sizeof (ret) - 1] = 255;
++      p[sizeof (ret) - 2] = '\n';
++      p[0] = 0;
++    }
++  else
++    memcmp (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++  if (dl_random == NULL)
++    ret = stack_chk_guard;
++  else
++    memcmp (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index 4d857404a3..f5606f373f 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -731,6 +731,9 @@ weak_extern (_dl_starting_up)
+ extern int _dl_starting_up_internal attribute_hidden;
+ #endif
+ 
++/* Random data provided by the kernel.  */
++extern void *_dl_random attribute_hidden;
++
+ /* OS-dependent function to open the zero-fill device.  */
+ extern int _dl_sysdep_open_zero_fill (void); /* dl-sysdep.c */
+ 
+diff --git a/sysdeps/unix/sysv/linux/dl-osinfo.h b/sysdeps/unix/sysv/linux/dl-osinfo.h
+index 5271d4e4de..ee8eaf20e4 100644
+--- a/sysdeps/unix/sysv/linux/dl-osinfo.h
++++ b/sysdeps/unix/sysv/linux/dl-osinfo.h
+@@ -60,22 +60,20 @@ dl_fatal (const char *str)
+   } while (0)
+ 
+ static inline uintptr_t __attribute__ ((always_inline))
+-_dl_setup_stack_chk_guard (void)
++_dl_setup_stack_chk_guard (void *dl_random)
+ {
+   uintptr_t ret;
+-#ifdef ENABLE_STACKGUARD_RANDOMIZE
+-  int fd = __open ("/dev/urandom", O_RDONLY);
+-  if (fd >= 0)
+-    {
+-      ssize_t reslen = __read (fd, &ret, sizeof (ret));
+-      __close (fd);
+-      if (reslen == (ssize_t) sizeof (ret))
+-	return ret;
+-    }
+-#endif
+-  ret = 0;
+-  unsigned char *p = (unsigned char *) &ret;
+-  p[sizeof (ret) - 1] = 255;
+-  p[sizeof (ret) - 2] = '\n';
++    /* We need in the moment only 8 bytes on 32-bit platforms and 16
++       bytes on 64-bit platforms.  Therefore we can use the data
++       directly and not use the kernel-provided data to seed a PRNG.  */
++    memcpy (&ret, dl_random, sizeof (ret));
++  return ret;
++}
++
++static inline uintptr_t __attribute__ ((always_inline))
++_dl_setup_pointer_guard (void *dl_random, uintptr_t stack_chk_guard)
++{
++  uintptr_t ret;
++    memcpy (&ret, (char *) dl_random + sizeof (ret), sizeof (ret));
+   return ret;
+ }
+diff --git a/csu/libc-start.c b/csu/libc-start.c
+index a14ed71616a..80b672f88d8 100644
+--- a/csu/libc-start.c
++++ b/csu/libc-start.c
+@@ -140,7 +140,7 @@ LIBC_START_MAIN (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
+   __pthread_initialize_minimal ();
+ 
+   /* Set up the stack checker's canary.  */
+-  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard ();
++  uintptr_t stack_chk_guard = _dl_setup_stack_chk_guard (_dl_random);
+ # ifdef THREAD_SET_STACK_GUARD
+   THREAD_SET_STACK_GUARD (stack_chk_guard);
+ # else

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -75,6 +75,12 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # rpc/types.h include issue, should be from local version, not system.
     patch("fb21f89.patch", when="@:2.16")
 
+    # Avoid linking libgcc_eh
+    patch("95f5a9a.patch", when="@2.16")
+    patch("95f5a9a-2.15.patch", when="@2.14:2.15")
+    patch("95f5a9a-2.13.patch", when="@2.12:2.13")
+    patch("95f5a9a-2.11.patch", when="@:2.11")
+
     # Use init_array (modified commit 4a531bb to unconditionally define
     # NO_CTORS_DTORS_SECTIONS)
     patch("4a531bb.patch", when="@:2.12")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -57,11 +57,6 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     version("2.6.1", sha256="6be7639ccad715d25eef560ce9d1637ef206fb9a162714f6ab8167fc0d971cae")
     version("2.5", sha256="16d3ac4e86eed75d85d80f1f214a6bd58d27f13590966b5ad0cc181df85a3493")
 
-    # Spack commit 29aa7117f42f758bc537e03e4bedf66ced0accfa has older versions
-    # of glibc, but they are removed, because glibc < 2.17 links against
-    # libgcc_s and libgcc_eh, see glibc commit "Avoid use of libgcc_s and
-    # libgcc_eh when building glibc." 95f5a9a866695da4e038aa4e6ccbbfd5d9cf63b7
-
     # Fix for newer GCC, related to -fno-common
     patch("locs.patch", when="@2.23:2.25")
     patch("locs-2.22.patch", when="@:2.22")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -87,6 +87,14 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     # linker flag output regex
     patch("7c8a673.patch", when="@:2.9")
 
+    # Use AT_RANDOM provided by the kernel instead of /dev/urandom;
+    # recent gcc + binutils have issues with the inline assembly in
+    # the fallback code, so better to use the kernel-provided value.
+    patch("965cb60.patch", when="@2.8:2.9")
+    patch("965cb60-2.7.patch", when="@2.7")
+    patch("965cb60-2.6.patch", when="@2.6")
+    patch("965cb60-2.5.patch", when="@2.5")
+
     # include_next <limits.h> not working
     patch("67fbfa5.patch", when="@:2.7")
 
@@ -97,6 +105,12 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
             # for some reason CPPFLAGS -U_FORTIFY_SOURCE is not enough, it has to be CFLAGS
             env.append_flags("CPPFLAGS", "-U_FORTIFY_SOURCE")
             env.append_flags("CFLAGS", "-O2 -g -fno-stack-protector -U_FORTIFY_SOURCE")
+        if self.spec.satisfies("@:2.9"):
+            # missing defines in elf.h after 965cb60.patch
+            env.append_flags("CFLAGS", "-DAT_BASE_PLATFORM=24 -DAT_RANDOM=25")
+        if self.spec.satisfies("@:2.6"):
+            # change of defaults in gcc 10
+            env.append_flags("CFLAGS", "-fcommon")
         if self.spec.satisfies("@2.5"):
             env.append_flags("CFLAGS", "-fgnu89-inline")
 

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -76,7 +76,8 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     patch("fb21f89.patch", when="@:2.16")
 
     # Avoid linking libgcc_eh
-    patch("95f5a9a.patch", when="@2.16")
+    patch("95f5a9a-stub.patch", when="@:2.16")
+    patch("95f5a9a-2.16.patch", when="@2.16")
     patch("95f5a9a-2.15.patch", when="@2.14:2.15")
     patch("95f5a9a-2.13.patch", when="@2.12:2.13")
     patch("95f5a9a-2.11.patch", when="@:2.11")


### PR DESCRIPTION
This resolves an interesting circular dependency between gcc and glibc:

1. glibc < 2.17 depends on `libgcc.a` and `libgcc_eh.a`
2. `libgcc_eh.a` is only built when gcc is configured with
   `--enable-shared`
3. building shared libraries requires `crt*.o` and `libc.so` from glibc.

With this patch, the circular deps are broken, and you can:

1. install glibc headers
2. build static libgcc.a + xgcc
3. build glibc with xgcc linking libgcc.a
4. build the rest of gcc with new glibc

[It is left as an exercise to the reader to install glibc headers :laughing:]

This should also fix the build `glibc@:2.16 %gcc` if you skip "proper" bootstrap
outlined above (building libgcc.a and glibc together).
The `libgcc_eh.a` archive is the only GCC runtime library that needs the symbol
`_dl_find_object` from a recent GNU extension in glibc. So, if your host glibc is
new, and you don't build glibc and gcc together, you wouldn't be able to build
old glibc, since that symbol wouldn't appear in just-built glibc.

---

It also fixes an issue observed when using the ubuntu 23.04 default toolchain,
where some inline assembly causes an assembler error. That issue was resolved
in glibc commit 4300afc1697ae703e0c5899ad66f55f3b12a8b6a and some others
that add support for AT_RANDOM auxval set by the kernel; that avoids a fallback
codepath that triggers the issue. (So you can't use this patch with very very ancient
kernels).