### PR TITLE
perl-dbd-mysql update to 4.050

### DIFF
--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -12,8 +12,14 @@ class PerlDbdMysql(PerlPackage):
     homepage = "https://metacpan.org/pod/DBD::mysql"
     url = "https://search.cpan.org/CPAN/authors/id/M/MI/MICHIELB/DBD-mysql-4.043.tar.gz"
 
+    version(
+        "4.050",
+        sha256="4f48541ff15a0a7405f76adc10f81627c33996fbf56c95c26c094444c0928d78",
+        url="https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-4.050.tar.gz",
+    )
     version("4.043", sha256="629f865e8317f52602b2f2efd2b688002903d2e4bbcba5427cb6188b043d6f99")
 
+    depends_on("perl-devel-checklib", type="build", when="@4.050:")
     depends_on("perl-test-deep", type=("build", "run"))
     depends_on("perl-dbi", type=("build", "run"))
     depends_on("mysql-client")

--- a/var/spack/repos/builtin/packages/perl-devel-checklib/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-checklib/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDevelChecklib(PerlPackage):
+    """Devel::CheckLib - check that a library is available"""
+
+    homepage = "https://metacpan.org/pod/Devel::CheckLib"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-1.16.tar.gz"
+    maintainers("snehring")
+
+    version("1.16", sha256="869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca")


### PR DESCRIPTION
Was having trouble compiling this for the version of mariadb I had installed, luckily an update resolved it.

New version has a new build dependency.