### PR TITLE
intel-oneapi-mpi: Support external libfabric in created modules

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -61,6 +61,11 @@ class IntelOneApiPackage(Package):
         """Path to component <prefix>/<component>/<version>."""
         return self.prefix.join(join_path(self.component_dir, self.spec.version))
 
+    @property
+    def env_script_args(self):
+        """Additional arguments to pass to vars.sh script."""
+        return ()
+
     def install(self, spec, prefix):
         self.install_component(basename(self.url_for_version(spec.version)))
 
@@ -124,7 +129,7 @@ class IntelOneApiPackage(Package):
         if "~envmods" not in self.spec:
             env.extend(
                 EnvironmentModifications.from_sourcing_file(
-                    join_path(self.component_prefix, "env", "vars.sh")
+                    join_path(self.component_prefix, "env", "vars.sh"), *self.env_script_args
                 )
             )
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -111,6 +111,13 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     def component_dir(self):
         return "mpi"
 
+    @property
+    def env_script_args(self):
+        if "+external-libfabric" in self.spec:
+            return ("-i_mpi_ofi_internal=0",)
+        else:
+            return ()
+
     def setup_dependent_package(self, module, dep_spec):
         if "+generic-names" in self.spec:
             self.spec.mpicc = join_path(self.component_prefix.bin, "mpicc")


### PR DESCRIPTION
Currently, the **vars.sh** script is called without arguments for all builds of intel-oneapi-mpi, but this forces the internal libfabric to be set for `FI_PROVIDER_PATH` regardless of whether `+external_libfabric` was set. This PR proposes a new property, allowing for a tuple of arguments to be sent to the `setup_run_environment` method, and thus removing the internal libfabric settings from modules when external libfabric is enabled.