### PR TITLE
darwin aarch64: bring back compilers.yaml gfortran

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/darwin/aarch64/compilers.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/darwin/aarch64/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: apple-clang@15.0.0
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /opt/homebrew/bin/gfortran
+      fc: /opt/homebrew/bin/gfortran
+    flags: {}
+    operating_system: ventura
+    target: aarch64
+    modules: []
+    environment: {}
+    extra_rpaths: []


### PR DESCRIPTION
gfortran is potentially (?) not detected, so partially revert remove of config.

Let's wait for https://gitlab.spack.io/spack/spack/-/pipelines/526727 to see if this is actually required.