### PR TITLE
Add ability to print license information on a concrete spec

### DIFF
--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -218,3 +218,9 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
     else:
         output = spec(name + "@" + version)
         assert version in output
+
+
+def test_spec_license():
+    output = spec("zlib")
+
+    assert "license=Zlib" in output

--- a/var/spack/repos/builtin.mock/packages/zlib/package.py
+++ b/var/spack/repos/builtin.mock/packages/zlib/package.py
@@ -52,3 +52,5 @@ class Zlib(Package):
         if self.run_tests:
             make("check")
         make("install")
+
+    license("Zlib")


### PR DESCRIPTION
This patch adds the ability to spec.format() to print license information when it is available (after a spec has been concretized). This patch also prints out this information by default when running command line subcommands like spack spec.