### PR TITLE
py-typing-extensions: add 4.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -12,9 +12,10 @@ class PyTypingExtensions(PythonPackage):
     added to the typing module, such as Protocol (see PEP 544 for
     details about protocols and static duck typing)."""
 
-    homepage = "https://github.com/python/typing/tree/master/typing_extensions"
+    homepage = "https://github.com/python/typing_extensions"
     pypi = "typing_extensions/typing_extensions-3.7.4.tar.gz"
 
+    version("4.8.0", sha256="df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef")
     version("4.6.3", sha256="d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5")
     version("4.5.0", sha256="5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb")
     version("4.3.0", sha256="e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6")
@@ -28,7 +29,7 @@ class PyTypingExtensions(PythonPackage):
     version("3.6.6", sha256="51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f")
 
     # typing-extensions 4+ uses flit
-    depends_on("python@3.7:", when="@4.2:", type=("build", "run"))
+    depends_on("python@3.8:", when="@4.8:", type=("build", "run"))
     depends_on("py-flit-core@3.4:3", when="@4:", type="build")
 
     # Historical dependencies

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -28,8 +28,9 @@ class PyTypingExtensions(PythonPackage):
     version("3.7.2", sha256="fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71")
     version("3.6.6", sha256="51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f")
 
-    # typing-extensions 4+ uses flit
     depends_on("python@3.8:", when="@4.8:", type=("build", "run"))
+    # Needed to ensure that Spack can bootstrap with Python 3.6
+    depends_on("python@3.7:", when="@4.2:", type=("build", "run"))
     depends_on("py-flit-core@3.4:3", when="@4:", type="build")
 
     # Historical dependencies


### PR DESCRIPTION
https://github.com/python/typing_extensions/tree/4.8.0