### PR TITLE
Add new package awscli-v2 and its missing dependency awscrt

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install awscli-v2
-#
-# You can edit this file again by typing:
-#
-#     spack edit awscli-v2
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -23,7 +23,7 @@ class AwscliV2(AutotoolsPackage):
     depends_on("py-docutils@0.10:0.19")
     depends_on("py-cryptography@3.3.2:40.0.1")
     depends_on("py-ruamel-yaml@0.15:0.17.21")
-    depends_on("py-ruamel-yaml-clib@0.2:0.2.6")
+    depends_on("py-ruamel-yaml-clib@0.2:0.2.7")
     depends_on("py-prompt-toolkit@3.0.24:3.0.38")
     depends_on("py-distro@1.5:1.8")
     depends_on("awscrt@0.16.4:0.16.17")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -21,7 +21,7 @@ class AwscliV2(AutotoolsPackage):
     depends_on("py-pip@22:23", type=("build"))
     depends_on("py-colorama@0.2.5:0.4.6")
     depends_on("py-docutils@0.10:0.19")
-    depends_on("py-cryptography@3.3.2:39")
+    depends_on("py-cryptography@3.3.2:40.0.1")
     depends_on("py-ruamel-yaml@0.15:0.17.20")
     depends_on("py-ruamel-yaml-clib@0.2:0.2.6")
     depends_on("py-prompt-toolkit@3.0.24:3.0.38")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class AwscliV2(AutotoolsPackage):
+class AwscliV2(PythonPackage):
     """This package provides a unified command line interface to Amazon Web Services."""
 
     homepage = "https://docs.aws.amazon.com/cli"
@@ -19,14 +19,14 @@ class AwscliV2(AutotoolsPackage):
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-flit-core@3.7.1:3.8.0", type=("build"))
     depends_on("py-pip@22:23", type=("build"))
-    depends_on("py-colorama@0.2.5:0.4.6")
-    depends_on("py-docutils@0.10:0.19")
-    depends_on("py-cryptography@3.3.2:40.0.1")
-    depends_on("py-ruamel-yaml@0.15:0.17.21")
-    depends_on("py-ruamel-yaml-clib@0.2:0.2.7")
-    depends_on("py-prompt-toolkit@3.0.24:3.0.38")
-    depends_on("py-distro@1.5:1.8")
-    depends_on("awscrt@0.16.4:0.16.16")
-    depends_on("py-python-dateutil@2.1:2")
-    depends_on("py-jmespath@0.7.1:1.0")
-    depends_on("py-urllib3@1.25.4:1.26")
+    depends_on("py-colorama@0.2.5:0.4.6", type=("build", "run"))
+    depends_on("py-docutils@0.10:0.19", type=("build", "run"))
+    depends_on("py-cryptography@3.3.2:40.0.1", type=("build", "run"))
+    depends_on("py-ruamel-yaml@0.15:0.17.21", type=("build", "run"))
+    depends_on("py-ruamel-yaml-clib@0.2:0.2.7", type=("build", "run"))
+    depends_on("py-prompt-toolkit@3.0.24:3.0.38", type=("build", "run"))
+    depends_on("py-distro@1.5:1.8", type=("build", "run"))
+    depends_on("py-awscrt@0.16.4:0.16.16", type=("build", "run"))
+    depends_on("py-python-dateutil@2.1:2", type=("build", "run"))
+    depends_on("py-jmespath@0.7.1:1.0", type=("build", "run"))
+    depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -22,7 +22,7 @@ class AwscliV2(AutotoolsPackage):
     depends_on("py-colorama@0.2.5:0.4.6")
     depends_on("py-docutils@0.10:0.19")
     depends_on("py-cryptography@3.3.2:40.0.1")
-    depends_on("py-ruamel-yaml@0.15:0.17.20")
+    depends_on("py-ruamel-yaml@0.15:0.17.21")
     depends_on("py-ruamel-yaml-clib@0.2:0.2.6")
     depends_on("py-prompt-toolkit@3.0.24:3.0.38")
     depends_on("py-distro@1.5:1.8")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -18,7 +18,6 @@ class AwscliV2(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-flit-core@3.7.1:3.8.0", type=("build"))
-    depends_on("py-pip@22:23", type=("build"))
     depends_on("py-colorama@0.2.5:0.4.6", type=("build", "run"))
     depends_on("py-docutils@0.10:0.19", type=("build", "run"))
     depends_on("py-cryptography@3.3.2:40.0.1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -26,7 +26,7 @@ class AwscliV2(AutotoolsPackage):
     depends_on("py-ruamel-yaml-clib@0.2:0.2.7")
     depends_on("py-prompt-toolkit@3.0.24:3.0.38")
     depends_on("py-distro@1.5:1.8")
-    depends_on("awscrt@0.16.4:0.16.17")
+    depends_on("awscrt@0.16.4:0.16.16")
     depends_on("py-python-dateutil@2.1:2")
     depends_on("py-jmespath@0.7.1:1.0")
     depends_on("py-urllib3@1.25.4:1.26")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -17,8 +17,8 @@ class AwscliV2(AutotoolsPackage):
     version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-flit-core@3.7:3.8", type=("build")
-    depends_on("py-pip@22:23", type=("build")
+    depends_on("py-flit-core@3.7:3.8", type=("build"))
+    depends_on("py-pip@22:23", type=("build"))
     depends_on("py-colorama@0.2.5:0.4.6")
     depends_on("py-docutils@0.10:0.19")
     depends_on("py-cryptography@3.3.2:39")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -17,7 +17,7 @@ class AwscliV2(AutotoolsPackage):
     version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
 
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-flit-core@3.7:3.8", type=("build"))
+    depends_on("py-flit-core@3.7.1:3.8.0", type=("build"))
     depends_on("py-pip@22:23", type=("build"))
     depends_on("py-colorama@0.2.5:0.4.6")
     depends_on("py-docutils@0.10:0.19")

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install awscli-v2
+#
+# You can edit this file again by typing:
+#
+#     spack edit awscli-v2
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class AwscliV2(AutotoolsPackage):
+    """This package provides a unified command line interface to Amazon Web Services."""
+
+    homepage = "https://docs.aws.amazon.com/cli"
+    url = "https://github.com/aws/aws-cli/archive/refs/tags/2.13.22.tar.gz"
+
+    maintainers("climbfuji")
+
+    version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("py-flit-core@3.7:3.8", type=("build")
+    depends_on("py-pip@22:23", type=("build")
+    depends_on("py-colorama@0.2.5:0.4.6")
+    depends_on("py-docutils@0.10:0.19")
+    depends_on("py-cryptography@3.3.2:39")
+    depends_on("py-ruamel-yaml@0.15:0.17.20")
+    depends_on("py-ruamel-yaml-clib@0.2:0.2.6")
+    depends_on("py-prompt-toolkit@3.0.24:3.0.38")
+    depends_on("py-distro@1.5:1.8")
+    depends_on("awscrt@0.16.4:0.16.17")
+    depends_on("py-python-dateutil@2.1:2")
+    depends_on("py-jmespath@0.7.1:1.0")
+    depends_on("py-urllib3@1.25.4:1.26")

--- a/var/spack/repos/builtin/packages/awscrt/package.py
+++ b/var/spack/repos/builtin/packages/awscrt/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install awscli-v2
-#
-# You can edit this file again by typing:
-#
-#     spack edit awscli-v2
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/awscrt/package.py
+++ b/var/spack/repos/builtin/packages/awscrt/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install awscli-v2
+#
+# You can edit this file again by typing:
+#
+#     spack edit awscli-v2
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class Awscrt(PythonPackage):
+    """Python 3 bindings for the AWS Common Runtime."""
+
+    homepage = "https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html"
+    pypi = "awscrt/awscrt-0.16.16.tar.gz"
+
+    maintainers("climbfuji")
+
+    version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Awscrt(PythonPackage):
+class PyAwscrt(PythonPackage):
     """Python 3 bindings for the AWS Common Runtime."""
 
     homepage = "https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html"
@@ -16,5 +16,4 @@ class Awscrt(PythonPackage):
 
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
-    depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools", type=("build"))


### PR DESCRIPTION
## Description

This PR adds a new package `awscli-v2` for the `2.x.y` series of the AWS Command Line Interface. The `1.x.y` series is vastly different in its requirements and uses a different build process. I was wondering if I should try to combine the two in the existing `awscli` package or not. Seeking feedback on this decision, since I am not sure what is the best approach.

Note that this PR is also adding a missing dependency for `awscli-v2`, `py-awscrt`.

I tested building and using it on my macOS with apple-clang@13.1.6.