### PR TITLE
git: optimize again

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -253,8 +253,6 @@ class Git(AutotoolsPackage):
                     extlib_bits.append(spec["gettext"].libs.search_flags)
                 extlib_bits.append("-lintl")
                 env.append_flags("EXTLIBS", " ".join(extlib_bits))
-            if not is_system_path(spec["gettext"].prefix):
-                env.append_flags("CFLAGS", spec["gettext"].headers.include_flags)
 
         if not self.spec["curl"].satisfies("libs=shared"):
             curlconfig = which(os.path.join(self.spec["curl"].prefix.bin, "curl-config"))


### PR DESCRIPTION
Setting CFLAGS in git causes the -O2 optimization flag to be dropped.

The include flag should be CPPFLAGS anyways, but also it's unnecessary because the compiler wrapper injects it.