### PR TITLE
Better error message when wrong platform is used

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -923,7 +923,8 @@ pkg_fact(Package, variant_single_value("dev_path"))
 %-----------------------------------------------------------------------------
 
 % if no platform is set, fall back to the default
-:- attr("node_platform", _, Platform), not allowed_platform(Platform).
+error(100, "platform '{0}' is not allowed on the current host", Platform)
+  :- attr("node_platform", _, Platform), not allowed_platform(Platform).
 
 attr("node_platform", PackageNode, Platform)
  :- attr("node", PackageNode),


### PR DESCRIPTION
fixes #40299

This shows:
```
$ spack spec zlib arch=cray-cnl7-broadwell
==> Error: concretization failed for the following reasons:

   1. zlib compiler '%gcc@13.2.0' incompatible with 'os=cnl7'
   2. platform 'cray' is not allowed on the current host
```
on:

* **Spack:** 0.21.0.dev0 (476f5951be9882633c222767870b525b48a97444)
* **Python:** 3.11.5
* **Platform:** linux-ubuntu20.04-icelake
* **Concretizer:** clingo
