### PR TITLE
Make the `llnl` package independent of `spack`

### DIFF
--- a/lib/spack/llnl/syscmd/__init__.py
+++ b/lib/spack/llnl/syscmd/__init__.py
@@ -28,6 +28,7 @@ from .environment import (
     validate,
 )
 from .executable import CommandNotFoundError, Executable, ProcessError, which, which_string
+from .sourcing import environment_after_sourcing_files, from_sourcing_file
 
 __all__ = [
     "EnvironmentModifications",
@@ -55,4 +56,6 @@ __all__ = [
     "Executable",
     "which_string",
     "CommandNotFoundError",
+    "from_sourcing_file",
+    "environment_after_sourcing_files",
 ]

--- a/lib/spack/llnl/syscmd/__init__.py
+++ b/lib/spack/llnl/syscmd/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Provides classes and functions to manipulate environment modifications, and to
+call arbitrary commands in a subprocess, within a controlled environment.
+"""
+from .environment import (
+    SYSTEM_DIRS,
+    TRACING_ENABLED,
+    AppendPath,
+    EnvironmentModifications,
+    PrependPath,
+    RemovePath,
+    SetEnv,
+    UnsetEnv,
+    dump_environment,
+    env_flag,
+    filter_system_paths,
+    get_path,
+    inspect_path,
+    is_system_path,
+    path_put_first,
+    pickle_environment,
+    preserve_environment,
+    sanitize,
+    set_env,
+    validate,
+)
+
+__all__ = [
+    "EnvironmentModifications",
+    "SetEnv",
+    "dump_environment",
+    "preserve_environment",
+    "sanitize",
+    "UnsetEnv",
+    "AppendPath",
+    "PrependPath",
+    "RemovePath",
+    "pickle_environment",
+    "inspect_path",
+    "filter_system_paths",
+    "is_system_path",
+    "env_flag",
+    "get_path",
+    "validate",
+    "path_put_first",
+    "set_env",
+    "SYSTEM_DIRS",
+    "TRACING_ENABLED",
+]

--- a/lib/spack/llnl/syscmd/__init__.py
+++ b/lib/spack/llnl/syscmd/__init__.py
@@ -27,6 +27,7 @@ from .environment import (
     set_env,
     validate,
 )
+from .executable import CommandNotFoundError, Executable, ProcessError, which, which_string
 
 __all__ = [
     "EnvironmentModifications",
@@ -49,4 +50,9 @@ __all__ = [
     "set_env",
     "SYSTEM_DIRS",
     "TRACING_ENABLED",
+    "which",
+    "ProcessError",
+    "Executable",
+    "which_string",
+    "CommandNotFoundError",
 ]

--- a/lib/spack/llnl/syscmd/environment.py
+++ b/lib/spack/llnl/syscmd/environment.py
@@ -14,9 +14,9 @@ import sys
 from functools import wraps
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 
-from llnl.path import path_to_os_path, system_path_filter
-from llnl.util import tty
-from llnl.util.lang import dedupe
+from ..path import path_to_os_path, system_path_filter
+from ..util import tty
+from ..util.lang import dedupe
 
 if sys.platform == "win32":
     SYSTEM_PATHS = [

--- a/lib/spack/llnl/syscmd/executable.py
+++ b/lib/spack/llnl/syscmd/executable.py
@@ -9,8 +9,8 @@ import subprocess
 import sys
 from pathlib import Path, PurePath
 
-import llnl.util.tty as tty
-from llnl.syscmd import EnvironmentModifications
+from ..util import tty
+from .environment import EnvironmentModifications
 
 __all__ = ["Executable", "which", "ProcessError"]
 

--- a/lib/spack/llnl/syscmd/sourcing.py
+++ b/lib/spack/llnl/syscmd/sourcing.py
@@ -1,9 +1,14 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import json
 import os.path
 import sys
 from typing import Any, Dict, Tuple, Union
 
-from llnl.syscmd import EnvironmentModifications, Executable, sanitize, which
+from .environment import EnvironmentModifications, sanitize
+from .executable import Executable, which
 
 Path = str
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -23,11 +23,10 @@ from itertools import accumulate
 from typing import Callable, Iterable, List, Match, Optional, Tuple, Union
 
 import llnl.util.symlink
+from llnl.syscmd import Executable, which
 from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
 from llnl.util.symlink import islink, readlink, resolve_link_target_relative_to_the_link, symlink
-
-from spack.util.executable import Executable, which
 
 from ..path import path_to_os_path, system_path_filter
 

--- a/lib/spack/llnl/util/tty/pty.py
+++ b/lib/spack/llnl/util/tty/pty.py
@@ -22,8 +22,7 @@ import time
 import traceback
 
 import llnl.util.tty.log as log
-
-from spack.util.executable import which
+from llnl.syscmd import which
 
 termios = None
 try:

--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -5,12 +5,12 @@
 
 import os
 
+from llnl.syscmd import Executable, ProcessError
 from llnl.util.lang import memoized
 
 import spack.spec
 import spack.version
 from spack.compilers.clang import Clang
-from spack.util.executable import Executable, ProcessError
 
 
 class ABI:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -29,6 +29,7 @@ from urllib.error import HTTPError, URLError
 import llnl.util.filesystem as fsys
 import llnl.util.lang
 import llnl.util.tty as tty
+from llnl.syscmd import which
 from llnl.util.filesystem import BaseDirectoryVisitor, mkdirp, visit_directory_tree
 
 import spack.caches
@@ -63,7 +64,6 @@ from spack.package_prefs import get_package_dir_permissions, get_package_group
 from spack.relocate_text import utf8_paths_to_single_binary_regex
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 
 BUILD_CACHE_RELATIVE_PATH = "build_cache"
 BUILD_CACHE_KEYS_RELATIVE_PATH = "_pgp"

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -19,7 +19,6 @@ from llnl.util import tty
 
 import spack.platforms
 import spack.store
-import spack.util.executable
 
 from .config import spec_for_current_python
 
@@ -193,11 +192,11 @@ def _executables_in_store(
             if (
                 os.path.exists(bin_dir)
                 and os.path.isdir(bin_dir)
-                and spack.util.executable.which_string(*executables, path=bin_dir)
+                and llnl.syscmd.which_string(*executables, path=bin_dir)
             ):
                 llnl.syscmd.path_put_first("PATH", [bin_dir])
                 if query_info is not None:
-                    query_info["command"] = spack.util.executable.which(*executables, path=bin_dir)
+                    query_info["command"] = llnl.syscmd.which(*executables, path=bin_dir)
                     query_info["spec"] = concrete_spec
                 return True
     return False

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -13,12 +13,12 @@ from typing import Dict, Optional, Sequence, Union
 
 import archspec.cpu
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 from llnl.util import tty
 
 import spack.platforms
 import spack.store
-import spack.util.environment
 import spack.util.executable
 
 from .config import spec_for_current_python
@@ -195,7 +195,7 @@ def _executables_in_store(
                 and os.path.isdir(bin_dir)
                 and spack.util.executable.which_string(*executables, path=bin_dir)
             ):
-                spack.util.environment.path_put_first("PATH", [bin_dir])
+                llnl.syscmd.path_put_first("PATH", [bin_dir])
                 if query_info is not None:
                     query_info["command"] = spack.util.executable.which(*executables, path=bin_dir)
                     query_info["spec"] = concrete_spec

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -47,7 +47,6 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.user_environment
-import spack.util.executable
 import spack.util.path
 import spack.util.spack_yaml
 import spack.util.url
@@ -410,7 +409,7 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
 def ensure_executables_in_path_or_raise(
     executables: list,
     abstract_spec: str,
-    cmd_check: Optional[Callable[[spack.util.executable.Executable], bool]] = None,
+    cmd_check: Optional[Callable[[llnl.syscmd.Executable], bool]] = None,
 ):
     """Ensure that some executables are in path or raise.
 
@@ -419,7 +418,7 @@ def ensure_executables_in_path_or_raise(
             in order. The function exits on the first one found.
         abstract_spec (str): abstract spec that provides the executables
         cmd_check (object): callable predicate that takes a
-            ``spack.util.executable.Executable`` command and validate it. Should return
+            ``llnl.syscmd.Executable`` command and validate it. Should return
             ``True`` if the executable is acceptable, ``False`` otherwise.
             Can be used to, e.g., ensure a suitable version of the command before
             accepting for bootstrapping.
@@ -431,7 +430,7 @@ def ensure_executables_in_path_or_raise(
         Executable object
 
     """
-    cmd = spack.util.executable.which(*executables)
+    cmd = llnl.syscmd.which(*executables)
     if cmd:
         if not cmd_check or cmd_check(cmd):
             return cmd
@@ -521,7 +520,7 @@ def patchelf_root_spec() -> str:
     return _root_spec("patchelf@0.13.1:")
 
 
-def verify_patchelf(patchelf: "spack.util.executable.Executable") -> bool:
+def verify_patchelf(patchelf: "llnl.syscmd.Executable") -> bool:
     """Older patchelf versions can produce broken binaries, so we
     verify the version here.
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -541,7 +541,7 @@ def verify_patchelf(patchelf: "llnl.syscmd.Executable") -> bool:
     return version >= spack.version.Version("0.13.1")
 
 
-def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
+def ensure_patchelf_in_path_or_raise() -> llnl.syscmd.Executable:
     """Ensure patchelf is in the PATH or raise."""
     # The old concretizer is not smart and we're doing its job: if the latest patchelf
     # does not concretize because the compiler doesn't support C++17, we try to

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -31,6 +31,7 @@ import sys
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import llnl.syscmd
 from llnl.util import tty
 from llnl.util.lang import GroupedExceptionHandler
 
@@ -46,7 +47,6 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.user_environment
-import spack.util.environment
 import spack.util.executable
 import spack.util.path
 import spack.util.spack_yaml

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -13,12 +13,12 @@ from typing import List
 
 import archspec.cpu
 
+import llnl.syscmd
 from llnl.util import tty
 
 import spack.environment
 import spack.tengine
 import spack.util.cpus
-import spack.util.executable
 
 from ._common import _root_spec
 from .config import root_path, spec_for_current_python, store_path

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -13,7 +13,6 @@ from typing import List
 
 import archspec.cpu
 
-import llnl.syscmd
 from llnl.util import tty
 
 import spack.environment

--- a/lib/spack/spack/bootstrap/status.py
+++ b/lib/spack/spack/bootstrap/status.py
@@ -6,7 +6,9 @@
 import platform
 from typing import List, Optional, Sequence, Tuple, Union
 
-import spack.util.executable
+import llnl.syscmd
+
+import spack.spec
 
 from ._common import _executables_in_store, _python_import, _try_import_from_store
 from .config import ensure_bootstrap_configuration
@@ -22,14 +24,14 @@ from .environment import (
 
 ExecutablesType = Union[str, Sequence[str]]
 RequiredResponseType = Tuple[bool, Optional[str]]
-SpecLike = Union["spack.spec.Spec", str]
+SpecLike = Union[spack.spec.Spec, str]
 
 
 def _required_system_executable(exes: ExecutablesType, msg: str) -> RequiredResponseType:
     """Search for an executable is the system path only."""
     if isinstance(exes, str):
         exes = (exes,)
-    if spack.util.executable.which_string(*exes):
+    if llnl.syscmd.which_string(*exes):
         return True, None
     return False, msg
 
@@ -40,7 +42,7 @@ def _required_executable(
     """Search for an executable in the system path or in the bootstrap store."""
     if isinstance(exes, str):
         exes = (exes,)
-    if spack.util.executable.which_string(*exes) or _executables_in_store(exes, query_spec):
+    if llnl.syscmd.which_string(*exes) or _executables_in_store(exes, query_spec):
         return True, None
     return False, msg
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -47,6 +47,16 @@ from typing import List, Tuple
 
 import llnl.util.tty as tty
 from llnl.string import plural
+from llnl.syscmd import (
+    SYSTEM_DIRS,
+    EnvironmentModifications,
+    env_flag,
+    filter_system_paths,
+    get_path,
+    inspect_path,
+    is_system_path,
+    validate,
+)
 from llnl.util.filesystem import join_path
 from llnl.util.lang import dedupe, stable_partition
 from llnl.util.symlink import symlink
@@ -77,15 +87,6 @@ from spack.error import NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
 from spack.installer import InstallError
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.environment import (
-    SYSTEM_DIRS,
-    EnvironmentModifications,
-    env_flag,
-    filter_system_paths,
-    get_path,
-    is_system_path,
-    validate,
-)
 from spack.util.executable import Executable
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.module_cmd import load_module, module, path_from_modules

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -54,7 +54,6 @@ from llnl.syscmd import (
     env_flag,
     filter_system_paths,
     get_path,
-    inspect_path,
     is_system_path,
     validate,
 )

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -50,6 +50,7 @@ from llnl.string import plural
 from llnl.syscmd import (
     SYSTEM_DIRS,
     EnvironmentModifications,
+    Executable,
     env_flag,
     filter_system_paths,
     get_path,
@@ -87,7 +88,6 @@ from spack.error import NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
 from spack.installer import InstallError
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.executable import Executable
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.module_cmd import load_module, module, path_from_modules
 
@@ -1379,7 +1379,7 @@ def get_package_context(traceback, context=3):
 
 class ChildError(InstallError):
     """Special exception class for wrapping exceptions from child processes
-       in Spack's build environment.
+    in Spack's build environment.
 
     The main features of a ChildError are:
 
@@ -1413,7 +1413,7 @@ class ChildError(InstallError):
 
     # List of errors considered "build errors", for which we'll show log
     # context instead of Python context.
-    build_errors = [("spack.util.executable", "ProcessError")]
+    build_errors = [("llnl.syscmd.executable", "ProcessError")]
 
     def __init__(self, msg, module, classname, traceback_string, log_name, log_type, context):
         super().__init__(msg)

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -2,11 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import llnl.syscmd
 import llnl.util.filesystem as fs
 
 import spack.directives
 import spack.package_base
-import spack.util.executable
 
 from .autotools import AutotoolsBuilder, AutotoolsPackage
 
@@ -22,7 +22,7 @@ class AspellBuilder(AutotoolsBuilder):
         prezip = spec["aspell"].prefix.bin.prezip
         destdir = prefix
 
-        sh = spack.util.executable.which("sh")
+        sh = llnl.syscmd.which("sh")
         sh(
             "./configure",
             "--vars",

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -11,6 +11,7 @@ from typing import List
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 
 import spack.build_environment
 import spack.builder
@@ -18,7 +19,6 @@ import spack.package_base
 from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
 from spack.operating_systems.mac_os import macos_version
-from spack.util.executable import Executable
 from spack.version import Version
 
 from ._checks import (

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -11,6 +11,7 @@ import tempfile
 import xml.etree.ElementTree as ElementTree
 
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 from llnl.util.filesystem import (
     HeaderList,
     LibraryList,
@@ -25,7 +26,6 @@ from llnl.util.filesystem import (
 import spack.error
 from spack.build_environment import dso_suffix
 from spack.package_base import InstallError
-from spack.util.executable import Executable
 from spack.util.prefix import Prefix
 from spack.util.sourcing import from_sourcing_file
 from spack.version import Version, ver

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -25,9 +25,9 @@ from llnl.util.filesystem import (
 import spack.error
 from spack.build_environment import dso_suffix
 from spack.package_base import InstallError
-from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 from spack.util.prefix import Prefix
+from spack.util.sourcing import from_sourcing_file
 from spack.version import Version, ver
 
 from .generic import Package
@@ -1054,7 +1054,7 @@ class IntelPackage(Package):
         # if sys.platform == 'darwin':
         #     args = ()
 
-        env.extend(EnvironmentModifications.from_sourcing_file(f, *args))
+        env.extend(from_sourcing_file(f, *args))
 
         if self.spec.name in ("intel", "intel-parallel-studio"):
             # this package provides compilers

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -11,7 +11,7 @@ import tempfile
 import xml.etree.ElementTree as ElementTree
 
 import llnl.util.tty as tty
-from llnl.syscmd import Executable
+from llnl.syscmd import Executable, from_sourcing_file
 from llnl.util.filesystem import (
     HeaderList,
     LibraryList,
@@ -27,7 +27,6 @@ import spack.error
 from spack.build_environment import dso_suffix
 from spack.package_base import InstallError
 from spack.util.prefix import Prefix
-from spack.util.sourcing import from_sourcing_file
 from spack.version import Version, ver
 
 from .generic import Package

--- a/lib/spack/spack/build_systems/lua.py
+++ b/lib/spack/spack/build_systems/lua.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+import llnl.syscmd
 from llnl.util.filesystem import find
 
 import spack.builder
 import spack.package_base
-import spack.util.executable
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
 
@@ -38,11 +38,11 @@ class LuaPackage(spack.package_base.PackageBase):
 
     @property
     def lua(self):
-        return spack.util.executable.Executable(self.spec["lua-lang"].prefix.bin.lua)
+        return llnl.syscmd.Executable(self.spec["lua-lang"].prefix.bin.lua)
 
     @property
     def luarocks(self):
-        lr = spack.util.executable.Executable(self.spec["lua-lang"].prefix.bin.luarocks)
+        lr = llnl.syscmd.Executable(self.spec["lua-lang"].prefix.bin.luarocks)
         return lr
 
 

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import llnl.util.filesystem as fs
+from llnl.syscmd import which
 
 import spack.builder
 import spack.package_base
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
-from spack.util.executable import which
 
 from ._checks import BaseBuilder
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -10,7 +10,7 @@ import shutil
 from os.path import basename, isdir
 
 from llnl.util import tty
-from llnl.syscmd import Executable
+from llnl.syscmd import Executable, from_sourcing_file
 from llnl.util.filesystem import HeaderList, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -9,15 +9,14 @@ import platform
 import shutil
 from os.path import basename, isdir
 
-from llnl.util import tty
 from llnl.syscmd import Executable, from_sourcing_file
-from llnl.util.filesystem import HeaderList, find_libraries, join_path, mkdirp
+from llnl.util import tty
+from llnl.util.filesystem import HeaderList, LibraryList, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, variant
 from spack.package_base import InstallError
-from spack.util.sourcing import from_sourcing_file
 
 from .generic import Package
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -16,8 +16,8 @@ from llnl.util.link_tree import LinkTree
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, variant
 from spack.package_base import InstallError
-from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
+from spack.util.sourcing import from_sourcing_file
 
 from .generic import Package
 
@@ -142,7 +142,7 @@ class IntelOneApiPackage(Package):
         # Only if environment modifications are desired (default is +envmods)
         if "~envmods" not in self.spec:
             env.extend(
-                EnvironmentModifications.from_sourcing_file(
+                from_sourcing_file(
                     self.component_prefix.env.join("vars.sh"), *self.env_script_args
                 )
             )

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -10,13 +10,13 @@ import shutil
 from os.path import basename, isdir
 
 from llnl.util import tty
-from llnl.util.filesystem import HeaderList, LibraryList, find_libraries, join_path, mkdirp
+from llnl.syscmd import Executable
+from llnl.util.filesystem import HeaderList, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, variant
 from spack.package_base import InstallError
-from spack.util.executable import Executable
 from spack.util.sourcing import from_sourcing_file
 
 from .generic import Package

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -5,12 +5,12 @@
 import inspect
 import os
 
+from llnl.syscmd import Executable
 from llnl.util.filesystem import filter_file
 
 import spack.builder
 import spack.package_base
 from spack.directives import build_system, extends
-from spack.util.executable import Executable
 
 from ._checks import BaseBuilder, execute_build_time_tests
 

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -8,13 +8,13 @@ from typing import Optional, Tuple
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
+from llnl.syscmd import env_flag
 
 import spack.builder
 from spack.build_environment import SPACK_NO_PARALLEL_MAKE
 from spack.directives import build_system, extends, maintainers
 from spack.package_base import PackageBase
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.environment import env_flag
 from spack.util.executable import Executable, ProcessError
 
 

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -8,14 +8,13 @@ from typing import Optional, Tuple
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
-from llnl.syscmd import env_flag
+from llnl.syscmd import Executable, ProcessError, env_flag
 
 import spack.builder
 from spack.build_environment import SPACK_NO_PARALLEL_MAKE
 from spack.directives import build_system, extends, maintainers
 from spack.package_base import PackageBase
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.executable import Executable, ProcessError
 
 
 class RacketPackage(PackageBase):

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -7,6 +7,7 @@ import os
 import re
 
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 from llnl.util.filesystem import find, working_dir
 
 import spack.builder
@@ -14,7 +15,6 @@ import spack.install_test
 import spack.package_base
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
-from spack.util.executable import Executable
 
 from ._checks import BaseBuilder, execute_install_time_tests
 

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -526,7 +526,7 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
         Spack's store.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
+            env (llnl.syscmd.EnvironmentModifications): environment
                 modifications to be applied when the package is built. Package authors
                 can call methods on it to alter the build environment.
         """
@@ -554,7 +554,7 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
             variable.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
+            env (llnl.syscmd.EnvironmentModifications): environment
                 modifications to be applied when the dependent package is built.
                 Package authors can call methods on it to alter the build environment.
 

--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -6,11 +6,11 @@
 import os
 
 import llnl.util.tty as tty
+from llnl.syscmd import ProcessError
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.paths
 import spack.util.git
-from spack.util.executable import ProcessError
 
 _SPACK_UPSTREAM = "https://github.com/spack/spack"
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -6,6 +6,7 @@ import argparse
 import os
 
 import llnl.util.tty as tty
+from llnl.syscmd import dump_environment, pickle_environment
 
 import spack.cmd
 import spack.deptypes as dt
@@ -16,7 +17,6 @@ import spack.store
 from spack import build_environment, traverse
 from spack.cmd.common import arguments
 from spack.context import Context
-from spack.util.environment import dump_environment, pickle_environment
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -9,6 +9,7 @@ import sys
 import urllib.parse
 
 import llnl.util.tty as tty
+from llnl.syscmd import ProcessError, which
 from llnl.util.filesystem import mkdirp
 
 import spack.repo
@@ -17,7 +18,6 @@ import spack.util.web
 from spack.spec import Spec
 from spack.url import UndetectableNameError, UndetectableVersionError, parse_name, parse_version
 from spack.util.editor import editor
-from spack.util.executable import ProcessError, which
 from spack.util.format import get_version_lines
 from spack.util.naming import mod_to_class, simplify_name, valid_fully_qualified_module_name
 

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from glob import glob
 
 import llnl.util.tty as tty
+from llnl.syscmd import which
 from llnl.util.filesystem import working_dir
 
 import spack.config
@@ -17,7 +18,6 @@ import spack.paths
 import spack.platforms
 import spack.util.git
 from spack.main import get_version
-from spack.util.executable import which
 
 description = "debugging commands for troubleshooting Spack"
 section = "developer"

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -12,7 +12,6 @@ from llnl.util.tty.color import cprint, get_color_when
 import spack.cmd
 import spack.environment as ev
 import spack.solver.asp as asp
-import spack.util.environment
 import spack.util.spack_json as sjson
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -14,6 +14,7 @@ from typing import Optional
 import llnl.string as string
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.syscmd import EnvironmentModifications
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
@@ -31,7 +32,6 @@ import spack.schema.env
 import spack.spec
 import spack.tengine
 from spack.cmd.common import arguments
-from spack.util.environment import EnvironmentModifications
 
 description = "manage virtual environments"
 section = "environments"

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -18,7 +18,6 @@ import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "manage external packages in Spack configuration"

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -5,8 +5,6 @@
 
 import sys
 
-import llnl.syscmd
-
 import llnl.util.tty as tty
 
 import spack.cmd

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -5,6 +5,8 @@
 
 import sys
 
+import llnl.syscmd
+
 import llnl.util.tty as tty
 
 import spack.cmd
@@ -12,7 +14,6 @@ import spack.cmd.find
 import spack.environment as ev
 import spack.store
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "add package to the user environment"

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -6,10 +6,10 @@ import os
 import posixpath
 import sys
 
+import llnl.syscmd
 from llnl.path import convert_to_posix_path
 
 import spack.paths
-import spack.util.executable
 from spack.spec import Spec
 
 description = "generate Windows installer"
@@ -100,7 +100,7 @@ def make_installer(parser, args):
         spack_logo = posixpath.join(posix_root, "share/spack/logo/favicon.ico")
 
         try:
-            spack.util.executable.Executable(cmake_path)(
+            llnl.syscmd.Executable(cmake_path)(
                 "-S",
                 source_dir,
                 "-B",
@@ -111,30 +111,30 @@ def make_installer(parser, args):
                 "-DSPACK_LOGO=%s" % spack_logo,
                 "-DSPACK_GIT_VERBOSITY=%s" % git_verbosity,
             )
-        except spack.util.executable.ProcessError:
+        except llnl.syscmd.ProcessError:
             print("Failed to generate installer")
-            return spack.util.executable.ProcessError.returncode
+            return llnl.syscmd.ProcessError.returncode
 
         try:
-            spack.util.executable.Executable(cpack_path)(
+            llnl.syscmd.Executable(cpack_path)(
                 "--config", "%s/CPackConfig.cmake" % output_dir, "-B", "%s/" % output_dir
             )
-        except spack.util.executable.ProcessError:
+        except llnl.syscmd.ProcessError:
             print("Failed to generate installer")
-            return spack.util.executable.ProcessError.returncode
+            return llnl.syscmd.ProcessError.returncode
         try:
-            spack.util.executable.Executable(os.environ.get("WIX") + "/bin/candle.exe")(
+            llnl.syscmd.Executable(os.environ.get("WIX") + "/bin/candle.exe")(
                 "-ext",
                 "WixBalExtension",
                 "%s/bundle.wxs" % output_dir,
                 "-out",
                 "%s/bundle.wixobj" % output_dir,
             )
-        except spack.util.executable.ProcessError:
+        except llnl.syscmd.ProcessError:
             print("Failed to generate installer chain")
-            return spack.util.executable.ProcessError.returncode
+            return llnl.syscmd.ProcessError.returncode
         try:
-            spack.util.executable.Executable(os.environ.get("WIX") + "/bin/light.exe")(
+            llnl.syscmd.Executable(os.environ.get("WIX") + "/bin/light.exe")(
                 "-sw1134",
                 "-ext",
                 "WixBalExtension",
@@ -142,9 +142,9 @@ def make_installer(parser, args):
                 "-out",
                 "%s/Spack.exe" % output_dir,
             )
-        except spack.util.executable.ProcessError:
+        except llnl.syscmd.ProcessError:
             print("Failed to generate installer chain")
-            return spack.util.executable.ProcessError.returncode
+            return llnl.syscmd.ProcessError.returncode
         print("Successfully generated Spack.exe in %s" % (output_dir))
     else:
         print("The make-installer command is currently only supported on Windows.")

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -8,13 +8,13 @@ import itertools
 import os
 import sys
 
+import llnl.syscmd
 import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
 import spack.paths
 import spack.repo
-import spack.util.executable as exe
 import spack.util.package_hash as ph
 from spack.cmd.common import arguments
 
@@ -169,7 +169,7 @@ def pkg_hash(args):
 
 def get_grep(required=False):
     """Get a grep command to use with ``spack pkg grep``."""
-    return exe.which(os.environ.get("SPACK_GREP") or "grep", required=required)
+    return llnl.syscmd.which(os.environ.get("SPACK_GREP") or "grep", required=required)
 
 
 def pkg_grep(args, unknown_args):

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -10,11 +10,11 @@ from itertools import zip_longest
 
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
+from llnl.syscmd import which
 from llnl.util.filesystem import working_dir
 
 import spack.paths
 import spack.util.git
-from spack.util.executable import which
 
 description = "runs source code style checks on spack"
 section = "developer"

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -6,8 +6,6 @@
 import os
 import sys
 
-import llnl.syscmd
-
 import spack.cmd
 import spack.error
 import spack.user_environment as uenv

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -6,10 +6,11 @@
 import os
 import sys
 
+import llnl.syscmd
+
 import spack.cmd
 import spack.error
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "remove package from the user environment"

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -14,6 +14,7 @@ import tempfile
 from typing import List, Optional, Sequence
 
 import llnl.path
+import llnl.syscmd
 import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.syscmd import EnvironmentModifications, filter_system_paths
@@ -22,7 +23,6 @@ from llnl.util.filesystem import path_contains_subdirectory, paths_containing_li
 import spack.compilers
 import spack.error
 import spack.spec
-import spack.util.executable
 import spack.util.module_cmd
 import spack.version
 
@@ -38,7 +38,7 @@ def _get_compiler_version_output(compiler_path, version_arg, ignore_errors=()):
         compiler_path (path): path of the compiler to be invoked
         version_arg (str): the argument used to extract version information
     """
-    compiler = spack.util.executable.Executable(compiler_path)
+    compiler = llnl.syscmd.Executable(compiler_path)
     compiler_invocation_args = {
         "output": str,
         "error": str,
@@ -59,7 +59,7 @@ def get_compiler_version_output(compiler_path, *args, **kwargs):
     # not just executable name. If we don't do this, and the path changes
     # (e.g., during testing), we can get incorrect results.
     if not os.path.isabs(compiler_path):
-        compiler_path = spack.util.executable.which_string(compiler_path, required=True)
+        compiler_path = llnl.syscmd.which_string(compiler_path, required=True)
 
     return _get_compiler_version_output(compiler_path, *args, **kwargs)
 
@@ -347,7 +347,7 @@ class Compiler:
         def accessible_exe(exe):
             # compilers may contain executable names (on Cray or user edited)
             if not os.path.isabs(exe):
-                exe = spack.util.executable.which_string(exe)
+                exe = llnl.syscmd.which_string(exe)
                 if not exe:
                     return False
             return os.path.isfile(exe) and os.access(exe, os.X_OK)
@@ -379,7 +379,7 @@ class Compiler:
                 if real_version == spack.version.Version("unknown"):
                     return self.version
                 self._real_version = real_version
-            except spack.util.executable.ProcessError:
+            except llnl.syscmd.ProcessError:
                 self._real_version = self.version
         return self._real_version
 
@@ -430,7 +430,7 @@ class Compiler:
                 csource.write(
                     "int main(int argc, char* argv[]) { " "(void)argc; (void)argv; return 0; }\n"
                 )
-            compiler_exe = spack.util.executable.Executable(first_compiler)
+            compiler_exe = llnl.syscmd.Executable(first_compiler)
             for flag_type in flags:
                 for flag in self.flags.get(flag_type, []):
                     compiler_exe.add_default_arg(flag)
@@ -441,7 +441,7 @@ class Compiler:
                     compiler_exe(self.verbose_flag, fin, "-o", fout, output=str, error=str)
                 )  # str for py2
             return _parse_non_system_link_dirs(output)
-        except spack.util.executable.ProcessError as pe:
+        except llnl.syscmd.ProcessError as pe:
             tty.debug("ProcessError: Command exited with non-zero status: " + pe.long_message)
             return []
         finally:
@@ -540,7 +540,7 @@ class Compiler:
         Use the runtime environment of the compiler (modules and environment
         modifications) to enable the compiler to run properly on any platform.
         """
-        cc = spack.util.executable.Executable(self.cc)
+        cc = llnl.syscmd.Executable(self.cc)
         with self.compiler_environment():
             output = cc(
                 self.version_argument,

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Sequence
 import llnl.path
 import llnl.util.lang
 import llnl.util.tty as tty
+from llnl.syscmd import EnvironmentModifications, filter_system_paths
 from llnl.util.filesystem import path_contains_subdirectory, paths_containing_libs
 
 import spack.compilers
@@ -24,7 +25,6 @@ import spack.spec
 import spack.util.executable
 import spack.util.module_cmd
 import spack.version
-from spack.util.environment import filter_system_paths
 
 __all__ = ["Compiler"]
 
@@ -664,7 +664,7 @@ class Compiler:
                 spack.util.module_cmd.load_module(module)
 
             # apply other compiler environment changes
-            env = spack.util.environment.EnvironmentModifications()
+            env = EnvironmentModifications()
             env.extend(spack.schema.environment.parse(self.environment))
             env.apply_modifications()
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -746,9 +746,9 @@ def detect_version(
                 return value, None
 
             error = f"Couldn't get version for compiler {path}".format(path)
-        except spack.util.executable.ProcessError as e:
+        except llnl.syscmd.ProcessError as e:
             error = f"Couldn't get version for compiler {path}\n" + str(e)
-        except spack.util.executable.ProcessTimeoutError as e:
+        except llnl.syscmd.ProcessTimeoutError as e:
             error = f"Couldn't get version for compiler {path}\n" + str(e)
         except Exception as e:
             # Catching "Exception" here is fine because it just

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -17,6 +17,7 @@ import archspec.cpu
 import llnl.util.filesystem as fs
 import llnl.util.lang
 import llnl.util.tty as tty
+from llnl.syscmd import get_path
 
 import spack.compiler
 import spack.config
@@ -26,7 +27,6 @@ import spack.paths
 import spack.platforms
 import spack.spec
 import spack.version
-from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
 _path_instance_vars = ["cc", "cxx", "f77", "fc"]

--- a/lib/spack/spack/compilers/apple_clang.py
+++ b/lib/spack/spack/compilers/apple_clang.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
 
+import llnl.syscmd
 import llnl.util.lang
 
 import spack.compiler
 import spack.compilers.clang
-import spack.util.executable
 from spack.version import Version
 
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -6,11 +6,11 @@
 import os
 import re
 
+import llnl.syscmd
 from llnl.util.filesystem import ancestor
 
 import spack.compiler
 import spack.compilers.apple_clang as apple_clang
-import spack.util.executable
 from spack.version import Version
 
 
@@ -226,7 +226,7 @@ class Gcc(spack.compiler.Compiler):
     def prefix(self):
         # GCC reports its install prefix when running ``-print-search-dirs``
         # on the first line ``install: <prefix>``.
-        cc = spack.util.executable.Executable(self.cc)
+        cc = llnl.syscmd.Executable(self.cc)
         with self.compiler_environment():
             gcc_output = cc("-print-search-dirs", output=str, error=str)
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -10,10 +10,11 @@ import sys
 import tempfile
 from typing import Dict, List, Set
 
+import llnl.syscmd
+
 import spack.compiler
 import spack.operating_systems.windows_os
 import spack.platforms
-import spack.util.executable
 from spack.compiler import Compiler
 from spack.error import SpackError
 from spack.version import Version, VersionRange
@@ -321,7 +322,7 @@ class Msvc(Compiler):
                 sps = spack.operating_systems.windows_os.WindowsOs.compiler_search_paths
             except AttributeError:
                 raise SpackError("Windows compiler search paths not established")
-            clp = spack.util.executable.which_string("cl", path=sps)
+            clp = llnl.syscmd.which_string("cl", path=sps)
             ver = cls.default_version(clp)
         else:
             ver = fc_ver

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -21,6 +21,7 @@ import re
 import sys
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
+import llnl.syscmd
 import llnl.util.tty
 
 import spack.config
@@ -404,7 +405,7 @@ def find_win32_additional_install_paths() -> List[str]:
     windows_search_ext.extend(
         spack.config.get("config:additional_external_search_paths", default=[])
     )
-    windows_search_ext.extend(spack.util.environment.get_path("PATH"))
+    windows_search_ext.extend(llnl.syscmd.get_path("PATH"))
     return windows_search_ext
 
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -14,13 +14,12 @@ import sys
 import warnings
 from typing import Dict, List, Optional, Set, Tuple
 
+import llnl.syscmd
 import llnl.util.filesystem
 import llnl.util.lang
 import llnl.util.tty
 
 import spack.util.elf as elf_utils
-import spack.util.environment
-import spack.util.environment as environment
 import spack.util.ld_so_conf
 
 from .common import (
@@ -140,10 +139,10 @@ def libraries_in_ld_and_system_library_path(
 
         # Environment variables
         if sys.platform == "darwin":
-            search_paths.extend(environment.get_path("DYLD_LIBRARY_PATH"))
-            search_paths.extend(environment.get_path("DYLD_FALLBACK_LIBRARY_PATH"))
+            search_paths.extend(llnl.syscmd.get_path("DYLD_LIBRARY_PATH"))
+            search_paths.extend(llnl.syscmd.get_path("DYLD_FALLBACK_LIBRARY_PATH"))
         elif sys.platform.startswith("linux"):
-            search_paths.extend(environment.get_path("LD_LIBRARY_PATH"))
+            search_paths.extend(llnl.syscmd.get_path("LD_LIBRARY_PATH"))
 
         # Dynamic linker paths
         search_paths.extend(spack.util.ld_so_conf.host_dynamic_linker_search_paths())
@@ -183,7 +182,7 @@ def libraries_in_windows_paths(path_hints: Optional[List[str]] = None) -> Dict[s
             variables as well as the standard system library paths.
     """
     search_hints = (
-        path_hints if path_hints is not None else spack.util.environment.get_path("PATH")
+        path_hints if path_hints is not None else llnl.syscmd.get_path("PATH")
     )
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*search_hints)
     # on Windows, some libraries (.dlls) are found in the bin directory or sometimes

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -181,9 +181,7 @@ def libraries_in_windows_paths(path_hints: Optional[List[str]] = None) -> Dict[s
             constructed based on the set of PATH environment
             variables as well as the standard system library paths.
     """
-    search_hints = (
-        path_hints if path_hints is not None else llnl.syscmd.get_path("PATH")
-    )
+    search_hints = path_hints if path_hints is not None else llnl.syscmd.get_path("PATH")
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*search_hints)
     # on Windows, some libraries (.dlls) are found in the bin directory or sometimes
     # at the search root. Add both of those options to the search scheme
@@ -335,7 +333,7 @@ class Finder:
 
 class ExecutablesFinder(Finder):
     def default_path_hints(self) -> List[str]:
-        return spack.util.environment.get_path("PATH")
+        return llnl.syscmd.get_path("PATH")
 
     def search_patterns(self, *, pkg: "spack.package_base.PackageBase") -> List[str]:
         result = []

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -18,6 +18,7 @@ import urllib.request
 import warnings
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as clr
@@ -42,7 +43,6 @@ import spack.store
 import spack.subprocess_context
 import spack.user_environment as uenv
 import spack.util.cpus
-import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
 import spack.util.parallel

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1620,7 +1620,7 @@ class Environment:
 
     def _env_modifications_for_view(
         self, view: ViewDescriptor, reverse: bool = False
-    ) -> spack.util.environment.EnvironmentModifications:
+    ) -> llnl.syscmd.EnvironmentModifications:
         try:
             with spack.store.STORE.db.read_transaction():
                 installed_roots = [s for s in self.concrete_roots() if s.installed]
@@ -1631,12 +1631,12 @@ class Environment:
                 f"could not {'unload' if reverse else 'load'} runtime environment due "
                 f"to {e.__class__.__name__}: {e}"
             )
-            return spack.util.environment.EnvironmentModifications()
+            return llnl.syscmd.EnvironmentModifications()
         return mods.reversed() if reverse else mods
 
     def add_view_to_env(
-        self, env_mod: spack.util.environment.EnvironmentModifications, view: str
-    ) -> spack.util.environment.EnvironmentModifications:
+        self, env_mod: llnl.syscmd.EnvironmentModifications, view: str
+    ) -> llnl.syscmd.EnvironmentModifications:
         """Collect the environment modifications to activate an environment using the provided
         view. Removes duplicate paths.
 
@@ -1657,8 +1657,8 @@ class Environment:
         return env_mod
 
     def rm_view_from_env(
-        self, env_mod: spack.util.environment.EnvironmentModifications, view: str
-    ) -> spack.util.environment.EnvironmentModifications:
+        self, env_mod: llnl.syscmd.EnvironmentModifications, view: str
+    ) -> llnl.syscmd.EnvironmentModifications:
         """Collect the environment modifications to deactivate an environment using the provided
         view. Reverses the action of ``add_view_to_env``.
 

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -7,12 +7,12 @@ import textwrap
 from typing import Optional
 
 import llnl.util.tty as tty
+from llnl.syscmd import EnvironmentModifications
 from llnl.util.tty.color import colorize
 
 import spack.environment as ev
 import spack.repo
 import spack.store
-from spack.util.environment import EnvironmentModifications
 
 
 def activate_header(env, shell, prompt=None, view: Optional[str] = None):
@@ -147,8 +147,9 @@ def activate(
         view: generate commands to add runtime environment variables for named view
 
     Returns:
-        spack.util.environment.EnvironmentModifications: Environment variables
-        modifications to activate environment."""
+        llnl.syscmd.EnvironmentModifications: Environment variables
+        modifications to activate environment.
+    """
     ev.activate(env, use_env_repo=use_env_repo)
 
     env_mods = EnvironmentModifications()

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -38,6 +38,7 @@ import llnl.util
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.string import comma_and, quote
+from llnl.syscmd import CommandNotFoundError, which
 from llnl.util.filesystem import get_single_file, mkdirp, temp_cwd, working_dir
 from llnl.util.symlink import symlink
 
@@ -53,7 +54,6 @@ import spack.util.web as web_util
 import spack.version
 import spack.version.git_ref_lookup
 from spack.util.compression import decompressor_for
-from spack.util.executable import CommandNotFoundError, which
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []

--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -6,6 +6,7 @@
 import os
 
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 from llnl.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
 from llnl.util.lang import elide_list
 
@@ -13,7 +14,6 @@ import spack.bootstrap
 import spack.config
 import spack.relocate
 from spack.util.elf import ElfParsingError, parse_elf
-from spack.util.executable import Executable
 
 
 def is_shared_library_elf(filepath):

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -38,7 +38,7 @@ def set_up_license(pkg):
             # Create a new license file
             write_license_file(pkg, license_path)
 
-            # use spack.util.executable so the editor does not hang on return here
+            # use llnl.syscmd so the editor does not hang on return here
             ed.editor(license_path, exec_fn=ed.executable)
         else:
             # Use already existing license file

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -15,6 +15,7 @@ import sys
 from collections import Counter, OrderedDict
 from typing import Callable, List, Optional, Tuple, Type, TypeVar, Union
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.string import plural
@@ -526,7 +527,7 @@ def test_part(pkg: Pb, test_name: str, purpose: str, work_dir: str = ".", verbos
             for line in out:
                 print(line.rstrip("\n"))
 
-            if exc_type is spack.util.executable.ProcessError or exc_type is TypeError:
+            if exc_type is llnl.syscmd.ProcessError or exc_type is TypeError:
                 iostr = io.StringIO()
                 spack.build_environment.write_log_summary(
                     iostr, "test", tester.test_log_file, last=1

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -42,7 +42,7 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple
 import llnl.util.filesystem as fs
 import llnl.util.lock as lk
 import llnl.util.tty as tty
-from llnl.syscmd import EnvironmentModifications, dump_environment
+from llnl.syscmd import EnvironmentModifications, dump_environment, which
 from llnl.util.lang import pretty_seconds
 from llnl.util.tty.color import colorize
 from llnl.util.tty.log import log_output
@@ -61,10 +61,8 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.spec
 import spack.store
-import spack.util.executable
 import spack.util.path
 import spack.util.timer as timer
-from spack.util.executable import which
 
 #: Counter to support unique spec sequencing that is used to ensure packages
 #: with the same priority are (initially) processed in the order in which they

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -42,6 +42,7 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple
 import llnl.util.filesystem as fs
 import llnl.util.lock as lk
 import llnl.util.tty as tty
+from llnl.syscmd import EnvironmentModifications, dump_environment
 from llnl.util.lang import pretty_seconds
 from llnl.util.tty.color import colorize
 from llnl.util.tty.log import log_output
@@ -63,7 +64,6 @@ import spack.store
 import spack.util.executable
 import spack.util.path
 import spack.util.timer as timer
-from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.executable import which
 
 #: Counter to support unique spec sequencing that is used to ensure packages

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -26,6 +26,7 @@ from typing import List, Tuple
 
 import archspec.cpu
 
+import llnl.syscmd
 import llnl.util.lang
 import llnl.util.tty as tty
 import llnl.util.tty.colify
@@ -43,7 +44,6 @@ import spack.solver.asp
 import spack.spec
 import spack.store
 import spack.util.debug
-import spack.util.environment
 import spack.util.git
 import spack.util.path
 from spack.error import SpackError
@@ -587,7 +587,7 @@ def setup_main_options(args):
     if args.debug:
         spack.util.debug.register_interrupt_handler()
         spack.config.set("config:debug", True, scope="command_line")
-        spack.util.environment.TRACING_ENABLED = True
+        llnl.syscmd.TRACING_ENABLED = True
 
     if args.timestamp:
         tty.set_timestamp(True)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -561,8 +561,11 @@ def make_argument_parser(**kwargs):
     return parser
 
 
-def send_warning_to_tty(message, *args):
+def send_warning_to_tty(message, category, filename, lineno, file=None, line=None):
     """Redirects messages to tty.warn."""
+    if category == FutureWarning:
+        tty.warn(f"{message}:\n\tfrom {filename}:{lineno}")
+        return
     tty.warn(message)
 
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -37,6 +37,7 @@ import re
 import string
 from typing import List, Optional
 
+import llnl.syscmd
 import llnl.util.filesystem
 import llnl.util.tty as tty
 from llnl.util.lang import dedupe, memoized
@@ -55,7 +56,6 @@ import spack.spec
 import spack.store
 import spack.tengine as tengine
 import spack.user_environment
-import spack.util.environment
 import spack.util.file_permissions as fp
 import spack.util.path
 import spack.util.spack_yaml as syaml
@@ -682,9 +682,7 @@ class BaseContext(tengine.Context):
 
     def modification_needs_formatting(self, modification):
         """Returns True if environment modification entry needs to be formatted."""
-        return (
-            not isinstance(modification, (spack.util.environment.SetEnv)) or not modification.raw
-        )
+        return not isinstance(modification, (llnl.syscmd.SetEnv)) or not modification.raw
 
     @tengine.context_property
     @memoized
@@ -722,8 +720,8 @@ class BaseContext(tengine.Context):
         else:
             view = None
 
-        env = spack.util.environment.inspect_path(
-            self.spec.prefix, prefix_inspections, exclude=spack.util.environment.is_system_path
+        env = llnl.syscmd.inspect_path(
+            self.spec.prefix, prefix_inspections, exclude=llnl.syscmd.is_system_path
         )
 
         # Let the extendee/dependency modify their extensions/dependencies
@@ -782,9 +780,7 @@ class BaseContext(tengine.Context):
     def has_manpath_modifications(self):
         """True if MANPATH environment variable is modified."""
         for modification_type, cmd in self.environment_modifications:
-            if not isinstance(
-                cmd, (spack.util.environment.PrependPath, spack.util.environment.AppendPath)
-            ):
+            if not isinstance(cmd, (llnl.syscmd.PrependPath, llnl.syscmd.AppendPath)):
                 continue
             if cmd.name == "MANPATH":
                 return True

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -8,6 +8,7 @@ import itertools
 import os.path
 from typing import Dict, List, Optional, Tuple
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 
@@ -17,7 +18,6 @@ import spack.error
 import spack.repo
 import spack.spec
 import spack.tengine as tengine
-import spack.util.environment
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
 
@@ -75,7 +75,7 @@ def guess_core_compilers(name, store=False) -> List[spack.spec.CompilerSpec]:
             # A compiler is considered to be a core compiler if any of the
             # C, C++ or Fortran compilers reside in a system directory
             is_system_compiler = any(
-                os.path.dirname(getattr(compiler, x, "")) in spack.util.environment.SYSTEM_DIRS
+                os.path.dirname(getattr(compiler, x, "")) in llnl.syscmd.SYSTEM_DIRS
                 for x in ("cc", "cxx", "f77", "fc")
             )
             if is_system_compiler:

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -10,8 +10,8 @@ import re
 import llnl.util.filesystem as fs
 import llnl.util.lang
 import llnl.util.tty as tty
+from llnl.syscmd import get_path
 
-from spack.util.environment import get_path
 from spack.util.module_cmd import module
 
 from .linux_distro import LinuxDistro

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -8,8 +8,8 @@ import platform as py_platform
 import re
 
 import llnl.util.lang
+from llnl.syscmd import Executable
 
-from spack.util.executable import Executable
 from spack.version import Version
 
 from ._operating_system import OperatingSystem
@@ -50,7 +50,7 @@ def macos_version():
     try:
         output = Executable("sw_vers")(output=str, fail_on_error=False)
     except Exception:
-        # FileNotFoundError, or spack.util.executable.ProcessError
+        # FileNotFoundError, or llnl.syscmd.ProcessError
         pass
     else:
         match = re.search(r"ProductVersion:\s*([0-9.]+)", output)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -19,10 +19,18 @@ pwd = getcwd
 # import most common types used in packages
 from typing import Dict, List, Optional
 
+# Backward compatibility from implicit imports before
+# https://github.com/spack/spack/pull/40262
 import llnl.util.filesystem
 from llnl.syscmd import *
 from llnl.util.filesystem import *
 from llnl.util.symlink import symlink
+
+import spack.compiler
+import spack.compilers
+import spack.error
+import spack.platforms
+import spack.variant
 
 # These props will be overridden when the build env is set up.
 from spack.build_environment import MakeExecutable

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -102,6 +102,7 @@ from spack.package_base import (
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.cpus import determine_number_of_jobs
 from spack.variant import (
+    DisjointSetsOfValues,
     any_combination_of,
     auto_or_any_combination_of,
     conditional,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -20,10 +20,9 @@ pwd = getcwd
 from typing import Dict, List, Optional
 
 import llnl.util.filesystem
+from llnl.syscmd import *
 from llnl.util.filesystem import *
 from llnl.util.symlink import symlink
-
-import spack.util.executable
 
 # These props will be overridden when the build env is set up.
 from spack.build_environment import MakeExecutable
@@ -102,7 +101,6 @@ from spack.package_base import (
 )
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.executable import *
 from spack.variant import (
     any_combination_of,
     auto_or_any_combination_of,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -51,7 +51,6 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.url
-import spack.util.environment
 import spack.util.path
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
@@ -2098,7 +2097,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """Sets up the run environment for a package.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
+            env (llnl.syscmd.EnvironmentModifications): environment
                 modifications to be applied when the package is run. Package authors
                 can call methods on it to alter the run environment.
         """
@@ -2115,7 +2114,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         for dependencies.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
+            env (llnl.syscmd.EnvironmentModifications): environment
                 modifications to be applied when the dependent package is run.
                 Package authors can call methods on it to alter the build environment.
 

--- a/lib/spack/spack/package_test.py
+++ b/lib/spack/spack/package_test.py
@@ -5,7 +5,7 @@
 
 import os
 
-from spack.util.executable import Executable, which
+from llnl.syscmd import Executable, which
 
 
 def compile_c_and_execute(source_file, include_flags, link_flags):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -12,6 +12,7 @@ import sys
 
 import llnl.util.filesystem
 import llnl.util.lang
+from llnl.syscmd import which, which_string
 from llnl.url import allowed_archive
 
 import spack
@@ -22,7 +23,6 @@ import spack.repo
 import spack.stage
 import spack.util.spack_json as sjson
 from spack.util.crypto import Checker, checksum
-from spack.util.executable import which, which_string
 
 
 def apply_patch(stage, patch_path, level=1, working_dir="."):

--- a/lib/spack/spack/platforms/_functions.py
+++ b/lib/spack/spack/platforms/_functions.py
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
 
+import llnl.syscmd
 import llnl.util.lang
-
-import spack.util.environment
 
 from .cray import Cray
 from .darwin import Darwin
@@ -65,7 +64,7 @@ def prevent_cray_detection():
     """Context manager that prevents the detection of the Cray platform"""
     reset()
     try:
-        with spack.util.environment.set_env(MODULEPATH=""):
+        with llnl.syscmd.set_env(MODULEPATH=""):
             yield
     finally:
         reset()

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -10,13 +10,13 @@ import re
 import archspec.cpu
 
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 
 import spack.target
 import spack.version
 from spack.operating_systems.cray_backend import CrayBackend
 from spack.operating_systems.cray_frontend import CrayFrontend
 from spack.paths import build_env_path
-from spack.util.executable import Executable
 from spack.util.module_cmd import module
 
 from ._platform import NoPlatformError, Platform

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 import macholib.mach_o
 import macholib.MachO
 
+import llnl.syscmd as executable
 import llnl.util.filesystem as fs
 import llnl.util.lang
 import llnl.util.tty as tty
@@ -24,7 +25,6 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.util.elf as elf
-import spack.util.executable as executable
 
 from .relocate_text import BinaryFilePrefixReplacer, TextFilePrefixReplacer
 

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -41,7 +41,7 @@ def parse(config_obj):
         config_obj: a configuration dictionary conforming to the
             schema definition for environment modifications
     """
-    import spack.util.environment as ev
+    import llnl.syscmd as ev
 
     env = ev.EnvironmentModifications()
     for command, variable in config_obj.items():

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -63,6 +63,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import llnl.path
 import llnl.string
+import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
@@ -86,7 +87,6 @@ import spack.store
 import spack.target
 import spack.traverse as traverse
 import spack.util.crypto
-import spack.util.executable
 import spack.util.hash
 import spack.util.module_cmd as md
 import spack.util.prefix
@@ -1072,7 +1072,7 @@ def _command_default_handler(descriptor, spec, cls):
     path = os.path.join(home.bin, spec.name)
 
     if fs.is_exe(path):
-        return spack.util.executable.Executable(path)
+        return llnl.syscmd.Executable(path)
     else:
         msg = "Unable to locate {0} command in {1}"
         raise RuntimeError(msg.format(spec.name, home.bin))

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -6,6 +6,7 @@ import functools
 
 import archspec.cpu
 
+import llnl.syscmd
 import llnl.util.tty as tty
 
 import spack.compiler
@@ -148,7 +149,7 @@ class Target:
                 compiler = spack.compilers.compilers_for_spec(compiler).pop()
             try:
                 compiler_version = compiler.real_version
-            except spack.util.executable.ProcessError as e:
+            except llnl.syscmd.ProcessError as e:
                 # log this and just return compiler.version instead
                 tty.debug(str(e))
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -10,6 +10,7 @@ import posixpath
 import pytest
 
 from llnl.path import Path, convert_to_platform_path
+from llnl.syscmd import EnvironmentModifications
 from llnl.util.filesystem import HeaderList, LibraryList
 
 import spack.build_environment
@@ -21,7 +22,6 @@ from spack.build_environment import UseMode, _static_to_shared_library, dso_suff
 from spack.context import Context
 from spack.paths import build_env_path
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -10,7 +10,7 @@ import posixpath
 import pytest
 
 from llnl.path import Path, convert_to_platform_path
-from llnl.syscmd import EnvironmentModifications
+from llnl.syscmd import EnvironmentModifications, Executable
 from llnl.util.filesystem import HeaderList, LibraryList
 
 import spack.build_environment
@@ -22,7 +22,6 @@ from spack.build_environment import UseMode, _static_to_shared_library, dso_suff
 from spack.context import Context
 from spack.paths import build_env_path
 from spack.util.cpus import determine_number_of_jobs
-from spack.util.executable import Executable
 
 
 def os_pathsep_join(path, *pths):

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -5,9 +5,10 @@
 
 import pytest
 
+import llnl.syscmd
+
 import spack.cmd.create
 import spack.stage
-import spack.util.executable
 import spack.util.url as url_util
 
 
@@ -42,7 +43,7 @@ def url_and_build_system(request, tmpdir):
     the appropriate file name and returns their url along with
     the correct build-system guess
     """
-    tar = spack.util.executable.which("tar")
+    tar = llnl.syscmd.which("tar")
     orig_dir = tmpdir.chdir()
     filename, system = request.param
     tmpdir.ensure("archive", filename)

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -10,6 +10,7 @@ import py.path
 import pytest
 
 import llnl.util.filesystem as fs
+from llnl.syscmd import which
 
 import spack.build_systems.autotools
 import spack.build_systems.cmake
@@ -18,7 +19,6 @@ import spack.platforms
 import spack.repo
 from spack.build_environment import ChildError, setup_package
 from spack.spec import Spec
-from spack.util.executable import which
 
 DATA_PATH = os.path.join(spack.paths.test_path, "data")
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -11,11 +11,12 @@ import os
 
 import pytest
 
+from llnl.syscmd import SYSTEM_DIRS, set_env
+
 import spack.build_environment
 import spack.config
 import spack.spec
 from spack.paths import build_env_path
-from spack.util.environment import SYSTEM_DIRS, set_env
 from spack.util.executable import Executable, ProcessError
 
 #

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -11,13 +11,12 @@ import os
 
 import pytest
 
-from llnl.syscmd import SYSTEM_DIRS, set_env
+from llnl.syscmd import SYSTEM_DIRS, Executable, ProcessError, set_env
 
 import spack.build_environment
 import spack.config
 import spack.spec
 from spack.paths import build_env_path
-from spack.util.executable import Executable, ProcessError
 
 #
 # Complicated compiler test command

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -7,11 +7,12 @@ import os
 
 import pytest
 
+from llnl.syscmd import which
+
 import spack.cmd.create
 import spack.util.editor
 from spack.main import SpackCommand
 from spack.url import UndetectableNameError
-from spack.util.executable import which
 
 create = SpackCommand("create")
 

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -9,10 +9,11 @@ import platform
 
 import pytest
 
+from llnl.syscmd import which
+
 import spack.config
 import spack.platforms
 from spack.main import SpackCommand, get_version
-from spack.util.executable import which
 
 debug = SpackCommand("debug")
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -16,6 +16,7 @@ import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.link_tree
 import llnl.util.tty as tty
+from llnl.syscmd import Executable
 
 import spack.cmd.env
 import spack.config
@@ -33,7 +34,6 @@ from spack.cmd.env import _env_create
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
-from spack.util.executable import Executable
 from spack.util.path import substitute_path_variables
 from spack.version import Version
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -12,6 +12,7 @@ from argparse import Namespace
 
 import pytest
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 import llnl.util.link_tree
 import llnl.util.tty as tty
@@ -655,7 +656,7 @@ packages:
         e.install_all()
         e.write()
 
-        env_mod = spack.util.environment.EnvironmentModifications()
+        env_mod = llnl.syscmd.EnvironmentModifications()
         e.add_view_to_env(env_mod, "default")
         env_variables = {}
         env_mod.apply_modifications(env_variables)

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -8,13 +8,12 @@ import os
 import pytest
 
 import llnl.util.filesystem as fs
+from llnl.syscmd import ProcessError
 
 import spack.bootstrap
-import spack.util.executable
 import spack.util.gpg
 from spack.main import SpackCommand
 from spack.paths import mock_gpg_data_path, mock_gpg_keys_path
-from spack.util.executable import ProcessError
 
 #: spack command used by tests below
 gpg = SpackCommand("gpg")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -25,7 +25,6 @@ import spack.environment as ev
 import spack.hash_types as ht
 import spack.package_base
 import spack.store
-import spack.util.executable
 from spack.error import SpackError
 from spack.main import SpackCommand
 from spack.parser import SpecSyntaxError
@@ -667,23 +666,21 @@ def test_cdash_install_from_spec_json(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_build_error_output(tmpdir, mock_fetch, install_mockery, capfd):
+def test_build_error_output(mock_fetch, install_mockery, capfd):
     with capfd.disabled():
-        msg = ""
         try:
             install("build-error")
             assert False, "no exception was raised!"
         except spack.build_environment.ChildError as e:
             msg = e.long_message
 
-        assert "configure: error: in /path/to/some/file:" in msg
-        assert "configure: error: cannot run C compiled programs." in msg
+    assert "configure: error: in /path/to/some/file:" in msg
+    assert "configure: error: cannot run C compiled programs." in msg
 
 
 @pytest.mark.disable_clean_stage_check
-def test_build_warning_output(tmpdir, mock_fetch, install_mockery, capfd):
+def test_build_warning_output(mock_fetch, install_mockery, capfd):
     with capfd.disabled():
-        msg = ""
         try:
             install("build-warnings")
             assert False, "no exception was raised!"

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.spec
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.main import SpackCommand
 
 load = SpackCommand("load")

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -9,13 +9,13 @@ import shutil
 
 import pytest
 
+from llnl.syscmd import which
 from llnl.util.filesystem import FileFilter
 
 import spack.main
 import spack.paths
 import spack.repo
 from spack.cmd.style import changed_files
-from spack.util.executable import which
 
 #: directory with sample style files
 style_data = os.path.join(spack.paths.test_path, "data", "style")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -8,13 +8,13 @@ from copy import copy
 
 import pytest
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 
 import spack.compiler
 import spack.compilers
 import spack.spec
 from spack.compiler import Compiler
-from spack.util.executable import ProcessError
 
 
 @pytest.fixture()
@@ -213,7 +213,7 @@ def call_compiler(exe, *args, **kwargs):
 def test_get_compiler_link_paths(monkeypatch, exe, flagname):
     # create fake compiler that emits mock verbose output
     compiler = MockCompiler()
-    monkeypatch.setattr(spack.util.executable.Executable, "__call__", call_compiler)
+    monkeypatch.setattr(llnl.syscmd.Executable, "__call__", call_compiler)
 
     # Grab executable path to test
     paths = [getattr(compiler, exe)]
@@ -821,9 +821,9 @@ fi
 
     # Make compiler fail when getting implicit rpaths
     def _call(*args, **kwargs):
-        raise ProcessError("Failed intentionally")
+        raise llnl.syscmd.ProcessError("Failed intentionally")
 
-    monkeypatch.setattr(spack.util.executable.Executable, "__call__", _call)
+    monkeypatch.setattr(llnl.syscmd.Executable, "__call__", _call)
 
     # Run and no change to environment
     compilers = spack.compilers.get_compilers([compiler_dict])
@@ -832,7 +832,7 @@ fi
     try:
         _ = compiler.get_real_version()
         assert False
-    except ProcessError:
+    except llnl.syscmd.ProcessError:
         # Confirm environment does not change after failed call
         assert "SPACK_TEST_CMP_ON" not in os.environ
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -13,7 +13,6 @@ import llnl.util.filesystem as fs
 import spack.compiler
 import spack.compilers
 import spack.spec
-import spack.util.environment
 from spack.compiler import Compiler
 from spack.util.executable import ProcessError
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -25,6 +25,7 @@ import pytest
 import archspec.cpu.microarchitecture
 import archspec.cpu.schema
 
+import llnl.syscmd
 import llnl.util.lang
 import llnl.util.lock
 import llnl.util.tty as tty
@@ -49,7 +50,6 @@ import spack.stage
 import spack.store
 import spack.subprocess_context
 import spack.test.cray_manifest
-import spack.util.executable
 import spack.util.git
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
@@ -514,7 +514,7 @@ def _skip_if_missing_executables(request):
 
     if marker:
         required_execs = marker.args
-        missing_execs = [x for x in required_execs if spack.util.executable.which(x) is None]
+        missing_execs = [x for x in required_execs if llnl.syscmd.which(x) is None]
         if missing_execs:
             msg = "could not find executables: {0}"
             pytest.skip(msg.format(", ".join(missing_execs)))
@@ -1101,7 +1101,7 @@ def mock_archive(request, tmpdir_factory):
     """Creates a very simple archive directory with a configure script and a
     makefile that installs to a prefix. Tars it up into an archive.
     """
-    tar = spack.util.executable.which("tar")
+    tar = llnl.syscmd.which("tar")
     if not tar:
         pytest.skip("requires tar to be installed")
 
@@ -1161,7 +1161,7 @@ def _parse_cvs_date(line):
 @pytest.fixture(scope="session")
 def mock_cvs_repository(tmpdir_factory):
     """Creates a very simple CVS repository with two commits and a branch."""
-    cvs = spack.util.executable.which("cvs", required=True)
+    cvs = llnl.syscmd.which("cvs", required=True)
 
     tmpdir = tmpdir_factory.mktemp("mock-cvs-repo-dir")
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
@@ -1439,7 +1439,7 @@ def mock_git_repository(git, tmpdir_factory):
 @pytest.fixture(scope="session")
 def mock_hg_repository(tmpdir_factory):
     """Creates a very simple hg repository with two commits."""
-    hg = spack.util.executable.which("hg")
+    hg = llnl.syscmd.which("hg")
     if not hg:
         pytest.skip("requires mercurial to be installed")
 
@@ -1479,11 +1479,11 @@ def mock_hg_repository(tmpdir_factory):
 @pytest.fixture(scope="session")
 def mock_svn_repository(tmpdir_factory):
     """Creates a very simple svn repository with two commits."""
-    svn = spack.util.executable.which("svn")
+    svn = llnl.syscmd.which("svn")
     if not svn:
         pytest.skip("requires svn to be installed")
 
-    svnadmin = spack.util.executable.which("svnadmin", required=True)
+    svnadmin = llnl.syscmd.which("svnadmin", required=True)
 
     tmpdir = tmpdir_factory.mktemp("mock-svn-stage")
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
@@ -1863,7 +1863,7 @@ def binary_with_rpaths(prefix_tmpdir):
                 message
             )
         )
-        gcc = spack.util.executable.which("gcc")
+        gcc = llnl.syscmd.which("gcc")
         executable = source.dirpath("main.x")
         # Encode relative RPATHs using `$ORIGIN` as the root prefix
         rpaths = [x if os.path.isabs(x) else os.path.join("$ORIGIN", x) for x in rpaths]

--- a/lib/spack/spack/test/cvs_fetch.py
+++ b/lib/spack/spack/test/cvs_fetch.py
@@ -7,12 +7,12 @@ import os
 
 import pytest
 
+from llnl.syscmd import which
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 from spack.fetch_strategy import CvsFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 from spack.version import Version
 
 pytestmark = pytest.mark.skipif(not which("cvs"), reason="requires CVS to be installed")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -22,6 +22,7 @@ except ImportError:
 import jsonschema
 
 import llnl.util.lock as lk
+from llnl.syscmd import Executable
 from llnl.util.tty.colify import colify
 
 import spack.database
@@ -32,7 +33,6 @@ import spack.spec
 import spack.store
 import spack.version as vn
 from spack.schema.database_index import schema
-from spack.util.executable import Executable
 
 pytestmark = pytest.mark.db
 

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -15,12 +15,13 @@ from llnl.syscmd import (
     RemovePath,
     SetEnv,
     UnsetEnv,
+    environment_after_sourcing_files,
     filter_system_paths,
+    from_sourcing_file,
     is_system_path,
 )
 
 from spack.paths import spack_root
-from spack.util.sourcing import environment_after_sourcing_files, from_sourcing_file
 
 datadir = os.path.join(spack_root, "lib", "spack", "spack", "test", "data")
 

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -7,9 +7,8 @@ import os
 
 import pytest
 
-import spack.util.environment as environment
-from spack.paths import spack_root
-from spack.util.environment import (
+import llnl.syscmd as environment
+from llnl.syscmd import (
     AppendPath,
     EnvironmentModifications,
     PrependPath,
@@ -19,6 +18,8 @@ from spack.util.environment import (
     filter_system_paths,
     is_system_path,
 )
+
+from spack.paths import spack_root
 from spack.util.sourcing import environment_after_sourcing_files, from_sourcing_file
 
 datadir = os.path.join(spack_root, "lib", "spack", "spack", "test", "data")

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -19,6 +19,7 @@ from spack.util.environment import (
     filter_system_paths,
     is_system_path,
 )
+from spack.util.sourcing import environment_after_sourcing_files, from_sourcing_file
 
 datadir = os.path.join(spack_root, "lib", "spack", "spack", "test", "data")
 
@@ -252,9 +253,9 @@ def test_source_files(files_to_be_sourced):
     env = EnvironmentModifications()
     for filename in files_to_be_sourced:
         if filename.endswith("sourceme_parameters.sh"):
-            env.extend(EnvironmentModifications.from_sourcing_file(filename, "intel64"))
+            env.extend(from_sourcing_file(filename, "intel64"))
         else:
-            env.extend(EnvironmentModifications.from_sourcing_file(filename))
+            env.extend(from_sourcing_file(filename))
 
     modifications = env.group_by_name()
 
@@ -351,7 +352,7 @@ def test_preserve_environment(prepare_environment_for_tests):
 )
 @pytest.mark.usefixtures("prepare_environment_for_tests")
 def test_environment_from_sourcing_files(files, expected, deleted):
-    env = environment.environment_after_sourcing_files(*files)
+    env = environment_after_sourcing_files(*files)
 
     # Test that variables that have been modified are still there and contain
     # the expected output
@@ -490,7 +491,7 @@ def test_from_environment_diff(before, after, search_list):
 def test_exclude_lmod_variables():
     # Construct the list of environment modifications
     file = os.path.join(datadir, "sourceme_lmod.sh")
-    env = EnvironmentModifications.from_sourcing_file(file)
+    env = from_sourcing_file(file)
 
     # Check that variables related to lmod are not in there
     modifications = env.group_by_name()
@@ -502,7 +503,7 @@ def test_exclude_lmod_variables():
 def test_exclude_modules_variables():
     # Construct the list of environment modifications
     file = os.path.join(datadir, "sourceme_modules.sh")
-    env = EnvironmentModifications.from_sourcing_file(file)
+    env = from_sourcing_file(file)
 
     # Check that variables related to modules are not in there
     modifications = env.group_by_name()

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -7,6 +7,7 @@ import os
 
 import pytest
 
+from llnl.syscmd import which
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.config
@@ -14,7 +15,6 @@ import spack.repo
 from spack.fetch_strategy import HgFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 from spack.version import Version
 
 # Test functionality covered is supported on Windows, but currently failing

--- a/lib/spack/spack/test/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/test/hooks/absolutify_elf_sonames.py
@@ -9,10 +9,10 @@ import os
 import pytest
 
 import llnl.util.filesystem as fs
+from llnl.syscmd import Executable
 
 import spack.platforms
 from spack.hooks.absolutify_elf_sonames import SharedLibrariesVisitor, find_and_patch_sonames
-from spack.util.executable import Executable
 
 
 def skip_unless_linux(f):

--- a/lib/spack/spack/test/llnl/syscmd/__init__.py
+++ b/lib/spack/spack/test/llnl/syscmd/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -17,8 +17,7 @@ import pytest
 import llnl.util.lang as lang
 import llnl.util.tty.log as log
 import llnl.util.tty.pty as pty
-
-from spack.util.executable import which
+from llnl.syscmd import which
 
 termios: Optional[ModuleType] = None
 try:

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -6,10 +6,10 @@
 
 import pytest
 
+import llnl.syscmd as exe
 import llnl.util.filesystem as fs
 
 import spack.paths
-import spack.util.executable as exe
 import spack.util.git
 from spack.main import get_version, main
 

--- a/lib/spack/spack/test/make_executable.py
+++ b/lib/spack/spack/test/make_executable.py
@@ -13,8 +13,9 @@ import sys
 
 import pytest
 
+from llnl.syscmd import path_put_first
+
 from spack.build_environment import MakeExecutable
-from spack.util.environment import path_put_first
 
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="MakeExecutable not supported on Windows"

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -8,16 +8,15 @@ import os
 
 import pytest
 
+from llnl.syscmd import which
 from llnl.util.symlink import resolve_link_target_relative_to_the_link
 
 import spack.mirror
 import spack.repo
-import spack.util.executable
 import spack.util.spack_json as sjson
 import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 from spack.util.spack_yaml import SpackYAMLError
 
 pytestmark = [

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -7,6 +7,8 @@ import os
 
 import pytest
 
+import llnl.syscmd
+
 import spack.environment as ev
 import spack.main
 import spack.modules.lmod
@@ -358,7 +360,7 @@ class TestLmod:
         module_configuration("missing_core_compilers")
 
         # Our mock paths must be detected as system paths
-        monkeypatch.setattr(spack.util.environment, "SYSTEM_DIRS", ["/path/to"])
+        monkeypatch.setattr(llnl.syscmd, "SYSTEM_DIRS", ["/path/to"])
 
         # We don't want to really write into user configuration
         # when running tests

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -10,6 +10,7 @@ import sys
 
 import pytest
 
+from llnl.syscmd import Executable
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.patch
@@ -19,7 +20,6 @@ import spack.util.compression
 import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import Executable
 
 # various sha256 sums (using variables for legibility)
 # many file based shas will differ between Windows and other platforms

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -9,6 +9,8 @@ import shutil
 
 import pytest
 
+import llnl.syscmd
+
 import spack.concretize
 import spack.paths
 import spack.platforms
@@ -17,7 +19,6 @@ import spack.relocate_text as relocate_text
 import spack.spec
 import spack.store
 import spack.tengine
-import spack.util.executable
 
 pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")
 
@@ -31,7 +32,7 @@ def skip_unless_linux(f):
 
 def rpaths_for(new_binary):
     """Return the RPATHs or RUNPATHs of a binary."""
-    patchelf = spack.util.executable.which("patchelf")
+    patchelf = llnl.syscmd.which("patchelf")
     output = patchelf("--print-rpath", str(new_binary), output=str)
     return output.strip()
 
@@ -53,7 +54,7 @@ def make_dylib(tmpdir_factory):
     - Writes the same rpath twice
     - Writes its install path as an absolute path
     """
-    cc = spack.util.executable.which("cc")
+    cc = llnl.syscmd.which("cc")
 
     def _factory(abs_install_name="abs", extra_rpaths=[]):
         assert all(extra_rpaths)
@@ -86,7 +87,7 @@ def make_dylib(tmpdir_factory):
 
 @pytest.fixture()
 def make_object_file(tmpdir):
-    cc = spack.util.executable.which("cc")
+    cc = llnl.syscmd.which("cc")
 
     def _factory():
         src = tmpdir.join("bar.c")

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -16,12 +16,12 @@ import tempfile
 import pytest
 
 import llnl.util.filesystem as fs
+from llnl.syscmd import which
 
 import spack.hooks.sbang as sbang
 import spack.paths
 import spack.store
 import spack.util.spack_yaml as syaml
-from spack.util.executable import which
 
 if sys.platform != "win32":
     import grp

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -14,12 +14,12 @@ import sys
 
 import pytest
 
+import llnl.syscmd
 from llnl.util.filesystem import getuid, mkdirp, partition_path, touch, working_dir
 
 import spack.error
 import spack.paths
 import spack.stage
-import spack.util.executable
 import spack.util.url as url_util
 from spack.resource import Resource
 from spack.stage import DIYStage, ResourceStage, Stage, StageComposite
@@ -246,7 +246,7 @@ def mock_stage_archive(tmp_build_stage_dir):
 
         # Create the archive file
         with tmpdir.as_cwd():
-            tar = spack.util.executable.which("tar", required=True)
+            tar = llnl.syscmd.which("tar", required=True)
             tar(*tar_args)
 
         Archive = collections.namedtuple("Archive", ["url", "tmpdir", "stage_path", "archive_dir"])
@@ -288,7 +288,7 @@ def mock_expand_resource(tmpdir):
     test_file.write("test content\n")
 
     with tmpdir.as_cwd():
-        tar = spack.util.executable.which("tar", required=True)
+        tar = llnl.syscmd.which("tar", required=True)
         tar("czf", str(archive_name), subdir)
 
     MockResource = collections.namedtuple("MockResource", ["url", "files"])

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -7,6 +7,7 @@ import os
 
 import pytest
 
+from llnl.syscmd import which
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.config
@@ -14,7 +15,6 @@ import spack.repo
 from spack.fetch_strategy import SvnFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 from spack.version import Version
 
 pytestmark = [

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -7,12 +7,12 @@ import os
 
 import pytest
 
+import llnl.syscmd
 from llnl.util.filesystem import join_path, mkdirp, touch
 
 import spack.install_test
 import spack.spec
 from spack.install_test import TestStatus
-from spack.util.executable import which
 
 
 def _true(*args, **kwargs):
@@ -300,7 +300,7 @@ def test_test_part_fail(tmpdir, install_mockery_mutable_config, mock_fetch, mock
 
     name = "test_fail"
     with spack.install_test.test_part(pkg, name, "fake ProcessError"):
-        raise spack.util.executable.ProcessError("Mock failure")
+        raise llnl.syscmd.ProcessError("Mock failure")
 
     for part_name, status in pkg.tester.test_parts.items():
         assert part_name.endswith(name)
@@ -315,7 +315,7 @@ def test_test_part_pass(install_mockery_mutable_config, mock_fetch, mock_test_st
     name = "test_echo"
     msg = "nothing"
     with spack.install_test.test_part(pkg, name, "echo"):
-        echo = which("echo")
+        echo = llnl.syscmd.which("echo")
         echo(msg)
 
     for part_name, status in pkg.tester.test_parts.items():
@@ -350,7 +350,7 @@ def test_test_part_missing_exe_fail_fast(
     with spack.config.override("config:fail_fast", True):
         with pytest.raises(spack.install_test.TestFailure, match="object is not callable"):
             with spack.install_test.test_part(pkg, name, "fail fast"):
-                missing = which("no-possible-program")
+                missing = llnl.syscmd.which("no-possible-program")
                 missing()
 
     test_parts = pkg.tester.test_parts
@@ -371,7 +371,7 @@ def test_test_part_missing_exe(
 
     name = "test_missing_exe"
     with spack.install_test.test_part(pkg, name, "missing exe"):
-        missing = which("no-possible-program")
+        missing = llnl.syscmd.which("no-possible-program")
         missing()
 
     test_parts = pkg.tester.test_parts

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -9,7 +9,9 @@ import sys
 
 import pytest
 
+import llnl.syscmd
 import llnl.util.tty as tty
+from llnl.syscmd import which
 from llnl.util.filesystem import is_exe, working_dir
 
 import spack.config
@@ -17,11 +19,9 @@ import spack.error
 import spack.fetch_strategy as fs
 import spack.repo
 import spack.util.crypto as crypto
-import spack.util.executable
 import spack.util.web as web_util
 from spack.spec import Spec
 from spack.stage import Stage
-from spack.util.executable import which
 
 
 @pytest.fixture(params=list(crypto.hashes.keys()))
@@ -332,10 +332,10 @@ def test_missing_curl(tmpdir, monkeypatch):
 
     def _which(*args, **kwargs):
         err_msg = err_fmt.format(args[0])
-        raise spack.util.executable.CommandNotFoundError(err_msg)
+        raise llnl.syscmd.CommandNotFoundError(err_msg)
 
     # Patching the 'which' symbol imported by fetch_strategy needed due
-    # to 'from spack.util.executable import which' in this module.
+    # to 'from llnl.syscmd import which' in this module.
     monkeypatch.setattr(fs, "which", _which)
 
     testpath = str(tmpdir)
@@ -360,10 +360,10 @@ def test_url_fetch_text_curl_failures(tmpdir, monkeypatch):
 
     def _which(*args, **kwargs):
         err_msg = err_fmt.format(args[0])
-        raise spack.util.executable.CommandNotFoundError(err_msg)
+        raise llnl.syscmd.CommandNotFoundError(err_msg)
 
     # Patching the 'which' symbol imported by spack.util.web needed due
-    # to 'from spack.util.executable import which' in this module.
+    # to 'from llnl.syscmd import which' in this module.
     monkeypatch.setattr(spack.util.web, "which", _which)
 
     with spack.config.override("config:url_fetch_method", "curl"):
@@ -388,10 +388,10 @@ def test_url_missing_curl(tmpdir, monkeypatch):
 
     def _which(*args, **kwargs):
         err_msg = err_fmt.format(args[0])
-        raise spack.util.executable.CommandNotFoundError(err_msg)
+        raise llnl.syscmd.CommandNotFoundError(err_msg)
 
     # Patching the 'which' symbol imported by spack.util.web needed due
-    # to 'from spack.util.executable import which' in this module.
+    # to 'from llnl.syscmd import which' in this module.
     monkeypatch.setattr(spack.util.web, "which", _which)
 
     with spack.config.override("config:url_fetch_method", "curl"):

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -13,11 +13,11 @@ from itertools import product
 import pytest
 
 import llnl.url
+from llnl.syscmd import CommandNotFoundError
 from llnl.util.filesystem import working_dir
 
 from spack.paths import spack_root
 from spack.util import compression
-from spack.util.executable import CommandNotFoundError
 
 datadir = os.path.join(spack_root, "lib", "spack", "spack", "test", "data", "compression")
 

--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -8,11 +8,11 @@ import io
 
 import pytest
 
+import llnl.syscmd
 import llnl.util.filesystem as fs
 
 import spack.platforms
 import spack.util.elf as elf
-import spack.util.executable
 from spack.hooks.drop_redundant_rpaths import drop_redundant_rpaths
 
 
@@ -32,7 +32,7 @@ def skip_unless_linux(f):
     [("-Wl,--disable-new-dtags", False), ("-Wl,--enable-new-dtags", True)],
 )
 def test_elf_parsing_shared_linking(linker_flag, is_runpath, tmpdir):
-    gcc = spack.util.executable.which("gcc")
+    gcc = llnl.syscmd.which("gcc")
 
     with fs.working_dir(str(tmpdir)):
         # Create a library to link to so we can force a dynamic section in an ELF file

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -9,10 +9,10 @@ from pathlib import PurePath
 
 import pytest
 
+import llnl.syscmd as ex
 import llnl.util.filesystem as fs
 
 import spack
-import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 
 

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 
-import llnl.syscmd as environment
+from llnl.syscmd import environment
 
 import spack.build_environment
 import spack.config

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -6,11 +6,12 @@ import os
 import re
 import sys
 
+import llnl.syscmd as environment
+
 import spack.build_environment
 import spack.config
 import spack.error
 import spack.spec
-import spack.util.environment as environment
 from spack import traverse
 from spack.context import Context
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -12,10 +12,10 @@ import sys
 from typing import BinaryIO, Callable, Dict, List, Optional
 
 import llnl.url
+from llnl.syscmd import CommandNotFoundError, which
 from llnl.util import tty
 
 from spack.error import SpackError
-from spack.util.executable import CommandNotFoundError, which
 
 try:
     import bz2  # noqa

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -16,10 +16,10 @@ import os
 import shlex
 from typing import Callable, List
 
+import llnl.syscmd
 import llnl.util.tty as tty
 
 import spack.config
-import spack.util.executable
 
 #: editors to try if VISUAL and EDITOR are not set
 _default_editors = ["vim", "vi", "emacs", "nano", "notepad"]
@@ -46,17 +46,17 @@ def _find_exe_from_env_var(var: str):
     if not args:
         return None, []
 
-    exe = spack.util.executable.which_string(args[0])
+    exe = llnl.syscmd.which_string(args[0])
     args = [exe] + args[1:]
     return exe, args
 
 
 def executable(exe: str, args: List[str]) -> int:
-    """Wrapper that makes ``spack.util.executable.Executable`` look like ``os.execv()``.
+    """Wrapper that makes ``llnl.syscmd.Executable`` look like ``os.execv()``.
 
     Use this with ``editor()`` if you want it to return instead of running ``execv``.
     """
-    cmd = spack.util.executable.Executable(exe)
+    cmd = llnl.syscmd.Executable(exe)
     cmd(*args[1:], fail_on_error=False)
     return cmd.returncode
 
@@ -99,7 +99,7 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
         try:
             return exec_fn(exe, args) == 0
 
-        except (OSError, spack.util.executable.ProcessError) as e:
+        except (OSError, llnl.syscmd.ProcessError) as e:
             if spack.config.get("config:debug"):
                 raise
 
@@ -137,7 +137,7 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
     # nothing worked -- try the first default we can find don't bother
     # trying them all -- if we get here and one fails, something is
     # probably much more deeply wrong with the environment.
-    exe = spack.util.executable.which_string(*_default_editors)
+    exe = llnl.syscmd.which_string(*_default_editors)
     if exe and try_exec(exe, [exe] + list(args)):
         return True
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
+import warnings
+
+from llnl.util import lang
+
+warnings.warn(
+    f"{__name__} has been deprecated in favor of llnl.syscmd, "
+    f"and will be removed from Spack v0.23",
+    FutureWarning,
+    stacklevel=2,
+)
+sys.modules[__name__] = lang.ModuleDelegate(deprecated=__name__, substitutes=["llnl.syscmd"])

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -6,20 +6,17 @@
 import collections
 import contextlib
 import inspect
-import json
 import os
 import os.path
 import pickle
 import re
 import sys
 from functools import wraps
-from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 
 from llnl.path import path_to_os_path, system_path_filter
 from llnl.util import tty
 from llnl.util.lang import dedupe
-
-from .executable import Executable, which
 
 if sys.platform == "win32":
     SYSTEM_PATHS = [
@@ -698,88 +695,6 @@ class EnvironmentModifications:
         return cmds
 
     @staticmethod
-    def from_sourcing_file(
-        filename: Path, *arguments: str, **kwargs: Any
-    ) -> "EnvironmentModifications":
-        """Returns the environment modifications that have the same effect as
-        sourcing the input file.
-
-        Args:
-            filename: the file to be sourced
-            *arguments: arguments to pass on the command line
-
-        Keyword Args:
-            shell (str): the shell to use (default: ``bash``)
-            shell_options (str): options passed to the shell (default: ``-c``)
-            source_command (str): the command to run (default: ``source``)
-            suppress_output (str): redirect used to suppress output of command
-                (default: ``&> /dev/null``)
-            concatenate_on_success (str): operator used to execute a command
-                only when the previous command succeeds (default: ``&&``)
-            exclude ([str or re]): ignore any modifications of these
-                variables (default: [])
-            include ([str or re]): always respect modifications of these
-                variables (default: []). Supersedes any excluded variables.
-            clean (bool): in addition to removing empty entries,
-                also remove duplicate entries (default: False).
-        """
-        tty.debug(f"EnvironmentModifications.from_sourcing_file: {filename}")
-        # Check if the file actually exists
-        if not os.path.isfile(filename):
-            msg = f"Trying to source non-existing file: {filename}"
-            raise RuntimeError(msg)
-
-        # Prepare include and exclude lists of environment variable names
-        exclude = kwargs.get("exclude", [])
-        include = kwargs.get("include", [])
-        clean = kwargs.get("clean", False)
-
-        # Other variables unrelated to sourcing a file
-        exclude.extend(
-            [
-                # Bash internals
-                "SHLVL",
-                "_",
-                "PWD",
-                "OLDPWD",
-                "PS1",
-                "PS2",
-                "ENV",
-                # Environment Modules or Lmod
-                "LOADEDMODULES",
-                "_LMFILES_",
-                "MODULEPATH",
-                "MODULERCFILE",
-                "BASH_FUNC_ml()",
-                "BASH_FUNC_module()",
-                # Environment Modules-specific configuration
-                "MODULESHOME",
-                "BASH_FUNC__module_raw()",
-                r"MODULES_(.*)",
-                r"__MODULES_(.*)",
-                r"(\w*)_mod(quar|share)",
-                # Lmod-specific configuration
-                r"LMOD_(.*)",
-            ]
-        )
-
-        # Compute the environments before and after sourcing
-        before = sanitize(
-            environment_after_sourcing_files(os.devnull, **kwargs),
-            exclude=exclude,
-            include=include,
-        )
-        file_and_args = (filename,) + arguments
-        after = sanitize(
-            environment_after_sourcing_files(file_and_args, **kwargs),
-            exclude=exclude,
-            include=include,
-        )
-
-        # Delegate to the other factory
-        return EnvironmentModifications.from_environment_diff(before, after, clean)
-
-    @staticmethod
     def from_environment_diff(
         before: MutableMapping[str, str], after: MutableMapping[str, str], clean: bool = False
     ) -> "EnvironmentModifications":
@@ -1015,84 +930,6 @@ def preserve_environment(*variables: str):
             msg += ' {0} was set to "{1}", will be unset'
             tty.debug(msg.format(var, os.environ[var]))
             del os.environ[var]
-
-
-def environment_after_sourcing_files(
-    *files: Union[Path, Tuple[str, ...]], **kwargs
-) -> Dict[str, str]:
-    """Returns a dictionary with the environment that one would have
-    after sourcing the files passed as argument.
-
-    Args:
-        *files: each item can either be a string containing the path
-            of the file to be sourced or a sequence, where the first element
-            is the file to be sourced and the remaining are arguments to be
-            passed to the command line
-
-    Keyword Args:
-        env (dict): the initial environment (default: current environment)
-        shell (str): the shell to use (default: ``/bin/bash`` or ``cmd.exe`` (Windows))
-        shell_options (str): options passed to the shell (default: ``-c`` or ``/C`` (Windows))
-        source_command (str): the command to run (default: ``source``)
-        suppress_output (str): redirect used to suppress output of command
-            (default: ``&> /dev/null``)
-        concatenate_on_success (str): operator used to execute a command
-            only when the previous command succeeds (default: ``&&``)
-    """
-    # Set the shell executable that will be used to source files
-    if sys.platform == "win32":
-        shell_cmd = kwargs.get("shell", "cmd.exe")
-        shell_options = kwargs.get("shell_options", "/C")
-        suppress_output = kwargs.get("suppress_output", "")
-        source_command = kwargs.get("source_command", "")
-    else:
-        shell_cmd = kwargs.get("shell", "/bin/bash")
-        shell_options = kwargs.get("shell_options", "-c")
-        suppress_output = kwargs.get("suppress_output", "&> /dev/null")
-        source_command = kwargs.get("source_command", "source")
-    concatenate_on_success = kwargs.get("concatenate_on_success", "&&")
-
-    shell = Executable(shell_cmd)
-
-    def _source_single_file(file_and_args, environment):
-        shell_options_list = shell_options.split()
-
-        source_file = [source_command]
-        source_file.extend(x for x in file_and_args)
-        source_file = " ".join(source_file)
-
-        # If the environment contains 'python' use it, if not
-        # go with sys.executable. Below we just need a working
-        # Python interpreter, not necessarily sys.executable.
-        python_cmd = which("python3", "python", "python2")
-        python_cmd = python_cmd.path if python_cmd else sys.executable
-
-        dump_cmd = "import os, json; print(json.dumps(dict(os.environ)))"
-        dump_environment_cmd = python_cmd + f' -E -c "{dump_cmd}"'
-
-        # Try to source the file
-        source_file_arguments = " ".join(
-            [source_file, suppress_output, concatenate_on_success, dump_environment_cmd]
-        )
-        output = shell(
-            *shell_options_list,
-            source_file_arguments,
-            output=str,
-            env=environment,
-            ignore_quotes=True,
-        )
-
-        return json.loads(output)
-
-    current_environment = kwargs.get("env", dict(os.environ))
-    for file in files:
-        # Normalize the input to the helper function
-        if isinstance(file, str):
-            file = (file,)
-
-        current_environment = _source_single_file(file, environment=current_environment)
-
-    return current_environment
 
 
 def sanitize(

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
+import warnings
+
+from llnl.util import lang
+
+warnings.warn(
+    f"{__name__} has been deprecated in favor of llnl.syscmd, "
+    f"and will be removed from Spack v0.23",
+    FutureWarning,
+    stacklevel=2,
+)
+sys.modules[__name__] = lang.ModuleDelegate(deprecated=__name__, substitutes=["llnl.syscmd"])

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -11,6 +11,8 @@ from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 
+from spack.util.environment import EnvironmentModifications
+
 __all__ = ["Executable", "which", "ProcessError"]
 
 
@@ -25,7 +27,6 @@ class Executable:
         self.exe = [file_path]
 
         self.default_env = {}
-        from spack.util.environment import EnvironmentModifications  # no cycle
 
         self.default_envmod = EnvironmentModifications()
         self.returncode = None
@@ -150,8 +151,6 @@ class Executable:
         env = os.environ.copy() if env_arg is None else {}
         self.default_envmod.apply_modifications(env)
         env.update(self.default_env)
-
-        from spack.util.environment import EnvironmentModifications  # no cycle
 
         # Apply env argument
         if isinstance(env_arg, EnvironmentModifications):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -11,8 +11,6 @@ from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 
-import spack.error
-
 __all__ = ["Executable", "which", "ProcessError"]
 
 
@@ -204,12 +202,12 @@ class Executable:
             quoted_args = [arg for arg in args if re.search(r'^".*"$|^\'.*\'$', arg)]
             if quoted_args:
                 tty.warn(
-                    "Quotes in command arguments can confuse scripts like" " configure.",
+                    "Quotes in command arguments can confuse scripts like configure.",
                     "The following arguments may cause problems when executed:",
                     str("\n".join(["    " + arg for arg in quoted_args])),
                     "Quotes aren't needed because spack doesn't use a shell. "
                     "Consider removing them.",
-                    "If multiple levels of quotation are required, use " "`ignore_quotes=True`.",
+                    "If multiple levels of quotation are required, use `ignore_quotes=True`.",
                 )
 
         cmd = self.exe + list(args)
@@ -362,7 +360,7 @@ def which(*args, **kwargs):
     return Executable(exe) if exe else None
 
 
-class ProcessError(spack.error.SpackError):
+class ProcessError(RuntimeError):
     """ProcessErrors are raised when Executables exit with an error code."""
 
 
@@ -371,5 +369,5 @@ class ProcessTimeoutError(ProcessError):
     specified timeout exceed that time"""
 
 
-class CommandNotFoundError(spack.error.SpackError):
+class CommandNotFoundError(RuntimeError):
     """Raised when ``which()`` can't find a required executable."""

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -10,8 +10,7 @@ import sys
 from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
-
-from spack.util.environment import EnvironmentModifications
+from llnl.syscmd import EnvironmentModifications
 
 __all__ = ["Executable", "which", "ProcessError"]
 

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -7,9 +7,8 @@
 import sys
 from typing import Optional
 
+import llnl.syscmd as exe
 import llnl.util.lang
-
-import spack.util.executable as exe
 
 
 @llnl.util.lang.memoized

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -8,9 +8,10 @@ import functools
 import os
 import re
 
+import llnl.syscmd
+
 import spack.error
 import spack.paths
-import spack.util.executable
 import spack.version
 
 #: Executable instance for "gpg", initialized lazily
@@ -343,13 +344,13 @@ def _verify_exe_or_raise(exe):
 
 
 def _gpgconf():
-    exe = spack.util.executable.which("gpgconf", "gpg2conf", "gpgconf2")
+    exe = llnl.syscmd.which("gpgconf", "gpg2conf", "gpgconf2")
     _verify_exe_or_raise(exe)
 
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
     try:
         exe("--dry-run", "--create-socketdir", output=os.devnull, error=os.devnull)
-    except spack.util.executable.ProcessError:
+    except llnl.syscmd.ProcessError:
         # no dice
         exe = None
 
@@ -357,7 +358,7 @@ def _gpgconf():
 
 
 def _gpg():
-    exe = spack.util.executable.which("gpg2", "gpg")
+    exe = llnl.syscmd.which("gpg2", "gpg")
     _verify_exe_or_raise(exe)
     return exe
 

--- a/lib/spack/spack/util/sourcing.py
+++ b/lib/spack/spack/util/sourcing.py
@@ -3,7 +3,8 @@ import os.path
 import sys
 from typing import Any, Dict, Tuple, Union
 
-from .environment import EnvironmentModifications, sanitize
+from llnl.syscmd import EnvironmentModifications, sanitize
+
 from .executable import Executable, which
 
 Path = str

--- a/lib/spack/spack/util/sourcing.py
+++ b/lib/spack/spack/util/sourcing.py
@@ -1,0 +1,162 @@
+import json
+import os.path
+import sys
+from typing import Any, Dict, Tuple, Union
+
+from .environment import EnvironmentModifications, sanitize
+from .executable import Executable, which
+
+Path = str
+
+
+def from_sourcing_file(filename: Path, *arguments: str, **kwargs: Any) -> EnvironmentModifications:
+    """Returns the environment modifications that have the same effect as
+    sourcing the input file.
+
+    Args:
+        filename: the file to be sourced
+        *arguments: arguments to pass on the command line
+
+    Keyword Args:
+        shell (str): the shell to use (default: ``bash``)
+        shell_options (str): options passed to the shell (default: ``-c``)
+        source_command (str): the command to run (default: ``source``)
+        suppress_output (str): redirect used to suppress output of command
+            (default: ``&> /dev/null``)
+        concatenate_on_success (str): operator used to execute a command
+            only when the previous command succeeds (default: ``&&``)
+        exclude ([str or re]): ignore any modifications of these
+            variables (default: [])
+        include ([str or re]): always respect modifications of these
+            variables (default: []). Supersedes any excluded variables.
+        clean (bool): in addition to removing empty entries,
+            also remove duplicate entries (default: False).
+    """
+    # Check if the file actually exists
+    if not os.path.isfile(filename):
+        msg = f"Trying to source non-existing file: {filename}"
+        raise RuntimeError(msg)
+
+    # Prepare include and exclude lists of environment variable names
+    exclude = kwargs.get("exclude", [])
+    include = kwargs.get("include", [])
+    clean = kwargs.get("clean", False)
+
+    # Other variables unrelated to sourcing a file
+    exclude.extend(
+        [
+            # Bash internals
+            "SHLVL",
+            "_",
+            "PWD",
+            "OLDPWD",
+            "PS1",
+            "PS2",
+            "ENV",
+            # Environment Modules or Lmod
+            "LOADEDMODULES",
+            "_LMFILES_",
+            "MODULEPATH",
+            "MODULERCFILE",
+            "BASH_FUNC_ml()",
+            "BASH_FUNC_module()",
+            # Environment Modules-specific configuration
+            "MODULESHOME",
+            "BASH_FUNC__module_raw()",
+            r"MODULES_(.*)",
+            r"__MODULES_(.*)",
+            r"(\w*)_mod(quar|share)",
+            # Lmod-specific configuration
+            r"LMOD_(.*)",
+        ]
+    )
+
+    # Compute the environments before and after sourcing
+    before = sanitize(
+        environment_after_sourcing_files(os.devnull, **kwargs), exclude=exclude, include=include
+    )
+    file_and_args = (filename,) + arguments
+    after = sanitize(
+        environment_after_sourcing_files(file_and_args, **kwargs), exclude=exclude, include=include
+    )
+
+    # Delegate to the other factory
+    return EnvironmentModifications.from_environment_diff(before, after, clean)
+
+
+def environment_after_sourcing_files(
+    *files: Union[Path, Tuple[str, ...]], **kwargs
+) -> Dict[str, str]:
+    """Returns a dictionary with the environment that one would have
+    after sourcing the files passed as argument.
+
+    Args:
+        *files: each item can either be a string containing the path
+            of the file to be sourced or a sequence, where the first element
+            is the file to be sourced and the remaining are arguments to be
+            passed to the command line
+
+    Keyword Args:
+        env (dict): the initial environment (default: current environment)
+        shell (str): the shell to use (default: ``/bin/bash`` or ``cmd.exe`` (Windows))
+        shell_options (str): options passed to the shell (default: ``-c`` or ``/C`` (Windows))
+        source_command (str): the command to run (default: ``source``)
+        suppress_output (str): redirect used to suppress output of command
+            (default: ``&> /dev/null``)
+        concatenate_on_success (str): operator used to execute a command
+            only when the previous command succeeds (default: ``&&``)
+    """
+    # Set the shell executable that will be used to source files
+    if sys.platform == "win32":
+        shell_cmd = kwargs.get("shell", "cmd.exe")
+        shell_options = kwargs.get("shell_options", "/C")
+        suppress_output = kwargs.get("suppress_output", "")
+        source_command = kwargs.get("source_command", "")
+    else:
+        shell_cmd = kwargs.get("shell", "/bin/bash")
+        shell_options = kwargs.get("shell_options", "-c")
+        suppress_output = kwargs.get("suppress_output", "&> /dev/null")
+        source_command = kwargs.get("source_command", "source")
+    concatenate_on_success = kwargs.get("concatenate_on_success", "&&")
+
+    shell = Executable(shell_cmd)
+
+    def _source_single_file(file_and_args, environment):
+        shell_options_list = shell_options.split()
+
+        source_file = [source_command]
+        source_file.extend(x for x in file_and_args)
+        source_file = " ".join(source_file)
+
+        # If the environment contains 'python' use it, if not
+        # go with sys.executable. Below we just need a working
+        # Python interpreter, not necessarily sys.executable.
+        python_cmd = which("python3", "python", "python2")
+        python_cmd = python_cmd.path if python_cmd else sys.executable
+
+        dump_cmd = "import os, json; print(json.dumps(dict(os.environ)))"
+        dump_environment_cmd = python_cmd + f' -E -c "{dump_cmd}"'
+
+        # Try to source the file
+        source_file_arguments = " ".join(
+            [source_file, suppress_output, concatenate_on_success, dump_environment_cmd]
+        )
+        output = shell(
+            *shell_options_list,
+            source_file_arguments,
+            output=str,
+            env=environment,
+            ignore_quotes=True,
+        )
+
+        return json.loads(output)
+
+    current_environment = kwargs.get("env", dict(os.environ))
+    for file in files:
+        # Normalize the input to the helper function
+        if isinstance(file, str):
+            file = (file,)
+
+        current_environment = _source_single_file(file, environment=current_environment)
+
+    return current_environment

--- a/lib/spack/spack/util/sourcing.py
+++ b/lib/spack/spack/util/sourcing.py
@@ -3,9 +3,7 @@ import os.path
 import sys
 from typing import Any, Dict, Tuple, Union
 
-from llnl.syscmd import EnvironmentModifications, sanitize
-
-from .executable import Executable, which
+from llnl.syscmd import EnvironmentModifications, Executable, sanitize, which
 
 Path = str
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -22,6 +22,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import HTTPSHandler, Request, build_opener
 
 import llnl.url
+from llnl.syscmd import CommandNotFoundError, which
 from llnl.util import lang, tty
 from llnl.util.filesystem import mkdirp, rename, working_dir
 
@@ -29,7 +30,6 @@ import spack.config
 import spack.error
 import spack.util.url as url_util
 
-from .executable import CommandNotFoundError, which
 from .gcs import GCSBlob, GCSBucket, GCSHandler
 from .s3 import UrllibS3Handler, get_s3_session
 
@@ -306,7 +306,7 @@ def fetch_url_text(url, curl=None, dest_dir="."):
 
     Arguments:
         url (str): URL whose contents are to be fetched
-        curl (spack.util.executable.Executable or None): (optional) curl
+        curl (llnl.syscmd.Executable or None): (optional) curl
             executable if curl is the configured fetch method
         dest_dir (str): (optional) destination directory for fetched text
             file
@@ -373,7 +373,7 @@ def url_exists(url, curl=None):
 
     Arguments:
         url (str): URL whose existence is being checked
-        curl (spack.util.executable.Executable or None): (optional) curl
+        curl (llnl.syscmd.Executable or None): (optional) curl
             executable if curl is the configured fetch method
 
     Returns (bool): True if it exists; False otherwise.

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -8,13 +8,13 @@ import re
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
+import llnl.syscmd
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.caches
 import spack.fetch_strategy
 import spack.paths
 import spack.repo
-import spack.util.executable
 import spack.util.hash
 import spack.util.spack_json as sjson
 import spack.version
@@ -154,7 +154,7 @@ class GitRefLookup(AbstractRefLookup):
                 self.fetcher.git(
                     "cat-file", "-e", "%s^{commit}" % ref, output=os.devnull, error=os.devnull
                 )
-            except spack.util.executable.ProcessError:
+            except llnl.syscmd.ProcessError:
                 raise VersionLookupError("%s is not a valid git ref for %s" % (ref, self.pkg_name))
 
             # List tags (refs) by date, so last reference of a tag is newest

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -5,7 +5,6 @@
 import os
 import re
 
-import spack.package_base
 from spack.package import *
 
 
@@ -22,7 +21,7 @@ class FindExternals1(AutotoolsPackage):
         exes = [x for x in exe_to_path.keys() if "find-externals1-exe" in x]
         if not exes:
             return
-        exe = spack.util.executable.Executable(exe_to_path[exes[0]])
+        exe = Executable(exe_to_path[exes[0]])
         output = exe("--version", output=str)
         if output:
             match = re.search(r"find-externals1.*version\s+(\S+)", output)

--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -286,7 +286,7 @@ class Acfl(Package):
                 if match.group(1).count(".") == 1:
                     return match.group(1) + ".0." + match.group(2)
                 return match.group(1) + "." + match.group(2)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -7,7 +7,6 @@ import platform
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Anaconda3(Package):
@@ -224,4 +223,4 @@ class Anaconda3(Package):
 
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")
-        env.extend(EnvironmentModifications.from_sourcing_file(filename))
+        env.extend(from_sourcing_file(filename))

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -8,7 +8,6 @@ import socket
 from os.path import join as pjoin
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 def get_spec_path(spec, package_name, path_replacements={}, use_bin=False):

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Bash(AutotoolsPackage, GNUMirrorPackage):

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -6,7 +6,6 @@
 from collections import defaultdict
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Cdo(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -9,7 +9,6 @@ import spack.paths
 import spack.user_environment
 from spack.package import *
 from spack.pkg.builtin.clingo import Clingo
-from spack.util.environment import EnvironmentModifications
 
 
 class ClingoBootstrap(Clingo):

--- a/var/spack/repos/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/builtin/packages/coin3d/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import autotools, cmake
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 
@@ -80,7 +81,7 @@ class Coin3d(AutotoolsPackage, CMakePackage):
     )
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define_from_variant("COIN_BUILD_DOCUMENTATION_MAN", "man"),
@@ -91,7 +92,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args += self.enable_or_disable("framework")

--- a/var/spack/repos/builtin/packages/conda4aarch64/package.py
+++ b/var/spack/repos/builtin/packages/conda4aarch64/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Conda4aarch64(Package):
@@ -30,4 +29,4 @@ class Conda4aarch64(Package):
 
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")
-        env.extend(EnvironmentModifications.from_sourcing_file(filename))
+        env.extend(from_sourcing_file(filename))

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -8,8 +8,6 @@ import os.path
 import sys
 
 import spack.platforms
-import spack.util.environment
-import spack.util.executable
 from spack.build_environment import dso_suffix
 from spack.build_systems import cmake, makefile
 from spack.package import *
@@ -800,7 +798,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         # Apparently the Makefile bases its paths on PWD
         # so we need to set PWD = self.build_directory
-        with spack.util.environment.set_env(PWD=self.build_directory):
+        with set_env(PWD=self.build_directory):
             super().build(pkg, spec, prefix)
 
             with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -7,7 +7,6 @@ import glob
 import os.path
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Elfutils(AutotoolsPackage, SourcewarePackage):

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+from spack.build_systems import autotools, cmake
 from spack.package import *
 
 
@@ -86,7 +87,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
                 env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss"))
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         spec = self.spec
         args = [
@@ -121,7 +122,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             customPip.install(pkg, spec, prefix)
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args.extend(self.with_or_without("cuda", activation_value="prefix"))

--- a/var/spack/repos/builtin/packages/fj/package.py
+++ b/var/spack/repos/builtin/packages/fj/package.py
@@ -7,7 +7,6 @@ import re
 import llnl.util.tty as tty
 
 import spack.compiler
-import spack.util.executable
 from spack.package import *
 
 
@@ -37,7 +36,7 @@ class Fj(Package):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.package import *
 
 
@@ -215,7 +214,7 @@ class FluxCore(AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
@@ -137,7 +136,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/flux-security/package.py
+++ b/var/spack/repos/builtin/packages/flux-security/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.package import *
 
 
@@ -52,7 +51,7 @@ class FluxSecurity(AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -42,7 +42,6 @@ from spack.pkg.builtin.openfoam import (
     rewrite_environ_files,
     write_environ,
 )
-from spack.util.environment import EnvironmentModifications
 
 
 class FoamExtend(Package):
@@ -128,7 +127,7 @@ class FoamExtend(Package):
         if os.path.isfile(bashrc):
             # post-install: source the installed bashrc
             try:
-                mods = EnvironmentModifications.from_sourcing_file(
+                mods = from_sourcing_file(
                     bashrc,
                     clean=True,  # Remove duplicate entries
                     blacklist=[  # Blacklist these

--- a/var/spack/repos/builtin/packages/freesurfer/package.py
+++ b/var/spack/repos/builtin/packages/freesurfer/package.py
@@ -7,7 +7,6 @@ import glob
 import os
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Freesurfer(Package):

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -7,7 +7,6 @@ import glob
 import os
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Fsl(Package, CudaPackage):
@@ -180,7 +179,7 @@ class Fsl(Package, CudaPackage):
         # the post install script does not get confused.
         vars_to_unset = ["PYTHONPATH", "PYTHONHOME"]
 
-        with spack.util.environment.preserve_environment(*vars_to_unset):
+        with preserve_environment(*vars_to_unset):
             for v in vars_to_unset:
                 del os.environ[v]
 
@@ -198,7 +197,7 @@ class Fsl(Package, CudaPackage):
         fslsetup = join_path(self.stage.source_path, "etc", "fslconf", "fsl.sh")
 
         if os.path.isfile(fslsetup):
-            env.extend(EnvironmentModifications.from_sourcing_file(fslsetup))
+            env.extend(from_sourcing_file(fslsetup))
 
     def setup_run_environment(self, env):
         # Set the environment variables after copying tree
@@ -206,4 +205,4 @@ class Fsl(Package, CudaPackage):
         fslsetup = join_path(self.prefix, "etc", "fslconf", "fsl.sh")
 
         if os.path.isfile(fslsetup):
-            env.extend(EnvironmentModifications.from_sourcing_file(fslsetup))
+            env.extend(from_sourcing_file(fslsetup))

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -134,7 +134,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
             try:
                 git = which("git")
                 git("describe", "--long", "--always", output="version.git")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 spack.main.send_warning_to_tty("Omitting version stamp due to git error")
 
         # The GASNet-EX library has a highly multi-dimensional configure space,

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -14,7 +14,6 @@ import llnl.util.tty as tty
 from llnl.util.lang import classproperty
 
 import spack.platforms
-import spack.util.executable
 from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
@@ -544,7 +543,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                 match = version_regex.search(output)
                 if match:
                     return match.group(1)
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 pass
             except Exception as e:
                 tty.debug(e)

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -9,7 +9,6 @@ import sys
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
-from spack.util.environment import filter_system_paths, is_system_path
 
 
 class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Gettext(AutotoolsPackage, GNUMirrorPackage):

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -7,7 +7,6 @@ import os
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Git(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -5,8 +5,9 @@
 
 import os.path
 
+import spack.builder
+from spack.build_systems import autotools, meson
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Glib(MesonPackage, AutotoolsPackage):
@@ -285,7 +286,7 @@ class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
             filter_file(pattern, repl, myfile, backup=False)
 
 
-class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(BaseBuilder, meson.MesonBuilder):
     def meson_args(self):
         args = []
         if self.spec.satisfies("@2.63.5:"):
@@ -327,7 +328,7 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
         return args
 
 
-class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         if "+libmount" in self.spec:

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Gnupg(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Groff(AutotoolsPackage, GNUMirrorPackage):

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -7,6 +7,7 @@ import os
 
 import llnl.util.filesystem as fs
 
+from spack.build_systems import cmake
 from spack.package import *
 
 
@@ -397,7 +398,7 @@ class Gromacs(CMakePackage, CudaPackage):
                 )
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     @run_after("build")
     def build_test_binaries(self):
         """Build the test binaries.

--- a/var/spack/repos/builtin/packages/heasoft/package.py
+++ b/var/spack/repos/builtin/packages/heasoft/package.py
@@ -8,7 +8,6 @@ import os
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Heasoft(AutotoolsPackage):
@@ -141,7 +140,7 @@ class Heasoft(AutotoolsPackage):
     def setup_run_environment(self, env):
         try:
             env.extend(
-                EnvironmentModifications.from_sourcing_file(
+                from_sourcing_file(
                     join_path(self.spec.prefix, "headas-config_spack.sh"), clean=True
                 )
             )

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -118,7 +118,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -111,7 +111,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack.package import *
 
 
@@ -88,7 +87,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/builtin/packages/hiprand/package.py
@@ -48,7 +48,7 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -72,7 +72,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -115,7 +115,7 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "amdgpu_target",
         description="AMD GPU architecture",
-        values=spack.variant.DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
+        values=DisjointSetsOfValues(("auto",), ("none",), amdgpu_targets)
         .with_default("auto")
         .with_error(
             "the values 'auto' and 'none' are mutually exclusive with any of the other values"

--- a/var/spack/repos/builtin/packages/hiredis/package.py
+++ b/var/spack/repos/builtin/packages/hiredis/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake, makefile
 from spack.package import *
 
 
@@ -40,7 +41,7 @@ class Hiredis(MakefilePackage, CMakePackage):
     depends_on("openssl@1.1:", type=("build", "link"), when="+test_ssl")
 
 
-class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
+class MakefileBuilder(makefile.MakefileBuilder):
     @property
     def build_targets(self):
         use_ssl = 1 if "+ssl" in self.spec else 0
@@ -58,7 +59,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             fix_darwin_install_name(self.prefix.lib)
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         build_test = not ("+test" in self.spec)
         ssl_test = ("+test_ssl" in self.spec) and ("+test" in self.spec)

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -240,7 +240,7 @@ class Intel(IntelPackage):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(str(e))

--- a/var/spack/repos/builtin/packages/ipm/package.py
+++ b/var/spack/repos/builtin/packages/ipm/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class Ipm(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake, meson
 from spack.package import *
 
 
@@ -68,7 +69,7 @@ class Jsoncpp(CMakePackage, MesonPackage):
         )
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define("BUILD_SHARED_LIBS", True),
@@ -81,6 +82,6 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         return ["-Dtests={}".format("true" if self.pkg.run_tests else "false")]

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Lftp(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Libarchive(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake
 from spack.package import *
 
 
@@ -97,7 +98,7 @@ class LibjpegTurbo(CMakePackage, AutotoolsPackage):
         return find_libraries("libjpeg*", root=self.prefix, recursive=True)
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_SHARED", "shared"),

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import autotools, cmake
 from spack.package import *
 
 
@@ -53,7 +54,7 @@ class Libssh2(AutotoolsPackage, CMakePackage):
     patch("pr-1114.patch", when="@1.7:")
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define("BUILD_TESTING", False),
@@ -72,7 +73,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = ["--disable-tests", "--disable-docker-tests", "--disable-examples-build"]
         args += self.enable_or_disable("shared")

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -10,7 +10,6 @@ import sys
 import llnl.util.tty as tty
 
 import spack.build_environment
-import spack.util.executable
 from spack.package import *
 
 
@@ -257,7 +256,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
             match = version_regex.search(output)
             if match:
                 return match.group(match.lastindex)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -10,7 +10,6 @@ import sys
 import llnl.util.tty as tty
 
 import spack.build_environment
-import spack.util.executable
 from spack.package import *
 
 
@@ -631,7 +630,7 @@ class Llvm(CMakePackage, CudaPackage):
             match = version_regex.search(output)
             if match:
                 return match.group(match.lastindex)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -8,7 +8,6 @@ import os
 
 import spack.build_environment
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class LuaImplPackage(MakefilePackage):

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -174,7 +174,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
             pkg_config_path = "{0}/lib/pkgconfig".format(self.prefix)
-            with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
+            with set_env(PKG_CONFIG_PATH=pkg_config_path):
                 make("c")
                 self.run_test("./example_sparse", purpose="MAGMA smoke test - sparse solver")
                 self.run_test(

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
-import spack.build_systems.meson
+from spack.build_systems import meson
 from spack.package import *
 
 
@@ -71,9 +71,7 @@ class Mesa(MesonPackage):
     #   @:21  - swr was removed in 22.0
     variant(
         "swr",
-        values=spack.variant.DisjointSetsOfValues(
-            ("none",), ("auto",), ("avx", "avx2", "knl", "skx")
-        )
+        values=DisjointSetsOfValues(("none",), ("auto",), ("avx", "avx2", "knl", "skx"))
         .with_non_feature_values("auto")
         .with_non_feature_values("none")
         .with_default("auto"),
@@ -184,7 +182,7 @@ class Mesa(MesonPackage):
         return find_libraries(lib_name, root=self.spec.prefix, recursive=True)
 
 
-class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         spec = self.spec
         args = [

--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -44,9 +44,7 @@ class Mesa18(AutotoolsPackage):
     variant("llvm", default=True, description="Enable LLVM.")
     variant(
         "swr",
-        values=spack.variant.DisjointSetsOfValues(
-            ("none",), ("auto",), ("avx", "avx2", "knl", "skx")
-        )
+        values=DisjointSetsOfValues(("none",), ("auto",), ("avx", "avx2", "knl", "skx"))
         .with_non_feature_values("auto")
         .with_non_feature_values("none")
         .with_default("auto"),

--- a/var/spack/repos/builtin/packages/miniconda2/package.py
+++ b/var/spack/repos/builtin/packages/miniconda2/package.py
@@ -6,7 +6,6 @@
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 
 class Miniconda2(Package):
@@ -67,4 +66,4 @@ class Miniconda2(Package):
 
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")
-        env.extend(EnvironmentModifications.from_sourcing_file(filename))
+        env.extend(from_sourcing_file(filename))

--- a/var/spack/repos/builtin/packages/miniconda3/package.py
+++ b/var/spack/repos/builtin/packages/miniconda3/package.py
@@ -7,7 +7,6 @@ import platform
 from os.path import split
 
 from spack.package import *
-from spack.util.environment import EnvironmentModifications
 
 _versions = {
     "22.11.1": {
@@ -103,4 +102,4 @@ class Miniconda3(Package):
 
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")
-        env.extend(EnvironmentModifications.from_sourcing_file(filename))
+        env.extend(from_sourcing_file(filename))

--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -7,7 +7,6 @@ import os
 
 import spack.build_systems.cmake
 from spack.package import *
-from spack.util.executable import which
 
 
 class Mmg(CMakePackage):

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Mono(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -5,7 +5,6 @@
 import os
 
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class MpasModel(MakefilePackage):

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -99,7 +99,7 @@ class Nag(Package):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -5,6 +5,7 @@
 import glob
 import os
 
+from spack.build_systems import generic
 from spack.package import *
 
 
@@ -59,7 +60,7 @@ class Nasm(AutotoolsPackage, Package):
             )
 
 
-class GenericBuilder(spack.build_systems.generic.GenericBuilder):
+class GenericBuilder(generic.GenericBuilder):
     def install(self, pkg, spec, prefix):
         with working_dir(self.stage.source_path, create=True):
             # build NASM with nmake

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -12,7 +12,6 @@ from llnl.util.lang import dedupe
 import spack.builder
 from spack.build_systems import autotools, cmake
 from spack.package import *
-from spack.util.environment import filter_system_paths
 
 
 class NetcdfC(CMakePackage, AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 class NinjaFortran(Package):
@@ -61,7 +60,7 @@ class NinjaFortran(Package):
         split_ver = str(ver).split(".")
         url_version = ".".join(split_ver[:3]) + "." + split_ver[4]
 
-        if version < spack.version.Version("1.8.2.1"):
+        if version < Version("1.8.2.1"):
             url = "https://github.com/Kitware/ninja/archive/v{0}.kitware.dyndep-1.tar.gz"
         else:
             url = (

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -5,7 +5,6 @@
 import sys
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 class Ninja(Package):

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 import tempfile
 
-import spack.util.environment
 from spack.package import *
 
 
@@ -145,7 +144,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         # Spack's build environment when running tests
         vars_to_unset = ["CC", "CXX", "F77", "FC"]
 
-        with spack.util.environment.preserve_environment(*vars_to_unset):
+        with preserve_environment(*vars_to_unset):
             # Delete temporarily the environment variables that point
             # to Spack compiler wrappers
             for v in vars_to_unset:

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -49,7 +49,6 @@ from spack.pkg.builtin.openfoam import (
     rewrite_environ_files,
     write_environ,
 )
-from spack.util.environment import EnvironmentModifications
 
 
 class OpenfoamOrg(Package):
@@ -186,7 +185,7 @@ class OpenfoamOrg(Package):
     def setup_run_environment(self, env):
         bashrc = self.prefix.etc.bashrc
         try:
-            env.extend(EnvironmentModifications.from_sourcing_file(bashrc, clean=True))
+            env.extend(from_sourcing_file(bashrc, clean=True))
         except Exception as e:
             msg = "unexpected error when sourcing OpenFOAM bashrc [{0}]"
             tty.warn(msg.format(str(e)))

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -48,7 +48,6 @@ import llnl.util.tty as tty
 
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
-from spack.util.environment import EnvironmentModifications
 
 # Not the nice way of doing things, but is a start for refactoring
 __all__ = [
@@ -483,7 +482,7 @@ class Openfoam(Package):
         if os.path.isfile(bashrc):
             # post-install: source the installed bashrc
             try:
-                mods = EnvironmentModifications.from_sourcing_file(
+                mods = from_sourcing_file(
                     bashrc,
                     clean=True,  # Remove duplicate entries
                     blacklist=[  # Blacklist these

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -212,7 +212,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
         if not os.path.exists(test_dir):
             raise SkipTest("Skipping smoke tests, directory doesn't exist")
         with working_dir(test_dir, create=False):
-            with spack.util.environment.set_env(PAPIROOT=self.prefix):
+            with set_env(PAPIROOT=self.prefix):
                 make()
                 exe_simple = which("simple")
                 exe_simple()

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -213,7 +213,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     @classmethod
     def determine_version(cls, exe):
-        perl = spack.util.executable.Executable(exe)
+        perl = Executable(exe)
         output = perl("--version", output=str, error=str)
         if output:
             match = re.search(r"perl.*\(v([0-9.]+)\)", output)
@@ -224,7 +224,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     @classmethod
     def determine_variants(cls, exes, version):
         for exe in exes:
-            perl = spack.util.executable.Executable(exe)
+            perl = Executable(exe)
             output = perl("-V", output=str, error=str)
             variants = ""
             if output:

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -313,7 +313,7 @@ class Phist(CMakePackage):
                 tty.warn("========================== %s =======================" % hint)
                 try:
                     make("check")
-                except spack.util.executable.ProcessError:
+                except ProcessError:
                     raise InstallError("run-test of phist ^mpich: Hint: " + hint)
             else:
                 make("check")

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Procps(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems import cmake
 from spack.package import *
 
 
@@ -90,7 +91,7 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("py-flaky", type="test")
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     build_directory = "build"
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -18,9 +18,9 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import is_nonsymlink_exe_with_shebang, path_contains_subdirectory
 from llnl.util.lang import dedupe
 
+import spack.paths
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
-from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
 
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -8,7 +8,6 @@ import sys
 
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Root(CMakePackage):

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Silo(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -113,7 +113,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("kokkos +wrapper+cuda_lambda", when="+cuda+kokkos")
 
     # fix for older spacks
-    if spack.version.Version(spack.spack_version) >= spack.version.Version("0.17"):
+    if Version(spack.spack_version) >= spack.version.Version("0.17"):
         depends_on("kokkos-kernels ~shared", when="+kokkos-kernels")
 
     for _flag in list(CudaPackage.cuda_arch_values):

--- a/var/spack/repos/builtin/packages/spack/package.py
+++ b/var/spack/repos/builtin/packages/spack/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.variant import DisjointSetsOfValues
 
 
 class Spack(Package):

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -6,7 +6,6 @@
 from platform import machine
 
 from spack.package import *
-from spack.util.environment import set_env
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Subversion(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Tar(AutotoolsPackage, GNUMirrorPackage):

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -9,7 +9,6 @@ import sys
 from llnl.util.filesystem import find_first
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 is_windows = sys.platform == "win32"
 

--- a/var/spack/repos/builtin/packages/xlc/package.py
+++ b/var/spack/repos/builtin/packages/xlc/package.py
@@ -41,7 +41,7 @@ class Xlc(Package):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(str(e))

--- a/var/spack/repos/builtin/packages/xlf/package.py
+++ b/var/spack/repos/builtin/packages/xlf/package.py
@@ -38,7 +38,7 @@ class Xlf(Package):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)


### PR DESCRIPTION
closes #34767

This PR completely separates the `llnl` Python package from `spack`. The new package `llnl.syscmd` is a good candidate for extraction from Spack, similarly to `sbang` and `archspec`.

Modifications:
- [x] Moved `spack.util.environment` and `spack.util.executable` into `llnl.syscmd`

The current dependency graph is:

![llnl](https://github.com/spack/spack/assets/4199709/b74e05be-4263-4969-8287-e801cc3cb744)
