### PR TITLE
PythonPackage: allow archive_files to be overridden

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -409,7 +409,7 @@ class PythonPipBuilder(BaseBuilder):
     legacy_long_methods = ("install_options", "global_options", "config_settings")
 
     #: Names associated with package attributes in the old build-system format
-    legacy_attributes = ("build_directory", "install_time_test_callbacks")
+    legacy_attributes = ("archive_files", "build_directory", "install_time_test_callbacks")
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["test"]


### PR DESCRIPTION
Extracted out of #40539 and #40057.

Packages like `py-scipy` override `archive_files` to include additional meson logs, but these aren't actually respected without this PR.