### PR TITLE
added json export for variants

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -18,6 +18,8 @@ import llnl.util.tty.color
 
 import spack.directives
 import spack.error as error
+import spack.util.spack_json as sjson
+import spack.util.spack_yaml as syaml
 from spack.util.string import comma_or
 
 special_variant_values = [None, "none", "*"]
@@ -662,6 +664,10 @@ class VariantMap(lang.HashableMap):
             string.write(str(self[key]))
 
         return string.getvalue()
+
+    def to_json(self, stream=None):
+        variants_dict = syaml.syaml_dict(sorted(v.yaml_entry() for _, v in self.items()))
+        return sjson.dump(variants_dict, stream)
 
 
 def substitute_abstract_variants(spec):


### PR DESCRIPTION
This adds the ability to export `VariantMap` as JSON, making it easier to process this data in a context where the Spack parser isn’t available.

If tests are needed, I was looking at [this](https://github.com/spack/spack/blob/87f99de3fb2d064549db4a156e4f5c33e98e3308/lib/spack/spack/test/spec_yaml.py#L38-L41) as a model, but this wouldn’t completely apply since there is no equivalent `from_json` method for the class.