### PR TITLE
Docs: Update spec variant checks plus a few extra changes and "bug" fixes

### DIFF
--- a/lib/spack/docs/build_systems/cachedcmakepackage.rst
+++ b/lib/spack/docs/build_systems/cachedcmakepackage.rst
@@ -87,7 +87,7 @@ A typical usage of these methods may look something like this:
 
 .. code-block:: python
 
-   def initconfig_mpi_entries(self)
+   def initconfig_mpi_entries(self):
        # Get existing MPI configurations
        entries = super(self, Foo).initconfig_mpi_entries()
 
@@ -95,25 +95,25 @@ A typical usage of these methods may look something like this:
        # This spec has an MPI variant, and we need to enable MPI when it is on.
        # This hypothetical package controls MPI with the ``FOO_MPI`` option to
        # cmake.
-       if '+mpi' in self.spec:
-           entries.append(cmake_cache_option('FOO_MPI', True, "enable mpi"))
+       if self.spec.satisfies("+mpi"):
+           entries.append(cmake_cache_option("FOO_MPI", True, "enable mpi"))
        else:
-           entries.append(cmake_cache_option('FOO_MPI', False, "disable mpi"))
+           entries.append(cmake_cache_option("FOO_MPI", False, "disable mpi"))
 
    def initconfig_package_entries(self):
        # Package specific options
        entries = []
 
-       entries.append('#Entries for build options')
+       entries.append("#Entries for build options")
 
-       bar_on = '+bar' in self.spec
-       entries.append(cmake_cache_option('FOO_BAR', bar_on, 'toggle bar'))
+       bar_on = self.spec.satisfies("+bar")
+       entries.append(cmake_cache_option("FOO_BAR", bar_on, "toggle bar"))
 
-       entries.append('#Entries for dependencies')
+       entries.append("#Entries for dependencies")
 
-       if self.spec['blas'].name == 'baz':  # baz is our blas provider
-       entries.append(cmake_cache_string('FOO_BLAS', 'baz', 'Use baz'))
-       entries.append(cmake_cache_path('BAZ_PREFIX', self.spec['baz'].prefix))
+       if self.spec["blas"].name == "baz":  # baz is our blas provider
+           entries.append(cmake_cache_string("FOO_BLAS", "baz", "Use baz"))
+           entries.append(cmake_cache_path("BAZ_PREFIX", self.spec["baz"].prefix))
 
 ^^^^^^^^^^^^^^^^^^^^^^
 External documentation

--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -54,8 +54,8 @@ to terminate such build attempts with a suitable message:
 
 .. code-block:: python
 
-    conflicts('cuda_arch=none', when='+cuda',
-              msg='CUDA architecture is required')
+    conflicts("cuda_arch=none", when="+cuda",
+              msg="CUDA architecture is required")
 
 Similarly, if your software does not support all versions of the property,
 you could add ``conflicts`` to your package for those versions.  For example,
@@ -66,13 +66,13 @@ custom message should a user attempt such a build:
 .. code-block:: python
 
     unsupported_cuda_archs = [
-        '10', '11', '12', '13',
-        '20', '21',
-        '30', '32', '35', '37'
+        "10", "11", "12", "13",
+        "20", "21",
+        "30", "32", "35", "37"
     ]
     for value in unsupported_cuda_archs:
-        conflicts('cuda_arch={0}'.format(value), when='+cuda',
-                  msg='CUDA architecture {0} is not supported'.format(value))
+        conflicts(f"cuda_arch={value}", when="+cuda",
+                  msg=f"CUDA architecture {value} is not supported")
 
 ^^^^^^^
 Methods
@@ -107,16 +107,16 @@ class of your package.  For example, you can add it to your
             spec = self.spec
             args = []
             ...
-            if '+cuda' in spec:
+            if spec.satisfies("+cuda"):
                 # Set up the cuda macros needed by the build
-                args.append('-DWITH_CUDA=ON')
-                cuda_arch_list = spec.variants['cuda_arch'].value
+                args.append("-DWITH_CUDA=ON")
+                cuda_arch_list = spec.variants["cuda_arch"].value
                 cuda_arch = cuda_arch_list[0]
-                if cuda_arch != 'none':
-                    args.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch))
+                if cuda_arch != "none":
+                    args.append(f"-DCUDA_FLAGS=-arch=sm_{cuda_arch}")
             else:
                 # Ensure build with cuda is disabled
-                args.append('-DWITH_CUDA=OFF')
+                args.append("-DWITH_CUDA=OFF")
             ...
             return args
 
@@ -125,7 +125,7 @@ You will need to customize options as needed for your build.
 
 This example also illustrates how to check for the ``cuda`` variant using
 ``self.spec`` and how to retrieve the ``cuda_arch`` variant's value, which
-is a list, using ``self.spec.variants['cuda_arch'].value``.
+is a list, using ``self.spec.variants["cuda_arch"].value``.
 
 With over 70 packages using ``CudaPackage`` as of January 2021 there are
 lots of examples to choose from to get more ideas for using this package.

--- a/lib/spack/docs/build_systems/custompackage.rst
+++ b/lib/spack/docs/build_systems/custompackage.rst
@@ -57,13 +57,13 @@ If you look at the ``perl`` package, you'll see:
 
 .. code-block:: python
 
-   phases = ['configure', 'build', 'install']
+   phases = ["configure", "build", "install"]
 
 Similarly, ``cmake`` defines:
 
 .. code-block:: python
 
-   phases = ['bootstrap', 'build', 'install']
+   phases = ["bootstrap", "build", "install"]
 
 If we look at the ``cmake`` example, this tells Spack's ``PackageBase``
 class to run the ``bootstrap``, ``build``, and ``install`` functions
@@ -78,7 +78,7 @@ If we look at ``perl``, we see that it defines a ``configure`` method:
 .. code-block:: python
 
    def configure(self, spec, prefix):
-       configure = Executable('./Configure')
+       configure = Executable("./Configure")
        configure(*self.configure_args())
 
 There is also a corresponding ``configure_args`` function that handles
@@ -92,7 +92,7 @@ phases are pretty simple:
        make()
 
    def install(self, spec, prefix):
-       make('install')
+       make("install")
 
 The ``cmake`` package looks very similar, but with a ``bootstrap``
 function instead of ``configure``:
@@ -100,14 +100,14 @@ function instead of ``configure``:
 .. code-block:: python
 
    def bootstrap(self, spec, prefix):
-       bootstrap = Executable('./bootstrap')
+       bootstrap = Executable("./bootstrap")
        bootstrap(*self.bootstrap_args())
 
    def build(self, spec, prefix):
        make()
 
    def install(self, spec, prefix):
-       make('install')
+       make("install")
 
 Again, there is a ``boostrap_args`` function that determines the
 correct bootstrap flags to use.
@@ -128,16 +128,16 @@ before or after a particular phase. For example, in ``perl``, we see:
 
 .. code-block:: python
 
-   @run_after('install')
+   @run_after("install")
    def install_cpanm(self):
        spec = self.spec
 
-       if '+cpanm' in spec:
-           with working_dir(join_path('cpanm', 'cpanm')):
-               perl = spec['perl'].command
-               perl('Makefile.PL')
+       if spec.satisfies("+cpanm"):
+           with working_dir(join_path("cpanm", "cpanm")):
+               perl = spec["perl"].command
+               perl("Makefile.PL")
                make()
-               make('install')
+               make("install")
 
 This extra step automatically installs ``cpanm`` in addition to the
 base Perl installation.
@@ -174,10 +174,10 @@ In the ``perl`` package, we can see:
 
 .. code-block:: python
 
-   @run_after('build')
+   @run_after("build")
    @on_package_attributes(run_tests=True)
    def test(self):
-       make('test')
+       make("test")
 
 As you can guess, this runs ``make test`` *after* building the package,
 if and only if testing is requested. Again, this is not specific to
@@ -189,7 +189,7 @@ custom build systems, it can be added to existing build systems as well.
 
    .. code-block:: python
 
-      @run_after('install')
+      @run_after("install")
       @on_package_attributes(run_tests=True)
 
    works as expected. However, if you reverse the ordering:
@@ -197,7 +197,7 @@ custom build systems, it can be added to existing build systems as well.
    .. code-block:: python
 
       @on_package_attributes(run_tests=True)
-      @run_after('install')
+      @run_after("install")
 
    the tests will always be run regardless of whether or not
    ``--test=root`` is requested. See https://github.com/spack/spack/issues/3833

--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -59,7 +59,7 @@ using GNU Make, you should add a dependency on ``gmake``:
 
 .. code-block:: python
 
-   depends_on('gmake', type='build')
+   depends_on("gmake", type="build")
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,8 +93,8 @@ there are any other variables you need to set, you can do this in the
 .. code-block:: python
 
    def edit(self, spec, prefix):
-       env['PREFIX'] = prefix
-       env['BLASLIB'] = spec['blas'].libs.ld_flags
+       env["PREFIX"] = prefix
+       env["BLASLIB"] = spec["blas"].libs.ld_flags
 
 
 `cbench <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/cbench/package.py>`_
@@ -113,7 +113,7 @@ you can do this like so:
 
 .. code-block:: python
 
-   build_targets = ['CC=cc']
+   build_targets = ["CC=cc"]
 
 
 If you do need access to the spec, you can create a property like so:
@@ -125,8 +125,8 @@ If you do need access to the spec, you can create a property like so:
        spec = self.spec
 
        return [
-           'CC=cc',
-           'BLASLIB={0}'.format(spec['blas'].libs.ld_flags),
+           "CC=cc",
+           f"BLASLIB={spec['blas'].libs.ld_flags}",
        ]
 
 
@@ -145,12 +145,12 @@ and a ``filter_file`` method to help with this. For example:
 .. code-block:: python
 
    def edit(self, spec, prefix):
-       makefile = FileFilter('Makefile')
+       makefile = FileFilter("Makefile")
 
-       makefile.filter(r'^\s*CC\s*=.*',  'CC = '  + spack_cc)
-       makefile.filter(r'^\s*CXX\s*=.*', 'CXX = ' + spack_cxx)
-       makefile.filter(r'^\s*F77\s*=.*', 'F77 = ' + spack_f77)
-       makefile.filter(r'^\s*FC\s*=.*',  'FC = '  + spack_fc)
+       makefile.filter(r"^\s*CC\s*=.*",  f"CC = {spack_cc}")
+       makefile.filter(r"^\s*CXX\s*=.*", f"CXX = {spack_cxx}")
+       makefile.filter(r"^\s*F77\s*=.*", f"F77 = {spack_f77}")
+       makefile.filter(r"^\s*FC\s*=.*",  f"FC = {spack_fc}")
 
 
 `stream <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/stream/package.py>`_
@@ -181,16 +181,16 @@ well for storing variables:
 
    def edit(self, spec, prefix):
        config = {
-           'CC': 'cc',
-           'MAKE': 'make',
+           "CC": "cc",
+           "MAKE": "make",
        }
 
-       if '+blas' in spec:
-           config['BLAS_LIBS'] = spec['blas'].libs.joined()
+       if spec.satisfies("+blas"):
+           config["BLAS_LIBS"] = spec["blas"].libs.joined()
 
-       with open('make.inc', 'w') as inc:
+       with open("make.inc", "w") as inc:
            for key in config:
-               inc.write('{0} = {1}\n'.format(key, config[key]))
+               inc.write(f"{key} = {config[key]}\n")
 
 
 `elk <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/elk/package.py>`_
@@ -204,14 +204,14 @@ them in a list:
 
    def edit(self, spec, prefix):
        config = [
-           'INSTALL_DIR = {0}'.format(prefix),
-           'INCLUDE_DIR = $(INSTALL_DIR)/include',
-           'LIBRARY_DIR = $(INSTALL_DIR)/lib',
+           f"INSTALL_DIR = {prefix}",
+           "INCLUDE_DIR = $(INSTALL_DIR)/include",
+           "LIBRARY_DIR = $(INSTALL_DIR)/lib",
        ]
 
-       with open('make.inc', 'w') as inc:
+       with open("make.inc", "w") as inc:
            for var in config:
-               inc.write('{0}\n'.format(var))
+               inc.write(f"{var}\n")
 
 
 `hpl <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/hpl/package.py>`_
@@ -284,7 +284,7 @@ can tell Spack where to locate it like so:
 
 .. code-block:: python
 
-   build_directory = 'src'
+   build_directory = "src"
 
 
 ^^^^^^^^^^^^^^^^^^^
@@ -299,8 +299,8 @@ install the package:
 
    def install(self, spec, prefix):
        mkdir(prefix.bin)
-       install('foo', prefix.bin)
-       install_tree('lib', prefix.lib)
+       install("foo", prefix.bin)
+       install_tree("lib", prefix.lib)
 
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -152,16 +152,16 @@ set. Once set, ``pypi`` will be used to define the ``homepage``,
 
 .. code-block:: python
 
-   homepage = 'https://pypi.org/project/setuptools/'
-   url      = 'https://pypi.org/packages/source/s/setuptools/setuptools-49.2.0.zip'
-   list_url = 'https://pypi.org/simple/setuptools/'
+   homepage = "https://pypi.org/project/setuptools/"
+   url      = "https://pypi.org/packages/source/s/setuptools/setuptools-49.2.0.zip"
+   list_url = "https://pypi.org/simple/setuptools/"
 
 
 is equivalent to:
 
 .. code-block:: python
 
-   pypi = 'setuptools/setuptools-49.2.0.zip'
+   pypi = "setuptools/setuptools-49.2.0.zip"
 
 
 If a package has a different homepage listed on PyPI, you can
@@ -208,7 +208,7 @@ dependencies to your package:
 
 .. code-block:: python
 
-   depends_on('py-setuptools@42:', type='build')
+   depends_on("py-setuptools@42:", type="build")
 
 
 Note that ``py-wheel`` is already listed as a build dependency in the
@@ -232,7 +232,7 @@ Look for dependencies under the following keys:
 * ``dependencies`` under ``[project]``
 
   These packages are required for building and installation. You can
-  add them with ``type=('build', 'run')``.
+  add them with ``type=("build", "run")``.
 
 * ``[project.optional-dependencies]``
 
@@ -279,12 +279,12 @@ distutils library, and has almost the exact same API. In addition to
 * ``setup_requires``
 
   These packages are usually only needed at build-time, so you can
-  add them with ``type='build'``.
+  add them with ``type="build"``.
 
 * ``install_requires``
 
   These packages are required for building and installation. You can
-  add them with ``type=('build', 'run')``.
+  add them with ``type=("build", "run")``.
 
 * ``extras_require``
 
@@ -296,7 +296,7 @@ distutils library, and has almost the exact same API. In addition to
 
   These are packages that are required to run the unit tests for the
   package. These dependencies can be specified using the
-  ``type='test'`` dependency type. However, the PyPI tarballs rarely
+  ``type="test"`` dependency type. However, the PyPI tarballs rarely
   contain unit tests, so there is usually no reason to add these.
 
 See https://setuptools.pypa.io/en/latest/userguide/dependency_management.html
@@ -321,7 +321,7 @@ older versions of flit may use the following keys:
 * ``requires`` under ``[tool.flit.metadata]``
 
   These packages are required for building and installation. You can
-  add them with ``type=('build', 'run')``.
+  add them with ``type=("build", "run")``.
 
 * ``[tool.flit.metadata.requires-extra]``
 
@@ -434,12 +434,12 @@ the BLAS/LAPACK library you want pkg-config to search for:
 
 .. code-block:: python
 
-   depends_on('py-pip@22.1:', type='build')
+   depends_on("py-pip@22.1:", type="build")
 
    def config_settings(self, spec, prefix):
        return {
-           'blas': spec['blas'].libs.names[0],
-           'lapack': spec['lapack'].libs.names[0],
+           "blas": spec["blas"].libs.names[0],
+           "lapack": spec["lapack"].libs.names[0],
        }
 
 
@@ -463,10 +463,10 @@ has an optional dependency on ``libyaml`` that can be enabled like so:
 
    def global_options(self, spec, prefix):
        options = []
-       if '+libyaml' in spec:
-           options.append('--with-libyaml')
+       if spec.satisfies("+libyaml"):
+           options.append("--with-libyaml")
        else:
-           options.append('--without-libyaml')
+           options.append("--without-libyaml")
        return options
 
 
@@ -492,10 +492,10 @@ allows you to specify the directories to search for ``libyaml``:
 
    def install_options(self, spec, prefix):
        options = []
-       if '+libyaml' in spec:
+       if spec.satisfies("+libyaml"):
            options.extend([
-               spec['libyaml'].libs.search_flags,
-               spec['libyaml'].headers.include_flags,
+               spec["libyaml"].libs.search_flags,
+               spec["libyaml"].headers.include_flags,
            ])
        return options
 
@@ -556,7 +556,7 @@ detected are wrong, you can provide the names yourself by overriding
 
 .. code-block:: python
 
-   import_modules = ['six']
+   import_modules = ["six"]
 
 
 Sometimes the list of module names to import depends on how the
@@ -571,9 +571,9 @@ This can be expressed like so:
 
    @property
    def import_modules(self):
-       modules = ['yaml']
-       if '+libyaml' in self.spec:
-           modules.append('yaml.cyaml')
+       modules = ["yaml"]
+       if self.spec.satisfies("+libyaml"):
+           modules.append("yaml.cyaml")
        return modules
 
 
@@ -586,14 +586,14 @@ Instead of defining the ``import_modules`` explicitly, only the subset
 of module names to be skipped can be defined by using ``skip_modules``.
 If a defined module has submodules, they are skipped as well, e.g.,
 in case the ``plotting`` modules should be excluded from the
-automatically detected ``import_modules`` ``['nilearn', 'nilearn.surface',
-'nilearn.plotting', 'nilearn.plotting.data']`` set:
+automatically detected ``import_modules`` ``["nilearn", "nilearn.surface",
+"nilearn.plotting", "nilearn.plotting.data"]`` set:
 
 .. code-block:: python
 
-        skip_modules = ['nilearn.plotting']
+        skip_modules = ["nilearn.plotting"]
 
-This will set ``import_modules`` to ``['nilearn', 'nilearn.surface']``
+This will set ``import_modules`` to ``["nilearn", "nilearn.surface"]``
 
 Import tests can be run during the installation using ``spack install
 --test=root`` or at any time after the installation using
@@ -612,11 +612,11 @@ after the ``install`` phase:
 
 .. code-block:: python
 
-   @run_after('install')
+   @run_after("install")
    @on_package_attributes(run_tests=True)
    def install_test(self):
-       with working_dir('spack-test', create=True):
-           python('-c', 'import numpy; numpy.test("full", verbose=2)')
+       with working_dir("spack-test", create=True):
+           python("-c", "import numpy; numpy.test('full', verbose=2)")
 
 
 when testing is enabled during the installation (i.e., ``spack install
@@ -638,7 +638,7 @@ provides Python bindings in a ``python`` directory, you can use:
 
 .. code-block:: python
 
-   build_directory = 'python'
+   build_directory = "python"
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/rocmpackage.rst
+++ b/lib/spack/docs/build_systems/rocmpackage.rst
@@ -81,28 +81,27 @@ class of your package.  For example, you can add it to your
     class MyRocmPackage(CMakePackage, ROCmPackage):
         ...
         # Ensure +rocm and amdgpu_targets are passed to dependencies
-        depends_on('mydeppackage', when='+rocm')
+        depends_on("mydeppackage", when="+rocm")
         for val in ROCmPackage.amdgpu_targets:
-            depends_on('mydeppackage amdgpu_target={0}'.format(val),
-                       when='amdgpu_target={0}'.format(val))
+            depends_on(f"mydeppackage amdgpu_target={val}",
+                       when=f"amdgpu_target={val}")
         ...
 
         def cmake_args(self):
             spec = self.spec
             args = []
             ...
-            if '+rocm' in spec:
+            if spec.satisfies("+rocm"):
                 # Set up the hip macros needed by the build
                 args.extend([
-                    '-DENABLE_HIP=ON',
-                    '-DHIP_ROOT_DIR={0}'.format(spec['hip'].prefix)])
-                rocm_archs = spec.variants['amdgpu_target'].value
-                if 'none' not in rocm_archs:
-                    args.append('-DHIP_HIPCC_FLAGS=--amdgpu-target={0}'
-                                .format(",".join(rocm_archs)))
+                    "-DENABLE_HIP=ON",
+                    f"-DHIP_ROOT_DIR={spec['hip'].prefix}"])
+                rocm_archs = spec.variants["amdgpu_target"].value
+                if "none" not in rocm_archs:
+                    args.append(f"-DHIP_HIPCC_FLAGS=--amdgpu-target={','.join(rocm_archs}")
             else:
                 # Ensure build with hip is disabled
-                args.append('-DENABLE_HIP=OFF')
+                args.append("-DENABLE_HIP=OFF")
             ...
             return args
         ...
@@ -114,7 +113,7 @@ build.
 
 This example also illustrates how to check for the ``rocm`` variant using
 ``self.spec`` and how to retrieve the ``amdgpu_target`` variant's value
-using ``self.spec.variants['amdgpu_target'].value``.
+using ``self.spec.variants["amdgpu_target"].value``.
 
 All five packages using ``ROCmPackage`` as of January 2021 also use the
 :ref:`CudaPackage <cudapackage>`. So it is worth looking at those packages

--- a/lib/spack/docs/build_systems/sconspackage.rst
+++ b/lib/spack/docs/build_systems/sconspackage.rst
@@ -57,7 +57,7 @@ overridden like so:
 .. code-block:: python
 
    def test(self):
-       scons('check')
+       scons("check")
 
 
 ^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ base class already contains:
 
 .. code-block:: python
 
-   depends_on('scons', type='build')
+   depends_on("scons", type="build")
 
 
 If you want to specify a particular version requirement, you can override
@@ -96,7 +96,7 @@ this in your package:
 
 .. code-block:: python
 
-   depends_on('scons@2.3.0:', type='build')
+   depends_on("scons@2.3.0:", type="build")
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,14 +238,14 @@ the package build phase. This is done by overriding ``build_args`` like so:
 
    def build_args(self, spec, prefix):
        args = [
-         'PREFIX={0}'.format(prefix),
-         'ZLIB={0}'.format(spec['zlib'].prefix),
+         f"PREFIX={prefix}",
+         f"ZLIB={spec['zlib'].prefix}",
        ]
 
-       if '+debug' in spec:
-           args.append('DEBUG=yes')
+       if spec.satisfies("+debug"):
+           args.append("DEBUG=yes")
        else:
-           args.append('DEBUG=no')
+           args.append("DEBUG=no")
 
        return args
 
@@ -275,8 +275,8 @@ environment variables. For example, cantera has the following option:
    * env_vars: [ string ]
        Environment variables to propagate through to SCons. Either the
        string "all" or a comma separated list of variable names, e.g.
-       'LD_LIBRARY_PATH,HOME'.
-       - default: 'LD_LIBRARY_PATH,PYTHONPATH'
+       "LD_LIBRARY_PATH,HOME".
+       - default: "LD_LIBRARY_PATH,PYTHONPATH"
 
 
 In the case of cantera, using ``env_vars=all`` allows us to use

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1549,7 +1549,7 @@ its value:
 
     def configure_args(self):
         ...
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             extra_args.append("--enable-shared")
         else:
             extra_args.append("--disable-shared")
@@ -1636,7 +1636,7 @@ Within a package recipe a multi-valued variant is tested using a ``key=value`` s
 
   .. code-block:: python
 
-    if "languages=jit" in spec:
+    if spec.satisfies("languages=jit"):
         options.append("--enable-host-shared")
 
 """""""""""""""""""""""""""""""""""""""""""
@@ -3501,7 +3501,7 @@ need to override methods like ``configure_args``:
 
    def configure_args(self):
         args = ["--enable-cxx"] + self.enable_or_disable("libs")
-        if "libs=static" in self.spec:
+        if self.spec.satisfies("libs=static"):
             args.append("--with-pic")
         return args
 
@@ -4364,7 +4364,7 @@ for supported features, for instance:
 
 .. code-block:: python
 
-   if "avx512" in spec.target:
+   if spec.satisfies("target=avx512"):
        args.append("--with-avx512")
 
 The snippet above will append the ``--with-avx512`` item to a list of arguments only if the corresponding


### PR DESCRIPTION
It is pretty common that I suggest switching from `"+variant" in spec` to `spec.satisfies("+variant")` so changed all occurrences and like to paste links to the docs so it would be nice if the docs reflect the switch.

While I was changing the files, I switched each file's examples to use f-strings and black's double quotes.

Also fixed a code-block example to python; added an example of using a helper method as an alternative to the current example (with a link to the helper's documentation); and an ending paragraph to a note.