### PR TITLE
glib: add patch with a fix for PTRACE_0_EXITKILL

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -177,7 +177,7 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch(
         "https://gitlab.gnome.org/GNOME/glib/-/commit/bda87264372c006c94e21ffb8ff9c50ecb3e14bd.diff",
         sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
-        when="@2.78.0"
+        when="@2.78.0",
     )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -173,7 +173,7 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch("meson-gettext-2.66.patch", when="@2.66:2.68,2.72")
     patch("meson-gettext-2.70.patch", when="@2.70")
 
-    # Don't use PTRACE_O_EXITKILL if it's not defined:
+    # Don't use PTRACE_O_EXITKILL if it's not defined
     patch("ptrace.patch",
           "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3588.diff",
           sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -173,6 +173,12 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch("meson-gettext-2.66.patch", when="@2.66:2.68,2.72")
     patch("meson-gettext-2.70.patch", when="@2.70")
 
+    # Don't use PTRACE_O_EXITKILL if it's not defined:
+    patch("ptrace.patch",
+          "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3588.diff",
+          sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
+          when="@2.78.0")
+
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""
         url = "https://download.gnome.org/sources/glib"

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -174,8 +174,7 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch("meson-gettext-2.70.patch", when="@2.70")
 
     # Don't use PTRACE_O_EXITKILL if it's not defined
-    patch("ptrace.patch",
-          "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3588.diff",
+    patch("https://gitlab.gnome.org/GNOME/glib/-/commit/bda87264372c006c94e21ffb8ff9c50ecb3e14bd.diff",
           sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
           when="@2.78.0")
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -174,9 +174,11 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch("meson-gettext-2.70.patch", when="@2.70")
 
     # Don't use PTRACE_O_EXITKILL if it's not defined
-    patch("https://gitlab.gnome.org/GNOME/glib/-/commit/bda87264372c006c94e21ffb8ff9c50ecb3e14bd.diff",
-          sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
-          when="@2.78.0")
+    patch(
+        "https://gitlab.gnome.org/GNOME/glib/-/commit/bda87264372c006c94e21ffb8ff9c50ecb3e14bd.diff",
+        sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
+        when="@2.78.0"
+    )
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""


### PR DESCRIPTION
glib 2.78.0 doesn't build on Centos 7. Previous versions don't use this
`PTRACE_0_EXITKILL`