### PR TITLE
whizard: Make sure to detect LCIO if requested

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -103,6 +103,8 @@ class Whizard(AutotoolsPackage):
         # and seems incompatible with
         # filter_compiler_wrappers, thus the
         # actual compilers need to be used to build
+        if self.spec.satisfies("+lcio"):
+            env.set("LCIO", self.spec["lcio"].prefix)
         env.set("CC", self.compiler.cc)
         env.set("CXX", self.compiler.cxx)
         env.set("FC", self.compiler.fc)


### PR DESCRIPTION
Whizard depends on `LCIO` being set to the install prefix of LCIO it should link against during configure time to detect it.

Fixes key4hep/key4hep-spack#533