### PR TITLE
More helpful error when patch lookup fails

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -312,21 +312,19 @@ class PatchCache:
     def to_json(self, stream):
         sjson.dump({"patches": self.index}, stream)
 
-    def patch_for_package(self, sha256, pkg):
+    def patch_for_package(self, sha256: str, pkg):
         """Look up a patch in the index and build a patch object for it.
 
         Arguments:
-            sha256 (str): sha256 hash to look up
+            sha256: sha256 hash to look up
             pkg (spack.package_base.PackageBase): Package object to get patch for.
 
         We build patch objects lazily because building them requires that
-        we have information about the package's location in its repo.
-
-        """
+        we have information about the package's location in its repo."""
         sha_index = self.index.get(sha256)
         if not sha_index:
-            raise NoSuchPatchError(
-                "Couldn't find patch for package %s with sha256: %s" % (pkg.fullname, sha256)
+            raise PatchLookupError(
+                f"Couldn't find patch for package {pkg.fullname} with sha256: {sha256}"
             )
 
         # Find patches for this class or any class it inherits from
@@ -335,8 +333,8 @@ class PatchCache:
             if patch_dict:
                 break
         else:
-            raise NoSuchPatchError(
-                "Couldn't find patch for package %s with sha256: %s" % (pkg.fullname, sha256)
+            raise PatchLookupError(
+                f"Couldn't find patch for package {pkg.fullname} with sha256: {sha256}"
             )
 
         # add the sha256 back (we take it out on write to save space,
@@ -403,6 +401,10 @@ class PatchCache:
 
 class NoSuchPatchError(spack.error.SpackError):
     """Raised when a patch file doesn't exist."""
+
+
+class PatchLookupError(NoSuchPatchError):
+    """Raised when a patch file cannot be located from sha256."""
 
 
 class PatchDirectiveError(spack.error.SpackError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -74,6 +74,7 @@ import spack.dependency as dp
 import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
+import spack.patch
 import spack.paths
 import spack.platforms
 import spack.provider_index
@@ -3906,7 +3907,15 @@ class Spec:
                 for sha256 in self.variants["patches"]._patches_in_order_of_appearance:
                     index = spack.repo.PATH.patch_index
                     pkg_cls = spack.repo.PATH.get_pkg_class(self.name)
-                    patch = index.patch_for_package(sha256, pkg_cls)
+                    try:
+                        patch = index.patch_for_package(sha256, pkg_cls)
+                    except spack.patch.PatchLookupError as e:
+                        raise spack.error.SpecError(
+                            f"{e}. This usually means the patch was modified or removed. "
+                            "To fix this, either reconcretize or use the original package "
+                            "repository"
+                        ) from e
+
                     self._patches.append(patch)
 
         return self._patches


### PR DESCRIPTION
Closes #13233

The original issues (`spack uninstall` requiring the patch to exist) is no longer an issue, so fixing the issue is just about making the error more actionable.

```
==> Error: Couldn't find patch for package builtin.perl with sha256:
814e4d1c7496e6b23834e7c88da3d69139418860fbc488fe82fd226b450a4be7. This usually
means the patch was modified or removed. To fix this, either reconcretize or
use the original package repository
```

hopefully more useful than "Couldn't find patch for package builtin.perl with sha256: ..."
