### PR TITLE
intel-tbb: apply gcc patch only for gcc

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -125,7 +125,7 @@ class IntelTbb(CMakePackage, MakefilePackage):
     patch("gcc_generic-pedantic-4.4.patch", level=1, when="@:2019.0")
 
     # Patch and conflicts for GCC 13 support (#1031).
-    patch("gcc_13-2021.patch", when="@2021.1:")
+    patch("gcc_13-2021.patch", when="@2021.1: %gcc")
     conflicts("%gcc@13", when="@:2021.3")
 
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.


### PR DESCRIPTION
Without this PR an attempt to install intel-tbb on a macOS system (using apple-clang), is stuck at the patch phase : 

```
==> Installing intel-tbb-2021.9.0-4kldpsao2hsuqjxeipy5ll77ikhlb7ue [11/11]
==> No binary for intel-tbb-2021.9.0-4kldpsao2hsuqjxeipy5ll77ikhlb7ue found: installing from source
==> Using cached archive: /Users/laurent/spack/var/spack/cache/_source-cache/archive/1c/1ce48f34dada7837f510735ff1172f6e2c261b09460e3bf773b49791d247d24e.tar.gz
File to patch:
```