### PR TITLE
visit: Add NetCDF format support

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -198,7 +198,7 @@ class Visit(CMakePackage):
         # NetCDF components are in separate directories using Spack, which is
         # not what Visit's CMake logic expects
         if "+netcdf" in self.spec:
-            filter_file("(set\(NETCDF_CXX_DIR)", r"#\1", "src/CMake/FindNetcdf.cmake")
+            filter_file(r"(set\(NETCDF_CXX_DIR)", r"#\1", "src/CMake/FindNetcdf.cmake")
 
     def flag_handler(self, name, flags):
         if name in ("cflags", "cxxflags"):

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -78,6 +78,7 @@ class Visit(CMakePackage):
     variant("osmesa", default=False, description="Use OSMesa for off-screen CPU rendering")
     variant("adios2", default=True, description="Enable ADIOS2 file format")
     variant("hdf5", default=True, description="Enable HDF5 file format")
+    variant("netcdf", default=True, description="Enable NetCDF file format")
     variant("silo", default=True, description="Enable Silo file format")
     variant("python", default=True, description="Enable Python support")
     variant("mpi", default=True, description="Enable parallel engine")
@@ -142,6 +143,11 @@ class Visit(CMakePackage):
     depends_on("hdf5+mpi", when="+hdf5+mpi")
     depends_on("hdf5~mpi", when="+hdf5~mpi")
 
+    # Enable netCDF library based on MPI variant and OLD C++ interface
+    depends_on("netcdf-c+mpi", when="+netcdf+mpi")
+    depends_on("netcdf-c~mpi", when="+netcdf~mpi")
+    depends_on("netcdf-cxx", when="+netcdf")
+
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10
     depends_on("silo@4.10: +shared", when="+silo")
@@ -188,6 +194,11 @@ class Visit(CMakePackage):
         # VTK's module flies (e.g. lib/cmake/vtk-8.1/Modules/vtktiff.cmake)
         for filename in find("src", "CMakeLists.txt"):
             filter_file(r"\bvtk(tiff|jpeg|png)", r"${vtk\1_LIBRARIES}", filename)
+
+        # NetCDF components are in separate directories using Spack, which is
+        # not what Visit's CMake logic expects
+        if "+netcdf" in self.spec:
+            filter_file("(set\(NETCDF_CXX_DIR)", r"#\1", "src/CMake/FindNetcdf.cmake")
 
     def flag_handler(self, name, flags):
         if name in ("cflags", "cxxflags"):
@@ -291,6 +302,14 @@ class Visit(CMakePackage):
             args.append(self.define("HDF5_DIR", spec["hdf5"].prefix))
             if "+mpi" in spec and "+mpi" in spec["hdf5"]:
                 args.append(self.define("VISIT_HDF5_MPI_DIR", spec["hdf5"].prefix))
+
+        if "+netcdf" in spec:
+            args.extend(
+                [
+                    self.define("NETCDF_DIR", spec["netcdf-c"].prefix),
+                    self.define("NETCDF_CXX_DIR", spec["netcdf-cxx"].prefix),
+                ]
+            )
 
         if "+silo" in spec:
             args.append(self.define("VISIT_SILO_DIR", spec["silo"].prefix))


### PR DESCRIPTION
NetCDF is supported by VisIt but has not been an implemented variant in the Spack recipe. This PR adds support for NetCDF files (and will also add support for formats dependent on the *old* netcdf-cxx library).