### PR TITLE
spack checksum: improve interactive filtering

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -16,6 +16,7 @@ import spack.repo
 import spack.spec
 import spack.stage
 import spack.util.crypto
+import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.package_base import PackageBase, deprecated_version, preferred_version
 from spack.util.editor import editor
@@ -129,6 +130,31 @@ def checksum(parser, args):
             remote_versions = pkg.fetch_remote_versions(args.jobs)
         url_dict = remote_versions
 
+    # A spidered URL can differ from the package.py *computed* URL, pointing to different tarballs.
+    # For example, GitHub release pages sometimes have multiple tarballs with different shasum:
+    # - releases/download/1.0/<pkg>-1.0.tar.gz (uploaded tarball)
+    # - archive/refs/tags/1.0.tar.gz           (generated tarball)
+    # We wanna ensure that `spack checksum` and `spack install` ultimately use the same URL, so
+    # here we check whether the crawled and computed URLs disagree, and if so, prioritize the
+    # former if that URL exists (just sending a HEAD request that is).
+    url_changed_for_version = set()
+    for version, url in url_dict.items():
+        possible_urls = pkg.all_urls_for_version(version)
+        if url not in possible_urls:
+            for possible_url in possible_urls:
+                if web_util.url_exists(possible_url):
+                    url_dict[version] = possible_url
+                    break
+            else:
+                url_changed_for_version.add(version)
+
+    if url_changed_for_version:
+        for v in url_changed_for_version:
+            tty.warn(
+                f"URL for version {v} may have changed "
+                f"from {', '.join(pkg.all_urls_for_version(v))} to {url_dict[v]}"
+            )
+
     if not url_dict:
         tty.die(f"Could not find any remote versions for {pkg.name}")
     elif len(url_dict) > 1 and not args.batch and sys.stdin.isatty():
@@ -138,14 +164,6 @@ def checksum(parser, args):
         url_dict = filtered_url_dict
     else:
         tty.info(f"Found {llnl.string.plural(len(url_dict), 'version')} of {pkg.name}")
-
-    # TODO: fix inconsistencies with discovered URL and computed pkg.all_urls_for_version
-    # for version, url in url_dict.items():
-    #     possible_urls = pkg.all_urls_for_version(version)
-    #     if url not in pkg.all_urls_for_version(version):
-    #         tty.warn(
-    #             f"Detected version {version} with URL {url}, which is different from the package file: {possible_urls}"
-    #         )
 
     version_hashes = spack.stage.get_checksums_for_versions(
         url_dict, pkg.name, keep_stage=args.keep_stage, fetch_options=pkg.fetch_options

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -148,17 +148,12 @@ def checksum(parser, args):
             else:
                 url_changed_for_version.add(version)
 
-    if url_changed_for_version:
-        for v in url_changed_for_version:
-            tty.warn(
-                f"URL for version {v} may have changed "
-                f"from {', '.join(pkg.all_urls_for_version(v))} to {url_dict[v]}"
-            )
-
     if not url_dict:
         tty.die(f"Could not find any remote versions for {pkg.name}")
     elif len(url_dict) > 1 and not args.batch and sys.stdin.isatty():
-        filtered_url_dict = spack.stage.interactive_version_filter(url_dict, pkg.versions)
+        filtered_url_dict = spack.stage.interactive_version_filter(
+            url_dict, pkg.versions, url_changes=url_changed_for_version
+        )
         if filtered_url_dict is None:
             exit(0)
         url_dict = filtered_url_dict

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -28,6 +28,7 @@ from llnl.util.filesystem import (
     partition_path,
     remove_linked_tree,
 )
+from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
 import spack.caches
@@ -914,18 +915,18 @@ def interactive_version_filter(
 
         print_header = True
 
-        tty.msg(
-            colorize(
-                "@w{commands:} "
-                "@*w{1} @*b{c}hecksum, "
-                "@*w{2} @*b{o}pen editor, "
-                "@*w{3} @*b{f}ilter, "
-                "@*w{4} @*b{a}sk each, "
-                "@*w{5} @*b{n}ew only, "
-                "@*w{6} @*b{r}estart, "
-                "@*w{7} @*b{q}uit"
-            )
+        print("commands:")
+        commands = (
+            "@*w{1} @*b{[c]}hecksum",
+            "@*w{2} @*b{[o]}pen editor",
+            "@*w{3} @*b{[f]}ilter",
+            "@*w{4} @*b{[a]}sk each",
+            "@*w{5} @*b{[n]}ew only",
+            "@*w{6} @*b{[r]}estart",
+            "@*w{7} @*b{[q]}uit",
         )
+        colify(list(map(colorize, commands)), indent=2)
+
         try:
             command = input(colorize("@*g{command>} ")).strip().lower()
         except EOFError:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -888,14 +888,18 @@ def interactive_version_filter(
 
     while True:
         num_ver = len(sorted_and_filtered)
-        num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
 
         has_filter = version_filter != VersionList([":"])
-        extra_msg = f"Filtering by {version_filter}." if has_filter else ""
+
+        header = [f"Selected {llnl.string.plural(num_ver, 'version')}"]
+        if known_versions:
+            num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
+            header.append(f"{llnl.string.plural(num_new, 'version')} are new")
+        if has_filter:
+            header.append(f"Filtering by {version_filter}")
 
         tty.msg(
-            f"Selected {llnl.string.plural(num_ver, 'version')}, "
-            f"{llnl.string.plural(num_new, 'version')} are new. {extra_msg}",
+            ". ".join(header) + ".",
             *llnl.util.lang.elide_list(
                 [f"{str(v):{max_len}}  {url_dict[v]}" for v in sorted_and_filtered]
             ),
@@ -904,7 +908,7 @@ def interactive_version_filter(
 
         tty.msg(
             colorize(
-                "@*w{Commands}. "
+                "@w{Commands}. "
                 "1: @*b{c}hecksum, "
                 "2: @*b{o}pen editor, "
                 "3: @*b{f}ilter, "

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -870,7 +870,7 @@ def interactive_version_filter(
     url_dict: Dict[StandardVersion, str],
     known_versions: Iterable[StandardVersion] = (),
     *,
-    url_changes: Set[StandardVersion] = frozenset(),
+    url_changes: Set[StandardVersion] = set(),
     input: Callable[..., str] = input,
 ) -> Optional[Dict[StandardVersion, str]]:
     """Interactively filter the list of spidered versions.

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -891,12 +891,14 @@ def interactive_version_filter(
         if print_header:
             has_filter = version_filter != VersionList([":"])
             header = []
-            if len(sorted_and_filtered) == len(url_dict):
+            if len(sorted_and_filtered) == len(orig_url_dict):
                 header.append(
                     f"Selected {llnl.string.plural(len(sorted_and_filtered), 'version')}"
                 )
             else:
-                header.append(f"Selected {len(sorted_and_filtered)} of {len(url_dict)} versions")
+                header.append(
+                    f"Selected {len(sorted_and_filtered)} of {len(orig_url_dict)} versions"
+                )
             if known_versions:
                 num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
                 header.append(f"{llnl.string.plural(num_new, 'new version')}")

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -921,13 +921,13 @@ def interactive_version_filter(
 
         print("commands:")
         commands = (
-            "@*w{1} @*b{[c]}hecksum",
-            "@*w{2} @*b{[o]}pen editor",
-            "@*w{3} @*b{[f]}ilter",
-            "@*w{4} @*b{[a]}sk each",
-            "@*w{5} @*b{[n]}ew only",
-            "@*w{6} @*b{[r]}estart",
-            "@*w{7} @*b{[q]}uit",
+            "@*b{[c]}hecksum",
+            "@*b{[o]}pen editor",
+            "@*b{[f]}ilter",
+            "@*b{[a]}sk each",
+            "@*b{[n]}ew only",
+            "@*b{[r]}estart",
+            "@*b{[q]}uit",
         )
         colify(list(map(colorize, commands)), indent=2)
 
@@ -937,9 +937,9 @@ def interactive_version_filter(
             print()
             command = "q"
 
-        if command in ("1", "c"):
+        if command == "c":
             break
-        elif command in ("2", "o"):
+        elif command == "o":
             # Create a temporary file in the stage dir with lines of the form
             # <version> <url>
             # which the user can modify. Once the editor is closed, the file is
@@ -984,7 +984,7 @@ def interactive_version_filter(
                 sorted_and_filtered = sorted(url_dict.keys(), reverse=True)
 
             os.unlink(filepath)
-        elif command in ("3", "f"):
+        elif command == "f":
             tty.msg(
                 colorize(
                     f"Examples filters: {VERSION_COLOR}1.2@. "
@@ -1005,7 +1005,7 @@ def interactive_version_filter(
                 continue
             # Apply filter
             sorted_and_filtered = [v for v in sorted_and_filtered if v.satisfies(version_filter)]
-        elif command in ("4", "a"):
+        elif command == "a":
             i = 0
             while i < len(sorted_and_filtered):
                 v = sorted_and_filtered[i]
@@ -1023,13 +1023,13 @@ def interactive_version_filter(
             else:
                 # Went over each version, so go to checksumming
                 break
-        elif command in ("5", "n"):
+        elif command == "n":
             sorted_and_filtered = [v for v in sorted_and_filtered if v not in known_versions]
-        elif command in ("6", "r"):
+        elif command == "r":
             url_dict = orig_url_dict
             sorted_and_filtered = sorted(url_dict.keys(), reverse=True)
             version_filter = VersionList([":"])
-        elif command in ("7", "q"):
+        elif command == "q":
             try:
                 if input("Really quit [y/N]? ").strip().lower() in ("y", "yes"):
                     return None

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -887,23 +887,23 @@ def interactive_version_filter(
     orig_url_dict = url_dict  # only copy when using editor to modify
 
     while True:
-        num_ver = len(sorted_and_filtered)
-
         has_filter = version_filter != VersionList([":"])
-
-        header = [f"Selected {llnl.string.plural(num_ver, 'version')}"]
+        header = []
+        if len(sorted_and_filtered) == len(url_dict):
+            header.append(f"Selected {llnl.string.plural(len(sorted_and_filtered), 'version')}")
+        else:
+            header.append(f"Selected {len(sorted_and_filtered)} of {len(url_dict)} versions")
         if known_versions:
             num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
-            header.append(f"{llnl.string.plural(num_new, 'version')} are new")
+            header.append(f"{llnl.string.plural(num_new, 'new version')}")
         if has_filter:
-            header.append(f"Filtering by {version_filter}")
+            header.append(colorize(f"Filtered by {spack.spec.VERSION_COLOR}{version_filter}@."))
 
-        tty.msg(
-            ". ".join(header) + ".",
-            *llnl.util.lang.elide_list(
-                [f"{str(v):{max_len}}  {url_dict[v]}" for v in sorted_and_filtered]
-            ),
-        )
+        version_with_url = [
+            colorize(f"{spack.spec.VERSION_COLOR}{str(v):{max_len}}@.  ") + url_dict[v]
+            for v in sorted_and_filtered
+        ]
+        tty.msg(". ".join(header), *llnl.util.lang.elide_list(version_with_url))
         print()
 
         tty.msg(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -931,7 +931,7 @@ def interactive_version_filter(
                 for v in sorted_and_filtered:
                     f.write(f"{str(v):{max_len}}  {url_dict[v]}\n")
 
-            editor([tmpfile], exec_fn=executable)
+            editor(tmpfile, exec_fn=executable)
 
             with open(tmpfile, "r") as f:
                 url_dict.clear()

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -13,7 +13,7 @@ import shutil
 import stat
 import sys
 import tempfile
-from typing import Callable, Dict, Iterable, Optional
+from typing import Callable, Dict, Iterable, Optional, Set
 
 import llnl.string
 import llnl.util.lang
@@ -870,6 +870,7 @@ def interactive_version_filter(
     url_dict: Dict[StandardVersion, str],
     known_versions: Iterable[StandardVersion] = (),
     *,
+    url_changes: Set[StandardVersion] = frozenset(),
     input: Callable[..., str] = input,
 ) -> Optional[Dict[StandardVersion, str]]:
     """Interactively filter the list of spidered versions.
@@ -907,7 +908,10 @@ def interactive_version_filter(
                 header.append(colorize(f"Filtered by {VERSION_COLOR}{version_filter}@."))
 
             version_with_url = [
-                colorize(f"{VERSION_COLOR}{str(v):{max_len}}@.  ") + url_dict[v]
+                colorize(
+                    f"{VERSION_COLOR}{str(v):{max_len}}@.  {url_dict[v]}"
+                    f"{'  @K{# NOTE: change of URL}' if v in url_changes else ''}"
+                )
                 for v in sorted_and_filtered
             ]
             tty.msg(". ".join(header), *llnl.util.lang.elide_list(version_with_url))

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -922,7 +922,7 @@ def interactive_version_filter(
         print("commands:")
         commands = (
             "@*b{[c]}hecksum",
-            "@*b{[o]}pen editor",
+            "@*b{[e]}dit",
             "@*b{[f]}ilter",
             "@*b{[a]}sk each",
             "@*b{[n]}ew only",
@@ -939,7 +939,7 @@ def interactive_version_filter(
 
         if command == "c":
             break
-        elif command == "o":
+        elif command == "e":
             # Create a temporary file in the stage dir with lines of the form
             # <version> <url>
             # which the user can modify. Once the editor is closed, the file is

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -155,7 +155,7 @@ def test_checksum_interactive_ask_each():
 def test_checksum_interactive_quit_from_ask_each():
     # Enter ask each mode, select the second item, then quit from submenu, then checksum, which
     # should still include the last item at which ask each stopped.
-    input = input_from_commands("a", "n", "y", "q", "c")
+    input = input_from_commands("a", "n", "y", None, "c")
     assert interactive_version_filter(
         {
             Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -7,12 +7,12 @@ import argparse
 
 import pytest
 
-import llnl.util.tty as tty
-
 import spack.cmd.checksum
 import spack.repo
 import spack.spec
 from spack.main import SpackCommand
+from spack.stage import interactive_version_filter
+from spack.version import Version
 
 spack_checksum = SpackCommand("checksum")
 
@@ -56,18 +56,134 @@ def test_checksum(arguments, expected, mock_packages, mock_clone_repo, mock_stag
         assert "version(" in output
 
 
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
-def test_checksum_interactive(mock_packages, mock_fetch, mock_stage, monkeypatch):
-    # TODO: mock_fetch doesn't actually work with stage, working around with ignoring
-    # fail_on_error for now
-    def _get_number(*args, **kwargs):
-        return 1
+def input_from_commands(*commands):
+    """Create a function that returns the next command from a list of inputs for interactive spack
+    checksum. If None is encountered, this is equivalent to EOF / ^D."""
+    commands = iter(commands)
 
-    monkeypatch.setattr(tty, "get_number", _get_number)
+    def _input(prompt):
+        cmd = next(commands)
+        if cmd is None:
+            raise EOFError
+        assert isinstance(cmd, str)
+        return cmd
 
-    output = spack_checksum("preferred-test", fail_on_error=False)
-    assert "version of preferred-test" in output
-    assert "version(" in output
+    return _input
+
+
+def test_checksum_interactive_filter():
+    # Filter effectively by 1:1.0, then checksum.
+    input = input_from_commands("f", "@1:", "f", "@:1.0", "c")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        input=input,
+    ) == {
+        Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz",
+        Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+    }
+
+
+def test_checksum_interactive_return_from_filter_prompt():
+    # Enter and then exit filter subcommand.
+    input = input_from_commands("f", None, "c")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        input=input,
+    ) == {
+        Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+        Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz",
+        Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+        Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+    }
+
+
+def test_checksum_interactive_quit_returns_none():
+    # Quit after filtering something out (y to confirm quit)
+    input = input_from_commands("f", "@1:", "q", "y")
+    assert (
+        interactive_version_filter(
+            {
+                Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+                Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+                Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+            },
+            input=input,
+        )
+        is None
+    )
+
+
+def test_checksum_interactive_reset_resets():
+    # Filter 1:, then reset, then filter :0, should just given 0.9 (it was filtered out
+    # before reset)
+    input = input_from_commands("f", "@1:", "r", "f", ":0", "c")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        input=input,
+    ) == {Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz"}
+
+
+def test_checksum_interactive_ask_each():
+    # Ask each should run on the filtered list. First select 1.x, then select only the second
+    # entry, which is 1.0.1.
+    input = input_from_commands("f", "@1:", "a", "n", "y", "n")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        input=input,
+    ) == {Version("1.0.1"): "https://www.example.com/pkg-1.0.1.tar.gz"}
+
+
+def test_checksum_interactive_quit_from_ask_each():
+    # Enter ask each mode, select the second item, then quit from submenu, then checksum, which
+    # should still include the last item at which ask each stopped.
+    input = input_from_commands("a", "n", "y", "q", "c")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        input=input,
+    ) == {
+        Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+        Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+    }
+
+
+def test_checksum_interactive_new_only():
+    # The 1.0 version is known already, and should be dropped on `n`.
+    input = input_from_commands("n", "c")
+    assert interactive_version_filter(
+        {
+            Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+            Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+            Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+        },
+        known_versions=[Version("1.0")],
+        input=input,
+    ) == {
+        Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+        Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+    }
 
 
 def test_checksum_versions(mock_packages, mock_clone_repo, mock_fetch, mock_stage):

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -647,7 +647,7 @@ def find_versions_of_archive(
     list_urls |= additional_list_urls
 
     # Grab some web pages to scrape.
-    pages, links = spack.util.web.spider(list_urls, depth=list_depth, concurrency=concurrency)
+    _, links = spack.util.web.spider(list_urls, depth=list_depth, concurrency=concurrency)
 
     # Scrape them for archive URLs
     regexes = []

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -61,7 +61,7 @@ def executable(exe: str, args: List[str]) -> int:
     return cmd.returncode
 
 
-def editor(*args: List[str], exec_fn: Callable[[str, List[str]], int] = os.execv) -> bool:
+def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> bool:
     """Invoke the user's editor.
 
     This will try to execute the following, in order:


### PR DESCRIPTION
Instead of asking for "How many versions" about a list that's truncated, give users the option to interactively filter, similar to the `git clean -i` interface.  Especially the command "open in editor" feels like a huge improvement in selecting versions before downloading them.

<img width="780" alt="Screenshot 2023-10-10 at 18 29 24" src="https://github.com/spack/spack/assets/194764/7c988a92-bab7-4655-b347-97fe93f9ca8e">





