### PR TITLE
xxdiff: add new package 

### DIFF
--- a/var/spack/repos/builtin/packages/xxdiff/package.py
+++ b/var/spack/repos/builtin/packages/xxdiff/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Xxdiff(MakefilePackage):
+    """Graphical File And Directories Comparator And Merge Tool."""
+
+    homepage = "https://furius.ca/xxdiff/"
+    git = "https://github.com/blais/xxdiff.git"
+
+    maintainers("vanderwb")
+
+    version("latest", branch = "master")
+
+    depends_on("flex@2.5.31:")
+    depends_on("bison")
+    depends_on("qt@5:", type=("build", "link", "run"))
+
+    def edit(self, spec, prefix):
+        env['QMAKE'] = 'qmake'
+
+    def build(self, spec, prefix):
+        with working_dir("src"):
+            # Create the makefile
+            make("-f", "Makefile.bootstrap")
+            make()
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install('bin/xxdiff', prefix.bin)

--- a/var/spack/repos/builtin/packages/xxdiff/package.py
+++ b/var/spack/repos/builtin/packages/xxdiff/package.py
@@ -14,14 +14,14 @@ class Xxdiff(MakefilePackage):
 
     maintainers("vanderwb")
 
-    version("latest", branch = "master")
+    version("latest", branch="master")
 
     depends_on("flex@2.5.31:")
     depends_on("bison")
     depends_on("qt@5:", type=("build", "link", "run"))
 
     def edit(self, spec, prefix):
-        env['QMAKE'] = 'qmake'
+        env["QMAKE"] = "qmake"
 
     def build(self, spec, prefix):
         with working_dir("src"):
@@ -31,4 +31,4 @@ class Xxdiff(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install('bin/xxdiff', prefix.bin)
+        install("bin/xxdiff", prefix.bin)

--- a/var/spack/repos/builtin/packages/xxdiff/package.py
+++ b/var/spack/repos/builtin/packages/xxdiff/package.py
@@ -15,10 +15,10 @@ class Xxdiff(MakefilePackage):
     maintainers("vanderwb")
 
     version("master", branch="master")
-    version("2023-01-10", commit="604300e")
+    version("2023-01-10", commit="604300ea9875611726ba885fb14f872b964df579")
 
-    depends_on("flex@2.5.31:")
-    depends_on("bison")
+    depends_on("flex@2.5.31:", type="build")
+    depends_on("bison", type="build")
     depends_on("qt@5:", type=("build", "link", "run"))
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xxdiff/package.py
+++ b/var/spack/repos/builtin/packages/xxdiff/package.py
@@ -14,7 +14,8 @@ class Xxdiff(MakefilePackage):
 
     maintainers("vanderwb")
 
-    version("latest", branch="master")
+    version("master", branch="master")
+    version("2023-01-10", commit="604300e")
 
     depends_on("flex@2.5.31:")
     depends_on("bison")


### PR DESCRIPTION
This PR adds the `xxdiff` package, which is used for graphical comparative diffing.