### PR TITLE
Bazel patch specs were too restrictive

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -479,13 +479,14 @@ class Bazel(Package):
     # https://blog.bazel.build/2021/05/21/bazel-4-1.html
     conflicts("platform=darwin target=aarch64:", when="@:4.0")
 
-    # patches for compiling bazel-4.1:4 with gcc-11
+    # patches for compiling various older bazels which had ICWYU
+    # violations revealed by (but not unique to) GCC 11 header changes.
     # these are derived from
     # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29084/
-    patch("gcc11_1.patch", when="@0.3.2:4%gcc@11:")
-    patch("gcc11_2.patch", when="@0.3.2:4%gcc@11:")
-    patch("gcc11_3.patch", when="@0.3:4%gcc@11:")
-    patch("gcc11_4.patch", when="@4.1:4%gcc@11:")
+    patch("gcc11_1.patch", when="@0.3.2:4")
+    patch("gcc11_2.patch", when="@0.3.2:4")
+    patch("gcc11_3.patch", when="@0.3:4")
+    patch("gcc11_4.patch", when="@4.1:4")
 
     # bazel-4.0.0 does not compile with gcc-11
     # newer versions of grpc and abseil dependencies are needed but are not in


### PR DESCRIPTION
These patches should always be applied - the existing Bazel code is always wrong, working on some older compilers was a lucky fluke.