### PR TITLE
spack checksum: handle all versions dropped better

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -154,7 +154,7 @@ def checksum(parser, args):
         filtered_url_dict = spack.stage.interactive_version_filter(
             url_dict, pkg.versions, url_changes=url_changed_for_version
         )
-        if filtered_url_dict is None:
+        if not filtered_url_dict:
             exit(0)
         url_dict = filtered_url_dict
     else:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -893,7 +893,9 @@ def interactive_version_filter(
         if print_header:
             has_filter = version_filter != VersionList([":"])
             header = []
-            if len(sorted_and_filtered) == len(orig_url_dict):
+            if not sorted_and_filtered:
+                header.append("No versions selected")
+            elif len(sorted_and_filtered) == len(orig_url_dict):
                 header.append(
                     f"Selected {llnl.string.plural(len(sorted_and_filtered), 'version')}"
                 )
@@ -901,7 +903,7 @@ def interactive_version_filter(
                 header.append(
                     f"Selected {len(sorted_and_filtered)} of {len(orig_url_dict)} versions"
                 )
-            if known_versions:
+            if sorted_and_filtered and known_versions:
                 num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
                 header.append(f"{llnl.string.plural(num_new, 'new version')}")
             if has_filter:

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -169,6 +169,22 @@ def test_checksum_interactive_quit_from_ask_each():
     }
 
 
+def test_checksum_interactive_nothing_left():
+    """If nothing is left after interactive filtering, return an empty dict."""
+    input = input_from_commands("f", "@2", "c")
+    assert (
+        interactive_version_filter(
+            {
+                Version("1.1"): "https://www.example.com/pkg-1.1.tar.gz",
+                Version("1.0"): "https://www.example.com/pkg-1.0.tar.gz",
+                Version("0.9"): "https://www.example.com/pkg-0.9.tar.gz",
+            },
+            input=input,
+        )
+        == {}
+    )
+
+
 def test_checksum_interactive_new_only():
     # The 1.0 version is known already, and should be dropped on `n`.
     input = input_from_commands("n", "c")


### PR DESCRIPTION
Early exit when no versions are selected, instead of showing a mysterious error about `max_workers > 0`.
