### PR TITLE
ffmpeg: fix build with XCode 15

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -128,6 +128,10 @@ class Ffmpeg(AutotoolsPackage):
         headers.directories = [self.prefix.include]
         return headers
 
+    @when("@:6.0 %apple-clang@15:")
+    def setup_build_environment(self, env):
+        env.append_flags("LDFLAGS", "-Wl,-ld_classic")
+
     def enable_or_disable_meta(self, variant, options):
         switch = "enable" if "+{0}".format(variant) in self.spec else "disable"
         return ["--{0}-{1}".format(switch, option) for option in options]


### PR DESCRIPTION
As reported in #40159, a shared library build of ffmpeg 6.0 fails with the linker that was added with XCode 15: ld: building exports trie: duplicate symbol '_av_ac3_parse_header' clang: error: linker command failed with exit code 1 (use -v to see invocation)

Forcing the old linker with -Wl,-ld_classic works around this.

Fixes #40159