### PR TITLE
Fix velvet variants

### DIFF
--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -20,6 +20,8 @@ class Velvet(MakefilePackage):
     homepage = "https://www.ebi.ac.uk/~zerbino/velvet/"
     url = "https://www.ebi.ac.uk/~zerbino/velvet/velvet_1.2.10.tgz"
 
+    maintainers("snehring")
+
     version("1.2.10", sha256="884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640")
 
     variant(

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -22,22 +22,29 @@ class Velvet(MakefilePackage):
 
     version("1.2.10", sha256="884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640")
 
-    variant("categories", default='2',
-            description="Number of channels which can be handled independently",
-            values=is_positive_int)
-    variant("maxkmerlength", default='31',
-            description="Longest kmer size you can use in an analysis",
-            values=is_positive_int)
-    variant("bigassembly", default=False,
-            description="Allow assemblies with more than 2^31 reads")
-    variant("vbigassembly", default=False,
-            description="Allow unsigned 64-bit array index values (also enables bigassembly)")
-    variant("longsequences", default=False,
-            description="Allow assembling contigs longer than 32kb")
-    variant("openmp", default=False,
-            description="Enable multithreading")
-    variant("single_cov_cat", default=False,
-            description="Per-library coverage")
+    variant(
+        "categories",
+        default="2",
+        description="Number of channels which can be handled independently",
+        values=is_positive_int,
+    )
+    variant(
+        "maxkmerlength",
+        default="31",
+        description="Longest kmer size you can use in an analysis",
+        values=is_positive_int,
+    )
+    variant("bigassembly", default=False, description="Allow assemblies with more than 2^31 reads")
+    variant(
+        "vbigassembly",
+        default=False,
+        description="Allow unsigned 64-bit array index values (also enables bigassembly)",
+    )
+    variant(
+        "longsequences", default=False, description="Allow assembling contigs longer than 32kb"
+    )
+    variant("openmp", default=False, description="Enable multithreading")
+    variant("single_cov_cat", default=False, description="Per-library coverage")
 
     depends_on("zlib-api")
 
@@ -47,18 +54,18 @@ class Velvet(MakefilePackage):
             makefile.filter("-m64", "")
         maxkmerlength = self.spec.variants["maxkmerlength"].value
         categories = self.spec.variants["categories"].value
-        makefile.filter('^MAXKMERLENGTH\s*=\s*.*', f'MAXKMERLENGTH = {maxkmerlength}')
-        makefile.filter('^CATEGORIES\s*=\s*.*', f'CATEGORIES = {categories}')
+        makefile.filter("^MAXKMERLENGTH\s*=\s*.*", f"MAXKMERLENGTH = {maxkmerlength}")
+        makefile.filter("^CATEGORIES\s*=\s*.*", f"CATEGORIES = {categories}")
         if "+bigassembly" in self.spec:
-            makefile.filter('^ifdef BIGASSEMBLY', 'BIGASSEMBLY=1\nifdef BIGASSEMBLY')
+            makefile.filter("^ifdef BIGASSEMBLY", "BIGASSEMBLY=1\nifdef BIGASSEMBLY")
         if "+vbigassembly" in self.spec:
-            makefile.filter('^ifdef VBIGASSEMBLY', 'VBIGASSEMBLY=1\nifdef VBIGASSEMBLY')
+            makefile.filter("^ifdef VBIGASSEMBLY", "VBIGASSEMBLY=1\nifdef VBIGASSEMBLY")
         if "+longsequences" in self.spec:
-            makefile.filter('^ifdef LONGSEQUENCES', 'LONGSEQUENCES=1\nifdef LONGSEQUENCES')
+            makefile.filter("^ifdef LONGSEQUENCES", "LONGSEQUENCES=1\nifdef LONGSEQUENCES")
         if "+openmp" in self.spec:
-            makefile.filter('^ifdef OPENMP', 'OPENMP=1\nifdef OPENMP')
+            makefile.filter("^ifdef OPENMP", "OPENMP=1\nifdef OPENMP")
         if "+single_cov_cat" in self.spec:
-            makefile.filter('^ifdef SINGLE_COV_CAT', 'SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT')
+            makefile.filter("^ifdef SINGLE_COV_CAT", "SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -7,10 +7,11 @@ from spack.package import *
 
 
 def is_positive_int(x):
-    if isinstance(x, int) and x>0:
+    if x.isdigit() and int(x)>0:
         return True
     else:
         return False
+
 
 class Velvet(MakefilePackage):
     """Velvet is a de novo genomic assembler specially designed for short read
@@ -21,7 +22,7 @@ class Velvet(MakefilePackage):
 
     version("1.2.10", sha256="884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640")
 
-    variant("maxkmerlength", default=31,
+    variant("maxkmerlength", default='31',
             description="Longest kmer size you can use in an analysis",
             values=is_positive_int)
 

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -22,9 +22,22 @@ class Velvet(MakefilePackage):
 
     version("1.2.10", sha256="884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640")
 
+    variant("categories", default='2',
+            description="Number of channels which can be handled independently",
+            values=is_positive_int)
     variant("maxkmerlength", default='31',
             description="Longest kmer size you can use in an analysis",
             values=is_positive_int)
+    variant("bigassembly", default=False,
+            description="Allow assemblies with more than 2^31 reads")
+    variant("vbigassembly", default=False,
+            description="Allow unsigned 64-bit array index values (also enables bigassembly)")
+    variant("longsequences", default=False,
+            description="Allow assembling contigs longer than 32kb")
+    variant("openmp", default=False,
+            description="Enable multithreading")
+    variant("single_cov_cat", default=False,
+            description="Per-library coverage")
 
     depends_on("zlib-api")
 
@@ -33,7 +46,20 @@ class Velvet(MakefilePackage):
         if spec.target.family == "aarch64":
             makefile.filter("-m64", "")
         maxkmerlength = self.spec.variants["maxkmerlength"].value
+        categories = self.spec.variants["categories"].value
         makefile.filter('^MAXKMERLENGTH\s*=\s*.*', f'MAXKMERLENGTH = {maxkmerlength}')
+        makefile.filter('^CATEGORIES\s*=\s*.*', f'CATEGORIES = {categories}')
+        if "+bigassembly" in self.spec:
+            makefile.filter('^ifdef BIGASSEMBLY', f'BIGASSEMBLY=1\nifdef BIGASSEMBLY')
+        if "+vbigassembly" in self.spec:
+            makefile.filter('^ifdef VBIGASSEMBLY', f'VBIGASSEMBLY=1\nifdef VBIGASSEMBLY')
+        if "+longsequences" in self.spec:
+            makefile.filter('^ifdef LONGSEQUENCES', f'LONGSEQUENCES=1\nifdef LONGSEQUENCES')
+        if "+openmp" in self.spec:
+            makefile.filter('^ifdef OPENMP', f'OPENMP=1\nifdef OPENMP')
+        if "+single_cov_cat" in self.spec:
+            makefile.filter('^ifdef SINGLE_COV_CAT', f'SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT')
+
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -6,6 +6,12 @@
 from spack.package import *
 
 
+def is_positive_int(x):
+    if isinstance(x, int) and x>0:
+        return True
+    else:
+        return False
+
 class Velvet(MakefilePackage):
     """Velvet is a de novo genomic assembler specially designed for short read
     sequencing technologies."""
@@ -15,12 +21,18 @@ class Velvet(MakefilePackage):
 
     version("1.2.10", sha256="884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640")
 
+    variant("maxkmerlength", default=31,
+            description="Longest kmer size you can use in an analysis",
+            values=is_positive_int)
+
     depends_on("zlib-api")
 
     def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
         if spec.target.family == "aarch64":
-            makefile = FileFilter("Makefile")
             makefile.filter("-m64", "")
+        maxkmerlength = self.spec.variants["maxkmerlength"].value
+        makefile.filter('^MAXKMERLENGTH\s*=\s*.*', f'MAXKMERLENGTH = {maxkmerlength}')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 def is_positive_int(x):
-    if x.isdigit() and int(x)>0:
+    if x.isdigit() and int(x) > 0:
         return True
     else:
         return False
@@ -59,7 +59,6 @@ class Velvet(MakefilePackage):
             makefile.filter('^ifdef OPENMP', 'OPENMP=1\nifdef OPENMP')
         if "+single_cov_cat" in self.spec:
             makefile.filter('^ifdef SINGLE_COV_CAT', 'SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT')
-
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -50,15 +50,15 @@ class Velvet(MakefilePackage):
         makefile.filter('^MAXKMERLENGTH\s*=\s*.*', f'MAXKMERLENGTH = {maxkmerlength}')
         makefile.filter('^CATEGORIES\s*=\s*.*', f'CATEGORIES = {categories}')
         if "+bigassembly" in self.spec:
-            makefile.filter('^ifdef BIGASSEMBLY', f'BIGASSEMBLY=1\nifdef BIGASSEMBLY')
+            makefile.filter('^ifdef BIGASSEMBLY', 'BIGASSEMBLY=1\nifdef BIGASSEMBLY')
         if "+vbigassembly" in self.spec:
-            makefile.filter('^ifdef VBIGASSEMBLY', f'VBIGASSEMBLY=1\nifdef VBIGASSEMBLY')
+            makefile.filter('^ifdef VBIGASSEMBLY', 'VBIGASSEMBLY=1\nifdef VBIGASSEMBLY')
         if "+longsequences" in self.spec:
-            makefile.filter('^ifdef LONGSEQUENCES', f'LONGSEQUENCES=1\nifdef LONGSEQUENCES')
+            makefile.filter('^ifdef LONGSEQUENCES', 'LONGSEQUENCES=1\nifdef LONGSEQUENCES')
         if "+openmp" in self.spec:
-            makefile.filter('^ifdef OPENMP', f'OPENMP=1\nifdef OPENMP')
+            makefile.filter('^ifdef OPENMP', 'OPENMP=1\nifdef OPENMP')
         if "+single_cov_cat" in self.spec:
-            makefile.filter('^ifdef SINGLE_COV_CAT', f'SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT')
+            makefile.filter('^ifdef SINGLE_COV_CAT', 'SINGLE_COV_CAT=1\nifdef SINGLE_COV_CAT')
 
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -54,8 +54,8 @@ class Velvet(MakefilePackage):
             makefile.filter("-m64", "")
         maxkmerlength = self.spec.variants["maxkmerlength"].value
         categories = self.spec.variants["categories"].value
-        makefile.filter("^MAXKMERLENGTH\s*=\s*.*", f"MAXKMERLENGTH = {maxkmerlength}")
-        makefile.filter("^CATEGORIES\s*=\s*.*", f"CATEGORIES = {categories}")
+        makefile.filter(r"^MAXKMERLENGTH\s*=\s*.*", f"MAXKMERLENGTH = {maxkmerlength}")
+        makefile.filter(r"^CATEGORIES\s*=\s*.*", f"CATEGORIES = {categories}")
         if "+bigassembly" in self.spec:
             makefile.filter("^ifdef BIGASSEMBLY", "BIGASSEMBLY=1\nifdef BIGASSEMBLY")
         if "+vbigassembly" in self.spec:


### PR DESCRIPTION
Velvet has several compilation settings missing from the default package. For example, [the Bioconda version of velvet has `MAXKMERLENGTH=191`](https://bioinformatics.stackexchange.com/a/20380) versus the upstream default of `31`.

This PR adds variants for all the `#ifdef` lines in the Makefile, except for `BUNDLEDZLIB` that's already handled by the existing `zlib-api` dependency.  Default values match upstream.