### PR TITLE
octopus: split netcdf-c and netcdf-fortran dependency

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -93,13 +93,14 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("libxc@2:4", when="@8:9")
     depends_on("libxc@5.1.0:", when="@10:")
     depends_on("libxc@5.1.0:", when="@develop")
+    depends_on("netcdf-fortran", when="+netcdf")  # NetCDF fortran lib without mpi variant
     with when("+mpi"):  # list all the parallel dependencies
         depends_on("fftw@3:+mpi+openmp", when="@8:9")  # FFT library
         depends_on("fftw-api@3:+mpi+openmp", when="@10:")
         depends_on("libvdwxc+mpi", when="+libvdwxc")
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
-        depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+        depends_on("netcdf-c+mpi", when="+netcdf")  # Link dependency of NetCDF fortran lib
         depends_on("berkeleygw@2.1+mpi", when="+berkeleygw")
 
     with when("~mpi"):  # list all the serial dependencies
@@ -108,7 +109,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("libvdwxc~mpi", when="+libvdwxc")
         depends_on("arpack-ng~mpi", when="+arpack")
         depends_on("elpa~mpi", when="+elpa")
-        depends_on("netcdf-fortran ^netcdf-c~~mpi", when="+netcdf")
+        depends_on("netcdf-c~~mpi", when="+netcdf")  # Link dependency of NetCDF fortran lib
         depends_on("berkeleygw@2.1~mpi", when="+berkeleygw")
 
     depends_on("etsf-io", when="+etsf-io")


### PR DESCRIPTION
Spack cant  spec octopus with the latest develop:
```shell
$ spack --debug spec octopus +mpi+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack+netcdf
==> [2023-10-13-16:58:23.941671] Error: Spack concretizer internal error. Please submit a bug report and include the command, environment if applicable and the following error message.                                            octopus+arpack+berkeleygw+cgal~cuda~debug+elpa+etsf-io+libyaml+likwid~metis+mpi+netcdf+nfft+nlopt+parmetis+pfft+pnfft+python~scalapack+sparskit is unsatisfiable, errors are:                                               Traceback (most recent call last):                        File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/cmd/__init__.py", line 218, in parse_specs            spec.concretize(tests=tests)  # implies normalize     File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/spec.py", line 2967, in concretize
    self._new_concretize(tests)                           File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/spec.py", line 2940, in _new_concretize               result.raise_if_unsat()
  File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/solver/asp.py", line 506, in raise_if_unsat
    raise InternalConcretizerError(constraints, conflict
s=conflicts)                                            spack.solver.asp.InternalConcretizerError: Spack concretizer internal error. Please submit a bug report and incl
ude the command, environment if applicable and the following error message.                                         octopus+arpack+berkeleygw+cgal~cuda~debug+elpa+etsf-io+libyaml+likwid~metis+mpi+netcdf+nfft+nlopt+parmetis+pfft+pnfft+python~scalapack+sparskit is unsatisfiable, errors are:                                                                                                       The above exception was the direct cause of the following exception:                                                                                                    Traceback (most recent call last):
  File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/main.py", line 1022, in main
    return _main(argv)                                    File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/main.py", line 977, in _main                          return finish_parse_and_run(parser, cmd_name, env_format_error)                                               File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/main.py", line 1005, in finish_parse_and_run          return _invoke_command(command, parser, args, unknown)                                                        File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/main.py", line 646, in _invoke_command                return_val = command(parser, args)
  File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/cmd/spec.py", line 101, in spec                       concretized_specs = spack.cmd.parse_specs(args.specs, concretize=True)
  File "/scratch/karnada/spackbox/spacklatest/lib/spack/spack/cmd/__init__.py", line 232, in parse_specs
    raise spack.error.SpackError(msg) from e
spack.error.SpackError: Spack concretizer internal error. Please submit a bug report and include the command, environment if applicable and the following error message.
    octopus+arpack+berkeleygw+cgal~cuda~debug+elpa+etsf-io+libyaml+likwid~metis+mpi+netcdf+nfft+nlopt+parmetis+pfft+pnfft+python~scalapack+sparskit is unsatisfiable, errors are:

```
This does work on the latest stable release.
@fangohr at https://github.com/fangohr/octopus-in-spack/issues/96 found out by trial and error that it is due to the netcdf-c and netcdf-fortran dependency definition.
and the following works:
```shell
$ spack spec octopus +mpi+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack^netcdf-fortran^netcdf-c+mpi 
```

This MR splits the two dependencies and makes the spec command work.

I am not sure why this broke to begin with and if this is really the best solution. Perhaps someone from the spack team can help here?