### PR TITLE
py-isort: needs setuptools build dep before v5

### DIFF
--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -29,6 +29,8 @@ class PyImportlibMetadata(PythonPackage):
     version("0.19", sha256="23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8")
     version("0.18", sha256="cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db")
 
+    depends_on("python@3.8:", when="@6.8.0:", type=("build", "run"))
+    depends_on("python@3.7:", when="@4.9.0:", type=("build", "run"))
     depends_on("py-setuptools@56:", when="@4.6.4:", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm@3.4.1:+toml", when="@3:", type="build")

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -30,6 +30,7 @@ class PyImportlibMetadata(PythonPackage):
     version("0.18", sha256="cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db")
 
     depends_on("python@3.8:", when="@6.8.0:", type=("build", "run"))
+    # lowerbound needed as spack itself supports python 3.6 (can be dropped in spack 0.21) 
     depends_on("python@3.7:", when="@4.9.0:", type=("build", "run"))
     depends_on("py-setuptools@56:", when="@4.6.4:", type="build")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -30,7 +30,7 @@ class PyImportlibMetadata(PythonPackage):
     version("0.18", sha256="cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db")
 
     depends_on("python@3.8:", when="@6.8.0:", type=("build", "run"))
-    # lowerbound needed as spack itself supports python 3.6 (can be dropped in spack 0.21) 
+    # lowerbound needed as spack itself supports python 3.6 (can be dropped in spack 0.21)
     depends_on("python@3.7:", when="@4.9.0:", type=("build", "run"))
     depends_on("py-setuptools@56:", when="@4.6.4:", type="build")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-isort/package.py
+++ b/var/spack/repos/builtin/packages/py-isort/package.py
@@ -24,6 +24,7 @@ class PyIsort(PythonPackage):
     depends_on("python@3.8:", when="@5.12:", type=("build", "run"))
     depends_on("python@3.6.1:3", when="@5:5.10", type=("build", "run"))
     depends_on("py-setuptools", when="@:4", type=("build", "run"))
+    depends_on("py-setuptools", type="run")
     depends_on("py-poetry-core@1:", when="@5:", type="build")
     depends_on("py-colorama@0.4.3:", when="+colors @5.12:", type=("build", "run"))
     depends_on("py-colorama@0.4.3:0.4", when="+colors @:5.11", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-isort/package.py
+++ b/var/spack/repos/builtin/packages/py-isort/package.py
@@ -23,7 +23,7 @@ class PyIsort(PythonPackage):
 
     depends_on("python@3.8:", when="@5.12:", type=("build", "run"))
     depends_on("python@3.6.1:3", when="@5:5.10", type=("build", "run"))
-    depends_on("py-setuptools", when="@:4", type="build")
+    depends_on("py-setuptools", when="@:4", type=("build", "run"))
     depends_on("py-poetry-core@1:", when="@5:", type="build")
     depends_on("py-colorama@0.4.3:", when="+colors @5.12:", type=("build", "run"))
     depends_on("py-colorama@0.4.3:0.4", when="+colors @:5.11", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-isort/package.py
+++ b/var/spack/repos/builtin/packages/py-isort/package.py
@@ -24,7 +24,6 @@ class PyIsort(PythonPackage):
     depends_on("python@3.8:", when="@5.12:", type=("build", "run"))
     depends_on("python@3.6.1:3", when="@5:5.10", type=("build", "run"))
     depends_on("py-setuptools", when="@:4", type=("build", "run"))
-    depends_on("py-setuptools", type="run")
     depends_on("py-poetry-core@1:", when="@5:", type="build")
     depends_on("py-colorama@0.4.3:", when="+colors @5.12:", type=("build", "run"))
     depends_on("py-colorama@0.4.3:0.4", when="+colors @:5.11", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-isort/package.py
+++ b/var/spack/repos/builtin/packages/py-isort/package.py
@@ -23,7 +23,8 @@ class PyIsort(PythonPackage):
 
     depends_on("python@3.8:", when="@5.12:", type=("build", "run"))
     depends_on("python@3.6.1:3", when="@5:5.10", type=("build", "run"))
-    depends_on("py-poetry-core@1:", type="build")
+    depends_on("py-setuptools", when="@:4", type="build")
+    depends_on("py-poetry-core@1:", when="@5:", type="build")
     depends_on("py-colorama@0.4.3:", when="+colors @5.12:", type=("build", "run"))
     depends_on("py-colorama@0.4.3:0.4", when="+colors @:5.11", type=("build", "run"))
 


### PR DESCRIPTION
Detected in #40224.

In the past, system setuptools could be picked up when using an external
python, so py-isort@4 would install fine. With the linked PR, pip can
only consider packages that Spack controls from PYTHONPATH, so the issue
of missing py-setuptools showed up.
