### PR TITLE
README.md: tweak matrix description to indicate bridging

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ Resources:
 
 * **Slack workspace**: [spackpm.slack.com](https://spackpm.slack.com).
   To get an invitation, visit [slack.spack.io](https://slack.spack.io).
-* **Matrix space**: [#spack-space:matrix.org](https://matrix.to/#/#spack-space:matrix.org).
-* [**Github Discussions**](https://github.com/spack/spack/discussions): not just for discussions, also Q&A.
+* **Matrix space**: [#spack-space:matrix.org](https://matrix.to/#/#spack-space:matrix.org):
+  [bridged](https://github.com/matrix-org/matrix-appservice-slack#matrix-appservice-slack) to Slack.
+* [**Github Discussions**](https://github.com/spack/spack/discussions):
+  not just for discussions, also Q&A.
 * **Mailing list**: [groups.google.com/d/forum/spack](https://groups.google.com/d/forum/spack)
 * **Twitter**: [@spackpm](https://twitter.com/spackpm). Be sure to
   `@mention` us!


### PR DESCRIPTION
This tweaks the matrix description to indicate that it's bridged with Slack. So people don't think they're missing out (even though the icon says there are only 3 users on Matrix).