### PR TITLE
py-fenics-dolfinx: add version upper bound for Python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -25,9 +25,9 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("hdf5", type="build")
     depends_on("pkgconfig", type="build")
 
-    depends_on("python@3.8:", type=("build", "run"), when="@main")
-    depends_on("python@3.8:3.10", type=("build", "run"), when="@0.5:")
-    depends_on("python@3.7:3.10", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.6.1:", type=("build", "run"))
+    depends_on("python@3.8:3.10", when="@0.5:0.6.0", type=("build", "run"))
+    depends_on("python@3.7:3.10", when="@0.4", type=("build", "run"))
 
     depends_on("fenics-dolfinx@main", when="@main")
     depends_on("fenics-dolfinx@0.6.0", when="@0.6.0")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -24,8 +24,10 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("cmake@3.19:", type="build")
     depends_on("hdf5", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("python@3.8:", type=("build", "run"), when="@0.5:")
-    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("python@3.8:", type=("build", "run"), when="@main")
+    depends_on("python@3.8:3.10", type=("build", "run"), when="@0.5:")
+    depends_on("python@3.7::3.10", type=("build", "run"))
 
     depends_on("fenics-dolfinx@main", when="@main")
     depends_on("fenics-dolfinx@0.6.0", when="@0.6.0")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -27,7 +27,7 @@ class PyFenicsDolfinx(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"), when="@main")
     depends_on("python@3.8:3.10", type=("build", "run"), when="@0.5:")
-    depends_on("python@3.7::3.10", type=("build", "run"))
+    depends_on("python@3.7:3.10", type=("build", "run"))
 
     depends_on("fenics-dolfinx@main", when="@main")
     depends_on("fenics-dolfinx@0.6.0", when="@0.6.0")


### PR DESCRIPTION
Releases of the DOLFINx Python interface fail with Python 3.11 (fixed in development version). This PR sets Python 3.10 as an upper bound for the release versions of DOLFINx.