### PR TITLE
py-rasterio: add v1.3.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -20,6 +20,7 @@ class PyRasterio(PythonPackage):
     maintainers("adamjstewart")
 
     version("master", branch="master")
+    version("1.3.9", sha256="fc6d0d290492fa1a5068711cfebb21cc936968891b7ed9da0690c8a7388885c5")
     version("1.3.8", sha256="ffdd18e78efdf8ad5861065fd812a66dd34264293317ff6540a078ea891cdef8")
     version("1.3.7", sha256="abfdcb8f10210b8fad939f40d545d6c47e9e3b5cf4a43773ca8dd11c58204304")
     version("1.3.6", sha256="c8b90eb10e16102d1ab0334a7436185f295de1c07f0d197e206d1c005fc33905")
@@ -37,6 +38,7 @@ class PyRasterio(PythonPackage):
     version("1.0a12", sha256="47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c")
 
     # From pyproject.toml
+    depends_on("py-setuptools@67.8:", when="@1.3.9:", type="build")
     depends_on("py-cython@0.29.29:", when="@1.3.3:", type="build")
     depends_on("py-cython@0.29.24:0.29", when="@1.3.0:1.3.2", type="build")
 


### PR DESCRIPTION
https://github.com/rasterio/rasterio/releases/tag/1.3.9

Builds fine with cython 0, not need to pin