### PR TITLE
Garfield++: Add a dependent run environment

### DIFF
--- a/var/spack/repos/builtin/packages/garfieldpp/package.py
+++ b/var/spack/repos/builtin/packages/garfieldpp/package.py
@@ -55,3 +55,6 @@ class Garfieldpp(CMakePackage):
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set("GARFIELD_INSTALL", self.prefix)
         env.set("HEED_DATABASE", self.prefix.share.Heed.database)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set("HEED_DATABASE", self.prefix.share.Heed.database)


### PR DESCRIPTION
The env variable `HEED_DATABASE` is also needed for dependents.