### PR TITLE
Unify directive dict structure

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -967,10 +967,10 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
             summary = f"{pkg_name}: wrong 'when=' condition for the '{provided}' virtual"
             errors.extend(_extracts_errors(triggers, summary))
 
-        for _, triggers in pkg_cls.requirements.items():
-            triggers = [when_spec for when_spec, _, _ in triggers]
-            summary = f"{pkg_name}: wrong 'when=' condition in 'requires' directive"
-            errors.extend(_extracts_errors(triggers, summary))
+        for when, requirements, details in _error_items(pkg_cls.requirements):
+            errors.append(
+                error_cls(f"{pkg_name}: wrong 'when=' condition in 'requires' directive", details)
+            )
 
         for when, _, details in _error_items(pkg_cls.patches):
             errors.append(

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -667,8 +667,8 @@ def _unknown_variants_in_directives(pkgs, error_cls):
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
         # Check "conflicts" directive
-        for conflict, triggers in pkg_cls.conflicts.items():
-            for trigger, _ in triggers:
+        for trigger, conflicts in pkg_cls.conflicts.items():
+            for conflict, _ in conflicts:
                 vrn = spack.spec.Spec(conflict)
                 try:
                     vrn.constrain(trigger)

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -694,15 +694,13 @@ def _unknown_variants_in_directives(pkgs, error_cls):
                 )
 
         # Check "depends_on" directive
-        for _, triggers in pkg_cls.dependencies.items():
-            triggers = list(triggers)
-            for trigger in list(triggers):
-                vrn = spack.spec.Spec(trigger)
-                errors.extend(
-                    _analyze_variants_in_directive(
-                        pkg_cls, vrn, directive="depends_on", error_cls=error_cls
-                    )
+        for trigger in pkg_cls.dependencies:
+            vrn = spack.spec.Spec(trigger)
+            errors.extend(
+                _analyze_variants_in_directive(
+                    pkg_cls, vrn, directive="depends_on", error_cls=error_cls
                 )
+            )
 
         # Check "patch" directive
         for _, triggers in pkg_cls.provided.items():
@@ -736,70 +734,60 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         filename = spack.repo.PATH.filename_for_package_name(pkg_name)
-        for dependency_name, dependency_data in pkg_cls.dependencies.items():
-            # Check if there are nested dependencies declared. We don't want directives like:
-            #
-            #     depends_on('foo+bar ^fee+baz')
-            #
-            # but we'd like to have two dependencies listed instead.
-            for when, dependency_edge in dependency_data.items():
-                dependency_spec = dependency_edge.spec
-                nested_dependencies = dependency_spec.dependencies()
+
+        for when, deps_by_name in pkg_cls.dependencies.items():
+            for dep_name, dep in deps_by_name.items():
+                # Check if there are nested dependencies declared. We don't want directives like:
+                #
+                #     depends_on('foo+bar ^fee+baz')
+                #
+                # but we'd like to have two dependencies listed instead.
+                nested_dependencies = dep.spec.dependencies()
                 if nested_dependencies:
-                    summary = (
-                        f"{pkg_name}: invalid nested dependency "
-                        f"declaration '{str(dependency_spec)}'"
-                    )
+                    summary = f"{pkg_name}: nested dependency declaration '{dep.spec}'"
+                    ndir = len(nested_dependencies) + 1
                     details = [
-                        f"split depends_on('{str(dependency_spec)}', when='{str(when)}') "
-                        f"into {len(nested_dependencies) + 1} directives",
+                        f"split depends_on('{dep.spec}', when='{when}') into {ndir} directives",
                         f"in {filename}",
                     ]
                     errors.append(error_cls(summary=summary, details=details))
 
-                for s in (dependency_spec, when):
-                    if s.virtual and s.variants:
-                        summary = f"{pkg_name}: virtual dependency cannot have variants"
-                        details = [
-                            f"remove variants from '{str(s)}' in depends_on directive",
-                            f"in {filename}",
-                        ]
-                        errors.append(error_cls(summary=summary, details=details))
+                # No need to analyze virtual packages
+                if spack.repo.PATH.is_virtual(dep_name):
+                    continue
 
-            # No need to analyze virtual packages
-            if spack.repo.PATH.is_virtual(dependency_name):
-                continue
+                # check for unknown dependencies
+                try:
+                    dependency_pkg_cls = spack.repo.PATH.get_pkg_class(dep_name)
+                except spack.repo.UnknownPackageError:
+                    # This dependency is completely missing, so report
+                    # and continue the analysis
+                    summary = (
+                        f"{pkg_name}: unknown package '{dep_name}' in " "'depends_on' directive"
+                    )
+                    details = [f" in {filename}"]
+                    errors.append(error_cls(summary=summary, details=details))
+                    continue
 
-            try:
-                dependency_pkg_cls = spack.repo.PATH.get_pkg_class(dependency_name)
-            except spack.repo.UnknownPackageError:
-                # This dependency is completely missing, so report
-                # and continue the analysis
-                summary = pkg_name + ": unknown package '{0}' in " "'depends_on' directive".format(
-                    dependency_name
-                )
-                details = [" in " + filename]
-                errors.append(error_cls(summary=summary, details=details))
-                continue
-
-            for _, dependency_edge in dependency_data.items():
-                dependency_variants = dependency_edge.spec.variants
+                # check variants
+                dependency_variants = dep.spec.variants
                 for name, value in dependency_variants.items():
                     try:
                         v, _ = dependency_pkg_cls.variants[name]
                         v.validate_or_raise(value, pkg_cls=dependency_pkg_cls)
                     except Exception as e:
                         summary = (
-                            pkg_name + ": wrong variant used for a "
-                            "dependency in a 'depends_on' directive"
+                            f"{pkg_name}: wrong variant used for dependency in 'depends_on()'"
                         )
-                        error_msg = str(e).strip()
+
                         if isinstance(e, KeyError):
-                            error_msg = "the variant {0} does not " "exist".format(error_msg)
-                        error_msg += " in package '" + dependency_name + "'"
+                            error_msg = (
+                                f"variant {str(e).strip()} does not exist in package {dep_name}"
+                            )
+                        error_msg += f" in package '{dep_name}'"
 
                         errors.append(
-                            error_cls(summary=summary, details=[error_msg, "in " + filename])
+                            error_cls(summary=summary, details=[error_msg, f"in {filename}"])
                         )
 
     return errors
@@ -866,14 +854,17 @@ def _version_constraints_are_satisfiable_by_some_version_in_repo(pkgs, error_cls
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
         filename = spack.repo.PATH.filename_for_package_name(pkg_name)
-        dependencies_to_check = []
-        for dependency_name, dependency_data in pkg_cls.dependencies.items():
-            # Skip virtual dependencies for the time being, check on
-            # their versions can be added later
-            if spack.repo.PATH.is_virtual(dependency_name):
-                continue
 
-            dependencies_to_check.extend([edge.spec for edge in dependency_data.values()])
+        dependencies_to_check = []
+
+        for _, deps_by_name in pkg_cls.dependencies.items():
+            for dep_name, dep in deps_by_name.items():
+                # Skip virtual dependencies for the time being, check on
+                # their versions can be added later
+                if spack.repo.PATH.is_virtual(dep_name):
+                    continue
+
+                dependencies_to_check.append(dep.spec)
 
         host_architecture = spack.spec.ArchSpec.default_arch()
         for s in dependencies_to_check:
@@ -945,18 +936,28 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
+        def _refers_to_pkg(when):
+            when_spec = spack.spec.Spec(when)
+            return when_spec.name is None or when_spec.name == pkg_name
+
+        def _error_items(when_dict):
+            for when, elts in when_dict.items():
+                if not _refers_to_pkg(when):
+                    yield when, elts, [f"using '{when}', should be '^{when}'"]
+
         def _extracts_errors(triggers, summary):
             _errors = []
             for trigger in list(triggers):
-                when_spec = spack.spec.Spec(trigger)
-                if when_spec.name is not None and when_spec.name != pkg_name:
+                if not _refers_to_pkg(trigger):
                     details = [f"using '{trigger}', should be '^{trigger}'"]
                     _errors.append(error_cls(summary=summary, details=details))
             return _errors
 
-        for dname, triggers in pkg_cls.dependencies.items():
-            summary = f"{pkg_name}: wrong 'when=' condition for the '{dname}' dependency"
-            errors.extend(_extracts_errors(triggers, summary))
+        for when, dnames, details in _error_items(pkg_cls.dependencies):
+            errors.extend(
+                error_cls(f"{pkg_name}: wrong 'when=' condition for '{dname}' dependency", details)
+                for dname in dnames
+            )
 
         for vname, (variant, triggers) in pkg_cls.variants.items():
             summary = f"{pkg_name}: wrong 'when=' condition for the '{vname}' variant"
@@ -971,13 +972,15 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
             summary = f"{pkg_name}: wrong 'when=' condition in 'requires' directive"
             errors.extend(_extracts_errors(triggers, summary))
 
-        triggers = list(pkg_cls.patches)
-        summary = f"{pkg_name}: wrong 'when=' condition in 'patch' directives"
-        errors.extend(_extracts_errors(triggers, summary))
+        for when, _, details in _error_items(pkg_cls.patches):
+            errors.append(
+                error_cls(f"{pkg_name}: wrong 'when=' condition in 'patch' directives", details)
+            )
 
-        triggers = list(pkg_cls.resources)
-        summary = f"{pkg_name}: wrong 'when=' condition in 'resource' directives"
-        errors.extend(_extracts_errors(triggers, summary))
+        for when, _, details in _error_items(pkg_cls.resources):
+            errors.append(
+                error_cls(f"{pkg_name}: wrong 'when=' condition in 'resource' directives", details)
+            )
 
     return llnl.util.lang.dedupe(errors)
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -474,13 +474,7 @@ def print_virtuals(pkg, args):
     color.cprint("")
     color.cprint(section_title("Virtual Packages: "))
     if pkg.provided:
-        inverse_map = {}
-        for spec, whens in pkg.provided.items():
-            for when in whens:
-                if when not in inverse_map:
-                    inverse_map[when] = set()
-                inverse_map[when].add(spec)
-        for when, specs in reversed(sorted(inverse_map.items())):
+        for when, specs in reversed(sorted(pkg.provided.items())):
             line = "    %s provides %s" % (
                 when.colorized(),
                 ", ".join(s.colorized() for s in specs),

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1580,6 +1580,49 @@ def fetch_remote_configs(url: str, dest_dir: str, skip_existing: bool = True) ->
     raise ConfigFileError(f"Cannot retrieve configuration (yaml) from {url}")
 
 
+def get_mark_from_yaml_data(obj):
+    """Try to get ``spack.util.spack_yaml`` mark from YAML data.
+
+    We try the object, and if that fails we try its first member (if it's a container).
+
+    Returns:
+        mark if one is found, otherwise None.
+    """
+    # mark of object itelf
+    mark = getattr(obj, "_start_mark", None)
+    if mark:
+        return mark
+
+    # mark of first member if it is a container
+    if isinstance(obj, (list, dict)):
+        first_member = next(iter(obj), None)
+        if first_member:
+            mark = getattr(first_member, "_start_mark", None)
+
+    return mark
+
+
+def parse_spec_from_yaml_string(string: str) -> "spack.spec.Spec":
+    """Parse a spec from YAML and add file/line info to errors, if it's available.
+
+    Parse a ``Spec`` from the supplied string, but also intercept any syntax errors and
+    add file/line information for debugging using file/line annotations from the string.
+
+    Arguments:
+        string: a string representing a ``Spec`` from config YAML.
+
+    """
+    try:
+        spec = spack.spec.Spec(string)
+        return spec
+    except spack.parser.SpecSyntaxError as e:
+        mark = spack.config.get_mark_from_yaml_data(string)
+        if mark:
+            msg = f"{mark.name}:{mark.line + 1}: {str(e)}"
+            raise spack.parser.SpecSyntaxError(msg) from e
+        raise e
+
+
 class ConfigError(SpackError):
     """Superclass for all Spack config related errors."""
 
@@ -1625,23 +1668,9 @@ class ConfigFormatError(ConfigError):
     def _get_mark(self, validation_error, data):
         """Get the file/line mark fo a validation error from a Spack YAML file."""
 
-        def _get_mark_or_first_member_mark(obj):
-            # mark of object itelf
-            mark = getattr(obj, "_start_mark", None)
-            if mark:
-                return mark
-
-            # mark of first member if it is a container
-            if isinstance(obj, (list, dict)):
-                first_member = next(iter(obj), None)
-                if first_member:
-                    mark = getattr(first_member, "_start_mark", None)
-                    if mark:
-                        return mark
-
         # Try various places, starting with instance and parent
         for obj in (validation_error.instance, validation_error.parent):
-            mark = _get_mark_or_first_member_mark(obj)
+            mark = get_mark_from_yaml_data(obj)
             if mark:
                 return mark
 

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -79,4 +79,7 @@ class Dependency:
 
     def __repr__(self) -> str:
         types = dt.flag_to_chars(self.depflag)
-        return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}]>"
+        if self.patches:
+            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}, {self.patches}]>"
+        else:
+            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}]>"

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -91,7 +91,7 @@ Patcher = Callable[[Union["spack.package_base.PackageBase", Dependency]], None]
 PatchesType = Optional[Union[Patcher, str, List[Union[Patcher, str]]]]
 
 
-def make_when_spec(value: WhenType) -> Optional["spack.spec.Spec"]:
+def _make_when_spec(value: WhenType) -> Optional["spack.spec.Spec"]:
     """Create a ``Spec`` that indicates when a directive should be applied.
 
     Directives with ``when`` specs, e.g.:
@@ -471,7 +471,7 @@ def _depends_on(
     type: DepType = dt.DEFAULT_TYPES,
     patches: PatchesType = None,
 ):
-    when_spec = make_when_spec(when)
+    when_spec = _make_when_spec(when)
     if not when_spec:
         return
 
@@ -547,7 +547,7 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
 
     def _execute_conflicts(pkg: "spack.package_base.PackageBase"):
         # If when is not specified the conflict always holds
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 
@@ -599,7 +599,7 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
     """
 
     def _execute_extends(pkg):
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 
@@ -627,7 +627,7 @@ def provides(*specs, when: Optional[str] = None):
     def _execute_provides(pkg):
         import spack.parser  # Avoid circular dependency
 
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 
@@ -685,7 +685,7 @@ def patch(
                 "Patches are not allowed in {0}: package has no code.".format(pkg.name)
             )
 
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 
@@ -813,7 +813,7 @@ def variant(
     description = str(description).strip()
 
     def _execute_variant(pkg):
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         when_specs = [when_spec]
 
         if not re.match(spack.spec.IDENTIFIER_RE, name):
@@ -855,7 +855,7 @@ def resource(**kwargs):
 
     def _execute_resource(pkg):
         when = kwargs.get("when")
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 
@@ -921,17 +921,17 @@ def maintainers(*names: str):
 
 def _execute_license(pkg, license_identifier: str, when):
     # If when is not specified the license always holds
-    when_spec = make_when_spec(when)
+    when_spec = _make_when_spec(when)
     if not when_spec:
         return
 
     for other_when_spec in pkg.licenses:
         if when_spec.intersects(other_when_spec):
             when_message = ""
-            if when_spec != make_when_spec(None):
+            if when_spec != _make_when_spec(None):
                 when_message = f"when {when_spec}"
             other_when_message = ""
-            if other_when_spec != make_when_spec(None):
+            if other_when_spec != _make_when_spec(None):
                 other_when_message = f"when {other_when_spec}"
             err_msg = (
                 f"{pkg.name} is specified as being licensed as {license_identifier} "
@@ -992,7 +992,7 @@ def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
             )
             raise DirectiveError(err_msg)
 
-        when_spec = make_when_spec(when)
+        when_spec = _make_when_spec(when)
         if not when_spec:
             return
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -613,7 +613,7 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
 
 
 @directive(dicts=("provided", "provided_together"))
-def provides(*specs, when: Optional[str] = None):
+def provides(*specs: SpecType, when: WhenType = None):
     """Allows packages to provide a virtual dependency.
 
     If a package provides "mpi", other packages can declare that they depend on "mpi",
@@ -624,7 +624,7 @@ def provides(*specs, when: Optional[str] = None):
         when: condition when this provides clause needs to be considered
     """
 
-    def _execute_provides(pkg):
+    def _execute_provides(pkg: "spack.package_base.PackageBase"):
         import spack.parser  # Avoid circular dependency
 
         when_spec = _make_when_spec(when)
@@ -634,6 +634,7 @@ def provides(*specs, when: Optional[str] = None):
         # ``when`` specs for ``provides()`` need a name, as they are used
         # to build the ProviderIndex.
         when_spec.name = pkg.name
+
         spec_objs = [spack.spec.Spec(x) for x in specs]
         spec_names = [x.name for x in spec_objs]
         if len(spec_names) > 1:
@@ -643,9 +644,8 @@ def provides(*specs, when: Optional[str] = None):
             if pkg.name == provided_spec.name:
                 raise CircularReferenceError("Package '%s' cannot provide itself." % pkg.name)
 
-            if provided_spec not in pkg.provided:
-                pkg.provided[provided_spec] = set()
-            pkg.provided[provided_spec].add(when_spec)
+            provided_set = pkg.provided.setdefault(when_spec, set())
+            provided_set.add(provided_spec)
 
     return _execute_provides
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -965,7 +965,7 @@ def license(
 
 
 @directive("requirements")
-def requires(*requirement_specs, policy="one_of", when=None, msg=None):
+def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
     """Allows a package to request a configuration to be present in all valid solutions.
 
     For instance, a package that is known to compile only with GCC can declare:
@@ -984,7 +984,7 @@ def requires(*requirement_specs, policy="one_of", when=None, msg=None):
         msg: optional user defined message
     """
 
-    def _execute_requires(pkg):
+    def _execute_requires(pkg: "spack.package_base.PackageBase"):
         if policy not in ("one_of", "any_of"):
             err_msg = (
                 f"the 'policy' argument of the 'requires' directive in {pkg.name} is set "
@@ -997,9 +997,10 @@ def requires(*requirement_specs, policy="one_of", when=None, msg=None):
             return
 
         # Save in a list the requirements and the associated custom messages
-        when_spec_list = pkg.requirements.setdefault(tuple(requirement_specs), [])
+        requirement_list = pkg.requirements.setdefault(when_spec, [])
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-        when_spec_list.append((when_spec, policy, msg_with_name))
+        requirements = tuple(spack.spec.Spec(s) for s in requirement_specs)
+        requirement_list.append((requirements, policy, msg_with_name))
 
     return _execute_requires
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -525,7 +525,7 @@ def _depends_on(
 
 
 @directive("conflicts")
-def conflicts(conflict_spec, when=None, msg=None):
+def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str] = None):
     """Allows a package to define a conflict.
 
     Currently, a "conflict" is a concretized configuration that is known
@@ -545,16 +545,16 @@ def conflicts(conflict_spec, when=None, msg=None):
         msg (str): optional user defined message
     """
 
-    def _execute_conflicts(pkg):
+    def _execute_conflicts(pkg: "spack.package_base.PackageBase"):
         # If when is not specified the conflict always holds
         when_spec = make_when_spec(when)
         if not when_spec:
             return
 
         # Save in a list the conflicts and the associated custom messages
-        when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
+        conflict_spec_list = pkg.conflicts.setdefault(when_spec, [])
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-        when_spec_list.append((when_spec, msg_with_name))
+        conflict_spec_list.append((spack.spec.Spec(conflict_spec), msg_with_name))
 
     return _execute_conflicts
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -562,6 +562,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     versions: dict
     dependencies: Dict["spack.spec.Spec", Dict[str, "spack.dependency.Dependency"]]
     conflicts: Dict["spack.spec.Spec", List[Tuple["spack.spec.Spec", Optional[str]]]]
+    requirements: Dict[
+        "spack.spec.Spec", List[Tuple[Tuple["spack.spec.Spec", ...], str, Optional[str]]]
+    ]
     patches: Dict["spack.spec.Spec", List["spack.patch.Patch"]]
 
     #: By default, packages are not virtual

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -560,11 +560,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     # Declare versions dictionary as placeholder for values.
     # This allows analysis tools to correctly interpret the class attributes.
     versions: dict
-
-    # Same for dependencies
     dependencies: Dict["spack.spec.Spec", Dict[str, "spack.dependency.Dependency"]]
-
-    # and patches
+    conflicts: Dict["spack.spec.Spec", List[Tuple["spack.spec.Spec", Optional[str]]]]
     patches: Dict["spack.spec.Spec", List["spack.patch.Patch"]]
 
     #: By default, packages are not virtual

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -389,10 +389,9 @@ class PatchCache:
                 patch_dict.pop("sha256")  # save some space
                 index[patch.sha256] = {pkg_class.fullname: patch_dict}
 
-        # and patches on dependencies
-        for name, conditions in pkg_class.dependencies.items():
-            for cond, dependency in conditions.items():
-                for pcond, patch_list in dependency.patches.items():
+        for deps_by_name in pkg_class.dependencies.values():
+            for dependency in deps_by_name.values():
+                for patch_list in dependency.patches.values():
                     for patch in patch_list:
                         dspec_cls = repository.get_pkg_class(dependency.spec.name)
                         patch_dict = patch.to_dict()

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -128,8 +128,8 @@ class ProviderIndex(_IndexBase):
         assert not self.repository.is_virtual_safe(spec.name), msg
 
         pkg_provided = self.repository.get_pkg_class(spec.name).provided
-        for provided_spec, provider_specs in pkg_provided.items():
-            for provider_spec_readonly in provider_specs:
+        for provider_spec_readonly, provided_specs in pkg_provided.items():
+            for provided_spec in provided_specs:
                 # TODO: fix this comment.
                 # We want satisfaction other than flags
                 provider_spec = provider_spec_readonly.copy()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1234,29 +1234,30 @@ class SpackSolverSetup:
         return [fn.attr("node_target_satisfies", spec.name, target)]
 
     def conflict_rules(self, pkg):
-        default_msg = "{0}: '{1}' conflicts with '{2}'"
-        no_constraint_msg = "{0}: conflicts with '{1}'"
-        for trigger, constraints in pkg.conflicts.items():
-            trigger_msg = f"conflict is triggered when {str(trigger)}"
-            trigger_spec = spack.spec.Spec(trigger)
-            trigger_id = self.condition(
-                trigger_spec, name=trigger_spec.name or pkg.name, msg=trigger_msg
-            )
+        for when_spec, conflict_specs in pkg.conflicts.items():
+            when_spec_msg = "conflict constraint %s" % str(when_spec)
+            when_spec_id = self.condition(when_spec, name=pkg.name, msg=when_spec_msg)
 
-            for constraint, conflict_msg in constraints:
+            for conflict_spec, conflict_msg in conflict_specs:
+                conflict_spec = spack.spec.Spec(conflict_spec)
                 if conflict_msg is None:
-                    if constraint == spack.spec.Spec():
-                        conflict_msg = no_constraint_msg.format(pkg.name, trigger)
+                    conflict_msg = f"{pkg.name}: "
+                    if when_spec == spack.spec.Spec():
+                        conflict_msg += f"conflicts with '{conflict_spec}'"
                     else:
-                        conflict_msg = default_msg.format(pkg.name, trigger, constraint)
+                        conflict_msg += f"'{conflict_spec}' conflicts with '{when_spec}'"
 
-                spec_for_msg = (
-                    spack.spec.Spec(pkg.name) if constraint == spack.spec.Spec() else constraint
+                spec_for_msg = conflict_spec
+                if conflict_spec == spack.spec.Spec():
+                    spec_for_msg = spack.spec.Spec(pkg.name)
+                conflict_spec_msg = f"conflict is triggered when {str(spec_for_msg)}"
+                conflict_spec_id = self.condition(
+                    conflict_spec, name=conflict_spec.name or pkg.name, msg=conflict_spec_msg
                 )
-                constraint_msg = f"conflict applies to spec {str(spec_for_msg)}"
-                constraint_id = self.condition(constraint, name=pkg.name, msg=constraint_msg)
                 self.gen.fact(
-                    fn.pkg_fact(pkg.name, fn.conflict(trigger_id, constraint_id, conflict_msg))
+                    fn.pkg_fact(
+                        pkg.name, fn.conflict(conflict_spec_id, when_spec_id, conflict_msg)
+                    )
                 )
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1643,8 +1643,8 @@ class SpackSolverSetup:
 
     def package_dependencies_rules(self, pkg):
         """Translate 'depends_on' directives into ASP logic."""
-        for _, conditions in sorted(pkg.dependencies.items()):
-            for cond, dep in sorted(conditions.items()):
+        for cond, deps_by_name in sorted(pkg.dependencies.items()):
+            for _, dep in sorted(deps_by_name.items()):
                 depflag = dep.depflag
                 # Skip test dependencies if they're not requested
                 if not self.tests:
@@ -1741,6 +1741,7 @@ class SpackSolverSetup:
             pkg_name, policy, requirement_grp = rule.pkg_name, rule.policy, rule.requirements
 
             requirement_weight = 0
+            # TODO: don't call make_when_spec here; do it in directives.
             main_requirement_condition = spack.directives.make_when_spec(rule.condition)
             if main_requirement_condition is False:
                 continue
@@ -1750,7 +1751,7 @@ class SpackSolverSetup:
                 msg = f"condition to activate requirement {requirement_grp_id}"
                 try:
                     main_condition_id = self.condition(
-                        main_requirement_condition, name=pkg_name, msg=msg
+                        main_requirement_condition, name=pkg_name, msg=msg  # type: ignore
                     )
                 except Exception as e:
                     if rule.kind != RequirementKind.DEFAULT:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1303,8 +1303,8 @@ class SpackSolverSetup:
 
     def requirement_rules_from_package_py(self, pkg):
         rules = []
-        for requirements, conditions in pkg.requirements.items():
-            for when_spec, policy, message in conditions:
+        for when_spec, requirement_list in pkg.requirements.items():
+            for requirements, policy, message in requirement_list:
                 rules.append(
                     RequirementRule(
                         pkg_name=pkg.name,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2876,13 +2876,14 @@ class Spec:
                 continue
 
             # Add any patches from the package to the spec.
-            patches = []
+            patches = set()
             for cond, patch_list in s.package_class.patches.items():
                 if s.satisfies(cond):
                     for patch in patch_list:
-                        patches.append(patch)
+                        patches.add(patch)
             if patches:
                 spec_to_patches[id(s)] = patches
+
         # Also record all patches required on dependencies by
         # depends_on(..., patch=...)
         for dspec in root.traverse_edges(deptype=all, cover="edges", root=False):
@@ -2890,17 +2891,25 @@ class Spec:
                 continue
 
             pkg_deps = dspec.parent.package_class.dependencies
-            if dspec.spec.name not in pkg_deps:
-                continue
 
             patches = []
-            for cond, dependency in pkg_deps[dspec.spec.name].items():
+            for cond, deps_by_name in pkg_deps.items():
+                if not dspec.parent.satisfies(cond):
+                    continue
+
+                dependency = deps_by_name.get(dspec.spec.name)
+                if not dependency:
+                    continue
+
                 for pcond, patch_list in dependency.patches.items():
-                    if dspec.parent.satisfies(cond) and dspec.spec.satisfies(pcond):
+                    if dspec.spec.satisfies(pcond):
                         patches.extend(patch_list)
+
             if patches:
-                all_patches = spec_to_patches.setdefault(id(dspec.spec), [])
-                all_patches.extend(patches)
+                all_patches = spec_to_patches.setdefault(id(dspec.spec), set())
+                for patch in patches:
+                    all_patches.add(patch)
+
         for spec in root.traverse():
             if id(spec) not in spec_to_patches:
                 continue
@@ -3163,13 +3172,17 @@ class Spec:
         If no conditions are True (and we don't depend on it), return
         ``(None, None)``.
         """
-        conditions = self.package_class.dependencies[name]
-
         vt.substitute_abstract_variants(self)
         # evaluate when specs to figure out constraints on the dependency.
         dep = None
-        for when_spec, dependency in conditions.items():
-            if self.satisfies(when_spec):
+        for when_spec, deps_by_name in self.package_class.dependencies.items():
+            if not self.satisfies(when_spec):
+                continue
+
+            for dep_name, dependency in deps_by_name.items():
+                if dep_name != name:
+                    continue
+
                 if dep is None:
                     dep = dp.Dependency(Spec(self.name), Spec(name), depflag=0)
                 try:
@@ -3344,7 +3357,7 @@ class Spec:
 
         while changed:
             changed = False
-            for dep_name in self.package_class.dependencies:
+            for dep_name in self.package_class.dependency_names():
                 # Do we depend on dep_name?  If so pkg_dep is not None.
                 dep = self._evaluate_dependency_conditions(dep_name)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2788,7 +2788,7 @@ class Spec:
         for dep in self.traverse():
             visited_user_specs.add(dep.name)
             pkg_cls = spack.repo.PATH.get_pkg_class(dep.name)
-            visited_user_specs.update(x.name for x in pkg_cls(dep).provided)
+            visited_user_specs.update(pkg_cls(dep).provided_virtual_names())
 
         extra = set(user_spec_deps.keys()).difference(visited_user_specs)
         if extra:
@@ -3774,11 +3774,9 @@ class Spec:
                     return False
 
                 if pkg.provides(virtual_spec.name):
-                    for provided, when_specs in pkg.provided.items():
-                        if any(
-                            non_virtual_spec.intersects(when, deps=False) for when in when_specs
-                        ):
-                            if provided.intersects(virtual_spec):
+                    for when_spec, provided in pkg.provided.items():
+                        if non_virtual_spec.intersects(when_spec, deps=False):
+                            if any(vpkg.intersects(virtual_spec) for vpkg in provided):
                                 return True
             return False
 
@@ -3881,9 +3879,9 @@ class Spec:
                     return False
 
                 if pkg.provides(other.name):
-                    for provided, when_specs in pkg.provided.items():
-                        if any(self.satisfies(when, deps=False) for when in when_specs):
-                            if provided.intersects(other):
+                    for when_spec, provided in pkg.provided.items():
+                        if self.satisfies(when_spec, deps=False):
+                            if any(vpkg.intersects(other) for vpkg in provided):
                                 return True
             return False
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2823,10 +2823,11 @@ class Spec:
                 # external specs are already built, don't worry about whether
                 # it's possible to build that configuration with Spack
                 continue
-            for conflict_spec, when_list in x.package_class.conflicts.items():
-                if x.satisfies(conflict_spec):
-                    for when_spec, msg in when_list:
-                        if x.satisfies(when_spec):
+
+            for when_spec, conflict_list in x.package_class.conflicts.items():
+                if x.satisfies(when_spec):
+                    for conflict_spec, msg in conflict_list:
+                        if x.satisfies(conflict_spec):
                             when = when_spec.copy()
                             when.name = x.name
                             matches.append((x, conflict_spec, when, msg))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1905,7 +1905,7 @@ class TestConcretize:
         """
         # Add a conflict to "mpich" that match an already installed "mpich~debug"
         pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
-        monkeypatch.setitem(pkg_cls.conflicts, "~debug", [(Spec(), None)])
+        monkeypatch.setitem(pkg_cls.conflicts, Spec(), [("~debug", None)])
 
         # If we concretize with --fresh the conflict is taken into account
         with spack.config.override("concretizer:reuse", False):

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -29,8 +29,8 @@ def test_true_directives_exist(mock_packages):
     cls = spack.repo.PATH.get_pkg_class("when-directives-true")
 
     assert cls.dependencies
-    assert spack.spec.Spec() in cls.dependencies["extendee"]
-    assert spack.spec.Spec() in cls.dependencies["b"]
+    assert "extendee" in cls.dependencies[spack.spec.Spec()]
+    assert "b" in cls.dependencies[spack.spec.Spec()]
 
     assert cls.resources
     assert spack.spec.Spec() in cls.resources
@@ -43,7 +43,7 @@ def test_constraints_from_context(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
-    assert spack.spec.Spec("@1.0") in pkg_cls.dependencies["b"]
+    assert "b" in pkg_cls.dependencies[spack.spec.Spec("@1.0")]
 
     assert pkg_cls.conflicts
     assert (spack.spec.Spec("+foo@1.0"), None) in pkg_cls.conflicts["%gcc"]
@@ -54,7 +54,7 @@ def test_constraints_from_context_are_merged(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
-    assert spack.spec.Spec("@0.14:15 ^b@3.8:4.0") in pkg_cls.dependencies["c"]
+    assert "c" in pkg_cls.dependencies[spack.spec.Spec("@0.14:15 ^b@3.8:4.0")]
 
 
 @pytest.mark.regression("27754")

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -101,7 +101,7 @@ def test_license_directive(config, mock_packages, package_name, expected_license
 
 def test_duplicate_exact_range_license():
     package = namedtuple("package", ["licenses", "name"])
-    package.licenses = {spack.directives.make_when_spec("+foo"): "Apache-2.0"}
+    package.licenses = {spack.spec.Spec("+foo"): "Apache-2.0"}
     package.name = "test_package"
 
     msg = (
@@ -115,7 +115,7 @@ def test_duplicate_exact_range_license():
 
 def test_overlapping_duplicate_licenses():
     package = namedtuple("package", ["licenses", "name"])
-    package.licenses = {spack.directives.make_when_spec("+foo"): "Apache-2.0"}
+    package.licenses = {spack.spec.Spec("+foo"): "Apache-2.0"}
     package.name = "test_package"
 
     msg = (

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -46,7 +46,7 @@ def test_constraints_from_context(mock_packages):
     assert "b" in pkg_cls.dependencies[spack.spec.Spec("@1.0")]
 
     assert pkg_cls.conflicts
-    assert (spack.spec.Spec("+foo@1.0"), None) in pkg_cls.conflicts["%gcc"]
+    assert (spack.spec.Spec("%gcc"), None) in pkg_cls.conflicts[spack.spec.Spec("+foo@1.0")]
 
 
 @pytest.mark.regression("26656")

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -71,7 +71,8 @@ def test_possible_direct_dependencies(mock_packages, mpileaks_possible_deps):
 
 def test_possible_dependencies_virtual(mock_packages, mpi_names):
     expected = dict(
-        (name, set(spack.repo.PATH.get_pkg_class(name).dependencies)) for name in mpi_names
+        (name, set(dep for dep in spack.repo.PATH.get_pkg_class(name).dependencies_by_name()))
+        for name in mpi_names
     )
 
     # only one mock MPI has a dependency

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -61,14 +61,15 @@ class TestPackage:
         import spack.pkg.builtin.mock.mpich as mp  # noqa: F401
         from spack.pkg.builtin import mock  # noqa: F401
 
-    def test_inheritance_of_diretives(self):
+    def test_inheritance_of_directives(self):
         pkg_cls = spack.repo.PATH.get_pkg_class("simple-inheritance")
 
         # Check dictionaries that should have been filled by directives
-        assert len(pkg_cls.dependencies) == 3
-        assert "cmake" in pkg_cls.dependencies
-        assert "openblas" in pkg_cls.dependencies
-        assert "mpi" in pkg_cls.dependencies
+        dependencies = pkg_cls.dependencies_by_name()
+        assert len(dependencies) == 3
+        assert "cmake" in dependencies
+        assert "openblas" in dependencies
+        assert "mpi" in dependencies
         assert len(pkg_cls.provided) == 2
 
         # Check that Spec instantiation behaves as we expect

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -196,16 +196,18 @@ def test_nested_directives(mock_packages):
 
     # this ensures that results of dependency patches were properly added
     # to Dependency objects.
-    libelf_dep = next(iter(patcher.dependencies["libelf"].values()))
+    deps_by_name = patcher.dependencies_by_name()
+
+    libelf_dep = deps_by_name["libelf"][0]
     assert len(libelf_dep.patches) == 1
     assert len(libelf_dep.patches[Spec()]) == 1
 
-    libdwarf_dep = next(iter(patcher.dependencies["libdwarf"].values()))
+    libdwarf_dep = deps_by_name["libdwarf"][0]
     assert len(libdwarf_dep.patches) == 2
     assert len(libdwarf_dep.patches[Spec()]) == 1
     assert len(libdwarf_dep.patches[Spec("@20111030")]) == 1
 
-    fake_dep = next(iter(patcher.dependencies["fake"].values()))
+    fake_dep = deps_by_name["fake"][0]
     assert len(fake_dep.patches) == 1
     assert len(fake_dep.patches[Spec()]) == 2
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -51,7 +51,7 @@ def set_dependency(saved_deps, monkeypatch):
 
         cond = Spec(pkg_cls.name)
         dependency = Dependency(pkg_cls, spec)
-        monkeypatch.setitem(pkg_cls.dependencies, spec.name, {cond: dependency})
+        monkeypatch.setitem(pkg_cls.dependencies, cond, {spec.name: dependency})
 
     return _mock
 


### PR DESCRIPTION
Metadata created by directives on Spack packages isn't structured consistently, and it makes implementing similar functionality for different directives difficult and repetitive, e.g. with the `drop` directive in #35045.  It can also cause us to lose information about some parts of packages, e.g. how we lose the defaults of conditional variants in #38302.

Fundamentally, everything in a Spack package is *conditional*, which distinguishes Spack from other package managers.  The right way to key directive metadata is *by condition*, which prevents issues like the ones described above.  Also, storing by condition *seems* to make package loading faster, because there tend to be fewer top-level condition keys (from things like `with when(<condition>):` in packages than there are duplicated conditions in sub-dictionaries when you put conditions under some other top-level key (like the dependency name).

This PR converts Spack's metadata format as follows:

| Directive                   | Old                                                                 | New                                                                      |
|-----------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------------|
| `conflicts`                 | <pre>conflict_spec:<br/>   [(when_spec, msg), ...]</pre>              | <pre>when_spec:<br/>   [ (conflict, msg), ... ]</pre>                      |
| `requires`                  | <pre>(requirement_spec, ...):<br/>   [(when_spec, policy, msg)]</pre> | <pre>when_spec:<br/>   [<br/>    ((requirement_spec, ...), policy, msg),<br/>    ...<br/>  ]</pre> |
| `depends_on`                | <pre>name:<br/>   { when_spec: Dependency }</pre>                     | <pre>when_spec:<br/>   { name: Dependency }</pre>                          |
| `provides`                  | <pre>provided_spec:<br/>   { when_spec, ... }</pre>                   | <pre>when_spec:<br/>   { provided_spec, ... }</pre>                        |
| `extends`                   | <pre>name:<br/>   (extendee_spec, unused_kwargs)</pre>                | <pre>when_spec:<br/>   [extendee_spec, ...]</pre>                          |
| `resource`<br/> (no change) | <pre>when_spec:<br/>   [Resource, ...]</pre>                          | <pre>when_spec:<br/>   [Resource, ...]</pre>                               |
| `patch`<br/> (no change)    | <pre>when_spec:<br/>   [Patch, ...]</pre>                            | <pre>when_spec:<br/>   [Patch, ...]</pre>                                |

Notably missing from the list above are variants and versions. Variants require quite a bit more work, and I am leaving them for a follow-on PR, as they require a lot more refactoring of packages and I think that will merit its own discussion.

Versions should likely be done as well, but we don't yet support `when` on them. Likely that should be done too, as we have users who would like to put conditions (particularly platform/OS conditions) on them. That is also a significant refactor for a future PR.

This PR does a few refactorings along with the changes above:

1.  `extendee_args`: this method is unused, and we no longer pass `kwargs` to `extends()` directive.
2. Code and concretizer refactors for all the code in Spack that *uses* the directives above. 
4. Add typing information to `PackageBase` for all the dictionaries above, ensuring that we parse all data that needs to be a `Spec` early (thus failing early), and that we get consistent metadata dictionaries on our package classes.
5.  Make `_make_when_spec()` internal to `directives.py` and don't use it in the solver.  We don't need to make specs in the solver if we guarantee (via `mypy` that they're constructed when packages are parsed.