### PR TITLE
py-click: fix Python 3.6 support

### DIFF
--- a/var/spack/repos/builtin/packages/py-click/package.py
+++ b/var/spack/repos/builtin/packages/py-click/package.py
@@ -25,6 +25,8 @@ class PyClick(PythonPackage):
     )
     version("6.6", sha256="cc6a19da8ebff6e7074f731447ef7e112bd23adf3de5c597cf9989f2fd8defe9")
 
+    # Needed to ensure that Spack can bootstrap black with Python 3.6
+    depends_on("python@3.7:", when="@8.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-importlib-metadata", when="@8: ^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
CI is broken due to #40473 

@alalazo the test you added to ensure that Python 3.6 bootstrapping still works doesn't fail on the PR that breaks things, only on all subsequent PRs.

@tgamblin when we can stop supporting `spack style` bootstrapping on EOL Python versions? We can still support every other part of Spack for Python 3.6 if you want, but this is only going to get worse when we drop Python 3.7 this fall and 3.8 next year.