### PR TITLE
Bug fixes in py-awscrt to fix build errors reported in #40386

### DIFF
--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -16,7 +16,7 @@ class PyAwscrt(PythonPackage):
 
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
-    depends_on("cmake", type=("build"))
+    depends_on("cmake@3.1:", type=("build"))
     depends_on("openssl", type=("build"), when="platform=linux")
     depends_on("py-setuptools", type=("build"))
 

--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -17,3 +17,8 @@ class PyAwscrt(PythonPackage):
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
     depends_on("py-setuptools", type=("build"))
+
+    # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)
+    def setup_build_environment(self, env):
+        with when("platform=linux"):
+            env.set("AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO", 1)

--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -16,6 +16,8 @@ class PyAwscrt(PythonPackage):
 
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
+    depends_on("cmake", type=("build"))
+    depends_on("openssl", type=("build"), when="platform=linux")
     depends_on("py-setuptools", type=("build"))
 
     # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)


### PR DESCRIPTION
This PR fixes the build errors reported in https://github.com/spack/spack/issues/40386 by instructing `py-awscrt` to use the spack-provided `libcrypto` (`openssl` library) on Linux, and by adding an explicit dependency on `cmake` for all platforms.

Resolves https://github.com/spack/spack/issues/40386