### PR TITLE
modeltest-ng: adding new version, swapping maintainer

### DIFF
--- a/var/spack/repos/builtin/packages/modeltest-ng/package.py
+++ b/var/spack/repos/builtin/packages/modeltest-ng/package.py
@@ -24,8 +24,10 @@ class ModeltestNg(CMakePackage):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("openmpi", when="+mpi")
-   # 40217: ICE by gcc-toolset-12-gcc-12.2.1-7.4.el8.aarch64 of Rocky Linux 8.8:
-   conflicts("%gcc@12.2.1", when="target=aarch64:")
+
+    # 40217: ICE by gcc-toolset-12-gcc-12.2.1-7.4.el8.aarch64 of Rocky Linux 8.8:
+    conflicts("%gcc@12.2.0:12.2", when="target=aarch64:", msg="ICE with gcc@12.2 on aarch64")
+
     requires(
         "@20220721:", when="target=aarch64:", msg="Support for aarch64 was added after 20220721."
     )

--- a/var/spack/repos/builtin/packages/modeltest-ng/package.py
+++ b/var/spack/repos/builtin/packages/modeltest-ng/package.py
@@ -24,7 +24,8 @@ class ModeltestNg(CMakePackage):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("openmpi", when="+mpi")
-
+   # 40217: ICE by gcc-toolset-12-gcc-12.2.1-7.4.el8.aarch64 of Rocky Linux 8.8:
+   conflicts("%gcc@12.2.1", when="target=aarch64:")
     requires(
         "@20220721:", when="target=aarch64:", msg="Support for aarch64 was added after 20220721."
     )

--- a/var/spack/repos/builtin/packages/modeltest-ng/package.py
+++ b/var/spack/repos/builtin/packages/modeltest-ng/package.py
@@ -13,8 +13,9 @@ class ModeltestNg(CMakePackage):
     url = "https://github.com/ddarriba/modeltest/archive/refs/tags/v0.1.7.tar.gz"
     git = "https://github.com/ddarriba/modeltest.git"
 
-    maintainers("dorton21")
+    maintainers("snehring")
 
+    version("20220721", commit="1066356b984100897b8bd38ac771c5c950984c01", submodules=True)
     version("0.1.7", commit="cc028888f1d4222aaa53b99c6b02cd934a279001", submodules=True)
 
     variant("mpi", default=False, description="Enable MPI")
@@ -23,6 +24,10 @@ class ModeltestNg(CMakePackage):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("openmpi", when="+mpi")
+
+    requires(
+        "@20220721:", when="target=aarch64:", msg="Support for aarch64 was added after 20220721."
+    )
 
     def cmake_args(self):
         return [self.define_from_variant("ENABLE_MPI", "mpi")]


### PR DESCRIPTION
Also allows for aarch64 compiles