### PR TITLE
py-pyqt6: add v6.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyqt6/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt6/package.py
@@ -13,6 +13,7 @@ class PyPyqt6(SIPPackage):
     url = "https://files.pythonhosted.org/packages/source/P/PyQt6/PyQt6-6.5.1.tar.gz"
     list_url = "https://pypi.org/simple/PyQt6/"
 
+    version("6.5.2", sha256="1487ee7350f9ffb66d60ab4176519252c2b371762cbe8f8340fd951f63801280")
     version("6.5.1", sha256="e166a0568c27bcc8db00271a5043936226690b6a4a74ce0a5caeb408040a97c3")
 
     # pyproject.toml


### PR DESCRIPTION
https://pypi.org/project/PyQt6/#files

While installing and testing I ran #38809 and #38793 again.