### PR TITLE
Drop support for spack external find pythonX.Y

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -326,7 +326,7 @@ class Python(Package):
     # An in-source build with --enable-optimizations fails for python@3.X
     build_directory = "spack-build"
 
-    executables = [r"^python[\d.]*[mw]?$"]
+    executables = [r"^python\d?$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Closes #40625 @mwkrentel 

`spec["python"].command` will still find the correct Python to use when multiple versions exist in a single prefix, but users will have to manually add those to `packages.yaml` since many packages can and will break as a result.

We may also need to consider dropping pythonX support if Python 4 is ever released.