### PR TITLE
petsc: add conflict on rocm 5.6: for now

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -160,9 +160,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     # https://github.com/spack/spack/issues/37416
     conflicts("^rocprim@5.3.0:5.3.2", when="+rocm")
     # petsc 3.20 has workaround for breaking change in hipsparseSpSV_solve api,
-    # but it seems to misdetect hipsparse@5.6.1 as 5.6.0, so the workaround doesn't
-    # help
-    conflicts("^hipsparse@5.6:", when="+rocm")
+    # but it seems to misdetect hipsparse@5.6.1 as 5.6.0, so the workaround
+    # only makes things worse
+    conflicts("^hipsparse@5.6", when="+rocm @3.20.0")
 
     # 3.8.0 has a build issue with MKL - so list this conflict explicitly
     conflicts("^intel-mkl", when="@3.8.0")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -159,6 +159,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     # https://github.com/spack/spack/issues/37416
     conflicts("^rocprim@5.3.0:5.3.2", when="+rocm")
+    # petsc 3.20 has workaround for breaking change in hipsparseSpSV_solve api,
+    # but it seems to misdetect hipsparse@5.6.1 as 5.6.0, so the workaround doesn't
+    # help
+    conflicts("^hipsparse@5.6:", when="+rocm")
 
     # 3.8.0 has a build issue with MKL - so list this conflict explicitly
     conflicts("^intel-mkl", when="@3.8.0")


### PR DESCRIPTION
petsc 3.20 has a fix to deal with a breaking change in the
`hipsparseSpSV_solve` API, except that it can't get the rocm patch
version number right, likely because rocm sets a wrong one.

See #40260
