### PR TITLE
fix ck build for 5.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/composable-kernel/package.py
+++ b/var/spack/repos/builtin/packages/composable-kernel/package.py
@@ -64,14 +64,14 @@ class ComposableKernel(CMakePackage):
         ]
         if "auto" not in self.spec.variants["amdgpu_target"]:
             args.append(self.define_from_variant("AMDGPU_TARGETS", "amdgpu_target"))
-        if "@5.6.1:" in self.spec:
+        if self.spec.satisfies("@5.6.1:"):
             args.append(self.define("INSTANCES_ONLY", "ON"))
         return args
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
             # only instances is necessary to build and install
-            if "@5.6.1:" in self.spec:
+            if self.spec.satisfies("@5.6.1:"):
                 make()
             else:
                 make("instances")

--- a/var/spack/repos/builtin/packages/composable-kernel/package.py
+++ b/var/spack/repos/builtin/packages/composable-kernel/package.py
@@ -64,9 +64,14 @@ class ComposableKernel(CMakePackage):
         ]
         if "auto" not in self.spec.variants["amdgpu_target"]:
             args.append(self.define_from_variant("AMDGPU_TARGETS", "amdgpu_target"))
+        if "@5.6.1:" in self.spec:
+            args.append(self.define("INSTANCES_ONLY", "ON"))
         return args
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
             # only instances is necessary to build and install
-            make("instances")
+            if "@5.6.1:" in self.spec:
+                make()
+            else:
+                make("instances")

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -160,6 +160,7 @@ class MiopenHip(CMakePackage):
         depends_on("nlohmann-json", type="link")
         depends_on("composable-kernel@" + ver, when="@" + ver)
     for ver in ["5.4.0", "5.4.3", "5.5.0"]:
+        depends_on("nlohmann-json", type="link")
         depends_on("rocmlir@" + ver, when="@" + ver)
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -216,6 +216,7 @@ class MiopenHip(CMakePackage):
         if self.spec.satisfies("@5.5.1:"):
             args.append(self.define("MIOPEN_USE_COMPOSABLEKERNEL", "ON"))
             args.append(self.define("MIOPEN_ENABLE_AI_KERNEL_TUNING", "OFF"))
+            args.append(self.define("MIOPEN_USE_MLIR", "OFF"))
         args.append(
             "-DNLOHMANN_JSON_INCLUDE={0}".format(self.spec["nlohmann-json"].prefix.include)
         )


### PR DESCRIPTION
This pr is to fix the following error which occurs when building composable-kernel@5.6.1:
```
make[3]: Entering directory '/tmp/root/spack-stage/spack-stage-composable-kernel-5.6.1-x5elgeyjsssifrim2shnwapog5kxgplh/spack-build-x5elgey'
make[3]: *** No rule to make target 'device_batched_gemm_multi_d_instance', needed by 'CMakeFiles/instances'.  Stop.
make[3]: Leaving directory '/tmp/root/spack-stage/spack-stage-composable-kernel-5.6.1-x5elgeyjsssifrim2shnwapog5kxgplh/spack-build-x5elgey'
make[2]: *** [CMakeFiles/Makefile2:3925: CMakeFiles/instances.dir/all] Error 2
make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-composable-kernel-5.6.1-x5elgeyjsssifrim2shnwapog5kxgplh/spack-build-x5elgey'
make[1]: *** [CMakeFiles/Makefile2:3932: CMakeFiles/instances.dir/rule] Error 2
make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-composable-kernel-5.6.1-x5elgeyjsssifrim2shnwapog5kxgplh/spack-build-x5elgey'
make: *** [Makefile:293: instances] Error 2
```
