### PR TITLE
rkcommon: checksum 1.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/rkcommon/package.py
+++ b/var/spack/repos/builtin/packages/rkcommon/package.py
@@ -16,6 +16,7 @@ class Rkcommon(CMakePackage):
 
     # maintainers("github_user1",o"github_user2")
 
+    version("1.11.0", sha256="9cfeedaccdefbdcf23c465cb1e6c02057100c4a1a573672dc6cfea5348cedfdd")
     version("1.10.0", sha256="57a33ce499a7fc5a5aaffa39ec7597115cf69ed4ff773546b5b71ff475ee4730")
     version("1.9.0", sha256="b68aa02ef44c9e35c168f826a14802bb5cc6a9d769ba4b64b2c54f347a14aa53")
     version("1.8.0", sha256="f037c15f7049610ef8bca37500b2ab00775af60ebbb9d491ba5fc2e5c04a7794")


### PR DESCRIPTION
new version, required by openvkl@1.3.2 and by ospray@2.11: