### PR TITLE
py-gpy: re-cythonize & drop python upperbound

### DIFF
--- a/var/spack/repos/builtin/packages/py-fn-py/package.py
+++ b/var/spack/repos/builtin/packages/py-fn-py/package.py
@@ -13,6 +13,10 @@ class PyFnPy(PythonPackage):
     homepage = "https://github.com/fnpy/fn.py"
     url = "https://github.com/fnpy/fn.py/archive/v0.5.2.tar.gz"
 
+    version("0.6.0", sha256="85d4d4ae6ce3c13e9dbe45df2895188f742ebddbf100a95d360d73a8965ee0c8")
     version("0.5.2", sha256="fda2253d792867a79514496932630622df9340f214a2f4b2d597b60a8cc3d96b")
 
     depends_on("py-setuptools", type="build")
+
+    # Uses inspect.getargspec
+    depends_on("python@:3.10", when="@:0.5", type=("run", "build"))

--- a/var/spack/repos/builtin/packages/py-gpy/package.py
+++ b/var/spack/repos/builtin/packages/py-gpy/package.py
@@ -13,6 +13,7 @@ class PyGpy(PythonPackage):
     pypi = "gpy/GPy-1.9.9.tar.gz"
     maintainers("liuyangzhuan")
 
+    version("1.10.0", sha256="a2b793ef8d0ac71739e7ba1c203bc8a5afa191058b42caa617e0e29aa52aa6fb")
     version("1.9.9", sha256="04faf0c24eacc4dea60727c50a48a07ddf9b5751a3b73c382105e2a31657c7ed")
     version("0.8.8", sha256="e135d928cf170e2ec7fb058a035b5a7e334dc6b84d0bfb981556782528341988")
 
@@ -22,4 +23,11 @@ class PyGpy(PythonPackage):
     depends_on("py-six", type=("build", "run"))
     depends_on("py-paramz@0.9.0:", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
-    depends_on("python@:3.8", type=("build", "run"))
+
+    @run_before("install")
+    def touch_sources(self):
+        # This packages uses deprecated build_ext, for which we cannot
+        # automatically force recythonization.
+        # See also https://github.com/SheffieldML/GPy/pull/1020
+        for src in find(".", "*.pyx"):
+            touch(src)

--- a/var/spack/repos/builtin/packages/py-gpy/package.py
+++ b/var/spack/repos/builtin/packages/py-gpy/package.py
@@ -20,6 +20,7 @@ class PyGpy(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.7:", type=("build", "run"))
     depends_on("py-scipy@0.16:", type=("build", "run"))
+    depends_on("py-scipy@1.3:", when="@1.10.0:", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
     depends_on("py-paramz@0.9.0:", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")

--- a/var/spack/repos/builtin/packages/py-gpy/package.py
+++ b/var/spack/repos/builtin/packages/py-gpy/package.py
@@ -23,6 +23,7 @@ class PyGpy(PythonPackage):
     depends_on("py-scipy@1.3:", when="@1.10.0:", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
     depends_on("py-paramz@0.9.0:", type=("build", "run"))
+    # cython is install_requires, but not used at runtime, so stick to build type
     depends_on("py-cython@0.29:", type="build")
 
     @run_before("install")

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -49,6 +51,13 @@ class PyStatsmodels(PythonPackage):
     depends_on("py-packaging@21.3:", type=("build", "run"), when="@0.13.2:")
 
     depends_on("py-pytest", type="test")
+
+    @run_before("install")
+    def remove_generated_sources(self):
+        # Automatic recythonization doesn't work here, because cythonize is called
+        # with force=False by default, so remove generated C files manually.
+        for f in find(".", "*.c"):
+            os.unlink(f)
 
     @run_after("install")
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
py-gpy: the upperbound is only necessary because of forward incompatible generated C code, but that's not an issue when recythonizing, so the python upperbound can be dropped.