### PR TITLE
assimp: new version 5.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -17,6 +17,7 @@ class Assimp(CMakePackage):
     maintainers("wdconinc")
 
     version("master", branch="master")
+    version("5.3.1", sha256="a07666be71afe1ad4bc008c2336b7c688aca391271188eb9108d0c6db1be53f1")
     version("5.2.5", sha256="b5219e63ae31d895d60d98001ee5bb809fb2c7b2de1e7f78ceeb600063641e1a")
     version("5.2.4", sha256="6a4ff75dc727821f75ef529cea1c4fc0a7b5fc2e0a0b2ff2f6b7993fe6cb54ba")
     version("5.2.3", sha256="b20fc41af171f6d8f1f45d4621f18e6934ab7264e71c37cd72fd9832509af2a8")


### PR DESCRIPTION
This adds the newly released version 5.3.1 (with bugfixes one week after 5.3.0). No build system changes from a look at the differences in CMakeLists.txt. Full diff at https://github.com/assimp/assimp/compare/v5.2.5...v5.3.1.

Tested and built:
```
==> Installing assimp-5.3.1-2jn6hguju5lgwyswizub4ynh7mwivpjw [9/9]
==> No binary for assimp-5.3.1-2jn6hguju5lgwyswizub4ynh7mwivpjw found: installing from source
==> Fetching https://github.com/assimp/assimp/archive/v5.3.1.tar.gz
==> Ran patch() for assimp
==> assimp: Executing phase: 'cmake'
==> assimp: Executing phase: 'build'
==> assimp: Executing phase: 'install'
==> assimp: Successfully installed assimp-5.3.1-2jn6hguju5lgwyswizub4ynh7mwivpjw
  Stage: 8.54s.  Cmake: 1.83s.  Build: 7m 37.42s.  Install: 1.23s.  Post-install: 0.30s.  Total: 7m 49.89s
[+] /opt/software/linux-ubuntu23.04-skylake/gcc-12.3.0/assimp-5.3.1-2jn6hguju5lgwyswizub4ynh7mwivpjw
```