### PR TITLE
falco: new package @1.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -18,7 +18,7 @@ class Falco(AutotoolsPackage):
 
     depends_on("gmake", type="build")
     depends_on("zlib-ng")
-    depends_on("htslib", when="+htslib")
+    depends_on("htslib", when="+htslib", description="Add support for BAM files")
 
     def configure_args(self):
         if self.spec.satisfies("+htslib"):

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Falco(AutotoolsPackage):
+    """A C++ drop-in replacement of FastQC to assess the quality of sequence read data"""
+
+    homepage = "https://falco.readthedocs.io/"
+    url = "https://github.com/smithlabcode/falco/releases/download/v1.2.1/falco-1.2.1.tar.gz"
+
+    version("1.2.1", sha256="33de8aafac45c7aea055ed7ab837d0a39d12dcf782816cea8a6c648acb911057")
+
+    variant("htslib", default=False)
+
+    depends_on("zlib-ng")
+    # depends_on("openmpi")
+    depends_on("htslib", when="+htslib")
+
+    def configure_args(self):
+        args = ["--disable-dependency-tracking"]
+        if self.spec.satisfies("+htslib"):
+            args.append("--enable-hts")
+        return args

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Falco(AutotoolsPackage):
     """A C++ drop-in replacement of FastQC to assess the quality of sequence read data"""
 
-    homepage = "https://falco.readthedocs.io/"
+    homepage = "https://github.com/smithlabcode/falco"
     url = "https://github.com/smithlabcode/falco/releases/download/v1.2.1/falco-1.2.1.tar.gz"
 
     version("1.2.1", sha256="33de8aafac45c7aea055ed7ab837d0a39d12dcf782816cea8a6c648acb911057")

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -14,11 +14,11 @@ class Falco(AutotoolsPackage):
 
     version("1.2.1", sha256="33de8aafac45c7aea055ed7ab837d0a39d12dcf782816cea8a6c648acb911057")
 
-    variant("htslib", default=False)
+    variant("htslib", default=False, description="Add support for BAM files")
 
     depends_on("gmake", type="build")
     depends_on("zlib-ng")
-    depends_on("htslib", when="+htslib", description="Add support for BAM files")
+    depends_on("htslib", when="+htslib")
 
     def configure_args(self):
         if self.spec.satisfies("+htslib"):

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -16,11 +16,11 @@ class Falco(AutotoolsPackage):
 
     variant("htslib", default=False)
 
+    depends_on("gmake", type="build")
     depends_on("zlib-ng")
     depends_on("htslib", when="+htslib")
 
     def configure_args(self):
-        args = ["--disable-dependency-tracking"]
-        if self.spec.satisfies("+htslib"):
-            args.append("--enable-hts")
-        return args
+       if self.spec.satisfies("+htslib"):
+           return ["--enable-htslib"]
+       return []

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -21,6 +21,6 @@ class Falco(AutotoolsPackage):
     depends_on("htslib", when="+htslib")
 
     def configure_args(self):
-       if self.spec.satisfies("+htslib"):
-           return ["--enable-htslib"]
-       return []
+        if self.spec.satisfies("+htslib"):
+            return ["--enable-htslib"]
+        return []

--- a/var/spack/repos/builtin/packages/falco/package.py
+++ b/var/spack/repos/builtin/packages/falco/package.py
@@ -17,7 +17,6 @@ class Falco(AutotoolsPackage):
     variant("htslib", default=False)
 
     depends_on("zlib-ng")
-    # depends_on("openmpi")
     depends_on("htslib", when="+htslib")
 
     def configure_args(self):


### PR DESCRIPTION
Adding `falco@1.2.1`. All behaves normally except `./configure` expects `gmake` specifically and complains without it.