### PR TITLE
Python version dependency for supporting nwchem-702 build

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -53,7 +53,8 @@ class Nwchem(Package):
     depends_on("mpi")
     depends_on("scalapack")
     depends_on("fftw-api")
-    depends_on("python@3", type=("build", "link", "run"))
+    depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")
+    depends_on("python@3", type=("build", "link", "run"), when="@7.2.0:")
 
     def install(self, spec, prefix):
         scalapack = spec["scalapack"].libs


### PR DESCRIPTION
Python version dependency for nwchem was changed as part of commit [33833a4](https://github.com/spack/spack/commit/33833a4f32eb5f6ba013001613c6216f59db8f48).
This commit is causing failure for nwchem-702 build because of a known python version dependency issue which causes failure for nwchem version @:7.0.2 with python-3.10 and later (two digits for minor version, [nwchemgit/nwchem#271](https://github.com/nwchemgit/nwchem/issues/271))

This PR is to revert that change for commit [33833a4](https://github.com/spack/spack/commit/33833a4f32eb5f6ba013001613c6216f59db8f48).