### PR TITLE
Add `spack scout` command

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import argparse
 import sys
 
 import llnl.string

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
+
+import argparse
 import sys
 
 import llnl.string
@@ -18,6 +19,7 @@ import spack.util.crypto
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.package_base import PackageBase, deprecated_version, preferred_version
+from spack.package_file import add_versions_to_package
 from spack.util.editor import editor
 from spack.util.format import get_version_lines
 from spack.version import Version
@@ -175,7 +177,15 @@ def checksum(parser, args):
     print()
 
     if args.add_to_package:
-        add_versions_to_package(pkg, version_lines)
+        version_lines = "\n".join(map(lambda v: v + " # FIXME", version_lines.split("\n")))
+
+        num_versions_added = add_versions_to_package(pkg, version_lines)
+        filename = spack.repo.PATH.filename_for_package_name(pkg.name)
+        tty.msg(f"Added {num_versions_added} new versions to {pkg.name}")
+        tty.msg(f"Open {filename} to review the additions.")
+
+        if sys.stdout.isatty():
+            editor(filename)
 
 
 def print_checksum_status(pkg: PackageBase, version_hashes: dict):
@@ -219,60 +229,3 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict):
     if failed:
         print()
         tty.die("Invalid checksums found.")
-
-
-def add_versions_to_package(pkg: PackageBase, version_lines: str):
-    """
-    Add checksumed versions to a package's instructions and open a user's
-    editor so they may double check the work of the function.
-
-    Args:
-        pkg (spack.package_base.PackageBase): A package class for a given package in Spack.
-        version_lines (str): A string of rendered version lines.
-
-    """
-    # Get filename and path for package
-    filename = spack.repo.PATH.filename_for_package_name(pkg.name)
-    num_versions_added = 0
-
-    version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")
-    version_re = re.compile(r'[\t ]+version\(\s*"([^"]+)"[^\)]*\)')
-
-    # Split rendered version lines into tuple of (version, version_line)
-    # We reverse sort here to make sure the versions match the version_lines
-    new_versions = []
-    for ver_line in version_lines.split("\n"):
-        match = version_re.match(ver_line)
-        if match:
-            new_versions.append((Version(match.group(1)), ver_line))
-
-    with open(filename, "r+") as f:
-        contents = f.read()
-        split_contents = version_statement_re.split(contents)
-
-        for i, subsection in enumerate(split_contents):
-            # If there are no more versions to add we should exit
-            if len(new_versions) <= 0:
-                break
-
-            # Check if the section contains a version
-            contents_version = version_re.match(subsection)
-            if contents_version is not None:
-                parsed_version = Version(contents_version.group(1))
-
-                if parsed_version < new_versions[0][0]:
-                    split_contents[i:i] = [new_versions.pop(0)[1], " # FIXME", "\n"]
-                    num_versions_added += 1
-
-                elif parsed_version == new_versions[0][0]:
-                    new_versions.pop(0)
-
-        # Seek back to the start of the file so we can rewrite the file contents.
-        f.seek(0)
-        f.writelines("".join(split_contents))
-
-        tty.msg(f"Added {num_versions_added} new versions to {pkg.name}")
-        tty.msg(f"Open {filename} to review the additions.")
-
-    if sys.stdout.isatty():
-        editor(filename)

--- a/lib/spack/spack/cmd/scout.py
+++ b/lib/spack/spack/cmd/scout.py
@@ -1,0 +1,116 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import argparse
+
+from llnl.util import tty
+from llnl.util.tty.colify import colify
+
+import spack.repo
+import spack.spec
+import spack.store
+from spack.installer import InstallError, PackageInstaller
+from spack.package_file import add_versions_to_package
+from spack.util.format import get_version_lines
+from spack.version import infinity_versions
+
+description = "discover and test new versions of a package"
+section = "packaging"
+level = "long"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        "--mark",
+        default="implicit",
+        choices=["implicit", "explicit"],
+        help="mark pkgs after installation to keep/cleanup",
+    )
+    subparser.add_argument(
+        "--test",
+        "-t",
+        default=None,
+        choices=["root", "all"],
+        help="build pkgs with tests to validate",
+    )
+    subparser.add_argument("pkgs", nargs=argparse.REMAINDER, help="packages to update")
+
+
+def scout(parser, args):
+    for pkg_name in args.pkgs:
+        tty.info(f"Checking for updates to {pkg_name}")
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        pkg = pkg_cls(spack.spec.Spec(pkg_name))
+
+        # retrieve a list of the known package versions
+        safe_versions = sorted(pkg.versions, reverse=True)
+        if len(safe_versions) <= 0:
+            tty.warn(f"No previously checksummed versions for {pkg_name}")
+
+        # retrieve a list of new unchecksummed versions
+        fetched_versions = pkg.fetch_remote_versions()
+        if len(fetched_versions) <= 0:
+            tty.die(f"Unable to find any remote versions for {pkg_name}")
+
+        # filter out any infinite versions such as git branches
+        numeric_safe_versions = set(
+            filter(lambda v: str(v) not in infinity_versions, safe_versions)
+        )
+
+        # get the highest known and remote version
+        highest_safe_version = max(numeric_safe_versions)
+        highest_fetched_version = max(fetched_versions)
+
+        # exit if no newer versions have been released
+        if highest_fetched_version <= highest_safe_version:
+            tty.info(f"No new version found for {pkg_name}")
+            continue
+
+        # create url_dict to map the newer remote version to a url
+        url_dict = {highest_fetched_version: fetched_versions[highest_fetched_version]}
+
+        # checksum the newer remote version
+        version_hashes = spack.stage.get_checksums_for_versions(url_dict, pkg.name, batch=True)
+
+        # take a backup of a package's class file
+        filename = spack.repo.PATH.filename_for_package_name(pkg.name)
+        with open(filename, "r+") as f:
+            file_backup = f.read()
+
+        # render the version lines to add to the package file
+        version_lines = get_version_lines(version_hashes, url_dict)
+        added_lines = add_versions_to_package(pkg, version_lines)
+
+        # ensure that a newer version was added to the package
+        if added_lines < 1:
+            tty.warn(f"Could not add new version to {pkg_name}")
+            continue
+
+        # create spec of newer version to build
+        spec = spack.spec.Spec(f"{pkg_name}@={highest_fetched_version}")
+        spec.concretize()
+
+        # attempt to build the updated package
+        try:
+            install_kwargs = {}
+            if args.test is not None:
+                install_kwargs["test"] = [pkg_name]
+
+            builder = PackageInstaller([(spec.package, install_kwargs)])
+            builder.install()
+
+            # mark packages as implicit by default to cleanup with "spack gc"
+            spack.store.STORE.db.update_explicit(spec, args.mark == "explicit")
+
+        # overwrite modified file with backup on failed build
+        except InstallError:
+            with open(filename, "w") as f:
+                f.write(file_backup)
+
+            tty.warn(f"Could not build {pkg_name}@{highest_fetched_version}")
+            continue
+
+        tty.msg(f"Sucessfully built {pkg_name}@{highest_fetched_version} and added version to")
+        colify([filename], indent=4)

--- a/lib/spack/spack/cmd/scout.py
+++ b/lib/spack/spack/cmd/scout.py
@@ -24,8 +24,8 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument(
         "--mark",
-        default="implicit",
-        choices=["implicit", "explicit"],
+        default="explicit",
+        choices=["i", "implicit", "e", "explicit"],
         help="mark pkgs after installation to keep/cleanup",
     )
     subparser.add_argument(
@@ -96,13 +96,14 @@ def scout(parser, args):
         try:
             install_kwargs = {}
             if args.test is not None:
-                install_kwargs["test"] = [pkg_name]
+                install_kwargs["test"] = [pkg_name] if args.test == "root" else True
 
             builder = PackageInstaller([(spec.package, install_kwargs)])
             builder.install()
 
-            # mark packages as implicit by default to cleanup with "spack gc"
-            spack.store.STORE.db.update_explicit(spec, explicit=(args.mark == "explicit"))
+            # mark packages as implicit if requested to cleanup with "spack gc"
+            if args.mark in ("implicit", "i"):
+                spack.store.STORE.db.update_explicit(spec, explicit=False)
 
         # overwrite modified file with backup on failed build
         except InstallError:

--- a/lib/spack/spack/cmd/scout.py
+++ b/lib/spack/spack/cmd/scout.py
@@ -102,7 +102,7 @@ def scout(parser, args):
             builder.install()
 
             # mark packages as implicit by default to cleanup with "spack gc"
-            spack.store.STORE.db.update_explicit(spec, args.mark == "explicit")
+            spack.store.STORE.db.update_explicit(spec, explicit=(args.mark == "explicit"))
 
         # overwrite modified file with backup on failed build
         except InstallError:

--- a/lib/spack/spack/cmd/scout.py
+++ b/lib/spack/spack/cmd/scout.py
@@ -72,7 +72,7 @@ def scout(parser, args):
         url_dict = {highest_fetched_version: fetched_versions[highest_fetched_version]}
 
         # checksum the newer remote version
-        version_hashes = spack.stage.get_checksums_for_versions(url_dict, pkg.name, batch=True)
+        version_hashes = spack.stage.get_checksums_for_versions(url_dict, pkg.name)
 
         # take a backup of a package's class file
         filename = spack.repo.PATH.filename_for_package_name(pkg.name)

--- a/lib/spack/spack/package_file.py
+++ b/lib/spack/spack/package_file.py
@@ -1,0 +1,63 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
+import spack.repo
+from spack.package_base import PackageBase
+from spack.version import Version
+
+
+def add_versions_to_package(pkg: PackageBase, version_lines: str):
+    """
+    Add checksumed versions to a package's instructions and open a user's
+    editor so they may double check the work of the function.
+
+    Args:
+        pkg (spack.package_base.PackageBase): A package class for a program.
+        version_lines (str): A string of rendered version lines.
+
+    """
+    # Get filename and path for package
+    filename = spack.repo.PATH.filename_for_package_name(pkg.name)
+    num_versions_added = 0
+
+    version_statement_re = re.compile(r"([\t ]+version\([^\)]*\))")
+    version_re = re.compile(r'[\t ]+version\(\s*"([^"]+)"[^\)]*\)')
+
+    # Split rendered version lines into tuple of (version, version_line)
+    # We reverse sort here to make sure the versions match the version_lines
+    new_versions = []
+    for ver_line in version_lines.split("\n"):
+        match = version_re.match(ver_line)
+        if match:
+            new_versions.append((Version(match.group(1)), ver_line))
+
+    with open(filename, "r+") as f:
+        contents = f.read()
+        split_contents = version_statement_re.split(contents)
+
+        for i, subsection in enumerate(split_contents):
+            # If there are no more versions to add we should exit
+            if len(new_versions) <= 0:
+                break
+
+            # Check if the section contains a version
+            contents_version = version_re.match(subsection)
+            if contents_version is not None:
+                parsed_version = Version(contents_version.group(1))
+
+                if parsed_version < new_versions[0][0]:
+                    split_contents[i:i] = [new_versions.pop(0)[1], "\n"]
+                    num_versions_added += 1
+
+                elif parsed_version == new_versions[0][0]:
+                    new_versions.pop(0)
+
+        # Seek back to the start of the file so we can rewrite the file contents.
+        f.seek(0)
+        f.writelines("".join(split_contents))
+
+    return num_versions_added

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -401,7 +401,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage scout solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1793,6 +1793,15 @@ _spack_restage() {
         SPACK_COMPREPLY="-h --help"
     else
         _all_packages
+    fi
+}
+
+_spack_scout() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --mark --test -t"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2662,7 +2662,7 @@ set -g __fish_spack_optspecs_spack_scout h/help mark= t/test=
 
 complete -c spack -n '__fish_spack_using_command scout' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command scout' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command scout' -l mark -r -f -a 'implicit explicit'
+complete -c spack -n '__fish_spack_using_command scout' -l mark -r -f -a 'i implicit e explicit'
 complete -c spack -n '__fish_spack_using_command scout' -l mark -r -d 'mark pkgs after installation to keep/cleanup'
 complete -c spack -n '__fish_spack_using_command scout' -l test -s t -r -f -a 'root all'
 complete -c spack -n '__fish_spack_using_command scout' -l test -s t -r -d 'build pkgs with tests to validate'

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -412,6 +412,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a rm -d 'remove spe
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a repo -d 'manage package source repositories'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a resource -d 'list downloadable resources (tarballs, repos, patches, etc.)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a restage -d 'revert checked out package source code'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a scout -d 'discover and test new versions of a package'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a solve -d 'concretize a specs using an ASP solver'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a spec -d 'show what would be installed, given a spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a stage -d 'expand downloaded archive in preparation for install'
@@ -2655,6 +2656,16 @@ set -g __fish_spack_optspecs_spack_restage h/help
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 restage' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
+
+# spack scout
+set -g __fish_spack_optspecs_spack_scout h/help mark= t/test=
+
+complete -c spack -n '__fish_spack_using_command scout' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command scout' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command scout' -l mark -r -f -a 'implicit explicit'
+complete -c spack -n '__fish_spack_using_command scout' -l mark -r -d 'mark pkgs after installation to keep/cleanup'
+complete -c spack -n '__fish_spack_using_command scout' -l test -s t -r -f -a 'root all'
+complete -c spack -n '__fish_spack_using_command scout' -l test -s t -r -d 'build pkgs with tests to validate'
 
 # spack solve
 set -g __fish_spack_optspecs_spack_solve h/help show= l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json c/cover= t/types timers stats U/fresh reuse reuse-deps


### PR DESCRIPTION
This PR adds `spack scout` a command for maintainers to more easily find and update packages in the repository.

Scout adds combined functionality from commands `versions`, `checksum`, and `install` to automatically discover new package versions and build them to verify the existing package installation instructions. This command can further be combined in with a CI system to automatically find and build new package on a nightly or weekly basis.

Example Usage:
```
> spack scout zlib
```
```
> spack scout $(spack maintainers --by-user alecbcs)
```