### PR TITLE
parser: use non-capturing groups

### DIFF
--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -73,10 +73,10 @@ IS_WINDOWS = sys.platform == "win32"
 #: Valid name for specs and variants. Here we are not using
 #: the previous "w[\w.-]*" since that would match most
 #: characters that can be part of a word in any language
-IDENTIFIER = r"([a-zA-Z_0-9][a-zA-Z_0-9\-]*)"
-DOTTED_IDENTIFIER = rf"({IDENTIFIER}(\.{IDENTIFIER})+)"
-GIT_HASH = r"([A-Fa-f0-9]{40})"
-GIT_VERSION = rf"((git\.({DOTTED_IDENTIFIER}|{IDENTIFIER}))|({GIT_HASH}))"
+IDENTIFIER = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9\-]*)"
+DOTTED_IDENTIFIER = rf"(?:{IDENTIFIER}(?:\.{IDENTIFIER})+)"
+GIT_HASH = r"(?:[A-Fa-f0-9]{40})"
+GIT_VERSION = rf"(?:(?:git\.(?:{DOTTED_IDENTIFIER}|{IDENTIFIER}))|(?:{GIT_HASH}))"
 
 NAME = r"[a-zA-Z_0-9][a-zA-Z_0-9\-.]*"
 
@@ -85,15 +85,15 @@ HASH = r"[a-zA-Z_0-9]+"
 #: A filename starts either with a "." or a "/" or a "{name}/,
 # or on Windows, a drive letter followed by a colon and "\"
 # or "." or {name}\
-WINDOWS_FILENAME = r"(\.|[a-zA-Z0-9-_]*\\|[a-zA-Z]:\\)([a-zA-Z0-9-_\.\\]*)(\.json|\.yaml)"
-UNIX_FILENAME = r"(\.|\/|[a-zA-Z0-9-_]*\/)([a-zA-Z0-9-_\.\/]*)(\.json|\.yaml)"
+WINDOWS_FILENAME = r"(?:\.|[a-zA-Z0-9-_]*\\|[a-zA-Z]:\\)(?:[a-zA-Z0-9-_\.\\]*)(?:\.json|\.yaml)"
+UNIX_FILENAME = r"(?:\.|\/|[a-zA-Z0-9-_]*\/)(?:[a-zA-Z0-9-_\.\/]*)(?:\.json|\.yaml)"
 if not IS_WINDOWS:
     FILENAME = UNIX_FILENAME
 else:
     FILENAME = WINDOWS_FILENAME
 
-VALUE = r"([a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
-QUOTED_VALUE = r"[\"']+([a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
+VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
+QUOTED_VALUE = r"[\"']+(?:[a-zA-Z_0-9\-+\*.,:=\~\/\\\s]+)[\"']+"
 
 VERSION = r"=?([a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
 VERSION_RANGE = rf"({VERSION}\s*:\s*{VERSION}(?!\s*=)|:\s*{VERSION}(?!\s*=)|{VERSION}\s*:|:)"
@@ -125,34 +125,34 @@ class TokenType(TokenBase):
     """
 
     # Dependency
-    DEPENDENCY = r"(\^)"
+    DEPENDENCY = r"(?:\^)"
     # Version
-    VERSION_HASH_PAIR = rf"(@({GIT_VERSION})=({VERSION}))"
-    VERSION = rf"(@\s*({VERSION_LIST}))"
+    VERSION_HASH_PAIR = rf"(?:@(?:{GIT_VERSION})=(?:{VERSION}))"
+    VERSION = rf"(?:@\s*(?:{VERSION_LIST}))"
     # Variants
-    PROPAGATED_BOOL_VARIANT = rf"((\+\+|~~|--)\s*{NAME})"
-    BOOL_VARIANT = rf"([~+-]\s*{NAME})"
-    PROPAGATED_KEY_VALUE_PAIR = rf"({NAME}\s*==\s*({VALUE}|{QUOTED_VALUE}))"
-    KEY_VALUE_PAIR = rf"({NAME}\s*=\s*({VALUE}|{QUOTED_VALUE}))"
+    PROPAGATED_BOOL_VARIANT = rf"(?:(?:\+\+|~~|--)\s*{NAME})"
+    BOOL_VARIANT = rf"(?:[~+-]\s*{NAME})"
+    PROPAGATED_KEY_VALUE_PAIR = rf"(?:{NAME}\s*==\s*(?:{VALUE}|{QUOTED_VALUE}))"
+    KEY_VALUE_PAIR = rf"(?:{NAME}\s*=\s*(?:{VALUE}|{QUOTED_VALUE}))"
     # Compilers
-    COMPILER_AND_VERSION = rf"(%\s*({NAME})([\s]*)@\s*({VERSION_LIST}))"
-    COMPILER = rf"(%\s*({NAME}))"
+    COMPILER_AND_VERSION = rf"(?:%\s*(?:{NAME})(?:[\s]*)@\s*(?:{VERSION_LIST}))"
+    COMPILER = rf"(?:%\s*(?:{NAME}))"
     # FILENAME
-    FILENAME = rf"({FILENAME})"
+    FILENAME = rf"(?:{FILENAME})"
     # Package name
-    FULLY_QUALIFIED_PACKAGE_NAME = rf"({DOTTED_IDENTIFIER})"
-    UNQUALIFIED_PACKAGE_NAME = rf"({IDENTIFIER})"
+    FULLY_QUALIFIED_PACKAGE_NAME = rf"(?:{DOTTED_IDENTIFIER})"
+    UNQUALIFIED_PACKAGE_NAME = rf"(?:{IDENTIFIER})"
     # DAG hash
-    DAG_HASH = rf"(/({HASH}))"
+    DAG_HASH = rf"(?:/(?:{HASH}))"
     # White spaces
-    WS = r"(\s+)"
+    WS = r"(?:\s+)"
 
 
 class ErrorTokenType(TokenBase):
     """Enum with regexes for error analysis"""
 
     # Unexpected character
-    UNEXPECTED = r"(.[\s]*)"
+    UNEXPECTED = r"(?:.[\s]*)"
 
 
 class Token:


### PR DESCRIPTION
Should avoid many small copies of the input we never use.

Version regex capture groups were fixed in #40344.

As an example, the `spack.parser.ALL_TOKENS` regex has 69 (!) capture groups. Running it on

```
%gcc@1,2:4,5:
```

gives 14 matches... that's rather excessive.

Combining this and #40344 parsing gets about 8-10% faster, benchmarked on:

```
$ wc specs.txt  # one spec per line
  1000   3708 119013 specs.txt
```

```python
# before
In [1]: import spack.parser

In [2]: %timeit spack.parser.SpecParser(open("specs.txt").read()).all_specs()
74.6 ms ± 230 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

```python
# after
In [1]: import spack.parser

In [2]: %timeit spack.parser.SpecParser(open("specs.txt").read()).all_specs()
68.5 ms ± 273 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
