### PR TITLE
Add dlaf variant to cp2k

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -84,6 +84,12 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         when="@6.1:",
     )
     variant(
+        "dlaf",
+        default=False,
+        description="Enable DLA-Future eigensolver and Cholesky decomposition",
+        when="@master build_system=cmake",  #  TODO: Pin version when integrated in a release
+    )
+    variant(
         "sirius",
         default=False,
         description="Enable planewave electronic structure calculations via SIRIUS",
@@ -225,6 +231,15 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         depends_on("elpa@2021.05:", when="@8.3:")
         depends_on("elpa@2021.11.001:", when="@9.1:")
         depends_on("elpa@2023.05.001:", when="@2023.2:")
+
+    with when("+dlaf"):
+        conflicts(
+            "~mpi", msg="DLA-Future requires MPI. Only the distributed eigensolver is available."
+        )
+        depends_on("dla-future@0.2.1: +scalapack")
+        depends_on("dla-future ~cuda~rocm", when="~cuda~rocm")
+        depends_on("dla-future +cuda", when="+cuda")
+        depends_on("dla-future +rocm", when="+rocm")
 
     with when("+plumed"):
         depends_on("plumed+shared")
@@ -945,6 +960,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         args += [
             self.define_from_variant("CP2K_ENABLE_REGTESTS", "enable_regtests"),
             self.define_from_variant("CP2K_USE_ELPA", "elpa"),
+            self.define_from_variant("CP2K_USE_DLAF", "dlaf"),
             self.define_from_variant("CP2K_USE_LIBINT2", "libint"),
             self.define_from_variant("CP2K_USE_SIRIUS", "sirius"),
             self.define_from_variant("CP2K_USE_SPLA", "spla"),

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -87,7 +87,8 @@ class Cp2k(MakefilePackage, CudaPackage, CMakePackage, ROCmPackage):
         "dlaf",
         default=False,
         description="Enable DLA-Future eigensolver and Cholesky decomposition",
-        when="@master build_system=cmake",  #  TODO: Pin version when integrated in a release
+        # TODO: Pin version when integrated in a release
+        when="@master build_system=cmake",
     )
     variant(
         "sirius",


### PR DESCRIPTION
Add `dlaf` variant for the upcoming DLA-Future integration in CP2K.