### PR TITLE
[fix] py-werkzeug: add constraint in python dependence

### DIFF
--- a/var/spack/repos/builtin/packages/py-werkzeug/package.py
+++ b/var/spack/repos/builtin/packages/py-werkzeug/package.py
@@ -31,6 +31,7 @@ class PyWerkzeug(PythonPackage):
     version("0.11.11", sha256="e72c46bc14405cba7a26bd2ce28df734471bc9016bc8b4cb69466c2c14c2f7e5")
 
     depends_on("python@3.8:", when="@2.3:", type=("build", "run"))
+    depends_on("python@:3.9", when="@:0.12", type=("build", "run"))
     depends_on("py-flit-core@:3", when="@2.3.7:", type="build")
     depends_on("py-markupsafe@2.1.1:", when="@2.2:", type=("build", "run"))
 


### PR DESCRIPTION
py-werkzeug@:0.12 does not work with python@3.10:

Test with py-werkzeug 0.12.2 and python 3.10:
```
$ python3.10 -c 'import werkzeug'
py-werkzeug-0.12.2/lib/python3.11/site-packages/werkzeug/datastructures.py", line 16, in <module>
from collections import Container, Iterable, MutableSet
ImportError: cannot import name 'Container' from 'collections'
```

Test with py-werkzeug 0.12.2 and python 3.9:
```
python3.9 -c "from collections import Container"
<string>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```