### PR TITLE
abacus: use f-strings

### DIFF
--- a/var/spack/repos/builtin/packages/abacus/package.py
+++ b/var/spack/repos/builtin/packages/abacus/package.py
@@ -65,7 +65,7 @@ NP      = 14\n"
                 spec["fftw"].prefix,
                 spec["elpa"].prefix,
                 inc_var,
-                "{0}".format(spec["elpa"].version),
+                f"{spec['elpa'].version}",
                 spec["cereal"].prefix,
             )
         )


### PR DESCRIPTION
Update legacy `.format()` calls to f-strings.