### PR TITLE
foam-extend: add v5.0

### DIFF
--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -59,7 +59,8 @@ class FoamExtend(Package):
     version("4.1", git="http://git.code.sf.net/p/foam-extend/foam-extend-4.1.git")
     version("4.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-4.0.git")
     version("3.2", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.2.git")
-    version("3.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.0.git")
+    version("3.1", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.1.git", deprecated=True)
+    version("3.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.0.git", deprecated=True)
 
     # variant('int64', default=False,
     #         description='Compile with 64-bit label')

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -53,12 +53,12 @@ class FoamExtend(Package):
     and owner of the OPENFOAM trademark.
     """
 
-    homepage = "http://www.extend-project.de/"
+    homepage = "https://sourceforge.net/projects/foam-extend/"
 
+    version("5.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-5.0.git")
     version("4.1", git="http://git.code.sf.net/p/foam-extend/foam-extend-4.1.git")
     version("4.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-4.0.git")
     version("3.2", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.2.git")
-    version("3.1", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.1.git")
     version("3.0", git="http://git.code.sf.net/p/foam-extend/foam-extend-3.0.git")
 
     # variant('int64', default=False,
@@ -87,6 +87,7 @@ class FoamExtend(Package):
     # mgridgen is statically linked
     depends_on("parmgridgen", when="+parmgridgen", type="build")
     depends_on("paraview@:5.0.1", when="+paraview")
+    depends_on("mesquite")
 
     # General patches
     common = ["spack-Allwmake", "README-spack"]
@@ -201,10 +202,28 @@ class FoamExtend(Package):
         """Relative location of architecture-specific libraries"""
         return join_path("lib", self.foam_arch)
 
+    def rename_source(self):
+        """The github tarfiles have weird names that do not correspond to the
+        canonical name. We need to rename these, but leave a symlink for
+        spack to work with.
+        """
+        # Note that this particular Foam-Extned requires absolute directories
+        # to build correctly!
+        parent = os.path.dirname(self.stage.source_path)
+        original = os.path.basename(self.stage.source_path)
+        target = "foam-extend-{0}".format(self.version)
+        # Could also grep through etc/bashrc for WM_PROJECT_VERSION
+        with working_dir(parent):
+            if original != target and not os.path.lexists(target):
+                os.rename(original, target)
+                os.symlink(target, original)
+                tty.info("renamed {0} -> {1}".format(original, target))
+
     def patch(self):
         """Adjust OpenFOAM build for spack.
         Where needed, apply filter as an alternative to normal patching."""
         add_extra_files(self, self.common, self.assets)
+        self.rename_source()
 
         # Adjust ParMGridGen - this is still a mess
         files = [
@@ -262,6 +281,12 @@ class FoamExtend(Package):
             "flex": {"FLEX_SYSTEM": 1, "FLEX_DIR": spec["flex"].prefix},
             "bison": {"BISON_SYSTEM": 1, "BISON_DIR": spec["flex"].prefix},
             "zlib": {"ZLIB_SYSTEM": 1, "ZLIB_DIR": spec["zlib-api"].prefix},
+            "mesquite": {
+                "MESQUITE_SYSTEM": 1,
+                "MESQUITE_DIR": spec["mesquite"].prefix,
+                "MESQUITE_INCLUDE_DIR": spec["mesquite"].prefix.include,
+                "NESQUITE_LIB_DIR": spec["mesquite"].prefix.lib,
+            },
         }
         # Adjust configuration via prefs - sort second
         self.etc_prefs["001"].update(self.foam_arch.foam_dict())


### PR DESCRIPTION
The current of foam-extend doesn't work properly. I've fixed it to make it work correctly.
Also added a new version in the process. 
I have tested versions 4.1 and 5.0 on gcc 9.4 cascadelake.