### PR TITLE
unparse: also support generic type aliases

### DIFF
--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -1150,7 +1150,7 @@ class Unparser:
     def visit_TypeAlias(self, node):
         self.fill("type ")
         self.dispatch(node.name)
-        if getattr(node, "type_params", False):
+        if node.type_params:
             self.write("[")
             interleave(lambda: self.write(", "), self.dispatch, node.type_params)
             self.write("]")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -1150,6 +1150,10 @@ class Unparser:
     def visit_TypeAlias(self, node):
         self.fill("type ")
         self.dispatch(node.name)
+        if getattr(node, "type_params", False):
+            self.write("[")
+            interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.write("]")
         self.write(" = ")
         self.dispatch(node.value)
 


### PR DESCRIPTION
Unparse dropped the type params for generic type aliases:

```python
type X[T: int] = list[T]
```

normalized incorrectly to

```python
type X = list[T]
```

This PR fixes that. When I wrote the other PR that added 3.12 support I didn't realize unparse was also part of Python itself...

Unfortunately, the v0.20 would also need this for correctness, even though it's unlikely people use this in package.py...

(Apparently Python does not have any tests for generic type aliases internally...)
