### PR TITLE
unparse: ast.Constant and ast.Num are always defined

### DIFF
--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -886,8 +886,7 @@ class Unparser:
         # Special case: 3.__abs__() is a syntax error, so if node.value
         # is an integer literal then we need to either parenthesize
         # it or add an extra space to get 3 .__abs__().
-        num_type = getattr(ast, "Constant", getattr(ast, "Num", None))
-        if isinstance(node.value, num_type) and isinstance(node.value.n, int):
+        if isinstance(node.value, (ast.Constant, ast.Num)) and isinstance(node.value.n, int):
             self.write(" ")
         self.write(".")
         self.write(node.attr)


### PR DESCRIPTION
> Changed in version 3.8: Class ast.Constant is now used for all
> constants.

> Deprecated since version 3.8: Old classes `ast.Num`, `ast.Str`,
> `ast.Bytes`, `ast.NameConstant` and `ast.Ellipsis` are still
> available, but they will be removed in future Python releases. In the
> meantime, instantiating them will return an instance of a different
> class.

So, it's still OK to use those directly; mypy can't statically follow
the old & dynamic isinstance check.

Or was the idea to be more forward compatible? I doubt this will be
removed in Python 3, though.