### PR TITLE
fix installation error of bear

### DIFF
--- a/var/spack/repos/builtin/packages/bear/package.py
+++ b/var/spack/repos/builtin/packages/bear/package.py
@@ -23,10 +23,10 @@ class Bear(CMakePackage):
     version("2.0.4", sha256="33ea117b09068aa2cd59c0f0f7535ad82c5ee473133779f1cc20f6f99793a63e")
 
     depends_on("pkgconfig", when="@3:")
-    depends_on("fmt", when="@3.0.0:")
-    depends_on("grpc", when="@3.0.0:")
+    depends_on("fmt@8", when="@3.0.0:")
+    depends_on("grpc +shared", when="@3.0.0:")
     depends_on("nlohmann-json", when="@3.0.0:")
-    depends_on("spdlog", when="@3.0.0:")
+    depends_on("spdlog +fmt_external", when="@3.0.0:")
     depends_on("cmake@2.8:", type="build")
     depends_on("python", type="build")
     depends_on("googletest", type="test", when="@3:")

--- a/var/spack/repos/builtin/packages/grpc/package.py
+++ b/var/spack/repos/builtin/packages/grpc/package.py
@@ -59,7 +59,7 @@ class Grpc(CMakePackage):
     depends_on("zlib-api")
     depends_on("c-ares")
     depends_on("abseil-cpp", when="@1.27:")
-    depends_on("re2+pic", when="@1.33.1:")
+    depends_on("re2+pic@2023-09-01", when="@1.33.1:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/re2/package.py
+++ b/var/spack/repos/builtin/packages/re2/package.py
@@ -14,6 +14,9 @@ class Re2(CMakePackage):
     url = "https://github.com/google/re2/archive/2020-08-01.tar.gz"
 
     version(
+        "2023-09-01", sha256="5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b"
+    )
+    version(
         "2021-06-01", sha256="26155e050b10b5969e986dab35654247a3b1b295e0532880b5a9c13c0a700ceb"
     )
     version(
@@ -25,6 +28,8 @@ class Re2(CMakePackage):
 
     variant("shared", default=False, description="Build shared instead of static libraries")
     variant("pic", default=True, description="Enable position independent code")
+
+    depends_on("abseil-cpp", when="@2023-09-01:")
 
     # shared libs must have position-independent code
     conflicts("+shared ~pic")


### PR DESCRIPTION
This PR fixes installation issue about `bear`.

* The purpose pinning `fmt`'s major version is to resolve dependency conflict about `fmt` by `+fmt_external` on `fmt`.
* The new `re2` version (`2023-09-01`) provides `re2.pc` file. It resolves compilation error on `grpc`.
* `+shared` on `grpc` resolves link errors between `grpc` and `zlib`.

## Related issue

* https://github.com/spack/spack/issues/34213