### PR TITLE
Adios2: add kokkos variant

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -221,7 +221,6 @@ spack:
   # - upcxx               # upcxx: /opt/intel/oneapi/mpi/2021.10.0//libfabric/bin/fi_info: error while loading shared libraries: libfabric.so.1: cannot open shared object file: No such file or directory
 
   # GPU
-  - adios2 +sycl
   - aml +ze
   - amrex +sycl
   - arborx +sycl ^kokkos +sycl +openmp cxxstd=17 +tests +examples

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -221,14 +221,15 @@ spack:
   # - upcxx               # upcxx: /opt/intel/oneapi/mpi/2021.10.0//libfabric/bin/fi_info: error while loading shared libraries: libfabric.so.1: cannot open shared object file: No such file or directory
 
   # GPU
+  - adios2 +sycl
   - aml +ze
   - amrex +sycl
   - arborx +sycl ^kokkos +sycl +openmp cxxstd=17 +tests +examples
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17 +tests +examples
   - kokkos +sycl +openmp cxxstd=17 +tests +examples
   - kokkos-kernels build_type=Release %oneapi ^kokkos +sycl +openmp cxxstd=17 +tests +examples
-  - tau +mpi +opencl +level_zero ~pdt   # tau: requires libdrm.so to be installed
   - slate +sycl
+  - tau +mpi +opencl +level_zero ~pdt   # tau: requires libdrm.so to be installed
   # --
   # - ginkgo +oneapi                    # InstallError: Ginkgo's oneAPI backend requires theDPC++ compiler as main CXX compiler.
   # - hpctoolkit +level_zero            # dyninst@12.3.0%gcc: /usr/bin/ld: libiberty/./d-demangle.c:142: undefined reference to `_intel_fast_memcpy'; can't mix intel-tbb@%oneapi with dyninst%gcc

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -28,8 +28,6 @@ spack:
         blas: [openblas]
         mpi: [mpich]
       variants: +mpi cuda_arch=70
-    adios2:
-      require: "@2.8:"
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
     elfutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -28,6 +28,8 @@ spack:
         blas: [openblas]
         mpi: [mpich]
       variants: +mpi cuda_arch=70
+    adios2:
+      require: "@2.8:"
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
     elfutils:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -258,6 +258,7 @@ spack:
   - tau +mpi +rocm   # tau: has issue with `spack env depfile` build
 
   # ROCM 908
+  - adios2 +rocm amdgpu_target=gfx908
   - amrex +rocm amdgpu_target=gfx908
   - arborx +rocm amdgpu_target=gfx908
   - cabana +rocm amdgpu_target=gfx908
@@ -297,6 +298,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
+  - adios2 +rocm amdgpu_target=gfx90a
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm amdgpu_target=gfx90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -258,7 +258,7 @@ spack:
   - tau +mpi +rocm   # tau: has issue with `spack env depfile` build
 
   # ROCM 908
-  - adios2 +rocm amdgpu_target=gfx908
+  - adios2 +kokkos +rocm amdgpu_target=gfx908
   - amrex +rocm amdgpu_target=gfx908
   - arborx +rocm amdgpu_target=gfx908
   - cabana +rocm amdgpu_target=gfx908
@@ -298,7 +298,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
-  - adios2 +rocm amdgpu_target=gfx90a
+  - adios2 +kokkos +rocm amdgpu_target=gfx90a
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm amdgpu_target=gfx90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -305,6 +305,7 @@ spack:
   - tau +mpi +rocm   # tau: has issue with `spack env depfile` build
 
   # ROCM 908
+  - adios2 +rocm amdgpu_target=gfx908
   - amrex +rocm amdgpu_target=gfx908
   - arborx +rocm amdgpu_target=gfx908
   - cabana +rocm amdgpu_target=gfx908
@@ -344,6 +345,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
+  - adios2 +rocm amdgpu_target=gfx90a
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm amdgpu_target=gfx90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -305,7 +305,7 @@ spack:
   - tau +mpi +rocm   # tau: has issue with `spack env depfile` build
 
   # ROCM 908
-  - adios2 +rocm amdgpu_target=gfx908
+  - adios2 +kokkos +rocm amdgpu_target=gfx908
   - amrex +rocm amdgpu_target=gfx908
   - arborx +rocm amdgpu_target=gfx908
   - cabana +rocm amdgpu_target=gfx908
@@ -345,7 +345,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
-  - adios2 +rocm amdgpu_target=gfx90a
+  - adios2 +kokkos +rocm amdgpu_target=gfx90a
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm amdgpu_target=gfx90a

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -62,7 +62,8 @@ class Adios2(CMakePackage, CudaPackage):
     variant(
         "libpressio", default=False, when="@2.8:", description="Enable LibPressio for compression"
     )
-    variant("blosc", default=True, when="@2.4:", description="Enable Blosc compression")
+    variant("blosc", default=True, when="@2.4:2.8", description="Enable Blosc compression")
+    variant("blosc2", default=True, when="@2.9:", description="Enable Blosc2 compression")
     variant("bzip2", default=True, when="@2.4:", description="Enable BZip2 compression")
     variant("zfp", default=True, description="Enable ZFP compression")
     variant("png", default=True, when="@2.4:", description="Enable PNG compression")
@@ -78,7 +79,7 @@ class Adios2(CMakePackage, CudaPackage):
         description="Enable the DataMan engine for WAN transports",
     )
     variant("dataspaces", default=False, when="@2.5:", description="Enable support for DATASPACES")
-    variant("ssc", default=True, description="Enable the SSC staging engine")
+    variant("ssc", default=True, when="@:2.7", description="Enable the SSC staging engine")
     variant("hdf5", default=False, description="Enable the HDF5 engine")
     variant(
         "aws",
@@ -135,8 +136,8 @@ class Adios2(CMakePackage, CudaPackage):
     depends_on("hdf5+mpi", when="+hdf5+mpi")
 
     depends_on("libpressio", when="+libpressio")
-    depends_on("c-blosc", when="@:2.8 +blosc")
-    depends_on("c-blosc2", when="@2.9: +blosc")
+    depends_on("c-blosc", when="+blosc")
+    depends_on("c-blosc2", when="+blosc2")
     depends_on("bzip2", when="+bzip2")
     depends_on("libpng@1.6:", when="+png")
     depends_on("zfp@0.5.1:0.5", when="+zfp")
@@ -202,6 +203,7 @@ class Adios2(CMakePackage, CudaPackage):
             from_variant("BUILD_SHARED_LIBS", "shared"),
             from_variant("ADIOS2_USE_AWSSDK", "aws"),
             from_variant("ADIOS2_USE_Blosc", "blosc"),
+            from_variant("ADIOS2_USE_Blosc2", "blosc2"),
             from_variant("ADIOS2_USE_BZip2", "bzip2"),
             from_variant("ADIOS2_USE_DataMan", "dataman"),
             from_variant("ADIOS2_USE_DataSpaces", "dataspaces"),

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -122,8 +122,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     # Propagate CUDA target to kokkos for +cuda
     for cuda_arch in CudaPackage.cuda_arch_values:
         depends_on(
-            "kokkos cuda_arch=%s" % cuda_arch,
-            when="+kokkos +cuda cuda_arch=%s" % cuda_arch,
+            "kokkos cuda_arch=%s" % cuda_arch, when="+kokkos +cuda cuda_arch=%s" % cuda_arch
         )
 
     # Propagate AMD GPU target to kokkos for +rocm

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -95,7 +95,6 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # Optional language bindings, C++11 and C always provided
-    variant("cuda", default=False, when="@2.8:", description="Enable CUDA support")
     variant("kokkos", default=False, when="@2.9:", description="Enable Kokkos support")
     variant("sycl", default=False, when="@2.10:", description="Enable SYCL support")
     variant("python", default=False, description="Enable the Python bindings")
@@ -134,11 +133,12 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="@:2.7")
     conflicts("+rocm", when="@:2.8")
-    conflicts("+rocm", when="+cuda")
-    conflicts("+rocm", when="~kokkos", msg="ADIOS2 does not support HIP without Kokkos")
 
     conflicts("+cuda", when="+sycl")
+    conflicts("+rocm", when="+cuda")
     conflicts("+rocm", when="+sycl")
+
+    conflicts("+rocm", when="~kokkos", msg="ADIOS2 does not support HIP without Kokkos")
     conflicts("+sycl", when="~kokkos", msg="ADIOS2 does not support SYCL without Kokkos")
 
     for _platform in ["linux", "darwin", "cray"]:

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -102,7 +102,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     amdgpu_target_variants = ["amdgpu_target={0}".format(x) for x in ROCmPackage.amdgpu_targets]
 
     dav_sdk_depends_on(
-        "adios2+shared+mpi+python+blosc+sst+ssc+dataman",
+        "adios2+shared+mpi+python+sst+dataman",
         when="+adios2",
         propagate=["cuda", "hdf5", "sz", "zfp", "fortran"] + cuda_arch_variants,
     )


### PR DESCRIPTION
This adds Kokkos variant which the backends SYCL,ROCM, and CUDA. This also makes the adios2 package to be also a subsclass of ROCmPAckage.

This also update both the blosc and the ssc variant.

Fixes: https://github.com/ornladios/ADIOS2/issues/3854