### PR TITLE
Per-os-config feature -- third time is the charm? 

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -240,9 +240,9 @@ The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` mig
 
 .. _platform-scopes:
 
-------------------------
-Platform-specific Scopes
-------------------------
+-----------------------------------------
+Platform-, OS- and Target-specific Scopes
+-----------------------------------------
 
 For each scope above (excluding environment scopes), there can also be
 platform-specific settings.  For example, on most platforms, GCC is
@@ -253,23 +253,41 @@ configuration is set in
 precedence over settings in the ``defaults`` scope, but can still be
 overridden by settings in ``system``, ``system/darwin``, ``site``,
 ``site/darwin``, ``user``, ``user/darwin``, ``custom``, or
-``custom/darwin``. So, the full scope precedence is:
+``custom/darwin``.
+
+Following this pattern, the scope hierarchy can be further deepened by
+operating system-specific (e.g. `sonoma`, or `almalinux9`) and
+target-specific (e.g. `m1`, or `cascadelake`) scopes. The full scope
+hierarchy is therefore:
 
 #. ``defaults``
 #. ``defaults/<platform>``
+#. ``defaults/<platform>/<os>``
+#. ``defaults/<platform>/<os>/<target>``
 #. ``system``
 #. ``system/<platform>``
+#. ``system/<platform>/<os>``
+#. ``system/<platform>/<os>/<target>``
 #. ``site``
 #. ``site/<platform>``
+#. ``site/<platform>/<os>``
+#. ``site/<platform>/<os>/<target>``
 #. ``user``
 #. ``user/<platform>``
+#. ``user/<platform>/<os>``
+#. ``user/<platform>/<os>/<target>``
 #. ``custom``
 #. ``custom/<platform>``
+#. ``custom/<platform>/<os>``
+#. ``custom/<platform>/<os>/<target>``
+
+The system config scope has a ``<platform>`` section for sites at which
+``/etc`` is mounted on multiple heterogeneous machines.
 
 You can get the name to use for ``<platform>`` by running ``spack arch
---platform``. The system config scope has a ``<platform>`` section for
-sites at which ``/etc`` is mounted on multiple heterogeneous machines.
-
+--platform``.  Similarly, the names for ``<os>`` and ``<target>`` can be
+obtained with ``spack arch --operating-system``, and ``spack arch
+--target``, respectively.
 
 .. _config-scope-precedence:
 
@@ -285,7 +303,7 @@ lower-precedence settings. Completely ignoring higher-level configuration
 options is supported with the ``::`` notation for keys (see
 :ref:`config-overrides` below).
 
-There are also special notations for string concatenation and precendense override:
+There are also special notations for string concatenation and precedence override:
 
 * ``+:`` will force *prepending* strings or lists. For lists, this is the default behavior.
 * ``-:`` works similarly, but for *appending* values.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -260,29 +260,16 @@ operating system-specific (e.g. `sonoma`, or `almalinux9`) and
 target-specific (e.g. `m1`, or `cascadelake`) scopes. The full scope
 hierarchy is therefore:
 
-#. ``defaults``
-#. ``defaults/<platform>``
-#. ``defaults/<platform>/<os>``
-#. ``defaults/<platform>/<os>/<target>``
-#. ``system``
-#. ``system/<platform>``
-#. ``system/<platform>/<os>``
-#. ``system/<platform>/<os>/<target>``
-#. ``site``
-#. ``site/<platform>``
-#. ``site/<platform>/<os>``
-#. ``site/<platform>/<os>/<target>``
-#. ``user``
-#. ``user/<platform>``
-#. ``user/<platform>/<os>``
-#. ``user/<platform>/<os>/<target>``
-#. ``custom``
-#. ``custom/<platform>``
-#. ``custom/<platform>/<os>``
-#. ``custom/<platform>/<os>/<target>``
+#. ``defaults[/<platform>[/<os>[/<target>]]]``
+#. ``system[/<platform>[/<os>[/<target>]]]``
+#. ``site[/<platform>[/<os>[/<target>]]]``
+#. ``user[/<platform>[/<os>[/<target>]]]``
+#. ``custom[/<platform>[/<os>[/<target>]]]``
 
-The system config scope has a ``<platform>`` section for sites at which
-``/etc`` is mounted on multiple heterogeneous machines.
+Any scope overrides the ones above it in the directory tree.
+
+The system config scope has a platform-based hierarchy for sites at
+which ``/etc`` is mounted on multiple heterogeneous machines.
 
 You can get the name to use for ``<platform>`` by running ``spack arch
 --platform``.  Similarly, the names for ``<os>`` and ``<target>`` can be

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -122,21 +122,19 @@ def _read_and_sanitize_configuration() -> Dict[str, Any]:
 
 
 def _bootstrap_config_scopes() -> Sequence["spack.config.ConfigScope"]:
-    tty.debug("[BOOTSTRAP CONFIG SCOPE] name=_builtin")
     config_scopes: MutableSequence["spack.config.ConfigScope"] = [
         spack.config.InternalConfigScope("_builtin", spack.config.CONFIG_DEFAULTS)
     ]
+    tty.debug("[BOOTSTRAP CONFIG SCOPE] name=_builtin")
     configuration_paths = (spack.config.CONFIGURATION_DEFAULTS_PATH, ("bootstrap", _config_path()))
     for name, path in configuration_paths:
-        platform = spack.platforms.host().name
-        platform_scope = spack.config.DirectoryConfigScope(
-            f"{name}/{platform}", os.path.join(path, platform)
-        )
+        msg = "[BOOTSTRAP CONFIG SCOPE] {name}, {path}"
+        tty.debug(msg.format(name=name, path=path))
         generic_scope = spack.config.DirectoryConfigScope(name, path)
-        config_scopes.extend([generic_scope, platform_scope])
-        msg = "[BOOTSTRAP CONFIG SCOPE] name={0}, path={1}"
-        tty.debug(msg.format(generic_scope.name, generic_scope.path))
-        tty.debug(msg.format(platform_scope.name, platform_scope.path))
+        config_scopes.append(generic_scope)
+        for scope in spack.config.platform_scopes(name, path):
+            tty.debug(msg.format(name=scope.name, path=scope.path))
+            config_scopes.append(scope)
     return config_scopes
 
 


### PR DESCRIPTION
The previous pull requests for this #16834 and   #31028 got funky after rebasing, so doing a fresh branch. 

This is an implementation for Feature requests  #31026, and #2700  fixed for latest version.
 
It just adds an Operating System Release (i.e. "scientific7" "almalinux9") config branch along the lines of the the
platform one ("linux" "MacOs").   Many configs (i.e. packages.yaml) are more specific than just platform, and this
lets you support multiple OS versions in one spack tree. 