### PR TITLE
ci: run unit-tests with Python 3.12

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
         concretizer: ['clingo']
         on_develop:
         - ${{ github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -75,7 +75,7 @@ jobs:
           SPACK_PYTHON: python
       run: |
           . share/spack/setup-env.sh
-          spack bootstrap disable spack-install
+          # spack bootstrap disable spack-install
           spack bootstrap now
           spack -v solve zlib
     - name: Run unit tests


### PR DESCRIPTION
:warning: At the moment this PR is just to check if we have failures using Python 3.12 :warning: 