### PR TITLE
cmake: Stop adding ldflags to CMAKE_STATIC_LINKER_FLAGS.

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -142,10 +142,10 @@ class CMakePackage(spack.package_base.PackageBase):
         # We specify for each of them.
         if flags["ldflags"]:
             ldflags = " ".join(flags["ldflags"])
-            ld_string = "-DCMAKE_{0}_LINKER_FLAGS={1}"
             # cmake has separate linker arguments for types of builds.
-            for type in ["EXE", "MODULE", "SHARED"]:
-                self.cmake_flag_args.append(ld_string.format(type, ldflags))
+            self.cmake_flag_args.append("-DCMAKE_EXE_LINKER_FLAGS={0}".format(ldflags))
+            self.cmake_flag_args.append("-DCMAKE_MODULE_LINKER_FLAGS={0}".format(ldflags))
+            self.cmake_flag_args.append("-DCMAKE_SHARED_LINKER_FLAGS={0}".format(ldflags))
 
         # CMake has libs options separated by language. Apply ours to each.
         if flags["ldlibs"]:

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -144,7 +144,7 @@ class CMakePackage(spack.package_base.PackageBase):
             ldflags = " ".join(flags["ldflags"])
             ld_string = "-DCMAKE_{0}_LINKER_FLAGS={1}"
             # cmake has separate linker arguments for types of builds.
-            for type in ["EXE", "MODULE", "SHARED", "STATIC"]:
+            for type in ["EXE", "MODULE", "SHARED"]:
                 self.cmake_flag_args.append(ld_string.format(type, ldflags))
 
         # CMake has libs options separated by language. Apply ours to each.

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -143,9 +143,9 @@ class CMakePackage(spack.package_base.PackageBase):
         if flags["ldflags"]:
             ldflags = " ".join(flags["ldflags"])
             # cmake has separate linker arguments for types of builds.
-            self.cmake_flag_args.append("-DCMAKE_EXE_LINKER_FLAGS={0}".format(ldflags))
-            self.cmake_flag_args.append("-DCMAKE_MODULE_LINKER_FLAGS={0}".format(ldflags))
-            self.cmake_flag_args.append("-DCMAKE_SHARED_LINKER_FLAGS={0}".format(ldflags))
+            self.cmake_flag_args.append(f"-DCMAKE_EXE_LINKER_FLAGS={ldflags}")
+            self.cmake_flag_args.append(f"-DCMAKE_MODULE_LINKER_FLAGS={ldflags}")
+            self.cmake_flag_args.append(f"-DCMAKE_SHARED_LINKER_FLAGS={ldflags}")
 
         # CMake has libs options separated by language. Apply ours to each.
         if flags["ldlibs"]:

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -121,7 +121,6 @@ class TestFlagHandlers:
             "-DCMAKE_EXE_LINKER_FLAGS=-mthreads",
             "-DCMAKE_MODULE_LINKER_FLAGS=-mthreads",
             "-DCMAKE_SHARED_LINKER_FLAGS=-mthreads",
-            "-DCMAKE_STATIC_LINKER_FLAGS=-mthreads",
         }
 
     def test_ld_libs_cmake(self, temp_env):


### PR DESCRIPTION
Because those end up being passed to ar which does not understand linker arguments. This was making ldflags largely unusuable for statically linked cmake packages.