### PR TITLE
topaz: new package @0.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/topaz/package.py
+++ b/var/spack/repos/builtin/packages/topaz/package.py
@@ -12,9 +12,9 @@ class Topaz(PythonPackage):
     featuring micrograph and tomogram denoising with DNNs."""
 
     homepage = "https://topaz-em.readthedocs.io/"
-    git = "https://github.com/tbepler/topaz.git"
+    pypi = "topaz-em/topaz-em-0.2.5.tar.gz"
 
-    version("0.2.5", tag="v0.2.5")
+    version("0.2.5", sha256="002a6eb775598b6c4df0225f3a488bfe6a6da9246e8ca42eb4e7d58f694c25cc")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-torch@1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/topaz/package.py
+++ b/var/spack/repos/builtin/packages/topaz/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Topaz(PythonPackage):
+    """topaz: Pipeline for particle picking in cryo-electron microscopy images using
+    convolutional neural networks trained from positive and unlabeled examples. Also
+    featuring micrograph and tomogram denoising with DNNs."""
+
+    homepage = "https://topaz-em.readthedocs.io/"
+    git = "https://github.com/tbepler/topaz.git"
+
+    version("0.2.5", tag="v0.2.5")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-torch@1:", type=("build", "run"))
+    depends_on("py-torchvision", type=("build", "run"))
+    depends_on("py-numpy@1.11:", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-scikit-learn@0.19.0:", type=("build", "run"))
+    depends_on("py-scipy@0.17.0:", type=("build", "run"))
+    depends_on("py-pillow@6.2.0:", type=("build", "run"))
+    depends_on("py-future", type=("build", "run"))


### PR DESCRIPTION
Adding a new package for CryoEM ... `topaz`.

Installs fine for me without requiring any other dependency updates. Install tested with the spec `topaz@0.2.5 ^py-torch+cuda cuda_arch=86 ^cuda@12`