### PR TITLE
Restore virtuals normalization on edge construction

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -740,7 +740,7 @@ class DependencySpec:
         self.parent = parent
         self.spec = spec
         self.depflag = depflag
-        self.virtuals = virtuals
+        self.virtuals = tuple(sorted(set(virtuals)))
 
     def update_deptypes(self, depflag: dt.DepFlag) -> bool:
         """Update the current dependency types"""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -11,6 +11,7 @@ from spack.error import SpecError, UnsatisfiableSpecError
 from spack.spec import (
     ArchSpec,
     CompilerSpec,
+    DependencySpec,
     Spec,
     SpecFormatSigilError,
     SpecFormatStringError,
@@ -1326,3 +1327,15 @@ def test_abstract_hash_intersects_and_satisfies(default_mock_concretization):
     # disjoint concretization space
     assert_disjoint(abstract_none, concrete)
     assert_disjoint(abstract_none, abstract_5)
+
+
+def test_edge_equality_does_not_depend_on_virtual_order():
+    """Tests that two edges that are constructed with just a different order of the virtuals in
+    the input parameters are equal to each other.
+    """
+    parent, child = Spec("parent"), Spec("child")
+    edge1 = DependencySpec(parent, child, depflag=0, virtuals=("mpi", "lapack"))
+    edge2 = DependencySpec(parent, child, depflag=0, virtuals=("lapack", "mpi"))
+    assert edge1 == edge2
+    assert tuple(sorted(edge1.virtuals)) == edge1.virtuals
+    assert tuple(sorted(edge2.virtuals)) == edge1.virtuals

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -500,3 +500,8 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
 
     openmpi_edges = s2.edges_to_dependencies(name="openmpi")
     assert len(openmpi_edges) == 1
+
+    # The virtuals attribute must be a tuple, when read from a
+    # JSON or YAML file, not a list
+    for edge in s2.traverse_edges():
+        assert isinstance(edge.virtuals, tuple), edge


### PR DESCRIPTION
The recent merge of #39472 introduced a bug in the construction of `DependencySpec`, see https://github.com/spack/spack/pull/39472#discussion_r1332937937. The bug was undetected as there were no tests checking that the `virtuals` attribute of edges was properly normalized to a sorted tuple of strings.

This PR restore the normalization and adds regression tests to detect these kind of issues in the future. An example of how the unit tests would currently fail on develop is:

![Screenshot from 2023-09-21 14-16-05](https://github.com/spack/spack/assets/4199709/fa330de7-d204-400d-a7bc-613793fca981)
