### PR TITLE
py-tinyarray: add version 1.2.4, needed for python@3.10

### DIFF
--- a/var/spack/repos/builtin/packages/py-tinyarray/package.py
+++ b/var/spack/repos/builtin/packages/py-tinyarray/package.py
@@ -30,5 +30,4 @@ class PyTinyarray(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     # See https://gitlab.kwant-project.org/kwant/tinyarray/-/merge_requests/14
-    conflicts("^python@3.10:", when="@:1.2.3", 
-            msg="py-tinyarray must be @1.2.4: for python@3.10")
+    conflicts("^python@3.10:", when="@:1.2.3", msg="py-tinyarray must be @1.2.4: for python@3.10")

--- a/var/spack/repos/builtin/packages/py-tinyarray/package.py
+++ b/var/spack/repos/builtin/packages/py-tinyarray/package.py
@@ -22,8 +22,13 @@ class PyTinyarray(PythonPackage):
     # package is updated
     maintainers("payerle")
 
+    version("1.2.4", sha256="ecd3428fd8a48b61fc5f0a413ede03e27db3a1dd53fcd49e24a36d11a8a29aba")
     version("1.2.3", sha256="47a06f801ed4b3d438f4f7098e244cd0c6d7db09428b1bc5ee813e52234dee9f")
     version("1.2.2", sha256="660d6d8532e1db5efbebae2861e5733a7082486fbdeb47d57d84b8f477d697e4")
     version("1.2.1", sha256="47a06f801ed4b3d438f4f7098e244cd0c6d7db09428b1bc5ee813e52234dee9f")
 
     depends_on("py-setuptools", type="build")
+
+    # See https://gitlab.kwant-project.org/kwant/tinyarray/-/merge_requests/14
+    conflicts("^python@3.10:", when="@:1.2.3", 
+            msg="py-tinyarray must be @1.2.4: for python@3.10")


### PR DESCRIPTION
Added @1.2.4
Require @1.2.4 when using python@3.10: