### PR TITLE
modules env changes: directly execute underlying module executable

### DIFF
--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -812,7 +812,7 @@ echo "4.4.4"
         "flags": {},
         "operating_system": "fake",
         "target": "fake",
-        "modules": ["turn_on"],
+        "modules": [],
         "environment": {},
         "extra_rpaths": [],
     }

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -31,7 +31,7 @@ def test_module_function_change_env(tmp_path):
     environb = {b"TEST_MODULE_ENV_VAR": b"TEST_FAIL", b"NOT_AFFECTED": b"NOT_AFFECTED"}
     src_file = tmp_path / "src_me"
     src_file.write_text("export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n")
-    module("load", str(src_file), module_template=f". {src_file} 2>&1", environb=environb)
+    module("load", str(src_file), module_template=f". {src_file}", environb=environb)
     assert environb[b"TEST_MODULE_ENV_VAR"] == b"TEST_SUCCESS"
     assert environb[b"NOT_AFFECTED"] == b"NOT_AFFECTED"
 
@@ -42,7 +42,7 @@ def test_module_function_no_change(tmpdir):
         f.write("echo TEST_MODULE_FUNCTION_PRINT")
 
     old_env = os.environ.copy()
-    text = module("show", src_file, module_template=". {0} 2>&1".format(src_file))
+    text = module("show", src_file, module_template=f". {src_file}")
 
     assert text == "TEST_MODULE_FUNCTION_PRINT\n"
     assert os.environ == old_env

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -147,7 +147,11 @@ def path_from_modules(modules):
     best_choice = None
     for module_name in modules:
         # Read the current module and return a candidate path
-        text = module("show", module_name).split("\n")
+        try:
+            text = module("show", module_name).split("\n")
+        except ModuleCommandError as e:
+            tty.warn(f"Unable extract prefix from module {module_name}: {e}")
+            continue
         candidate_path = get_path_from_module_contents(text, module_name)
 
         if candidate_path and not os.path.exists(candidate_path):

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -50,9 +50,10 @@ def module(
     else:
         # Otherwise assume the `module` shell function is defined in the shell we start
         script = f"module {quoted_args}"
-        shell_path = SHELL.decode() if SHELL and os.access(SHELL, os.X_OK) else "/bin/bash"
+        if SHELL and os.access(SHELL, os.X_OK):
+            shell_path = SHELL.decode()
 
-    # When this module command modifies environment variables, we retrieve those environment as
+    # When this module command modifies environment variables, we retrieve those variables as a
     # \0 separated list of key=value pairs from stdout using a
     if args[0] in module_change_commands:
         # stdout should have environment from awk output; stderr should have error message
@@ -76,7 +77,7 @@ def module(
         environb.update(new_environb)
 
     else:
-        # Simply execute commands that don't change state and return output (which is on stderr)
+        # Simply execute commands that don't change state and return output
         cmd = [shell_path, "-c", f"{script} >&2"]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         _, stderr = proc.communicate()
@@ -248,5 +249,5 @@ class ModuleCommandError(spack.error.SpackError):
     def from_failure(cls, command: str, returncode: int, stderr: bytes):
         return cls(
             f"`module {command}` failed with exit "
-            f"code {returncode}: {stderr.decode(errors='ignore')}"
+            f"code {returncode}: {stderr.decode(errors='ignore').strip()}"
         )


### PR DESCRIPTION
#### Issues
1. The subshell spawned in `module_cmd.py` may not have the `module` shell function defined (e.g. wrong shell, or maybe it's not sourced at startup, maybe it requires a login shell, maybe it sources a different module startup script than the user had before executing spack, etc)
2. Spack does not detect failure of `module load ...`

#### Solution
1. Detect module executable (not shell function) in env variables, directly invoke it and eval stdout in a default shell (i.e. `/bin/sh`).
2. Replace `<command>; awk ...` with `<command> && awk ...` to propagate the exit code.

Currently output looks as follows:

```
==> Installing mimalloc-2.1.2-zdbpwhqwtadbvbuwvh2cwplxb7uxedjn [3/3]
==> No binary for mimalloc-2.1.2-zdbpwhqwtadbvbuwvh2cwplxb7uxedjn found: installing from source
==> Error: ModuleCommandError: Cannot load module for cmake@3.27.9/io7lzbt: `module show CMake/3.27` failed with exit code 1
```