### PR TITLE
Print an error when git command is missing

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -734,7 +734,11 @@ class GitFetchStrategy(VCSFetchStrategy):
     @property
     def git(self):
         if not self._git:
-            self._git = spack.util.git.git()
+            try:
+                self._git = spack.util.git.git(required=True)
+            except CommandNotFoundError as exc:
+                tty.error(str(exc))
+                raise
 
             # Disable advice for a quieter fetch
             # https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.2.txt


### PR DESCRIPTION
Print an error message when the git fetcher fails due to `git` command not found, just like when `curl` is not found.

Before this PR, when the git command was missing, packages like `clingo-bootstrap@spack` would only print `FetchError: All fetchers failed`.

Also, the actual underlying error (as seen in `spack -vd`) was a `RecursionError: maximum recursion depth exceeded` (`git() -> git_version() -> git()`), this PR fixes that too.
