### PR TITLE
Get utilities necessary for successful PIO build

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -55,6 +55,11 @@ class Parallelio(CMakePackage):
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
     resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
+    resource(
+        name="CMake_Fortran_utils",
+        git="https://github.com/CESM-Development/CMake_Fortran_utils.git",
+        tag="CMake_Fortran_utils_150308",
+    )
 
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="@:2.5.8 +fortran %gcc@10:")


### PR DESCRIPTION
Some parallelio cmake tests expect files provided by https://github.com/CESM-Development/CMake_Fortran_utils. This is specified by USER_CMAKE_MODULE_PATH in the current Spack recipe, but the extra resource is not obtained. It turns out that PIO builds successfully most of the time without them, but some tests may fail (e.g., searching for the mpi.mod).

This PR fixes this by obtaining this utils repo before the build.