### PR TITLE
perl: change permissions  in order to apply patch on version 5.38.0

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -272,8 +272,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Zlib.xs"),
         ]
         for filename in files_to_chmod:
-            perm = os.stat(filename).st_mode
-            os.chmod(filename, perm | 0o200)
+            try:
+                perm = os.stat(filename).st_mode
+                os.chmod(filename, perm | 0o200)
+            except IOError:
+                continue
 
     def nmake_arguments(self):
         args = []

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -32,7 +32,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     url = "http://www.cpan.org/src/5.0/perl-5.34.0.tar.gz"
     tags = ["windows"]
 
-    maintainers = "LydDeb"
+    maintainers("LydDeb")
 
     executables = [r"^perl(-?\d+.*)?$"]
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -258,13 +258,20 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # aren't writeable so make pp.c user writeable
     # before patching. This should probably walk the
     # source and make everything writeable in the future.
+    # The patch "zlib-ng.patch" also fail. So, apply chmod
+    # to Makefile.PL and Zlib.xs too.
     def do_stage(self, mirror_only=False):
         # Do Spack's regular stage
         super().do_stage(mirror_only)
-        # Add write permissions on file to be patched
-        filename = join_path(self.stage.source_path, "pp.c")
-        perm = os.stat(filename).st_mode
-        os.chmod(filename, perm | 0o200)
+        # Add write permissions on files to be patched
+        files_to_chmod = [
+                    join_path(self.stage.source_path, "pp.c"),
+                    join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Makefile.PL"),
+                    join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Zlib.xs"),
+                    ]
+        for filename in files_to_chmod:
+            perm = os.stat(filename).st_mode
+            os.chmod(filename, perm | 0o200)
 
     def nmake_arguments(self):
         args = []

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -32,6 +32,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     url = "http://www.cpan.org/src/5.0/perl-5.34.0.tar.gz"
     tags = ["windows"]
 
+    maintainers = "LydDeb"
+
     executables = [r"^perl(-?\d+.*)?$"]
 
     # see https://www.cpan.org/src/README.html for

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -265,10 +265,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         super().do_stage(mirror_only)
         # Add write permissions on files to be patched
         files_to_chmod = [
-                    join_path(self.stage.source_path, "pp.c"),
-                    join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Makefile.PL"),
-                    join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Zlib.xs"),
-                    ]
+            join_path(self.stage.source_path, "pp.c"),
+            join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Makefile.PL"),
+            join_path(self.stage.source_path, "cpan/Compress-Raw-Zlib/Zlib.xs"),
+        ]
         for filename in files_to_chmod:
             perm = os.stat(filename).st_mode
             os.chmod(filename, perm | 0o200)


### PR DESCRIPTION
 I try to install perl@5.38.0 on a lustre filesystem but the command `patch("zlib-ng.patch", when="@5.38 ^zlib-ng@2.1.2:")` fail on files
* cpan/Compress-Raw-Zlib/Makefile.PL
* cpan/Compress-Raw-Zlib/Zlib.xs
because there are read only.

This commit will change permissions on these files.