### PR TITLE
qt-base: fix-build without opengl

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -235,6 +235,9 @@ class QtBase(QtPackage):
         for k in features:
             define("FEATURE_" + k, True)
 
+        if "~opengl" in spec:
+            args.append(self.define("INPUT_opengl", "no"))
+
         # INPUT_* arguments: undefined/no/qt/system
         sys_inputs = ["doubleconversion"]
         if "+sql" in spec:


### PR DESCRIPTION
Fixes #38809

QT by default searches and uses the system opengl and throws an error if it is not found. To build without any opengl this has to be disabled with an additional flag.