### PR TITLE
cython: add build-tools tag

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -11,6 +11,7 @@ class PyCython(PythonPackage):
 
     homepage = "https://github.com/cython/cython"
     pypi = "cython/Cython-0.29.21.tar.gz"
+    tags = ["build-tools"]
 
     version("3.0.0", sha256="350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82")
     version(


### PR DESCRIPTION
cython is one of the candidates for multiple build deps, cause the ecosystem is rather split between 0.29.x vs 3.0.x only.
