### PR TITLE
Use string representation of deptypes for concrete specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1883,7 +1883,11 @@ class SpackSolverSetup:
                             continue
                         # skip build dependencies of already-installed specs
                         if concrete_build_deps or dtype != dt.BUILD:
-                            clauses.append(fn.attr("depends_on", spec.name, dep.name, dtype))
+                            clauses.append(
+                                fn.attr(
+                                    "depends_on", spec.name, dep.name, dt.flag_to_string(dtype)
+                                )
+                            )
                             for virtual_name in dspec.virtuals:
                                 clauses.append(
                                     fn.attr("virtual_on_edge", spec.name, dep.name, virtual_name)


### PR DESCRIPTION
Bug introduced in #39472, extracted from #39590

Currently, for reusable specs we have facts like:
```
imposed_constraint("s6vou4jcpnq6oz3gpnaxblcvivlqsqtn","depends_on","python","xz",1).
```
where we use the enum value (`1`) instead of the string representation of the dependency type. This PR fixes it so that the fact above looks like:
```
imposed_constraint("s6vou4jcpnq6oz3gpnaxblcvivlqsqtn","depends_on","python","xz","link").
```
