### PR TITLE
openmpi: fix build with XCode 15

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -776,6 +776,12 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
         return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
 
+    # work around a failure in ./configure: https://github.com/open-mpi/ompi/issues/11935
+    # instead of the issue's patch, this has the advantage that it also works with @4.0
+    @when("@:6.0 %apple-clang@15:")
+    def setup_build_environment(self, env):
+        env.append_flags("LDFLAGS", "-Wl,-ld_classic")
+
     def setup_run_environment(self, env):
         # Because MPI is both a runtime and a compiler, we have to setup the
         # compiler components as part of the run environment.

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -820,6 +820,8 @@ class Openmpi(AutotoolsPackage, CudaPackage):
             "PKGINCLUDEDIR",
         ]:
             env.unset("OPAL_%s" % suffix)
+        if self.spec.satisfies("@:4.1.5 %apple-clang@15:"):
+            env.append_flags("LDFLAGS", "-Wl,-ld_classic")
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, "mpicc")

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -778,7 +778,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     # work around a failure in ./configure: https://github.com/open-mpi/ompi/issues/11935
     # instead of the issue's patch, this has the advantage that it also works with @4.0
-    @when("@:6.0 %apple-clang@15:")
+    @when("@:4.1.5 %apple-clang@15:")
     def setup_build_environment(self, env):
         env.append_flags("LDFLAGS", "-Wl,-ld_classic")
 


### PR DESCRIPTION
Works around issue reported here: https://github.com/open-mpi/ompi/issues/11935 The fix supplied there should go into openmpi@4.1.6.

But just supplying LDFLAGS in order to use the old linker has the advantage that it also works with @4.0 and is less intrusive than applying the patch and recreating ./configure with ./autogen.pl --force.