### PR TITLE
[cp2k] Use fftw3 MKL by default when cp2k is compiled with mkl

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/cmake-fixes-2023.2.patch
+++ b/var/spack/repos/builtin/packages/cp2k/cmake-fixes-2023.2.patch
@@ -1,10 +1,22 @@
-From 1897cbf3e467dc765f733b09af041fe8f25fa906 Mon Sep 17 00:00:00 2001
+From b75eb217115820059aba26d1ff1a8657e3841e7d Mon Sep 17 00:00:00 2001
 From: Mathieu Taillefumier <mathieu.taillefumier@free.fr>
-Date: Thu, 19 Oct 2023 12:21:50 +0200
-Subject: [PATCH] [cmake] fix for building gromacs and cp2k with cmake and spack
+Date: Mon, 23 Oct 2023 15:50:44 +0200
+Subject: [PATCH] cmake-fixes-2023.2
+
+---
+ CMakeLists.txt            |  63 +++++++-----
+ cmake/FindBlas.cmake      | 174 +++++++++++++++++-----------------
+ cmake/FindLapack.cmake    |  47 ++++-----
+ cmake/cp2k.pc.in          |  19 ----
+ cmake/cp2kConfig.cmake.in | 195 ++++++++++++++++++++------------------
+ cmake/libcp2k.pc.in       |  11 +++
+ src/CMakeLists.txt        |  18 ++--
+ 7 files changed, 276 insertions(+), 251 deletions(-)
+ delete mode 100644 cmake/cp2k.pc.in
+ create mode 100644 cmake/libcp2k.pc.in
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3f81c7b524..1b6c6a0636 100644
+index 3f81c7b52..f2d85d033 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -49,7 +49,8 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
@@ -17,7 +29,18 @@ index 3f81c7b524..1b6c6a0636 100644
  
  find_package(PkgConfig)
  
-@@ -115,8 +116,8 @@ cmake_dependent_option(CP2K_ENABLE_FFTW3_OPENMP_SUPPORT
+@@ -108,6 +109,10 @@ option(CP2K_USE_LIBXSMM "Use libxsmm for small gemms (supports x86 platforms)"
+        OFF)
+ option(CP2K_BUILD_DBCSR "Duild dbcsr at the same time than cp2k." OFF)
+ option(BUILD_SHARED_LIBS "Build cp2k shared library" ON)
++option(
++  CP2K_USE_FFTW3_WITH_MKL
++  "If set to ON use the original implementation of fftw3 instead of the MKL implementation."
++  OFF)
+ 
+ cmake_dependent_option(CP2K_ENABLE_ELPA_OPENMP_SUPPORT
+                        "Enable elpa openmp support" ON "CP2K_USE_ELPA" OFF)
+@@ -115,8 +120,8 @@ cmake_dependent_option(CP2K_ENABLE_FFTW3_OPENMP_SUPPORT
                         "Enable FFTW openmp support" ON "CP2K_USE_FFTW3" OFF)
  cmake_dependent_option(CP2K_ENABLE_FFTW3_THREADS_SUPPORT
                         "Enable FFTW THREADS support" OFF "CP2K_USE_FFTW3" OFF)
@@ -28,7 +51,71 @@ index 3f81c7b524..1b6c6a0636 100644
  
  cmake_dependent_option(
    DBCSR_USE_ACCEL
-@@ -748,7 +749,7 @@ add_subdirectory(src)
+@@ -527,7 +532,7 @@ if(CP2K_USE_ACCEL MATCHES "CUDA")
+   endif()
+ 
+   set(CP2K_USE_CUDA ON)
+-  message(STATUS ``"-- CUDA compiler and libraries found")
++  message(STATUS "-- CUDA compiler and libraries found")
+ elseif(CP2K_USE_ACCEL MATCHES "HIP")
+   enable_language(HIP)
+   # Find hip
+@@ -620,27 +625,36 @@ endif()
+ 
+ # FFTW3
+ 
++set(CP2K_USE_FFTW3_ OFF)
+ if(CP2K_USE_FFTW3)
+-  find_package(Fftw REQUIRED)
+-  if(CP2K_ENABLE_FFTW3_THREADS_SUPPORT AND CP2K_ENABLE_FFTW3_OPENMP_SUPPORT)
+-    message(
+-      FATAL_ERROR
+-        "Fftw3 threads and openmp supports can not be used at the same time")
+-  endif()
++  if(CP2K_USE_FFTW3_WITH_MKL OR NOT TARGET CP2K::BLAS::MKL::blas)
++    find_package(Fftw REQUIRED)
++    if(CP2K_ENABLE_FFTW3_THREADS_SUPPORT AND CP2K_ENABLE_FFTW3_OPENMP_SUPPORT)
++      message(
++        FATAL_ERROR
++          "Fftw3 threads and openmp supports can not be used at the same time")
++    endif()
+ 
+-  if((CP2K_ENABLE_FFTW3_THREADS_SUPPORT) AND (NOT TARGET
+-                                              CP2K::FFTW3::fftw3_threads))
+-    message(
+-      FATAL_ERROR
+-        "fftw3 was compiled without multithreading support (--enable-threads option in fftw build system)."
+-    )
+-  endif()
++    if((CP2K_ENABLE_FFTW3_THREADS_SUPPORT) AND (NOT TARGET
++                                                CP2K::FFTW3::fftw3_threads))
++      message(
++        FATAL_ERROR
++          "fftw3 was compiled without multithreading support (--enable-threads option in fftw build system)."
++      )
++    endif()
+ 
+-  if((CP2K_ENABLE_FFTW3_OPENMP_SUPPORT) AND (NOT TARGET CP2K::FFTW3::fftw3_omp))
+-    message(
+-      FATAL_ERROR
+-        "fftw3 was compiled without openmp support  (--enable-openmp option in fftw build system)."
+-    )
++    if((CP2K_ENABLE_FFTW3_OPENMP_SUPPORT) AND (NOT TARGET CP2K::FFTW3::fftw3_omp
++                                              ))
++      message(
++        FATAL_ERROR
++          "fftw3 was compiled without openmp support  (--enable-openmp option in fftw build system)."
++      )
++    endif()
++    # we use this variable later on to include the fftw target whenever mkl is
++    # found or not
++    set(CP2K_USE_FFTW3_ ON)
++  else()
++    message("-- Using the MKL implementation of FFTW3.")
+   endif()
+ endif()
+ 
+@@ -748,7 +762,7 @@ add_subdirectory(src)
  include(GNUInstallDirs)
  
  get_target_property(CP2K_LIBS cp2k_link_libs INTERFACE_LINK_LIBRARIES)
@@ -37,19 +124,18 @@ index 3f81c7b524..1b6c6a0636 100644
  
  message(
    STATUS "--------------------------------------------------------------------")
-@@ -1039,6 +1040,10 @@ install(FILES "${PROJECT_BINARY_DIR}/cp2kConfig.cmake"
+@@ -1039,6 +1053,9 @@ install(FILES "${PROJECT_BINARY_DIR}/cp2kConfig.cmake"
                "${PROJECT_BINARY_DIR}/cp2kConfigVersion.cmake"
          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cp2k")
  
 +install(FILES "${PROJECT_BINARY_DIR}/libcp2k.pc"
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 +
-+
  install(
    DIRECTORY "${PROJECT_SOURCE_DIR}/cmake"
    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cp2k"
 diff --git a/cmake/FindBlas.cmake b/cmake/FindBlas.cmake
-index 6e5fb78240..335cbd964a 100644
+index 6e5fb7824..335cbd964 100644
 --- a/cmake/FindBlas.cmake
 +++ b/cmake/FindBlas.cmake
 @@ -15,104 +15,108 @@ if(NOT
@@ -247,7 +333,7 @@ index 6e5fb78240..335cbd964a 100644
  # having the fortran interface is usually enough. C, C++ and others languages
  # might require this information though
 diff --git a/cmake/FindLapack.cmake b/cmake/FindLapack.cmake
-index 966e0d78d3..77a1e04258 100644
+index 966e0d78d..77a1e0425 100644
 --- a/cmake/FindLapack.cmake
 +++ b/cmake/FindLapack.cmake
 @@ -20,33 +20,34 @@ include(FindPackageHandleStandardArgs)
@@ -310,7 +396,7 @@ index 966e0d78d3..77a1e04258 100644
                                    REQUIRED_VARS CP2K_LAPACK_LINK_LIBRARIES)
 diff --git a/cmake/cp2k.pc.in b/cmake/cp2k.pc.in
 deleted file mode 100644
-index 5b4a095660..0000000000
+index 5b4a09566..000000000
 --- a/cmake/cp2k.pc.in
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -335,10 +421,10 @@ index 5b4a095660..0000000000
 -#Libs.private: -L"${libdir}" @CP2K_LIBS@
 \ No newline at end of file
 diff --git a/cmake/cp2kConfig.cmake.in b/cmake/cp2kConfig.cmake.in
-index a3acd47442..a9e0eb5a58 100644
+index a3acd4744..1c310e19b 100644
 --- a/cmake/cp2kConfig.cmake.in
 +++ b/cmake/cp2kConfig.cmake.in
-@@ -5,112 +5,120 @@
+@@ -5,112 +5,121 @@
  #!   SPDX-License-Identifier: GPL-2.0-or-later                                                     !
  #!-------------------------------------------------------------------------------------------------!
  
@@ -405,9 +491,10 @@ index a3acd47442..a9e0eb5a58 100644
 +    find_dependency(MPI REQUIRED)
 +  endif()
 +
-+  if(@CP2K_USE_FFTW3@)
++  if(@CP2K_USE_FFTW3@ OR @CP2K_USE_FFTW3_WITH_MKL@)
 +    find_dependency(Fftw REQUIRED)
 +  endif()
++  
 +  # QUIP
 +  if(@CP2K_USE_QUIP@)
 +    find_dependency(Quip REQUIRED)
@@ -554,7 +641,7 @@ index a3acd47442..a9e0eb5a58 100644
 -include("${CMAKE_CURRENT_LIST_DIR}/cp2kTargets.cmake")
 diff --git a/cmake/libcp2k.pc.in b/cmake/libcp2k.pc.in
 new file mode 100644
-index 0000000000..618af55e28
+index 000000000..618af55e2
 --- /dev/null
 +++ b/cmake/libcp2k.pc.in
 @@ -0,0 +1,11 @@
@@ -570,19 +657,41 @@ index 0000000000..618af55e28
 +Cflags: -I"${includedir}/cp2k" -I"${includedir}/cp2k/@CMAKE_Fortran_COMPILER_ID@-@CMAKE_Fortran_COMPILER_VERSION@"
 +Libs: -L"${libdir}" -lcp2k
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index dbc955885e..e003d4f88d 100644
+index dbc955885..1178101ad 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
+@@ -1536,9 +1536,9 @@ target_link_libraries(
+     $<$<BOOL:${CP2K_USE_SPGLIB}>:CP2K::LIBSPG::libspg>
+     $<$<BOOL:${CP2K_USE_LIBXC}>:CP2K::Libxc::xc>
+     $<$<BOOL:${CP2K_USE_ELPA}>:CP2K::ELPA::elpa>
+-    $<$<BOOL:${CP2K_USE_FFTW3}>:CP2K::FFTW3::fftw3>
+-    $<$<BOOL:${CP2K_ENABLE_FFTW3_THREADS_SUPPORT}>:CP2K::FFTW3::fftw3_threads>
+-    $<$<BOOL:${CP2K_ENABLE_FFTW3_OPENMP_SUPPORT}>:CP2K::FFTW3::fftw3_omp>
++    $<$<BOOL:${CP2K_USE_FFTW3_}>:CP2K::FFTW3::fftw3>
++    $<$<AND:$<BOOL:${CP2K_ENABLE_FFTW3_THREADS_SUPPORT}>,$<BOOL:${CP2K_USE_FFTW3_}>>:CP2K::FFTW3::fftw3_threads>
++    $<$<AND:$<BOOL:${CP2K_ENABLE_FFTW3_OPENMP_SUPPORT}>,$<BOOL:${CP2K_USE_FFTW3_}>>:CP2K::FFTW3::fftw3_omp>
+     $<$<BOOL:${CP2K_USE_SPLA}>:SPLA::spla>
+     $<$<BOOL:${CP2K_USE_LIBINT2}>:CP2K::Libint2::int2>
+     $<$<BOOL:${CP2K_USE_TORCH}>:${TORCH_LIBRARIES}>
 @@ -1555,7 +1555,7 @@ target_compile_definitions(
    cp2k
    PUBLIC $<$<BOOL:${CP2K_USE_MPI}>:__parallel>
           $<$<BOOL:${CP2K_USE_MPI}>:__SCALAPACK>
 -         $<$<BOOL:${CP2K_ENABLE_F08_MPI}>:__MPI_08>
-+         $<$<BOOL:${CP2K_USE_MPI_F08}>:__MPI_08>
++         $<$<BOOL:${CP2K_USE_MPI_F08}>:__MPI_F08>
           __COMPILE_DATE=\"${CP2K_TIMESTAMP}\"
           __COMPILE_HOST=\"${CP2K_HOST_NAME}\"
           __COMPILE_REVISION=\"${CP2K_GIT_HASH}\"
-@@ -1774,12 +1774,12 @@ install(
+@@ -1577,7 +1577,7 @@ target_compile_definitions(
+          $<$<BOOL:${CP2K_USE_SPLA_GEMM_OFFLOADING}>:__OFFLOAD_GEMM>
+          $<$<BOOL:${CP2K_USE_ELPA}>:__ELPA>
+          $<$<BOOL:${CP2K_USE_LIBXC}>:__LIBXC>
+-         $<$<BOOL:${CP2K_USE_FFTW3}>:__FFTW3>
++         $<$<BOOL:${CP2K_USE_FFTW3_}>:__FFTW3>
+          $<$<BOOL:${CP2K_USE_LIBINT2}>:__LIBINT>
+          $<$<BOOL:${CP2K_USE_PEXSI}>:__LIBPEXSI>
+          $<$<BOOL:${CP2K_USE_LIBTORCH}>:__LIBTORCH>
+@@ -1774,12 +1774,14 @@ install(
    EXPORT cp2k_targets
    FILE cp2kTargets.cmake
    NAMESPACE cp2k::
@@ -590,11 +699,16 @@ index dbc955885e..e003d4f88d 100644
 +  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
  
 -install(FILES start/libcp2k.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cp2k")
-+install(FILES start/libcp2k.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
++install(FILES start/libcp2k.h
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
  
  install(
    DIRECTORY "${PROJECT_BINARY_DIR}/src/mod_files"
 -  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cp2k"
-+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
++  DESTINATION
++    "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
    FILES_MATCHING
    PATTERN "*.mod")
+-- 
+2.41.0
+

--- a/var/spack/repos/builtin/packages/cp2k/cmake-fixes-2023.2.patch
+++ b/var/spack/repos/builtin/packages/cp2k/cmake-fixes-2023.2.patch
@@ -72,7 +72,7 @@ index 3f81c7b52..f2d85d033 100644
 -      FATAL_ERROR
 -        "Fftw3 threads and openmp supports can not be used at the same time")
 -  endif()
-+  if(CP2K_USE_FFTW3_WITH_MKL OR NOT TARGET CP2K::BLAS::MKL::blas)
++  if(CP2K_USE_FFTW3_WITH_MKL OR NOT CP2K_BLAS_VENDOR MATCHES "MKL")
 +    find_package(Fftw REQUIRED)
 +    if(CP2K_ENABLE_FFTW3_THREADS_SUPPORT AND CP2K_ENABLE_FFTW3_OPENMP_SUPPORT)
 +      message(


### PR DESCRIPTION
- Use the fftw implementation found in `libmkl_{intel,gf}_lp64.so`  instead of fftw3 when cp2k is compiled with mkl support. It should ease gromacs compilation with mkl and cp2k support.
-  Fix a typo