### PR TITLE
libzmq: modernize and deprecate `@:4.3.2`

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -25,17 +25,81 @@ class Libzmq(AutotoolsPackage):
     version("4.3.5", sha256="6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43")
     version("4.3.4", sha256="c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5")
     version("4.3.3", sha256="9d9285db37ae942ed0780c016da87060497877af45094ff9e1a1ca736e3875a2")
-    version("4.3.2", sha256="ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763")
-    version("4.3.1", sha256="bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb")
-    version("4.3.0", sha256="8e9c3af6dc5a8540b356697081303be392ade3f014615028b3c896d0148397fd")
-    version("4.2.5", sha256="cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f")
-    version("4.2.2", sha256="5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b")
-    version("4.1.4", sha256="e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378")
-    version("4.1.2", sha256="f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927")
-    version("4.1.1", sha256="43d61e5706b43946aad4a661400627bcde9c63cc25816d4749c67b64c3dab8db")
-    version("4.0.7", sha256="e00b2967e074990d0538361cc79084a0a92892df2c6e7585da34e4c61ee47b03")
-    version("4.0.6", sha256="28a2a9c9b77014c39087a498942449df18bb9885cdb63334833525a1d19f2894")
-    version("4.0.5", sha256="3bc93c5f67370341428364ce007d448f4bb58a0eaabd0a60697d8086bc43342b")
+
+    # Policy: https://spack.readthedocs.io/en/latest/packaging_guide.html#deprecating-old-versions
+    #
+    # Version   Deprecation Reason
+    # =======   ===============================================================================
+    # @:4.3.2   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13132,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15166,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36400,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-20234,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-20235,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-20236,
+    #           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-20237,
+    #           poor modern compiler support, see conflicts
+    # @:4.3.1   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250
+    #   @:4.2   legacy release 2018 (https://github.com/zeromq/libzmq/releases/tag/v4.2.5)
+    #   @:4.1   legacy release 2016 (http://wiki.zeromq.org/intro:get-the-software),
+    #           http://download.zeromq.org/zeromq-4.1.4.tar.gz -> 503 Service Unavailable
+    #   @:4.0   legacy release 2016 (http://wiki.zeromq.org/intro:get-the-software),
+    #           http://download.zeromq.org/zeromq-4.0.7.tar.gz -> 503 Service Unavailable
+
+    version(
+        "4.3.2",
+        sha256="ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763",
+        deprecated=True,
+    )
+    version(
+        "4.3.1",
+        sha256="bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb",
+        deprecated=True,
+    )
+    version(
+        "4.3.0",
+        sha256="8e9c3af6dc5a8540b356697081303be392ade3f014615028b3c896d0148397fd",
+        deprecated=True,
+    )
+    version(
+        "4.2.5",
+        sha256="cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f",
+        deprecated=True,
+    )
+    version(
+        "4.2.2",
+        sha256="5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b",
+        deprecated=True,
+    )
+    version(
+        "4.1.4",
+        sha256="e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378",
+        deprecated=True,
+    )
+    version(
+        "4.1.2",
+        sha256="f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927",
+        deprecated=True,
+    )
+    version(
+        "4.1.1",
+        sha256="43d61e5706b43946aad4a661400627bcde9c63cc25816d4749c67b64c3dab8db",
+        deprecated=True,
+    )
+    version(
+        "4.0.7",
+        sha256="e00b2967e074990d0538361cc79084a0a92892df2c6e7585da34e4c61ee47b03",
+        deprecated=True,
+    )
+    version(
+        "4.0.6",
+        sha256="28a2a9c9b77014c39087a498942449df18bb9885cdb63334833525a1d19f2894",
+        deprecated=True,
+    )
+    version(
+        "4.0.5",
+        sha256="3bc93c5f67370341428364ce007d448f4bb58a0eaabd0a60697d8086bc43342b",
+        deprecated=True,
+    )
 
     variant("docs", default=False, description="Build documentation")
     variant("drafts", default=False, description="Build and install draft classes and methods")

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -119,11 +119,11 @@ class Libzmq(AutotoolsPackage):
     conflicts("%gcc@8:", when="@:4.2.2")
     conflicts("%gcc@11:", when="@:4.3.2")
 
-    depends_on("autoconf", type="build", when="@master")
-    depends_on("automake", type="build", when="@master")
-    depends_on("libtool", type="build", when="@master")
-    depends_on("docbook-xml", type="build", when="+docs")
-    depends_on("docbook-xsl", type="build", when="+docs")
+    with when("@master"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("ruby-asciidoctor", type="build", when="+docs")
     depends_on("pkgconfig", type="build")
 
     depends_on("libbsd", when="+libbsd")

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -12,8 +12,12 @@ class Libzmq(AutotoolsPackage):
     """The ZMQ networking/concurrency library and core API"""
 
     homepage = "https://zguide.zeromq.org/"
-    url = "https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz"
     git = "https://github.com/zeromq/libzmq.git"
+
+    def url_for_version(self, ver):
+        if ver <= Version("4.1.4"):
+            return f"http://download.zeromq.org/zeromq-{ver}.tar.gz"
+        return f"https://github.com/zeromq/libzmq/releases/download/v{ver}/zeromq-{ver}.tar.gz"
 
     maintainers("dennisklein")
 
@@ -90,12 +94,6 @@ class Libzmq(AutotoolsPackage):
         when="@4.3.3:4.3.4",
     )
 
-    def url_for_version(self, version):
-        if version <= Version("4.1.4"):
-            url = "http://download.zeromq.org/zeromq-{0}.tar.gz"
-        else:
-            url = "https://github.com/zeromq/libzmq/releases/download/v{0}/zeromq-{0}.tar.gz"
-        return url.format(version)
 
     @when("@master")
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -48,61 +48,18 @@ class Libzmq(AutotoolsPackage):
     #   @:4.0   legacy release 2016 (http://wiki.zeromq.org/intro:get-the-software),
     #           http://download.zeromq.org/zeromq-4.0.7.tar.gz -> 503 Service Unavailable
 
-    version(
-        "4.3.2",
-        sha256="ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763",
-        deprecated=True,
-    )
-    version(
-        "4.3.1",
-        sha256="bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb",
-        deprecated=True,
-    )
-    version(
-        "4.3.0",
-        sha256="8e9c3af6dc5a8540b356697081303be392ade3f014615028b3c896d0148397fd",
-        deprecated=True,
-    )
-    version(
-        "4.2.5",
-        sha256="cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f",
-        deprecated=True,
-    )
-    version(
-        "4.2.2",
-        sha256="5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b",
-        deprecated=True,
-    )
-    version(
-        "4.1.4",
-        sha256="e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378",
-        deprecated=True,
-    )
-    version(
-        "4.1.2",
-        sha256="f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927",
-        deprecated=True,
-    )
-    version(
-        "4.1.1",
-        sha256="43d61e5706b43946aad4a661400627bcde9c63cc25816d4749c67b64c3dab8db",
-        deprecated=True,
-    )
-    version(
-        "4.0.7",
-        sha256="e00b2967e074990d0538361cc79084a0a92892df2c6e7585da34e4c61ee47b03",
-        deprecated=True,
-    )
-    version(
-        "4.0.6",
-        sha256="28a2a9c9b77014c39087a498942449df18bb9885cdb63334833525a1d19f2894",
-        deprecated=True,
-    )
-    version(
-        "4.0.5",
-        sha256="3bc93c5f67370341428364ce007d448f4bb58a0eaabd0a60697d8086bc43342b",
-        deprecated=True,
-    )
+    with default_args(deprecated=True):
+        version("4.3.2", sha256="ebd7b5c830d6428956b67a0454a7f8cbed1de74b3b01e5c33c5378e22740f763")
+        version("4.3.1", sha256="bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb")
+        version("4.3.0", sha256="8e9c3af6dc5a8540b356697081303be392ade3f014615028b3c896d0148397fd")
+        version("4.2.5", sha256="cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f")
+        version("4.2.2", sha256="5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b")
+        version("4.1.4", sha256="e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378")
+        version("4.1.2", sha256="f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927")
+        version("4.1.1", sha256="43d61e5706b43946aad4a661400627bcde9c63cc25816d4749c67b64c3dab8db")
+        version("4.0.7", sha256="e00b2967e074990d0538361cc79084a0a92892df2c6e7585da34e4c61ee47b03")
+        version("4.0.6", sha256="28a2a9c9b77014c39087a498942449df18bb9885cdb63334833525a1d19f2894")
+        version("4.0.5", sha256="3bc93c5f67370341428364ce007d448f4bb58a0eaabd0a60697d8086bc43342b")
 
     variant("docs", default=False, description="Build documentation")
     variant("drafts", default=False, description="Build and install draft classes and methods")
@@ -122,12 +79,13 @@ class Libzmq(AutotoolsPackage):
     conflicts("%gcc@8:", when="@:4.2.2")
     conflicts("%gcc@11:", when="@:4.3.2")
 
-    with when("@master"):
-        depends_on("autoconf", type="build")
-        depends_on("automake", type="build")
-        depends_on("libtool", type="build")
-        depends_on("ruby-asciidoctor", type="build", when="+docs")
-    depends_on("pkgconfig", type="build")
+    with default_args(type="build"):
+        depends_on("pkgconfig")
+        with when("@master"):
+            depends_on("autoconf")
+            depends_on("automake")
+            depends_on("libtool")
+            depends_on("ruby-asciidoctor")
 
     depends_on("libbsd", when="+libbsd")
     depends_on("libsodium", when="+libsodium")


### PR DESCRIPTION
I have grepped the builtin repo for `libzmq` dependents and did not find any conflicts with the proposed deprecation.

Note, the [libzmq v4.3.3 release](https://github.com/zeromq/libzmq/releases/tag/v4.3.3) is already three years old.