### PR TITLE
Improve compiler audit and use in CI

### DIFF
--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -85,11 +85,51 @@ _double_compiler_definition = [
 ]
 
 
+# Data used in the test below to audit conflicting compiler definitions
+_conflicting_compiler_definition = [
+    {
+        "compiler": {
+            "spec": "clang@14.0.0",
+            "paths": {
+                "cc": "/usr/bin/clang",
+                "cxx": "/usr/bin/clang++",
+                "f77": "null",
+                "fc": "null",
+            },
+            "flags": {},
+            "operating_system": "ubuntu22.04",
+            "target": "x86_64",
+            "modules": [],
+            "environment": {},
+            "extra_rpaths": [],
+        }
+    },
+    {
+        "compiler": {
+            "spec": "clang@15.0.0",
+            "paths": {
+                "cc": "/usr/bin/clang",
+                "cxx": "/usr/bin/clang++",
+                "f77": "null",
+                "fc": "null",
+            },
+            "flags": {},
+            "operating_system": "ubuntu22.04",
+            "target": "x86_64",
+            "modules": [],
+            "environment": {},
+            "extra_rpaths": [],
+        }
+    },
+]
+
+
 @pytest.mark.parametrize(
     "config_section,data,failing_check",
     [
-        # Double compiler definitions in compilers.yaml
+        # Double or conflicting compiler definitions in compilers.yaml
         ("compilers", _double_compiler_definition, "CFG-COMPILER"),
+        ("compilers", _conflicting_compiler_definition, "CFG-COMPILER"),
         # Multiple definitions of the same external spec in packages.yaml
         (
             "packages",

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -11,8 +11,10 @@ ci:
   - build-job:
       before_script-:
       - - spack list --count  # ensure that spack's cache is populated
-      - - spack env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
-        - spack compiler list
+      - - spack compiler find
+        - spack env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
+        - spack audit configs
+        - spack config blame compilers
         - if [ -n "$SPACK_BUILD_JOBS" ]; then spack config add "config:build_jobs:$SPACK_BUILD_JOBS"; fi
       - - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
         # AWS runners mount E4S public key (verification), UO runners mount public/private (signing/verification)


### PR DESCRIPTION
Add another audit to compilers to check for compilers with the same configuration, but different specs, which arose recently when a subset of the mac runners were upgraded (changing compiler from apple-clang-14 to apple-clang-15).

Use the enahnced audit command to make sure compilers found on the system and compilers brought in by the upstream-generated environment don't conflict, and exit 1 if so.

Example of conflicting compiler configs and new audit output:

```console
root@98a5c1e72c0c:/# spack config blame compilers
---                                                        compilers:
/work/spack/var/spack/environments/tutorial/spack.yaml:12  - compiler:
/work/spack/var/spack/environments/tutorial/spack.yaml:13      spec: clang@=14.0.0
/work/spack/var/spack/environments/tutorial/spack.yaml:14      paths:
/work/spack/var/spack/environments/tutorial/spack.yaml:15        cc: /usr/bin/clang
/work/spack/var/spack/environments/tutorial/spack.yaml:16        cxx: /usr/bin/clang++
/work/spack/var/spack/environments/tutorial/spack.yaml:17        f77: null
/work/spack/var/spack/environments/tutorial/spack.yaml:18        fc: null
/work/spack/var/spack/environments/tutorial/spack.yaml:19      flags: {}
/work/spack/var/spack/environments/tutorial/spack.yaml:20      operating_system: ubuntu22.04
/work/spack/var/spack/environments/tutorial/spack.yaml:21      target: x86_64
/work/spack/var/spack/environments/tutorial/spack.yaml:22      modules: []
/work/spack/var/spack/environments/tutorial/spack.yaml:23      environment: {}
/work/spack/var/spack/environments/tutorial/spack.yaml:24      extra_rpaths: []
/work/spack/etc/spack/linux/compilers.yaml:2               - compiler:
/work/spack/etc/spack/linux/compilers.yaml:3                   spec: clang@=15.0.0
/work/spack/etc/spack/linux/compilers.yaml:4                   paths:
/work/spack/etc/spack/linux/compilers.yaml:5                     cc: /usr/bin/clang
/work/spack/etc/spack/linux/compilers.yaml:6                     cxx: /usr/bin/clang++
/work/spack/etc/spack/linux/compilers.yaml:7                     f77: null
/work/spack/etc/spack/linux/compilers.yaml:8                     fc: null
/work/spack/etc/spack/linux/compilers.yaml:9                   flags: {}
/work/spack/etc/spack/linux/compilers.yaml:10                  operating_system: ubuntu22.04
/work/spack/etc/spack/linux/compilers.yaml:11                  target: x86_64
/work/spack/etc/spack/linux/compilers.yaml:12                  modules: []
/work/spack/etc/spack/linux/compilers.yaml:13                  environment: {}
/work/spack/etc/spack/linux/compilers.yaml:14                  extra_rpaths: []

root@98a5c1e72c0c:/# spack audit configs
CFG-COMPILER: 1 issue found
1. Compiler definitions conflict: ['clang@=14.0.0', 'clang@=15.0.0']

```