### PR TITLE
ldak: add v5.2 & add maintainer

### DIFF
--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -12,31 +12,68 @@ class Ldak(Package):
     homepage = "https://dougspeed.com/ldak/"
     url = "https://dougspeed.com/wp-content/uploads/source.zip"
 
-    version("5.1", sha256="ae3eb8c2ef31af210e138336fd6edcd0e3a26ea9bae89fd6c0c6ea33e3a1517e")
+    maintainers("snehring")
 
-    variant("mkl", default=False, description="Use MKL")
+    version("5.2", sha256="ba3de4eb4f2d664b3c2a54bef2eb66d1a498ac423179e97a5795d010161b1805")
+    version(
+        "5.1",
+        sha256="ae3eb8c2ef31af210e138336fd6edcd0e3a26ea9bae89fd6c0c6ea33e3a1517e",
+        deprecated=True,
+    )
+
+    variant("glpk", default=False, description="Use glpk instead of vendored qsopt")
 
     depends_on("zlib-api")
     depends_on("blas")
     depends_on("lapack")
-    depends_on("mkl", when="+mkl")
+    depends_on("openblas threads=openmp", when="^openblas")
+    depends_on("intel-mkl threads=openmp", when="^intel-mkl")
+    depends_on("intel-oneapi-mkl threads=openmp", when="^intel-oneapi-mkl")
+    depends_on("glpk", when="+glpk")
 
-    for t in ["aarch64", "arm", "ppc", "ppc64", "ppc64le", "ppcle", "sparc", "sparc64", "x86"]:
-        conflicts("target={0}:".format(t), msg="libspot is available linux x86_64 only")
+    requires("target=x86_64:", when="~glpk", msg="bundled qsopt is only for x86_64")
+    requires(
+        "^mkl",
+        "^openblas",
+        policy="one_of",
+        msg="Only mkl or openblas are supported for blas/lapack with ldak",
+    )
+    conflicts("platform=cray", when="~glpk", msg="bundled qsopt only for linux or mac")
 
-    def setup_build_environment(self, env):
-        env.append_flags("LDLIBS", "-lm")
-        env.append_flags("LDLIBS", "-lz")
-        libs = (self.spec["lapack"].libs + self.spec["blas"].libs).ld_flags
-        env.append_flags("LDLIBS", libs)
-        if self.spec.platform == "darwin":
-            env.append_flags("LDLIBS", "libqsopt.mac.a")
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        libs = [
+            "-lm",
+            (self.spec["lapack"].libs + self.spec["blas"].libs).link_flags,
+            self.spec["zlib-api"].libs.link_flags,
+        ]
+        includes = [
+            (self.spec["lapack"].headers + self.spec["blas"].headers).include_flags,
+            self.spec["zlib-api"].headers.include_flags,
+        ]
+
+        if self.spec.satisfies("~glpk"):
+            if self.spec.satisfies("platform=darwin"):
+                libs.append("libqsopt.mac.a")
+            else:
+                libs.append("libqsopt.linux.a")
         else:
-            env.append_flags("LDLIBS", "libqsopt.linux.a")
+            includes.append(self.spec["glpk"].headers.include_flags)
+            libs.append(self.spec["glpk"].libs.link_flags)
+        if self.spec.satisfies("^mkl"):
+            filter_file("#define MKL.*", "#define MKL 1", "ldak.c")
+        if self.spec.satisfies("^openblas"):
+            filter_file("#define MKL.*", "#define MKL 2", "ldak.c")
+            filter_file("#if MKL==2", "#if MKL==2\n#include <cblas.h>\n", "ldak.c")
+        if self.spec.satisfies("+glpk"):
+            filter_file("#define MET.*", "#define MET 1", "ldak.c")
+            filter_file('#include"glpk.h"', "#include<glpk.h>", "ldak.c")
+            filter_file(r"weights\[", "tally3[", "weightfuns.c")
+        cc = Executable(spack_cc)
+        args = ["ldak.c", "-fopenmp", "-o", "ldak"] + includes + libs
+        cc(*args)
 
     def install(self, spec, prefix):
-        if self.spec.satisfies("~mkl"):
-            filter_file("#define MKL.*", "#define MKL 0", "ldak.c")
-        make("ldak")
         mkdirp(prefix.bin)
         install("ldak", prefix.bin.ldak)

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -71,7 +71,7 @@ class Ldak(Package):
             filter_file('#include"glpk.h"', "#include<glpk.h>", "ldak.c")
             filter_file(r"weights\[", "tally3[", "weightfuns.c")
         cc = Executable(spack_cc)
-        args = ["ldak.c", "-fopenmp", "-o", "ldak"] + includes + libs
+        args = ["ldak.c", self.compiler.openmp_flag, "-o", "ldak"] + includes + libs
         cc(*args)
 
     def install(self, spec, prefix):


### PR DESCRIPTION
I reworked the build a bit, mostly because I noticed the code contained references for working with openblas and glpk, which could open the possibility of aarch64 support. It does compile on aarch64 now.