### PR TITLE
py-pyzmq: force recythonize of older versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -41,8 +41,6 @@ class PyPyzmq(PythonPackage):
     version("16.0.2", sha256="0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d")
     version("14.7.0", sha256="77994f80360488e7153e64e5959dc5471531d1648e3a4bff14a714d074a38cc2")
 
-    # Python 3.9 build issues
-    depends_on("python@2.7,3.3:3.8", type=("build", "run"), when="@16:18.0")
     depends_on("python@2.6:2.7,3.2:3.8", type=("build", "run"), when="@:14")
 
     # pyproject.toml
@@ -61,6 +59,15 @@ class PyPyzmq(PythonPackage):
 
     # Undocumented dependencies
     depends_on("py-gevent", type=("build", "run"))
+
+    @run_before("install")
+    @when("@15:19")
+    def remove_cythonized_files(self):
+        # Before v20.0.0 an ancient cythonize API was used, for which we cannot
+        # force re-cythonization. Re-cythonizing v14.x fails in general, so
+        # restrict to 15:19
+        for f in find(".", "*.pyx"):
+            touch(f)
 
     @run_before("install")
     def setup(self):


### PR DESCRIPTION
Force re-cythonization to drop the upperbound on python when possible, this is
only necessary for versions that use an ancient API of cython, for which Spack
can't automatically do this. Newer cython complains about v14, so I left that one
out.

This should bump `nrm` to Python 3.11 in CI.

