### PR TITLE
allow packages to request no submodules be updated

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -326,9 +326,7 @@ class DirectiveMeta(type):
         return _decorator
 
 
-SubmoduleCallback = Callable[
-    ["spack.package_base.PackageBase"], Union[str, List[str], bool]
-]
+SubmoduleCallback = Callable[["spack.package_base.PackageBase"], Union[str, List[str], bool]]
 directive = DirectiveMeta.directive
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -323,8 +323,10 @@ class DirectiveMeta(type):
         return _decorator
 
 
+SubmoduleCallback = Callable[
+    "spack.package_base.PackageBase", Union[str, List[str], bool]
+]
 directive = DirectiveMeta.directive
-
 
 @directive("versions")
 def version(
@@ -354,7 +356,7 @@ def version(
     tag: Optional[str] = None,
     branch: Optional[str] = None,
     get_full_repo: Optional[bool] = None,
-    submodules: Optional[bool] = None,
+    submodules: Union[SubmoduleCallback, Optional[bool]] = False,
     submodules_delete: Optional[bool] = None,
     # other version control
     svn: Optional[str] = None,

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -358,7 +358,7 @@ def version(
     tag: Optional[str] = None,
     branch: Optional[str] = None,
     get_full_repo: Optional[bool] = None,
-    submodules: Union[SubmoduleCallback, Optional[bool]] = False,
+    submodules: Union[SubmoduleCallback, Optional[bool]] = None,
     submodules_delete: Optional[bool] = None,
     # other version control
     svn: Optional[str] = None,

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -323,10 +323,9 @@ class DirectiveMeta(type):
         return _decorator
 
 
-SubmoduleCallback = Callable[
-    "spack.package_base.PackageBase", Union[str, List[str], bool]
-]
+SubmoduleCallback = Callable["spack.package_base.PackageBase", Union[str, List[str], bool]]
 directive = DirectiveMeta.directive
+
 
 @directive("versions")
 def version(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -33,7 +33,7 @@ import collections.abc
 import functools
 import os.path
 import re
-from typing import Any, Callable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import llnl.util.lang
 import llnl.util.tty.color
@@ -55,6 +55,9 @@ from spack.version import (
     VersionError,
     VersionLookupError,
 )
+
+if TYPE_CHECKING:
+    import spack.package_base
 
 __all__ = [
     "DirectiveError",

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -33,7 +33,7 @@ import collections.abc
 import functools
 import os.path
 import re
-from typing import Any, Callable, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Union
 
 import llnl.util.lang
 import llnl.util.tty.color

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -326,7 +326,9 @@ class DirectiveMeta(type):
         return _decorator
 
 
-SubmoduleCallback = Callable["spack.package_base.PackageBase", Union[str, List[str], bool]]
+SubmoduleCallback = Callable[
+    ["spack.package_base.PackageBase"], Union[str, List[str], bool]
+]
 directive = DirectiveMeta.directive
 
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -907,9 +907,12 @@ class GitFetchStrategy(VCSFetchStrategy):
         git_commands = []
         submodules = self.submodules
         if callable(submodules):
-            submodules = list(submodules(self.package))
-            git_commands.append(["submodule", "init", "--"] + submodules)
-            git_commands.append(["submodule", "update", "--recursive"])
+            submodules = submodules(self.package)
+            if submodules:
+                if isinstance(submodules, str):
+                    submodules = [submodules]
+                git_commands.append(["submodule", "init", "--"] + submodules)
+                git_commands.append(["submodule", "update", "--recursive"])
         elif submodules:
             git_commands.append(["submodule", "update", "--init", "--recursive"])
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -363,3 +363,30 @@ def test_gitsubmodules_delete(
         assert not os.path.isdir(file_path)
         file_path = os.path.join(s.package.stage.source_path, "third_party/submodule1")
         assert not os.path.isdir(file_path)
+
+
+@pytest.mark.disable_clean_stage_check
+def test_gitsubmodules_falsey(
+    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
+):
+    """
+    Test GitFetchStrategy behavior when callable submodules returns Falsey
+    """
+
+    def submodules_callback(package):
+        return False
+
+    type_of_test = "tag-branch"
+    t = mock_git_repository.checks[type_of_test]
+
+    # Construct the package under test
+    s = default_mock_concretization("git-test")
+    args = copy.copy(t.args)
+    args["submodules"] = submodules_callback
+    monkeypatch.setitem(s.package.versions, Version("git"), args)
+    s.package.do_stage()
+    with working_dir(s.package.stage.source_path):
+        file_path = os.path.join(s.package.stage.source_path, "third_party/submodule0/r0_file_0")
+        assert not os.path.isfile(file_path)
+        file_path = os.path.join(s.package.stage.source_path, "third_party/submodule1/r0_file_1")
+        assert not os.path.isfile(file_path)


### PR DESCRIPTION
When a package returns a falsy from a call to a submodule function, do not update submodules (otherwise *all* submodules are updated).

closes #40408