### PR TITLE
error messages: condition chaining

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1525,7 +1525,11 @@ class Environment:
         batch = []
         for j, (i, concrete, duration) in enumerate(
             spack.util.parallel.imap_unordered(
-                _concretize_task, args, processes=num_procs, debug=tty.is_debug()
+                _concretize_task,
+                args,
+                processes=num_procs,
+                debug=tty.is_debug(),
+                maxtaskperchild=1,
             )
         ):
             batch.append((i, concrete))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1757,8 +1757,8 @@ class SpackSolverSetup:
             # Declare external conditions with a local index into packages.yaml
             for local_idx, spec in enumerate(external_specs):
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
-                condition_id = self.condition(spec, msg=msg)
-                self.gen.fact(fn.pkg_fact(pkg_name, fn.possible_external(condition_id, local_idx)))
+                external_imposition = [fn.attr("external_conditions_hold", spec.name, local_idx)]
+                condition_id = self.condition(spec, external_imposition, msg=msg)
                 self.possible_versions[spec.name].add(spec.version)
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1497,8 +1497,9 @@ class SpackSolverSetup:
         Returns:
             int: id of the condition created by this function
         """
+        # Defensive copy of string or spec
+        named_cond = required_spec.copy()
         if isinstance(named_cond, spack.spec.Spec):
-            named_cond = required_spec.copy()
             named_cond.name = named_cond.name or name
             name = named_cond.name
         assert name, "must provide name for anonymous conditions!"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1345,6 +1345,9 @@ class SpackSolverSetup:
         # virtuals
         self.package_provider_rules(pkg)
 
+        # dependencies
+        self.package_dependencies_rules(pkg)
+
         # virtual preferences
         self.virtual_preferences(
             pkg.name,
@@ -1352,13 +1355,6 @@ class SpackSolverSetup:
         )
 
         self.package_requirement_rules(pkg)
-
-        # trigger and effect tables
-        self.trigger_rules()
-        self.effect_rules()
-
-        # dependencies have special triggers/effects, have to be handled separately
-        self.package_dependencies_rules(pkg)
 
         # trigger and effect tables
         self.trigger_rules()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1577,7 +1577,7 @@ class SpackSolverSetup:
                 if not depflag:
                     continue
 
-                msg = "%s depends on %s" % (pkg.name, dep.spec.name)
+                msg = "%s depends on %s" % (pkg.name, dep.spec)
                 if cond != spack.spec.Spec():
                     msg += " when %s" % cond
                 else:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1484,10 +1484,15 @@ class SpackSolverSetup:
     def condition(self, required_spec, imposed_spec=None, name=None, msg=None, node=False):
         """Generate facts for a dependency or virtual provider condition.
 
+        Constraints can be passed as a Spec, or as a list of AspFunction objects constructed
+        manually using self.spec_clauses(). The latter format is supported for cases where
+        individual constraints must be added or removed.
+
         Arguments:
-            required_spec (spack.spec.Spec): the spec that triggers this condition
-            imposed_spec (spack.spec.Spec or None): the spec with constraints that
-                are imposed when this condition is triggered
+            required_spec (spack.spec.Spec or List[AspFunction]): the constraints that triggers
+                this condition
+            imposed_spec (spack.spec.Spec, List[AspFunction], or None): the constraints that are
+                imposed when this condition is triggered
             name (str or None): name for `required_spec` (required if
                 required_spec is anonymous, ignored if not)
             msg (str or None): description of the condition
@@ -1496,8 +1501,8 @@ class SpackSolverSetup:
         Returns:
             int: id of the condition created by this function
         """
-        named_cond = required_spec.copy()
         if isinstance(named_cond, spack.spec.Spec):
+            named_cond = required_spec.copy()
             named_cond.name = named_cond.name or name
             name = named_cond.name
         assert name, "must provide name for anonymous conditions!"
@@ -1613,7 +1618,7 @@ class SpackSolverSetup:
                     if t & depflag
                 ]
 
-                _ = self.condition(required, imposed, pkg.name, msg)
+                self.condition(required, imposed, pkg.name, msg)
 
                 self.gen.newline()
 
@@ -1777,7 +1782,7 @@ class SpackSolverSetup:
             for local_idx, spec in enumerate(external_specs):
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
                 external_imposition = [fn.attr("external_conditions_hold", spec.name, local_idx)]
-                _ = self.condition(spec, external_imposition, msg=msg)
+                self.condition(spec, external_imposition, msg=msg)
                 self.possible_versions[spec.name].add(spec.version)
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1325,9 +1325,6 @@ class SpackSolverSetup:
         # virtuals
         self.package_provider_rules(pkg)
 
-        # dependencies
-        self.package_dependencies_rules(pkg)
-
         # virtual preferences
         self.virtual_preferences(
             pkg.name,
@@ -1339,6 +1336,14 @@ class SpackSolverSetup:
         # trigger and effect tables
         self.trigger_rules()
         self.effect_rules()
+
+        # dependencies have special triggers/effects, have to be handled separately
+        self.package_dependencies_rules(pkg)
+
+        # trigger and effect tables
+        self.trigger_rules()
+        self.effect_rules()
+
 
     def trigger_rules(self):
         """Flushes all the trigger rules collected so far, and clears the cache."""
@@ -1578,15 +1583,18 @@ class SpackSolverSetup:
                 else:
                     pass
 
-                condition_id = self.condition(cond, dep.spec, pkg.name, msg)
-                self.gen.fact(
-                    fn.pkg_fact(pkg.name, fn.dependency_condition(condition_id, dep.spec.name))
-                )
+                required_spec = cond.copy()
+                required_spec.name = cond.name or pkg.name
+                required = self.spec_clauses(required_spec, body=True)
+                required += [fn.attr("track_dependencies", pkg.name)]
+                imposed = self.spec_clauses(dep.spec)
+                imposed += [
+                    fn.attr("dependency_holds", pkg.name, dep.spec.name, dt.flag_to_string(t))
+                    for t in dt.ALL_FLAGS
+                    if t & depflag
+                ]
 
-                for t in dt.ALL_FLAGS:
-                    if t & depflag:
-                        # there is a declared dependency of type t
-                        self.gen.fact(fn.dependency_type(condition_id, dt.flag_to_string(t)))
+                condition_id = self.condition(required, imposed, pkg.name, msg)
 
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1180,7 +1180,7 @@ class SpackSolverSetup:
         default_msg = "{0}: '{1}' conflicts with '{2}'"
         no_constraint_msg = "{0}: conflicts with '{1}'"
         for trigger, constraints in pkg.conflicts.items():
-            trigger_msg = "conflict trigger %s" % str(trigger)
+            trigger_msg = "conflict is triggered when %s" % str(trigger)
             trigger_spec = spack.spec.Spec(trigger)
             trigger_id = self.condition(
                 trigger_spec, name=trigger_spec.name or pkg.name, msg=trigger_msg
@@ -1192,7 +1192,10 @@ class SpackSolverSetup:
                         conflict_msg = no_constraint_msg.format(pkg.name, trigger)
                     else:
                         conflict_msg = default_msg.format(pkg.name, trigger, constraint)
-                constraint_msg = "conflict constraint %s" % str(constraint)
+
+                constraint_msg = "conflict applies to spec %s" % str(
+                    spack.spec.Spec(pkg.name) if constraint == spack.spec.Spec() else constraint
+                )
                 constraint_id = self.condition(constraint, name=pkg.name, msg=constraint_msg)
                 self.gen.fact(
                     fn.pkg_fact(pkg.name, fn.conflict(trigger_id, constraint_id, conflict_msg))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -759,7 +759,6 @@ class ErrorHandler:
 
         parent_dir = pathlib.Path(__file__).parent
         errors_lp = parent_dir / "error_messages.lp"
-        display_lp = parent_dir / "display.lp"
 
         def on_model(model):
             self.full_model = model.symbols(shown=True, terms=True)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -763,20 +763,9 @@ class ErrorHandler:
         def on_model(model):
             self.full_model = model.symbols(shown=True, terms=True)
 
-        desymbolify = lambda a: a.string if a.type == clingo.SymbolType.String else a.number
         with error_causation.backend() as backend:
             for atom in self.model:
-                symbol = getattr(fn, atom.name)
-                for arg in atom.arguments:
-                    if arg.type == clingo.SymbolType.String:
-                        symbol = symbol(arg.string)
-                    elif arg.type == clingo.SymbolType.Number:
-                        symbol = symbol(arg.number)
-                    else:
-                        # It's a node
-                        args = getattr(fn, arg.name)(*[desymbolify(a) for a in arg.arguments])
-                        symbol = symbol(args)
-                atom_id = backend.add_atom(symbol.symbol())
+                atom_id = backend.add_atom(atom)
                 backend.add_rule([atom_id], [], choice=False)
 
             error_causation.load(str(errors_lp))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -958,7 +958,6 @@ class PyclingoDriver:
                 if sym.name not in ("attr", "error", "opt_criterion"):
                     tty.debug(
                         "UNKNOWN SYMBOL: %s(%s)"
-
                         % (sym.name, ", ".join([str(s) for s in intermediate_repr(sym.arguments)]))
                     )
 
@@ -1344,7 +1343,6 @@ class SpackSolverSetup:
         self.trigger_rules()
         self.effect_rules()
 
-
     def trigger_rules(self):
         """Flushes all the trigger rules collected so far, and clears the cache."""
         self.gen.h2("Trigger conditions")
@@ -1594,7 +1592,7 @@ class SpackSolverSetup:
                     if t & depflag
                 ]
 
-                condition_id = self.condition(required, imposed, pkg.name, msg)
+                _ = self.condition(required, imposed, pkg.name, msg)
 
                 self.gen.newline()
 
@@ -1694,7 +1692,7 @@ class SpackSolverSetup:
                         imposed_spec=spec,
                         name=pkg_name,
                         node=virtual,
-                        msg=f"{spec_str} is a requirement for package {pkg_name}"
+                        msg=f"{spec_str} is a requirement for package {pkg_name}",
                     )
                 except Exception as e:
                     # Do not raise if the rule comes from the 'all' subsection, since usability
@@ -1758,7 +1756,7 @@ class SpackSolverSetup:
             for local_idx, spec in enumerate(external_specs):
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
                 external_imposition = [fn.attr("external_conditions_hold", spec.name, local_idx)]
-                condition_id = self.condition(spec, external_imposition, msg=msg)
+                _ = self.condition(spec, external_imposition, msg=msg)
                 self.possible_versions[spec.name].add(spec.version)
                 self.gen.newline()
 
@@ -2623,13 +2621,17 @@ class SpackSolverSetup:
             # Effect imposes the spec
             imposed_spec_key = str(spec)
             cache = self._effect_cache[spec.name]
-            msg = "literal specs have different requirements. clear cache before computing literals"
-            assert imposed_spec_key not in cache,     msg
+            msg = (
+                "literal specs have different requirements. clear cache before computing literals"
+            )
+            assert imposed_spec_key not in cache, msg
             effect_id = next(self._effect_id_counter)
             requirements = self.spec_clauses(spec)
             for clause in requirements:
                 if clause.args[0] == "variant_set":
-                    requirements.append(fn.attr("variant_default_value_from_cli", *clause.args[1:]))
+                    requirements.append(
+                        fn.attr("variant_default_value_from_cli", *clause.args[1:])
+                    )
             requirements.append(fn.attr("virtual_root" if spec.virtual else "root", spec.name))
             cache[imposed_spec_key] = (effect_id, requirements)
             self.gen.fact(fn.pkg_fact(spec.name, fn.condition_effect(condition_id, effect_id)))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1675,7 +1675,11 @@ class SpackSolverSetup:
 
                 try:
                     member_id = self.condition(
-                        required_spec=when_spec, imposed_spec=spec, name=pkg_name, node=virtual
+                        required_spec=when_spec,
+                        imposed_spec=spec,
+                        name=pkg_name,
+                        node=virtual,
+                        msg=f"{spec_str} is a requirement for package {pkg_name}"
                     )
                 except Exception as e:
                     # Do not raise if the rule comes from the 'all' subsection, since usability

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -693,7 +693,6 @@ class ErrorHandler:
     def __init__(self, model):
         self.model = model
         self.full_model = None
-        self.error_args = extract_args(model, "error")
 
     def multiple_values_error(self, attribute, pkg):
         return f'Cannot select a single "{attribute}" for package "{pkg}"'
@@ -760,7 +759,8 @@ class ErrorHandler:
         return "\n".join([header] + messages)
 
     def raise_if_errors(self):
-        if not self.error_args:
+        initial_error_args = extract_args(self.model, "error")
+        if not initial_error_args:
             return
 
         error_causation = clingo.Control()
@@ -781,9 +781,9 @@ class ErrorHandler:
             _ = error_causation.solve(on_model=on_model)
 
         # No choices so there will be only one model
-        self.error_args = extract_args(self.full_model, "error")
+        error_args = extract_args(self.full_model, "error")
         errors = sorted(
-            [(int(priority), msg, args) for priority, msg, *args in self.error_args], reverse=True
+            [(int(priority), msg, args) for priority, msg, *args in error_args], reverse=True
         )
         msg = self.message(errors)
         raise UnsatisfiableSpecError(msg)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -781,7 +781,6 @@ class ErrorHandler:
                 backend.add_rule([atom_id], [], choice=False)
 
             error_causation.load(str(errors_lp))
-            error_causation.load(str(display_lp))
             error_causation.ground([("base", []), ("error_messages", [])])
             _ = error_causation.solve(on_model=on_model)
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -635,11 +635,11 @@ possible_provider_weight(node(DependencyID, Dependency), VirtualNode, 100, "fall
     pkg_fact(Package, version_declared(Version, Weight, "external")) }
     :- external(node(ID, Package)).
 
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
+error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec version", Package)
   :- external(node(ID, Package)),
      not external_version(node(ID, Package), _, _).
 
-error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
+error(100, "Attempted to use external for '{0}' which does not satisfy a unique configured external spec version", Package)
   :- external(node(ID, Package)),
      2 { external_version(node(ID, Package), Version, Weight) }.
 
@@ -668,18 +668,15 @@ external(PackageNode) :- attr("external_spec_selected", PackageNode, _).
 
 % determine if an external spec has been selected
 attr("external_spec_selected", node(ID, Package), LocalIndex) :-
-    external_conditions_hold(node(ID, Package), LocalIndex),
+    attr("external_conditions_hold", node(ID, Package), LocalIndex),
     attr("node", node(ID, Package)),
     not attr("hash", node(ID, Package), _).
-
-external_conditions_hold(node(PackageID, Package), LocalIndex) :-
-    pkg_fact(Package, possible_external(ID, LocalIndex)), condition_holds(ID, node(PackageID, Package)).
 
 % it cannot happen that a spec is external, but none of the external specs
 % conditions hold.
 error(100, "Attempted to use external for '{0}' which does not satisfy any configured external spec", Package)
  :- external(node(ID, Package)),
-    not external_conditions_hold(node(ID, Package), _).
+    not attr("external_conditions_hold", node(ID, Package), _).
 
 %-----------------------------------------------------------------------------
 % Config required semantics
@@ -897,8 +894,9 @@ variant_default_not_used(node(ID, Package), Variant, Value)
 % The variant is set in an external spec
 external_with_variant_set(node(NodeID, Package), Variant, Value)
  :- attr("variant_value", node(NodeID, Package), Variant, Value),
-    condition_requirement(ID, "variant_value", Package, Variant, Value),
-    pkg_fact(Package, possible_external(ID, _)),
+    condition_requirement(TriggerID, "variant_value", Package, Variant, Value),
+    trigger_and_effect(Package, TriggerID, EffectID),
+    imposed_constraint(EffectID, "external_conditions_hold", Package, _),
     external(node(NodeID, Package)),
     attr("node", node(NodeID, Package)).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -40,7 +40,7 @@
 :- provider(_, VirtualNode), not attr("virtual_node", VirtualNode), internal_error("provider with no virtual node").
 :- provider(PackageNode, _), not attr("node", PackageNode), internal_error("provider with no real node").
 
-:- attr("root", node(ID, PackageNode)), ID > min_dupe_id, internal_error("root in non-minimum unification set").
+:- attr("root", node(ID, PackageNode)), ID > min_dupe_id, internal_error("root with a non-minimal duplicate ID").
 
 % Nodes in the "root" unification set cannot depend on non-root nodes if the dependency is "link" or "run"
 :- attr("depends_on", node(min_dupe_id, Package), node(ID, _), "link"), ID != min_dupe_id, unification_set("root", node(min_dupe_id, Package)), internal_error("link dependency out of the root unification set").
@@ -48,7 +48,7 @@
 
 % Rules on "unification sets", i.e. on sets of nodes allowing a single configuration of any given package
 unify(SetID, PackageName) :- unification_set(SetID, node(_, PackageName)).
-:- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName), internal_error("unified package in multiple unification sets").
+:- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName).
 
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -373,11 +373,13 @@ attr("node_flag_source", node(X, A1), A2, node(Y, A3))
      imposed_constraint(ID, "node_flag_source", A1, A2, A3),
      condition_set(node(Y, A3), node(X, A1)).
 
-attr("provider_set", node(PDupID, Provider), node(VDupID, Virtual))
-  :- impose(ID, RequestingNode),
-     imposed_constraint(ID, "provider_set", Provider, Virtual),
-     condition_set(RequestingNode, node(PDupID, Provider)),
-     condition_set(RequestingNode, node(VDupID, Virtual)).
+% Provider set is relevant only for literals, since it's the only place where `^[virtuals=foo] bar`
+% might appear in the HEAD of a rule
+attr("provider_set", node(min_dupe_id, Provider), node(min_dupe_id, Virtual))
+  :- solve_literal(TriggerID),
+     trigger_and_effect(_, TriggerID, EffectID),
+     impose(EffectID, _),
+     imposed_constraint(EffectID, "provider_set", Provider, Virtual).
 
 provider(ProviderNode, VirtualNode) :- attr("provider_set", ProviderNode, VirtualNode).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -10,9 +10,8 @@
 % ID of the nodes in the "root" link-run sub-DAG
 #const min_dupe_id = 0.
 
-#const link_run = 0.
-#const direct_link_run =1.
-#const direct_build = 2.
+#const direct_link_run = 0.
+#const direct_build = 1.
 
 % Allow clingo to create nodes
 { attr("node", node(0..X-1, Package))         } :- max_dupes(Package, X), not virtual(Package).
@@ -149,7 +148,7 @@ mentioned_in_literal(Root, Mentioned) :-
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, "provider_set", _, Mentioned).
 
-condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned), link_run) :-
+condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned)) :-
   mentioned_in_literal(Root, Mentioned).
 
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -115,29 +115,53 @@ multiple_nodes_attribute("depends_on").
 multiple_nodes_attribute("virtual_on_edge").
 multiple_nodes_attribute("provider_set").
 
-% Map constraint on the literal ID to facts on the node
-attr(Name, node(min_dupe_id, A1))             :- literal(LiteralID, Name, A1), solve_literal(LiteralID).
-attr(Name, node(min_dupe_id, A1), A2)         :- literal(LiteralID, Name, A1, A2), solve_literal(LiteralID), not multiple_nodes_attribute(Name).
-attr(Name, node(min_dupe_id, A1), A2, A3)     :- literal(LiteralID, Name, A1, A2, A3), solve_literal(LiteralID), not multiple_nodes_attribute(Name).
-attr(Name, node(min_dupe_id, A1), A2, A3, A4) :- literal(LiteralID, Name, A1, A2, A3, A4), solve_literal(LiteralID).
+trigger_condition_holds(TriggerID, node(min_dupe_id, Package)) :-
+  solve_literal(TriggerID),
+  pkg_fact(Package, condition_trigger(_, TriggerID)),
+  literal(TriggerID).
 
-% Special cases where nodes occur in arguments other than A1
-attr("node_flag_source", node(min_dupe_id, A1), A2, node(min_dupe_id, A3)) :- literal(LiteralID, "node_flag_source", A1, A2, A3), solve_literal(LiteralID).
-attr("depends_on",       node(min_dupe_id, A1), node(min_dupe_id, A2), A3) :- literal(LiteralID, "depends_on",       A1, A2, A3), solve_literal(LiteralID).
+trigger_node(TriggerID, Node, Node) :-
+  trigger_condition_holds(TriggerID, Node),
+  literal(TriggerID).
 
-attr("virtual_node", node(min_dupe_id, Virtual))                              :- literal(LiteralID, "provider_set", _,        Virtual), solve_literal(LiteralID).
-attr("provider_set", node(min_dupe_id, Provider), node(min_dupe_id, Virtual)) :- literal(LiteralID, "provider_set", Provider, Virtual), solve_literal(LiteralID).
-provider(node(min_dupe_id, Provider), node(min_dupe_id, Virtual))             :- literal(LiteralID, "provider_set", Provider, Virtual), solve_literal(LiteralID).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, _, Mentioned).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, _, Mentioned, _).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, _, Mentioned, _, _).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, _, Mentioned, _, _, _).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, "depends_on", _, _, Mentioned, _).
+mentioned_in_literal(Root, Mentioned) :-
+  literal(TriggerID),
+  trigger_and_effect(Root, TriggerID, EffectID),
+  imposed_constraint(EffectID, "provider_set", _, Mentioned).
+
+condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned), link_run) :-
+  mentioned_in_literal(Root, Mentioned).
+
+provider(ProviderNode, VirtualNode) :- attr("provider_set", ProviderNode, VirtualNode).
 
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"
-explicitly_requested_root(node(min_dupe_id, A1)) :- literal(LiteralID, "root", A1), solve_literal(LiteralID).
+explicitly_requested_root(node(min_dupe_id, Package)) :-
+  solve_literal(TriggerID),
+  trigger_and_effect(Package, TriggerID, EffectID),
+  imposed_constraint(EffectID, "root", Package).
 
 #defined concretize_everything/0.
 #defined literal/1.
-#defined literal/3.
-#defined literal/4.
-#defined literal/5.
-#defined literal/6.
 
 % Attributes for node packages which must have a single value
 attr_single_value("version").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -125,31 +125,7 @@ trigger_node(TriggerID, Node, Node) :-
 
 % Since we trigger the existence of literal nodes from a condition, we need to construct
 % the condition_set/2 manually below
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, _, Mentioned).
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, _, Mentioned, _).
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, _, Mentioned, _, _).
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, _, Mentioned, _, _, _).
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, "depends_on", _, _, Mentioned, _).
-mentioned_in_literal(Root, Mentioned) :-
-  solve_literal(TriggerID),
-  trigger_and_effect(Root, TriggerID, EffectID),
-  imposed_constraint(EffectID, "provider_set", _, Mentioned).
-
+mentioned_in_literal(Root, Mentioned) :- mentioned_in_literal(TriggerID, Root, Mentioned), solve_literal(TriggerID).
 condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned)) :-  mentioned_in_literal(Root, Mentioned).
 
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -458,24 +458,11 @@ depends_on(PackageNode, DependencyNode) :- attr("depends_on", PackageNode, Depen
 % concrete. We chop off dependencies for externals, and dependencies of
 % concrete specs don't need to be resolved -- they arise from the concrete
 % specs themselves.
-dependency_holds(node(NodeID, Package), Dependency, Type) :-
-  pkg_fact(Package, dependency_condition(ID, Dependency)),
-  dependency_type(ID, Type),
-  build(node(NodeID, Package)),
-  not external(node(NodeID, Package)),
-  condition_holds(ID, node(NodeID, Package)).
-
-% We cut off dependencies of externals (as we don't really know them).
-% Don't impose constraints on dependencies that don't exist.
-do_not_impose(EffectID, node(NodeID, Package)) :-
-  not dependency_holds(node(NodeID, Package), Dependency, _),
-  attr("node", node(NodeID, Package)),
-  pkg_fact(Package, dependency_condition(ID, Dependency)),
-  pkg_fact(Package, condition_effect(ID, EffectID)).
+attr("track_dependencies", Node) :- build(Node), not external(Node).
 
 % If a dependency holds on a package node, there must be one and only one dependency node satisfying it
 1 { attr("depends_on", PackageNode, node(0..Y-1, Dependency), Type) : max_dupes(Dependency, Y) } 1
-  :- dependency_holds(PackageNode, Dependency, Type),
+  :- attr("dependency_holds", PackageNode, Dependency, Type),
      not virtual(Dependency).
 
 % all nodes in the graph must be reachable from some root
@@ -523,7 +510,7 @@ error(100, "Package '{0}' needs to provide both '{1}' and '{2}' together, but pr
 % if a package depends on a virtual, it's not external and we have a
 % provider for that virtual then it depends on the provider
 node_depends_on_virtual(PackageNode, Virtual, Type)
-  :- dependency_holds(PackageNode, Virtual, Type),
+  :- attr("dependency_holds", PackageNode, Virtual, Type),
      virtual(Virtual),
      not external(PackageNode).
 
@@ -533,7 +520,7 @@ node_depends_on_virtual(PackageNode, Virtual) :- node_depends_on_virtual(Package
   :- node_depends_on_virtual(PackageNode, Virtual, Type).
 
 attr("virtual_on_edge", PackageNode, ProviderNode, Virtual)
-  :- dependency_holds(PackageNode, Virtual, Type),
+  :- attr("dependency_holds", PackageNode, Virtual, Type),
      attr("depends_on", PackageNode, ProviderNode, Type),
      provider(ProviderNode, node(_, Virtual)),
      not external(PackageNode).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -30,27 +30,25 @@
 :- attr("variant_value", PackageNode, _, _), not attr("node", PackageNode).
 :- attr("node_flag_compiler_default", PackageNode), not attr("node", PackageNode).
 :- attr("node_flag", PackageNode, _, _), not attr("node", PackageNode).
-:- attr("node_flag_source", PackageNode, _, _), not attr("node", PackageNode).
 :- attr("no_flags", PackageNode, _), not attr("node", PackageNode).
 :- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode).
 :- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode).
 :- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode).
 :- attr("node_flag_source", ParentNode, _, _), not attr("node", ParentNode).
 :- attr("node_flag_source", _, _, ChildNode), not attr("node", ChildNode).
+:- attr("virtual_node", VirtualNode), not provider(_, VirtualNode), internal_error("virtual node with no provider").
+:- provider(_, VirtualNode), not attr("virtual_node", VirtualNode), internal_error("provider with no virtual node").
+:- provider(PackageNode, _), not attr("node", PackageNode), internal_error("provider with no real node").
 
-:- attr("virtual_node", VirtualNode), not provider(_, VirtualNode).
-:- provider(_, VirtualNode), not attr("virtual_node", VirtualNode).
-:- provider(PackageNode, _), not attr("node", PackageNode).
-
-:- attr("root", node(ID, PackageNode)), ID > min_dupe_id.
+:- attr("root", node(ID, PackageNode)), ID > min_dupe_id, internal_error("root in non-minimum unification set").
 
 % Nodes in the "root" unification set cannot depend on non-root nodes if the dependency is "link" or "run"
-:- attr("depends_on", node(min_dupe_id, Package), node(ID, _), "link"), ID != min_dupe_id, unification_set("root", node(min_dupe_id, Package)).
-:- attr("depends_on", node(min_dupe_id, Package), node(ID, _), "run"),  ID != min_dupe_id, unification_set("root", node(min_dupe_id, Package)).
+:- attr("depends_on", node(min_dupe_id, Package), node(ID, _), "link"), ID != min_dupe_id, unification_set("root", node(min_dupe_id, Package)), internal_error("link dependency out of the root unification set").
+:- attr("depends_on", node(min_dupe_id, Package), node(ID, _), "run"),  ID != min_dupe_id, unification_set("root", node(min_dupe_id, Package)), internal_error("run dependency out of the root unification set").
 
 % Rules on "unification sets", i.e. on sets of nodes allowing a single configuration of any given package
 unify(SetID, PackageName) :- unification_set(SetID, node(_, PackageName)).
-:- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName).
+:- 2 { unification_set(SetID, node(_, PackageName)) }, unify(SetID, PackageName), internal_error("unified package in multiple unification sets").
 
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
@@ -86,22 +84,24 @@ unification_set(SetID, VirtualNode)
 %----
 
 % In the "root" unification set only ID = 0 are allowed
-:- unification_set("root", node(ID, _)), ID != 0.
+:- unification_set("root", node(ID, _)), ID != 0, internal_error("root unification set has node with non-zero unification set ID").
 
 % In the "root" unification set we allow only packages from the link-run possible subDAG
-:- unification_set("root", node(_, Package)), not possible_in_link_run(Package), not virtual(Package).
+:- unification_set("root", node(_, Package)), not possible_in_link_run(Package), not virtual(Package), internal_error("package outside possible link/run graph in root unification set").
 
 % Each node must belong to at least one unification set
-:- attr("node", PackageNode), not unification_set(_, PackageNode).
+:- attr("node", PackageNode), not unification_set(_, PackageNode), internal_error("node belongs to no unification set").
 
 % Cannot have a node with an ID, if lower ID of the same package are not used
 :- attr("node", node(ID1, Package)),
    not attr("node", node(ID2, Package)),
-   max_dupes(Package, X), ID1=0..X-1, ID2=0..X-1, ID2 < ID1.
+   max_dupes(Package, X), ID1=0..X-1, ID2=0..X-1, ID2 < ID1,
+   internal_error("node skipped id number").
 
 :- attr("virtual_node", node(ID1, Package)),
    not attr("virtual_node", node(ID2, Package)),
-   max_dupes(Package, X), ID1=0..X-1, ID2=0..X-1, ID2 < ID1.
+   max_dupes(Package, X), ID1=0..X-1, ID2=0..X-1, ID2 < ID1,
+   internal_error("virtual node skipped id number").
 
 %-----------------------------------------------------------------------------
 % Map literal input specs to facts that drive the solve
@@ -235,7 +235,8 @@ possible_version_weight(node(ID, Package), Weight)
 
 1 { version_weight(node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
   :- attr("version", node(ID, Package), Version),
-     attr("node", node(ID, Package)).
+     attr("node", node(ID, Package)),
+     internal_error("version weights must exist and be unique").
 
 % node_version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
@@ -249,7 +250,8 @@ possible_version_weight(node(ID, Package), Weight)
 % bound on the choice rule to avoid false positives with the error below
 1 { attr("version", node(ID, Package), Version) : pkg_fact(Package, version_satisfies(Constraint, Version)) }
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     pkg_fact(Package, version_satisfies(Constraint, _)).
+     pkg_fact(Package, version_satisfies(Constraint, _)),
+     internal_error("must choose a single version to satisfy version constraints").
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -123,33 +123,34 @@ trigger_node(TriggerID, Node, Node) :-
   trigger_condition_holds(TriggerID, Node),
   literal(TriggerID).
 
+% Since we trigger the existence of literal nodes from a condition, we need to construct
+% the condition_set/2 manually below
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, _, Mentioned).
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, _, Mentioned, _).
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, _, Mentioned, _, _).
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, _, Mentioned, _, _, _).
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, "depends_on", _, _, Mentioned, _).
 mentioned_in_literal(Root, Mentioned) :-
-  literal(TriggerID),
+  solve_literal(TriggerID),
   trigger_and_effect(Root, TriggerID, EffectID),
   imposed_constraint(EffectID, "provider_set", _, Mentioned).
 
-condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned)) :-
-  mentioned_in_literal(Root, Mentioned).
+condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned)) :-  mentioned_in_literal(Root, Mentioned).
 
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"
 explicitly_requested_root(node(min_dupe_id, Package)) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -152,8 +152,6 @@ mentioned_in_literal(Root, Mentioned) :-
 condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned), link_run) :-
   mentioned_in_literal(Root, Mentioned).
 
-provider(ProviderNode, VirtualNode) :- attr("provider_set", ProviderNode, VirtualNode).
-
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"
 explicitly_requested_root(node(min_dupe_id, Package)) :-
   solve_literal(TriggerID),
@@ -388,7 +386,7 @@ imposed_nodes(ConditionID, PackageNode, node(X, A1))
 
 % Conditions that hold impose may impose constraints on other specs
 attr(Name, node(X, A1))             :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1),             imposed_nodes(ID, PackageNode, node(X, A1)).
-attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2),         imposed_nodes(ID, PackageNode, node(X, A1)).
+attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2),         imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
 attr(Name, node(X, A1), A2, A3)     :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3),     imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
 attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(ID, PackageNode, node(X, A1)).
 
@@ -398,6 +396,14 @@ attr("node_flag_source", node(X, A1), A2, node(Y, A3))
   :- impose(ID, node(X, A1)),
      imposed_constraint(ID, "node_flag_source", A1, A2, A3),
      condition_set(node(Y, A3), node(X, A1)).
+
+attr("provider_set", node(PDupID, Provider), node(VDupID, Virtual))
+  :- impose(ID, RequestingNode),
+     imposed_constraint(ID, "provider_set", Provider, Virtual),
+     condition_set(RequestingNode, node(PDupID, Provider)),
+     condition_set(RequestingNode, node(VDupID, Virtual)).
+
+provider(ProviderNode, VirtualNode) :- attr("provider_set", ProviderNode, VirtualNode).
 
 % Here we can't use the condition set because it's a recursive definition, that doesn't define the
 % node index, and leads to unsatisfiability. Hence we say that one and only one node index must

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -730,7 +730,8 @@ requirement_group_satisfied(node(ID, Package), X) :-
   activate_requirement(node(NodeID1, Package1), RequirementID),
   pkg_fact(Package1, condition_effect(ConditionID, EffectID)),
   imposed_constraint(EffectID, "node_flag_source", Package1, FlagType, Package2),
-  imposed_packages(NodeID2, Package2).
+  imposed_nodes(EffectID, node(NodeID2, Package2), node(NodeID1, Package1)).
+
 
 requirement_weight(node(ID, Package), Group, W) :-
   W = #min {

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -23,5 +23,10 @@
 #show error/4.
 #show error/5.
 #show error/6.
+#show error/7.
+
+% error cause information
+#show condition_cause/3.
+#show condition_reason/2.
 
 % debug

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -24,6 +24,8 @@
 #show error/5.
 #show error/6.
 #show error/7.
+#show error/8.
+#show error/9.
 
 % error cause information
 #show condition_cause/3.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -44,5 +44,6 @@
 #show external_version/3.
 #show trigger_and_effect/3.
 #show unification_set/2.
+#show provider/2.
 
 % debug

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -23,20 +23,9 @@
 #show error/4.
 #show error/5.
 #show error/6.
-#show error/7.
-#show error/8.
-#show error/9.
 
-#defined error/7.
-#defined error/8.
-#defined error/9.
-
-% error cause information
-#show condition_cause/3.
+% for error causation
 #show condition_reason/2.
-
-#defined condition_cause/3.
-#defined condition_reason/2.
 
 % For error messages to use later
 #show pkg_fact/2.
@@ -55,4 +44,5 @@
 #show external_version/3.
 #show trigger_and_effect/3.
 #show unification_set/2.
+
 % debug

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -45,5 +45,8 @@
 #show trigger_and_effect/3.
 #show unification_set/2.
 #show provider/2.
+#show condition_nodes/3.
+#show trigger_node/3.
+#show imposed_nodes/3.
 
 % debug

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -27,8 +27,32 @@
 #show error/8.
 #show error/9.
 
+#defined error/7.
+#defined error/8.
+#defined error/9.
+
 % error cause information
 #show condition_cause/3.
 #show condition_reason/2.
 
+#defined condition_cause/3.
+#defined condition_reason/2.
+
+% For error messages to use later
+#show pkg_fact/2.
+#show condition_holds/2.
+#show imposed_constraint/3.
+#show imposed_constraint/4.
+#show imposed_constraint/5.
+#show imposed_constraint/6.
+#show condition_requirement/3.
+#show condition_requirement/4.
+#show condition_requirement/5.
+#show condition_requirement/6.
+#show node_has_variant/2.
+#show build/1.
+#show external/1.
+#show external_version/3.
+#show trigger_and_effect/3.
+#show unification_set/2.
 % debug

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -47,7 +47,7 @@ condition_cause(Condition2, Condition1, ID) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(0, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)
+error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -229,3 +229,5 @@ error(0, Msg, startcauses, TriggerID, ConstraintID)
 #defined trigger_and_effect/3.
 #defined build/1.
 #defined node_has_variant/2.
+#defined provider/2.
+#defined external_version/3.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -47,7 +47,7 @@ condition_cause(Condition2, Condition1, ID) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(0, "AAACannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ID, ConstraintCause)
+error(0, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ID, ConstraintCause)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -11,7 +11,7 @@
 
 % Create a causal tree between trigger conditions by locating the effect conditions
 % that are triggers for another condition. Condition2 is caused by Condition1
-condition_cause(Condition2, Condition1, ID) :-
+condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package),
@@ -23,7 +23,7 @@ condition_cause(Condition2, Condition1, ID) :-
   imposed_constraint(Effect, Name, Package),
   imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
-condition_cause(Condition2, Condition1, ID) :-
+condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1),
@@ -35,7 +35,7 @@ condition_cause(Condition2, Condition1, ID) :-
   imposed_constraint(Effect, Name, Package, A1),
   imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
-condition_cause(Condition2, Condition1, ID) :-
+condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2),
@@ -47,7 +47,7 @@ condition_cause(Condition2, Condition1, ID) :-
   imposed_constraint(Effect, Name, Package, A1, A2),
   imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
-condition_cause(Condition2, Condition1, ID) :-
+condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2, A3),
@@ -62,7 +62,7 @@ condition_cause(Condition2, Condition1, ID) :-
 % special condition cause for dependency conditions
 % we can't simply impose the existence of the node for dependency conditions
 % because we need to allow for the choice of which dupe ID the node gets
-condition_cause(Condition2, Condition1, ID) :-
+condition_cause(Condition2, ID2, Condition1, ID1) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, "node", Package),
@@ -76,28 +76,29 @@ condition_cause(Condition2, Condition1, ID) :-
   attr("depends_on", node(X, Parent), node(ID, Package), Type).
 
 % The literal startcauses is used to separate the variables that are part of the error from the
-% ones describing the causal tree of the error.
+% ones describing the causal tree of the error. After startcauses, each successive pair must be
+% a condition and a condition_set id for which it holds.
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)
+error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause, CauseID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
-     condition_holds(ConstraintCause, node(_, TriggerPkg)),
+     condition_holds(ConstraintCause, node(CauseID, TriggerPkg)),
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)).
 
-error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constraint2, startcauses, Cause1, Cause2)
+error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constraint2, startcauses, Cause1, C1ID, Cause2, C2ID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint1),
      pkg_fact(TriggerPkg1, condition_effect(Cause1, EffectID1)),
      imposed_constraint(EffectID1, "node_version_satisfies", Package, Constraint1),
-     condition_holds(Cause1, node(_, TriggerPkg1)),
+     condition_holds(Cause1, node(C1ID, TriggerPkg1)),
      % two constraints
      attr("node_version_satisfies", node(ID, Package), Constraint2),
      pkg_fact(TriggerPkg2, condition_effect(Cause2, EffectID2)),
      imposed_constraint(EffectID2, "node_version_satisfies", Package, Constraint2),
-     condition_holds(Cause2, node(_, TriggerPkg2)),
+     condition_holds(Cause2, node(C2ID, TriggerPkg2)),
      % version chosen
      attr("version", node(ID, Package), Version),
      % version satisfies one but not the other
@@ -105,16 +106,16 @@ error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constrai
      not pkg_fact(Package, version_satisfies(Constraint2, Version)).
 
 % causation tracking error for no or multiple virtual providers
-error(0, "Cannot find a valid provider for virtual {0}", Virtual, startcauses, Cause)
+error(0, "Cannot find a valid provider for virtual {0}", Virtual, startcauses, Cause, CID)
   :- attr("virtual_node", node(X, Virtual)),
      not provider(_, node(X, Virtual)),
      imposed_constraint(EID, "dependency_holds", Parent, Virtual, Type),
      pkg_fact(TriggerPkg, condition_effect(Cause, EID)),
-     condition_holds(Cause, node(_, TriggerPkg)).
+     condition_holds(Cause, node(CID, TriggerPkg)).
 
 
 % At most one variant value for single-valued variants
-error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Requested 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, Cause2)
+error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Requested 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, X, Cause2, X)
   :- attr("node", node(X, Package)),
      node_has_variant(node(X, Package), Variant),
      pkg_fact(Package, variant_single_value(Variant)),
@@ -130,12 +131,12 @@ error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Re
      Value1 < Value2. % see[1] in concretize.lp
 
 % Externals have to specify external conditions
-error(0, "Attempted to use external for {0} which does not satisfy any configured external spec version", Package, startcauses, ExternalCause)
+error(0, "Attempted to use external for {0} which does not satisfy any configured external spec version", Package, startcauses, ExternalCause, CID)
   :- external(node(ID, Package)),
      attr("external_spec_selected", node(ID, Package), Index),
      imposed_constraint(EID, "external_conditions_hold", Package, Index),
      pkg_fact(TriggerPkg, condition_effect(ExternalCause, EID)),
-     condition_holds(ExternalCause, node(_, TriggerPkg)),
+     condition_holds(ExternalCause, node(CID, TriggerPkg)),
      not external_version(node(ID, Package), _, _).
 
 error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}') is an external constraint for {0} which was not satisfied", Package, Name, A1)
@@ -162,7 +163,7 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      condition_requirement(TID, Name, A1, A2, A3),
      not attr(Name, node(_, A1), A2, A3).
 
-error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        'Spec({0} {1}={2})' is an external constraint for {0} which was not satisfied\n        'Spec({0} {1}={3})' required", Package, Variant, Value, OtherValue, startcauses, OtherValueCause)
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        'Spec({0} {1}={2})' is an external constraint for {0} which was not satisfied\n        'Spec({0} {1}={3})' required", Package, Variant, Value, OtherValue, startcauses, OtherValueCause, CID)
   :- external(node(ID, Package)),
      not attr("external_conditions_hold", node(ID, Package), _),
      imposed_constraint(EID, "external_conditions_hold", Package, _),
@@ -172,7 +173,7 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      attr("variant_value", node(ID, Package), Variant, OtherValue),
      imposed_constraint(EID2, "variant_set", Package, Variant, OtherValue),
      pkg_fact(TriggerPkg, condition_effect(OtherValueCause, EID2)),
-     condition_holds(OtherValueCause, node(_, TriggerPkg)).
+     condition_holds(OtherValueCause, node(CID, TriggerPkg)).
 
 error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}', '{5}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3, A4)
   :- external(node(ID, Package)),
@@ -183,7 +184,7 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      not attr(Name, node(_, A1), A2, A3, A4).
 
 % error message with causes for conflicts
-error(0, Msg, startcauses, TriggerID, ConstraintID)
+error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
   :- attr("node", node(ID, Package)),
      pkg_fact(Package, conflict(TriggerID, ConstraintID, Msg)),
      % node(ID1, TriggerPackage) is node(ID2, Package) in most, but not all, cases
@@ -203,8 +204,10 @@ error(0, Msg, startcauses, TriggerID, ConstraintID)
 #show error/7.
 #show error/8.
 #show error/9.
+#show error/10.
+#show error/11.
 
-#show condition_cause/3.
+#show condition_cause/4.
 #show condition_reason/2.
 
 % Define all variables used to avoid warnings at runtime when the model doesn't happen to have one

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -155,6 +155,18 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      condition_requirement(TID, Name, A1, A2, A3, A4),
      not attr(Name, node(_, A1), A2, A3, A4).
 
+% error message with causes for conflicts
+error(0, Msg, startcauses, TriggerID, ConstraintID)
+  :- attr("node", node(ID, Package)),
+     pkg_fact(Package, conflict(TriggerID, ConstraintID, Msg)),
+     % node(ID1, TriggerPackage) is node(ID2, Package) in most, but not all, cases
+     condition_holds(TriggerID, node(ID1, TriggerPackage)),
+     condition_holds(ConstraintID, node(ID2, Package)),
+     unification_set(X, node(ID2, Package)),
+     unification_set(X, node(ID1, TriggerPackage)),
+     not external(node(ID, Package)),  % ignore conflicts for externals
+     not attr("hash", node(ID, Package), _).  % ignore conflicts for installed packages
+
 % variables to show
 #show error/2.
 #show error/3.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -10,39 +10,39 @@
 % Create a causal tree between trigger conditions by locating the effect conditions
 % that are triggers for another condition. Condition2 is caused by Condition1
 condition_cause(Condition2, Condition1, ID) :-
-  condition_holds(Condition2, node(ID, Package)),
-  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_holds(Condition2, node(ID2, Package2)),
+  pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package),
   attr(Name, node(ID, Package)),
-  condition_holds(Condition1, node(ID, Package)),
-  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  condition_holds(Condition1, node(ID1, Package1)),
+  pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package).
 
 condition_cause(Condition2, Condition1, ID) :-
-  condition_holds(Condition2, node(ID, Package)),
-  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_holds(Condition2, node(ID2, Package2)),
+  pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1),
   attr(Name, node(ID, Package), A1),
-  condition_holds(Condition1, node(ID, Package)),
-  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  condition_holds(Condition1, node(ID1, Package1)),
+  pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1).
 
 condition_cause(Condition2, Condition1, ID) :-
-  condition_holds(Condition2, node(ID, Package)),
-  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_holds(Condition2, node(ID2, Package2)),
+  pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2),
   attr(Name, node(ID, Package), A1, A2),
-  condition_holds(Condition1, node(ID, Package)),
-  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  condition_holds(Condition1, node(ID1, Package1)),
+  pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1, A2).
 
 condition_cause(Condition2, Condition1, ID) :-
-  condition_holds(Condition2, node(ID, Package)),
-  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_holds(Condition2, node(ID2, Package2)),
+  pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2, A3),
   attr(Name, node(ID, Package), A1, A2, A3),
-  condition_holds(Condition1, node(ID, Package)),
-  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  condition_holds(Condition1, node(ID1, Package1)),
+  pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1, A2, A3).
 
 % special condition cause for dependency conditions

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -86,6 +86,15 @@ error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constrai
      pkg_fact(Package, version_satisfies(Constraint1, Version)),
      not pkg_fact(Package, version_satisfies(Constraint2, Version)).
 
+% causation tracking error for no or multiple virtual providers
+error(0, "Cannot find a valid provider for virtual {0}", Virtual, startcauses, Cause)
+  :- attr("virtual_node", node(X, Virtual)),
+     not provider(_, node(X, Virtual)),
+     imposed_constraint(EID, "dependency_holds", Parent, Virtual, Type),
+     pkg_fact(TriggerPkg, condition_effect(Cause, EID)),
+     condition_holds(Cause, node(_, TriggerPkg)).
+
+
 % At most one variant value for single-valued variants
 error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Requested 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, Cause2)
   :- attr("node", node(X, Package)),

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -83,3 +83,19 @@ error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constrai
      % version satisfies one but not the other
      pkg_fact(Package, version_satisfies(Constraint1, Version)),
      not pkg_fact(Package, version_satisfies(Constraint2, Version)).
+
+% At most one variant value for single-valued variants
+error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Requested 'Spec({1}={2})' and 'Spec({1}={3})'", Package, Variant, Value1, Value2, startcauses, Cause1, Cause2)
+  :- attr("node", node(X, Package)),
+     node_has_variant(node(X, Package), Variant),
+     pkg_fact(Package, variant_single_value(Variant)),
+     build(node(X, Package)),
+     attr("variant_value", node(X, Package), Variant, Value1),
+     imposed_constraint(EID1, "variant_set", Package, Variant, Value1),
+     pkg_fact(TriggerPkg1, condition_effect(Cause1, EID1)),
+     condition_holds(Cause1, node(X, TriggerPkg1)),
+     attr("variant_value", node(X, Package), Variant, Value2),
+     imposed_constraint(EID2, "variant_set", Package, Variant, Value2),
+     pkg_fact(TriggerPkg2, condition_effect(Cause2, EID2)),
+     condition_holds(Cause2, node(X, TriggerPkg2)),
+     Value1 < Value2. % see[1] in concretize.lp

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -154,3 +154,42 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      trigger_and_effect(Package, TID, EID),
      condition_requirement(TID, Name, A1, A2, A3, A4),
      not attr(Name, node(_, A1), A2, A3, A4).
+
+% variables to show
+#show error/2.
+#show error/3.
+#show error/4.
+#show error/5.
+#show error/6.
+#show error/7.
+#show error/8.
+#show error/9.
+
+#show condition_cause/3.
+#show condition_reason/2.
+
+% Define all variables used to avoid warnings at runtime when the model doesn't happen to have one
+#defined error/2.
+#defined error/3.
+#defined error/4.
+#defined error/5.
+#defined error/6.
+#defined attr/2.
+#defined attr/3.
+#defined attr/4.
+#defined attr/5.
+#defined pkg_fact/2.
+#defined imposed_constraint/3.
+#defined imposed_constraint/4.
+#defined imposed_constraint/5.
+#defined imposed_constraint/6.
+#defined condition_requirement/3.
+#defined condition_requirement/4.
+#defined condition_requirement/5.
+#defined condition_requirement/6.
+#defined condition_holds/2.
+#defined unification_set/2.
+#defined external/1.
+#defined trigger_and_effect/3.
+#defined build/1.
+#defined node_has_variant/2.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -47,10 +47,10 @@ condition_cause(Condition2, Condition1, ID) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(0, "AAACannot satisfy '{0}@{1}'", node(ID, Package), Constraint, startcauses, ID, ConstraintCause)
+error(0, "AAACannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ID, ConstraintCause)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
-     pkg_fact(Package, condition_effect(ConstraintCause, EffectID)),
+     pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
-     condition_holds(ConstraintCause, node(ID, Package)),
+     condition_holds(ConstraintCause, node(_, TriggerPkg)),
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)).

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -15,37 +15,49 @@ condition_cause(Condition2, Condition1, ID) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package),
+  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   attr(Name, node(ID, Package)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
-  imposed_constraint(Effect, Name, Package).
+  imposed_constraint(Effect, Name, Package),
+  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, Condition1, ID) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1),
+  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   attr(Name, node(ID, Package), A1),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
-  imposed_constraint(Effect, Name, Package, A1).
+  imposed_constraint(Effect, Name, Package, A1),
+  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, Condition1, ID) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2),
+  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   attr(Name, node(ID, Package), A1, A2),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
-  imposed_constraint(Effect, Name, Package, A1, A2).
+  imposed_constraint(Effect, Name, Package, A1, A2),
+  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
 condition_cause(Condition2, Condition1, ID) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, Name, Package, A1, A2, A3),
+  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   attr(Name, node(ID, Package), A1, A2, A3),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
-  imposed_constraint(Effect, Name, Package, A1, A2, A3).
+  imposed_constraint(Effect, Name, Package, A1, A2, A3),
+  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)).
 
 % special condition cause for dependency conditions
 % we can't simply impose the existence of the node for dependency conditions
@@ -54,10 +66,13 @@ condition_cause(Condition2, Condition1, ID) :-
   condition_holds(Condition2, node(ID2, Package2)),
   pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
   condition_requirement(Trigger, "node", Package),
+  condition_nodes(Trigger, TriggerNode, node(ID, Package)),
+  trigger_node(Trigger, TriggerNode, node(ID2, Package2)),
   attr("node", node(ID, Package)),
   condition_holds(Condition1, node(ID1, Package1)),
   pkg_fact(Package1, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, "dependency_holds", Parent, Package, Type),
+  imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)),
   attr("depends_on", node(X, Parent), node(ID, Package), Type).
 
 % More specific error message if the version cannot satisfy some constraint

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -75,6 +75,9 @@ condition_cause(Condition2, Condition1, ID) :-
   imposed_nodes(Effect, node(ID1, Package1), node(ID, Package)),
   attr("depends_on", node(X, Parent), node(ID, Package), Type).
 
+% The literal startcauses is used to separate the variables that are part of the error from the
+% ones describing the causal tree of the error.
+
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
 error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -1,0 +1,56 @@
+% Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+% Spack Project Developers. See the top-level COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+%=============================================================================
+% This logic program adds detailed error messages to Spack's concretizer
+%=============================================================================
+
+% Create a causal tree between trigger conditions by locating the effect conditions
+% that are triggers for another condition. Condition2 is caused by Condition1
+condition_cause(Condition2, Condition1, ID) :-
+  condition_holds(Condition2, node(ID, Package)),
+  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_requirement(Trigger, Name, Package),
+  attr(Name, node(ID, Package)),
+  condition_holds(Condition1, node(ID, Package)),
+  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  imposed_constraint(Effect, Name, Package).
+
+condition_cause(Condition2, Condition1, ID) :-
+  condition_holds(Condition2, node(ID, Package)),
+  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_requirement(Trigger, Name, Package, A1),
+  attr(Name, node(ID, Package), A1),
+  condition_holds(Condition1, node(ID, Package)),
+  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  imposed_constraint(Effect, Name, Package, A1).
+
+condition_cause(Condition2, Condition1, ID) :-
+  condition_holds(Condition2, node(ID, Package)),
+  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_requirement(Trigger, Name, Package, A1, A2),
+  attr(Name, node(ID, Package), A1, A2),
+  condition_holds(Condition1, node(ID, Package)),
+  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  imposed_constraint(Effect, Name, Package, A1, A2).
+
+condition_cause(Condition2, Condition1, ID) :-
+  condition_holds(Condition2, node(ID, Package)),
+  pkg_fact(Package, condition_trigger(Condition2, Trigger)),
+  condition_requirement(Trigger, Name, Package, A1, A2, A3),
+  attr(Name, node(ID, Package), A1, A2, A3),
+  condition_holds(Condition1, node(ID, Package)),
+  pkg_fact(Package, condition_effect(Condition1, Effect)),
+  imposed_constraint(Effect, Name, Package, A1, A2, A3).
+
+% More specific error message if the version cannot satisfy some constraint
+% Otherwise covered by `no_version_error` and `versions_conflict_error`.
+error(0, "AAACannot satisfy '{0}@{1}'", node(ID, Package), Constraint, startcauses, ID, ConstraintCause)
+  :- attr("node_version_satisfies", node(ID, Package), Constraint),
+     pkg_fact(Package, condition_effect(ConstraintCause, EffectID)),
+     imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
+     condition_holds(ConstraintCause, node(ID, Package)),
+     attr("version", node(ID, Package), Version),
+     not pkg_fact(Package, version_satisfies(Constraint, Version)).

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -99,3 +99,44 @@ error(0, "'{0}' required multiple values for single-valued variant '{1}'\n    Re
      pkg_fact(TriggerPkg2, condition_effect(Cause2, EID2)),
      condition_holds(Cause2, node(X, TriggerPkg2)),
      Value1 < Value2. % see[1] in concretize.lp
+
+% Externals have to specify external conditions
+error(0, "Attempted to use external for {0} which does not satisfy any configured external spec version", Package, startcauses, ExternalCause)
+  :- external(node(ID, Package)),
+     attr("external_spec_selected", node(ID, Package), Index),
+     imposed_constraint(EID, "external_conditions_hold", Package, Index),
+     pkg_fact(TriggerPkg, condition_effect(ExternalCause, EID)),
+     condition_holds(ExternalCause, node(_, TriggerPkg)),
+     not external_version(node(ID, Package), _, _).
+
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}') is an external constraint for {0} which was not satisfied", Package, Name, A1)
+  :- external(node(ID, Package)),
+     not attr("external_conditions_hold", node(ID, Package), _),
+     imposed_constraint(EID, "external_conditions_hold", Package, _),
+     trigger_and_effect(Package, TID, EID),
+     condition_requirement(TID, Name, A1),
+     not attr(Name, node(_, A1)).
+
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2)
+  :- external(node(ID, Package)),
+     not attr("external_conditions_hold", node(ID, Package), _),
+     imposed_constraint(EID, "external_conditions_hold", Package, _),
+     trigger_and_effect(Package, TID, EID),
+     condition_requirement(TID, Name, A1, A2),
+     not attr(Name, node(_, A1), A2).
+
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3)
+  :- external(node(ID, Package)),
+     not attr("external_conditions_hold", node(ID, Package), _),
+     imposed_constraint(EID, "external_conditions_hold", Package, _),
+     trigger_and_effect(Package, TID, EID),
+     condition_requirement(TID, Name, A1, A2, A3),
+     not attr(Name, node(_, A1), A2, A3).
+
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}', '{5}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3, A4)
+  :- external(node(ID, Package)),
+     not attr("external_conditions_hold", node(ID, Package), _),
+     imposed_constraint(EID, "external_conditions_hold", Package, _),
+     trigger_and_effect(Package, TID, EID),
+     condition_requirement(TID, Name, A1, A2, A3, A4),
+     not attr(Name, node(_, A1), A2, A3, A4).

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -45,6 +45,19 @@ condition_cause(Condition2, Condition1, ID) :-
   pkg_fact(Package, condition_effect(Condition1, Effect)),
   imposed_constraint(Effect, Name, Package, A1, A2, A3).
 
+% special condition cause for dependency conditions
+% we can't simply impose the existence of the node for dependency conditions
+% because we need to allow for the choice of which dupe ID the node gets
+condition_cause(Condition2, Condition1, ID) :-
+  condition_holds(Condition2, node(ID2, Package2)),
+  pkg_fact(Package2, condition_trigger(Condition2, Trigger)),
+  condition_requirement(Trigger, "node", Package),
+  attr("node", node(ID, Package)),
+  condition_holds(Condition1, node(ID1, Package1)),
+  pkg_fact(Package1, condition_effect(Condition1, Effect)),
+  imposed_constraint(Effect, "dependency_holds", Parent, Package, Type),
+  attr("depends_on", node(X, Parent), node(ID, Package), Type).
+
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
 error(1, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -133,6 +133,18 @@ error(0, "Attempted to build package {0} which is not buildable and does not hav
      condition_requirement(TID, Name, A1, A2, A3),
      not attr(Name, node(_, A1), A2, A3).
 
+error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        'Spec({0} {1}={2})' is an external constraint for {0} which was not satisfied\n        'Spec({0} {1}={3})' required", Package, Variant, Value, OtherValue, startcauses, OtherValueCause)
+  :- external(node(ID, Package)),
+     not attr("external_conditions_hold", node(ID, Package), _),
+     imposed_constraint(EID, "external_conditions_hold", Package, _),
+     trigger_and_effect(Package, TID, EID),
+     condition_requirement(TID, "variant_value", Package, Variant, Value),
+     not attr("variant_value", node(ID, Package), Variant, Value),
+     attr("variant_value", node(ID, Package), Variant, OtherValue),
+     imposed_constraint(EID2, "variant_set", Package, Variant, OtherValue),
+     pkg_fact(TriggerPkg, condition_effect(OtherValueCause, EID2)),
+     condition_holds(OtherValueCause, node(_, TriggerPkg)).
+
 error(0, "Attempted to build package {0} which is not buildable and does not have a satisfying external\n        attr('{1}', '{2}', '{3}', '{4}', '{5}') is an external constraint for {0} which was not satisfied", Package, Name, A1, A2, A3, A4)
   :- external(node(ID, Package)),
      not attr("external_conditions_hold", node(ID, Package), _),

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -47,10 +47,26 @@ condition_cause(Condition2, Condition1, ID) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
-error(0, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ID, ConstraintCause)
+error(0, "Cannot satisfy '{0}@{1}'", Package, Constraint, startcauses, ConstraintCause)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
      condition_holds(ConstraintCause, node(_, TriggerPkg)),
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)).
+
+error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}", Package, Constraint1, Constraint2, startcauses, Cause1, Cause2)
+  :- attr("node_version_satisfies", node(ID, Package), Constraint1),
+     pkg_fact(TriggerPkg1, condition_effect(Cause1, EffectID1)),
+     imposed_constraint(EffectID1, "node_version_satisfies", Package, Constraint1),
+     condition_holds(Cause1, node(_, TriggerPkg1)),
+     % two constraints
+     attr("node_version_satisfies", node(ID, Package), Constraint2),
+     pkg_fact(TriggerPkg2, condition_effect(Cause2, EffectID2)),
+     imposed_constraint(EffectID2, "node_version_satisfies", Package, Constraint2),
+     condition_holds(Cause2, node(_, TriggerPkg2)),
+     % version chosen
+     attr("version", node(ID, Package), Version),
+     % version satisfies one but not the other
+     pkg_fact(Package, version_satisfies(Constraint1, Version)),
+     not pkg_fact(Package, version_satisfies(Constraint2, Version)).

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -7,6 +7,8 @@
 % This logic program adds detailed error messages to Spack's concretizer
 %=============================================================================
 
+#program error_messages.
+
 % Create a causal tree between trigger conditions by locating the effect conditions
 % that are triggers for another condition. Condition2 is caused by Condition1
 condition_cause(Condition2, Condition1, ID) :-

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -11,11 +11,6 @@
 %-----------------
 % Domain heuristic
 %-----------------
-% TODO: see what I can salvage from these
-%#heuristic attr("hash", node(0, Package), Hash) : literal(_, "root", Package). [45, init]
-%#heuristic attr("root", node(0, Package)) : literal(_, "root", Package). [45, true]
-%#heuristic attr("node", node(0, Package)) : literal(_, "root", Package). [45, true]
-%#heuristic attr("node", node(0, Package)) : literal(_, "node", Package). [45, true]
 
 % Root node
 #heuristic attr("version", node(0, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("root", node(0, Package)). [35, true]

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -11,10 +11,11 @@
 %-----------------
 % Domain heuristic
 %-----------------
-#heuristic attr("hash", node(0, Package), Hash) : literal(_, "root", Package). [45, init]
-#heuristic attr("root", node(0, Package)) : literal(_, "root", Package). [45, true]
-#heuristic attr("node", node(0, Package)) : literal(_, "root", Package). [45, true]
-#heuristic attr("node", node(0, Package)) : literal(_, "node", Package). [45, true]
+% TODO: see what I can salvage from these
+%#heuristic attr("hash", node(0, Package), Hash) : literal(_, "root", Package). [45, init]
+%#heuristic attr("root", node(0, Package)) : literal(_, "root", Package). [45, true]
+%#heuristic attr("node", node(0, Package)) : literal(_, "root", Package). [45, true]
+%#heuristic attr("node", node(0, Package)) : literal(_, "node", Package). [45, true]
 
 % Root node
 #heuristic attr("version", node(0, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("root", node(0, Package)). [35, true]
@@ -26,4 +27,3 @@
 
 % Providers
 #heuristic attr("node", node(0, Package)) : default_provider_preference(Virtual, Package, 0), possible_in_link_run(Package). [30, true]
-

--- a/lib/spack/spack/test/concretize_errors.py
+++ b/lib/spack/spack/test/concretize_errors.py
@@ -30,7 +30,7 @@ external_error_messages = [
         " which was not satisfied"
     ),
     "        'quantum-espresso+veritas' required",
-    "        required because quantum-espresso+veritas requested from CLI"
+    "        required because quantum-espresso+veritas requested from CLI",
 ]
 
 variant_error_messages = [
@@ -44,20 +44,19 @@ variant_error_messages = [
 external_config = {
     "packages:quantum-espresso": {
         "buildable": False,
-        "externals": [
-            {
-                "spec": "quantum-espresso@1.0~veritas",
-                "prefix": "/path/to/qe",
-            }
-        ]
+        "externals": [{"spec": "quantum-espresso@1.0~veritas", "prefix": "/path/to/qe"}],
     }
 }
 
-@pytest.mark.parametrize("error_messages,config_set,spec", [
-    (version_error_messages, {}, "quantum-espresso^fftw@1.1:"),
-    (external_error_messages, external_config, "quantum-espresso+veritas"),
-    (variant_error_messages, {}, "quantum-espresso+invino^fftw~mpi"),
-])
+
+@pytest.mark.parametrize(
+    "error_messages,config_set,spec",
+    [
+        (version_error_messages, {}, "quantum-espresso^fftw@1.1:"),
+        (external_error_messages, external_config, "quantum-espresso+veritas"),
+        (variant_error_messages, {}, "quantum-espresso+invino^fftw~mpi"),
+    ],
+)
 def test_error_messages(error_messages, config_set, spec, mock_packages, mutable_config):
     for path, conf in config_set.items():
         spack.config.set(path, conf)

--- a/lib/spack/spack/test/concretize_errors.py
+++ b/lib/spack/spack/test/concretize_errors.py
@@ -1,0 +1,69 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+import spack.solver.asp
+import spack.spec
+
+pytestmark = [
+    pytest.mark.not_on_windows("Windows uses old concretizer"),
+    pytest.mark.only_clingo("Original concretizer does not support configuration requirements"),
+]
+
+version_error_messages = [
+    "Cannot satisfy 'fftw@:1.0' and 'fftw@1.1:",
+    "        required because quantum-espresso depends on fftw@:1.0",
+    "          required because quantum-espresso ^fftw@1.1: requested from CLI",
+    "        required because quantum-espresso ^fftw@1.1: requested from CLI",
+]
+
+external_error_messages = [
+    (
+        "Attempted to build package quantum-espresso which is not buildable and does not have"
+        " a satisfying external"
+    ),
+    (
+        "        'quantum-espresso~veritas' is an external constraint for quantum-espresso"
+        " which was not satisfied"
+    ),
+    "        'quantum-espresso+veritas' required",
+    "        required because quantum-espresso+veritas requested from CLI"
+]
+
+variant_error_messages = [
+    "'fftw' required multiple values for single-valued variant 'mpi'",
+    "    Requested '~mpi' and '+mpi'",
+    "        required because quantum-espresso depends on fftw+mpi when +invino",
+    "          required because quantum-espresso+invino ^fftw~mpi requested from CLI",
+    "        required because quantum-espresso+invino ^fftw~mpi requested from CLI",
+]
+
+external_config = {
+    "packages:quantum-espresso": {
+        "buildable": False,
+        "externals": [
+            {
+                "spec": "quantum-espresso@1.0~veritas",
+                "prefix": "/path/to/qe",
+            }
+        ]
+    }
+}
+
+@pytest.mark.parametrize("error_messages,config_set,spec", [
+    (version_error_messages, {}, "quantum-espresso^fftw@1.1:"),
+    (external_error_messages, external_config, "quantum-espresso+veritas"),
+    (variant_error_messages, {}, "quantum-espresso+invino^fftw~mpi"),
+])
+def test_error_messages(error_messages, config_set, spec, mock_packages, mutable_config):
+    for path, conf in config_set.items():
+        spack.config.set(path, conf)
+
+    with pytest.raises(spack.solver.asp.UnsatisfiableSpecError) as e:
+        _ = spack.spec.Spec(spec).concretized()
+
+    for em in error_messages:
+        assert em in str(e.value)

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -165,7 +165,7 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   variables:
     KUBERNETES_CPU_REQUEST: 4000m
-    KUBERNETES_MEMORY_REQUEST: 32G
+    KUBERNETES_MEMORY_REQUEST: 16G
     # avoid moving targets like branches and tags
     SPACK_CONCRETIZER_REQUIRE_CHECKSUM: 1
     SPACK_BACKTRACE: 1

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -165,7 +165,7 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   variables:
     KUBERNETES_CPU_REQUEST: 4000m
-    KUBERNETES_MEMORY_REQUEST: 16G
+    KUBERNETES_MEMORY_REQUEST: 32G
     # avoid moving targets like branches and tags
     SPACK_CONCRETIZER_REQUIRE_CHECKSUM: 1
     SPACK_BACKTRACE: 1


### PR DESCRIPTION
fixes #40290

Supersedes #34500 

This is work to create chains of causation for error messages.

The current implementation is only completed for some of the many errors presented by the concretizer. The rest will need to be filled out over time, but this demonstrates the capability. 

The basic idea is to associate conditions in the solver with one another in causal relationships, and to associate errors with the proximate causes of their facts in the condition graph. Then we can construct causal trees to explain errors, which will hopefully present users with useful information to avoid the error or report issues.

Examples:

```
$ spack solve hdf5 ^cmake@3.0.1
==> Error: concretization failed for the following reasons:

   1. Cannot satisfy 'cmake@3.0.1'
   2. Cannot satisfy 'cmake@3.0.1'
        required because hdf5 ^cmake@3.0.1 requested from CLI 
   3. Cannot satisfy 'cmake@3.18:' and 'cmake@3.0.1
        required because hdf5 ^cmake@3.0.1 requested from CLI 
        required because hdf5 depends on cmake@3.18: when @1.13: 
          required because hdf5 ^cmake@3.0.1 requested from CLI 
   4. Cannot satisfy 'cmake@3.12:' and 'cmake@3.0.1
        required because hdf5 depends on cmake@3.12: 
          required because hdf5 ^cmake@3.0.1 requested from CLI 
        required because hdf5 ^cmake@3.0.1 requested from CLI
```

```
$ spack spec cmake ^curl~ldap   # <-- with curl configured non-buildable and an external with `+ldap`
==> Error: concretization failed for the following reasons:

   1. Attempted to use external for 'curl' which does not satisfy any configured external spec
   2. Attempted to build package curl which is not buildable and does not have a satisfying external
        attr('variant_value', 'curl', 'ldap', 'True') is an external constraint for curl which was not satisfied
   3. Attempted to build package curl which is not buildable and does not have a satisfying external
        attr('variant_value', 'curl', 'gssapi', 'True') is an external constraint for curl which was not satisfied
   4. Attempted to build package curl which is not buildable and does not have a satisfying external
        'curl+ldap' is an external constraint for curl which was not satisfied
        'curl~ldap' required
        required because cmake ^curl~ldap requested from CLI 
```

```
$ spack solve yambo+mpi ^hdf5~mpi
==> Error: concretization failed for the following reasons:

   1. 'hdf5' required multiple values for single-valued variant 'mpi'
   2. 'hdf5' required multiple values for single-valued variant 'mpi'
    Requested '~mpi' and '+mpi'
        required because yambo depends on hdf5+mpi when +mpi 
          required because yambo+mpi ^hdf5~mpi requested from CLI 
        required because yambo+mpi ^hdf5~mpi requested from CLI 
   3. 'hdf5' required multiple values for single-valued variant 'mpi'
    Requested '~mpi' and '+mpi'
        required because netcdf-c depends on hdf5+mpi when +mpi 
          required because netcdf-fortran depends on netcdf-c 
            required because yambo depends on netcdf-fortran 
              required because yambo+mpi ^hdf5~mpi requested from CLI 
          required because netcdf-fortran depends on netcdf-c@4.7.4: when @4.5.3: 
            required because yambo depends on netcdf-fortran 
              required because yambo+mpi ^hdf5~mpi requested from CLI 
          required because yambo depends on netcdf-c 
            required because yambo+mpi ^hdf5~mpi requested from CLI 
          required because yambo depends on netcdf-c+mpi when +mpi 
            required because yambo+mpi ^hdf5~mpi requested from CLI 
        required because yambo+mpi ^hdf5~mpi requested from CLI 
```

In addition to fleshing out the causes of other errors, I would like to find a way to associate different components of the error messages with different causes. In this example it's pretty easy to infer which part is which, but I'm not confident that will always be the case. But that's for future work.

~~Due to performance degradation concerns, the condition chaining work is implemented as a separate file that can be loaded only in debug mode. While the PR is WIP the more verbose error message are configured to be default because it's easier to work on that way.~~

See the previous PR #34500 for discussion of how the condition chains are incomplete. Given the improvements here, I think it's worth trying to get this in first before worrying too much about the cases that we aren't yet able to pick up on, but I also want to be sure to acknowledge that those exist.