### PR TITLE
Add missing platform in Charm++

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -187,9 +187,7 @@ class Charmpp(Package):
             ("linux", "ppc", "pami"): "pami-linux-ppc64le",
             ("linux", "ppc", "verbs"): "verbs-linux-ppc64le",
             ("linux", "arm", "netlrts"): "netlrts-linux-arm7",
-            ("linux", "arm", "multicore"): "multicore-linux-arm7",
             ("linux", "aarch64", "netlrts"): "netlrts-linux-arm8",
-            ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
             ("win", "x86_64", "mpi"): "mpi-win-x86_64",
             ("win", "x86_64", "multicore"): "multicore-win-x86_64",
             ("win", "x86_64", "netlrts"): "netlrts-win-x86_64",
@@ -203,6 +201,12 @@ class Charmpp(Package):
             versions.update({("linux", "i386", "multicore"): "multicore-linux"})
             versions.update({("linux", "i386", "netlrts"): "netlrts-linux"})
             versions.update({("linux", "i386", "uth"): "uth-linux"})
+            versions.update(
+                {
+                    ("linux", "arm", "multicore"): "multicore-linux-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+                }
+            )
         else:
             versions.update({("linux", "i386", "mpi"): "mpi-linux-i386"})
             versions.update({("linux", "i386", "multicore"): "multicore-linux-i386"})

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -187,7 +187,7 @@ class Charmpp(Package):
             ("linux", "ppc", "pami"): "pami-linux-ppc64le",
             ("linux", "ppc", "verbs"): "verbs-linux-ppc64le",
             ("linux", "arm", "netlrts"): "netlrts-linux-arm7",
-            ("linux", "arm", "multicore"): "multicore-arm7",
+            ("linux", "arm", "multicore"): "multicore-linux-arm7",
             ("linux", "aarch64", "netlrts"): "netlrts-linux-arm8",
             ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
             ("win", "x86_64", "mpi"): "mpi-win-x86_64",

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -201,6 +201,12 @@ class Charmpp(Package):
             versions.update({("linux", "i386", "multicore"): "multicore-linux"})
             versions.update({("linux", "i386", "netlrts"): "netlrts-linux"})
             versions.update({("linux", "i386", "uth"): "uth-linux"})
+            versions.update(
+                {
+                    ("linux", "arm", "multicore"): "multicore-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-arm8",
+                }
+            )
         else:
             versions.update({("linux", "i386", "mpi"): "mpi-linux-i386"})
             versions.update({("linux", "i386", "multicore"): "multicore-linux-i386"})

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -189,7 +189,7 @@ class Charmpp(Package):
             ("linux", "arm", "netlrts"): "netlrts-linux-arm7",
             ("linux", "arm", "multicore"): "multicore-arm7",
             ("linux", "aarch64", "netlrts"): "netlrts-linux-arm8",
-            ("linux", "aarch64", "multicore"): "multicore-arm8",
+            ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
             ("win", "x86_64", "mpi"): "mpi-win-x86_64",
             ("win", "x86_64", "multicore"): "multicore-win-x86_64",
             ("win", "x86_64", "netlrts"): "netlrts-win-x86_64",

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -201,16 +201,16 @@ class Charmpp(Package):
             versions.update({("linux", "i386", "multicore"): "multicore-linux"})
             versions.update({("linux", "i386", "netlrts"): "netlrts-linux"})
             versions.update({("linux", "i386", "uth"): "uth-linux"})
+        else:
+            versions.update({("linux", "i386", "mpi"): "mpi-linux-i386"})
+            versions.update({("linux", "i386", "multicore"): "multicore-linux-i386"})
+            versions.update({("linux", "i386", "netlrts"): "netlrts-linux-i386"})
             versions.update(
                 {
                     ("linux", "arm", "multicore"): "multicore-linux-arm7",
                     ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
                 }
             )
-        else:
-            versions.update({("linux", "i386", "mpi"): "mpi-linux-i386"})
-            versions.update({("linux", "i386", "multicore"): "multicore-linux-i386"})
-            versions.update({("linux", "i386", "netlrts"): "netlrts-linux-i386"})
 
         if (plat, mach, comm) not in versions:
             raise InstallError(


### PR DESCRIPTION
Add missing `linux` platform in Charm++ when building for `arm8`.