### PR TITLE
e4s arm: disable bricks due to graviton3 issue

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
@@ -81,7 +81,6 @@ spack:
   - axom
   - bolt
   - boost
-  - bricks ~cuda
   - butterflypack
   - cabana
   - caliper
@@ -90,6 +89,7 @@ spack:
   - conduit
   - datatransferkit
   - dyninst
+  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp  # +visit: ?
   - exaworks
   - flecsi
   - flit
@@ -189,21 +189,21 @@ spack:
   - vtk-m
   - zfp 
   # --
-  # - dealii                        # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
-  # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs@0.7.3: gcc: error: unrecognized command-line option '-mno-sse2'
   # - archer                        # part of llvm +omp_tsan
-  - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp  # +visit: ?
+  # - bricks ~cuda                  # not respecting target=aarch64?
+  # - dealii                        # slepc: make[1]: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo1313'.
   # - geopm                         # geopm: https://github.com/spack/spack/issues/38795
+  # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs@0.7.3: gcc: error: unrecognized command-line option '-mno-sse2'
   # - variorum                      # variorum: https://github.com/spack/spack/issues/38786
 
   # CUDA NOARCH
-  - bricks +cuda
   - flux-core +cuda
   - hpctoolkit +cuda
   - papi +cuda
   - tau +mpi +cuda
   # --
-  # - legion +cuda                    # legion: needs NVIDIA driver
+  # - bricks +cuda                  # not respecting target=aarch64?
+  # - legion +cuda                  # legion: needs NVIDIA driver
 
   # CUDA 75  
   - amrex +cuda cuda_arch=75


### PR DESCRIPTION
Bricks built OK on graviton2 but then failed to build numerous times on graviton3, unsure why.

This PR suspends ARM CI builds of bricks until we can figure out what is going on.

Successful CI builds on Graviton2
* [bricks/pxdtk7m 2023.08.25 gcc@=11.4.0 linux-ubuntu20.04-aarch64 E4S ARM](https://gitlab.spack.io/spack/spack/-/jobs/8431441)
* [bricks/6kspdys 2023.08.25 gcc@=11.4.0 linux-ubuntu20.04-aarch64 E4S ARM](https://gitlab.spack.io/spack/spack/-/jobs/8432324)

Failed CI builds on Graviton3
* [bricks/pxdtk7m 2023.08.25 gcc@=11.4.0 linux-ubuntu20.04-aarch64 E4S ARM](https://gitlab.spack.io/spack/spack/-/jobs/8430696)
* [bricks/6kspdys 2023.08.25 gcc@=11.4.0 linux-ubuntu20.04-aarch64 E4S ARM](https://gitlab.spack.io/spack/spack/-/jobs/8480384)

CC @scottwittenburg @drhansj @ztuowen