### PR TITLE
3proxy: use f-strings

### DIFF
--- a/var/spack/repos/builtin/packages/3proxy/package.py
+++ b/var/spack/repos/builtin/packages/3proxy/package.py
@@ -24,9 +24,7 @@ class _3proxy(MakefilePackage):
     depends_on("m4", type="build")
 
     def build(self, spec, prefix):
-        make("-f", "Makefile.{0}".format(platform.system()))
+        make("-f", f"Makefile.{platform.system()}")
 
     def install(self, spec, prefix):
-        make(
-            "-f", "Makefile.{0}".format(platform.system()), "prefix={0}".format(prefix), "install"
-        )
+        make("-f", f"Makefile.{platform.system()}", f"prefix={prefix}", "install")


### PR DESCRIPTION
Update legacy `.format()` calls to f-strings.