### PR TITLE
exago: Import `os` and add and logging tests variant.

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -48,6 +48,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
     variant("tests", default=True, description="Enable/Disable Testing")
+    variant("logging", default=False, description="Enable/Disable spdlog based logging")
 
     # Solver options
     variant("hiop", default=False, description="Enable/Disable HiOp")
@@ -182,6 +183,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("EXAGO_ENABLE_HIP", "rocm"),
                 self.define("PETSC_DIR", spec["petsc"].prefix),
                 self.define_from_variant("EXAGO_RUN_TESTS", "tests"),
+                self.define_from_variant("EXAGO_ENABLE_LOGGING", "logging"),
                 self.define_from_variant("EXAGO_ENABLE_MPI", "mpi"),
                 self.define_from_variant("EXAGO_ENABLE_RAJA", "raja"),
                 self.define_from_variant("EXAGO_ENABLE_HIOP", "hiop"),

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -47,7 +47,6 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     conflicts(
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
-    variant("tests", default=True, description="Enable/Disable Testing")
     variant("logging", default=False, description="Enable/Disable spdlog based logging")
 
     # Solver options
@@ -179,10 +178,11 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         args.extend(
             [
                 self.define("EXAGO_ENABLE_GPU", "+cuda" in spec or "+rocm" in spec),
+                self.define("PETSC_DIR", spec["petsc"].prefix),
+                self.define("EXAGO_RUN_TESTS", self.run_tests),
+                self.define("LAPACK_LIBRARIES", spec["lapack"].libs + spec["blas"].libs),
                 self.define_from_variant("EXAGO_ENABLE_CUDA", "cuda"),
                 self.define_from_variant("EXAGO_ENABLE_HIP", "rocm"),
-                self.define("PETSC_DIR", spec["petsc"].prefix),
-                self.define_from_variant("EXAGO_RUN_TESTS", "tests"),
                 self.define_from_variant("EXAGO_ENABLE_LOGGING", "logging"),
                 self.define_from_variant("EXAGO_ENABLE_MPI", "mpi"),
                 self.define_from_variant("EXAGO_ENABLE_RAJA", "raja"),
@@ -190,7 +190,6 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("EXAGO_ENABLE_IPOPT", "ipopt"),
                 self.define_from_variant("EXAGO_ENABLE_PYTHON", "python"),
                 self.define_from_variant("EXAGO_ENABLE_LOGGING", "logging"),
-                self.define("LAPACK_LIBRARIES", spec["lapack"].libs + spec["blas"].libs),
             ]
         )
 

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -13,7 +15,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/pnnl/ExaGO"
     git = "https://github.com/pnnl/ExaGO.git"
-    maintainers("ryandanehy", "CameronRutherford", "pelesh")
+    maintainers("ryandanehy", "cameronrutherford", "pelesh")
 
     version("1.5.1", commit="7abe482c8da0e247f9de4896f5982c4cacbecd78", submodules=True)
     version("1.5.0", commit="227f49573a28bdd234be5500b3733be78a958f15", submodules=True)
@@ -45,6 +47,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     conflicts(
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
+    variant("tests", default=True, description="Enable/Disable Testing")
 
     # Solver options
     variant("hiop", default=False, description="Enable/Disable HiOp")
@@ -178,7 +181,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("EXAGO_ENABLE_CUDA", "cuda"),
                 self.define_from_variant("EXAGO_ENABLE_HIP", "rocm"),
                 self.define("PETSC_DIR", spec["petsc"].prefix),
-                self.define("EXAGO_RUN_TESTS", True),
+                self.define_from_variant("EXAGO_RUN_TESTS", "tests"),
                 self.define_from_variant("EXAGO_ENABLE_MPI", "mpi"),
                 self.define_from_variant("EXAGO_ENABLE_RAJA", "raja"),
                 self.define_from_variant("EXAGO_ENABLE_HIOP", "hiop"),

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -19,7 +19,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/LLNL/hiop"
     git = "https://github.com/LLNL/hiop.git"
-    maintainers("ryandanehy", "CameronRutherford", "pelesh")
+    maintainers("ryandanehy", "cameronrutherford", "pelesh")
 
     # Most recent tagged snapshot is the preferred version when profiling.
     version("1.0.0", commit="10b7d3ee0a15cb4949ccee8c905d447b9528794f", submodules=True)


### PR DESCRIPTION
This is a bugfix only found when building exago without any major dependencies. Most of the time I imagine that we got a free `import os` from `hiop`, but when building `exago~hiop~ipopt~raja~cuda~rocm~logging~python`, we aren't so lucky.

I also thought it would be reasonable to let people control if tests are built and configured, as well as spdlog based logging.

#40149 - I added the name fix for my GitHub username here since this PR is ready to go.