### PR TITLE
packages: use "requires" to allow only selected compilers

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -72,15 +72,7 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="+sycl", msg=backend_msg)
     conflicts("+sycl", when="@:2023.06.00", msg="SYCL support requires BLAS++ version 2023.08.25")
 
-    # TODO: +sycl requires use of the intel-oneapi compiler, but we cannot express that directly.
-    #       For now, add conflicts for other compilers instead.
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "oneapi":
-            conflicts(
-                "%{0}".format(__compiler),
-                when="+sycl",
-                msg="blaspp+sycl must be compiled with %oneapi",
-            )
+    requires("%oneapi", when="+sycl", msg="blaspp+sycl must be compiled with %oneapi")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -5,7 +5,6 @@
 import glob
 import os
 
-import spack.compilers
 import spack.paths
 import spack.user_environment
 from spack.package import *
@@ -53,28 +52,26 @@ class ClingoBootstrap(Clingo):
     depends_on("cmake@3.16.0:", type="build")
 
     # On Linux we bootstrap with GCC or clang
-    for compiler_spec in [
-        c for c in spack.compilers.supported_compilers() if c not in ("gcc", "clang")
-    ]:
-        conflicts(
-            "%{0}".format(compiler_spec),
-            when="platform=linux",
-            msg="GCC or clang are required to bootstrap clingo on Linux",
-        )
-        conflicts(
-            "%{0}".format(compiler_spec),
-            when="platform=cray",
-            msg="GCC or clang are required to bootstrap clingo on Cray",
-        )
+    requires(
+        "%gcc",
+        "%clang",
+        when="platform=linux",
+        msg="GCC or clang are required to bootstrap clingo on Linux",
+    )
+    requires(
+        "%gcc",
+        "%clang",
+        when="platform=cray",
+        msg="GCC or clang are required to bootstrap clingo on Cray",
+    )
     conflicts("%gcc@:5", msg="C++14 support is required to bootstrap clingo")
 
     # On Darwin we bootstrap with Apple Clang
-    for compiler_spec in [c for c in spack.compilers.supported_compilers() if c != "apple-clang"]:
-        conflicts(
-            "%{0}".format(compiler_spec),
-            when="platform=darwin",
-            msg="Apple-clang is required to bootstrap clingo on MacOS",
-        )
+    requires(
+        "%apple-clang",
+        when="platform=darwin",
+        msg="Apple-clang is required to bootstrap clingo on MacOS",
+    )
 
     # Clingo needs the Python module to be usable by Spack
     conflicts("~python", msg="Python support is required to bootstrap Spack")

--- a/var/spack/repos/builtin/packages/exciting/package.py
+++ b/var/spack/repos/builtin/packages/exciting/package.py
@@ -39,23 +39,9 @@ class Exciting(MakefilePackage):
     depends_on("scalapack", when="+scalapack")
     # conflicts('%gcc@10:', msg='exciting cannot be built with GCC 10')
 
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "intel":
-            conflicts(
-                "%{0}".format(__compiler),
-                when="^mkl",
-                msg="Intel MKL only works with the Intel compiler",
-            )
-            conflicts(
-                "%{0}".format(__compiler),
-                when="^intel-mkl",
-                msg="Intel MKL only works with the Intel compiler",
-            )
-            conflicts(
-                "%{0}".format(__compiler),
-                when="^intel-mpi",
-                msg="Intel MPI only works with the Intel compiler",
-            )
+    requires("%intel", when="^mkl", msg="Intel MKL only works with the Intel compiler")
+    requires("%intel", when="^intel-mkl", msg="Intel MKL only works with the Intel compiler")
+    requires("%intel", when="^intel-mpi", msg="Intel MPI only works with the Intel compiler")
 
     def patch(self):
         """Fix bad logic in m_makespectrum.f90 for the Oxygen release"""

--- a/var/spack/repos/builtin/packages/gaussian-src/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-src/package.py
@@ -28,11 +28,7 @@ class GaussianSrc(Package):
     depends_on("tcsh", type="build")
 
     # All compilers except for pgi are in conflict:
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "pgi":
-            conflicts(
-                "%{0}".format(__compiler), msg="Gaussian can only be built with the PGI compiler"
-            )
+    requires("%pgi", msg="Gaussian can only be built with the PGI compiler")
 
     patch("16-C.01-replace-deprecated-pgf77-with-pgfortran.patch", when="@16-C.01")
     patch("16-C.01-fix-building-c-code-with-pgcc.patch", when="@16-C.01")

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.compilers
 from spack.build_environment import dso_suffix
 from spack.package import *
 
@@ -171,11 +170,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     # TODO: effectively gcc is a direct dependency of intel-oneapi-compilers, but we
     # cannot express that properly. For now, add conflicts for non-gcc compilers
     # instead.
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "gcc":
-            conflicts(
-                "%{0}".format(__compiler), msg="intel-oneapi-compilers must be installed with %gcc"
-            )
+    requires("%gcc", msg="intel-oneapi-compilers must be installed with %gcc")
 
     for v in versions:
         version(v["version"], expand=False, **v["cpp"])

--- a/var/spack/repos/builtin/packages/knem/package.py
+++ b/var/spack/repos/builtin/packages/knem/package.py
@@ -49,12 +49,7 @@ class Knem(AutotoolsPackage):
     # Ideally, we should list all non-Linux-based platforms here:
     conflicts("platform=darwin")
 
-    # All compilers except for gcc are in conflict:
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "gcc":
-            conflicts(
-                "%{0}".format(__compiler), msg="Linux kernel module must be compiled with gcc"
-            )
+    requires("%gcc", msg="Linux kernel module must be compiled with gcc")
 
     @run_before("build")
     def override_kernel_compiler(self):

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -85,15 +85,7 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="+sycl", msg=backend_msg)
     conflicts("+sycl", when="@:2023.06.00", msg="+sycl requires LAPACK++ version 2023.08.25")
 
-    # TODO: +sycl requires use of the intel-oneapi compiler, but we cannot express that directly.
-    #       For now, add conflicts for other compilers instead.
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "oneapi":
-            conflicts(
-                "%{0}".format(__compiler),
-                when="+sycl",
-                msg="lapackpp+sycl must be compiled with %oneapi",
-            )
+    requires("%oneapi", when="+sycl", msg="lapackpp+sycl must be compiled with %oneapi")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -179,9 +179,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("~python", when="@0.91:0.101")
     conflicts("~pfe", when="@0.91:0.101")
 
-    for comp in spack.compilers.supported_compilers():
-        if comp != "clang":
-            conflicts("+lld", when="%" + comp)
+    requires("%clang", when="+lld")
 
     conflicts("+lld", when="+gold")
     conflicts("+gold", when="platform=darwin", msg="gold does not work on Darwin")

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -377,11 +377,7 @@ class Nvhpc(Package):
     provides("lapack", when="+lapack")
     provides("mpi", when="+mpi")
 
-    # TODO: effectively gcc is a direct dependency of nvhpc, but we cannot express that
-    #  properly. For now, add conflicts for non-gcc compilers instead.
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "gcc":
-            conflicts("%{0}".format(__compiler), msg="nvhpc must be installed with %gcc")
+    requires("%gcc", msg="nvhpc must be installed with %gcc")
 
     def _version_prefix(self):
         return join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version)

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -84,15 +84,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("scalapack", type="test")
     depends_on("hipify-clang", when="@:2021.05.02 +rocm ^hip@5:")
 
-    # TODO: +sycl requires use of the intel-oneapi compiler, but we cannot express that directly.
-    #       For now, add conflicts for other compilers instead.
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "oneapi":
-            conflicts(
-                "%{0}".format(__compiler),
-                when="+sycl",
-                msg="slate+sycl must be compiled with %oneapi",
-            )
+    requires("%oneapi", when="+sycl", msg="slate+sycl must be compiled with %oneapi")
 
     cpp_17_msg = "Requires C++17 compiler support"
     conflicts("%gcc@:5", msg=cpp_17_msg)

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -344,13 +344,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("gotype=all", when="@12.15:")
 
     # CUDA without wrapper requires clang
-    for _compiler in spack.compilers.supported_compilers():
-        if _compiler != "clang":
-            conflicts(
-                "+cuda",
-                when="~wrapper %" + _compiler,
-                msg="trilinos~wrapper+cuda can only be built with the " "Clang compiler",
-            )
+    requires(
+        "%clang",
+        when="+cuda~wrapper",
+        msg="trilinos~wrapper+cuda can only be built with the Clang compiler",
+    )
     conflicts("+cuda_rdc", when="~cuda")
     conflicts("+rocm_rdc", when="~rocm")
     conflicts("+wrapper", when="~cuda")

--- a/var/spack/repos/builtin/packages/xpmem/package.py
+++ b/var/spack/repos/builtin/packages/xpmem/package.py
@@ -64,13 +64,7 @@ class Xpmem(AutotoolsPackage):
     conflicts("+kernel-module", when="platform=darwin")
 
     # All compilers except for gcc are in conflict with +kernel-module:
-    for __compiler in spack.compilers.supported_compilers():
-        if __compiler != "gcc":
-            conflicts(
-                "+kernel-module",
-                when="%{0}".format(__compiler),
-                msg="Linux kernel module must be compiled with gcc",
-            )
+    requires("%gcc", when="+kernel-module", msg="Linux kernel module must be compiled with gcc")
 
     def autoreconf(self, spec, prefix):
         Executable("./autogen.sh")()


### PR DESCRIPTION
A few packages have encoded an idiom that pre-dates the introduction of the `requires` directive, and they cycle over all compilers to conflict with the ones that are not supported.

Here instead we reverse the logic, and require the ones that are supported.