### PR TITLE
py-nanobind: simplify dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-nanobind/package.py
+++ b/var/spack/repos/builtin/packages/py-nanobind/package.py
@@ -24,6 +24,9 @@ class PyNanobind(PythonPackage):
 
     version("master", branch="master", submodules=True)
     version(
+        "1.6.2", tag="v1.6.2", commit="cc5ac7e61def198db2a8b65c6d630343987a9f1d", submodules=True
+    )
+    version(
         "1.5.2", tag="v1.5.2", commit="b0e24d5b0ab0d518317d6b263a257ae72d4d29a2", submodules=True
     )
     version(
@@ -43,8 +46,8 @@ class PyNanobind(PythonPackage):
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-scikit-build", type="build")
 
-    depends_on("py-cmake@3.17:", type="build")
-    depends_on("py-ninja", type="build")
+    depends_on("cmake@3.17:", type="build")
+    depends_on("ninja", type="build")
 
     @property
     def cmake_prefix_paths(self):


### PR DESCRIPTION
Change dependencies from `py-cmake` to `cmake`, and likewise for `ninja`.

`py-cmake` fails to build, see #40542, and doesn't seem to offer anything over `cmake` package.

Also adds a new version of nanonbind.

@adamjstewart 