### PR TITLE
adiak: use f-strings

### DIFF
--- a/var/spack/repos/builtin/packages/adiak/package.py
+++ b/var/spack/repos/builtin/packages/adiak/package.py
@@ -36,8 +36,8 @@ class Adiak(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies("+mpi"):
-            args.append("-DMPI_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx)
-            args.append("-DMPI_C_COMPILER=%s" % self.spec["mpi"].mpicc)
+            args.append(f"-DMPI_CXX_COMPILER={self.spec['mpi'].mpicxx}")
+            args.append(f"-DMPI_C_COMPILER={self.spec['mpi'].mpicc}")
             args.append("-DENABLE_MPI=ON")
         else:
             args.append("-DENABLE_MPI=OFF")


### PR DESCRIPTION
Update legacy `.format()` calls to f-strings.