### PR TITLE
Fix binutils regression: fix no linker but assembler problems

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -96,13 +96,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
         when="@2.37:",
     )
     variant("ld", default=False, description="Enable ld.")
-    # When you build binutils with ~ld and +gas and load it in your PATH, you
-    # may end up with incompatibilities between a potentially older system ld
-    # and a recent assembler. For instance the linker on ubuntu 16.04 from
-    # binutils 2.26 and the assembler from binutils 2.36.1 will result in:
-    # "unable to initialize decompress status for section .debug_info"
-    # when compiling with debug symbols on gcc.
-    variant("gas", default=False, when="+ld", description="Enable as assembler.")
+    variant("gas", default=False, description="Enable as assembler.")
     variant("interwork", default=False, description="Enable interwork.")
     variant("gprofng", default=False, description="Enable gprofng.", when="@2.39:")
     variant(
@@ -161,6 +155,14 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     conflicts(
         "~lto", when="+pgo", msg="Profile-guided optimization enables link-time optimization"
     )
+
+    # When you build binutils with ~ld and +gas and load it in your PATH, you
+    # may end up with incompatibilities between a potentially older system ld
+    # and a recent assembler. For instance the linker on ubuntu 16.04 from
+    # binutils 2.26 and the assembler from binutils 2.36.1 will result in:
+    # "unable to initialize decompress status for section .debug_info"
+    # when compiling with debug symbols on gcc.
+    conflicts("+gas", "~ld", msg="Assembler not always compatible with system ld")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Make sure binutils doesn't install gas without ld.

Originally fixed by #23065, but then broken in #30738. This PR partially reverts the later.

The regression was the `when="+ld"` condition added to the variant `gas`: it made `self.enable_or_disable("gas")` stop emitting a `--disable-gas`, and binutils's configure would re-enable gas by default.
