### PR TITLE
prerequisites: drop bash

### DIFF
--- a/lib/spack/docs/tables/system_prerequisites.csv
+++ b/lib/spack/docs/tables/system_prerequisites.csv
@@ -1,9 +1,8 @@
 Name, Supported Versions, Notes, Requirement Reason
-Python, 3.6--3.11, , Interpreter for Spack
+Python, 3.6--3.12, , Interpreter for Spack
 C/C++ Compilers, , , Building software
 make, , , Build software
 patch, , , Build software
-bash, , , Compiler wrappers
 tar, , , Extract/create archives
 gzip, , , Compress/Decompress archives
 unzip, , , Compress/Decompress archives


### PR DESCRIPTION
Not used by spack; may be used by packages, but that's another issue.

