### PR TITLE
Abstract Env path var modifications on Windows

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -216,6 +216,16 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
+def windows_drive() -> str:
+    """Return Windows drive string extracted from the PROGRAMFILES environment variable,
+    which is guaranteed to be defined for all logins.
+    """
+    match = re.match(r"([a-zA-Z]:)", os.environ["PROGRAMFILES"])
+    if match is None:
+        raise RuntimeError("cannot read the PROGRAMFILES environment variable")
+    return match.group(1)
+
+
 @memoized
 def file_command(*args):
     """Creates entry point to `file` system command with provided arguments"""
@@ -1878,6 +1888,13 @@ def _find_non_recursive(root, search_files):
     return answer
 
 
+@system_path_filter
+def find_and_filter(root, search_files, filter, recursive=False):
+    """Search root for files. A filter returning a boolean is applied
+    to each file and if true, the
+    """
+
+
 # Utilities for libraries and headers
 
 
@@ -2372,7 +2389,7 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
         suffixes = [static_ext]
 
     # List of libraries we are searching with suffixes
-    libraries = ["{0}.{1}".format(lib, suffix) for lib in libraries for suffix in suffixes]
+    libraries = [f"{lib}.{suffix}" for lib in libraries for suffix in suffixes]
 
     if not recursive:
         # If not recursive, look for the libraries directly in root
@@ -2427,6 +2444,30 @@ def find_all_libraries(root, recursive=False):
     return find_all_shared_libraries(root, recursive=recursive) + find_all_static_libraries(
         root, recursive=recursive
     )
+
+
+def find_executables(name: str, root: str, recursive: bool=False) -> Optional[List[str]]:
+    """Search root for executable with name
+
+    Args:
+        name (str): name of executable to be search for
+        root (str|pathlib.Path):  path to root of search
+        recursive (bool): toggle recursive search behavior
+
+    Return:
+        List[pathlib.Path]|None: a list of pathlib.Path objects indicating the path to the executable with `name`
+        if one was found
+    """
+    if sys.platfrom == "win32":
+        suffixes = list(map(str.lower, os.environ["PATHEXT"].split(";")))
+    search_space = [f"{name}.{suf}" for suf in suffixes]
+    return list(filter(lambda x: True if sys.platform == "win32" else True if is_exe(x) else False,  find(root, search_space, recursive)))
+
+
+def find_all_executables(root: str, recursive: bool =False) -> Optional[List[str]]:
+    """Convenience function to detect all executables under a given root
+        Same as find_executables with a glob for all names"""
+    return find_executables("*", root, recursive)
 
 
 class WindowsSimulatedRPath:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2446,7 +2446,7 @@ def find_all_libraries(root, recursive=False):
     )
 
 
-def find_executables(name: str, root: str, recursive: bool=False) -> Optional[List[str]]:
+def find_executables(name: str, root: str, recursive: bool = False) -> Optional[List[str]]:
     """Search root for executable with name
 
     Args:
@@ -2461,12 +2461,17 @@ def find_executables(name: str, root: str, recursive: bool=False) -> Optional[Li
     if sys.platfrom == "win32":
         suffixes = list(map(str.lower, os.environ["PATHEXT"].split(";")))
     search_space = [f"{name}.{suf}" for suf in suffixes]
-    return list(filter(lambda x: True if sys.platform == "win32" else True if is_exe(x) else False,  find(root, search_space, recursive)))
+    return list(
+        filter(
+            lambda x: True if sys.platform == "win32" else True if is_exe(x) else False,
+            find(root, search_space, recursive),
+        )
+    )
 
 
-def find_all_executables(root: str, recursive: bool =False) -> Optional[List[str]]:
+def find_all_executables(root: str, recursive: bool = False) -> Optional[List[str]]:
     """Convenience function to detect all executables under a given root
-        Same as find_executables with a glob for all names"""
+    Same as find_executables with a glob for all names"""
     return find_executables("*", root, recursive)
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -155,7 +155,8 @@ def translate_paths(name: str, env_val: str) -> str:
     """
 
     spack_paths = env_val.split(os.pathsep)
-    root = ShortLinkManager.get_next_view(name)
+    root = ShortLinkManager.get_next_view(env_val)
+    ShortLink(name, root, spack_paths).create_filesystem_view()
     return root
 
 
@@ -477,8 +478,7 @@ def set_wrapper_variables(pkg, env):
             env_paths.append(ci)
 
     tty.debug("Adding compiler bin/ paths: " + " ".join(env_paths))
-    for item in env_paths:
-        env.prepend_path("PATH", item)
+    env.prepend_path("PATH", translate_paths("PATH", os.pathsep.join(env_paths)))
     env.set_path(SPACK_ENV_PATH, env_paths)
 
     # Working directory for the spack command itself, for debug logs.
@@ -1076,7 +1076,7 @@ class SetupContext:
         for d in ("bin", "bin64"):
             bin_dir = os.path.join(dep.prefix, d)
             if os.path.isdir(bin_dir):
-                env.prepend_path("PATH", bin_dir)
+                env.prepend_path("PATH", translate_paths("PATH", bin_dir))
 
 
 def get_cmake_prefix_path(pkg):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -730,7 +730,7 @@ def load_external_modules(pkg):
             load_module(external_module)
 
 
-def setup_package(pkg, dirty, context: Context = Context.BUILD):
+def setup_package(pkg, dirty, context: Context = Context.BUILD, safe_windows=True):
     """Execute all environment setup routines."""
     if context not in (Context.BUILD, Context.TEST):
         raise ValueError(f"'context' must be Context.BUILD or Context.TEST - got {context}")
@@ -743,7 +743,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     # Keep track of env changes from packages separately, since we want to
     # issue warnings when packages make "suspicious" modifications.
     env_base = EnvironmentModifications() if dirty else clean_environment()
-    env_mods = EnvironmentModifications()
+    env_mods = EnvironmentModifications(safe_windows=safe_windows)
 
     # setup compilers for build contexts
     need_compiler = context == Context.BUILD or (

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -124,7 +124,7 @@ def emulate_env_utility(cmd_name, context: Context, args):
             ),
         )
 
-    build_environment.setup_package(spec.package, args.dirty, context)
+    build_environment.setup_package(spec.package, args.dirty, context, safe_windows=False)
 
     if args.dump:
         # Dump a source-able environment to a text file.

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -124,7 +124,7 @@ def emulate_env_utility(cmd_name, context: Context, args):
             ),
         )
 
-    build_environment.setup_package(spec.package, args.dirty, context, safe_windows=False)
+    build_environment.setup_package(spec.package, args.dirty, context)
 
     if args.dump:
         # Dump a source-able environment to a text file.

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -21,8 +21,8 @@ import re
 import sys
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
-import llnl.util.tty
 import llnl.util.filesystem
+import llnl.util.tty
 
 import spack.config
 import spack.operating_systems.windows_os as winOs

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -22,6 +22,7 @@ import sys
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 import llnl.util.tty
+import llnl.util.filesystem
 
 import spack.config
 import spack.operating_systems.windows_os as winOs
@@ -252,16 +253,6 @@ def update_configuration(
     return all_new_specs
 
 
-def _windows_drive() -> str:
-    """Return Windows drive string extracted from the PROGRAMFILES environment variable,
-    which is guaranteed to be defined for all logins.
-    """
-    match = re.match(r"([a-zA-Z]:)", os.environ["PROGRAMFILES"])
-    if match is None:
-        raise RuntimeError("cannot read the PROGRAMFILES environment variable")
-    return match.group(1)
-
-
 class WindowsCompilerExternalPaths:
     @staticmethod
     def find_windows_compiler_root_paths() -> List[str]:
@@ -385,7 +376,7 @@ def find_win32_additional_install_paths() -> List[str]:
     """Not all programs on Windows live on the PATH
     Return a list of other potential install locations.
     """
-    drive_letter = _windows_drive()
+    drive_letter = llnl.util.filesystem.windows_drive()
     windows_search_ext = []
     cuda_re = r"CUDA_PATH[a-zA-Z1-9_]*"
     # The list below should be expanded with other
@@ -420,7 +411,7 @@ def compute_windows_program_path_for_package(pkg: "spack.package_base.PackageBas
     # note windows paths are fine here as this method should only ever be invoked
     # to interact with Windows
     program_files = "{}\\Program Files{}\\{}"
-    drive_letter = _windows_drive()
+    drive_letter = llnl.util.filesystem.windows_drive()
 
     return [
         program_files.format(drive_letter, arch, name)

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -185,7 +185,7 @@ def test_escape_double_quotes_in_shell_modifications():
 def test_windows_safe_env_paths(monkeypatch, tmp_path):
     monkeypatch.setenv("PATH", "")
     safe_env_mods = envutil.EnvironmentModifications()
-    too_big_str = "a" * 150 # 1 char over Windows cmd cli length limit
+    too_big_str = "a" * 150  # 1 char over Windows cmd cli length limit
     too_big_dir = tmp_path / too_big_str
     too_big_dir.mkdir()
     safe_env_mods.append_path("PATH", too_big_dir)

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -179,3 +179,17 @@ def test_escape_double_quotes_in_shell_modifications():
         cmds = to_validate.shell_modifications()
         assert 'export VAR="$PATH:$ANOTHER_PATH"' in cmds
         assert r'export QUOTED_VAR="\"MY_VAL\""' in cmds
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only relevant on Windows")
+def test_windows_safe_env_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", "")
+    safe_env_mods = envutil.EnvironmentModifications()
+    too_big_str = "a" * 150 # 1 char over Windows cmd cli length limit
+    too_big_dir = tmp_path / too_big_str
+    too_big_dir.mkdir()
+    safe_env_mods.append_path("PATH", too_big_dir)
+    safe_env_mods.apply_modifications()
+    path = os.environ["PATH"]
+    assert len(path) < 300
+    assert envutil.win_env_view_manager._store[too_big_dir] == path

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -9,14 +9,17 @@ import inspect
 import json
 import os
 import os.path
+import pathlib
 import pickle
 import re
+import shutil
 import sys
 from functools import wraps
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple, Union
+import weakref
 
 from llnl.path import path_to_os_path, system_path_filter
-from llnl.util import tty
+from llnl.util import tty, symlink, filesystem
 from llnl.util.lang import dedupe
 
 from .executable import Executable, which
@@ -101,6 +104,27 @@ def system_env_normalize(func):
         return func(self, name, *args, **kwargs)
 
     return case_insensitive_modification
+
+
+def env_var_length_check(name: str, value: str) -> bool:
+    diff = 8192 - len(value)
+    if diff <= 0:
+        fail_on_long_env_var(name)
+    elif diff < 100:
+        warn_on_long_env_vars(name, value)
+        return True
+    return False
+
+
+def fail_on_long_env_var(name: str) ->None:
+    tty.die(f"Attempting to add to env variable: {name}\n\
+This operation will exceed the safe env variable length limit of 8192 characters\n\
+Spack will not be amending {name}")
+
+
+def warn_on_long_env_vars(name: str, value: str) -> None:
+    tty.warn(f"Attempting to add to env variable: {name}\n\
+{name} is {len(value)} characters. Safe limit is 8191")
 
 
 def is_system_path(path: Path) -> bool:
@@ -312,6 +336,57 @@ class NameValueModifier:
         raise NotImplementedError("must be implemented by derived classes")
 
 
+class WindowsPathModifierMixin:
+    """
+    Insulate path variable operations on Windows to ensure
+    safe env variable length limits are enforced
+
+    Abstract the "value" being added to an env variable
+    to reference a shorter path which has been symlinked to
+    mirror the contents of the original value.
+    Functional impact of env path variable modification is unchanged
+    """
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        if sys.platform == "win32":
+            root = win_env_view_manager.get_next_view(value)
+            self._env_view = WindowsEnvView(self.name, root, value, enabled=self.safe_windows)
+            self._value = root if self.safe_windows else value
+        else:
+            self._value = value
+
+
+class WindowsPathModifierMeta(type):
+    def __new__(cls, clsname, bases, attrs):
+        def wrapper(func):
+            def wrap(self, *args, **kwargs):
+                self._env_view.create_filesystem_view()
+                return func(self, *args, **kwargs)
+            return wrap
+        if sys.platform == "win32":
+            attrs["execute"] = wrapper(attrs["execute"])
+        return super().__new__(cls, clsname, bases, attrs)
+
+
+class SafeNameValueModifier(WindowsPathModifierMixin, NameValueModifier, metaclass=WindowsPathModifierMeta):
+    """NameValueModifier with added protections to prevent env variable smashing on Windows
+    A no-op on all other platforms"""
+    def __init__(self, name, value, *args, safe_windows=True, **kwargs):
+        self.safe_windows = safe_windows
+        self.name = name
+        self.value = value
+        super().__init__(name, value, *args, **kwargs)
+
+    def execute(self, env: MutableMapping[str, str]):
+        """Apply the modification to the mapping passed as input
+        Need to override these here so the metaclass doesn't complain about the missing attr"""
+        raise NotImplementedError("must be implemented by derived classes")
+
+
 class SetEnv(NameValueModifier):
     __slots__ = ("force", "raw")
 
@@ -358,14 +433,14 @@ class RemoveFlagsEnv(NameValueModifier):
         env[self.name] = self.separator.join(flags)
 
 
-class SetPath(NameValueModifier):
+class SetPath(SafeNameValueModifier):
     def execute(self, env: MutableMapping[str, str]):
         string_path = self.separator.join(str(item) for item in self.value)
         tty.debug(f"SetPath: {self.name}={string_path}", level=3)
         env[self.name] = string_path
 
 
-class AppendPath(NameValueModifier):
+class AppendPath(SafeNameValueModifier):
     def execute(self, env: MutableMapping[str, str]):
         tty.debug(f"AppendPath: {self.name}+{str(self.value)}", level=3)
         environment_value = env.get(self.name, "")
@@ -374,7 +449,7 @@ class AppendPath(NameValueModifier):
         env[self.name] = self.separator.join(directories)
 
 
-class PrependPath(NameValueModifier):
+class PrependPath(SafeNameValueModifier):
     def execute(self, env: MutableMapping[str, str]):
         tty.debug(f"PrependPath: {self.name}+{str(self.value)}", level=3)
         environment_value = env.get(self.name, "")
@@ -422,7 +497,7 @@ class EnvironmentModifications:
     """Keeps track of requests to modify the current environment."""
 
     def __init__(
-        self, other: Optional["EnvironmentModifications"] = None, traced: Union[None, bool] = None
+        self, other: Optional["EnvironmentModifications"] = None, traced: Union[None, bool] = None, safe_windows: bool = True
     ):
         """Initializes a new instance, copying commands from 'other'
         if it is not None.
@@ -431,8 +506,12 @@ class EnvironmentModifications:
             other: list of environment modifications to be extended (optional)
             traced: enable or disable stack trace inspection to log the origin
                 of the environment modifications
+            safe_windows: prevent modifications to the Windows env from smashing
+                          the env variables being modified due to cmd cli length limits
+                          default is True
         """
         self.traced = TRACING_ENABLED if traced is None else bool(traced)
+        self.safe_windows = safe_windows
         self.env_modifications: List[Union[NameModifier, NameValueModifier]] = []
         if other is not None:
             self.extend(other)
@@ -526,7 +605,7 @@ class EnvironmentModifications:
             elements: ordered list paths
             separator: separator for the paths (default: os.pathsep)
         """
-        item = SetPath(name, elements, separator=separator, trace=self._trace())
+        item = SetPath(name, elements, separator=separator, trace=self._trace(), safe_windows=self.safe_windows)
         self.env_modifications.append(item)
 
     @system_env_normalize
@@ -538,7 +617,7 @@ class EnvironmentModifications:
             path: path to be appended
             separator: separator for the paths (default: os.pathsep)
         """
-        item = AppendPath(name, path, separator=separator, trace=self._trace())
+        item = AppendPath(name, path, separator=separator, trace=self._trace(), safe_windows=self.safe_windows)
         self.env_modifications.append(item)
 
     @system_env_normalize
@@ -550,7 +629,7 @@ class EnvironmentModifications:
             path: path to be prepended
             separator: separator for the paths (default: os.pathsep)
         """
-        item = PrependPath(name, path, separator=separator, trace=self._trace())
+        item = PrependPath(name, path, separator=separator, trace=self._trace(), safe_windows=self.safe_windows)
         self.env_modifications.append(item)
 
     @system_env_normalize
@@ -1130,3 +1209,93 @@ def sanitize(
         environment.pop(k, None)
 
     return environment
+
+
+class WindowsEnvViewManager:
+    def __init__(self, root: str=None):
+        self.root = pathlib.Path(root) if root else self._establish_shortest_root()
+        self.current = "a"
+        self._store = collections.defaultdict(str)
+        self._finalizer = weakref.finalize(self, self.cleanup)
+
+    def _establish_shortest_root(self) -> pathlib.Path:
+        user = os.environ["USERPROFILE"]
+        drive = filesystem.windows_drive()
+        candidates = [f"{drive}\\", f"{drive}\\ProgramData"]
+        for candidate in candidates:
+            if os.access(candidate, os.W_OK):
+                self.root = pathlib.Path(candidate) / ".spack"
+                return self.root
+        self.root = pathlib.Path(user) / ".spack"
+        return self.root
+
+    def get_next_view(self, value) -> str:
+        def inc(c):
+            curr = ord(c[-1])
+            over = curr // 122
+            if over:
+                return (inc(c[:-1]) if len(c[:-1]) else 'a') + 'a'
+            return c[:-1] + chr(curr + 1)
+        current_value = self._store[value]
+        if current_value:
+            return current_value
+        next = str(self.root / self.current)
+        self._store[value] = next
+        self.current = inc(self.current)
+        return next
+
+    def cleanup(self):
+        shutil.rmtree(str(self.root))
+
+
+
+win_env_view_manager = WindowsEnvViewManager()
+
+
+class WindowsEnvView:
+    def __init__(self, name, root, *path_additions, enabled=True):
+        """
+            Args:
+                name (str): the env variable whose value is to be abtracted
+                root (str): root at which to create env view
+                path_additions (List[str]): directories that would
+                    normally be added to an env path variable.
+                    Entires in list should be directories that
+                    would typically be added to a path env var
+                    Contents of root of the directory will be added
+                    to a "view" into that directory with a shortened
+                    path to reduce length of env variables
+                enabled (bool): default is True, toggled whether or not
+                    this class is a no-op
+        """
+        self.enabled = enabled
+        self.name = name
+        self.root = pathlib.Path(root)
+        self._paths = path_additions
+
+    def _create_root(self):
+        if not self.root.exists():
+            self.root.mkdir(parents=True)
+
+    def _generate_link(self, path):
+        symlink.symlink(path, str(self.root / path))
+
+    def _collect_entries(self, path):
+        return path.iterdir()
+
+    def create_filesystem_view(self):
+        """Generate symlink view of path mods
+        One subdirectory from root is created per path mod
+        operation."""
+        if self.enabled:
+            self._create_root()
+            for entry in self._paths:
+                for pth in self._collect_entries(pathlib.Path(entry)):
+                    self._generate_link(pth)
+
+    def get_env_view(self) -> EnvironmentModifications:
+        """Generate env mods corresonding to view structure"""
+        env_mods = EnvironmentModifications()
+        for pth in self.root.iterdir():
+            env_mods.append_path(self.name, str(pth))
+        return env_mods


### PR DESCRIPTION
Windows CMD has a cmd length limit of 8181 characters (plus a newline)

When invoking a subshell, CMD applies this limit to env vars, and when the limit is exceeded, CMD starts to prune the end of the var until the var is under the limit. When invoking a command, CMD will prune or fail depending on the context

If Spack adds vars longer than this limit, unexpected behavior starts to happen if tools or users invoke subshells or use commands lines with an env var, unexpected behavior will occur. This is most obvious when CMake runs a cmd subshell from cmd, with an excessively long PATH. CMD prunes the end of the PATH, and CMD can no longer find itself, resulting in the error "cmd.exe: cmd.exe is not a program", however this can occur in any circumstance where a tool or user (or Spack in some cases) invokes CMD after Spack modifies the env.

Realistically this is only relevant for path vars as they can be quite long.

Spack fills the PATH, LIBS, INCLUDES, and CMAKE_PREFIX_PATH amoung others with paths from the DAG and other info packages add via their enviornment modification methods. This can quickly accumulate for a large dag, particularly if a users install prefix is long, to exceed the CMD limits.

This PR insulates env modifications on Windows to ensure this is less likely.

This is accomplished by:

* Intercepting calls to modify an env
* Creating a temp directory that is shoter than a Spack prefix
* Symlinking contents of directory that would be added to a path env var to that temp directory
* Adding that temp directory to the path env var instead
* Temp directory is destroyed when Spack exits

THIS PR IS A NO-OP ON UNIX