### PR TITLE
seacas: Update recipe to find faodel in recent versions of seacas

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -494,7 +494,7 @@ class Seacas(CMakePackage):
             # leaves off the faodel part
             faodel_incdir = spec["faodel"].prefix.include
             faodel_incdir2 = spec["faodel"].prefix.include.faodel
-            faodel_incdirs = [ faodel_incdir, faodel_incdir2 ]
+            faodel_incdirs = [faodel_incdir, faodel_incdir2]
             options.append(define("Faodel_INCLUDE_DIRS", ";".join(faodel_incdirs)))
             options.append(define("Faodel_LIBRARY_DIRS", spec["faodel"].prefix.lib))
 

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -304,6 +304,9 @@ class Seacas(CMakePackage):
         when="@:2023-10-24",
     )
 
+    # Based on install-tpl.sh script, cereal seems to only be used when faodel enabled
+    depends_on("cereal", when="@2021-04-02: +faodel")
+
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.lib)
 
@@ -485,6 +488,15 @@ class Seacas(CMakePackage):
         for pkg in ("Faodel", "BOOST"):
             if pkg.lower() in spec:
                 options.append(define(pkg + "_ROOT", spec[pkg.lower()].prefix))
+
+        if "+faodel" in spec:
+            # faodel headers are under $faodel_prefix/include/faodel but seacas
+            # leaves off the faodel part
+            faodel_incdir = spec["faodel"].prefix.include
+            faodel_incdir2 = spec["faodel"].prefix.include.faodel
+            faodel_incdirs = [ faodel_incdir, faodel_incdir2 ]
+            options.append(define("Faodel_INCLUDE_DIRS", ";".join(faodel_incdirs)))
+            options.append(define("Faodel_LIBRARY_DIRS", spec["faodel"].prefix.lib))
 
         options.append(from_variant("TPL_ENABLE_ADIOS2", "adios2"))
         if "+adios2" in spec:


### PR DESCRIPTION
@gsjaardema
This should fix #40237

Explciitly sets the CMake variables  Faodel_INCLUDE_DIRS and Faodel_LIBRARY_DIRS when +faodel. This seems to be needed for recent versions of seacas (seacas@2021-04-02:), but should be safe to do for all versions.

For Faodel_INCLUDE_DIRS, it looks like Faodel has header files under $(Faodel_Prefix)/include/faodel, but seacas is not including the "faodel" part in #includes.  So add both $(Faodel_Prefix)/include and $(Foadel_Prefix)/include/faodel

Also, it looks like a dependency on cereal was added in seacas@2021-04-02: +faodel. I do not see it documented as an optional library, and looking at the install-tpl.sh script included with seacas, there does not appear to be any flags to explicitly enable or disable the dependency, but it is automatically added whenever faodel is selected.  Based on that, I am *not* adding a +/-cereal variant, but adding cereal as a dependency for +faodel variants.