### PR TITLE
libtirpc: Add latest version and allow for builds on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/libtirpc/macos-1.3.3.patch
+++ b/var/spack/repos/builtin/packages/libtirpc/macos-1.3.3.patch
@@ -1,0 +1,105 @@
+diff --git a/src/Makefile.in b/src/Makefile.in
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -90,7 +90,7 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ @AUTHDES_TRUE@am__append_1 = auth_des.c  authdes_prot.c  des_crypt.c  des_impl.c  des_soft.c  svc_auth_des.c
+-@SYMVERS_TRUE@am__append_2 = -Wl,--version-script=$(srcdir)/libtirpc.map
++@SYMVERS_TRUE@am__append_2 = -Wl
+ @GSS_TRUE@am__append_3 = auth_gss.c authgss_prot.c svc_auth_gss.c \
+ @GSS_TRUE@			   rpc_gss_utils.c
+ 
+diff --git a/src/getpeereid.c b/src/getpeereid.c
+--- a/src/getpeereid.c
++++ b/src/getpeereid.c
+@@ -24,7 +24,7 @@
+  * SUCH DAMAGE.
+  */
+ 
+-
++#ifndef __APPLE__
+ #include <sys/param.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+@@ -49,3 +49,4 @@
+ 	*egid = uc.gid;
+ 	return (0);
+  }
++#endif
+diff --git a/src/rpc_com.h b/src/rpc_com.h
+--- a/src/rpc_com.h
++++ b/src/rpc_com.h
+@@ -42,6 +42,11 @@
+ 
+ #include <rpc/rpc_com.h>
+ 
++#ifdef __APPLE__
++    #define SOL_IPV6 IPPROTO_IPV6
++    #define SOL_IP IPPROTO_IP
++#endif
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/src/svc_dg.c b/src/svc_dg.c
+--- a/src/svc_dg.c
++++ b/src/svc_dg.c
+@@ -37,6 +37,7 @@
+  *
+  * Does some caching in the hopes of achieving execute-at-most-once semantics.
+  */
++#define __APPLE_USE_RFC_3542
+ #include <pthread.h>
+ #include <reentrant.h>
+ #include <sys/types.h>
+diff --git a/src/svc_raw.c b/src/svc_raw.c
+--- a/src/svc_raw.c
++++ b/src/svc_raw.c
+@@ -43,6 +43,7 @@
+ #include <sys/types.h>
+ #include <rpc/raw.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ #ifndef UDPMSGSIZE
+ #define	UDPMSGSIZE 8800
+diff --git a/src/xdr_float.c b/src/xdr_float.c
+--- a/src/xdr_float.c
++++ b/src/xdr_float.c
+@@ -83,7 +83,11 @@
+ };
+ #else
+ 
++#ifndef __APPLE__
+ #include <endian.h>
++#else
++#include <machine/endian.h>
++#endif
+ #define IEEEFP
+ 
+ #endif /* vax */
+diff --git a/tirpc/reentrant.h b/tirpc/reentrant.h
+--- a/tirpc/reentrant.h
++++ b/tirpc/reentrant.h
+@@ -36,7 +36,7 @@
+  * These definitions are only guaranteed to be valid on Linux. 
+  */
+ 
+-#if defined(__linux__)
++#if defined(__linux__) || defined(__APPLE__)
+ 
+ #include <pthread.h>
+ 
+diff --git a/tirpc/rpc/rpcent.h b/tirpc/rpc/rpcent.h
+--- a/tirpc/rpc/rpcent.h
++++ b/tirpc/rpc/rpcent.h
+@@ -50,7 +50,7 @@
+ 
+ /* These are defined in /usr/include/rpc/netdb.h, unless we are using
+    the C library without RPC support. */
+-#if defined(__UCLIBC__) && !defined(__UCLIBC_HAS_RPC__) || !defined(__GLIBC__)
++#if defined(__UCLIBC__) && !defined(__UCLIBC_HAS_RPC__) || !defined(__GLIBC__) && !defined(__APPLE__)
+ struct rpcent {
+ 	char	*r_name;	/* name of server for this rpc program */
+ 	char	**r_aliases;	/* alias list */

--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -22,10 +22,15 @@ class Libtirpc(AutotoolsPackage):
 
     # Remove -pipe flag to compiler in Makefiles when using nvhpc
     patch("libtirpc-remove-pipe-flag-for-nvhpc.patch", when="%nvhpc")
+    # Allow to build on macOS
+    # - Remove versioning linker flags and include
+    # - Include missing / apple specific headers
+    # - Add apple pre-processor guards to guard / ignore some sections
+    # Taken from:
+    # https://github.com/unfs3/unfs3/pull/25#issuecomment-1631198490
     patch("macos-1.3.3.patch", when="@1.3.3 platform=darwin")
 
-    # FIXME: build error on macOS
-    # auth_none.c:81:9: error: unknown type name 'mutex_t'
+    # Only the latest version is known to build on macOS
     conflicts("platform=darwin", when="@:1.3.2", msg="Does not build on macOS")
 
     @property
@@ -39,6 +44,8 @@ class Libtirpc(AutotoolsPackage):
         return hdrs or None
 
     def configure_args(self):
+        # See discussion in
+        # https://github.com/unfs3/unfs3/pull/25#issuecomment-1631198490
         if self.spec.satisfies("@1.3.3 platform=darwin"):
             return ["--disable-gssapi"]
         return []

--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -12,6 +12,7 @@ class Libtirpc(AutotoolsPackage):
     homepage = "https://sourceforge.net/projects/libtirpc/"
     url = "https://sourceforge.net/projects/libtirpc/files/libtirpc/1.1.4/libtirpc-1.1.4.tar.bz2/download"
 
+    version("1.3.3", sha256="6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3")
     version("1.2.6", sha256="4278e9a5181d5af9cd7885322fdecebc444f9a3da87c526e7d47f7a12a37d1cc")
     version("1.1.4", sha256="2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d")
 
@@ -21,10 +22,11 @@ class Libtirpc(AutotoolsPackage):
 
     # Remove -pipe flag to compiler in Makefiles when using nvhpc
     patch("libtirpc-remove-pipe-flag-for-nvhpc.patch", when="%nvhpc")
+    patch("macos-1.3.3.patch", when="@1.3.3 platform=darwin")
 
     # FIXME: build error on macOS
     # auth_none.c:81:9: error: unknown type name 'mutex_t'
-    conflicts("platform=darwin", msg="Does not build on macOS")
+    conflicts("platform=darwin", when="@:1.3.2", msg="Does not build on macOS")
 
     @property
     def headers(self):
@@ -35,3 +37,8 @@ class Libtirpc(AutotoolsPackage):
         if hdrs:
             hdrs.directories = [self.prefix.include.tirpc, self.prefix.include]
         return hdrs or None
+
+    def configure_args(self):
+        if self.spec.satisfies("@1.3.3 platform=darwin"):
+            return ["--disable-gssapi"]
+        return []

--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -30,7 +30,8 @@ class Libtirpc(AutotoolsPackage):
     # https://github.com/unfs3/unfs3/pull/25#issuecomment-1631198490
     patch("macos-1.3.3.patch", when="@1.3.3 platform=darwin")
 
-    # Only the latest version is known to build on macOS
+    # Only the latest version is known to build on macOS. Previous versions fail
+    # with auth_none.c:81:9: error: unknown type name 'mutex_t'
     conflicts("platform=darwin", when="@:1.3.2", msg="Does not build on macOS")
 
     @property


### PR DESCRIPTION
Add the latest version 1.3.3.

Add the [patch found here](https://github.com/unfs3/unfs3/pull/25#issuecomment-1631198490) and apply it for builds on mac OS. This allows me to build `libtirpc@1.3.3` on mac (intel).

```console
$spack debug report

* **Spack:** 0.21.0.dev0 (b8ddcd63b745a57ae80604db86e3ab22194d5beb)
* **Python:** 3.9.6
* **Platform:** darwin-ventura-skylake
* **Concretizer:** clingo
```