### PR TITLE
subread: removing mtune arg to compiler

### DIFF
--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -14,6 +14,7 @@ class Subread(MakefilePackage):
 
     homepage = "https://subread.sourceforge.net/"
     url = "https://sourceforge.net/projects/subread/files/subread-1.5.2/subread-1.5.2-source.tar.gz/download"
+    maintainers("snehring")
 
     version("2.0.6", sha256="f0fdda6b98634d2946028948c220253e10a0f27c7fa5f24913b65b3ac6cbb045")
     version("2.0.4", sha256="c54b37ed83b34318d8f119b5c02fb9d0a65c811195bcc9e1745df6daf74ca2db")
@@ -31,12 +32,11 @@ class Subread(MakefilePackage):
         with working_dir("src"):
             if plat.startswith("linux"):
                 filter_file("CC_EXEC = gcc", "CC_EXEC = {0}".format(spack_cc), "Makefile.Linux")
-                if spec.target.family == "aarch64":
-                    filter_file("-mtune=core2", "", "Makefile.Linux")
-                    if spec.satisfies("@1.6.2:2.0.0"):
-                        filter_file("-mtune=core2", "", "longread-one/Makefile")
-                    elif spec.satisfies("@1.6.0"):
-                        filter_file("-mtune=core2", "", "longread-mapping/Makefile")
+                filter_file("-mtune=core2", "", "Makefile.Linux")
+                if spec.satisfies("@1.6.2:"):
+                    filter_file("-mtune=core2", "", "longread-one/Makefile")
+                if spec.satisfies("@1.6.0"):
+                    filter_file("-mtune=core2", "", "longread-mapping/Makefile")
                 make("-f", "Makefile.Linux")
             elif plat.startswith("darwin"):
                 make("-f", "Makefile.MacOS")


### PR DESCRIPTION
Ran into this to fix errors on aarch64, but I think it's probably best to remove the -mtune anyway and leave that to users regardless of target.