### PR TITLE
linux-pam: add v1.5.3

### DIFF
--- a/var/spack/repos/builtin/packages/linux-pam/package.py
+++ b/var/spack/repos/builtin/packages/linux-pam/package.py
@@ -10,8 +10,9 @@ class LinuxPam(AutotoolsPackage):
     """Linux PAM (Pluggable Authentication Modules for Linux) project."""
 
     homepage = "http://www.linux-pam.org/"
-    url = "https://github.com/linux-pam/linux-pam/releases/download/v1.5.2/Linux-PAM-1.5.2.tar.xz"
+    url = "https://github.com/linux-pam/linux-pam/releases/download/v1.5.3/Linux-PAM-1.5.3.tar.xz"
 
+    version("1.5.3", sha256="7ac4b50feee004a9fa88f1dfd2d2fa738a82896763050cd773b3c54b0a818283")
     version("1.5.1", sha256="201d40730b1135b1b3cdea09f2c28ac634d73181ccd0172ceddee3649c5792fc")
     version("1.5.2", sha256="e4ec7131a91da44512574268f493c6d8ca105c87091691b8e9b56ca685d4f94d")
     version("1.5.0", sha256="02d39854b508fae9dc713f7733bbcdadbe17b50de965aedddd65bcb6cc7852c8")
@@ -23,6 +24,9 @@ class LinuxPam(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
 
+    conflicts("platform=darwin")
+    conflicts("platform=windows")
+
     def configure_args(self):
-        config_args = ["--includedir=" + self.prefix.include.security]
+        config_args = ["--includedir=" + self.prefix.include.security, "CFLAGS=-DYPERR_SUCCESS=0"]
         return config_args


### PR DESCRIPTION
Fixes #40419 (linux-pam missing build dependency rpc/rpc.h):

Older versions of `linux-pam` use `rpc/rpc.h` which no longer exists on current Linux systems.

Update to the current PAM release and fix its build on Ubuntu 22.04.