### PR TITLE
Remove warning for custom module configuration, when no module is enabled

### DIFF
--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -11,7 +11,6 @@ import spack.modules
 
 def _for_each_enabled(spec, method_name, explicit=None):
     """Calls a method for each enabled module"""
-    spack.modules.ensure_modules_are_enabled_or_warn()
     set_names = set(spack.config.get("modules", {}).keys())
     for name in set_names:
         enabled = spack.config.get("modules:%s:enable" % name)

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -7,15 +7,10 @@
 include Tcl non-hierarchical modules, Lua hierarchical modules, and others.
 """
 
-from .common import disable_modules, ensure_modules_are_enabled_or_warn
+from .common import disable_modules
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
-__all__ = [
-    "TclModulefileWriter",
-    "LmodModulefileWriter",
-    "disable_modules",
-    "ensure_modules_are_enabled_or_warn",
-]
+__all__ = ["TclModulefileWriter", "LmodModulefileWriter", "disable_modules"]
 
 module_types = {"tcl": TclModulefileWriter, "lmod": LmodModulefileWriter}

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -33,10 +33,8 @@ import copy
 import datetime
 import inspect
 import os.path
-import pathlib
 import re
 import string
-import warnings
 from typing import Optional
 
 import llnl.util.filesystem
@@ -818,43 +816,6 @@ class BaseContext(tengine.Context):
     def verbose(self):
         """Verbosity level."""
         return self.conf.verbose
-
-
-def ensure_modules_are_enabled_or_warn():
-    """Ensures that, if a custom configuration file is found with custom configuration for the
-    default tcl module set, then tcl module file generation is enabled. Otherwise, a warning
-    is emitted.
-    """
-
-    # TODO (v0.21 - Remove this function)
-    # Check if TCL module generation is enabled, return early if it is
-    enabled = spack.config.get("modules:default:enable", [])
-    if "tcl" in enabled:
-        return
-
-    # Check if we have custom TCL module sections
-    for scope in spack.config.CONFIG.file_scopes:
-        # Skip default configuration
-        if scope.name.startswith("default"):
-            continue
-
-        data = spack.config.get("modules:default:tcl", scope=scope.name)
-        if data:
-            config_file = pathlib.Path(scope.path)
-            if not scope.name.startswith("env"):
-                config_file = config_file / "modules.yaml"
-            break
-    else:
-        return
-
-    # If we are here we have a custom "modules" section in "config_file"
-    msg = (
-        f"detected custom TCL modules configuration in {config_file}, while TCL module file "
-        f"generation for the default module set is disabled. "
-        f"In Spack v0.20 module file generation has been disabled by default. To enable "
-        f"it run:\n\n\t$ spack config add 'modules:default:enable:[tcl]'\n"
-    )
-    warnings.warn(msg)
 
 
 class BaseModuleFileWriter:


### PR DESCRIPTION
The warning was added in v0.20 and was slated for removal in v0.21