### PR TITLE
Updating patch to enable flag mcode-object-version=none

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -715,11 +715,10 @@ class Hip(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         if self.spec.satisfies("@:5.1.0"):
             return
-        else:
-            if "@:5.5" in self.spec:
-                self.test_src_dir = "samples"
-            else:
-                self.test_src_dir = "hip-tests/samples"
+        elif self.spec.satisfies("@5.1:5.5"):
+            self.test_src_dir = "samples"
+        elif self.spec.satisfies("@5.6:"):
+            self.test_src_dir = "hip-tests/samples"
         self.cache_extra_test_sources([self.test_src_dir])
 
     def test_samples(self):

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/0002-Remove-explicit-RPATH-again.patch
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/0002-Remove-explicit-RPATH-again.patch
@@ -1,17 +1,17 @@
-From b5a49e6de81e7a6cba86694ee5ba2486cd999976 Mon Sep 17 00:00:00 2001
-From: Harmen Stoppels <harmenstoppels@gmail.com>
-Date: Fri, 28 Aug 2020 18:26:54 +0200
-Subject: [PATCH] Remove explicit RPATH again
+From fb6bc54d50ec511118557bfad7f1b892adcc1a1d Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Tue, 10 Oct 2023 01:15:08 +0000
+Subject: [PATCH] Updating patch for the latest code
 
 ---
  src/CMakeLists.txt | 3 ---
  1 file changed, 3 deletions(-)
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9de7842..66c6880 100644
+index 8fb02b1..b40c972 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -134,9 +134,6 @@ target_include_directories( ${CORE_RUNTIME_TARGET}
+@@ -122,9 +122,6 @@ target_include_directories( ${CORE_RUNTIME_TARGET}
    ${CMAKE_CURRENT_SOURCE_DIR}
    ${CMAKE_CURRENT_SOURCE_DIR}/libamdhsacode )
  
@@ -19,8 +19,8 @@ index 9de7842..66c6880 100644
 -set_property(TARGET ${CORE_RUNTIME_TARGET} PROPERTY INSTALL_RPATH "$ORIGIN;$ORIGIN/../../lib;$ORIGIN/../../lib64;$ORIGIN/../lib64" )
 -
  ## ------------------------- Linux Compiler and Linker options -------------------------
- set ( HSA_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=missing-braces -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -Wno-error=unused-variable -Wno-error=unused-function )
+ set ( HSA_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=missing-braces -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -Wno-error=unused-variable -Wno-error=unused-function )
  
 -- 
-2.25.1
+2.31.1
 

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -162,7 +162,7 @@ class HsaRocrDev(CMakePackage):
 
     # Both 3.5.0 and 3.7.0 force INSTALL_RPATH in different ways
     patch("0001-Do-not-set-an-explicit-rpath-by-default-since-packag.patch", when="@3.5.0")
-    patch("0002-Remove-explicit-RPATH-again.patch", when="@3.7.0:5.5")
+    patch("0002-Remove-explicit-RPATH-again.patch", when="@3.7.0:")
 
     root_cmakelists_dir = "src"
 

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -162,7 +162,7 @@ class HsaRocrDev(CMakePackage):
 
     # Both 3.5.0 and 3.7.0 force INSTALL_RPATH in different ways
     patch("0001-Do-not-set-an-explicit-rpath-by-default-since-packag.patch", when="@3.5.0")
-    patch("0002-Remove-explicit-RPATH-again.patch", when="@3.7.0:")
+    patch("0002-Remove-explicit-RPATH-again.patch", when="@3.7.0:5.6")
 
     root_cmakelists_dir = "src"
 

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -132,8 +132,11 @@ class HsakmtRoct(CMakePackage):
         else:
             return ["install"]
 
-    def cmake_args(self):
-        args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+        args = []
+        if self.spec.satisfies("@:5.4.3"):
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        else:
+            args.append(self.define("BUILD_SHARED_LIBS", False))
         if self.spec.satisfies("@5.4.3:"):
             args.append("-DCMAKE_INSTALL_LIBDIR=lib")
         return args

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -162,7 +162,11 @@ class LlvmAmdgpu(CMakePackage):
     # as per 5.2.0 llvm code. It used to be llvm/bin/../lib/libdevice.
     # Below patch is to look in the old path.
     patch("adjust-openmp-bitcode-directory-for-llvm-link.patch", when="@5.2.0:")
-    patch("patch-llvm-5.5.0.patch", when="@5.5:")
+
+    # Below patch is to set the flag -mcode-object-version=none until
+    # the below fix is available in device-libs release code.
+    # https://github.com/RadeonOpenCompute/ROCm-Device-Libs/commit/f0356159dbdc93ea9e545f9b61a7842f9c881fdf
+    patch("patch-llvm-5.5.0.patch", when="@5.5: +rocm-device-libs")
 
     # i1 muls can sometimes happen after SCEV.
     # They resulted in ISel failures because we were missing the patterns for them.

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -172,7 +172,7 @@ class LlvmAmdgpu(CMakePackage):
     # They resulted in ISel failures because we were missing the patterns for them.
     # This fix is targeting 6.1 rocm release.
     # Need patch until https://github.com/llvm/llvm-project/pull/67291 is merged.
-    patch("001-Add-i1-mul-patterns.patch", when="@5.6:")
+    patch("001-Add-i1-mul-patterns.patch", when="@5.6")
 
     conflicts("^cmake@3.19.0")
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -289,6 +289,9 @@ class LlvmAmdgpu(CMakePackage):
             args.append(self.define("GCC_INSTALL_PREFIX", self.compiler.prefix))
         if self.spec.satisfies("@5.4.3:"):
             args.append("-DCMAKE_INSTALL_LIBDIR=lib")
+        if self.spec.satisfies("@5.5.0:"):
+            args.append("-DCLANG_DEFAULT_RTLIB=compiler-rt")
+            args.append("-DCLANG_DEFAULT_UNWINDLIB=libgcc")
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/patch-llvm-5.5.0.patch
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/patch-llvm-5.5.0.patch
@@ -1,23 +1,35 @@
-From 08e22edba5d9c24dfad6af082a503061702f8a50 Mon Sep 17 00:00:00 2001
+From 7010d5da727825321d31863ceb9e2fe9eb22b5b9 Mon Sep 17 00:00:00 2001
 From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
-Date: Fri, 6 Oct 2023 19:04:20 +0000
-Subject: [PATCH] The condition check is applicable only for standalone build
+Date: Tue, 10 Oct 2023 05:16:47 +0000
+Subject: [PATCH] Condition check for enabling the flag
+ -mcode-object-version=none is failing in spack when device-libsis built with
+ llvm-amdgpu. The flag is required here as well as standalon build.
 
 ---
- rocm-device-libs/cmake/OCL.cmake | 2 --
- 1 file changed, 2 deletions(-)
+ rocm-device-libs/cmake/OCL.cmake | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
 
 diff --git a/rocm-device-libs/cmake/OCL.cmake b/rocm-device-libs/cmake/OCL.cmake
-index 773c6f62e..862f14441 100644
+index 773c6f62e..30f60030b 100644
 --- a/rocm-device-libs/cmake/OCL.cmake
 +++ b/rocm-device-libs/cmake/OCL.cmake
-@@ -38,9 +38,7 @@ execute_process (
-   ERROR_QUIET
- )
- file(REMOVE ${CMAKE_BINARY_DIR}/tmp.cl)
+@@ -30,17 +30,8 @@ if (WIN32)
+   set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -fshort-wchar)
+ endif()
+ 
+-# Disable code object version module flag if available.
+-file(WRITE ${CMAKE_BINARY_DIR}/tmp.cl "")
+-execute_process (
+-  COMMAND ${LLVM_TOOLS_BINARY_DIR}/clang${EXE_SUFFIX} ${CLANG_OCL_FLAGS} -Xclang -mcode-object-version=none ${CMAKE_BINARY_DIR}/tmp.cl
+-  RESULT_VARIABLE TEST_CODE_OBJECT_VERSION_NONE_RESULT
+-  ERROR_QUIET
+-)
+-file(REMOVE ${CMAKE_BINARY_DIR}/tmp.cl)
 -if (NOT TEST_CODE_OBJECT_VERSION_NONE_RESULT)
-   set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -Xclang -mcode-object-version=none)
+-  set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -Xclang -mcode-object-version=none)
 -endif()
++# Disable code object version module flag.
++set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -Xclang -mcode-object-version=none)
  
  set (BC_EXT .bc)
  set (LIB_SUFFIX ".lib${BC_EXT}")

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/patch-llvm-5.5.0.patch
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/patch-llvm-5.5.0.patch
@@ -1,13 +1,26 @@
-diff --git a/clang/include/clang/Driver/Options.td b/clang/include/clang/Driver/Options.td
-index bb4374b..36e7f7b 100644
---- a/clang/include/clang/Driver/Options.td
-+++ b/clang/include/clang/Driver/Options.td
-@@ -3739,7 +3739,7 @@ def mcode_object_version_EQ : Joined<["-"], "mcode-object-version=">, Group<m_Gr
-   Values<"none,2,3,4,5">,
-   NormalizedValuesScope<"TargetOptions">,
-   NormalizedValues<["COV_None", "COV_2", "COV_3", "COV_4", "COV_5"]>,
--  MarshallingInfoEnum<TargetOpts<"CodeObjectVersion">, "COV_5">;
-+  MarshallingInfoEnum<TargetOpts<"CodeObjectVersion">, "COV_4">;
+From 08e22edba5d9c24dfad6af082a503061702f8a50 Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Fri, 6 Oct 2023 19:04:20 +0000
+Subject: [PATCH] The condition check is applicable only for standalone build
+
+---
+ rocm-device-libs/cmake/OCL.cmake | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/rocm-device-libs/cmake/OCL.cmake b/rocm-device-libs/cmake/OCL.cmake
+index 773c6f62e..862f14441 100644
+--- a/rocm-device-libs/cmake/OCL.cmake
++++ b/rocm-device-libs/cmake/OCL.cmake
+@@ -38,9 +38,7 @@ execute_process (
+   ERROR_QUIET
+ )
+ file(REMOVE ${CMAKE_BINARY_DIR}/tmp.cl)
+-if (NOT TEST_CODE_OBJECT_VERSION_NONE_RESULT)
+   set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -Xclang -mcode-object-version=none)
+-endif()
  
- defm code_object_v3_legacy : SimpleMFlag<"code-object-v3",
-   "Legacy option to specify code object ABI V3",
+ set (BC_EXT .bc)
+ set (LIB_SUFFIX ".lib${BC_EXT}")
+-- 
+2.31.1
+


### PR DESCRIPTION
Updating patch to enable flag mcode-object-version=none for device-libs when it is built as part of llvm-amdgpu