### PR TITLE
hugo: add v0.118.2

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -18,6 +18,7 @@ class Hugo(Package):
 
     maintainers("alecbcs")
 
+    version("0.118.2", sha256="915d7dcb44fba949c80858f9c2a55a11256162ba28a9067752f808cfe8faedaa")
     version("0.112.7", sha256="d706e52c74f0fb00000caf4e95b98e9d62c3536a134d5e26b433b1fa1e2a74aa")
     version("0.111.3", sha256="b6eeb13d9ed2e5d5c6895bae56480bf0fec24a564ad9d17c90ede14a7b240999")
     version("0.111.2", sha256="66500ae3a03cbf51a6ccf7404d01f42fdc454aa1eaea599c934860bbf0aa2fc5")


### PR DESCRIPTION
Add hugo v0.118.2. 
 
**Test Plan:**
Built successfully using `gcc@10.4.0` on Debian 11.