### PR TITLE
libvorbis: drop -force_cpusubtype_ALL flag

### DIFF
--- a/var/spack/repos/builtin/packages/libvorbis/package.py
+++ b/var/spack/repos/builtin/packages/libvorbis/package.py
@@ -22,5 +22,8 @@ class Libvorbis(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
+    def patch(self):
+        filter_file(r"-force_cpusubtype_ALL", "", "configure", string=True)
+
     # `make check` crashes when run in parallel
     parallel = False


### PR DESCRIPTION
This flag was only relevant when targeting powerpc from apple-clang,
which we don't do. The flag is removed from apple-clang@15. Let's drop
it unconditionally.

Fixes broken darwin-aarch64 Gitlab pipeline
