### PR TITLE
Fix wrong subdirectory property in Racket packages

### DIFF
--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -64,7 +64,7 @@ class RacketBuilder(spack.builder.Builder):
 
     @property
     def subdirectory(self):
-        if self.racket_name:
+        if self.pkg.racket_name:
             return "pkgs/{0}".format(self.pkg.racket_name)
         return None
 

--- a/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
@@ -13,7 +13,7 @@ class RktRacketLib(RacketPackage):
 
     maintainers = ["elfprince13"]
 
-    version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f") #tag="v8.3"
+    version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f")  #tag="v8.3"
     depends_on("racket@8.3", type=("build", "run"), when="@8.3")
 
     racket_name = "racket-lib"

--- a/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class RktRacketLib(RacketPackage):
+    """Stub package for packages which are currently part of core racket installation (but which may change in the future)."""
+
+    git      = "ssh://git@github.com/racket/racket.git"
+    
+
+    maintainers = ['elfprince13']
+
+    version('8.3', commit='cab83438422bfea0e4bd74bc3e8305e6517cf25f') #tag='v8.3'
+    depends_on('racket@8.3', type=('build', 'run'), when='@8.3')
+
+    racket_name = 'racket-lib'

--- a/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
@@ -7,7 +7,8 @@ from spack.package import *
 
 
 class RktRacketLib(RacketPackage):
-    """Stub package for packages which are currently part of core racket installation (but which may change in the future)."""
+    """Stub package for packages which are currently part of core
+    racket installation (but which may change in the future)."""
 
     git = "ssh://git@github.com/racket/racket.git"
 

--- a/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
@@ -9,12 +9,11 @@ from spack.package import *
 class RktRacketLib(RacketPackage):
     """Stub package for packages which are currently part of core racket installation (but which may change in the future)."""
 
-    git      = "ssh://git@github.com/racket/racket.git"
-    
+    git = "ssh://git@github.com/racket/racket.git"
 
-    maintainers = ['elfprince13']
+    maintainers = ["elfprince13"]
 
-    version('8.3', commit='cab83438422bfea0e4bd74bc3e8305e6517cf25f') #tag='v8.3'
-    depends_on('racket@8.3', type=('build', 'run'), when='@8.3')
+    version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f") #tag="v8.3"
+    depends_on("racket@8.3", type=("build", "run"), when="@8.3")
 
-    racket_name = 'racket-lib'
+    racket_name = "racket-lib"

--- a/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-racket-lib/package.py
@@ -13,7 +13,7 @@ class RktRacketLib(RacketPackage):
 
     maintainers = ["elfprince13"]
 
-    version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f")  #tag="v8.3"
+    version("8.3", commit="cab83438422bfea0e4bd74bc3e8305e6517cf25f")  # tag="v8.3"
     depends_on("racket@8.3", type=("build", "run"), when="@8.3")
 
     racket_name = "racket-lib"

--- a/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
+++ b/var/spack/repos/builtin/packages/rkt-scheme-lib/package.py
@@ -17,3 +17,4 @@ class RktSchemeLib(RacketPackage):
     depends_on("rkt-base@8.3", type=("build", "run"), when="@8.3")
 
     racket_name = "scheme-lib"
+    subdirectory = None


### PR DESCRIPTION
fixes #40086 

All existing Racket packages without an explicitly defined `subdirectory` property were being calculated incorrectly, in most cases due to a typo in the build system, and in one case because build system default changed from `None` without an update here.

Also introduces the wrapper Racket package I was testing when this was discovered.
Rolling it in (a) as an additional test-case to make sure things work correctly (b) it only manipulates `raco` package manager state and does not actually add code to an installation).