### PR TITLE
python: Don't prefer 3.10

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -138,8 +138,6 @@ class Phist(CMakePackage):
     conflicts("^trilinos@14:", when="@:1.11.2")
     # Build error with cray-libsci because they define macro 'I', workaround in phist-1.11.2
     conflicts("^cray-libsci", when="@:1.11.1")
-    # phist@1.11.2 got rid of some deprecated python code
-    conflicts("^python@3.11:", when="@:1.11.1")
     # The builtin kernels switched from the 'mpi' to the 'mpi_f08' module in
     # phist 1.9.6, which causes compile-time errors with mpich and older
     # GCC versions.
@@ -175,7 +173,8 @@ class Phist(CMakePackage):
     # Python 3 or later is required for generating the Fortran 2003 bindings
     # since version 1.7, you can get rid of the dependency by switching off
     # the feature (e.g. use the '~fortran' variant)
-    depends_on("python@3:", when="@1.7: +fortran", type="build")
+    # For the upperbound see https://bitbucket.org/essex/phist/issues/246/does-not-build-with-python-311
+    depends_on("python@3:3.10", when="@1.7: +fortran", type="build")
     depends_on("mpi", when="+mpi")
     depends_on("trilinos@12:+tpetra gotype=long_long", when="kernel_lib=tpetra +int64")
     depends_on("trilinos@12:+tpetra gotype=int", when="kernel_lib=tpetra ~int64")

--- a/var/spack/repos/builtin/packages/py-numcodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-numcodecs/package.py
@@ -28,6 +28,7 @@ class PyNumcodecs(PythonPackage):
 
     depends_on("python@3.6:3", when="@0.7:", type=("build", "link", "run"))
     depends_on("python@2.7:2.8,3.5:", when="@:0.6", type=("build", "link", "run"))
+    depends_on("python@:3.10", when="@:0.10", type=("build", "link", "run"))
     depends_on("py-setuptools@18.1:", type="build")
     depends_on("py-setuptools-scm@1.5.5:", type="build")
     depends_on("py-cython", type="build")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -62,6 +62,8 @@ class PyProtobuf(PythonPackage):
     version("3.3.0", sha256="1cbcee2c45773f57cb6de7ee0eceb97f92b9b69c0178305509b162c0160c1f04")
     version("3.0.0", sha256="ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5")
 
+    # newer versions support python 3.11+, but we need to switch to bazel
+    depends_on("python@:3.10", type=("build", "link", "run"))
     depends_on("py-setuptools", type=("build", "run"))
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", when="@:4.21", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-scikit-learn-extra/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn-extra/package.py
@@ -19,7 +19,8 @@ class PyScikitLearnExtra(PythonPackage):
 
     version("0.2.0", sha256="3b1bb5fedde47920eb4b3fa0a0c18f80cc7359d9d0496720178788c6153b8019")
 
-    depends_on("python@3.6:", type=("build", "run"))
+    # For upperbound see https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/164
+    depends_on("python@3.6:3.10", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.28.5:", type="build")
     depends_on("py-numpy@1.13.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -45,11 +45,7 @@ class Python(Package):
     version("3.11.2", sha256="2411c74bda5bbcfcddaf4531f66d1adc73f247f529aee981b029513aefdbf849")
     version("3.11.1", sha256="baed518e26b337d4d8105679caf68c5c32630d702614fc174e98cb95c46bdfa4")
     version("3.11.0", sha256="64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb")
-    version(
-        "3.10.12",
-        sha256="a43cd383f3999a6f4a7db2062b2fc9594fefa73e175b3aedafa295a51a7bb65c",
-        preferred=True,
-    )
+    version("3.10.12", sha256="a43cd383f3999a6f4a7db2062b2fc9594fefa73e175b3aedafa295a51a7bb65c")
     version("3.10.11", sha256="f3db31b668efa983508bd67b5712898aa4247899a346f2eb745734699ccd3859")
     version("3.10.10", sha256="fba64559dde21ebdc953e4565e731573bb61159de8e4d4cedee70fb1196f610d")
     version("3.10.9", sha256="4ccd7e46c8898f4c7862910a1703aa0e63525913a519abb2f55e26220a914d88")


### PR DESCRIPTION
3.11 has been out for some time; the preference was introduced last November when 3.11 was added for the first time.