### PR TITLE
grads: add versions and variants

### DIFF
--- a/var/spack/repos/builtin/packages/gadap/cxx-updates.patch
+++ b/var/spack/repos/builtin/packages/gadap/cxx-updates.patch
@@ -1,0 +1,62 @@
+--- a/src/gaBaseTypes.cc	2008-07-25 14:43:25.000000000 -0600
++++ b/src/gaBaseTypes.cc	2023-09-13 14:59:50.000000000 -0600
+@@ -31,6 +31,7 @@
+ #include "gaBaseTypes.h"
+ #include "gaTypeFactory.h"
+ 
++
+ /** class declarations for gaStr and gaUrl are in gaBaseTypes.h so we
+  * can't declare them again, we have to define each function
+  * individually
+--- a/src/gaBaseTypes.h	2008-07-25 14:43:25.000000000 -0600
++++ b/src/gaBaseTypes.h	2023-09-13 14:44:39.000000000 -0600
+@@ -31,6 +31,7 @@
+  * 
+  */
+ 
++using namespace libdap;
+ 
+ class gaStr: public Str {
+ public:
+--- a/src/gaReports.cc	2008-07-25 14:43:25.000000000 -0600
++++ b/src/gaReports.cc	2023-09-13 14:50:28.000000000 -0600
+@@ -12,6 +12,7 @@
+  */
+ 
+ #include <iostream>
++#include <cstring>
+ #include "gaReports.h"
+ #include "gaUtils.h"
+ #include "Grid.h"
+--- a/src/gaTypeFactory.h	2008-07-25 14:43:25.000000000 -0600
++++ b/src/gaTypeFactory.h	2023-09-13 14:44:43.000000000 -0600
+@@ -28,6 +28,8 @@
+ 
+ #include <string>
+ 
++using namespace libdap;
++
+ // Class declarations; Make sure to include the corresponding headers in the
+ // implementation file.
+ 
+--- a/src/gaUtils.h	2008-07-25 14:43:25.000000000 -0600
++++ b/src/gaUtils.h	2023-09-13 14:46:27.000000000 -0600
+@@ -23,6 +23,8 @@
+ #include "Sequence.h"
+ #include "gadap.h"
+ 
++using namespace libdap;
++
+ typedef struct varinfo {
+   string name;
+   string longname;
+--- a/test/test.cc	2008-07-30 06:35:43.000000000 -0600
++++ b/test/test.cc	2023-09-13 15:12:48.000000000 -0600
+@@ -9,6 +9,7 @@
+ #include "gadap.h"
+ #include <iostream>
+ #include <string>
++#include <cstring>
+ 
+ using namespace std;
+ 

--- a/var/spack/repos/builtin/packages/gadap/package.py
+++ b/var/spack/repos/builtin/packages/gadap/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gadap(AutotoolsPackage):
+    """Enables OPeNDAP access of in situ data."""
+
+    homepage = "http://cola.gmu.edu/grads/gadoc/supplibs.html"
+    url = "http://cola.gmu.edu/grads/Supplibs/2.1/src/gadap-2.0.tar.gz"
+
+    maintainers("vanderwb")
+
+    version("2.0", sha256="ae9a989ca00ec29fb40616383d170883f07c022456db338399982a8a94ec0100")
+
+    depends_on("curl@7.18.0:")
+    depends_on("libdap4")
+    depends_on("libxml2")
+
+    # libdap uses namespacing in recent versions, so we need to patch this source
+    patch("cxx-updates.patch")
+
+    def setup_build_environment(self, env):
+        env.set("CFLAGS", "-fPIC")
+        env.set("CXXFLAGS", "-fPIC")

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -15,25 +15,35 @@ class Grads(AutotoolsPackage):
     HDF (version 4 and 5), and BUFR (for station data)."""
 
     homepage = "http://cola.gmu.edu/grads/grads.php"
-    url = "ftp://cola.gmu.edu/grads/2.2/grads-2.2.1-src.tar.gz"
 
+    maintainers("vanderwb")
+
+    version("2.2.3", sha256="2cbb67284fe64763c589ecaf08d5bd31144554dfd82a1fccf71e1cc424695a9e")
+    version("2.2.2", sha256="1b5a600d4d407ffcf2fbbbba42037a6e1ebfdb8246ba56b93c628e3c472b4ded")
     version("2.2.1", sha256="695e2066d7d131720d598bac0beb61ac3ae5578240a5437401dc0ffbbe516206")
 
     variant("geotiff", default=True, description="Enable GeoTIFF support")
     variant("shapefile", default=True, description="Enable Shapefile support")
+    variant("grib2", default=True, description="Enable GRIB2 support")
+    variant("dap", default=False, description="Enable DAP support")
 
-    """
-    # FIXME: Fails with undeclared functions (tdefi, tdef, ...) in gauser.c
-    variant('hdf5', default=False, description="Enable HDF5 support")
-    variant('hdf4', default=False, description="Enable HDF4 support")
-    variant('netcdf', default=False, description="Enable NetCDF support")
-    depends_on('hdf5', when='+hdf5')
-    depends_on('hdf', when='+hdf4')
-    depends_on('netcdf-c', when='+netcdf')
-    """
+    # TODO: This variant depends on the "simple X" library, which is no longer available
+    # from any trusted source. Revisit if this changes.
+    #variant("gui", default=False, description="Enable graphical user interface")
 
+    # These variants are broken in 2.2.1
+    # See https://github.com/j-m-adams/GrADS/issues/2
+    variant("hdf5", default=True, when="@2.2.2:", description="Enable HDF5 support")
+    variant("hdf4", default=True, when="@2.2.2:", description="Enable HDF4 support")
+    variant("netcdf", default=True, when="@2.2.2:", description="Enable NetCDF support")
+
+    depends_on("hdf5@:1.10", when="+hdf5")
+    depends_on("hdf", when="+hdf4")
+    depends_on("netcdf-c", when="+netcdf")
+    depends_on("g2c", when="+grib2")
     depends_on("libgeotiff", when="+geotiff")
     depends_on("shapelib", when="+shapefile")
+    depends_on("gadap", when="+dap")
     depends_on("udunits")
     depends_on("libgd")
     depends_on("libxmu")
@@ -41,8 +51,28 @@ class Grads(AutotoolsPackage):
     depends_on("readline")
     depends_on("pkgconfig", type="build")
 
+    # The project is hosted on GitHub for versions 2.2.2 and later
+    def url_for_version(self, version):
+        if version >= Version("2.2.2"):
+            url = "https://github.com/j-m-adams/GrADS/archive/refs/tags/v{}.tar.gz"
+            return url.format(version)
+        else:
+            url = "ftp://cola.gmu.edu/grads/{}/grads-{}-src.tar.gz"
+            return url.format(version.up_to(2), version)
+
+    # Name of grib2 C library has changed in recent versions
+    with when("+grib2"):
+        def patch(self):
+            filter_file("grib2c", "g2c", "configure")
+
     def setup_build_environment(self, env):
         env.set("SUPPLIBS", "/")
+
+        # Recent versions configure scripts break without PKG_CONFIG set
+        env.set("PKG_CONFIG", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
+
+        with when("^hdf~shared"):
+            env.set("LIBS", self.spec["hdf:transitive"].libs)
 
     def setup_run_environment(self, env):
         env.set("GADDIR", self.prefix.data)
@@ -58,4 +88,9 @@ class Grads(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.extend(self.with_or_without("geotiff"))
+        args.extend(self.with_or_without("hdf4"))
+        args.extend(self.with_or_without("hdf5"))
+        args.extend(self.with_or_without("netcdf"))
+        args.extend(self.with_or_without("gadap", variant="dap"))
+
         return args

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -72,7 +72,7 @@ class Grads(AutotoolsPackage):
         # Recent versions configure scripts break without PKG_CONFIG set
         env.set("PKG_CONFIG", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
 
-        if self.spec.satisfies("+hdf4") and self.spec["hdf"].satisfies("~shared"):
+        if "+hdf4" in self.spec and "~shared" in self.spec["hdf"]:
             env.set("LIBS", self.spec["hdf:transitive"].libs)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -29,7 +29,7 @@ class Grads(AutotoolsPackage):
 
     # TODO: This variant depends on the "simple X" library, which is no longer available
     # from any trusted source. Revisit if this changes.
-    #variant("gui", default=False, description="Enable graphical user interface")
+    # variant("gui", default=False, description="Enable graphical user interface")
 
     # These variants are broken in 2.2.1
     # See https://github.com/j-m-adams/GrADS/issues/2
@@ -62,6 +62,7 @@ class Grads(AutotoolsPackage):
 
     # Name of grib2 C library has changed in recent versions
     with when("+grib2"):
+
         def patch(self):
             filter_file("grib2c", "g2c", "configure")
 
@@ -71,7 +72,7 @@ class Grads(AutotoolsPackage):
         # Recent versions configure scripts break without PKG_CONFIG set
         env.set("PKG_CONFIG", self.spec["pkgconfig"].prefix.bin.join("pkg-config"))
 
-        with when("^hdf~shared"):
+        if self.spec.satisfies("+hdf4") and self.spec["hdf"].satisfies("~shared"):
             env.set("LIBS", self.spec["hdf:transitive"].libs)
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
The current grads recipe does not build HDF4/5 and NetCDF support because of a bug with pragmas in the source. This is corrected in newer versions 2.2.2 and 2.2.3, which have been added to the recipe. With these versions, those data formats are now supported as variants with default True. grib2 and DAP support have also been added for all versions.

Another package - gadap, is added, which is a dependency for grads DAP support. Finally, I have volunteered to maintain these package recipes.