### PR TITLE
CI: Fix timing search paths to ignore bootstrap

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -25,7 +25,7 @@ ci:
       - - spack config blame mirrors
         - spack --color=always --backtrace ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
       - - spack python ${CI_PROJECT_DIR}/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
-          --prefix /home/software/spack:${CI_PROJECT_DIR}
+          --prefix /home/software/spack:${CI_PROJECT_DIR}/opt/spack
           --log install_times.json
           ${SPACK_ARTIFACTS_ROOT}/user_data/install_times.json
       after_script:

--- a/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
+++ b/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
@@ -28,9 +28,17 @@ if __name__ == "__main__":
 
     # Aggregate the install timers into a single json
     data = []
+
+    # Look in the CWD for logs
+    local_log_path = os.path.join(os.path.getcwd(), args.log)
+    if os.path.exists(local_log_path):
+        with open(local_log_path) as fd:
+            data.append(json.load(fd))
+
+    # Look in the list of prefixes for logs
     for prefix in prefixes:
-        time_logs = find_logs(prefix, args.log)
-        for log in time_logs:
+        logs = find_logs(prefix, args.log)
+        for log in logs:
             with open(log) as fd:
                 data.append(json.load(fd))
 


### PR DESCRIPTION
Bootstrapped packages provide garbage timing data that should be ignored.