### PR TITLE
Tests: Ensure unique names for test_not_stripping_all_symbols

### DIFF
--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -143,7 +143,7 @@ def test_error_message_invalid_os(minimal_configuration):
 
 
 @pytest.mark.regression("34629,18030")
-def test_not_stripping_all_symbols(minimal_configuration):
+def test_not_stripping_all_symbols_minimal(minimal_configuration):
     """Tests that we are not stripping all symbols, so that libraries can still be
     used for linking.
     """

--- a/lib/spack/spack/test/container/singularity.py
+++ b/lib/spack/spack/test/container/singularity.py
@@ -43,7 +43,7 @@ def test_singularity_specific_properties(properties, expected, singularity_confi
 
 
 @pytest.mark.regression("34629,18030")
-def test_not_stripping_all_symbols(singularity_configuration):
+def test_not_stripping_all_symbols_singularity(singularity_configuration):
     """Tests that we are not stripping all symbols, so that libraries can still be
     used for linking.
     """


### PR DESCRIPTION
This PR distinguishes the names of the two `test_not_stripping_all_symbols` unit tests:  one for docker and one for singularity.  Otherwise there is a name collision.