### PR TITLE
meme: add 5.5.4, correct dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -23,7 +23,7 @@ class Meme(AutotoolsPackage):
     version("4.11.4", sha256="3e869ff57e327a9c8615dbef784e3f1095f7f7a0120cecd55efe10c3f2ee8eb3")
 
     variant("mpi", default=True, description="Enable MPI support")
-    variant("imagemagick", default=False, description="Enable imagemagick for png output")
+    variant("magick", default=False, description="Enable imagemagick for png output")
 
     # Perl runtime deps
     depends_on("perl@5.16:", type=("build", "run"))
@@ -37,7 +37,7 @@ class Meme(AutotoolsPackage):
     depends_on("libxml2")
     depends_on("libxslt")
     # Variant deps
-    depends_on("imagemagick", type=("build", "run"), when="+imagemagick")
+    depends_on("imagemagick", type=("build", "run"), when="+magick")
     depends_on("mpi", when="+mpi")
 
     patch("arm.patch", when="%arm")

--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -15,6 +15,7 @@ class Meme(AutotoolsPackage):
     homepage = "https://meme-suite.org"
     url = "http://meme-suite.org/meme-software/5.1.1/meme-5.1.1.tar.gz"
 
+    version("5.5.4", sha256="cda6011c2b855bf2563c4e7a2c255e11e99b5b6e5e73736ff008942507580153")
     version("5.3.0", sha256="b2ddec9db972fcf77b29c7deb62df8b1dd8a6638c13c1aa06a5d563c4a7ff756")
     version("5.2.0", sha256="0cbf8c2172e9b6c07855b8aeec457f4825f0b132f8cbb11192880e2f6033f54f")
     version("5.1.1", sha256="38d73d256d431ad4eb7da2c817ce56ff2b4e26c39387ff0d6ada088938b38eb5")
@@ -22,20 +23,30 @@ class Meme(AutotoolsPackage):
     version("4.11.4", sha256="3e869ff57e327a9c8615dbef784e3f1095f7f7a0120cecd55efe10c3f2ee8eb3")
 
     variant("mpi", default=True, description="Enable MPI support")
-    variant("image-magick", default=False, description="Enable image-magick for png output")
+    variant("imagemagick", default=False, description="Enable imagemagick for png output")
 
-    depends_on("zlib-api", type=("link"))
-    depends_on("libgcrypt", type=("link"))
-    depends_on("perl", type=("build", "run"))
-    depends_on("python@2.7:", type=("build", "run"))
-    depends_on("mpi", when="+mpi")
-    depends_on("imagemagick", type=("build", "run"), when="+image-magick")
+    # Perl runtime deps
+    depends_on("perl@5.16:", type=("build", "run"))
     depends_on("perl-xml-parser", type=("build", "run"))
-    depends_on("perl-xml-simple", when="@4.5.0:")
-    depends_on("libxml2", type=("build", "run"))
-    depends_on("libxslt", type=("build", "run"))
+    depends_on("perl-xml-simple", type=("build", "run"))
+    # Python runtime deps
+    depends_on("python", type=("build", "run"))
+    # Build deps
+    depends_on("zlib-ng")
+    depends_on("ghostscript")
+    depends_on("libxml2")
+    depends_on("libxslt")
+    # Variant deps
+    depends_on("imagemagick", type=("build", "run"), when="+imagemagick")
+    depends_on("mpi", when="+mpi")
 
     patch("arm.patch", when="%arm")
+
+    def patch(self):
+        # Remove flags not recognized by the NVIDIA compiler
+        if self.spec.satisfies("%nvhpc"):
+            filter_file("-fno-common", "", "configure")
+            filter_file("-Wno-unused", "", "configure")
 
     def url_for_version(self, version):
         url = "http://meme-suite.org/meme-software/{0}/meme{1}{2}.tar.gz"
@@ -43,14 +54,6 @@ class Meme(AutotoolsPackage):
         return url.format(version.up_to(3), sep, version)
 
     def configure_args(self):
-        spec = self.spec
-        args = []
-        if "~mpi" in spec:
-            args += ["--enable-serial"]
-        return args
-
-    def patch(self):
-        # Remove flags not recognized by the NVIDIA compiler
-        if self.spec.satisfies("%nvhpc"):
-            filter_file("-fno-common", "", "configure")
-            filter_file("-Wno-unused", "", "configure")
+        if "~mpi" in self.spec:
+            return ["--enable-serial"]
+        return []


### PR DESCRIPTION
`@5.3.0` was falling over at runtime with no access to `libxslt.so.1` as it wasn't in as a `link` type dependency. I've modified the necessary build dependencies so that they fall back to the `("build", "link")` default and done some tidying up.

Updated to `@5.5.4` while I'm here...