### PR TITLE
metkit: add v1.10.2 and v1.10.17

### DIFF
--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -15,6 +15,8 @@ class Metkit(CMakePackage):
 
     maintainers("skosukhin")
 
+    version("1.10.17", sha256="1c525891d77ed28cd4c87b065ba4d1aea24d0905452c18d885ccbd567bbfc9b1")
+    version("1.10.2", sha256="a038050962aecffda27b755c40b0a6ed0db04a2c22cad3d8c93e6109c8ab4b34")
     version("1.9.2", sha256="35d5f67196197cc06e5c2afc6d1354981e7c85a441df79a2fbd774e0c343b0b4")
     version("1.7.0", sha256="8c34f6d8ea5381bd1bcfb22462349d03e1592e67d8137e76b3cecf134a9d338c")
 
@@ -26,6 +28,7 @@ class Metkit(CMakePackage):
     depends_on("ecbuild@3.4:", type="build")
 
     depends_on("eckit@1.16:")
+    depends_on("eckit@1.21:", when="@1.10:")
 
     depends_on("eccodes@2.5:", when="+grib")
 

--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -31,6 +31,7 @@ class Metkit(CMakePackage):
     depends_on("eckit@1.21:", when="@1.10:")
 
     depends_on("eccodes@2.5:", when="+grib")
+    depends_on("eccodes@2.27:", when="@1.10.2: +grib")
 
     depends_on("odc", when="+odb")
 


### PR DESCRIPTION
Added metkit releases v1.10.2 and v1.10.17

Added `depends_on("eckit@1.21:", when="@1.10:")`
because _without_ eckit@1.21: or higher, metkit@1.10: build fails with error:
```
spack-src/src/metkit/mars/DHSProtocol.cc:88:43: error: 'hostAddress' is not a member of 'eckit::net::IPAddress'
```
`IPAddress::hostAdress` is introduced in eckit@1.21
