### PR TITLE
ci: print colored specs in concretization progress

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -206,20 +206,19 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
 
         for job in sorted(stage, key=lambda j: (not rebuild_decisions[j].rebuild, j)):
             s = spec_labels[job]
-            rebuild = rebuild_decisions[job].rebuild
             reason = rebuild_decisions[job].reason
             reason_msg = " ({0})".format(reason) if reason else ""
             spec_fmt = "{name}{@version}{%compiler}{/hash:7}"
-            if rebuild:
-                msg = f"@g{{[x]}}  {s.cformat(spec_fmt)}{reason_msg}"
+            if rebuild_decisions[job].rebuild:
+                status = colorize("@*g{[x]}  ")
+                msg = f"{status}{s.cformat(spec_fmt)}{reason_msg}"
             else:
-                grey_start = "@K{ -   "
-                grey_end = "}"
-                msg = f"{grey_start}{s.format(spec_fmt)}{reason_msg}"
+                msg = f"@K -   {s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:
                     msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
-                msg += grey_end
-            tty.msg(colorize(msg))
+                msg += "@."
+                msg = colorize(msg)
+            tty.msg(msg)
 
 
 def _compute_spec_deps(spec_list):

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -213,11 +213,9 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
                 status = colorize("@*g{[x]}  ")
                 msg = f"  {status}{s.cformat(spec_fmt)}{reason_msg}"
             else:
-                msg = s.format(spec_fmt)
+                msg = f"{s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:
-                    msg += " found on: " + ", ".join(rebuild_decisions[job].mirrors)
-                else:
-                    msg += reason_msg
+                    msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
                 msg = colorize(f"  @K -   {cescape(msg)}@.")
             tty.msg(msg)
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2270,11 +2270,11 @@ class CDashHandler:
         Returns: (str) current CDash build stamp"""
         build_stamp = os.environ.get("SPACK_CDASH_BUILD_STAMP")
         if build_stamp:
-            tty.verbose("Using build stamp ({0}) from the environment".format(build_stamp))
+            tty.debug("Using build stamp ({0}) from the environment".format(build_stamp))
             return build_stamp
 
         build_stamp = cdash_build_stamp(self.build_group, time.time())
-        tty.verbose("Generated new build stamp ({0})".format(build_stamp))
+        tty.debug("Generated new build stamp ({0})".format(build_stamp))
         return build_stamp
 
     @property  # type: ignore

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -25,7 +25,7 @@ from urllib.request import HTTPHandler, Request, build_opener
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
-from llnl.util.tty.color import colorize
+from llnl.util.tty.color import cescape, colorize
 
 import spack
 import spack.binary_distribution as bindist
@@ -213,11 +213,10 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
                 status = colorize("@*g{[x]}  ")
                 msg = f"  {status}{s.cformat(spec_fmt)}{reason_msg}"
             else:
-                msg = f"  @K -   {s.format(spec_fmt)}{reason_msg}"
+                msg = f"{s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:
                     msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
-                msg += "@."
-                msg = colorize(msg)
+                msg = colorize(f"  @K -   {cescape(msg)}@.")
             tty.msg(msg)
 
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -207,7 +207,7 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
         for job in sorted(stage, key=lambda j: (not rebuild_decisions[j].rebuild, j)):
             s = spec_labels[job]
             reason = rebuild_decisions[job].reason
-            reason_msg = " ({0})".format(reason) if reason else ""
+            reason_msg = f" ({reason})" if reason else ""
             spec_fmt = "{name}{@version}{%compiler}{/hash:7}"
             if rebuild_decisions[job].rebuild:
                 status = colorize("@*g{[x]}  ")

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -215,7 +215,7 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
             else:
                 msg = f"{s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:
-                    msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
+                    msg += f" [{', '.join(rebuild_decisions[job].mirrors)}]"
                 msg = colorize(f"  @K -   {cescape(msg)}@.")
             tty.msg(msg)
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -202,7 +202,7 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
 
     tty.msg("Staging summary ([x] means a job needs rebuilding):")
     for stage_index, stage in enumerate(stages):
-        tty.msg("  stage {0} ({1} jobs):".format(stage_index, len(stage)))
+        tty.msg(f"  stage {stage_index} ({len(stage)} jobs):")
 
         for job in sorted(stage, key=lambda j: (not rebuild_decisions[j].rebuild, j)):
             s = spec_labels[job]
@@ -211,9 +211,9 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
             spec_fmt = "{name}{@version}{%compiler}{/hash:7}"
             if rebuild_decisions[job].rebuild:
                 status = colorize("@*g{[x]}  ")
-                msg = f"{status}{s.cformat(spec_fmt)}{reason_msg}"
+                msg = f"  {status}{s.cformat(spec_fmt)}{reason_msg}"
             else:
-                msg = f"@K -   {s.format(spec_fmt)}{reason_msg}"
+                msg = f"  @K -   {s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:
                     msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
                 msg += "@."

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -209,14 +209,11 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
             rebuild = rebuild_decisions[job].rebuild
             reason = rebuild_decisions[job].reason
             reason_msg = " ({0})".format(reason) if reason else ""
-
-            rebuild_status = "@g{[x]}  "
             spec_fmt = "{name}{@version}{%compiler}{/hash:7}"
-
             if rebuild:
-                msg = f"{rebuild_status}{s.cformat(spec_fmt)}{reason_msg}"
+                msg = f"@g{{[x]}}  {s.cformat(spec_fmt)}{reason_msg}"
             else:
-                grey_start = "@K{"
+                grey_start = "@K{ -   "
                 grey_end = "}"
                 msg = f"{grey_start}{s.format(spec_fmt)}{reason_msg}"
                 if rebuild_decisions[job].mirrors:

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2250,13 +2250,13 @@ class CDashHandler:
                 spec.architecture,
                 self.build_group,
             )
-            tty.verbose(
+            tty.debug(
                 "Generated CDash build name ({0}) from the {1}".format(build_name, spec.name)
             )
             return build_name
 
         build_name = os.environ.get("SPACK_CDASH_BUILD_NAME")
-        tty.verbose("Using CDash build name ({0}) from the environment".format(build_name))
+        tty.debug("Using CDash build name ({0}) from the environment".format(build_name))
         return build_name
 
     @property  # type: ignore

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -213,9 +213,11 @@ def _print_staging_summary(spec_labels, stages, mirrors_to_check, rebuild_decisi
                 status = colorize("@*g{[x]}  ")
                 msg = f"  {status}{s.cformat(spec_fmt)}{reason_msg}"
             else:
-                msg = f"{s.format(spec_fmt)}{reason_msg}"
+                msg = s.format(spec_fmt)
                 if rebuild_decisions[job].mirrors:
-                    msg += " found on mirror: " + ", ".join(rebuild_decisions[job].mirrors)
+                    msg += " found on: " + ", ".join(rebuild_decisions[job].mirrors)
+                else:
+                    msg += reason_msg
                 msg = colorize(f"  @K -   {cescape(msg)}@.")
             tty.msg(msg)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1526,7 +1526,7 @@ class Environment:
             batch.append((i, concrete))
             percentage = (j + 1) / len(args) * 100
             tty.verbose(
-                f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i].colored_str}: "
+                f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i].colored_str} "
                 f"{concrete.cformat('{/hash:7}')}"
             )
             sys.stdout.flush()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1525,7 +1525,10 @@ class Environment:
         ):
             batch.append((i, concrete))
             percentage = (j + 1) / len(args) * 100
-            tty.verbose(f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i]}")
+            tty.verbose(
+                f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i].colored_str}: "
+                f"{concrete.cformat('/{hash:7}')}"
+            )
             sys.stdout.flush()
 
         # Add specs in original order

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1526,8 +1526,8 @@ class Environment:
             batch.append((i, concrete))
             percentage = (j + 1) / len(args) * 100
             tty.verbose(
-                f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i].colored_str} "
-                f"{concrete.cformat('{/hash:7}')}"
+                f"{duration:6.1f}s [{percentage:3.0f}%] {concrete.cformat('{hash:7}')} "
+                f"{root_specs[i].colored_str}"
             )
             sys.stdout.flush()
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1527,7 +1527,7 @@ class Environment:
             percentage = (j + 1) / len(args) * 100
             tty.verbose(
                 f"{duration:6.1f}s [{percentage:3.0f}%] {root_specs[i].colored_str}: "
-                f"{concrete.cformat('/{hash:7}')}"
+                f"{concrete.cformat('{/hash:7}')}"
             )
             sys.stdout.flush()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4492,10 +4492,16 @@ class Spec:
 
     def __str__(self):
         sorted_nodes = [self] + sorted(
-            self.traverse(root=False), key=lambda x: x.name or x.abstract_hash
+            self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)
         )
-        spec_str = " ^".join(d.format() for d in sorted_nodes)
-        return spec_str.strip()
+        return " ^".join(d.format() for d in sorted_nodes).strip()
+
+    @property
+    def colored_str(self):
+        sorted_nodes = [self] + sorted(
+            self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)
+        )
+        return " ^".join(d.cformat() for d in sorted_nodes).strip()
 
     def install_status(self):
         """Helper for tree to print DB install status."""

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -144,7 +144,7 @@ default:
     - spack python -c "import os,sys; print(os.path.expandvars(sys.stdin.read()))"
       < "${SPACK_CI_CONFIG_ROOT}/${PIPELINE_MIRROR_TEMPLATE}" > "${SPACK_CI_CONFIG_ROOT}/mirrors.yaml"
     - spack config add -f "${SPACK_CI_CONFIG_ROOT}/mirrors.yaml"
-    - spack -v
+    - spack -v  --color=always
       --config-scope "${SPACK_CI_CONFIG_ROOT}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}"
       --config-scope "${SPACK_CI_CONFIG_ROOT}/${SPACK_TARGET_PLATFORM}/${SPACK_TARGET_ARCH}"
@@ -197,7 +197,7 @@ default:
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
     - spack env activate --without-view .
-    - spack -v
+    - spack -v --color=always
       ci generate --check-index-only
       --buildcache-destination "${PUSH_BUILDCACHE_DEPRECATED}"
       --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -24,6 +24,8 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     version("3.7", sha256="b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26")
     version("3.6", sha256="d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6")
 
+    variant("rebuildme", default=True, description="ci test")
+
     build_directory = "spack-build"
 
     patch("nvhpc.patch", when="@3.7 %nvhpc")

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -24,8 +24,6 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     version("3.7", sha256="b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26")
     version("3.6", sha256="d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6")
 
-    variant("rebuildme", default=True, description="ci test")
-
     build_directory = "spack-build"
 
     patch("nvhpc.patch", when="@3.7 %nvhpc")


### PR DESCRIPTION
During concretization, print (edit: hash is moved before spec now)

![Screenshot from 2023-10-26 11-44-21](https://github.com/spack/spack/assets/194764/f729295b-0c5e-4c72-9da0-7cdc6ef18f77)

hopefully makes it a bit easier to link abstract and concrete specs.

And in the stage overview: condense to single line per spec, grey out pruned specs, colorize staged ones. (edit: dropped 'reason' text if its obvious from the list of mirrors that follow it)

![Screenshot from 2023-10-26 11-44-09](https://github.com/spack/spack/assets/194764/1d53d6b4-676a-4bba-bbd6-ce90cdf9d8d3)

