### PR TITLE
relion: add version 4.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -17,6 +17,7 @@ class Relion(CMakePackage, CudaPackage):
     url = "https://github.com/3dem/relion/archive/4.0.0.zip"
     maintainers("dacolombo")
 
+    version("4.0.1", sha256="7e0d56fd4068c99f943dc309ae533131d33870392b53a7c7aae7f65774f667be")
     version("4.0.0", sha256="0987e684e9d2dfd630f1ad26a6847493fe9fcd829ec251d8bc471d11701d51dd")
 
     # 3.1.4 latest release in 3.1 branch
@@ -89,6 +90,12 @@ class Relion(CMakePackage, CudaPackage):
     depends_on("mkl", when="+mklfft")
     depends_on("ctffind", type="run")
     depends_on("motioncor2", type="run", when="+external_motioncor2")
+
+    conflicts(
+        "^cuda@12:",
+        when="@:4.0.0",
+        msg="Cuda version >= 12 support requires RELION version 4.0.1 or later.",
+    )
 
     # TODO: more externals to add
     # Spack packages needed


### PR DESCRIPTION
Add RELION version 4.0.1.
This version fixes a compilation issue with CUDA 12, so a conflict is also added to reflect this.