### PR TITLE
xmlto: add more dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/xmlto/package.py
+++ b/var/spack/repos/builtin/packages/xmlto/package.py
@@ -18,5 +18,18 @@ class Xmlto(AutotoolsPackage):
     version("0.0.28", sha256="2f986b7c9a0e9ac6728147668e776d405465284e13c74d4146c9cbc51fd8aad3")
 
     # FIXME: missing a lot of dependencies
-    depends_on("libxslt")
+    depends_on("docbook-xsl", type=("build", "run"))
+    depends_on("libxml2", type=("build", "run"))  # xmllint
+    depends_on("libxslt", type=("build", "run"))  # xsltconf
     depends_on("util-linux", type=("build", "run"))  # getopt with support for longopts
+
+    depends_on("docbook-xml", type="run")
+
+    patch(
+        "https://src.fedoraproject.org/rpms/xmlto/raw/rawhide/f/xmlto-c99-1.patch",
+        sha256="056c8bebc25d8d1488cc6a3724e2bcafc0e5e0df5c50080559cdef99bd377839",
+    )
+    patch(
+        "https://src.fedoraproject.org/rpms/xmlto/raw/rawhide/f/xmlto-c99-2.patch",
+        sha256="50e39b1810bbf22a1d67944086c5681bcd58b8c325dfb251d56ac15d088fc17a",
+    )


### PR DESCRIPTION
`xmllint` is called by `xmlto` during generation of `libzmq`'s docs, so adding `libxml2`.

The docbook deps and the patches are taken from
https://src.fedoraproject.org/rpms/xmlto/blob/rawhide/f/xmlto.spec

There are still many more dependencies missing, but this is out of scope of this patch (which is only concerned about the use case of `libzmq`, see #40399).