### PR TITLE
openssh: fix compile issue with newer zlib, add version 9.4p1

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -23,6 +23,7 @@ class Openssh(AutotoolsPackage):
 
     tags = ["core-packages"]
 
+    version("9.4p1", sha256="3608fd9088db2163ceb3e600c85ab79d0de3d221e59192ea1923e23263866a85")
     version("9.3p1", sha256="e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8")
     version("9.2p1", sha256="3f66dbf1655fb45f50e1c56da62ab01218c228807b21338d634ebcdf9d71cf46")
     version("9.1p1", sha256="19f85009c7e3e23787f0236fbb1578392ab4d4bf9f8ec5fe6bc1cd7e8bfdd288")
@@ -58,6 +59,7 @@ class Openssh(AutotoolsPackage):
     depends_on("libedit")
     depends_on("ncurses")
     depends_on("zlib-api")
+    depends_on("zlib@:1.2", when="@:9.4p1 ^zlib")  # fails to compile with 1.3 as of 9.4p1
     depends_on("py-twisted", type="test")
     depends_on("libxcrypt", type="link")
 


### PR DESCRIPTION
Openssh doesn't like zlib 1.3 presently, which was tripping up an automated build process for my env.

Also adds 9.4.