### PR TITLE
py-nanobind add cmake path

### DIFF
--- a/var/spack/repos/builtin/packages/py-nanobind/package.py
+++ b/var/spack/repos/builtin/packages/py-nanobind/package.py
@@ -39,10 +39,5 @@ class PyNanobind(PythonPackage):
 
     @property
     def cmake_prefix_paths(self):
-        paths = [
-            join_path(self.prefix, self.spec["python"].package.platlib, "nanobind", "cmake")
-        ]
+        paths = [join_path(self.prefix, self.spec["python"].package.platlib, "nanobind", "cmake")]
         return paths
-
-
-

--- a/var/spack/repos/builtin/packages/py-nanobind/package.py
+++ b/var/spack/repos/builtin/packages/py-nanobind/package.py
@@ -36,3 +36,13 @@ class PyNanobind(PythonPackage):
 
     depends_on("py-cmake@3.17:", type="build")
     depends_on("py-ninja", type="build")
+
+    @property
+    def cmake_prefix_paths(self):
+        paths = [
+            join_path(self.prefix, self.spec["python"].package.platlib, "nanobind", "cmake")
+        ]
+        return paths
+
+
+


### PR DESCRIPTION
Adds the cmake-prefix path for nanobind so dependent packages can find it.