### PR TITLE
Python: allow OneAPI 2024 when it's released

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -318,7 +318,7 @@ class Python(Package):
 
     # See https://github.com/python/cpython/issues/106424
     # datetime.now(timezone.utc) segfaults
-    conflicts("@3.9:", when="%oneapi@2022.2.1:")
+    conflicts("@3.9:", when="%oneapi@2022.2.1:2023")
 
     # Used to cache various attributes that are expensive to compute
     _config_vars: Dict[str, Dict[str, str]] = {}


### PR DESCRIPTION
Extracted out of #40057 

According to https://github.com/python/cpython/issues/106424#issuecomment-1666572260, OneAPI 2024.0 will work.