### PR TITLE
vtk-m: update to latest release

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,7 +29,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
-    version("2.1.0-rc1", sha256="337df672ac5c2e0b442571a1380aa98ae70a155c93488c32198d055cb893417a")
+    version("2.1.0-rc2", sha256="94631fff9f668f40c9c797f03cf32a0d22d57111e309b1e8133c2a3f292b4af1")
     version(
         "2.0.0",
         sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3",


### PR DESCRIPTION
:tada: :tada: :tada: 


Finally! VTK-m v2.1.0-rc2 release is out.

This bring exiting new features and bugfixes. Find the release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/2.1/release-notes.md

Let me know if we need to change anything else in the package

ViB

:tada: :tada: :tada: