### PR TITLE
py-distributed: add v2023.9.3 and py-dask: add v2023.9.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -14,6 +14,7 @@ class PyDask(PythonPackage):
 
     maintainers("skosukhin")
 
+    version("2023.9.3", sha256="712090788a7822d538cf8f43f5afc887eebe7471bc46cc331424e1cfa248764c")
     version("2023.4.1", sha256="9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153")
     version("2022.10.2", sha256="42cb43f601709575fa46ce09e74bea83fdd464187024f56954e09d9b428ceaab")
     version("2021.6.2", sha256="8588fcd1a42224b7cfcd2ebc8ad616734abb6b1a4517efd52d89c7dd66eb91f8")
@@ -34,82 +35,83 @@ class PyDask(PythonPackage):
         description="Install requirements for dask.delayed (dask.imperative)",
     )
 
-    depends_on("python@3.8:", type=("build", "run"), when="@2022.10.2:")
+    depends_on("python@3.9:", when="@2023.5.1:", type=("build", "run"))
+    depends_on("python@3.8:", when="@2022.10.2:", type=("build", "run"))
 
+    depends_on("py-setuptools@62.6:", when="@2023.4.1:", type="build")
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
-    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.28+toml", when="@2023.4.1:", type="build")
 
-    # Common requirements
-    depends_on("py-packaging@20:", type="build", when="@2022.10.2:")
+    depends_on("py-click@8:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-click@7:", when="@2022.10.1:", type=("build", "run"))
+    depends_on("py-cloudpickle@1.5:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-cloudpickle@1.1.1:", when="@2021.3.1:", type=("build", "run"))
+    depends_on("py-fsspec@2021.9:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-fsspec@0.6:", when="@2021.3.1:", type=("build", "run"))
+    depends_on("py-packaging@20:", when="@2021.7.1:", type=("build", "run"))
+    depends_on("py-partd@1.2:", when="@2023.2.1:", type=("build", "run"))
+    depends_on("py-partd@0.3.10:", when="@2021.3.1:", type=("build", "run"))
+    depends_on("py-pyyaml@5.3.1:", when="@2022.1:", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-pyyaml@5.3.1:", type=("build", "run"), when="@2022.10.2:")
-    depends_on("py-cloudpickle@1.1.1:", type=("build", "run"), when="@2021.3.1:")
-    depends_on("py-cloudpickle@1.5.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@2021.3.1:")
-    depends_on("py-fsspec@2021.09.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2021.3.1:")
-    depends_on("py-toolz@0.10.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@2021.3.1:")
-    depends_on("py-partd@1.2.0:", type=("build", "run"), when="@2023.4.0:")
-    depends_on("py-click@7.0:", type=("build", "run"), when="@2022.10.2:")
-    depends_on("py-click@8.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-importlib-metadata@4.13.0:", type=("build", "run"), when="@2023.4.0:")
+    depends_on("py-toolz@0.10:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-toolz@0.8.2:", when="@2021.3.1:", type=("build", "run"))
+    depends_on("py-importlib-metadata@4.13:", when="@2023.3.2:", type=("build", "run"))
 
-    # Requirements for dask.array
-    depends_on("py-numpy@1.15.1:", type=("build", "run"), when="@2020.12.0: +array")
-    depends_on("py-numpy@1.16.0:", type=("build", "run"), when="@2021.3.1: +array")
-    depends_on("py-numpy@1.18.0:", type=("build", "run"), when="@2022.10.2: +array")
-    depends_on("py-numpy@1.21.0:", type=("build", "run"), when="@2023.4.0: +array")
-    # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +array")
+    with when("+array"):
+        depends_on("py-numpy@1.21:", when="@2023.2.1:", type=("build", "run"))
+        depends_on("py-numpy@1.18:", when="@2021.8:", type=("build", "run"))
+        depends_on("py-numpy@1.16:", when="@2021.3.1:", type=("build", "run"))
+        depends_on("py-numpy@1.15.1:", type=("build", "run"))
 
-    # Requirements for dask.bag
-    depends_on("py-cloudpickle@0.2.1:", type=("build", "run"), when="@0.8.2: +bag")
-    # The dependency on py-cloudpickle is non-optional starting version 2021.3.1
-    depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +bag")
-    # The dependency on py-fsspec is non-optional starting version 2021.3.1
-    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@:2021.3.0 +bag")
-    # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +bag")
-    # The dependency on py-partd is non-optional starting version 2021.3.1
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@:2021.3.0 +bag")
+        # The dependency on py-toolz is non-optional starting version 2021.3.1
+        depends_on("py-toolz@0.8.2:", when="@:2021.3.0", type=("build", "run"))
 
-    # Requirements for dask.dataframe
-    depends_on("py-numpy@1.15.1:", type=("build", "run"), when="@2020.12.0: +dataframe")
-    depends_on("py-numpy@1.16.0:", type=("build", "run"), when="@2021.3.1: +dataframe")
-    depends_on("py-numpy@1.18.0:", type=("build", "run"), when="@2022.10.2: +dataframe")
-    depends_on("py-numpy@1.21.0:", type=("build", "run"), when="@2023.4.0: +dataframe")
-    depends_on("py-pandas@0.25.0:", type=("build", "run"), when="@2020.12.0: +dataframe")
-    depends_on("py-pandas@1.0:", type=("build", "run"), when="@2022.10.2: +dataframe")
-    depends_on("py-pandas@1.3:", type=("build", "run"), when="@2023.4.0: +dataframe")
-    # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +dataframe")
-    # The dependency on py-partd is non-optional starting version 2021.3.1
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@:2021.3.0 +dataframe")
-    # The dependency on py-fsspec is non-optional starting version 2021.3.1
-    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@:2021.3.0 +dataframe")
+    # Variant does not exist starting from 2021.3.1
+    with when("+bag"):
+        # The dependencies are non-optional starting version 2021.3.1
+        depends_on("py-cloudpickle@0.2.2:", type=("build", "run"))
+        depends_on("py-fsspec@0.6:", type=("build", "run"))
+        depends_on("py-toolz@0.8.2:", type=("build", "run"))
+        depends_on("py-partd@0.3.10:", type=("build", "run"))
 
-    # Requirements for dask.distributed
-    depends_on(
-        "py-distributed@2020.12.0:2021.8.0", type=("build", "run"), when="@:2021.6.1 +distributed"
-    )
-    depends_on("py-distributed@2021.6.2", type=("build", "run"), when="@2021.6.2 +distributed")
-    depends_on("py-distributed@2022.10.2", type=("build", "run"), when="@2022.10.2 +distributed")
-    depends_on("py-distributed@2023.4.1", type=("build", "run"), when="@2023.4.1 +distributed")
+    with when("+dataframe"):
+        conflicts("~array", when="@2023.8:")
+        depends_on("py-pandas@1.3:", when="@2023.2.1:", type=("build", "run"))
+        depends_on("py-pandas@1:", when="@2021.8:", type=("build", "run"))
+        depends_on("py-pandas@0.25:", type=("build", "run"))
 
-    # Requirements for dask.diagnostics
-    depends_on("py-bokeh@1.0.0:1,2.0.1:", type=("build", "run"), when="+diagnostics")
-    depends_on("py-bokeh@2.4.2:2", type=("build", "run"), when="@2022.10.2:2023.3 +diagnostics")
-    depends_on("py-bokeh@2.4.2:", type=("build", "run"), when="@2023.4.0: +diagnostics")
-    depends_on("py-jinja2", type=("build", "run"), when="@2022.10.2: +diagnostics")
-    depends_on("py-jinja2@2.10.3:", type=("build", "run"), when="@2023.4.0: +diagnostics")
+        # The dependency is reused from the array variant starting version 2023.8
+        depends_on("py-numpy@1.21:", when="@2023.4.0:2023.7", type=("build", "run"))
+        depends_on("py-numpy@1.18:", when="@2021.8:2023.7", type=("build", "run"))
+        depends_on("py-numpy@1.16:", when="@2021.3.1:2023.7", type=("build", "run"))
+        depends_on("py-numpy@1.15.1:", when="@:2023.7", type=("build", "run"))
+        # The dependencies are non-optional starting version 2021.3.1
+        depends_on("py-toolz@0.8.2:", when="@:2021.3.0", type=("build", "run"))
+        depends_on("py-partd@0.3.10:", when="@:2021.3.0", type=("build", "run"))
+        depends_on("py-fsspec@0.6:", when="@:2021.3.0", type=("build", "run"))
 
-    # Requirements for dask.delayed
-    # The dependency on py-cloudpickle is non-optional starting version 2021.3.1
-    depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@:2021.3.0 +delayed")
-    # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +delayed")
+    with when("+distributed"):
+        depends_on("py-distributed@2023.9.3", when="@2023.9.3", type=("build", "run"))
+        depends_on("py-distributed@2023.4.1", when="@2023.4.1", type=("build", "run"))
+        depends_on("py-distributed@2022.10.2", when="@2022.10.2", type=("build", "run"))
+        depends_on("py-distributed@2021.6.2", when="@2021.6.2", type=("build", "run"))
+        depends_on("py-distributed@2021.4.1", when="@2021.4.1", type=("build", "run"))
+        # According to setup.py it "py-distributed >= 2.0" but the oldest version in
+        # spack is 2020.12.0
+        depends_on("py-distributed@2020.12.0", when="@2020.12.0", type=("build", "run"))
+
+    with when("+diagnostics"):
+        depends_on("py-bokeh@2.4.2:", when="@2023.4:", type=("build", "run"))
+        depends_on("py-bokeh@2.4.2:2", when="@2022.10.1:2023.3", type=("build", "run"))
+        depends_on("py-bokeh@1.0.0:1,2.0.1:", when="@:2021.11", type=("build", "run"))
+        depends_on("py-jinja2@2.10.3:", when="@2023.3:", type=("build", "run"))
+        depends_on("py-jinja2", when="@2021.8.1:", type=("build", "run"))
+
+    # Variant does not exist starting from 2021.3.1
+    with when("+delayed"):
+        # The dependencies are non-optional starting version 2021.3.1
+        depends_on("py-cloudpickle@0.2.2:", type=("build", "run"))
+        depends_on("py-toolz@0.8.2:", type=("build", "run"))
 
     @property
     def import_modules(self):

--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -11,25 +11,9 @@ class PyDistributed(PythonPackage):
 
     homepage = "https://distributed.dask.org/"
     pypi = "distributed/distributed-2.10.0.tar.gz"
+    git = "https://github.com/dask/distributed.git"
 
-    # 'distributed.dashboard.components' requires 'bokeh', but 'bokeh' is not listed as
-    # a dependency. Leave out of 'import_modules' list to avoid unnecessary dependency.
-    import_modules = [
-        "distributed",
-        "distributed.deploy",
-        "distributed.comm",
-        "distributed.comm.tests",
-        "distributed.protocol",
-        "distributed.cli",
-        "distributed.dashboard",
-        "distributed.http",
-        "distributed.http.tests",
-        "distributed.http.scheduler",
-        "distributed.http.scheduler.prometheus",
-        "distributed.http.worker",
-        "distributed.diagnostics",
-    ]
-
+    version("2023.9.3", sha256="1161efaf7aa520fd0653ec48ceb59d3bc7d8931be392cf8bc7b89079739243e5")
     version("2023.4.1", sha256="0140376338efdcf8db1d03f7c1fdbb5eab2a337b03e955d927c116824ee94ac5")
     version("2022.10.2", sha256="53f0a5bf6efab9a5ab3345cd913f6d3f3d4ea444ee2edbea331c7fef96fd67d0")
     version("2022.2.1", sha256="fb62a75af8ef33bbe1aa80a68c01a33a93c1cd5a332dd017ab44955bf7ecf65b")
@@ -37,40 +21,49 @@ class PyDistributed(PythonPackage):
     version("2021.4.1", sha256="4c1b189ec5aeaf770c473f730f4a3660dc655601abd22899e8a0662303662168")
     version("2020.12.0", sha256="2a0b6acc921cd4e0143a7c4383cdcbed7defbc4bd9dc3aab0c7f1c45f14f80e1")
 
+    depends_on("python@3.9:", when="@2023.5.1:", type=("build", "run"))
     depends_on("python@3.8:", when="@2022.2.1:", type=("build", "run"))
+    depends_on("py-setuptools@62.6:", when="@2023.4.1:", type="build")
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
-    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.28+toml", when="@2023.4.1:", type="build")
 
-    # In Spack py-dask+distributed depends on py-distributed, not the other way around.
-    # Hence, no need for depends_on("py-dask", ...)
+    depends_on("py-click@8:", when="@2023.4.1:", type=("build", "run"))
     depends_on("py-click@6.6:", type=("build", "run"))
-    depends_on("py-click@8.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-cloudpickle@1.5.0:", type=("build", "run"))
-    depends_on("py-jinja2", type=("build", "run"), when="@2022.2.1:")
-    depends_on("py-jinja2@2.10.3:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-locket@1:", type=("build", "run"), when="@2022.2.1:")
-    depends_on("py-msgpack@0.6.0:", type=("build", "run"))
-    depends_on("py-msgpack@1.0.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-packaging@20.0:", type=("build", "run"), when="@2022.2.1:")
-    depends_on("py-psutil@5.0:", type=("build", "run"))
-    depends_on("py-psutil@5.7.0:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-cloudpickle@1.5:", type=("build", "run"))
+    depends_on("py-dask@2023.9.3", when="@2023.9.3", type=("build", "run"))
+    depends_on("py-dask@2023.4.1", when="@2023.4.1", type=("build", "run"))
+    depends_on("py-jinja2@2.10.3:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-jinja2", when="@2022.2.1:", type=("build", "run"))
+    depends_on("py-locket@1:", when="@2022.2.1:", type=("build", "run"))
+    depends_on("py-msgpack@1:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-msgpack@0.6:", type=("build", "run"))
+    depends_on("py-packaging@20:", when="@2022.2.1:", type=("build", "run"))
+    depends_on("py-psutil@5.7.2:", when="@2023.5.1:", type=("build", "run"))
+    depends_on("py-psutil@5.7:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-psutil@5:", type=("build", "run"))
+    depends_on("py-pyyaml@5.3.1:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-sortedcontainers@2.0.5:", when="@2023.4.1:", type=("build", "run"))
     depends_on("py-sortedcontainers@:1,2.0.2:", type=("build", "run"))
-    depends_on("py-sortedcontainers@2.0.5:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-tblib@1.6:", type=("build", "run"))
-    depends_on("py-toolz@0.8.2:", type=("build", "run"))
     # Note that the setup.py is wrong for py-toolz, when="@2022.10.2".
     # See https://github.com/dask/distributed/pull/7309
-    depends_on("py-toolz@0.10.0:", type=("build", "run"), when="@2022.10.2:")
-    depends_on("py-tornado@5:", type=("build", "run"), when="^python@:3.7")
-    depends_on("py-tornado@6.0.3:", type=("build", "run"), when="^python@3.8:")
-    depends_on("py-tornado@6.0.3:6.1", type=("build", "run"), when="@2022.10.2:")
+    depends_on("py-toolz@0.10:", when="@2022.10.2:", type=("build", "run"))
+    depends_on("py-toolz@0.8.2:", type=("build", "run"))
+    depends_on("py-tornado@6.0.4:", when="@2023.5.1:", type=("build", "run"))
+    depends_on("py-tornado@6.0.3:", when="@2022.12:", type=("build", "run"))
+    depends_on("py-tornado@6.0.3:6.1", when="@2022.10.2:2022.11.1", type=("build", "run"))
+    depends_on("py-tornado@6.0.3:", when="^python@3.8:", type=("build", "run"))
+    depends_on("py-tornado@5:", when="^python@:3.7", type=("build", "run"))
+    depends_on("py-urllib3@1.24.3:", when="@2023.4.1:", type=("build", "run"))
+    depends_on("py-urllib3", when="@2022.10.2:", type=("build", "run"))
+    depends_on("py-zict@3:", when="@2023.9:", type=("build", "run"))
+    depends_on("py-zict@2.2:", when="@2023.4.1:", type=("build", "run"))
     depends_on("py-zict@0.1.3:", type=("build", "run"))
-    depends_on("py-zict@2.2.0:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-pyyaml@5.3.1:", type=("build", "run"), when="@2023.4.1:")
-    depends_on("py-urllib3", type=("build", "run"), when="@2022.10.2:")
-    depends_on("py-urllib3@1.24.3:", type=("build", "run"), when="@2023.4.1:")
+
+    # 'distributed.dashboard.components' requires 'bokeh', but 'bokeh' is not listed as
+    # a dependency. Leave out of 'import_modules' list to avoid unnecessary dependency.
+    skip_modules = ["distributed.dashboard.components"]
 
     def patch(self):
         if self.spec.satisfies("@:2023.3"):


### PR DESCRIPTION
https://github.com/dask/distributed/tree/2023.9.3
https://github.com/dask/dask/tree/2023.9.3

In `py-distributed` the `py-dask` dependency is needed (see [distributed/\_\_init\_\_.py](https://github.com/dask/distributed/blob/2023.9.3/distributed/__init__.py)). Although this creates a cyclic dependency for `py-dask+distributed` the packages install fine for me.