### PR TITLE
e4s-arm: drop bricks

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-arm/spack.yaml
@@ -81,7 +81,8 @@ spack:
   - axom
   - bolt
   - boost
-  - bricks ~cuda
+  # bricks needs work: no releases, faulty vectorization detection, -march=native ...
+  # - bricks ~cuda
   - butterflypack
   - cabana
   - caliper


### PR DESCRIPTION
- Fails to build because it doesn't test whether 512 bit sve vectorization is supported
- Doesn't have any releases
- Sets -march/-mcpu=native unconditionally


Better to drop this package untill they fix the package: https://github.com/CtopCsUtahEdu/bricklib/issues/10
