### PR TITLE
Remove distutils dependency in Spack

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -7,7 +7,6 @@ import os
 import re
 import subprocess
 import sys
-from distutils.version import StrictVersion
 from typing import Dict, List, Set
 
 import spack.compiler
@@ -115,11 +114,11 @@ class VCVarsInvocation(VarsInvocation):
 
 def get_valid_fortran_pth(comp_ver):
     cl_ver = str(comp_ver)
-    sort_fn = lambda fc_ver: StrictVersion(fc_ver)
+    sort_fn = lambda fc_ver: Version(fc_ver)
     sort_fc_ver = sorted(list(avail_fc_version), key=sort_fn)
     for ver in sort_fc_ver:
         if ver in fortran_mapping:
-            if StrictVersion(cl_ver) <= StrictVersion(fortran_mapping[ver]):
+            if Version(cl_ver) <= Version(fortran_mapping[ver]):
                 return fc_path[ver]
     return None
 

--- a/var/spack/repos/builtin/packages/spack/package.py
+++ b/var/spack/repos/builtin/packages/spack/package.py
@@ -61,10 +61,15 @@ class Spack(Package):
     # This should be read as "require at least curl", not "require curl".
     requires("fetchers=curl", when="@:0.16", msg="Curl is required for Spack < 0.17")
 
-    # Python (with spack python -i ipython support)
+    # Python
     depends_on("python@2.6.0:2.7,3.5:", type="run")
     depends_on("python@2.7.0:2.7,3.5:", type="run", when="@0.18.0:")
     depends_on("python@2.7.0:2.7,3.6:", type="run", when="@0.19.0:")
+
+    # Old Spack unfortunately depends on distutils, removed in Python 3.12
+    depends_on("python@:3.12", type="run", when="@0.18:0.20.1")
+
+    # spack python -i ipython support
     depends_on("py-ipython", type="run")
 
     # Concretizer


### PR DESCRIPTION
msvc.py: don't import distutils

Introduced in https://github.com/spack/spack/pull/27021, makes Spack forward incompatible with Python.

The module was already deprecated at the time of the PR.

The spack package is updated to reflect the incompatibility.
