### PR TITLE
Paraview: update freetype find patch for shared libs

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/FindFreetype.cmake.patch
+++ b/var/spack/repos/builtin/packages/paraview/FindFreetype.cmake.patch
@@ -1,8 +1,9 @@
+Submodule VTK contains modified content
 diff --git a/VTK/CMake/FindFreetype.cmake b/VTK/CMake/FindFreetype.cmake
-index b4532735c2..f06d32327e 100644
+index b4532735c2..51671d4c3c 100644
 --- a/VTK/CMake/FindFreetype.cmake
 +++ b/VTK/CMake/FindFreetype.cmake
-@@ -63,6 +63,30 @@ directory of a Freetype installation.
+@@ -63,6 +63,32 @@ directory of a Freetype installation.
  # I'm going to attempt to cut out the middleman and hope
  # everything still works.
  
@@ -14,6 +15,8 @@ index b4532735c2..f06d32327e 100644
 +    get_target_property(freetype_location freetype LOCATION)
 +    if (freetype_library_type STREQUAL STATIC_LIBRARY)
 +      set(freetype_library_type STATIC)
++    elseif (freetype_library_type STREQUAL SHARED_LIBRARY)
++      set(freetype_library_type SHARED)
 +    endif()
 +    get_target_property(freetype_interface_include_directories freetype INTERFACE_INCLUDE_DIRECTORIES)
 +    get_target_property(freetype_interface_link_libraries freetype INTERFACE_LINK_LIBRARIES)

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -293,7 +293,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.10:5.11.0")
 
     # Fix VTK to work with external freetype using CONFIG mode for find_package
-    # patch("FindFreetype.cmake.patch", when="@5.10.1:")
+    patch("FindFreetype.cmake.patch", when="@5.10.1:")
 
     # Fix VTK to remove deprecated ADIOS2 functions
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -293,7 +293,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.10:5.11.0")
 
     # Fix VTK to work with external freetype using CONFIG mode for find_package
-    patch("FindFreetype.cmake.patch", when="@5.10.1:")
+    # patch("FindFreetype.cmake.patch", when="@5.10.1:")
 
     # Fix VTK to remove deprecated ADIOS2 functions
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113


### PR DESCRIPTION
VTK's (and therefor Paraview's) FindFreetype module required patching to handle static import libraries from Freetype. However it did not cover shared libraries. This adds support for importing shared freetype into the VTK build system and the subsequent paraview build.