### PR TITLE
python: make 3.12 the preferred version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -83,6 +83,8 @@ class PyPip(Package, PythonExtension):
         expand=False,
     )
 
+    variant("rebuild-me-plz", default=False, description="CI testing")
+
     extends("python")
     depends_on("python@3.7:", when="@22:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -41,11 +41,7 @@ class Python(Package):
     build_targets: List[str] = []
 
     version("3.12.0", sha256="51412956d24a1ef7c97f1cb5f70e185c13e3de1f50d131c0aac6338080687afb")
-    version(
-        "3.11.4",
-        sha256="85c37a265e5c9dd9f75b35f954e31fbfc10383162417285e30ad25cc073a0d63",
-        preferred=True,
-    )
+    version("3.11.4", sha256="85c37a265e5c9dd9f75b35f954e31fbfc10383162417285e30ad25cc073a0d63")
     version("3.11.3", sha256="1a79f3df32265d9e6625f1a0b31c28eb1594df911403d11f3320ee1da1b3e048")
     version("3.11.2", sha256="2411c74bda5bbcfcddaf4531f66d1adc73f247f529aee981b029513aefdbf849")
     version("3.11.1", sha256="baed518e26b337d4d8105679caf68c5c32630d702614fc174e98cb95c46bdfa4")


### PR DESCRIPTION
This PR is to detect issues with Python 3.12 in CI.