### PR TITLE
pythia8: fix configure args

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -131,16 +131,16 @@ class Pythia8(AutotoolsPackage):
                 args.append("--with-boost=" + self.spec["boost"].prefix)
 
         if "+madgraph5amc" in self.spec:
-            args += "--with-mg5mes=" + self.spec["madgraph5amc"].prefix
+            args.append("--with-mg5mes=" + self.spec["madgraph5amc"].prefix)
         else:
-            args += "--without-mg5mes"
+            args.append("--without-mg5mes")
 
         args += self.with_or_without("hepmc3", activation_value="prefix")
 
         if "+fastjet" in self.spec:
-            args += "--with-fastjet3=" + self.spec["fastjet"].prefix
+            args.append("--with-fastjet3=" + self.spec["fastjet"].prefix)
         else:
-            args += "--without-fastjet3"
+            args.append("--without-fastjet3")
 
         args += self.with_or_without("evtgen", activation_value="prefix")
         args += self.with_or_without("root", activation_value="prefix")


### PR DESCRIPTION
Adding a string to a list in python with `+=` adds each character as one element of the list instead of adding the whole string as a single element so the configure args look like this:

```
--with-hepmc2=/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-10-06-paestum/x86_64-ubuntu22.04-g
cc11.3.0-opt/hepmc/2.06.11-3hwln5 - - w i t h o u t - m g 5 m e s --without-hepmc3 - - w i t h o u
 t - f a s t j e t 3 --without-evtgen --without-root --without-rivet --without-python --without-op
enmp --without-mpich --without-hdf5
```