### PR TITLE
vtk: fix GitLab patch

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -195,8 +195,8 @@ class Vtk(CMakePackage):
     )
 
     patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/commit/5a1c96e12e9b4a660d326be3bed115a2ceadb573.patch",
-        sha256="65175731c080961f85d779d613ac1f6bce89783745e54e864edec7637b03b18a",
+        "https://gitlab.kitware.com/vtk/vtk/-/commit/5a1c96e12e9b4a660d326be3bed115a2ceadb573.diff",
+        sha256="c446a90459b108082db5b28d9aeda99d030e636325e01929beba062cafb16b76",
         when="@9.1",
     )
 


### PR DESCRIPTION
GitLab's .patch URLs do not provide stable/full hashes, while .diff URLs do. See #40656 for more information.