### PR TITLE
krb5 update

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -35,6 +35,7 @@ class Krb5(AutotoolsPackage):
     depends_on("openssl")
     depends_on("gettext")
     depends_on("findutils", type="build")
+    depends_on("pkgconfig", type="build", when="^openssl~shared")
 
     variant(
         "shared", default=True, description="install shared libraries if True, static if false"
@@ -81,7 +82,9 @@ class Krb5(AutotoolsPackage):
             args.append("CFLAGS=-fcommon")
 
         if self.spec["openssl"].satisfies("~shared"):
-            args.append("LDFLAGS=-L%s -lz" % self.spec["zlib"].prefix.lib)
+            pkgconf = which("pkg-config")
+            ssllibs = pkgconf("--static", "--libs", "openssl", output=str)
+            args.append(f"LDFLAGS={ssllibs}")
 
         return args
 

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -80,6 +80,9 @@ class Krb5(AutotoolsPackage):
         if "%gcc@10:" in self.spec:
             args.append("CFLAGS=-fcommon")
 
+        if self.spec["openssl"].satisfies("~shared"):
+            args.append("LDFLAGS=-L%s -lz" % self.spec["zlib"].prefix.lib)
+
         return args
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
This PR adds support for static openssl to the krb5 recipe (currently this would fail on account of some zlib functions being undefined).