### PR TITLE
[gcc] Define '--target' matching operating system

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -757,7 +757,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
         # Re-use the GNU target triplet defined in the existing gcc
         existing_gcc = Executable("gcc")
-        triplet = exisitng_gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
+        triplet = existing_gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
         if triplet:
             options.append("--build={}".format(triplet))
             options.append("--target={}".format(triplet))

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -756,11 +756,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         ]
 
         # Re-use the GNU target triplet defined in the existing gcc
-        existing_gcc = Executable("gcc")
-        triplet = existing_gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
-        if triplet:
-            options.append("--build={}".format(triplet))
-            options.append("--target={}".format(triplet))
+        if spec.satisfies("%gcc"):
+            gcc = Executable(self.compiler.cc)
+            triplet = gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
+            if triplet:
+                options.append("--host={}".format(triplet))
+                options.append("--build={}".format(triplet))
+                options.append("--target={}".format(triplet))
 
         # Avoid excessive realpath/stat calls for every system header
         # by making -fno-canonical-system-headers the default.

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -756,7 +756,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         ]
 
         # Re-use the GNU target triplet defined in the existing gcc
-        exisitng_gcc = Executable("gcc")
+        existing_gcc = Executable("gcc")
         triplet = exisitng_gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
         if triplet:
             options.append("--build={}".format(triplet))

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -755,6 +755,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             "--disable-nls",
         ]
 
+        # Re-use the GNU target triplet defined in the existing gcc
+        exisitng_gcc = Executable("gcc")
+        triplet = exisitng_gcc("-###", error=str).partition("Target: ")[2].split("\n")[0]
+        if triplet:
+            options.append("--build={}".format(triplet))
+            options.append("--target={}".format(triplet))
+
         # Avoid excessive realpath/stat calls for every system header
         # by making -fno-canonical-system-headers the default.
         if self.version >= Version("4.8.0"):


### PR DESCRIPTION
The GNU target triplet is not always guessed correctly by the configure script. Use the pre-existing `gcc` to define the correct build target.

This fixes https://github.com/spack/spack/issues/27668 as the Intel compiler needs the correct Debian tuplet `x86_64-linux-gnu` as `target` in its underlying `gcc` to find files under `/usr/include/x86_64-linux-gnu`.

I looked into using the build scripts of the different `gcc` packages in Linux distributions, but there are just too many differences, e.g. Debian based distributions use their own triplets (https://wiki.debian.org/Multiarch/Tuples). As `gcc` is a dependency for Spack installation, we can safely assume that `existing_gcc` exists and can be used to report its build target.