### PR TITLE
py-kombu: pick older version of py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-kombu/package.py
+++ b/var/spack/repos/builtin/packages/py-kombu/package.py
@@ -23,7 +23,7 @@ class PyKombu(PythonPackage):
 
     variant("redis", default=False, description="Use redis transport")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@:55", type="build")
     depends_on("py-amqp@2.5.2:2.5", when="@:4.6.6", type=("build", "run"))
     depends_on("py-amqp@2.6.0:2.6", when="@4.6.7:4", type=("build", "run"))
     depends_on("py-amqp@5.0.0:5", when="@5.0.0:5.0.2", type=("build", "run"))


### PR DESCRIPTION
py-kombu still uses "license_file" in its setup.cfg, which looks to have been deprecated in favor of "license_files" in this commit:

https://github.com/pypa/setuptools/commit/749b97499ea36d9a7660ed73db622837ae64c57d

And that commit appears to have first appeared in version 56.0.0

The goal of this PR is to fix this build failure on `develop`: https://gitlab.spack.io/spack/spack/-/jobs/8805683