### PR TITLE
Add package py-macs3 and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-cykhash/package.py
+++ b/var/spack/repos/builtin/packages/py-cykhash/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCykhash(PythonPackage):
+    """Cython wrapper for khash-sets/maps, efficient implementation of isin and unique."""
+
+    homepage = "https://github.com/realead/cykhash"
+    pypi = "cykhash/cykhash-2.0.1.tar.gz"
+
+    maintainers("snehring")
+
+    version("2.0.1", sha256="b4794bc9f549114d8cf1d856d9f64e08ff5f246bf043cf369fdb414e9ceb97f7")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cython@0.28:", type="build")

--- a/var/spack/repos/builtin/packages/py-hmmlearn/package.py
+++ b/var/spack/repos/builtin/packages/py-hmmlearn/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHmmlearn(PythonPackage):
+    """hmmlearn is a set of algorithms for unsupervised learning and
+    inference of Hidden Markov Models."""
+
+    homepage = "https://github.com/hmmlearn/hmmlearn"
+    pypi = "hmmlearn/hmmlearn-0.3.0.tar.gz"
+
+    maintainers("snehring")
+
+    version("0.3.0", sha256="d13a91ea3695df881465e3d36132d7eef4e84d483f4ba538a4b46e24b5ea100f")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm@3.3:", type="build")
+    depends_on("py-pybind11@2.6:", type="build")
+
+    depends_on("py-numpy@1.10:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.16:", type=("build", "run"))
+    depends_on("py-scipy@0.19:", type=("build", "run"))
+
+    conflicts("py-scikit-learn@=0.22.0", msg="Not compatible with scikit-learn@0.22.0")

--- a/var/spack/repos/builtin/packages/py-macs3/package.py
+++ b/var/spack/repos/builtin/packages/py-macs3/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMacs3(PythonPackage):
+    """MACS: Model-based Analysis for ChIP-Seq"""
+
+    homepage = "https://github.com/macs3-project/MACS/"
+    pypi = "MACS3/MACS3-3.0.0b3.tar.gz"
+
+    maintainers("snehring")
+
+    version("3.0.0b3", sha256="caa794d4cfcd7368447eae15878505315dac44c21546e8fecebb3561e9cee362")
+
+    depends_on("py-setuptools@60.0:", type="build")
+    depends_on("py-cython@0.29:0", type="build")
+
+    depends_on("py-numpy@1.19:", type=("build", "run"))
+    depends_on("py-cykhash@2.0:2", type=("build", "run"))
+    depends_on("py-hmmlearn@0.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-macs3/package.py
+++ b/var/spack/repos/builtin/packages/py-macs3/package.py
@@ -16,9 +16,11 @@ class PyMacs3(PythonPackage):
 
     version("3.0.0b3", sha256="caa794d4cfcd7368447eae15878505315dac44c21546e8fecebb3561e9cee362")
 
+    depends_on("python@3.9:", type=("build", "run"))
+
     depends_on("py-setuptools@60.0:", type="build")
-    depends_on("py-cython@0.29:0", type="build")
+    depends_on("py-cython@0.29:0", type=("build", "run"))
 
     depends_on("py-numpy@1.19:", type=("build", "run"))
-    depends_on("py-cykhash@2.0:2", type=("build", "run"))
+    depends_on("py-cykhash@2", type=("build", "run"))
     depends_on("py-hmmlearn@0.3:", type=("build", "run"))


### PR DESCRIPTION
I'd debated renaming the py-macs2 package to py-macs and adding this to it, but they're separate projects on pypi, so I suppose py-macs3 is fine.