### PR TITLE
modules:prefix_inspections: allow empty dict

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -26,8 +26,8 @@ def prefix_inspections(platform):
         A dictionary mapping subdirectory names to lists of environment
             variables to modify with that directory if it exists.
     """
-    inspections = spack.config.get("modules:prefix_inspections", {})
-    if inspections:
+    inspections = spack.config.get("modules:prefix_inspections")
+    if isinstance(inspections, dict):
         return inspections
 
     inspections = {


### PR DESCRIPTION
Currently

```
modules:
  prefix_inspections:: {}
```

gives you the builtin defaults instead of no path -> environment variable mapping.

It should be fine to disable prefix_inspections entirely, since `spack load` already sets required runtime variables anyways.