### PR TITLE
vtk-m@2.0 +kokkos: constraint kokkos dep to kokkos@3.7:3.9 per issue #40268

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -102,6 +102,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     # VTK-m uses the default Kokkos backend
     depends_on("kokkos", when="+kokkos")
+    depends_on("kokkos@3.7:3.9", when="@2.0 +kokkos")
     # VTK-m native CUDA and Kokkos CUDA backends are not compatible
     depends_on("kokkos ~cuda", when="+kokkos +cuda +cuda_native")
     depends_on("kokkos +cuda", when="+kokkos +cuda ~cuda_native")


### PR DESCRIPTION
`vtk-m@2.0 +kokkos` only works with `kokkos@3.7:3.9` per comment from @kmorel:
* https://github.com/spack/spack/issues/40268#issuecomment-1742824674

Fixes https://github.com/spack/spack/issues/40268