### PR TITLE
schema/compilers.py: fix validation of 2+ entries

### DIFF
--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -14,63 +14,61 @@ import spack.schema.environment
 properties = {
     "compilers": {
         "type": "array",
-        "items": [
-            {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    "compiler": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "required": ["paths", "spec", "modules", "operating_system"],
-                        "properties": {
-                            "paths": {
-                                "type": "object",
-                                "required": ["cc", "cxx", "f77", "fc"],
-                                "additionalProperties": False,
-                                "properties": {
-                                    "cc": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "cxx": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "f77": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "fc": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                },
-                            },
-                            "flags": {
-                                "type": "object",
-                                "additionalProperties": False,
-                                "properties": {
-                                    "cflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "cxxflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "fflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "cppflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "ldflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                    "ldlibs": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                },
-                            },
-                            "spec": {"type": "string"},
-                            "operating_system": {"type": "string"},
-                            "target": {"type": "string"},
-                            "alias": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                            "modules": {
-                                "anyOf": [{"type": "string"}, {"type": "null"}, {"type": "array"}]
-                            },
-                            "implicit_rpaths": {
-                                "anyOf": [
-                                    {"type": "array", "items": {"type": "string"}},
-                                    {"type": "boolean"},
-                                ]
-                            },
-                            "environment": spack.schema.environment.definition,
-                            "extra_rpaths": {
-                                "type": "array",
-                                "default": [],
-                                "items": {"type": "string"},
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "compiler": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["paths", "spec", "modules", "operating_system"],
+                    "properties": {
+                        "paths": {
+                            "type": "object",
+                            "required": ["cc", "cxx", "f77", "fc"],
+                            "additionalProperties": False,
+                            "properties": {
+                                "cc": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "cxx": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "f77": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "fc": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                             },
                         },
-                    }
-                },
-            }
-        ],
+                        "flags": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "cflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "cxxflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "fflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "cppflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "ldflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                "ldlibs": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                            },
+                        },
+                        "spec": {"type": "string"},
+                        "operating_system": {"type": "string"},
+                        "target": {"type": "string"},
+                        "alias": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                        "modules": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}, {"type": "array"}]
+                        },
+                        "implicit_rpaths": {
+                            "anyOf": [
+                                {"type": "array", "items": {"type": "string"}},
+                                {"type": "boolean"},
+                            ]
+                        },
+                        "environment": spack.schema.environment.definition,
+                        "extra_rpaths": {
+                            "type": "array",
+                            "default": [],
+                            "items": {"type": "string"},
+                        },
+                    },
+                }
+            },
+        },
     }
 }
 


### PR DESCRIPTION
Fix the following syntax which is tuple validation (validating only the first entry):

```python
"compilers": {
    "type": "array",
    "items": [
        {
            "type": ...
        }
    ]
}
```

to

```python
"compilers": {
    "type": "array",
    "items": {
        "type": ...
    }
}
```

which is array validation of the entire list.

Oops...

I verified this is the only place where tuple validation is used and array validation was meant.