### PR TITLE
Update CITATION.cff with conf dates

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -62,6 +62,8 @@ preferred-citation:
     city: "Austin"
     region: "Texas"
     country: "US"
+    date-start: 2015-11-15
+    date-end: 2015-11-20
   month: 11
   year: 2015
   identifiers:


### PR DESCRIPTION
Add `start-date` and `end-date` to citation. The APA shows the start/end date but BibTex still does not.
I tested with `cffconvert` and on github in a [temp repo](https://github.com/markcmiller86/foobar)

As an aside, if you follow the `Site this repository` link and go to `View citation file`, it will produce a message about whether github was able to parse it or not. Its just a clue if its good and doesn't help fix the file but you at least know whether its working or not.

FYI, the reason I went down this path is that VisIt's citation file was not working either and then I remembered, I copied from Spack. So, I went to check spack's repo and discovered same problems VisIt's citation file was having and figured I might was well share what I learned while fixing VisIt :wink:.