### PR TITLE
GCC: fix build with Apple Clang 15

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -783,6 +783,11 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                     "--with-as=" + binutils.join("as"),
                 ]
             )
+        elif spec.satisfies("%apple-clang@15:"):
+            # https://github.com/iains/gcc-darwin-arm64/issues/117
+            # https://github.com/iains/gcc-12-branch/issues/22
+            # https://github.com/iains/gcc-13-branch/issues/8
+            options.append("--with-ld=/Library/Developer/CommandLineTools/usr/bin/ld-classic")
 
         # enable_bootstrap
         if spec.satisfies("+bootstrap"):


### PR DESCRIPTION
Another version of Apple Clang, another broken GCC build 😄 

This will allegedly be fixed in a future Xcode patch release, but I don't know when. Ping me when the next release comes out and I'll be happy to test. Until then, it's probably safer to leave the upper bound open ended.