### PR TITLE
Add explicit RPC dependency for libdap4

### DIFF
--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -35,9 +35,11 @@ class Libdap4(AutotoolsPackage):
     depends_on("rpc")
 
     def setup_build_environment(self, env):
-        # Configure script can insert library path here, resulting in a failure
+        # Configure script will search for RPC library, but not actually add RPC library references
+        # during configure tests. This can cause a failure with libtirpc if the following variable
+        # is not set.
         if self.spec.satisfies("^libtirpc"):
-            env.set("TIRPC_LIBS", "-ltirpc")
+            env.set("TIRPC_LIBS", self.spec["rpc"].libs)
 
     def configure_args(self):
         # libxml2 exports ./include/libxml2/ instead of ./include/, which we

--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -32,6 +32,12 @@ class Libdap4(AutotoolsPackage):
     depends_on("curl")
     depends_on("libxml2")
     depends_on("uuid")
+    depends_on("rpc")
+
+    def setup_build_environment(self, env):
+        # Configure script can insert library path here, resulting in a failure
+        if self.spec.satisfies("^libtirpc"):
+            env.set("TIRPC_LIBS", "-ltirpc")
 
     def configure_args(self):
         # libxml2 exports ./include/libxml2/ instead of ./include/, which we


### PR DESCRIPTION
Building `libdap4` on systems without certain XDR headers will cause failures, as there is an `rpc` dependency that is assumed by the package recipe:

```
checking for libtirpc >= 0.2.4... no
checking for library containing xdr_void... no
configure: WARNING: Cannot locate library containing xdr functions.
checking for xdr_uint32_t in -lc... no
checking for xdr_u_int32_t in -lc... no
checking for xdr_uint in -lc... no
checking for xdr_u_int in -lc... no
configure: error: Cannot determine DODS XDR integer sizes
```

This PR makes `rpc` an explicit dependency, and also sets the TIRPC_LIBS value if `rpc` is provided by `libtirpc`.