### PR TITLE
aocc: help compiler find include paths and libstdc++.so

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -91,3 +91,12 @@ class Aocc(Package):
     def install(self, spec, prefix):
         print("Installing AOCC Compiler ... ")
         install_tree(".", prefix)
+
+    @run_after("install")
+    def cfg_files(self):
+        # Add path to gcc/g++ such that clang/clang++ can always find a full gcc installation including libstdc++.so
+        if self.spec.satisfies("%gcc"):
+            compiler_options = "--gcc-toolchain={}".format(self.compiler.prefix)
+            for compiler in ["clang", "clang++"]:
+                with open(join_path(self.prefix.bin, "{}.cfg".format(compiler)), "w") as f:
+                    f.write(compiler_options)

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -94,7 +94,8 @@ class Aocc(Package):
 
     @run_after("install")
     def cfg_files(self):
-        # Add path to gcc/g++ such that clang/clang++ can always find a full gcc installation including libstdc++.so
+        # Add path to gcc/g++ such that clang/clang++ can always find a full gcc installation
+        # including libstdc++.so and header files.
         if self.spec.satisfies("%gcc") and self.compiler.cxx is not None:
             compiler_options = "--gcc-toolchain={}".format(self.compiler.prefix)
             for compiler in ["clang", "clang++"]:

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -95,7 +95,7 @@ class Aocc(Package):
     @run_after("install")
     def cfg_files(self):
         # Add path to gcc/g++ such that clang/clang++ can always find a full gcc installation including libstdc++.so
-        if self.spec.satisfies("%gcc"):
+        if self.spec.satisfies("%gcc") and self.compiler.cxx is not None:
             compiler_options = "--gcc-toolchain={}".format(self.compiler.prefix)
             for compiler in ["clang", "clang++"]:
                 with open(join_path(self.prefix.bin, "{}.cfg".format(compiler)), "w") as f:


### PR DESCRIPTION
Depending on the system installed compilers, this will currently fail:
```
spack install aocc
spack load aocc
spack compiler add
spack install cmake%aocc
```
as `clang++` will try to find compiler include paths and `libstdc++.so` in the system compiler paths. One concrete example is when a new version of `gcc` is installed but the `g++` only matches an older `gcc` version.

By adding `--gcc-toolchain` option by default `clang` will look for header files and libstdc++.so in the correct `gcc` path, e.g. one where there exists a C++ compiler as well.