### PR TITLE
py-gevent: relax dependency constraints

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -18,25 +18,21 @@ class PyGevent(PythonPackage):
     version("21.8.0", sha256="43e93e1a4738c922a2416baf33f0afb0a20b22d3dba886720bc037cd02a98575")
     version("1.5.0", sha256="b2814258e3b3fb32786bb73af271ad31f51e1ac01f33b37426b66cb8491b4c29")
 
-    # limits according to wheels available on PyPI
-    depends_on("python@3.8:3.12", when="@23.7.0:", type=("build", "run"))
-    depends_on("python@2.7:3.10", when="@21.8:21.12", type=("build", "run"))
-    depends_on("python@2.7:3.8", when="@1.5:20.6.0", type=("build", "run"))
+    depends_on("python@3.8:", when="@23.7.0:", type=("build", "run"))
+    depends_on("python@:3.10", when="@:21.12", type=("build", "run"))
 
     depends_on("py-setuptools@40.8:", when="@20.5.1:", type=("build", "run"))
     depends_on("py-setuptools@40.8:", when="@1.5:", type="build")
     depends_on("py-setuptools@24.2:", when="@:1.4", type="build")
-    depends_on("py-cython@3:", when="@20.5.1:", type="build")
+    # TODO: relax this until we support separate concretization of build deps by default
+    # depends_on("py-cython@3:", when="@20.5.1:", type="build")
     depends_on("py-cython@0.29.14:", when="@1.5:", type="build")
-    depends_on("py-cython@0.27:", when="@:1.4", type="build")
-    depends_on("py-cffi@1.12.3:", when="@1.5:", type=("build", "run"))  # from pyproject.toml
-    depends_on("py-cffi@1.4:", when="@:1.4", type=("build", "run"))
+    depends_on("py-cffi@1.12.3:", type=("build", "run"))
     depends_on("py-greenlet@3:", when="@23.7: ^python@3.12:", type=("build", "run"))
     depends_on("py-greenlet@2:", when="@22.10.2: ^python@:3.11", type=("build", "run"))
     depends_on("py-greenlet@1.1:1", when="@21.8:21.12.0", type=("build", "run"))
     depends_on("py-greenlet@0.4.17:1", when="@20.12:21.1.2", type=("build", "run"))
-    depends_on("py-greenlet@0.4.14:", when="@1.5:", type=("build", "run"))
-    depends_on("py-greenlet@0.4.13:", when="@:1.4", type=("build", "run"))
+    depends_on("py-greenlet@0.4.14:", type=("build", "run"))
     depends_on("py-zope-event", when="@20.5.1:", type=("build", "run"))
     depends_on("py-zope-interface", when="@20.5.1:", type=("build", "run"))
 


### PR DESCRIPTION
### Problem

The majority of packages in Spack only support cython 0. This includes things like numpy that are almost always guaranteed to be in a moderately sized DAG. However, gevent has required cython 3 for a long time now. Recent PRs also noted that gevent didn't support newer Python until recently. The result is that any environment containing both numpy and gevent could not be built with Python 3.9+.

### Solution

From experimentation, it turns out that cython 0 works fine for building the package. Also, even the oldest version of gevent builds fine with Python 3.10 (but not 3.11). This PR relaxes the constraints on both cython and python versions to be as flexible as possible.

I'm not sure what the consequences of this are long-term, but I'm hoping that @alalazo's efforts to support separate concretization of build deps will make at least our cython problems go away.