### PR TITLE
neovim: conflict for libluv problem on macOS + add newer versions of neovim and libluv

### DIFF
--- a/var/spack/repos/builtin/packages/libluv/package.py
+++ b/var/spack/repos/builtin/packages/libluv/package.py
@@ -14,7 +14,9 @@ class Libluv(CMakePackage):
     homepage = "https://github.com/luvit/luv"
     url = "https://github.com/luvit/luv/releases/download/1.36.0-0/luv-1.36.0-0.tar.gz"
 
+    version("1.45.0-0", sha256="fa6c46fb09f88320afa7f88017efd7b0d2b3a0158c5ba5b6851340b0332a2b81")
     version("1.44.2-1", sha256="3eb5c7bc44f61fbc4148ea30e3221d410263e0ffa285672851fc19debf9e5c30")
+    version("1.44.2-0", sha256="30639f8e0fac7fb0c3a04b94a00f73c6d218c15765347ceb0998a6b72464b6cf")
     version("1.43.0-0", sha256="567a6f3dcdcf8a9b54ddc57ffef89d1e950d72832b85ee81c8c83a9d4e0e9de2")
     version("1.42.0-1", sha256="4b6fbaa89d2420edf6070ad9e522993e132bd7eb2540ff754c2b9f1497744db2")
     version("1.42.0-0", sha256="b5228a9d0eaacd9f862b6270c732d5c90773a28ce53b6d9e32a14050e7947f36")

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -136,7 +136,7 @@ class Neovim(CMakePackage):
     # Support for `libvterm@0.2:` has been added in neovim@0.8.0
     # term: Add support for libvterm >= 0.2 (https://github.com/neovim/neovim/releases/tag/v0.8.0)
     # https://github.com/neovim/neovim/issues/16217#issuecomment-958590493
-    conflicts("^libvterm@0.2:", when="@:0.7")
+    conflicts("libvterm@0.2:", when="@:0.7")
 
     # https://github.com/neovim/neovim/issues/25770
     conflicts("libluv@1.44:", when="platform=darwin")

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -138,6 +138,9 @@ class Neovim(CMakePackage):
     # https://github.com/neovim/neovim/issues/16217#issuecomment-958590493
     conflicts("^libvterm@0.2:", when="@:0.7")
 
+    # https://github.com/neovim/neovim/issues/25770
+    conflicts("libluv@1.44:", when="platform=darwin")
+
     @when("^lua")
     def cmake_args(self):
         return [self.define("PREFER_LUA", True)]

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -17,6 +17,8 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable", commit="7d4bba7aa7a4a3444919ea7a3804094c290395ef")
+    version("0.9.4", sha256="148356027ee8d586adebb6513a94d76accc79da9597109ace5c445b09d383093")
+    version("0.9.2", sha256="06b8518bad4237a28a67a4fbc16ec32581f35f216b27f4c98347acee7f5fb369")
     version("0.9.1", sha256="8db17c2a1f4776dcda00e59489ea0d98ba82f7d1a8ea03281d640e58d8a3a00e")
     version("0.9.0", sha256="39d79107c54d2f3babcad2cd157c399241c04f6e75e98c18e8afaf2bb5e82937")
     version("0.8.3", sha256="adf45ff160e1d89f519b6114732eba03485ae469beb27919b0f7a4f6b44233c1")


### PR DESCRIPTION
Close #39563 #39973

As documented in https://github.com/neovim/neovim/issues/25770.

From `libluv@1.44` on, library name changes resulted in `neovim` using `libluv` as a dynamic library, which works correctly on linux, but not on macOS.

Waiting for a fix on neovim side, I translated this problem in a conflict for all upcoming versions of `libluv`.