### PR TITLE
Add static support for proj

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -166,7 +166,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         args.extend(self.enable_or_disable("shared"))
         args.extend(self.with_or_without("pic"))
 
-        if self.spec["libtiff"].satisfies("+jpeg~shared"):
+        if self.spec.satisfies("^libtiff+jpeg~shared"):
             args.append("LDFLAGS=%s" % self.spec["jpeg"].libs.ld_flags)
             args.append("LIBS=%s" % self.spec["jpeg"].libs.link_flags)
 

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -56,18 +56,8 @@ class Proj(CMakePackage, AutotoolsPackage):
 
     variant("tiff", default=True, description="Enable TIFF support")
     variant("curl", default=True, description="Enable curl support")
-    variant(
-        "shared",
-        default=True,
-        description="Enable shared libraries",
-        when="build_system=autotools",
-    )
-    variant(
-        "pic",
-        default=False,
-        description="Enable position-independent code (PIC)",
-        when="build_system=autotools",
-    )
+    variant("shared", default=True, description="Enable shared libraries")
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
 
     # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/PROJ-data
@@ -142,6 +132,8 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         args = [
             self.define_from_variant("ENABLE_TIFF", "tiff"),
             self.define_from_variant("ENABLE_CURL", "curl"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -56,8 +56,18 @@ class Proj(CMakePackage, AutotoolsPackage):
 
     variant("tiff", default=True, description="Enable TIFF support")
     variant("curl", default=True, description="Enable curl support")
-    variant("shared", default=True, description="Enable shared libraries", when="build_system=autotools")
-    variant("pic", default=False, description="Enable position-independent code (PIC)", when="build_system=autotools")
+    variant(
+        "shared",
+        default=True,
+        description="Enable shared libraries",
+        when="build_system=autotools",
+    )
+    variant(
+        "pic",
+        default=False,
+        description="Enable position-independent code (PIC)",
+        when="build_system=autotools",
+    )
 
     # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/PROJ-data

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -56,8 +56,8 @@ class Proj(CMakePackage, AutotoolsPackage):
 
     variant("tiff", default=True, description="Enable TIFF support")
     variant("curl", default=True, description="Enable curl support")
-    variant("shared", default=True, description="Enable shared libraries")
-    variant("pic", default=False, description="Enable position-independent code (PIC)")
+    variant("shared", default=True, description="Enable shared libraries", when="build_system=autotools")
+    variant("pic", default=False, description="Enable position-independent code (PIC)", when="build_system=autotools")
 
     # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/PROJ-data

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -56,6 +56,7 @@ class Proj(CMakePackage, AutotoolsPackage):
 
     variant("tiff", default=True, description="Enable TIFF support")
     variant("curl", default=True, description="Enable curl support")
+    variant("shared", default=True, description="Enable shared libraries")
 
     # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/PROJ-data
@@ -144,14 +145,13 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
             args.append("--with-external-gtest")
 
         if self.spec.satisfies("@7:"):
-            if "+tiff" in self.spec:
-                args.append("--enable-tiff")
-            else:
-                args.append("--disable-tiff")
+            args.extend(self.enable_or_disable("tiff"))
 
             if "+curl" in self.spec:
                 args.append("--with-curl=" + self.spec["curl"].prefix.bin.join("curl-config"))
             else:
                 args.append("--without-curl")
+
+        args.extend(self.enable_or_disable("shared"))
 
         return args

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -154,4 +154,8 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
 
         args.extend(self.enable_or_disable("shared"))
 
+        if self.spec["libtiff"].satisfies("+jpeg~shared"):
+            args.append("LDFLAGS=%s" % self.spec["jpeg"].libs.ld_flags)
+            args.append("LIBS=%s" % self.spec["jpeg"].libs.link_flags)
+
         return args

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -57,6 +57,7 @@ class Proj(CMakePackage, AutotoolsPackage):
     variant("tiff", default=True, description="Enable TIFF support")
     variant("curl", default=True, description="Enable curl support")
     variant("shared", default=True, description="Enable shared libraries")
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
 
     # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/PROJ-data
@@ -153,6 +154,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
                 args.append("--without-curl")
 
         args.extend(self.enable_or_disable("shared"))
+        args.extend(self.with_or_without("pic"))
 
         if self.spec["libtiff"].satisfies("+jpeg~shared"):
             args.append("LDFLAGS=%s" % self.spec["jpeg"].libs.ld_flags)


### PR DESCRIPTION
This PR adds static and pic variants to the proj package, as well as support for static libtiff dependency for build_system=autotools (there doesn't seem to be a clean solution for cmake-built proj).