### PR TITLE
zoltan: Fixes for #40198

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -166,7 +166,7 @@ class Zoltan(AutotoolsPackage):
         if config_cflags:
             config_args.append("--with-cflags={0}".format(" ".join(config_cflags)))
         if config_cxxflags:
-            config_args.append("--with-cxxflags={0}".format(" ".join(config_cflags)))
+            config_args.append("--with-cxxflags={0}".format(" ".join(config_cxxflags)))
         if config_fcflags:
             config_args.append("--with-fcflags={0}".format(" ".join(config_fcflags)))
         if config_ldflags:

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -92,6 +92,9 @@ class Zoltan(AutotoolsPackage):
         config_cflags = ["-O0" if "+debug" in spec else "-O3", "-g" if "+debug" in spec else ""]
 
         config_ldflags = []
+        config_libs = []
+        config_incdirs = []
+
         # PGI runtime libraries
         if "%pgi" in spec:
             config_ldflags.append("-pgf90libs")
@@ -102,9 +105,12 @@ class Zoltan(AutotoolsPackage):
             config_args.extend(["RANLIB=echo", "--with-ar=$(CXX) -shared $(LDFLAGS) -o"])
             config_cflags.append(self.compiler.cc_pic_flag)
             if spec.satisfies("%gcc"):
-                config_args.append("--with-libs=-lgfortran")
+                config_libs.append("-lgfortran")
+                # Although adding to config_libs _should_ suffice, it does not
+                # Add to ldflags as well
+                config_ldflags.append("-lgfortran")
             if spec.satisfies("%intel"):
-                config_args.append("--with-libs=-lifcore")
+                config_libs.append("-lifcore")
 
         if "+int64" in spec:
             config_args.append("--with-id-type=ulong")
@@ -116,10 +122,16 @@ class Zoltan(AutotoolsPackage):
                     "--with-parmetis",
                     "--with-parmetis-libdir={0}".format(parmetis_prefix.lib),
                     "--with-parmetis-incdir={0}".format(parmetis_prefix.include),
-                    "--with-incdirs=-I{0}".format(spec["metis"].prefix.include),
-                    "--with-ldflags=-L{0}".format(spec["metis"].prefix.lib),
                 ]
             )
+            config_ldflags.append("-L{0}".format(spec["metis"].prefix.lib))
+            config_incdirs.append("-I{0}".format(spec["metis"].prefix.include))
+            config_libs.append("-lparmetis")
+            config_libs.append("-lmetis")
+            # Although appending to config_libs _should_ suffice, it does not
+            # Add them to ldflags as well
+            config_ldflags.append("-lparmetis")
+            config_ldflags.append("-lmetis")
             if "+int64" in spec["metis"]:
                 config_args.append("--with-id-type=ulong")
             else:
@@ -143,19 +155,26 @@ class Zoltan(AutotoolsPackage):
                 config_args.extend(["FC={0}".format(spec["mpi"].mpifc)])
 
         config_fcflags = config_cflags[:]
+        config_cxxflags = config_cflags[:]
+
         if spec.satisfies("%gcc@10:+fortran"):
             config_fcflags.append("-fallow-argument-mismatch")
+
         # NOTE: Early versions of Zoltan come packaged with a few embedded
         # library packages (e.g. ParMETIS, Scotch), which messes with Spack's
         # ability to descend directly into the package's source directory.
-        config_args.extend(
-            [
-                "--with-cflags={0}".format(" ".join(config_cflags)),
-                "--with-cxxflags={0}".format(" ".join(config_cflags)),
-                "--with-fcflags={0}".format(" ".join(config_fcflags)),
-                "--with-ldflags={0}".format(" ".join(config_ldflags)),
-            ]
-        )
+        if config_cflags:
+            config_args.append("--with-cflags={0}".format(" ".join(config_cflags)))
+        if config_cxxflags:
+            config_args.append("--with-cxxflags={0}".format(" ".join(config_cflags)))
+        if config_fcflags:
+            config_args.append("--with-fcflags={0}".format(" ".join(config_fcflags)))
+        if config_ldflags:
+            config_args.append("--with-ldflags={0}".format(" ".join(config_ldflags)))
+        if config_libs:
+            config_args.append("--with-libs={0}".format(" ".join(config_libs)))
+        if config_incdirs:
+            config_args.append("--with-incdirs={0}".format(" ".join(config_incdirs)))
         return config_args
 
     # NOTE: Unfortunately, Zoltan doesn't provide any configuration


### PR DESCRIPTION
fixes #40198

Fix issue in configure_args which resulted in duplicate "--with-ldflags" arguments (with different values) being passed to configure.  And extended the fix to similar arguments.

Also, repeated some flags to "--with-libs" to "--with-ldflags" as when the flags were only in "--with-libs", they did not seem to be picked up everywhere.  I suspect this is a bug in the configure script, but adding to both locations seems to solve it and should not have any adverse effects.