### PR TITLE
metal: new package @2020-05-05

### DIFF
--- a/var/spack/repos/builtin/packages/metal/package.py
+++ b/var/spack/repos/builtin/packages/metal/package.py
@@ -12,7 +12,10 @@ class Metal(CMakePackage):
     homepage = "https://genome.sph.umich.edu/wiki/METAL"
     url = "https://github.com/statgen/METAL/archive/refs/tags/2020-05-05.tar.gz"
 
-    version("2020-05-05", sha256="0ffa2419ca2ab43766e7e6e8c97822c8ce1f5b6233fb5f992d1b1be1955fede7")
+    version(
+        "2020-05-05",
+        sha256="0ffa2419ca2ab43766e7e6e8c97822c8ce1f5b6233fb5f992d1b1be1955fede7",
+    )
 
     depends_on("cmake@3.1:", type="build")
     depends_on("zlib-ng")

--- a/var/spack/repos/builtin/packages/metal/package.py
+++ b/var/spack/repos/builtin/packages/metal/package.py
@@ -19,6 +19,5 @@ class Metal(CMakePackage):
 
     @run_after("install")
     def mv_binary(self):
-        mkdirp(self.prefix.bin)
         with working_dir(self.build_directory):
-            install("metal/metal", self.prefix.bin)
+            install_tree("bin", self.prefix.bin)

--- a/var/spack/repos/builtin/packages/metal/package.py
+++ b/var/spack/repos/builtin/packages/metal/package.py
@@ -13,8 +13,7 @@ class Metal(CMakePackage):
     url = "https://github.com/statgen/METAL/archive/refs/tags/2020-05-05.tar.gz"
 
     version(
-        "2020-05-05",
-        sha256="0ffa2419ca2ab43766e7e6e8c97822c8ce1f5b6233fb5f992d1b1be1955fede7",
+        "2020-05-05", sha256="0ffa2419ca2ab43766e7e6e8c97822c8ce1f5b6233fb5f992d1b1be1955fede7"
     )
 
     depends_on("cmake@3.1:", type="build")

--- a/var/spack/repos/builtin/packages/metal/package.py
+++ b/var/spack/repos/builtin/packages/metal/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Metal(CMakePackage):
+    """METAL is a tool for the meta-analysis of genome-wide association studies"""
+
+    homepage = "https://genome.sph.umich.edu/wiki/METAL"
+    url = "https://github.com/statgen/METAL/archive/refs/tags/2020-05-05.tar.gz"
+
+    version("2020-05-05", sha256="0ffa2419ca2ab43766e7e6e8c97822c8ce1f5b6233fb5f992d1b1be1955fede7")
+
+    depends_on("cmake@3.1:", type="build")
+    depends_on("zlib-ng")
+
+    @run_after("install")
+    def mv_binary(self):
+        mkdirp(self.prefix.bin)
+        with working_dir(self.build_directory):
+            install("metal/metal", self.prefix.bin)


### PR DESCRIPTION
Adding `metal`. Behaves fine for me but `make install` doesn't respect the prefix, so there's a manual step to move the binary at the end.