### PR TITLE
MFEM: add a patch for v4.6 for GCC 13

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/mfem-4.6.patch
+++ b/var/spack/repos/builtin/packages/mfem/mfem-4.6.patch
@@ -1,0 +1,12 @@
+diff --git a/general/kdtree.hpp b/general/kdtree.hpp
+index eebbdaa27..b35a33ea4 100644
+--- a/general/kdtree.hpp
++++ b/general/kdtree.hpp
+@@ -17,6 +17,7 @@
+ #include <fstream>
+ #include <iostream>
+ #include <cmath>
++#include <cstdint>
+ #include <tuple>
+ 
+ namespace mfem

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -468,6 +468,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     # upstream.
     patch("mfem-4.0.0-makefile-syntax-fix.patch", when="@4.0.0")
     patch("mfem-4.5.patch", when="@4.5.0")
+    patch("mfem-4.6.patch", when="@4.6.0")
 
     phases = ["configure", "build", "install"]
 


### PR DESCRIPTION
Based on https://github.com/mfem/mfem/pull/3903.
