### PR TITLE
Environments: Add support for including views

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -70,6 +70,7 @@ SECTION_SCHEMAS = {
     "compilers": spack.schema.compilers.schema,
     "concretizer": spack.schema.concretizer.schema,
     "definitions": spack.schema.definitions.schema,
+    "view": spack.schema.view.schema,
     "mirrors": spack.schema.mirrors.schema,
     "repos": spack.schema.repos.schema,
     "packages": spack.schema.packages.schema,

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -53,7 +53,6 @@ schema = {
                         },
                     },
                     "specs": spack.schema.spec_list_schema,
-                    "view": spack.schema.view.schema,
                 },
             ),
         }

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -53,38 +53,7 @@ schema = {
                         },
                     },
                     "specs": spack.schema.spec_list_schema,
-                    "view": {
-                        "anyOf": [
-                            {"type": "boolean"},
-                            {"type": "string"},
-                            {
-                                "type": "object",
-                                "patternProperties": {
-                                    r"\w+": {
-                                        "required": ["root"],
-                                        "additionalProperties": False,
-                                        "properties": {
-                                            "root": {"type": "string"},
-                                            "link": {
-                                                "type": "string",
-                                                "pattern": "(roots|all|run)",
-                                            },
-                                            "link_type": {"type": "string"},
-                                            "select": {
-                                                "type": "array",
-                                                "items": {"type": "string"},
-                                            },
-                                            "exclude": {
-                                                "type": "array",
-                                                "items": {"type": "string"},
-                                            },
-                                            "projections": projections_scheme,
-                                        },
-                                    }
-                                },
-                            },
-                        ]
-                    },
+                    "view": spack.schema.view.schema,
                 },
             ),
         }

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -23,6 +23,7 @@ import spack.schema.modules
 import spack.schema.packages
 import spack.schema.repos
 import spack.schema.upstreams
+import spack.schema.view
 
 #: Properties for inclusion in other schemas
 properties = union_dicts(
@@ -39,6 +40,7 @@ properties = union_dicts(
     spack.schema.packages.properties,
     spack.schema.repos.properties,
     spack.schema.upstreams.properties,
+    spack.schema.view.properties,
 )
 
 

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for view
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/view.py
+   :lines: 14-
+"""
+
+import spack.schema
+
+projections_scheme = spack.schema.projections.properties["projections"]
+
+#: Properties for inclusion in other schemas
+properties = {
+    "view": {
+        "anyOf": [
+            {"type": "boolean"},
+            {"type": "string"},
+            {
+                "type": "object",
+                "patternProperties": {
+                    r"\w+": {
+                        "required": ["root"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "root": {"type": "string"},
+                            "link": {"type": "string", "pattern": "(roots|all|run)"},
+                            "link_type": {"type": "string"},
+                            "select": {"type": "array", "items": {"type": "string"}},
+                            "exclude": {"type": "array", "items": {"type": "string"}},
+                            "projections": projections_scheme,
+                        },
+                    }
+                },
+            },
+        ]
+    }
+}
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Spack view configuration file schema",
+    "properties": properties,
+}

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2483,11 +2483,8 @@ def test_stack_view_multiple_views(
     with ev.read("test"):
         install()
 
-    shell = env("activate", "--sh", "test")
-    assert "PATH" in shell
-    assert str(default_dir / "bin") in shell
-
     with ev.read("test") as e:
+        assert os.path.exists(str(default_dir / "bin"))
         for spec in e._get_environment_specs():
             spec_subdir = f"{spec.version}-{spec.compiler.name}"
             comb_spec_dir = str(comb_dir / spec.name / spec_subdir)

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1168,19 +1168,19 @@ complete -c spack -n '__fish_spack_using_command config' -l scope -r -d 'configu
 
 # spack config get
 set -g __fish_spack_optspecs_spack_config_get h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config get' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams view'
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config get' -s h -l help -d 'show this help message and exit'
 
 # spack config blame
 set -g __fish_spack_optspecs_spack_config_blame h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config blame' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams view'
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config blame' -s h -l help -d 'show this help message and exit'
 
 # spack config edit
 set -g __fish_spack_optspecs_spack_config_edit h/help print-file
-complete -c spack -n '__fish_spack_using_command_pos 0 config edit' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams'
+complete -c spack -n '__fish_spack_using_command_pos 0 config edit' -f -a 'bootstrap cdash ci compilers concretizer config definitions mirrors modules packages repos upstreams view'
 complete -c spack -n '__fish_spack_using_command config edit' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config edit' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config edit' -l print-file -f -a print_file


### PR DESCRIPTION
~Depends on #33960 (for existing unit test updates resulting from reading include files in constructor).~

This PR adds support for including view configuration files.  At present named views are combined from included views and environment configuration files.

UPDATE:  Basic approach will be replaced once #42058 is complete.