### PR TITLE
fix mivisionx build for 5.6

### DIFF
--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -182,7 +182,7 @@ class Mivisionx(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("ffmpeg@:4", type="build", when="@:5.3")
-    depends_on("ffmpeg@4.4:", type="build", when="@5.4:")
+    depends_on("ffmpeg@4.4", type="build", when="@5.4:")
     depends_on("protobuf@:3", type="build")
     depends_on(
         "opencv@:3.4"


### PR DESCRIPTION
Restricting Mivisionx to using ffmpeg@4.4 instead of newer versions