### PR TITLE
(WIP) Bugfix: Python install phase 'test_imports' callback

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -35,6 +35,10 @@ from ._checks import BaseBuilder, execute_install_time_tests
 class PythonExtension(spack.package_base.PackageBase):
     maintainers("adamjstewart")
 
+    ##: Callback names for install-time test
+    # TBD: This could override the derived list of tests if desired feature
+    #install_time_test_callbacks = ["test_imports"]
+
     @property
     def import_modules(self):
         """Names of modules that the Python package provides.
@@ -286,7 +290,8 @@ class PythonPackage(PythonExtension):
     legacy_buildsystem = "python_pip"
 
     #: Callback names for install-time test
-    install_time_test_callbacks = ["test_imports"]
+    # TBD: This could override the derived list of tests if desired feature
+    #install_time_test_callbacks = ["test_imports"]
 
     build_system("python_pip")
 
@@ -402,17 +407,19 @@ def fixup_shebangs(path: str, old_interpreter: bytes, new_interpreter: bytes):
 class PythonPipBuilder(BaseBuilder):
     phases = ("install",)
 
-    #: Names associated with package methods in the old build-system format
-    legacy_methods = ("test_imports",)
+    ##: Callback names for install-time test
+    # TBD: This could override the derived list of tests if desired feature
+    #install_time_test_callbacks = ["test_imports"]
+
+    ##: Names associated with package methods in the old build-system format
+    # TBD: This could override the derived list of tests if desired feature
+    #legacy_methods = ("test_imports",)
 
     #: Same as legacy_methods, but the signature is different
     legacy_long_methods = ("install_options", "global_options", "config_settings")
 
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = ("build_directory", "install_time_test_callbacks")
-
-    #: Callback names for install-time test
-    install_time_test_callbacks = ["test_imports"]
 
     @staticmethod
     def std_args(cls):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -286,7 +286,7 @@ class PythonPackage(PythonExtension):
     legacy_buildsystem = "python_pip"
 
     #: Callback names for install-time test
-    install_time_test_callbacks = ["test"]
+    install_time_test_callbacks = ["test_imports"]
 
     build_system("python_pip")
 
@@ -403,7 +403,7 @@ class PythonPipBuilder(BaseBuilder):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format
-    legacy_methods = ("test",)
+    legacy_methods = ("test_imports",)
 
     #: Same as legacy_methods, but the signature is different
     legacy_long_methods = ("install_options", "global_options", "config_settings")
@@ -412,7 +412,7 @@ class PythonPipBuilder(BaseBuilder):
     legacy_attributes = ("build_directory", "install_time_test_callbacks")
 
     #: Callback names for install-time test
-    install_time_test_callbacks = ["test"]
+    install_time_test_callbacks = ["test_imports"]
 
     @staticmethod
     def std_args(cls):


### PR DESCRIPTION
Fixes #39167 

The install phase callbacks are using the deprecated stand-alone test method instead of the renamed one.  This is only a fix for python's `test_imports` method.