### PR TITLE
ci: pull E4S images from github instead of dockerhub

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -287,7 +287,7 @@ protected-publish:
 
 e4s-generate:
   extends: [ ".e4s", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01
+  image: ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01
 
 e4s-build:
   extends: [ ".e4s", ".build" ]
@@ -310,7 +310,7 @@ e4s-build:
 
 e4s-arm-generate:
   extends: [ ".e4s-arm", ".generate-aarch64" ]
-  image: ecpe4s/ubuntu20.04-runner-arm64-gcc-11.4:2023.08.01
+  image: ghcr.io/spack/ubuntu20.04-runner-arm64-gcc-11.4:2023.08.01
 
 e4s-arm-build:
   extends: [ ".e4s-arm", ".build" ]
@@ -333,7 +333,7 @@ e4s-arm-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-amd64-gcc-11.4-rocm5.4.3:2023.08.01
+  image: ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4-rocm5.4.3:2023.08.01
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]
@@ -379,7 +379,7 @@ gpu-tests-build:
 
 e4s-oneapi-generate:
   extends: [ ".e4s-oneapi", ".generate-x86_64"]
-  image: ecpe4s/ubuntu20.04-runner-amd64-oneapi-2023.2.1:2023.08.01
+  image: ghcr.io/spack/ubuntu20.04-runner-amd64-oneapi-2023.2.1:2023.08.01
 
 e4s-oneapi-build:
   extends: [ ".e4s-oneapi", ".build" ]
@@ -396,7 +396,7 @@ e4s-oneapi-build:
 # E4S on Power
 ########################################
 .e4s-power-generate-tags-and-image:
-  image: { "name": "ecpe4s/ubuntu20.04-runner-ppc64-gcc-11.4:2023.08.01", "entrypoint": [""] }
+  image: { "name": "ghcr.io/spack/ubuntu20.04-runner-ppc64-gcc-11.4:2023.08.01", "entrypoint": [""] }
   tags: ["spack", "public", "large", "ppc64le"]
 
 .e4s-power:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
@@ -187,7 +187,7 @@ spack:
   - veloc
   # - visit                         # silo: https://github.com/spack/spack/issues/39538
   - vtk-m
-  - zfp 
+  - zfp
   # --
   # - dealii                        # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
   # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs@0.7.3: gcc: error: unrecognized command-line option '-mno-sse2'
@@ -205,7 +205,7 @@ spack:
   # --
   # - legion +cuda                    # legion: needs NVIDIA driver
 
-  # CUDA 75  
+  # CUDA 75
   - amrex +cuda cuda_arch=75
   - arborx +cuda cuda_arch=75 ^kokkos +wrapper
   - cabana +cuda cuda_arch=75 ^kokkos +wrapper +cuda_lambda +cuda cuda_arch=75
@@ -245,7 +245,7 @@ spack:
   # - ecp-data-vis-sdk +adios2 +hdf5 +vtkm +zfp +paraview +cuda cuda_arch=75  # embree: https://github.com/spack/spack/issues/39534
   # - lammps +cuda cuda_arch=75     # lammps: needs NVIDIA driver
   # - lbann +cuda cuda_arch=75      # lbann: https://github.com/spack/spack/issues/38788
-  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=75 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787 
+  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=75 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787
   # - py-torch +cuda cuda_arch=75   # skipped, installed by other means
   # - slepc +cuda cuda_arch=75      # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
   # - upcxx +cuda cuda_arch=75      # upcxx: needs NVIDIA driver
@@ -290,7 +290,7 @@ spack:
   # - ecp-data-vis-sdk +adios2 +hdf5 +vtkm +zfp +paraview +cuda cuda_arch=80 # embree: https://github.com/spack/spack/issues/39534
   # - lammps +cuda cuda_arch=80     # lammps: needs NVIDIA driver
   # - lbann +cuda cuda_arch=80      # lbann: https://github.com/spack/spack/issues/38788
-  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=80 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787 
+  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=80 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787
   # - py-torch +cuda cuda_arch=80   # skipped, installed by other means
   # - slepc +cuda cuda_arch=80      # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
   # - upcxx +cuda cuda_arch=80      # upcxx: needs NVIDIA driver
@@ -333,7 +333,7 @@ spack:
   # - hypre +cuda cuda_arch=90      # concretizer: hypre +cuda requires cuda@:11, but cuda_arch=90 requires cuda@12:
   # - lammps +cuda cuda_arch=90     # lammps: needs NVIDIA driver
   # - lbann +cuda cuda_arch=90      # concretizer: Cannot select a single "version" for package "lbann"
-  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=90 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787 
+  # - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf ~cusz +mgard +cuda cuda_arch=90 # libpressio: CMake Error at CMakeLists.txt:498 (find_library): Could not find CUFile_LIBRARY using the following names: cufile ; +cusz: https://github.com/spack/spack/issues/38787
   # - omega-h +cuda cuda_arch=90    # omega-h: https://github.com/spack/spack/issues/39535
   # - py-torch +cuda cuda_arch=90   # skipped, installed by other means
   # - slepc +cuda cuda_arch=90      # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
@@ -345,7 +345,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ecpe4s/ubuntu20.04-runner-arm64-gcc-11.4:2023.08.01"
+        image: "ghcr.io/spack/ubuntu20.04-runner-arm64-gcc-11.4:2023.08.01"
 
   cdash:
     build-group: E4S ARM

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -135,7 +135,7 @@ spack:
   - lammps
   - lbann
   - legion
-  - libnrm 
+  - libnrm
   - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp
   - libquo
   - libunwind
@@ -241,7 +241,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu20.04-runner-amd64-oneapi-2023.2.1:2023.08.01
+        image: ghcr.io/spack/ubuntu20.04-runner-amd64-oneapi-2023.2.1:2023.08.01
 
   cdash:
     build-group: E4S OneAPI

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -189,7 +189,7 @@ spack:
   # - visit                                 # libext, libxkbfile, libxrender, libxt, silo (https://github.com/spack/spack/issues/39538), cairo
   - vtk-m
   - zfp
-  # -- 
+  # --
   # - archer                                # part of llvm +omp_tsan
   # - dealii                                # fltk: https://github.com/spack/spack/issues/38791
   # - geopm                                 # geopm: https://github.com/spack/spack/issues/38798
@@ -256,7 +256,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu20.04-runner-ppc64-gcc-11.4:2023.08.01
+        image: ghcr.io/spack/ubuntu20.04-runner-ppc64-gcc-11.4:2023.08.01
 
   cdash:
     build-group: E4S Power

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -230,7 +230,7 @@ spack:
       buildable: false
       externals:
       - spec: hipsolver@5.4.3
-        prefix: /opt/rocm-5.4.3 
+        prefix: /opt/rocm-5.4.3
     rocsolver:
       buildable: false
       externals:
@@ -340,7 +340,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ecpe4s/ubuntu20.04-runner-amd64-gcc-11.4-rocm5.4.3:2023.08.01"
+        image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4-rocm5.4.3:2023.08.01"
 
   cdash:
     build-group: E4S ROCm External

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -387,7 +387,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ecpe4s/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
+        image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
 
   cdash:
     build-group: E4S


### PR DESCRIPTION
I've re-tagged and pushed the new images to `ghcr.io`, and made them public, see [here](https://github.com/orgs/spack/packages?page=3).