### PR TITLE
intel-tbb: patch patch for Apple's patch

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/gcc_13-2021-v2.patch
+++ b/var/spack/repos/builtin/packages/intel-tbb/gcc_13-2021-v2.patch
@@ -16,6 +16,8 @@ Signed-off-by: Sam James <sam@gentoo.org>
 
 diff --git a/test/common/utils_assert.h b/test/common/utils_assert.h
 index 1df8ae72acc49fe38dac4d9bed4e9f4f26affcf5..0123ab881e124a800a5ebf8507050148038747d5 100644
+--- a/test/common/utils_assert.h
++++ b/test/common/utils_assert.h
 @@ -20,6 +20,8 @@
  #include "config.h"
  #include "utils_report.h"

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -125,7 +125,7 @@ class IntelTbb(CMakePackage, MakefilePackage):
     patch("gcc_generic-pedantic-4.4.patch", level=1, when="@:2019.0")
 
     # Patch and conflicts for GCC 13 support (#1031).
-    patch("gcc_13-2021.patch", when="@2021.1:")
+    patch("gcc_13-2021-v2.patch", when="@2021.1:")
     conflicts("%gcc@13", when="@:2021.3")
 
     # Patch cmakeConfig.cmake.in to find the libraries where we install them.


### PR DESCRIPTION
While e.g. GNU patch 2.7.6 (as provided by homebrew) would apply the previous version of this patch without problems, Apple's patch 2.0-12u11-Apple fails to find out which file to patch.

Adding two lines to the patch fixes that. Renamed the patch in order to not require a `spack clean -m`.

I think this is the root of the problem addressed in #40631.