### PR TITLE
Parser: fix ambiguity with whitespace in version ranges

### DIFF
--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -96,7 +96,7 @@ VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"(({VERSION})?:({VERSION}(?!=))?)"
+VERSION_RANGE = rf"(({VERSION})?:({VERSION}(?!\s*=))?)"
 VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
 
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -96,7 +96,7 @@ VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"(({VERSION})?:({VERSION})?)"
+VERSION_RANGE = rf"({VERSION}:{VERSION}(?!=)|:{VERSION}(?!=)|{VERSION}:|:)"
 VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
 
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -95,9 +95,9 @@ else:
 VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
-VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"(({VERSION})?:({VERSION}(?!\s*=))?)"
-VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
+VERSION = r"=?(?:[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
+VERSION_RANGE = rf"(?:(?:{VERSION})?:(?:{VERSION}(?!\s*=))?)"
+VERSION_LIST = rf"(?:{VERSION_RANGE}|{VERSION})(?:\s*,\s*(?:{VERSION_RANGE}|{VERSION}))*"
 
 
 class TokenBase(enum.Enum):

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -96,7 +96,7 @@ VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"({VERSION}\s*:\s*{VERSION}(?!\s*=)|:\s*{VERSION}(?!\s*=)|{VERSION}\s*:|:)"
+VERSION_RANGE = rf"({VERSION}:{VERSION}(?!=)|:{VERSION}(?!=)|{VERSION}:|:)"
 VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
 
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -96,7 +96,7 @@ VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"({VERSION}:{VERSION}(?!=)|:{VERSION}(?!=)|{VERSION}:|:)"
+VERSION_RANGE = rf"(({VERSION})?:({VERSION}(?!=))?)"
 VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
 
 

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -96,7 +96,7 @@ VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
 QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
-VERSION_RANGE = rf"({VERSION}:{VERSION}(?!=)|:{VERSION}(?!=)|{VERSION}:|:)"
+VERSION_RANGE = rf"(({VERSION})?:({VERSION})?)"
 VERSION_LIST = rf"({VERSION_RANGE}|{VERSION})(\s*[,]\s*({VERSION_RANGE}|{VERSION}))*"
 
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -517,6 +517,16 @@ def specfile_for(default_mock_concretization):
             [Token(TokenType.VERSION, value="@:0.4"), Token(TokenType.COMPILER, value="% nvhpc")],
             "@:0.4%nvhpc",
         ),
+        # `a@1:` and `b` are separate specs, not a single `a@1:b`.
+        (
+            "a@1: b",
+            [
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="a"),
+                Token(TokenType.VERSION, value="@1:"),
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="b"),
+            ],
+            "a@1:",
+        )
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -493,6 +493,14 @@ def specfile_for(default_mock_concretization):
             "@1.2: develop=foo",
         ),
         (
+            "@1.2:develop   = foo",
+            [
+                Token(TokenType.VERSION, value="@1.2:"),
+                Token(TokenType.KEY_VALUE_PAIR, value="develop   = foo"),
+            ],
+            "@1.2: develop=foo",
+        ),
+        (
             "% intel @ 12.1:12.6 + debug",
             [
                 Token(TokenType.COMPILER_AND_VERSION, value="% intel @ 12.1:12.6"),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -472,37 +472,17 @@ def specfile_for(default_mock_concretization):
             [Token(TokenType.PROPAGATED_KEY_VALUE_PAIR, value='cflags=="-O3 -g"')],
             'cflags=="-O3 -g"',
         ),
-        # Way too many spaces
+        # Whitespace is allowed in version lists
+        ("@1.2:1.4 , 1.6 ", [Token(TokenType.VERSION, value="@1.2:1.4 , 1.6")], "@1.2:1.4,1.6"),
+        # But not in ranges. `a@1:` and `b` are separate specs, not a single `a@1:b`.
         (
-            "@1.2 : 1.4 , 1.6 ",
-            [Token(TokenType.VERSION, value="@1.2 : 1.4 , 1.6")],
-            "@1.2:1.4,1.6",
-        ),
-        ("@1.2 :   develop", [Token(TokenType.VERSION, value="@1.2 :   develop")], "@1.2:develop"),
-        (
-            "@1.2 :   develop   = foo",
+            "a@1: b",
             [
-                Token(TokenType.VERSION, value="@1.2 :"),
-                Token(TokenType.KEY_VALUE_PAIR, value="develop   = foo"),
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="a"),
+                Token(TokenType.VERSION, value="@1:"),
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="b"),
             ],
-            "@1.2: develop=foo",
-        ),
-        (
-            "% intel @ 12.1 : 12.6 + debug",
-            [
-                Token(TokenType.COMPILER_AND_VERSION, value="% intel @ 12.1 : 12.6"),
-                Token(TokenType.BOOL_VARIANT, value="+ debug"),
-            ],
-            "%intel@12.1:12.6+debug",
-        ),
-        (
-            "@ 12.1 : 12.6 + debug - qt_4",
-            [
-                Token(TokenType.VERSION, value="@ 12.1 : 12.6"),
-                Token(TokenType.BOOL_VARIANT, value="+ debug"),
-                Token(TokenType.BOOL_VARIANT, value="- qt_4"),
-            ],
-            "@12.1:12.6+debug~qt_4",
+            "a@1:",
         ),
         (
             "@10.4.0:10,11.3.0:target=aarch64:",
@@ -517,16 +497,6 @@ def specfile_for(default_mock_concretization):
             [Token(TokenType.VERSION, value="@:0.4"), Token(TokenType.COMPILER, value="% nvhpc")],
             "@:0.4%nvhpc",
         ),
-        # `a@1:` and `b` are separate specs, not a single `a@1:b`.
-        (
-            "a@1: b",
-            [
-                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="a"),
-                Token(TokenType.VERSION, value="@1:"),
-                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="b"),
-            ],
-            "a@1:",
-        )
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -510,7 +510,7 @@ def specfile_for(default_mock_concretization):
             "@12.1:12.6+debug~qt_4",
         ),
         (
-            "@10.4.0:10,11.3.0:target=aarch64:",
+            "@10.4.0:10,11.3.0: target=aarch64:",
             [
                 Token(TokenType.VERSION, value="@10.4.0:10,11.3.0:"),
                 Token(TokenType.KEY_VALUE_PAIR, value="target=aarch64:"),
@@ -600,6 +600,8 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         ("y ^x@@1.2", "y ^x@@1.2\n   ^^^^^"),
         ("x@1.2::", "x@1.2::\n      ^"),
         ("x::", "x::\n ^^"),
+        # interpreted as range `@1:target`; space is required after the colon
+        ("@1:target=aarch64:", "\n         ^^^^^^^^^"),
     ],
 )
 def test_error_reporting(text, expected_in_error):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -485,6 +485,31 @@ def specfile_for(default_mock_concretization):
             "a@1:",
         ),
         (
+            "@1.2:   develop   = foo",
+            [
+                Token(TokenType.VERSION, value="@1.2:"),
+                Token(TokenType.KEY_VALUE_PAIR, value="develop   = foo"),
+            ],
+            "@1.2: develop=foo",
+        ),
+        (
+            "% intel @ 12.1:12.6 + debug",
+            [
+                Token(TokenType.COMPILER_AND_VERSION, value="% intel @ 12.1:12.6"),
+                Token(TokenType.BOOL_VARIANT, value="+ debug"),
+            ],
+            "%intel@12.1:12.6+debug",
+        ),
+        (
+            "@ 12.1:12.6 + debug - qt_4",
+            [
+                Token(TokenType.VERSION, value="@ 12.1:12.6"),
+                Token(TokenType.BOOL_VARIANT, value="+ debug"),
+                Token(TokenType.BOOL_VARIANT, value="- qt_4"),
+            ],
+            "@12.1:12.6+debug~qt_4",
+        ),
+        (
             "@10.4.0:10,11.3.0:target=aarch64:",
             [
                 Token(TokenType.VERSION, value="@10.4.0:10,11.3.0:"),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -510,7 +510,7 @@ def specfile_for(default_mock_concretization):
             "@12.1:12.6+debug~qt_4",
         ),
         (
-            "@10.4.0:10,11.3.0: target=aarch64:",
+            "@10.4.0:10,11.3.0:target=aarch64:",
             [
                 Token(TokenType.VERSION, value="@10.4.0:10,11.3.0:"),
                 Token(TokenType.KEY_VALUE_PAIR, value="target=aarch64:"),
@@ -600,8 +600,6 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         ("y ^x@@1.2", "y ^x@@1.2\n   ^^^^^"),
         ("x@1.2::", "x@1.2::\n      ^"),
         ("x::", "x::\n ^^"),
-        # interpreted as range `@1:target`; space is required after the colon
-        ("@1:target=aarch64:", "\n         ^^^^^^^^^"),
     ],
 )
 def test_error_reporting(text, expected_in_error):

--- a/var/spack/repos/builtin/packages/py-wasabi/package.py
+++ b/var/spack/repos/builtin/packages/py-wasabi/package.py
@@ -20,4 +20,4 @@ class PyWasabi(PythonPackage):
     depends_on(
         "py-typing-extensions@3.7.4.1:4.4", type=("build", "run"), when="@1.1.2:^python@:3.7"
     )
-    depends_on("py-colorama@0.4.6:", type=("build", "run"), when="@1.1.2: platform=windows")
+    depends_on("py-colorama@0.4.6:", type=("build", "run"), when="@1.1.2:platform=windows")

--- a/var/spack/repos/builtin/packages/py-wasabi/package.py
+++ b/var/spack/repos/builtin/packages/py-wasabi/package.py
@@ -20,4 +20,4 @@ class PyWasabi(PythonPackage):
     depends_on(
         "py-typing-extensions@3.7.4.1:4.4", type=("build", "run"), when="@1.1.2:^python@:3.7"
     )
-    depends_on("py-colorama@0.4.6:", type=("build", "run"), when="@1.1.2:platform=windows")
+    depends_on("py-colorama@0.4.6:", type=("build", "run"), when="@1.1.2: platform=windows")


### PR DESCRIPTION
Fixes #40342

This is a breaking change, but imho `develop` is broken, so it's rather a bugfix.

Allowing white space around `:` in version ranges introduces an ambiguity:

```
a@1: b
```

parses as `a@1:b` but should really be parsed as two separate specs `a@1:` and `b`.

With white space disallowed around `:` in ranges, the ambiguity is resolved.

---

White space is still allowed around the `,` separator in version lists, since there we unambiguously require a next version/range token anyways, and in fact the syntax with whitespaces around `,` is used in a bunch of packages.

---

Apart from that, there's this rather odd, **supported** syntax:

```
a@1:b = c
```

It's parsed as `[a, @1:, b=c]`. Apparently this syntax is relied on in *exactly one* package -- I think disallowing that would have made sense if it wasn't relied on... I've left this as is, and added an additional test for this syntax.