### PR TITLE
exago: fix v1.5.1 tag; only allow python up to 3.10 for for @:1.5

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -17,7 +17,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/pnnl/ExaGO.git"
     maintainers("ryandanehy", "cameronrutherford", "pelesh")
 
-    version("1.5.1", commit="7abe482c8da0e247f9de4896f5982c4cacbecd78", submodules=True)
+    version("1.5.1", tag="v1.5.1", submodules=True)
     version("1.5.0", commit="227f49573a28bdd234be5500b3733be78a958f15", submodules=True)
     version("1.4.1", commit="ea607c685444b5f345bfdc9a59c345f0f30adde2", submodules=True)
     version("1.4.0", commit="4f4c3fdb40b52ace2d6ba000e7f24b340ec8e886", submodules=True)
@@ -64,7 +64,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # Dependencies
-    depends_on("python@3.6:", when="@1.3.0:+python")
+    depends_on("python@3.6:3.10", when="@1.3.0:1.5+python")
     depends_on("py-pytest", type=("build", "run"), when="@1.5.0:+python")
     depends_on("py-mpi4py", when="@1.3.0:+mpi+python")
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -104,6 +104,10 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("magma@{0}:".format(magma_v), when="@{0}:+rocm".format(hiop_v))
 
     depends_on("cuda@11:", when="@develop:+cuda")
+
+    # https://github.com/spack/spack/issues/40678
+    depends_on("cuda@:11.9", when="@:1.0 +cuda")
+
     depends_on("raja", when="+raja")
     depends_on("umpire", when="+raja")
     depends_on("raja+openmp", when="+raja~cuda~rocm")


### PR DESCRIPTION
Fix version definition for `exago@1.5.1`
* git commit `7abe482c8da0e247f9de4896f5982c4cacbecd78` does not exist
* switch to tag `v1.5.1`

`exago@1.5.1 +python` does not build with `python@3.11` due to issue with the exago vendored `pybind11` and `python@3.11` -- update python requirement to reflect this constraint