### PR TITLE
intel-oneapi-compilers: ifx is located in bin not bin/intel64

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -279,9 +279,12 @@ class IntelOneapiCompilers(IntelOneApiPackage):
             common_flags + llvm_flags, self.component_prefix.linux.bin, ["icx", "icpx"]
         )
         self.write_config_file(
+            common_flags + classic_flags, self.component_prefix.linux.bin, ["ifx"]
+        )
+        self.write_config_file(
             common_flags + classic_flags,
             self.component_prefix.linux.bin.intel64,
-            ["icc", "icpc", "ifort", "ifx"],
+            ["icc", "icpc", "ifort"],
         )
 
     def _ld_library_path(self):


### PR DESCRIPTION
This is a fix on top of https://github.com/spack/spack/pull/40557 . Tagging @rscohn2 for review.