### PR TITLE
e4s-cray: drop in ci as there are no runners

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -827,16 +827,16 @@ e4s-cray-rhel-build:
   variables:
     SPACK_CI_STACK_NAME: e4s-cray-sles
 
-e4s-cray-sles-generate:
-  extends: [ ".generate-cray-sles", ".e4s-cray-sles" ]
+# e4s-cray-sles-generate:
+#   extends: [ ".generate-cray-sles", ".e4s-cray-sles" ]
 
-e4s-cray-sles-build:
-  extends: [ ".build", ".e4s-cray-sles" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-cray-sles-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: e4s-cray-sles-generate
+# e4s-cray-sles-build:
+#   extends: [ ".build", ".e4s-cray-sles" ]
+#   trigger:
+#     include:
+#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+#         job: e4s-cray-sles-generate
+#     strategy: depend
+#   needs:
+#     - artifacts: True
+#       job: e4s-cray-sles-generate


### PR DESCRIPTION
It holds up CI on develop
