### PR TITLE
Fix dev-build keep_stage behavior

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1805,14 +1805,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             verbose (bool): Display verbose build output (by default,
                 suppresses it)
         """
-        # Non-transitive dev specs need to keep the dev stage and be built from
-        # source every time. Transitive ones just need to be built from source.
-        dev_path_var = self.spec.variants.get("dev_path", None)
-        if dev_path_var:
-            kwargs["keep_stage"] = True
-
-        builder = PackageInstaller([(self, kwargs)])
-        builder.install()
+        PackageInstaller([(self, kwargs)]).install()
 
     # TODO (post-34236): Update tests and all packages that use this as a
     # TODO (post-34236): package method to the routine made available to

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -9,8 +9,10 @@ import pytest
 
 import llnl.util.filesystem as fs
 
+import spack.build_environment
 import spack.environment as ev
 import spack.spec
+import spack.store
 from spack.main import SpackCommand
 
 dev_build = SpackCommand("dev-build")
@@ -20,8 +22,8 @@ env = SpackCommand("env")
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
-def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
+def test_dev_build_basics(tmpdir, install_mockery):
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}")
     spec.concretize()
 
     assert "dev_path" in spec.variants
@@ -39,9 +41,8 @@ def test_dev_build_basics(tmpdir, mock_packages, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
-def test_dev_build_before(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
-    spec.concretize()
+def test_dev_build_before(tmpdir, install_mockery):
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, "w") as f:
@@ -56,9 +57,8 @@ def test_dev_build_before(tmpdir, mock_packages, install_mockery):
     assert not os.path.exists(spec.prefix)
 
 
-def test_dev_build_until(tmpdir, mock_packages, install_mockery):
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
-    spec.concretize()
+def test_dev_build_until(tmpdir, install_mockery):
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, "w") as f:
@@ -74,10 +74,9 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     assert not spack.store.STORE.db.query(spec, installed=True)
 
 
-def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
+def test_dev_build_until_last_phase(tmpdir, install_mockery):
     # Test that we ignore the last_phase argument if it is already last
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
-    spec.concretize()
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, "w") as f:
@@ -94,9 +93,8 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
-def test_dev_build_before_until(tmpdir, mock_packages, install_mockery, capsys):
-    spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
-    spec.concretize()
+def test_dev_build_before_until(tmpdir, install_mockery, capsys):
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
     with tmpdir.as_cwd():
         with open(spec.package.filename, "w") as f:
@@ -134,7 +132,6 @@ def mock_module_noop(*args):
 
 def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, working_env):
     monkeypatch.setattr(os, "execvp", print_spack_cc)
-
     monkeypatch.setattr(spack.build_environment, "module", mock_module_noop)
 
     with tmpdir.as_cwd():
@@ -142,7 +139,7 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, 
         assert "lib/spack/env" in output
 
 
-def test_dev_build_fails_already_installed(tmpdir, mock_packages, install_mockery):
+def test_dev_build_fails_already_installed(tmpdir, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
 
@@ -175,7 +172,7 @@ def test_dev_build_fails_no_version(mock_packages):
     assert "dev-build spec must have a single, concrete version" in output
 
 
-def test_dev_build_env(tmpdir, mock_packages, install_mockery, mutable_mock_env_path):
+def test_dev_build_env(tmpdir, install_mockery, mutable_mock_env_path):
     """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir("build")
@@ -191,7 +188,7 @@ def test_dev_build_env(tmpdir, mock_packages, install_mockery, mutable_mock_env_
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                """\
+                f"""\
 spack:
   specs:
   - dev-build-test-install@0.0.0
@@ -199,11 +196,9 @@ spack:
   develop:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
-      path: %s
+      path: {os.path.relpath(str(build_dir), start=str(envdir))}
 """
-                % os.path.relpath(str(build_dir), start=str(envdir))
             )
-
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
             install()
@@ -213,9 +208,7 @@ spack:
         assert f.read() == spec.package.replacement_string
 
 
-def test_dev_build_env_version_mismatch(
-    tmpdir, mock_packages, install_mockery, mutable_mock_env_path
-):
+def test_dev_build_env_version_mismatch(tmpdir, install_mockery, mutable_mock_env_path):
     """Test Spack constraints concretization by develop specs."""
     # setup dev-build-test-install package for dev build
     build_dir = tmpdir.mkdir("build")
@@ -231,7 +224,7 @@ def test_dev_build_env_version_mismatch(
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                """\
+                f"""\
 spack:
   specs:
   - dev-build-test-install@0.0.0
@@ -239,9 +232,8 @@ spack:
   develop:
     dev-build-test-install:
       spec: dev-build-test-install@1.1.1
-      path: %s
+      path: {build_dir}
 """
-                % build_dir
             )
 
         env("create", "test", "./spack.yaml")
@@ -250,9 +242,7 @@ spack:
                 install()
 
 
-def test_dev_build_multiple(
-    tmpdir, mock_packages, install_mockery, mutable_mock_env_path, mock_fetch
-):
+def test_dev_build_multiple(tmpdir, install_mockery, mutable_mock_env_path, mock_fetch):
     """Test spack install with multiple developer builds
 
     Test that only the root needs to be specified in the environment
@@ -284,20 +274,19 @@ def test_dev_build_multiple(
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                """\
+                f"""\
 spack:
   specs:
   - dev-build-test-dependent@0.0.0
 
   develop:
     dev-build-test-install:
-      path: %s
+      path: {leaf_dir}
       spec: dev-build-test-install@=1.0.0
     dev-build-test-dependent:
       spec: dev-build-test-dependent@0.0.0
-      path: %s
+      path: {root_dir}
 """
-                % (leaf_dir, root_dir)
             )
 
         env("create", "test", "./spack.yaml")
@@ -316,9 +305,7 @@ spack:
             assert f.read() == spec.package.replacement_string
 
 
-def test_dev_build_env_dependency(
-    tmpdir, mock_packages, install_mockery, mock_fetch, mutable_mock_env_path
-):
+def test_dev_build_env_dependency(tmpdir, install_mockery, mock_fetch, mutable_mock_env_path):
     """
     Test non-root specs in an environment are properly marked for dev builds.
     """
@@ -337,7 +324,7 @@ def test_dev_build_env_dependency(
     with envdir.as_cwd():
         with open("spack.yaml", "w") as f:
             f.write(
-                """\
+                f"""\
 spack:
   specs:
   - dependent-of-dev-build@0.0.0
@@ -345,11 +332,9 @@ spack:
   develop:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
-      path: %s
+      path: {os.path.relpath(str(build_dir), start=str(envdir))}
 """
-                % os.path.relpath(str(build_dir), start=str(envdir))
             )
-
         env("create", "test", "./spack.yaml")
         with ev.read("test"):
             # concretize in the environment to get the dev build info
@@ -371,7 +356,7 @@ spack:
 
 @pytest.mark.parametrize("test_spec", ["dev-build-test-install", "dependent-of-dev-build"])
 def test_dev_build_rebuild_on_source_changes(
-    test_spec, tmpdir, mock_packages, install_mockery, mutable_mock_env_path, mock_fetch
+    test_spec, tmpdir, install_mockery, mutable_mock_env_path, mock_fetch
 ):
     """Test dev builds rebuild on changes to source code.
 
@@ -416,4 +401,4 @@ spack:
             fs.touch(os.path.join(str(build_dir), "test"))
             output = install()
 
-    assert "Installing %s" % test_spec in output
+    assert f"Installing {test_spec}" in output

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -23,8 +23,7 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_dev_build_basics(tmpdir, install_mockery):
-    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}")
-    spec.concretize()
+    spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
     assert "dev_path" in spec.variants
 


### PR DESCRIPTION
`spack dev-build` incorrectly sets `keep_stage=True` for the entire DAG. This
is unnecessary, cause the `DIYStage` doesn't delete sources.

With this change, stage dirs of non-develop deps are removed post install,
as would be expected. This avoids issues in the PR #40380 which as a side
effect adds a dependency to packages installed with `dev-build` in tests.

Also some cleanup:
- `install_mockery` implies `mock_packages`
- use f-strings.
