### PR TITLE
elfutils: Fix +debuginfod again

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -85,10 +85,10 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     provides("elf@1")
 
-    # libarchive with iconv doesn't configure.
+    # libarchive with iconv doesn't configure (still broken as of libarchive@3.7.1)
     # see https://github.com/spack/spack/issues/36710
     # and https://github.com/libarchive/libarchive/issues/1819
-    conflicts("^libarchive@3.6.2 +iconv", when="+debuginfod")
+    conflicts("^libarchive +iconv", when="+debuginfod")
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=24964
     conflicts("%apple-clang")


### PR DESCRIPTION
Fix regression on the fix for #36710: the issue reappeared since new libarchive versions #39646.

The issue is not yet fixed upstream (see links in comment), so I just apply the workaround to all versions of libarchive. Until it is fixed upstream, and we can add the version constraint back.


