### PR TITLE
knem: fix GitLab patch

### DIFF
--- a/var/spack/repos/builtin/packages/knem/package.py
+++ b/var/spack/repos/builtin/packages/knem/package.py
@@ -32,8 +32,8 @@ class Knem(AutotoolsPackage):
     variant("hwloc", default=True, description="Enable hwloc in the user-space tools")
 
     patch(
-        "https://gitlab.inria.fr/knem/knem/-/commit/5c8cb902d6040df58cdc4e4e4c10d1f1426c3525.patch",
-        sha256="78885a02d6f031a793db6a7190549f8d64c8606b353051d65f8e3f802b801902",
+        "https://gitlab.inria.fr/knem/knem/-/commit/5c8cb902d6040df58cdc4e4e4c10d1f1426c3525.diff",
+        sha256="a422277f02247bde680d4a3c8ccb8c05498a79109ba1ade4a037bedd6efe3c79",
         when="@1.1.4",
     )
 


### PR DESCRIPTION
GitLab's .patch URLs do not provide stable/full hashes, while .diff URLs do. See #40656 for more information.