### PR TITLE
ADIOS2: v2.8 is not compatible with HDF5 v1.14:

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -130,6 +130,7 @@ class Adios2(CMakePackage, CudaPackage):
     depends_on("libzmq", when="+dataman")
     depends_on("dataspaces@1.8.0:", when="+dataspaces")
 
+    depends_on("hdf5@:1.12", when="@:2.8 +hdf5")
     depends_on("hdf5~mpi", when="+hdf5~mpi")
     depends_on("hdf5+mpi", when="+hdf5+mpi")
 


### PR DESCRIPTION
H5VL_class_t structure changed in HDF5 v1.14 and the function pointer signatures no longer match.