### PR TITLE
Fixes and options for package spglib

### DIFF
--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -54,4 +54,5 @@ class Spglib(CMakePackage):
         return find_libraries("libsymspg", root=self.prefix, shared=True, recursive=True)
 
     def cmake_args(self):
-        return [self.define_from_variant("USE_OMP", "openmp")]
+        pfx = "SPGLIB_" if self.spec.satisfies("@2.1.0:") else ""
+        return [self.define_from_variant(pfx + "USE_OMP", "openmp")]

--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -48,7 +48,7 @@ class Spglib(CMakePackage):
     version("1.10.0", sha256="117fff308731784bea2ddaf3d076f0ecbf3981b31ea1c1bfd5ce4f057a5325b1")
 
     variant("openmp", default=True, description="Build with OpenMP support", when="@1.16.2:")
-    variant("fortran", default=True, description="Build Fortran interface", when="@1.16.6:")
+    variant("fortran", default=True, description="Build Fortran interface", when="@1.16.4:")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -48,6 +48,7 @@ class Spglib(CMakePackage):
     version("1.10.0", sha256="117fff308731784bea2ddaf3d076f0ecbf3981b31ea1c1bfd5ce4f057a5325b1")
 
     variant("openmp", default=True, description="Build with OpenMP support", when="@1.16.2:")
+    variant("fortran", default=True, description="Build Fortran interface", when="@1.16.6:")
 
     @property
     def libs(self):
@@ -55,4 +56,5 @@ class Spglib(CMakePackage):
 
     def cmake_args(self):
         pfx = "SPGLIB_" if self.spec.satisfies("@2.1.0:") else ""
-        return [self.define_from_variant(pfx + "USE_OMP", "openmp")]
+        return [self.define_from_variant(pfx + "USE_OMP", "openmp"),
+                self.define_from_variant(pfx + "WITH_Fortran", "fortran")]

--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -56,5 +56,7 @@ class Spglib(CMakePackage):
 
     def cmake_args(self):
         pfx = "SPGLIB_" if self.spec.satisfies("@2.1.0:") else ""
-        return [self.define_from_variant(pfx + "USE_OMP", "openmp"),
-                self.define_from_variant(pfx + "WITH_Fortran", "fortran")]
+        return [
+            self.define_from_variant(pfx + "USE_OMP", "openmp"),
+            self.define_from_variant(pfx + "WITH_Fortran", "fortran"),
+        ]


### PR DESCRIPTION
The cmake option to enable openmp support since v2.1.0 is SPGLIB_USE_OMP.
Added option to build the fortran interface, although usually just installing the source header is sufficient.