### PR TITLE
hdf5: fix h5pfc symlink for 1.10.10:1.10

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -657,7 +657,7 @@ class Hdf5(CMakePackage):
         # 1.10.6 and 1.12.0. The current develop versions do not produce 'h5pfc'
         # at all. Here, we make sure that 'h5pfc' is available when Fortran and
         # MPI support are enabled (only for versions that generate 'h5fc').
-        if self.spec.satisfies("@1.8.22:1.8," "1.10.6:1.10," "1.12.0:1.12" "+fortran+mpi"):
+        if self.spec.satisfies("@1.8.22:1.8," "1.10.6:1.10.9," "1.12.0:1.12" "+fortran+mpi"):
             with working_dir(self.prefix.bin):
                 # No try/except here, fix the condition above instead:
                 symlink("h5fc", "h5pfc")


### PR DESCRIPTION
Since https://github.com/HDFGroup/hdf5/commit/86408c736fdad7e07c43421538b425fcd27adfd2 the symlink for h5pfc is no longer needed and the installation fails with

```
==> Installing hdf5-1.10.10-rcvhz6mc5vini62ojxr6cobo47v7qwhh [27/27]
==> No binary for hdf5-1.10.10-rcvhz6mc5vini62ojxr6cobo47v7qwhh found: installing from source
==> Using cached archive: /tmp/spack/var/spack/cache/_source-cache/archive/a6/a6877ab7bd5d769d2d68618fdb54beb50263dcc2a8c157fe7e2186925cdb02db.tar.gz
==> Ran patch() for hdf5
==> hdf5: Executing phase: 'cmake'
==> hdf5: Executing phase: 'build'
==> hdf5: Executing phase: 'install'
==> Error: FileExistsError: [Errno 17] File exists: 'h5fc' -> 'h5pfc'

/tmp/spack/var/spack/repos/builtin/packages/hdf5/package.py:663, in ensure_parallel_compiler_wrappers:
        660        if self.spec.satisfies("@1.8.22:1.8," "1.10.6:1.10," "1.12.0:1.12" "+fortran+mpi"):
        661            with working_dir(self.prefix.bin):
        662                # No try/except here, fix the condition above instead:
  >>    663                symlink("h5fc", "h5pfc")

```

Similar to https://github.com/spack/spack/pull/37468