### PR TITLE
fix variant initialization logic to allow proper handling of values="*"

### DIFF
--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -734,3 +734,38 @@ def test_conditional_value_comparable_to_bool(other):
     value = spack.variant.Value("98", when="@1.0")
     comparison = value == other
     assert comparison is False
+
+
+@pytest.mark.regression("40405")
+def test_wild_card_valued_variants_equivalent_to_str():
+    str_var = spack.variant.Variant(
+        name="str_var",
+        default="none",
+        values=str,
+        description="str variant",
+        multi=True,
+        validator=None,
+    )
+
+    wild_var = spack.variant.Variant(
+        name="wild_var",
+        default="none",
+        values="*",
+        description="* variant",
+        multi=True,
+        validator=None,
+    )
+
+    several_arbitrary_values=("doe", "re", "mi")
+    # "*" case
+    wild_output = wild_var.make_variant(several_arbitrary_values)
+    wild_var.validate_or_raise(wild_output)
+    # str case
+    str_output = str_var.make_variant(several_arbitrary_values)
+    str_var.validate_or_raise(str_output)
+    # swap and validate outputs
+    # must swap names to ensure the contents are the same
+    str_output.name = wild_var.name
+    wild_output.name = str_var.name
+    str_var.validate_or_raise(wild_output)
+    wild_var.validate_or_raise(str_output)

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -756,7 +756,7 @@ def test_wild_card_valued_variants_equivalent_to_str():
         validator=None,
     )
 
-    several_arbitrary_values=("doe", "re", "mi")
+    several_arbitrary_values = ("doe", "re", "mi")
     # "*" case
     wild_output = wild_var.make_variant(several_arbitrary_values)
     wild_var.validate_or_raise(wild_output)

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -738,6 +738,12 @@ def test_conditional_value_comparable_to_bool(other):
 
 @pytest.mark.regression("40405")
 def test_wild_card_valued_variants_equivalent_to_str():
+    """
+    There was a bug prioro to PR 40406 in that variants with wildcard values "*"
+    were being overwritten in the variant constructor.
+    The expected/appropriate behavior is for it to behave like value=str and this
+    test demonstrates that the two are now equivalent
+    """
     str_var = spack.variant.Variant(
         name="str_var",
         default="none",
@@ -763,9 +769,5 @@ def test_wild_card_valued_variants_equivalent_to_str():
     # str case
     str_output = str_var.make_variant(several_arbitrary_values)
     str_var.validate_or_raise(str_output)
-    # swap and validate outputs
-    # must swap names to ensure the contents are the same
-    str_output.name = wild_var.name
-    wild_output.name = str_var.name
-    str_var.validate_or_raise(wild_output)
-    wild_var.validate_or_raise(str_output)
+    # equivalence each instance already validated
+    assert str_output.value == wild_output.value

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -74,7 +74,7 @@ class Variant:
 
             self.single_value_validator = isa_type
 
-        if callable(values):
+        elif callable(values):
             # If 'values' is a callable, assume it is a single value
             # validator and reset the values to be explicit during debug
             self.single_value_validator = values


### PR DESCRIPTION
Fix for #40405.

Closes: #40405