### PR TITLE
spack checksum: show long flags in usage output

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -35,30 +35,30 @@ def setup_parser(subparser):
         help="don't clean up staging area when command completes",
     )
     subparser.add_argument(
-        "-b",
         "--batch",
+        "-b",
         action="store_true",
         default=False,
         help="don't ask which versions to checksum",
     )
     subparser.add_argument(
-        "-l",
         "--latest",
+        "-l",
         action="store_true",
         default=False,
         help="checksum the latest available version",
     )
     subparser.add_argument(
-        "-p",
         "--preferred",
+        "-p",
         action="store_true",
         default=False,
         help="checksum the known Spack preferred version",
     )
     modes_parser = subparser.add_mutually_exclusive_group()
     modes_parser.add_argument(
-        "-a",
         "--add-to-package",
+        "-a",
         action="store_true",
         default=False,
         help="add new versions to package",

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -681,7 +681,7 @@ _spack_change() {
 _spack_checksum() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --keep-stage -b --batch -l --latest -p --preferred -a --add-to-package --verify -j --jobs"
+        SPACK_COMPREPLY="-h --help --keep-stage --batch -b --latest -l --preferred -p --add-to-package -a --verify -j --jobs"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -906,14 +906,14 @@ complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -f -a he
 complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -f -a keep_stage
 complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -d 'don\'t clean up staging area when command completes'
-complete -c spack -n '__fish_spack_using_command checksum' -s b -l batch -f -a batch
-complete -c spack -n '__fish_spack_using_command checksum' -s b -l batch -d 'don\'t ask which versions to checksum'
-complete -c spack -n '__fish_spack_using_command checksum' -s l -l latest -f -a latest
-complete -c spack -n '__fish_spack_using_command checksum' -s l -l latest -d 'checksum the latest available version'
-complete -c spack -n '__fish_spack_using_command checksum' -s p -l preferred -f -a preferred
-complete -c spack -n '__fish_spack_using_command checksum' -s p -l preferred -d 'checksum the known Spack preferred version'
-complete -c spack -n '__fish_spack_using_command checksum' -s a -l add-to-package -f -a add_to_package
-complete -c spack -n '__fish_spack_using_command checksum' -s a -l add-to-package -d 'add new versions to package'
+complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -f -a batch
+complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -d 'don\'t ask which versions to checksum'
+complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -f -a latest
+complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -d 'checksum the latest available version'
+complete -c spack -n '__fish_spack_using_command checksum' -l preferred -s p -f -a preferred
+complete -c spack -n '__fish_spack_using_command checksum' -l preferred -s p -d 'checksum the known Spack preferred version'
+complete -c spack -n '__fish_spack_using_command checksum' -l add-to-package -s a -f -a add_to_package
+complete -c spack -n '__fish_spack_using_command checksum' -l add-to-package -s a -d 'add new versions to package'
 complete -c spack -n '__fish_spack_using_command checksum' -l verify -f -a verify
 complete -c spack -n '__fish_spack_using_command checksum' -l verify -d 'verify known package checksums'
 complete -c spack -n '__fish_spack_using_command checksum' -s j -l jobs -r -f -a jobs


### PR DESCRIPTION
Before:

```
$ spack checksum
usage: spack checksum [-hblp] [--keep-stage] [-a | --verify] [-j JOBS]
```

After:

```
$ spack checksum
usage: spack checksum [-h] [--keep-stage] [--batch] [--latest] [--preferred] [--add-to-package | --verify] [-j JOBS] package ...
```
