### PR TITLE
VersionRange: improve error message for empty range

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -17,6 +17,7 @@ from llnl.util.filesystem import working_dir
 import spack.package_base
 import spack.spec
 from spack.version import (
+    EmptyRangeError,
     GitVersion,
     StandardVersion,
     Version,
@@ -695,9 +696,9 @@ def test_version_range_nonempty():
 
 
 def test_empty_version_range_raises():
-    with pytest.raises(ValueError):
+    with pytest.raises(EmptyRangeError, match="2:1.0 is an empty range"):
         assert VersionRange("2", "1.0")
-    with pytest.raises(ValueError):
+    with pytest.raises(EmptyRangeError, match="2:1.0 is an empty range"):
         assert ver("2:1.0")
 
 

--- a/lib/spack/spack/version/__init__.py
+++ b/lib/spack/spack/version/__init__.py
@@ -16,6 +16,7 @@ if Version(x) <= Version(y).
 """
 
 from .common import (
+    EmptyRangeError,
     VersionChecksumError,
     VersionError,
     VersionLookupError,
@@ -54,5 +55,6 @@ __all__ = [
     "VersionError",
     "VersionChecksumError",
     "VersionLookupError",
+    "EmptyRangeError",
     "any_version",
 ]

--- a/lib/spack/spack/version/common.py
+++ b/lib/spack/spack/version/common.py
@@ -35,3 +35,7 @@ class VersionChecksumError(VersionError):
 
 class VersionLookupError(VersionError):
     """Raised for errors looking up git commits as versions."""
+
+
+class EmptyRangeError(VersionError):
+    """Raised when constructing an empty version range."""

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -12,6 +12,7 @@ from spack.util.spack_yaml import syaml_dict
 
 from .common import (
     COMMIT_VERSION,
+    EmptyRangeError,
     VersionLookupError,
     infinity_versions,
     is_git_version,
@@ -595,14 +596,17 @@ class GitVersion(ConcreteVersion):
 class ClosedOpenRange:
     def __init__(self, lo: StandardVersion, hi: StandardVersion):
         if hi < lo:
-            raise ValueError(f"{lo}:{hi} is an empty range")
+            raise EmptyRangeError(f"{lo}..{hi} is an empty range")
         self.lo: StandardVersion = lo
         self.hi: StandardVersion = hi
 
     @classmethod
     def from_version_range(cls, lo: StandardVersion, hi: StandardVersion):
         """Construct ClosedOpenRange from lo:hi range."""
-        return ClosedOpenRange(lo, next_version(hi))
+        try:
+            return ClosedOpenRange(lo, next_version(hi))
+        except EmptyRangeError as e:
+            raise EmptyRangeError(f"{lo}:{hi} is an empty range") from e
 
     def __str__(self):
         # This simplifies 3.1:<3.2 to 3.1:3.1 to 3.1


### PR DESCRIPTION
Previously it would throw an error involving `lo:next_version(hi)` instead of `lo:hi`, which was confusing.