### PR TITLE
OpenMPI: fix depends for  PMIx@4.2.3: compat

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -558,7 +558,10 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     # depends_on('pmix@1.1.2', when='@2.1.6')
     # depends_on('pmix@3.2.3', when='@4.1.2')
     depends_on("pmix@1.0:1", when="@2.0:2 ~internal-pmix")
-    depends_on("pmix@3.2:", when="@4.0:4 ~internal-pmix")
+    depends_on("pmix@3.2:4.2.2", when="@4.0:4.1.5 ~internal-pmix")
+    # 4.1.6 includes changes that fix compatibility with PMIx@4.2.3:
+    # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
+    depends_on("pmix@3.2:", when="@4.1.6:4 ~internal-pmix")
     depends_on("pmix@4.2:", when="@5.0:5 ~internal-pmix")
 
     # Libevent is required when *vendored* PMIx is used

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -555,14 +555,14 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     # PMIx is unavailable for @1, and required for @2:
     # OpenMPI @2: includes a vendored version:
-    # depends_on('pmix@1.1.2', when='@2.1.6')
-    # depends_on('pmix@3.2.3', when='@4.1.2')
-    depends_on("pmix@1.0:1", when="@2.0:2 ~internal-pmix")
-    depends_on("pmix@3.2:4.2.2", when="@4.0:4.1.5 ~internal-pmix")
-    # 4.1.6 includes changes that fix compatibility with PMIx@4.2.3:
-    # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
-    depends_on("pmix@3.2:", when="@4.1.6:4 ~internal-pmix")
-    depends_on("pmix@4.2:", when="@5.0:5 ~internal-pmix")
+    with when("~internal-pmix"):
+        depends_on("pmix@1", when="@2")
+        depends_on("pmix@3.2:", when="@4:")
+        depends_on("pmix@4.2:", when="@5:")
+
+        # pmix@4.2.3 contains a breaking change, compat fixed in openmpi@4.1.6
+        # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
+        depends_on("pmix@:4.2.2", when="@:4.1.5")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="@main")


### PR DESCRIPTION
PMIx 4.2.3+ includes changes that can break OpenMPI prior to 4.1.6: https://github.com/open-mpi/ompi/issues/11729 
We have also observed an issue with incorrect selection of the TCP btl over shared-memory for intra-node communication.

Fixes are available upstream from 4.1.6, and the issue can be avoided for previous OMPI versions by limiting the PMIx version range to @3.2:4.2.2