### PR TITLE
unparse: drop python 2 remnants

### DIFF
--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -270,16 +270,6 @@ class Unparser:
             self.write(", ")
             self.dispatch(node.msg)
 
-    def visit_Exec(self, node):
-        self.fill("exec ")
-        self.dispatch(node.body)
-        if node.globals:
-            self.write(" in ")
-            self.dispatch(node.globals)
-        if node.locals:
-            self.write(", ")
-            self.dispatch(node.locals)
-
     def visit_Global(self, node):
         self.fill("global ")
         interleave(lambda: self.write(", "), self.write, node.names)
@@ -337,31 +327,6 @@ class Unparser:
             self.fill("finally")
             with self.block():
                 self.dispatch(node.finalbody)
-
-    def visit_TryExcept(self, node):
-        self.fill("try")
-        with self.block():
-            self.dispatch(node.body)
-
-        for ex in node.handlers:
-            self.dispatch(ex)
-        if node.orelse:
-            self.fill("else")
-            with self.block():
-                self.dispatch(node.orelse)
-
-    def visit_TryFinally(self, node):
-        if len(node.body) == 1 and isinstance(node.body[0], ast.TryExcept):
-            # try-except-finally
-            self.dispatch(node.body)
-        else:
-            self.fill("try")
-            with self.block():
-                self.dispatch(node.body)
-
-        self.fill("finally")
-        with self.block():
-            self.dispatch(node.finalbody)
 
     def visit_ExceptHandler(self, node):
         self.fill("except")
@@ -647,11 +612,6 @@ class Unparser:
 
     def visit_NameConstant(self, node):
         self.write(repr(node.value))
-
-    def visit_Repr(self, node):
-        self.write("`")
-        self.dispatch(node.value)
-        self.write("`")
 
     def _write_constant(self, value):
         if isinstance(value, (float, complex)):


### PR DESCRIPTION
These node types don't exist in Python versions we require

- `TryExcept` and `TryFinally` were merged into `Try` in https://github.com/python/cpython/commit/43af12b0b488791d89a9c08b0ad9f1c5004b5ed7 (v2.7.5)
- `Exec` was removed in https://github.com/python/cpython/commit/7cae87ca7b0a3a7ce497cbd335c8ec82fe680476 (v2.7.4)
- `Repr` was removed in https://github.com/python/cpython/commit/e2e23ef97da1ce44c604d86d1f21c2701d7e581f (v2.7.4)
