### PR TITLE
apex: add new version 2.6.3 + deal with ompt build problem

### DIFF
--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -116,6 +116,9 @@ class Apex(CMakePackage):
     conflicts("+jemalloc", when="+gperftools")
     conflicts("+plugins", when="~activeharmony")
 
+    # https://github.com/UO-OACISS/apex/pull/177#issuecomment-1726322959
+    conflicts("+openmp", when="%gcc")
+
     # Patches
 
     # This patch ensures that the missing dependency_tree.hpp header is

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -18,6 +18,7 @@ class Apex(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("2.6.3", sha256="7fef12937d3bd1271a01abe44cb931b1d63823fb5c74287a332f3012ed7297d5")
     version("2.6.2", sha256="0c3ec26631db7925f50cf4e8920a778b57d11913f239a0eb964081f925129725")
     version("2.6.1", sha256="511dbab0af541489052a3d6379c48f9577e51654491d3b2c8545020e9d29fb29")
     version("2.6.0", sha256="25b4f6afd1083475dc6680b5da87759c62d31fcf368996185573694fc40d5317")


### PR DESCRIPTION
I faced a build problem with `apex+openmp`. After investigating, it turns out it shows up at least in all 2.6 versions (these are the non-deprecated ones; even if on 2.6.1 the problem looks a bit more articulated).

I took the chance to add the last version available, but at the same time I would like to update the package in order to address this problem either by:
- adding a conflict (i.e. `conflict("openmp", when=2.6:2.6.3` according to which release will get the fix)
- adding a patch (at least for 2.6.2 and 2.6.3, since 2.6.1 might be affected by more problems)

Looking forward to https://github.com/UO-OACISS/apex/pull/177 in order to evaluate how to proceed.