### PR TITLE
Fetch recola from gitlab and add a new version of collier

### DIFF
--- a/var/spack/repos/builtin/packages/collier/package.py
+++ b/var/spack/repos/builtin/packages/collier/package.py
@@ -18,6 +18,7 @@ class Collier(CMakePackage):
 
     maintainers("vvolkl")
 
+    version("1.2.8", sha256="5cb24ce24ba1f62b7a96c655b31e9fddccc603eff31e60f9033b16354a6afd89")
     version("1.2.7", sha256="fde4b144a17c1bf5aa2ceaa86c71c79da10c9de8fec7bd33c8bffb4198acd5ca")
     version("1.2.6", sha256="b0d517868c71d2d1b8b6d3e0c370a43c9eb18ea8393a6e80070a5a2206f7de36")
     version("1.2.5", sha256="3ec58a975ff0c3b1ca870bc38973476c923ff78fd3dd5850e296037852b94a8b")

--- a/var/spack/repos/builtin/packages/recola/package.py
+++ b/var/spack/repos/builtin/packages/recola/package.py
@@ -31,6 +31,11 @@ class Recola(CMakePackage):
         url="https://recola.hepforge.org/downloads/?f=recola-1.4.3.tar.gz",
         sha256="f6a7dce6e1f09821ba919524f786557984f216c001ab63e7793e8aa9a8560ceb",
     )
+    version(
+        "1.4.0",
+        url="https://recola.hepforge.org/downloads/?f=recola-1.4.0.tar.gz",
+        sha256="dc7db5ac9456dda2e6c03a63ad642066b0b5e4ceb8cae1f2a13ab33b35caaba8",
+    )
 
     depends_on("collier")
     depends_on("recola-sm")

--- a/var/spack/repos/builtin/packages/recola/package.py
+++ b/var/spack/repos/builtin/packages/recola/package.py
@@ -15,15 +15,17 @@ class Recola(CMakePackage):
 
     tags = ["hep"]
 
-    homepage = "https://recola.hepforge.org"
-    url = "https://recola.hepforge.org/downloads/?f=recola2-2.2.3.tar.gz"
+    homepage = "https://recola.gitlab.io/recola2/"
+    url = "https://gitlab.com/recola/recola2/-/archive/2.2.4/recola2-2.2.4.tar.gz"
 
     maintainers("vvolkl")
 
     variant("python", default=True, description="Build py-recola python bindings.")
 
-    version("2.2.4", sha256="16bdefb633d51842b4d32c39a43118d7052302cd63be456a473557e9b7e0316e")
-    version("2.2.3", sha256="db0f5e448ed603ac4073d4bbf36fd74f401a22876ad390c0d02c815a78106c5f")
+    version("2.2.4", sha256="212ae6141bc5de38c50be3e0c6947a3b0752aeb463cf850c22cfed5e61b1a64b")
+    version("2.2.3", sha256="8dc25798960c272434fcde93817ed92aad82b2a7cf07438bb4deb5688d301086")
+    version("2.2.2", sha256="a64cf2b4aa213289dfab6e2255a77264f281cd0ac85f5e9770c82b815272c5c9")
+    version("2.2.0", sha256="a64cf2b4aa213289dfab6e2255a77264f281cd0ac85f5e9770c82b815272c5c9")
     version(
         "1.4.3",
         url="https://recola.hepforge.org/downloads/?f=recola-1.4.3.tar.gz",


### PR DESCRIPTION
recola moved to gitlab: https://recola.hepforge.org now redirects to
https://recola.hepforge.org
The new collier version is unrelated to this move but it's a closely related
package to recola.