### PR TITLE
add recipes for sphinx-book-theme and its dependencies if unknown

### DIFF
--- a/var/spack/repos/builtin/packages/py-accessible-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-accessible-pygments/package.py
@@ -16,3 +16,4 @@ class PyAccessiblePygments(PythonPackage):
     version("0.0.4", sha256="e7b57a9b15958e9601c7e9eb07a440c813283545a20973f2574a5f453d0e953e")
 
     depends_on("py-pygments@1.5:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-accessible-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-accessible-pygments/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAccessiblePygments(PythonPackage):
+    """This package includes a collection of accessible themes for pygments based on
+    different sources."""
+
+    homepage = "https://github.com/Quansight-Labs/accessible-pygments"
+    pypi = "accessible-pygments/accessible-pygments-0.0.4.tar.gz"
+
+    version("0.0.4", sha256="e7b57a9b15958e9601c7e9eb07a440c813283545a20973f2574a5f453d0e953e")
+
+    depends_on("py-pygments@1.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pydata-sphinx-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-pydata-sphinx-theme/package.py
@@ -20,7 +20,7 @@ class PyPydataSphinxTheme(PythonPackage):
 
     depends_on("py-sphinx@5:", type=("build", "run"))
     depends_on("py-beautifulsoup4", type=("build", "run"))
-    depends_on("py-docutils@:0.16.999,0.17.1:", type=("build", "run"))
+    depends_on("py-docutils@:0.16,0.17.1:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))
     depends_on("py-babel", type=("build", "run"))
     depends_on("py-pygments@2.7:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pydata-sphinx-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-pydata-sphinx-theme/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPydataSphinxTheme(PythonPackage):
+    """A clean, three-column, Bootstrap-based Sphinx theme by and for the PyData community."""
+
+    homepage = "https://pydata-sphinx-theme.readthedocs.io/en/stable"
+    pypi = "pydata_sphinx_theme/pydata_sphinx_theme-0.14.1.tar.gz"
+
+    version("0.14.1", sha256="d8d4ac81252c16a002e835d21f0fea6d04cf3608e95045c816e8cc823e79b053")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-sphinx-theme-builder", type="build")
+
+    depends_on("py-sphinx@5:", type=("build", "run"))
+    depends_on("py-beautifulsoup4", type=("build", "run"))
+    depends_on("py-docutils@:0.16.999,0.17.1:", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"))
+    depends_on("py-babel", type=("build", "run"))
+    depends_on("py-pygments@2.7:", type=("build", "run"))
+    depends_on("py-accessible-pygments", type=("build", "run"))
+    depends_on("py-typing-extensions", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PySphinxBookTheme(PythonPackage):
     """Lightweight Sphinx theme designed to mimic the look-and-feel of an interactive book."""
 
-    homepage = "://sphinx-book-theme.readthedocs.io/en/latest"
+    homepage = "https://sphinx-book-theme.readthedocs.io/en/latest"
     pypi = "sphinx_book_theme/sphinx_book_theme-1.0.1.tar.gz"
 
     version("1.0.1", sha256="927b399a6906be067e49c11ef1a87472f1b1964075c9eea30fb82c64b20aedee")
@@ -18,5 +18,5 @@ class PySphinxBookTheme(PythonPackage):
 
     depends_on("py-sphinx-theme-builder@0.2.0a7:", type="build")
 
-    depends_on("py-sphinx@4:6.999", type=("build", "run"))
+    depends_on("py-sphinx@4:6", type=("build", "run"))
     depends_on("py-pydata-sphinx-theme@0.13.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-book-theme/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxBookTheme(PythonPackage):
+    """Lightweight Sphinx theme designed to mimic the look-and-feel of an interactive book."""
+
+    homepage = "://sphinx-book-theme.readthedocs.io/en/latest"
+    pypi = "sphinx_book_theme/sphinx_book_theme-1.0.1.tar.gz"
+
+    version("1.0.1", sha256="927b399a6906be067e49c11ef1a87472f1b1964075c9eea30fb82c64b20aedee")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-sphinx-theme-builder@0.2.0a7:", type="build")
+
+    depends_on("py-sphinx@4:6.999", type=("build", "run"))
+    depends_on("py-pydata-sphinx-theme@0.13.3:", type=("build", "run"))


### PR DESCRIPTION
`sphinx-book-theme` is a lightweight `sphinx` theme. I also added recipes for `accessible-pygments` and `pydata-sphinx-theme`.