### PR TITLE
Fix false detection of llvm-amdgpu as llvm and llvm-doe

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -252,6 +252,8 @@ class LlvmDoe(CMakePackage, CudaPackage):
             output = compiler("--version", output=str, error=str)
             if "Apple" in output:
                 return None
+            if "AMD" in output:
+                return None
             match = version_regex.search(output)
             if match:
                 return match.group(match.lastindex)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -597,6 +597,8 @@ class Llvm(CMakePackage, CudaPackage):
             output = compiler("--version", output=str, error=str)
             if "Apple" in output:
                 return None
+            if "AMD" in output:
+                return None
             match = version_regex.search(output)
             if match:
                 return match.group(match.lastindex)


### PR DESCRIPTION
`amdclang` version string always starts with `AMD`. Ignore this string when parsing `--version` output, just like we ignore `Apple`