### PR TITLE
Introduce a class to represent a "closed set of concrete specs"

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -236,7 +236,7 @@ def display_env(env, args, decorator, results):
 
     if args.show_concretized:
         tty.msg("Concretized roots")
-        cmd.display_specs(env.specs_by_hash.values(), args, decorator=decorator)
+        cmd.display_specs(env.root_specs_by_hash.values(), args, decorator=decorator)
         print()
 
     # Display a header for the installed packages section IF there are installed

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1435,44 +1435,6 @@ class Environment:
         ]
         return results
 
-    def concretize_and_add(self, user_spec, concrete_spec=None, tests=False):
-        """Concretize and add a single spec to the environment.
-
-        Concretize the provided ``user_spec`` and add it along with the
-        concretized result to the environment. If the given ``user_spec`` was
-        already present in the environment, this does not add a duplicate.
-        The concretized spec will be added unless the ``user_spec`` was
-        already present and an associated concrete spec was already present.
-
-        Args:
-            concrete_spec: if provided, then it is assumed that it is the
-                result of concretizing the provided ``user_spec``
-        """
-        if self.unify is True:
-            msg = (
-                "cannot install a single spec in an environment that is "
-                "configured to be concretized together. Run instead:\n\n"
-                "    $ spack add <spec>\n"
-                "    $ spack install\n"
-            )
-            raise SpackEnvironmentError(msg)
-
-        spec = Spec(user_spec)
-
-        if self.add(spec):
-            concrete = concrete_spec or spec.concretized(tests=tests)
-            self._add_concrete_spec(spec, concrete)
-        else:
-            # spec might be in the user_specs, but not installed.
-            # TODO: Redo name-based comparison for old style envs
-            spec = next(s for s in self.user_specs if s.satisfies(user_spec))
-            concrete = self.root_specs_by_hash.get(spec.dag_hash())
-            if not concrete:
-                concrete = spec.concretized(tests=tests)
-                self._add_concrete_spec(spec, concrete)
-
-        return concrete
-
     @property
     def default_view(self):
         if not self.has_view(default_view_name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1738,11 +1738,9 @@ class Environment:
         # If it's not a partial hash prefix we can early exit
         early_exit = len(dag_hash) == 32
         matches = []
-        for spec in traverse.traverse_nodes(
-            self.concrete_roots(), key=traverse.by_dag_hash, order="breadth"
-        ):
-            if spec.dag_hash().startswith(dag_hash):
-                matches.append(spec)
+        for current_hash, current_node in self.all_specs_by_hash.items():
+            if current_hash.startswith(dag_hash):
+                matches.append(current_node)
                 if early_exit:
                     break
         return matches

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1421,10 +1421,8 @@ class Environment:
 
         # Add specs in original order
         batch.sort(key=lambda x: x[0])
-        unified_specs = spack.solver.asp.ConcreteSpecsByHash()
         for root, (_, concrete) in zip(root_specs, batch):
-            unified_specs.add(concrete)
-            self._add_concrete_spec(root, unified_specs[concrete.dag_hash()])
+            self._add_concrete_spec(root, concrete)
 
         finish = time.time()
         tty.msg(f"Environment concretized in {finish - start:.2f} seconds")

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1755,11 +1755,7 @@ class Environment:
 
     def all_matching_specs(self, *specs: spack.spec.Spec) -> List[Spec]:
         """Returns all concretized specs in the environment satisfying any of the input specs"""
-        return [
-            s
-            for s in traverse.traverse_nodes(self.concrete_roots(), key=traverse.by_dag_hash)
-            if any(s.satisfies(t) for t in specs)
-        ]
+        return [s for s in self.all_specs_by_hash.values() if any(s.satisfies(t) for t in specs)]
 
     @spack.repo.autospec
     def matching_spec(self, spec):
@@ -1782,11 +1778,7 @@ class Environment:
         env_root_to_user = {root.dag_hash(): user for user, root in self.concretized_specs()}
         root_matches, dep_matches = [], []
 
-        for env_spec in traverse.traverse_nodes(
-            specs=[root for _, root in self.concretized_specs()],
-            key=traverse.by_dag_hash,
-            order="breadth",
-        ):
+        for env_spec in self.all_specs_by_hash.values():
             if not env_spec.satisfies(spec):
                 continue
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -54,6 +54,7 @@ import spack.version
 from spack import traverse
 from spack.filesystem_view import SimpleFilesystemView, inverse_view_func_parser, view_func_parser
 from spack.installer import PackageInstaller
+from spack.mapping import ConcreteSpecsByHash
 from spack.schema.env import TOP_LEVEL_KEY
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
@@ -808,7 +809,7 @@ class Environment:
         #: Roots associated with the last concretization, in order
         self.concretized_order: List[str] = []
         #: All the specs in the environment, including transitive, by hash
-        self.all_specs_by_hash = spack.solver.asp.ConcreteSpecsByHash()
+        self.all_specs_by_hash = ConcreteSpecsByHash()
         #: Concretized root specs by hash
         self.root_specs_by_hash: Dict[str, Spec] = {}
         #: Repository for this environment (memoized)
@@ -1116,8 +1117,7 @@ class Environment:
             matches = [s for s in list_to_change if s.satisfies(query_spec)]
 
         else:
-            # concrete specs match against concrete specs in the env
-            # by dag hash.
+            # concrete specs match against concrete specs in the env by dag hash.
             specs_hashes = zip(self.concretized_user_specs, self.concretized_order)
             matches = [s for s, h in specs_hashes if query_spec.dag_hash() == h]
 
@@ -1205,7 +1205,7 @@ class Environment:
         """Clears the internal state associated with managing user specs"""
         self.concretized_user_specs = []
         self.concretized_order = []
-        self.all_specs_by_hash = spack.solver.asp.ConcreteSpecsByHash()
+        self.all_specs_by_hash = ConcreteSpecsByHash()
         self.root_specs_by_hash = {}
 
     def deconcretize(self, spec: spack.spec.Spec, concrete: bool = True):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1238,6 +1238,10 @@ class Environment:
             # won't be here.
             if dag_hash in self.root_specs_by_hash:
                 del self.root_specs_by_hash[dag_hash]
+            try:
+                self.all_specs_by_hash.delete(spec, transitive=False)
+            except ValueError:
+                pass
 
     def _get_specs_to_concretize(
         self,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1690,11 +1690,11 @@ class Environment:
 
     def all_specs(self) -> List[Spec]:
         """Returns a list of all concrete specs"""
-        return list(self.all_specs_generator())
+        return list(self.all_specs_by_hash.values())
 
-    def all_hashes(self):
+    def all_hashes(self) -> List[str]:
         """Return hashes of all specs."""
-        return [s.dag_hash() for s in self.all_specs_generator()]
+        return [h for h in self.all_specs_by_hash]
 
     def roots(self):
         """Specs explicitly requested by the user *in this environment*.
@@ -1727,7 +1727,7 @@ class Environment:
     def concretized_specs(self):
         """Tuples of (user spec, concrete spec) for all concrete specs."""
         for s, h in zip(self.concretized_user_specs, self.concretized_order):
-            yield (s, self.root_specs_by_hash[h])
+            yield s, self.root_specs_by_hash[h]
 
     def concrete_roots(self):
         """Same as concretized_specs, except it returns the list of concrete

--- a/lib/spack/spack/mapping.py
+++ b/lib/spack/spack/mapping.py
@@ -1,0 +1,122 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import collections.abc
+from typing import Dict, List
+
+import spack.spec
+
+
+class ConcreteSpecsByHash(collections.abc.Mapping):
+    """Mapping containing concrete specs keyed by DAG hash.
+
+    The mapping is ensured to be consistent, i.e. if a spec in the mapping has a dependency with
+    hash X, it is ensured to be the same object in memory as the spec keyed by X.
+    """
+
+    def __init__(self) -> None:
+        self.data: Dict[str, spack.spec.Spec] = {}
+
+    def __getitem__(self, dag_hash: str) -> spack.spec.Spec:
+        return self.data[dag_hash]
+
+    def add(self, spec: spack.spec.Spec) -> bool:
+        """Adds a new concrete spec to the mapping. Returns True if the spec was just added,
+        False if the spec was already in the mapping.
+
+        Args:
+            spec: spec to be added
+
+        Raises:
+            ValueError: if the spec is not concrete
+        """
+        if not spec.concrete:
+            msg = (
+                f"trying to store the non-concrete spec '{spec}' in a container "
+                f"that only accepts concrete"
+            )
+            raise ValueError(msg)
+
+        dag_hash = spec.dag_hash()
+        if dag_hash in self.data:
+            return False
+
+        # Here we need to iterate on the input and rewire the copy.
+        self.data[dag_hash] = spec.copy(deps=False)
+        nodes_to_reconstruct = [spec]
+
+        while nodes_to_reconstruct:
+            input_parent = nodes_to_reconstruct.pop()
+            container_parent = self.data[input_parent.dag_hash()]
+
+            for edge in input_parent.edges_to_dependencies():
+                input_child = edge.spec
+                container_child = self.data.get(input_child.dag_hash())
+                # Copy children that don't exist yet
+                if container_child is None:
+                    container_child = input_child.copy(deps=False)
+                    self.data[input_child.dag_hash()] = container_child
+                    nodes_to_reconstruct.append(input_child)
+
+                # Rewire edges
+                container_parent.add_dependency_edge(
+                    dependency_spec=container_child, depflag=edge.depflag, virtuals=edge.virtuals
+                )
+        return True
+
+    def query(self, spec: spack.spec.Spec) -> List[spack.spec.Spec]:
+        """Returns a list of specs in the container matching the input query."""
+        return [s for s in self.data.values() if s.satisfies(spec)]
+
+    def delete(self, spec: spack.spec.Spec, transitive: bool = False) -> bool:
+        """Deletes a concrete spec from the container. Returns True if the spec was deleted,
+        False otherwise
+
+        Args:
+            spec: spec to be deleted
+            transitive: if True deletes all the dependents, if False deletes
+                only the spec iff it has no dependents
+        Raises:
+             ValueError: if the input spec is not concrete, or if the spec to be removed has
+                dependents and 'transitive' is False.
+        """
+        if not spec.concrete:
+            msg = f"cannot delete the non-concrete spec '{spec}'"
+            raise ValueError(msg)
+
+        dag_hash = spec.dag_hash()
+        if dag_hash not in self.data:
+            return False
+
+        root = self.data[dag_hash]
+        dependents = root.dependents()
+        if dependents and not transitive:
+            msg = (
+                f"cannot remove {spec.short_spec}, since it is needed by "
+                f"{', '.join(s.short_spec for s in dependents)}"
+            )
+            raise ValueError(msg)
+
+        for parent in dependents:
+            self.delete(parent, transitive=transitive)
+
+        dependents = root.dependents()
+        assert not dependents, "dependents should have been removed already"
+
+        # Remove references from this node
+        for dependency in root.dependencies():
+            dependency._dependents.edges[root.name] = [
+                x
+                for x in dependency._dependents.edges[root.name]
+                if x.parent.dag_hash() != dag_hash
+            ]
+
+        del self.data[dag_hash]
+        return True
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __iter__(self):
+        return iter(self.data)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1130,9 +1130,21 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
         return True
 
     def query(self, spec: spack.spec.Spec) -> List[spack.spec.Spec]:
+        """Returns a list of specs in the container matching the input query."""
         return [s for s in self.data.values() if s.satisfies(spec)]
 
     def delete(self, spec: spack.spec.Spec, transitive: bool = False) -> bool:
+        """Deletes a concrete spec from the container. Returns True if the spec was deleted,
+        False otherwise
+
+        Args:
+            spec: spec to be deleted
+            transitive: if True deletes all the dependents, if False deletes
+                only the spec iff it has no dependents
+        Raises:
+             ValueError: if the input spec is not concrete, or if the spec to be removed has
+                dependents and 'transitive' is False.
+        """
         if not spec.concrete:
             msg = f"cannot delete the non-concrete spec '{spec}'"
             raise ValueError(msg)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -88,6 +88,7 @@ import spack.variant
 import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
+from spack.mapping import ConcreteSpecsByHash
 
 from .counter import FullDuplicatesCounter, MinimalDuplicatesCounter, NoDuplicatesCounter
 
@@ -1070,120 +1071,6 @@ class PyclingoDriver:
             pprint.pprint(self.control.statistics)
 
         return result, timer, self.control.statistics
-
-
-class ConcreteSpecsByHash(collections.abc.Mapping):
-    """Mapping containing concrete specs keyed by DAG hash.
-
-    The mapping is ensured to be consistent, i.e. if a spec in the mapping has a dependency with
-    hash X, it is ensured to be the same object in memory as the spec keyed by X.
-    """
-
-    def __init__(self) -> None:
-        self.data: Dict[str, spack.spec.Spec] = {}
-
-    def __getitem__(self, dag_hash: str) -> spack.spec.Spec:
-        return self.data[dag_hash]
-
-    def add(self, spec: spack.spec.Spec) -> bool:
-        """Adds a new concrete spec to the mapping. Returns True if the spec was just added,
-        False if the spec was already in the mapping.
-
-        Args:
-            spec: spec to be added
-
-        Raises:
-            ValueError: if the spec is not concrete
-        """
-        if not spec.concrete:
-            msg = (
-                f"trying to store the non-concrete spec '{spec}' in a container "
-                f"that only accepts concrete"
-            )
-            raise ValueError(msg)
-
-        dag_hash = spec.dag_hash()
-        if dag_hash in self.data:
-            return False
-
-        # Here we need to iterate on the input and rewire the copy.
-        self.data[dag_hash] = spec.copy(deps=False)
-        nodes_to_reconstruct = [spec]
-
-        while nodes_to_reconstruct:
-            input_parent = nodes_to_reconstruct.pop()
-            container_parent = self.data[input_parent.dag_hash()]
-
-            for edge in input_parent.edges_to_dependencies():
-                input_child = edge.spec
-                container_child = self.data.get(input_child.dag_hash())
-                # Copy children that don't exist yet
-                if container_child is None:
-                    container_child = input_child.copy(deps=False)
-                    self.data[input_child.dag_hash()] = container_child
-                    nodes_to_reconstruct.append(input_child)
-
-                # Rewire edges
-                container_parent.add_dependency_edge(
-                    dependency_spec=container_child, depflag=edge.depflag, virtuals=edge.virtuals
-                )
-        return True
-
-    def query(self, spec: spack.spec.Spec) -> List[spack.spec.Spec]:
-        """Returns a list of specs in the container matching the input query."""
-        return [s for s in self.data.values() if s.satisfies(spec)]
-
-    def delete(self, spec: spack.spec.Spec, transitive: bool = False) -> bool:
-        """Deletes a concrete spec from the container. Returns True if the spec was deleted,
-        False otherwise
-
-        Args:
-            spec: spec to be deleted
-            transitive: if True deletes all the dependents, if False deletes
-                only the spec iff it has no dependents
-        Raises:
-             ValueError: if the input spec is not concrete, or if the spec to be removed has
-                dependents and 'transitive' is False.
-        """
-        if not spec.concrete:
-            msg = f"cannot delete the non-concrete spec '{spec}'"
-            raise ValueError(msg)
-
-        dag_hash = spec.dag_hash()
-        if dag_hash not in self.data:
-            return False
-
-        root = self.data[dag_hash]
-        dependents = root.dependents()
-        if dependents and not transitive:
-            msg = (
-                f"cannot remove {spec.short_spec}, since it is needed by "
-                f"{', '.join(s.short_spec for s in dependents)}"
-            )
-            raise ValueError(msg)
-
-        for parent in dependents:
-            self.delete(parent, transitive=transitive)
-
-        dependents = root.dependents()
-        assert not dependents, "dependents should have been removed already"
-
-        # Remove references from this node
-        for dependency in root.dependencies():
-            dependency._dependents.edges[root.name] = [
-                x
-                for x in dependency._dependents.edges[root.name]
-                if x.parent.dag_hash() != dag_hash
-            ]
-
-        del self.data[dag_hash]
-        return True
-
-    def __len__(self) -> int:
-        return len(self.data)
-
-    def __iter__(self):
-        return iter(self.data)
 
 
 class SpackSolverSetup:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -691,7 +691,7 @@ spack:
 
             root_spec_dag_hash = None
 
-            for h, s in env.specs_by_hash.items():
+            for h, s in env.root_specs_by_hash.items():
                 if s.name == pkg_name:
                     root_spec_dag_hash = h
 
@@ -944,7 +944,7 @@ spack:
             env.concretize()
             root_spec_dag_hash = None
 
-            for h, s in env.specs_by_hash.items():
+            for h, s in env.root_specs_by_hash.items():
                 if s.name == "archive-files":
                     root_spec_dag_hash = h
 
@@ -1974,7 +1974,7 @@ spack:
 
             job_spec = None
 
-            for h, s in env.specs_by_hash.items():
+            for h, s in env.root_specs_by_hash.items():
                 if s.name == "archive-files":
                     job_spec = s
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -129,7 +129,7 @@ def test_env_add_virtual():
 
     hashes = e.concretized_order
     assert len(hashes) == 1
-    spec = e.specs_by_hash[hashes[0]]
+    spec = e.root_specs_by_hash[hashes[0]]
     assert spec.intersects("mpi")
 
 
@@ -245,7 +245,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch):
     e = ev.read("test")
     assert e.user_specs[0].name == "cmake-client"
     assert e.concretized_user_specs[0].name == "cmake-client"
-    assert e.specs_by_hash[e.concretized_order[0]].name == "cmake-client"
+    assert e.root_specs_by_hash[e.concretized_order[0]].name == "cmake-client"
 
 
 def test_env_roots_marked_explicit(install_mockery, mock_fetch):
@@ -509,7 +509,7 @@ def test_to_lockfile_dict():
     e_copy = ev.create("test_copy")
 
     e_copy._read_lockfile_dict(context_dict)
-    assert e.specs_by_hash == e_copy.specs_by_hash
+    assert e.root_specs_by_hash == e_copy.root_specs_by_hash
 
 
 def test_env_repo():
@@ -581,7 +581,7 @@ spack:
 
     for h1, h2 in zip(e1.concretized_order, e2.concretized_order):
         assert h1 == h2
-        assert e1.specs_by_hash[h1] == e2.specs_by_hash[h2]
+        assert e1.root_specs_by_hash[h1] == e2.root_specs_by_hash[h2]
 
     for s1, s2 in zip(e1.concretized_user_specs, e2.concretized_user_specs):
         assert s1 == s2
@@ -608,7 +608,7 @@ spack:
 
     assert not e2.concretized_order
     assert not e2.concretized_user_specs
-    assert not e2.specs_by_hash
+    assert not e2.root_specs_by_hash
 
 
 @pytest.mark.usefixtures("config")
@@ -1327,7 +1327,7 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
 
     test = ev.read("test")
     # Save this spec to check later if it is still in the env
-    (mpileaks_hash,) = list(x for x, y in test.specs_by_hash.items() if y.name == "mpileaks")
+    (mpileaks_hash,) = list(x for x, y in test.root_specs_by_hash.items() if y.name == "mpileaks")
     orig_user_specs = test.user_specs
     orig_concretized_specs = test.concretized_order
 
@@ -1337,8 +1337,8 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
     test = ev.read("test")
     assert test.concretized_order == orig_concretized_specs
     assert test.user_specs.specs == orig_user_specs.specs
-    assert mpileaks_hash in test.specs_by_hash
-    assert not test.specs_by_hash[mpileaks_hash].package.installed
+    assert mpileaks_hash in test.root_specs_by_hash
+    assert not test.root_specs_by_hash[mpileaks_hash].package.installed
 
 
 def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
@@ -1353,7 +1353,7 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
         uninstall("-y", "-a", "--remove")
 
     test = ev.read("test")
-    assert not test.specs_by_hash
+    assert not test.root_specs_by_hash
     assert not test.concretized_order
     assert not test.user_specs
 
@@ -1382,7 +1382,7 @@ def test_indirect_build_dep(tmp_path):
         e_read = ev.read("test")
         (x_env_hash,) = e_read.concretized_order
 
-        x_env_spec = e_read.specs_by_hash[x_env_hash]
+        x_env_spec = e_read.root_specs_by_hash[x_env_hash]
         assert x_env_spec == x_concretized
 
 
@@ -1426,8 +1426,8 @@ def test_store_different_build_deps(tmp_path):
         e_read = ev.read("test")
         y_env_hash, x_env_hash = e_read.concretized_order
 
-        y_read = e_read.specs_by_hash[y_env_hash]
-        x_read = e_read.specs_by_hash[x_env_hash]
+        y_read = e_read.root_specs_by_hash[y_env_hash]
+        x_read = e_read.root_specs_by_hash[x_env_hash]
 
         # make sure the DAG hashes and build deps are preserved after
         # a round trip to/from the lockfile
@@ -2811,7 +2811,7 @@ spack:
     abspath.write(spack_yaml)
 
     def extract_dag_hash(environment):
-        _, dyninst = next(iter(environment.specs_by_hash.items()))
+        _, dyninst = next(iter(environment.root_specs_by_hash.items()))
         return dyninst["libelf"].dag_hash()
 
     # Concretize a first time and create a lockfile
@@ -2956,7 +2956,7 @@ spack:
     with ev.read("test") as e:
         install()
 
-        spec = e.specs_by_hash[e.concretized_order[0]]
+        spec = e.root_specs_by_hash[e.concretized_order[0]]
         view_prefix = e.default_view.get_projection_for_spec(spec)
         modules_glob = "%s/modules/**/*/*" % e.path
         modules = glob.glob(modules_glob)
@@ -3332,9 +3332,9 @@ def test_read_legacy_lockfile_and_reconcretize(
 
     env("create", "test", str(legacy_lockfile_path))
     test = ev.read("test")
-    assert len(test.specs_by_hash) == 1
+    assert len(test.root_specs_by_hash) == 1
 
-    single_root = next(iter(test.specs_by_hash.values()))
+    single_root = next(iter(test.root_specs_by_hash.values()))
 
     # v1 only has version 1.0, because v1 was keyed by DAG hash, and v1.0 overwrote
     # v0.5 on lockfile creation. v2 only has v0.5, because we specifically prefer
@@ -3351,10 +3351,10 @@ def test_read_legacy_lockfile_and_reconcretize(
     # After reconcretizing, we should again see two roots, one depending on each
     # of the dtbuild1 versions specified in the roots of the original lockfile.
     test = ev.read("test")
-    assert len(test.specs_by_hash) == 2
+    assert len(test.root_specs_by_hash) == 2
 
     expected_versions = set([Version("0.5"), Version("1.0")])
-    current_versions = set(s["dtbuild1"].version for s in test.specs_by_hash.values())
+    current_versions = set(s["dtbuild1"].version for s in test.root_specs_by_hash.values())
     assert current_versions == expected_versions
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2701,15 +2701,6 @@ def test_concretize_user_specs_together():
     assert all("mpich" not in spec for _, spec in e.concretized_specs())
 
 
-def test_cant_install_single_spec_when_concretizing_together():
-    e = ev.create("coconcretization")
-    e.unify = True
-
-    with pytest.raises(ev.SpackEnvironmentError, match=r"cannot install"):
-        e.concretize_and_add("zlib")
-        e.install_all()
-
-
 def test_duplicate_packages_raise_when_concretizing_together():
     e = ev.create("coconcretization")
     e.unify = True

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -49,7 +49,7 @@ def test_mirror_from_env(tmp_path, mock_packages, mock_fetch, config, mutable_mo
 
     e = ev.read(env_name)
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
-    for spec in e.specs_by_hash.values():
+    for spec in e.root_specs_by_hash.values():
         mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
         expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
         assert mirror_res == expected

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -67,10 +67,10 @@ spack:
         env("create", "test", "./spack.yaml")
         with ev.read("test") as e:
             concretize()
-            before = e.specs_by_hash
+            before = e.root_specs_by_hash
             undevelop("package-not-in-develop")  # does nothing
             concretize("-f")
-            after = e.specs_by_hash
+            after = e.root_specs_by_hash
 
     # nothing should have changed
     assert before == after

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2452,6 +2452,46 @@ class TestConcreteSpecsByHash:
                 assert node.dag_hash() in container
                 assert node is not container[node.dag_hash()]
 
+    @pytest.mark.parametrize(
+        "input_specs,queries",
+        [(["a foo=bar", "a foo=baz"], [("gmake", 1), ("^gmake", 2), ("foo=bar", 2)])],
+    )
+    def test_querying_specs(self, input_specs, queries, default_mock_concretization):
+        """Tests that querying the container with a few known specs, we'll get back the
+        expected number of results.
+        """
+        container = spack.solver.asp.ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        for query_spec, nexpected in queries:
+            matching_specs = container.query(query_spec)
+            assert len(matching_specs) == nexpected
+
+    @pytest.mark.parametrize(
+        "input_specs,query_spec",
+        [
+            (["a foo=bar", "a foo=baz"], "a"),
+            (["a foo=bar", "a foo=baz"], "b"),
+            (["a foo=bar", "a foo=baz"], "gmake"),
+        ],
+    )
+    def test_delete_specs(self, input_specs, query_spec, default_mock_concretization):
+        container = spack.solver.asp.ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        matching_specs = container.query(query_spec)
+        for delete_spec in matching_specs:
+            container.delete(delete_spec, transitive=True)
+
+        for spec in container.values():
+            assert not spec.satisfies(query_spec)
+            for parent_spec in spec.dependents():
+                assert not parent_spec.satisfies(query_spec)
+
 
 @pytest.fixture()
 def edges_test_repository():

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2433,66 +2433,6 @@ def test_drop_moving_targets(v_str, v_opts, checksummed):
     assert spack.solver.asp._is_checksummed_version((v, v_opts)) == checksummed
 
 
-class TestConcreteSpecsByHash:
-    """Tests the container of concrete specs"""
-
-    @pytest.mark.parametrize("input_specs", [["a"], ["a foobar=bar", "b"], ["a foobar=baz", "b"]])
-    def test_adding_specs(self, input_specs, default_mock_concretization):
-        """Tests that concrete specs in the container are equivalent, but stored as different
-        objects in memory.
-        """
-        container = spack.solver.asp.ConcreteSpecsByHash()
-        input_specs = [Spec(s).concretized() for s in input_specs]
-        for s in input_specs:
-            container.add(s)
-
-        for root in input_specs:
-            for node in root.traverse(root=True):
-                assert node == container[node.dag_hash()]
-                assert node.dag_hash() in container
-                assert node is not container[node.dag_hash()]
-
-    @pytest.mark.parametrize(
-        "input_specs,queries",
-        [(["a foo=bar", "a foo=baz"], [("gmake", 1), ("^gmake", 2), ("foo=bar", 2)])],
-    )
-    def test_querying_specs(self, input_specs, queries, default_mock_concretization):
-        """Tests that querying the container with a few known specs, we'll get back the
-        expected number of results.
-        """
-        container = spack.solver.asp.ConcreteSpecsByHash()
-        input_specs = [Spec(s).concretized() for s in input_specs]
-        for s in input_specs:
-            container.add(s)
-
-        for query_spec, nexpected in queries:
-            matching_specs = container.query(query_spec)
-            assert len(matching_specs) == nexpected
-
-    @pytest.mark.parametrize(
-        "input_specs,query_spec",
-        [
-            (["a foo=bar", "a foo=baz"], "a"),
-            (["a foo=bar", "a foo=baz"], "b"),
-            (["a foo=bar", "a foo=baz"], "gmake"),
-        ],
-    )
-    def test_delete_specs(self, input_specs, query_spec, default_mock_concretization):
-        container = spack.solver.asp.ConcreteSpecsByHash()
-        input_specs = [Spec(s).concretized() for s in input_specs]
-        for s in input_specs:
-            container.add(s)
-
-        matching_specs = container.query(query_spec)
-        for delete_spec in matching_specs:
-            container.delete(delete_spec, transitive=True)
-
-        for spec in container.values():
-            assert not spec.satisfies(query_spec)
-            for parent_spec in spec.dependents():
-                assert not parent_spec.satisfies(query_spec)
-
-
 @pytest.fixture()
 def edges_test_repository():
     repository_path = os.path.join(spack.paths.repos_path, "edges.test")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -48,10 +48,10 @@ def test_hash_change_no_rehash_concrete(tmp_path, mock_packages, config):
     # rewrite the hash
     old_hash = env.concretized_order[0]
     new_hash = "abc"
-    env.specs_by_hash[old_hash]._hash = new_hash
+    env.root_specs_by_hash[old_hash]._hash = new_hash
     env.concretized_order[0] = new_hash
-    env.specs_by_hash[new_hash] = env.specs_by_hash[old_hash]
-    del env.specs_by_hash[old_hash]
+    env.root_specs_by_hash[new_hash] = env.root_specs_by_hash[old_hash]
+    del env.root_specs_by_hash[old_hash]
     env.write()
 
     # Read environment
@@ -59,8 +59,8 @@ def test_hash_change_no_rehash_concrete(tmp_path, mock_packages, config):
 
     # Ensure read hashes are used (rewritten hash seen on read)
     assert read_in.concretized_order
-    assert read_in.concretized_order[0] in read_in.specs_by_hash
-    assert read_in.specs_by_hash[read_in.concretized_order[0]]._hash == new_hash
+    assert read_in.concretized_order[0] in read_in.root_specs_by_hash
+    assert read_in.root_specs_by_hash[read_in.concretized_order[0]]._hash == new_hash
 
 
 def test_env_change_spec(tmp_path, mock_packages, config):

--- a/lib/spack/spack/test/mapping.py
+++ b/lib/spack/spack/test/mapping.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+from spack.mapping import ConcreteSpecsByHash
+from spack.spec import Spec
+
+
+class TestConcreteSpecsByHash:
+    """Tests the container of concrete specs"""
+
+    @pytest.mark.parametrize("input_specs", [["a"], ["a foobar=bar", "b"], ["a foobar=baz", "b"]])
+    def test_adding_specs(self, input_specs, default_mock_concretization):
+        """Tests that concrete specs in the container are equivalent, but stored as different
+        objects in memory.
+        """
+        container = ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        for root in input_specs:
+            for node in root.traverse(root=True):
+                assert node == container[node.dag_hash()]
+                assert node.dag_hash() in container
+                assert node is not container[node.dag_hash()]
+
+    @pytest.mark.parametrize(
+        "input_specs,queries",
+        [(["a foo=bar", "a foo=baz"], [("gmake", 1), ("^gmake", 2), ("foo=bar", 2)])],
+    )
+    def test_querying_specs(self, input_specs, queries, default_mock_concretization):
+        """Tests that querying the container with a few known specs, we'll get back the
+        expected number of results.
+        """
+        container = ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        for query_spec, nexpected in queries:
+            matching_specs = container.query(query_spec)
+            assert len(matching_specs) == nexpected
+
+    @pytest.mark.parametrize(
+        "input_specs,query_spec",
+        [
+            (["a foo=bar", "a foo=baz"], "a"),
+            (["a foo=bar", "a foo=baz"], "b"),
+            (["a foo=bar", "a foo=baz"], "gmake"),
+        ],
+    )
+    def test_delete_specs(self, input_specs, query_spec, default_mock_concretization):
+        container = ConcreteSpecsByHash()
+        input_specs = [Spec(s).concretized() for s in input_specs]
+        for s in input_specs:
+            container.add(s)
+
+        matching_specs = container.query(query_spec)
+        for delete_spec in matching_specs:
+            container.delete(delete_spec, transitive=True)
+
+        for spec in container.values():
+            assert not spec.satisfies(query_spec)
+            for parent_spec in spec.dependents():
+                assert not parent_spec.satisfies(query_spec)


### PR DESCRIPTION
There are many places in Spack where we need to operate with a set of consistent spec objects, i.e. a set of specs where:
1. A single DAG hash refers to a single object in memory
2. Each spec has no references to other specs outside the set

This is, for instance, the case when we need to reconstruct a concrete spec during concretization, in particular if that spec is provided by more than one source of "reusable" specs (see #39590).

Another case is when we concretize or reconstruct environments. In those cases we have custom ad-hoc code to ensure consistency in memory. For concretization that would be:

https://github.com/spack/spack/blob/2f24aeb7f690a7cc73996479b0028a273e91d9df/lib/spack/spack/environment/environment.py#L1601-L1624

while when reading an environment from a lockfile:

https://github.com/spack/spack/blob/2f24aeb7f690a7cc73996479b0028a273e91d9df/lib/spack/spack/environment/environment.py#L2239-L2257

This PR is an attempt at collecting these similar operations together into a class, which can be reused in different places within the codebase. This class is a _mapping from hashes to concrete specs_ that:
1. Ensures consistency of the specs being managed
2. Provides methods to add, delete, query specs

The idea is to refine an API for the class in this PR, and use it for `Environments`, and apply it in later PRs also to Databases and Indexes.