### PR TITLE
py-kombu: fix setuptools bound

### DIFF
--- a/var/spack/repos/builtin/packages/py-kombu/package.py
+++ b/var/spack/repos/builtin/packages/py-kombu/package.py
@@ -25,7 +25,7 @@ class PyKombu(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     # "pytz>dev" in tests_require: setuptools parser changed in 0.60 and errors.
-    depends_on("py-setuptools@:59", when="4.6:5.2", type="build")
+    depends_on("py-setuptools@:59", when="@4.6:5.2", type="build")
 
     depends_on("py-amqp@2.5.2:2.5", when="@:4.6.6", type=("build", "run"))
     depends_on("py-amqp@2.6.0:2.6", when="@4.6.7:4", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-kombu/package.py
+++ b/var/spack/repos/builtin/packages/py-kombu/package.py
@@ -23,7 +23,10 @@ class PyKombu(PythonPackage):
 
     variant("redis", default=False, description="Use redis transport")
 
-    depends_on("py-setuptools@:55", type="build")
+    depends_on("py-setuptools", type="build")
+    # "pytz>dev" in tests_require: setuptools parser changed in 0.60 and errors.
+    depends_on("py-setuptools@:59", when="4.6:5.2", type="build")
+
     depends_on("py-amqp@2.5.2:2.5", when="@:4.6.6", type=("build", "run"))
     depends_on("py-amqp@2.6.0:2.6", when="@4.6.7:4", type=("build", "run"))
     depends_on("py-amqp@5.0.0:5", when="@5.0.0:5.0.2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-kombu/package.py
+++ b/var/spack/repos/builtin/packages/py-kombu/package.py
@@ -24,7 +24,7 @@ class PyKombu(PythonPackage):
     variant("redis", default=False, description="Use redis transport")
 
     depends_on("py-setuptools", type="build")
-    # "pytz>dev" in tests_require: setuptools parser changed in 0.60 and errors.
+    # "pytz>dev" in tests_require: setuptools parser changed in v60 and errors.
     depends_on("py-setuptools@:59", when="@4.6:5.2", type="build")
 
     depends_on("py-amqp@2.5.2:2.5", when="@:4.6.6", type=("build", "run"))


### PR DESCRIPTION
The real issue is a malformed string in `setup(tests_require=...)`, which
setuptools chokes on only since

https://github.com/pypa/setuptools/commit/a43f99fde07a2860729dca16e2761e442cd1e165

due to a change in parsing, which is v60.
