### PR TITLE
gitlab ci: submit the correct audience for protected publish jobs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -232,7 +232,7 @@ protected-publish:
     - spack buildcache update-index --keys "${SPACK_COPY_BUILDCACHE}"
   id_tokens:
     GITLAB_OIDC_TOKEN:
-      aud: "${OIDC_TOKEN_AUDIENCE}"
+      aud: "protected_binary_mirror"
 
 ########################################
 # TEMPLATE FOR ADDING ANOTHER PIPELINE


### PR DESCRIPTION
Protected publish jobs need to present the `protected_binary_mirror` audience token, even though they're not based on the `.base-job` definition.

This should fix recently cropped up error like [this](https://gitlab.spack.io/spack/spack/-/jobs/8225072) one.